### PR TITLE
Use absolute path when starting SNI

### DIFF
--- a/SNIClient.py
+++ b/SNIClient.py
@@ -532,9 +532,9 @@ def launch_sni(ctx: Context):
         snes_logger.info(f"Attempting to start {sni_path}")
         import sys
         if not sys.stdout:  # if it spawns a visible console, may as well populate it
-            subprocess.Popen(sni_path, cwd=os.path.dirname(sni_path))
+            subprocess.Popen(os.path.abspath(sni_path), cwd=os.path.dirname(sni_path))
         else:
-            subprocess.Popen(sni_path, cwd=os.path.dirname(sni_path), stdout=subprocess.DEVNULL,
+            subprocess.Popen(os.path.abspath(sni_path), cwd=os.path.dirname(sni_path), stdout=subprocess.DEVNULL,
                              stderr=subprocess.DEVNULL)
     else:
         snes_logger.info(


### PR DESCRIPTION
Causes reliability issues when relative path is used, see [subprocess doc](https://docs.python.org/3/library/subprocess.html#subprocess.Popen)

In my case, it did not start SNI at all.