### PR TITLE
Minecraft fixes

### DIFF
--- a/test/minecraft/TestAdvancements.py
+++ b/test/minecraft/TestAdvancements.py
@@ -1132,9 +1132,14 @@ class TestAdvancements(TestMinecraft):
     def test_42091(self):
         self.run_location_tests([
             ["Overpowered", False, []],
-            ["Overpowered", False, ['Progressive Resource Crafting'], ['Progressive Resource Crafting']],
-            ["Overpowered", False, ['Progressive Tools'], ['Flint and Steel', 'Progressive Tools', 'Progressive Tools']],
-            ["Overpowered", True, ['Progressive Resource Crafting', 'Progressive Resource Crafting', 'Progressive Tools', 'Progressive Tools']],
-            ["Overpowered", True, ['Progressive Resource Crafting', 'Progressive Resource Crafting', 'Progressive Tools', 'Bucket', 'Flint and Steel']],
+            ["Overpowered", False, [], ['Progressive Resource Crafting']],
+            ["Overpowered", False, [], ['Flint and Steel']],
+            ["Overpowered", False, ['Progressive Tools', 'Progressive Tools', 'Bucket', 'Flint and Steel']],
+            ["Overpowered", False, [], ['Progressive Weapons']],
+            ["Overpowered", False, [], ['Progressive Armor', 'Shield']],
+            ["Overpowered", True, ['Progressive Resource Crafting', 'Progressive Tools', 'Progressive Tools', 'Flint and Steel', 'Progressive Tools', 'Progressive Weapons', 'Progressive Armor']],
+            ["Overpowered", True, ['Progressive Resource Crafting', 'Progressive Tools', 'Progressive Tools', 'Flint and Steel', 'Bucket', 'Progressive Weapons', 'Progressive Armor']],
+            ["Overpowered", True, ['Progressive Resource Crafting', 'Progressive Tools', 'Progressive Tools', 'Flint and Steel', 'Progressive Tools', 'Progressive Weapons', 'Shield']],
+            ["Overpowered", True, ['Progressive Resource Crafting', 'Progressive Tools', 'Progressive Tools', 'Flint and Steel', 'Bucket', 'Progressive Weapons', 'Shield']],
             ])
 

--- a/worlds/minecraft/Locations.py
+++ b/worlds/minecraft/Locations.py
@@ -107,7 +107,7 @@ advancement_table = {
     "When Pigs Fly": AdvData(42088, 'Overworld'),
     "Overkill": AdvData(42089, 'Nether Fortress'),
     "Librarian": AdvData(42090, 'Overworld'),
-    "Overpowered": AdvData(42091, 'Overworld'),
+    "Overpowered": AdvData(42091, 'Bastion Remnant'),
 
     "Blaze Spawner": AdvData(None, 'Nether Fortress'),
     "Ender Dragon": AdvData(None, 'The End')
@@ -126,7 +126,6 @@ exclusion_table = {
         "Uneasy Alliance",
         "Cover Me in Debris",
         "A Complete Catalogue",
-        "Overpowered",
     },
     "insane": {
         "How Did We Get Here?",

--- a/worlds/minecraft/Rules.py
+++ b/worlds/minecraft/Rules.py
@@ -247,4 +247,5 @@ def set_rules(world: MultiWorld, player: int):
     set_rule(world.get_location("Overkill", player), lambda state: state._mc_can_brew_potions(player) and 
         (state.has("Progressive Weapons", player) or state.can_reach('The Nether', 'Region', player)))  # strength 1 + stone axe crit OR strength 2 + wood axe crit
     set_rule(world.get_location("Librarian", player), lambda state: state.has("Enchanting", player))
-    set_rule(world.get_location("Overpowered", player), lambda state: state.has("Progressive Resource Crafting", player, 2) and state._mc_has_gold_ingots(player))
+    set_rule(world.get_location("Overpowered", player), lambda state: state._mc_has_iron_ingots(player) and 
+        state.has('Progressive Tools', player, 2) and state._mc_basic_combat(player))  # mine gold blocks w/ iron pick

--- a/worlds/minecraft/__init__.py
+++ b/worlds/minecraft/__init__.py
@@ -41,7 +41,7 @@ class MinecraftWorld(World):
             'client_version': client_version,
             'structures': {exit: self.world.get_entrance(exit, self.player).connected_region.name for exit in exits},
             'advancement_goal': self.world.advancement_goal[self.player],
-            'egg_shards_required': self.world.egg_shards_required[self.player],
+            'egg_shards_required': min(self.world.egg_shards_required[self.player], self.world.egg_shards_available[self.player]),
             'egg_shards_available': self.world.egg_shards_available[self.player],
             'MC35': bool(self.world.send_defeated_mobs[self.player]),
             'race': self.world.is_race


### PR DESCRIPTION
- Egg shards will no longer require more than are placed
- The Overpowered advancement now logically requires access to a bastion remnant and the ability to mine the gold blocks found there. It is consequently no longer a hard-pool advancement. 