### PR TITLE
New column for generic tracker

### DIFF
--- a/WebHostLib/templates/genericTracker.html
+++ b/WebHostLib/templates/genericTracker.html
@@ -20,6 +20,7 @@
                         <tr>
                             <th>Item</th>
                             <th>Amount</th>
+                            <th>Order Received</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -28,6 +29,7 @@
                     <tr>
                         <td>{{ name | item_name }}</td>
                         <td>{{ count }}</td>
+                        <td>{{received_items[name]}}</td>
                     </tr>
                     {%- endfor -%}
 

--- a/WebHostLib/tracker.py
+++ b/WebHostLib/tracker.py
@@ -521,11 +521,16 @@ def getPlayerTracker(tracker: UUID, tracked_team: int, tracked_player: int):
 
     else:
         checked_locations = multisave.get("location_checks", {}).get((tracked_team, tracked_player), set())
+        player_received_items = {}
+        for key in multisave['received_items']:
+            if key[1] == tracked_player:
+                for NetworkItem in multisave['received_items'][key]:
+                    player_received_items[NetworkItem.item] = multisave['received_items'][key].index(NetworkItem) + 1
         return render_template("genericTracker.html",
                                inventory=inventory,
                                player=tracked_player, team=tracked_team, room=room, player_name=player_name,
-                               checked_locations= checked_locations, not_checked_locations = set(locations[tracked_player])-checked_locations)
-
+                               checked_locations=checked_locations, not_checked_locations=set(locations[tracked_player])-checked_locations,
+                               received_items=player_received_items)
 
 @app.route('/tracker/<suuid:tracker>')
 @cache.memoize(timeout=60)  # multisave is currently created at most every minute

--- a/WebHostLib/tracker.py
+++ b/WebHostLib/tracker.py
@@ -522,11 +522,8 @@ def getPlayerTracker(tracker: UUID, tracked_team: int, tracked_player: int):
     else:
         checked_locations = multisave.get("location_checks", {}).get((tracked_team, tracked_player), set())
         player_received_items = {}
-        if len(multisave) > 0:
-            for key in multisave['received_items']:
-                if key[1] == tracked_player and len(multisave['received_items'][key]) > 0:
-                    for NetworkItem in multisave['received_items'][key]:
-                        player_received_items[NetworkItem.item] = multisave['received_items'][key].index(NetworkItem) + 1
+        for order_index, networkItem in enumerate(multisave.get('received_items', {}).get((tracked_team, tracked_player), [])):
+            player_received_items[networkItem.item] = order_index + 1
         return render_template("genericTracker.html",
                                inventory=inventory,
                                player=tracked_player, team=tracked_team, room=room, player_name=player_name,

--- a/WebHostLib/tracker.py
+++ b/WebHostLib/tracker.py
@@ -522,10 +522,11 @@ def getPlayerTracker(tracker: UUID, tracked_team: int, tracked_player: int):
     else:
         checked_locations = multisave.get("location_checks", {}).get((tracked_team, tracked_player), set())
         player_received_items = {}
-        for key in multisave['received_items']:
-            if key[1] == tracked_player:
-                for NetworkItem in multisave['received_items'][key]:
-                    player_received_items[NetworkItem.item] = multisave['received_items'][key].index(NetworkItem) + 1
+        if len(multisave) > 0:
+            for key in multisave['received_items']:
+                if key[1] == tracked_player and len(multisave['received_items'][key]) > 0:
+                    for NetworkItem in multisave['received_items'][key]:
+                        player_received_items[NetworkItem.item] = multisave['received_items'][key].index(NetworkItem) + 1
         return render_template("genericTracker.html",
                                inventory=inventory,
                                player=tracked_player, team=tracked_team, room=room, player_name=player_name,


### PR DESCRIPTION
Adding an order received column for the generic tracker so you can sort by it and see the most recent items received. Progressive items will have the number of the last one acquired. Handles new games where item list doesn't exist yet, and tested with multiple games.