### PR TITLE
LttP: support multiple connected SNESes

### DIFF
--- a/LttPClient.py
+++ b/LttPClient.py
@@ -52,11 +52,26 @@ class LttPCommandProcessor(ClientCommandProcessor):
         self.output(f"Setting slow mode to {self.ctx.slow_mode}")
 
     @mark_raw
-    def _cmd_snes(self, snes_address: str = "") -> bool:
-        """Connect to a snes.
-        Optionally include network address of a snes to connect to, otherwise show available devices"""
+    def _cmd_snes(self, snes_options: str = "") -> bool:
+        """Connect to a snes. Optionally include network address of a snes to connect to, otherwise show available devices; and a SNES device number if more than one SNES is detected"""
+        
+        snes_address = self.ctx.snes_address
+        snes_device_number = -1
+        
+        options = snes_options.split()
+        num_options = len(options)
+        
+        if num_options > 0:
+            snes_address = options[0]
+            
+        if num_options > 1:
+            try:
+                snes_device_number = int(options[1])
+            except:
+                pass
+
         self.ctx.snes_reconnect_address = None
-        asyncio.create_task(snes_connect(self.ctx, snes_address if snes_address else self.ctx.snes_address))
+        asyncio.create_task(snes_connect(self.ctx, snes_address, snes_device_number))
         return True
 
     def _cmd_snes_close(self) -> bool:
@@ -504,6 +519,7 @@ async def snes_connect(ctx: Context, address):
             snes_logger.error('Already connected to SNI, likely awaiting a device.')
         return
 
+    device = None
     recv_task = None
     ctx.snes_state = SNESState.SNES_CONNECTING
     socket = await _snes_connect(ctx, address)
@@ -512,15 +528,29 @@ async def snes_connect(ctx: Context, address):
 
     try:
         devices = await get_snes_devices(ctx)
+        numDevices = len(devices)
 
-        if len(devices) == 1:
+        if numDevices == 1:
             device = devices[0]
         elif ctx.snes_reconnect_address:
             if ctx.snes_attached_device[1] in devices:
                 device = ctx.snes_attached_device[1]
             else:
                 device = devices[ctx.snes_attached_device[0]]
-        else:
+        elif numDevices > 1:
+            if deviceIndex == -1:
+                logger.info("Found " + str(numDevices) + " SNES devices; connect to one with /snes <address> <device number>:")
+
+                for idx, availableDevice in enumerate(devices):
+                    logger.info(str(idx + 1) + ": " + availableDevice)
+
+            elif (deviceIndex < 0) or (deviceIndex - 1) > numDevices:
+                logger.warning("SNES device number out of range")
+
+            else:
+                device = devices[deviceIndex - 1]
+            
+        if device is None:
             await snes_disconnect(ctx)
             return
 

--- a/LttPClient.py
+++ b/LttPClient.py
@@ -510,7 +510,7 @@ async def get_snes_devices(ctx: Context):
     return devices
 
 
-async def snes_connect(ctx: Context, address):
+async def snes_connect(ctx: Context, address, deviceIndex = -1):
     global SNES_RECONNECT_DELAY
     if ctx.snes_socket is not None and ctx.snes_state == SNESState.SNES_CONNECTED:
         if ctx.rom:
@@ -539,13 +539,13 @@ async def snes_connect(ctx: Context, address):
                 device = devices[ctx.snes_attached_device[0]]
         elif numDevices > 1:
             if deviceIndex == -1:
-                logger.info("Found " + str(numDevices) + " SNES devices; connect to one with /snes <address> <device number>:")
+                snes_logger.info("Found " + str(numDevices) + " SNES devices; connect to one with /snes <address> <device number>:")
 
                 for idx, availableDevice in enumerate(devices):
-                    logger.info(str(idx + 1) + ": " + availableDevice)
+                    snes_logger.info(str(idx + 1) + ": " + availableDevice)
 
             elif (deviceIndex < 0) or (deviceIndex - 1) > numDevices:
-                logger.warning("SNES device number out of range")
+                snes_logger.warning("SNES device number out of range")
 
             else:
                 device = devices[deviceIndex - 1]


### PR DESCRIPTION
Adds LttP client support for multiple SNES devices (actual consoles or emulators) being connected to a single QUsb2Snes instance.

If more than one SNES is present, lists the connected SNESes as e.g.:
```
[SNES]: Found 2 SNES devices; connect to one with /snes <address> <device number>:
1 - <device name>
2 - <device name>
```

Retains current default behavior of automatically connecting if a single SNES device is present (at the default SNES address, or a specific address given by the `--snes` command line switch).