### PR TITLE
Risk of Rain 2: logic updates

### DIFF
--- a/worlds/ror2/Items.py
+++ b/worlds/ror2/Items.py
@@ -1,6 +1,5 @@
 from BaseClasses import Item
 import typing
-from random import randint
 
 class RiskOfRainItem(Item):
     game: str = "Risk of Rain 2"
@@ -48,12 +47,12 @@ new_weights = {
     "Uncommon Item": 40,
     "Legendary Item": 10,
     "Boss Item": 5,
-    "Lunar Item": 15,
-    "Equipment": 25
+    "Lunar Item": 10,
+    "Equipment": 20
 }
 
 uncommon_weights = {
-    "Item Scrap, Green": 15,
+    "Item Scrap, Green": 45,
     "Item Scrap, Red": 5,
     "Item Scrap, Yellow": 1,
     "Item Scrap, White": 30,
@@ -62,7 +61,7 @@ uncommon_weights = {
     "Legendary Item": 10,
     "Boss Item": 5,
     "Lunar Item": 15,
-    "Equipment": 25
+    "Equipment": 20
 }
 
 legendary_weights = {
@@ -75,7 +74,7 @@ legendary_weights = {
     "Legendary Item": 100,
     "Boss Item": 5,
     "Lunar Item": 15,
-    "Equipment": 25
+    "Equipment": 20
 }
 
 lunartic_weights = {
@@ -96,8 +95,8 @@ no_scraps_weights = {
     "Item Scrap, Red": 0,
     "Item Scrap, Yellow": 0,
     "Item Scrap, White": 0,
-    "Common Item": 80,
-    "Uncommon Item": 30,
+    "Common Item": 100,
+    "Uncommon Item": 40,
     "Legendary Item": 15,
     "Boss Item": 5,
     "Lunar Item": 10,
@@ -117,6 +116,19 @@ even_weights = {
     "Equipment": 1
 }
 
+scraps_only = {
+    "Item Scrap, Green": 70,
+    "Item Scrap, White": 100,
+    "Item Scrap, Red": 30,
+    "Item Scrap, Yellow": 5,
+    "Common Item": 0,
+    "Uncommon Item": 0,
+    "Legendary Item": 0,
+    "Boss Item": 0,
+    "Lunar Item": 0,
+    "Equipment": 0
+}
+
 item_pool_weights: typing.Dict[int, typing.Dict[str, int]] = {
     0: default_weights,
     1: new_weights,
@@ -124,7 +136,8 @@ item_pool_weights: typing.Dict[int, typing.Dict[str, int]] = {
     3: legendary_weights,
     4: lunartic_weights,
     6: no_scraps_weights,
-    7: even_weights
+    7: even_weights,
+    8: scraps_only
 }
 
 lookup_id_to_name: typing.Dict[int, str] = {id: name for name, id in item_table.items() if id}

--- a/worlds/ror2/Options.py
+++ b/worlds/ror2/Options.py
@@ -130,7 +130,8 @@ class ItemWeights(Choice):
     Lunartic makes everything a lunar item.<br>
     Chaos generates the pool completely at random with rarer items having a slight cap to prevent this option being too easy.<br>
     No Scraps removes all scrap items from the item pool.<br>
-    Even generates the item pool with every item having an even weight."""
+    Even generates the item pool with every item having an even weight.<br>
+    Scraps Only will be only scrap items in the item pool."""
     displayname = "Item Weights"
     option_default = 0
     option_new = 1
@@ -140,6 +141,7 @@ class ItemWeights(Choice):
     option_chaos = 5
     option_no_scraps = 6
     option_even = 7
+    option_scraps_only = 8
 
 #define a dictionary for the weights of the generated item pool.
 ror2_weights: typing.Dict[str, type(Option)] = {

--- a/worlds/ror2/Rules.py
+++ b/worlds/ror2/Rules.py
@@ -8,7 +8,9 @@ class RiskOfRainLogic(LogicMixin):
         count: int = self.item_count("Common Item", player) + self.item_count("Uncommon Item", player) + \
                      self.item_count("Legendary Item", player) + self.item_count("Boss Item", player) + \
                      self.item_count("Lunar Item", player) + self.item_count("Equipment", player) + \
-                     self.item_count("Dio's Best Friend", player)
+                     self.item_count("Dio's Best Friend", player) + self.item_count("Item Scrap, White", player) + \
+                     self.item_count("Item Scrap, Green", player) + self.item_count("Item Scrap, Red", player) + \
+                     self.item_count("Item Scrap, Yellow", player)
         return count >= amount
 
 

--- a/worlds/ror2/__init__.py
+++ b/worlds/ror2/__init__.py
@@ -38,13 +38,13 @@ class RiskOfRainWorld(World):
             if pool_option == 5:
                 junk_pool = {
                     "Item Scrap, Green": self.world.random.randint(0, 80),
-                    "Item Scrap, Red": self.world.random.randint(0, 40),
-                    "Item Scrap, Yellow": self.world.random.randint(0, 50),
+                    "Item Scrap, Red": self.world.random.randint(0, 45),
+                    "Item Scrap, Yellow": self.world.random.randint(0, 30),
                     "Item Scrap, White": self.world.random.randint(0, 100),
                     "Common Item": self.world.random.randint(0, 100),
                     "Uncommon Item": self.world.random.randint(0, 70),
-                    "Legendary Item": self.world.random.randint(0, 45),
-                    "Boss Item": self.world.random.randint(0, 30),
+                    "Legendary Item": self.world.random.randint(0, 300),
+                    "Boss Item": self.world.random.randint(0, 20),
                     "Lunar Item": self.world.random.randint(0, 60),
                     "Equipment": self.world.random.randint(0, 40)
                 }
@@ -65,7 +65,8 @@ class RiskOfRainWorld(World):
             }
 
         if not self.world.enable_lunar[self.player]:
-            junk_pool.pop("Lunar Item")
+            if not pool_option == 4:
+                junk_pool.pop("Lunar Item")
 
         # Generate item pool
         itempool = []


### PR DESCRIPTION
Fixed lunartic so it will still generate all lunar items even if the player disables lunar items. Added all scraps to the logical requirements pool and brought back the scraps only preset. Adjusted a few preset weights.