### PR TITLE
[Timespinner] Fixed some placement logics

### DIFF
--- a/worlds/timespinner/Locations.py
+++ b/worlds/timespinner/Locations.py
@@ -76,12 +76,12 @@ def get_locations(world: Optional[MultiWorld], player: Optional[int]) -> Tuple[L
         LocationData('Sealed Caves (Sirens)', 'Upper sealed cave after sirens chest 1',  1337057),
         LocationData('Military Fortress', 'Military bomber chest',  1337058, lambda state: state.has('Timespinner Wheel', player) and state._timespinner_has_doublejump_of_npc(world, player)),
         LocationData('Military Fortress', 'Close combat room',  1337059),
-        LocationData('Military Fortress', 'Military soldiers bridge',  1337060),
-        LocationData('Military Fortress', 'Military giantess room',  1337061),
-        LocationData('Military Fortress', 'Military giantess bridge',  1337062),
-        LocationData('Military Fortress', 'Military B door chest 2',  1337063, lambda state: state._timespinner_has_doublejump(world, player) and state._timespinner_has_keycard_B(world, player)),
-        LocationData('Military Fortress', 'Military B door chest 1',  1337064, lambda state: state._timespinner_has_doublejump(world, player) and state._timespinner_has_keycard_B(world, player)),
-        LocationData('Military Fortress', 'Military pedestal',  1337065, lambda state: state._timespinner_has_doublejump(world, player) and (state._timespinner_has_doublejump_of_npc(world, player) or state._timespinner_has_forwarddash_doublejump(world, player))),
+        LocationData('Military Fortress (hangar)', 'Military soldiers bridge',  1337060),
+        LocationData('Military Fortress (hangar)', 'Military giantess room',  1337061),
+        LocationData('Military Fortress (hangar)', 'Military giantess bridge',  1337062),
+        LocationData('Military Fortress (hangar)', 'Military B door chest 2',  1337063, lambda state: state._timespinner_has_doublejump(world, player) and state._timespinner_has_keycard_B(world, player)),
+        LocationData('Military Fortress (hangar)', 'Military B door chest 1',  1337064, lambda state: state._timespinner_has_doublejump(world, player) and state._timespinner_has_keycard_B(world, player)),
+        LocationData('Military Fortress (hangar)', 'Military pedestal',  1337065, lambda state: state._timespinner_has_doublejump_of_npc(world, player) or state._timespinner_has_forwarddash_doublejump(world, player)),
         LocationData('The lab', 'Coffee break',  1337066),
         LocationData('The lab', 'Lower trash right',  1337067, lambda state: state._timespinner_has_doublejump(world, player)),
         LocationData('The lab', 'Lower trash left',  1337068, lambda state: state._timespinner_has_upwarddash(world, player)),
@@ -222,15 +222,15 @@ def get_locations(world: Optional[MultiWorld], player: Optional[int]) -> Tuple[L
     # 1337237 - 1337245 GyreArchives
     if not world or is_option_enabled(world, player, "GyreArchives"):
         location_table += (
-            LocationData('The lab (upper)', 'Ravenlord post fight (pedestal)',  1337237, lambda state: state.has('Merchant Crow', player)),
-            LocationData('Library top', 'Ifrit post fight (pedestal)',  1337238, lambda state: state.has('Kobo', player)),
-            LocationData('Ancient Pyramid (right)', 'Transition chest 1',  1337239),
-            LocationData('Ancient Pyramid (right)', 'Transition chest 2',  1337240),
-            LocationData('Ancient Pyramid (right)', 'Transition chest 3',  1337241),
-            LocationData('The lab (upper)', 'Ravenlord pre fight',  1337242, lambda state: state.has('Merchant Crow', player)),
-            LocationData('The lab (upper)', 'Ravenlord post fight (chest)',  1337243, lambda state: state.has('Merchant Crow', player)),
-            LocationData('Library top', 'Ifrit pre fight',  1337244, lambda state: state.has('Kobo', player)),
-            LocationData('Library top', 'Ifrit post fight (chest)',  1337245, lambda state: state.has('Kobo', player)),
+            LocationData('Ravenlord\'s Lair', 'Ravenlord post fight (pedestal)',  1337237),
+            LocationData('Ifrit\'s Lair', 'Ifrit post fight (pedestal)',  1337238),
+            LocationData('Temporal Gyre', 'Gyre chest 1',  1337239),
+            LocationData('Temporal Gyre', 'Gyre chest 2',  1337240),
+            LocationData('Temporal Gyre', 'Gyre chest 3',  1337241),
+            LocationData('Ravenlord\'s Lair', 'Ravenlord pre fight',  1337242),
+            LocationData('Ravenlord\'s Lair', 'Ravenlord post fight (chest)',  1337243),
+            LocationData('Ifrit\'s Lair', 'Ifrit pre fight',  1337244),
+            LocationData('Ifrit\'s Lair', 'Ifrit post fight (chest)', 1337245),
         )
  
     return tuple(location_table)

--- a/worlds/timespinner/Regions.py
+++ b/worlds/timespinner/Regions.py
@@ -14,15 +14,18 @@ def create_regions(world: MultiWorld, player: int, locations: Tuple[LocationData
         create_region(world, player, locations_per_region, location_cache, 'Lower lake desolation'),
         create_region(world, player, locations_per_region, location_cache, 'Library'),
         create_region(world, player, locations_per_region, location_cache, 'Library top'),
+        create_region(world, player, locations_per_region, location_cache, 'Ifrit\'s Lair'),
         create_region(world, player, locations_per_region, location_cache, 'Varndagroth tower left'),
         create_region(world, player, locations_per_region, location_cache, 'Varndagroth tower right (upper)'),
         create_region(world, player, locations_per_region, location_cache, 'Varndagroth tower right (lower)'),
         create_region(world, player, locations_per_region, location_cache, 'Varndagroth tower right (elevator)'),
         create_region(world, player, locations_per_region, location_cache, 'Sealed Caves (Sirens)'),
         create_region(world, player, locations_per_region, location_cache, 'Military Fortress'),
+        create_region(world, player, locations_per_region, location_cache, 'Military Fortress (hangar)'),
         create_region(world, player, locations_per_region, location_cache, 'The lab'),
         create_region(world, player, locations_per_region, location_cache, 'The lab (power off)'),
         create_region(world, player, locations_per_region, location_cache, 'The lab (upper)'),
+        create_region(world, player, locations_per_region, location_cache, 'Ravenlord\'s Lair'),
         create_region(world, player, locations_per_region, location_cache, 'Emperors tower'),
         create_region(world, player, locations_per_region, location_cache, 'Skeleton Shaft'),
         create_region(world, player, locations_per_region, location_cache, 'Sealed Caves (upper)'),
@@ -40,6 +43,7 @@ def create_regions(world: MultiWorld, player: int, locations: Tuple[LocationData
         create_region(world, player, locations_per_region, location_cache, 'Royal towers (lower)'),
         create_region(world, player, locations_per_region, location_cache, 'Royal towers'),
         create_region(world, player, locations_per_region, location_cache, 'Royal towers (upper)'),
+        create_region(world, player, locations_per_region, location_cache, 'Temporal Gyre'),
         create_region(world, player, locations_per_region, location_cache, 'Ancient Pyramid (left)'),
         create_region(world, player, locations_per_region, location_cache, 'Ancient Pyramid (right)'),
         create_region(world, player, locations_per_region, location_cache, 'Space time continuum')
@@ -68,6 +72,8 @@ def create_regions(world: MultiWorld, player: int, locations: Tuple[LocationData
     connect(world, player, names, 'Library', 'Varndagroth tower left', lambda state: state._timespinner_has_keycard_D(world, player))
     connect(world, player, names, 'Library', 'Space time continuum', lambda state: state.has('Twin Pyramid Key', player))
     connect(world, player, names, 'Library top', 'Library')
+    connect(world, player, names, 'Library top', 'Ifrit\'s Lair', lambda state: state.has('Kobo', player) and state.can_reach('Refugee Camp', 'Region', player))
+    connect(world, player, names, 'Ifrit\'s Lair', 'Library top')
     connect(world, player, names, 'Varndagroth tower left', 'Library')
     connect(world, player, names, 'Varndagroth tower left', 'Varndagroth tower right (upper)', lambda state: state._timespinner_has_keycard_C(world, player))
     connect(world, player, names, 'Varndagroth tower left', 'Varndagroth tower right (lower)', lambda state: state._timespinner_has_keycard_B(world, player))
@@ -86,14 +92,20 @@ def create_regions(world: MultiWorld, player: int, locations: Tuple[LocationData
     connect(world, player, names, 'Sealed Caves (Sirens)', 'Varndagroth tower right (lower)', lambda state: state.has('Elevator Keycard', player))
     connect(world, player, names, 'Sealed Caves (Sirens)', 'Space time continuum', lambda state: state.has('Twin Pyramid Key', player))
     connect(world, player, names, 'Military Fortress', 'Varndagroth tower right (lower)', lambda state: state._timespinner_can_kill_all_3_bosses(world, player))
-    connect(world, player, names, 'Military Fortress', 'The lab', lambda state: state._timespinner_has_keycard_B(world, player) and state._timespinner_has_doublejump(world, player))
+    connect(world, player, names, 'Military Fortress', 'Temporal Gyre', lambda state: state.has('Timespinner Wheel', player))
+    connect(world, player, names, 'Military Fortress', 'Military Fortress (hangar)', lambda state: state._timespinner_has_doublejump(world, player))
+    connect(world, player, names, 'Military Fortress (hangar)', 'Military Fortress')
+    connect(world, player, names, 'Military Fortress (hangar)', 'The lab', lambda state: state._timespinner_has_keycard_B(world, player) and state._timespinner_has_doublejump(world, player))
+    connect(world, player, names, 'Temporal Gyre', 'Military Fortress')
     connect(world, player, names, 'The lab', 'Military Fortress')
     connect(world, player, names, 'The lab', 'The lab (power off)', lambda state: state._timespinner_has_doublejump_of_npc(world, player))
     connect(world, player, names, 'The lab (power off)', 'The lab')
     connect(world, player, names, 'The lab (power off)', 'The lab (upper)', lambda state: state._timespinner_has_forwarddash_doublejump(world, player))
     connect(world, player, names, 'The lab (upper)', 'The lab (power off)')
+    connect(world, player, names, 'The lab (upper)', 'Ravenlord\'s Lair', lambda state: state.has('Merchant Crow', player))
     connect(world, player, names, 'The lab (upper)', 'Emperors tower', lambda state: state._timespinner_has_forwarddash_doublejump(world, player))
     connect(world, player, names, 'The lab (upper)', 'Ancient Pyramid (left)', lambda state: state.has_all({'Timespinner Wheel', 'Timespinner Spindle', 'Timespinner Gear 1', 'Timespinner Gear 2', 'Timespinner Gear 3'}, player))
+    connect(world, player, names, 'Ravenlord\'s Lair', 'The lab (upper)')
     connect(world, player, names, 'Emperors tower', 'The lab (upper)')
     connect(world, player, names, 'Skeleton Shaft', 'Lake desolation')
     connect(world, player, names, 'Skeleton Shaft', 'Sealed Caves (upper)', lambda state: state._timespinner_has_keycard_A(world, player))

--- a/worlds/timespinner/__init__.py
+++ b/worlds/timespinner/__init__.py
@@ -18,7 +18,7 @@ class TimespinnerWorld(World):
     game = "Timespinner"
     topology_present = True
     remote_items = False
-    data_version = 4
+    data_version = 5
 
     item_name_to_id = {name: data.code for name, data in item_table.items()}
     location_name_to_id = {location.name: location.code for location in get_locations(None, None)}


### PR DESCRIPTION
Fixed some placement logics regarding gyre archives & military fortress
Renamed 'Transition chest #' to 'Gyre chest #'