### PR TITLE
Fix TR small key getting shuffled away

### DIFF
--- a/worlds/alttp/Rules.py
+++ b/worlds/alttp/Rules.py
@@ -934,8 +934,9 @@ def set_trock_key_rules(world, player):
                     # A key is required in the Big Key Chest to prevent a possible softlock.  Place an extra key to ensure 100% locations still works
                     item = ItemFactory('Small Key (Turtle Rock)', player)
                     item.world = world
-                    world.push_item(world.get_location('Turtle Rock - Big Key Chest', player), item, False)
-                    world.get_location('Turtle Rock - Big Key Chest', player).event = True
+                    location = world.get_location('Turtle Rock - Big Key Chest', player)
+                    location.place_locked_item(item)
+                    location.event = True
                     toss_junk_item(world, player)
 
     if world.accessibility[player] != 'locations':


### PR DESCRIPTION
If one generates a world that trips the TR extra key logic, that small key can get shuffled away by shop shuffle (and presumably progression balancing). Let's not allow this. 