### PR TITLE
Ror2:  fix generation mistake

### DIFF
--- a/worlds/ror2/__init__.py
+++ b/worlds/ror2/__init__.py
@@ -104,13 +104,13 @@ class RiskOfRainWorld(World):
         item = RiskOfRainItem(name, True, item_id, self.player)
         return item
 
-
+# generate locations based on player setting
 def create_regions(world, player: int):
     world.regions += [
         create_region(world, player, 'Menu', None, ['Lobby']),
         create_region(world, player, 'Petrichor V',
                       [location for location in base_location_table] +
-                      [f"Item Pickup {i}" for i in range(1, 1 + world.total_locations[player])]) # i don't understand this line but it works
+                      [f"Item Pickup {i}" for i in range(1, 1 + world.total_locations[player])])
     ]
 
     world.get_entrance("Lobby", player).connect(world.get_region("Petrichor V", player))


### PR DESCRIPTION
Relocated a variable so that lunartic will always be able to generate. Reverted locations change so that they define correctly.