### PR TITLE
MultiServer: remove legacy datapackage keys

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -469,9 +469,6 @@ async def on_client_connected(ctx: Context, client: Client):
         # Name them by feature or fork, as you feel is appropriate.
         'tags': ctx.tags,
         'version': Utils.version_tuple,
-        # TODO ~0.2.0 remove forfeit_mode and remaining_mode in favor of permissions
-        'forfeit_mode': ctx.forfeit_mode,
-        'remaining_mode': ctx.remaining_mode,
         'permissions': {
             "forfeit": Permission.from_text(ctx.forfeit_mode),
             "remaining": Permission.from_text(ctx.remaining_mode),
@@ -497,10 +494,6 @@ async def on_client_joined(ctx: Context, client: Client):
         f"{ctx.get_aliased_name(client.team, client.slot)} (Team #{client.team + 1}) "
         f"playing {ctx.games[client.slot]} has joined. "
         f"Client({version_str}), {client.tags}).")
-    # TODO: remove with 0.2
-    if client.version < Version(0, 1, 7):
-        ctx.notify_client(client,
-                          "Warning: Your client's datapackage handling may be unsupported soon. (Version < 0.1.7)")
 
     ctx.client_connection_timers[client.team, client.slot] = datetime.datetime.now(datetime.timezone.utc)
 

--- a/Options.py
+++ b/Options.py
@@ -137,10 +137,8 @@ class Choice(Option):
     @classmethod
     def from_text(cls, text: str) -> Choice:
         text = text.lower()
-        # TODO: turn on after most people have adjusted their yamls to no longer have suboptions with "random" in them
-        # maybe in 0.2?
-        # if text == "random":
-        #     return cls(random.choice(list(cls.options.values())))
+        if text == "random":
+            return cls(random.choice(list(cls.name_lookup)))
         for optionname, value in cls.options.items():
             if optionname == text:
                 return cls(value)

--- a/worlds/__init__.py
+++ b/worlds/__init__.py
@@ -27,10 +27,6 @@ for world_name, world in AutoWorldRegister.world_types.items():
     lookup_any_location_id_to_name.update(world.location_id_to_name)
 
 network_data_package = {
-    # Remove with 0.2.0
-    "lookup_any_location_id_to_name": lookup_any_location_id_to_name,  # legacy, to be removed
-    "lookup_any_item_id_to_name": lookup_any_item_id_to_name,  # legacy, to be removed
-
     "version": sum(world.data_version for world in AutoWorldRegister.world_types.values()),
     "games": games,
 }

--- a/worlds/alttp/Options.py
+++ b/worlds/alttp/Options.py
@@ -231,13 +231,6 @@ class HeartColor(Choice):
     option_green = 2
     option_yellow = 3
 
-    @classmethod
-    def from_text(cls, text: str) -> Choice:
-        # remove when this becomes a base Choice feature
-        if text == "random":
-            return cls(random.randint(0, 3))
-        return super(HeartColor, cls).from_text(text)
-
 
 class QuickSwap(DefaultOnToggle):
     displayname = "L/R Quickswapping"


### PR DESCRIPTION
The intention is to merge this before 0.2.0 release. It is here as a warning and for easier testing for client developers.

If possible, I'd like to get everyone to test and confirm that their client will work with this;

- [x] LttPClient
- [x] FactorioClient
- [x] TextClient
- [ ] Slay the Spire
- [ ] Minecraft
- [ ] Risk of Rain 2
- [ ] Timespinner
- [ ] Subnautica
- [ ] Z3Client
- [ ] Z5Client