### PR TITLE
Exclusion bugfix

### DIFF
--- a/worlds/generic/Rules.py
+++ b/worlds/generic/Rules.py
@@ -25,11 +25,12 @@ def exclusion_rules(world, player: int, exclude_locations: typing.Set[str]):
     for loc_name in exclude_locations:
         try:
             location = world.get_location(loc_name, player)
-            add_item_rule(location, lambda i: not (i.advancement or i.never_exclude))
-            location.excluded = True
         except KeyError as e:  # failed to find the given location. Check if it's a legitimate location
             if loc_name not in world.worlds[player].location_name_to_id:
                 raise Exception(f"Unable to exclude location {loc_name} in player {player}'s world.") from e
+        else: 
+            add_item_rule(location, lambda i: not (i.advancement or i.never_exclude))
+            location.excluded = True
 
 def set_rule(spot, rule: CollectionRule):
     spot.access_rule = rule

--- a/worlds/generic/Rules.py
+++ b/worlds/generic/Rules.py
@@ -23,10 +23,13 @@ def locality_rules(world, player: int):
 
 def exclusion_rules(world, player: int, exclude_locations: typing.Set[str]):
     for loc_name in exclude_locations:
-        location = world.get_location(loc_name, player)
-        add_item_rule(location, lambda i: not (i.advancement or i.never_exclude))
-        location.excluded = True
-
+        try:
+            location = world.get_location(loc_name, player)
+            add_item_rule(location, lambda i: not (i.advancement or i.never_exclude))
+            location.excluded = True
+        except KeyError as e:  # failed to find the given location. Check if it's a legitimate location
+            if loc_name not in world.worlds[player].location_name_to_id:
+                raise Exception(f"Could not find location {loc_name} in player {player}'s world.") from e
 
 def set_rule(spot, rule: CollectionRule):
     spot.access_rule = rule

--- a/worlds/generic/Rules.py
+++ b/worlds/generic/Rules.py
@@ -29,7 +29,7 @@ def exclusion_rules(world, player: int, exclude_locations: typing.Set[str]):
             location.excluded = True
         except KeyError as e:  # failed to find the given location. Check if it's a legitimate location
             if loc_name not in world.worlds[player].location_name_to_id:
-                raise Exception(f"Could not find location {loc_name} in player {player}'s world.") from e
+                raise Exception(f"Unable to exclude location {loc_name} in player {player}'s world.") from e
 
 def set_rule(spot, rule: CollectionRule):
     spot.access_rule = rule


### PR DESCRIPTION
This fixes an issue raised by the inclusion of Master Quest dungeons. Since MQ dungeons causes some locations to not always be present in an OoT game, location exclusion may fail if the relevant location does not exist due to being located in the wrong dungeon type. This change prevents that error from occurring while still producing an error message for invalid exclusion settings, including if the player tries to exclude a location without an ID value.