### PR TITLE
Ocarina of Time fixes

### DIFF
--- a/worlds/oot/Options.py
+++ b/worlds/oot/Options.py
@@ -128,6 +128,14 @@ class LogicalChus(Toggle):
     displayname = "Bombchus Considered in Logic"
 
 
+class MQDungeons(Range):
+    """Number of MQ dungeons. The dungeons to replace are randomly selected."""
+    displayname = "Number of MQ Dungeons"
+    range_start = 0
+    range_end = 12
+    default = 0
+
+
 world_options: typing.Dict[str, type(Option)] = {
     "starting_age": StartingAge,
     # "shuffle_interior_entrances": InteriorEntrances,
@@ -141,7 +149,7 @@ world_options: typing.Dict[str, type(Option)] = {
     "triforce_goal": TriforceGoal,
     "extra_triforce_percentage": ExtraTriforces,
     "bombchus_in_logic": LogicalChus,
-    # "mq_dungeons": make_range(0, 12),
+    "mq_dungeons": MQDungeons,
 }
 
 

--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -155,7 +155,6 @@ class OOTWorld(World):
 
         # Determine which dungeons are MQ
         # Possible future plan: allow user to pick which dungeons are MQ
-        self.mq_dungeons = 0  # temporary disable for client-side issues
         mq_dungeons = self.world.random.sample(dungeon_table, self.mq_dungeons)
         self.dungeon_mq = {item['name']: (item in mq_dungeons) for item in dungeon_table}
 

--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -641,7 +641,11 @@ class OOTWorld(World):
             shop_locations = list(
                 filter(lambda location: location.type == 'Shop' and location.name not in self.shop_prices,
                        self.world.get_unfilled_locations(player=self.player)))
-            shop_items.sort(key=lambda item: int(item.advancement)) # place progression shop items first
+            shop_items.sort(key=lambda item: {
+                'Buy Deku Shield': 3*int(self.open_forest == 'closed'), 
+                'Buy Goron Tunic': 2, 
+                'Buy Zora Tunic': 2
+            }.get(item.name, int(item.advancement)))  # place Deku Shields if needed, then tunics, then other advancement, then junk
             self.world.random.shuffle(shop_locations)
             for item in shop_items:
                 self.world.itempool.remove(item)

--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -641,7 +641,7 @@ class OOTWorld(World):
             shop_locations = list(
                 filter(lambda location: location.type == 'Shop' and location.name not in self.shop_prices,
                        self.world.get_unfilled_locations(player=self.player)))
-            shop_items.sort(key=lambda item: 1 if item.name in {"Buy Goron Tunic", "Buy Zora Tunic"} else 0)
+            shop_items.sort(key=lambda item: int(item.advancement)) # place progression shop items first
             self.world.random.shuffle(shop_locations)
             for item in shop_items:
                 self.world.itempool.remove(item)


### PR DESCRIPTION
- Fixed a bug where shopsanity + closed forest would cause frequent generation failures due to inaccessible Deku Shield
- Reenabled Master Quest dungeon option (requires updated Lua script from Z5Client repo)