### PR TITLE
LTTP - Cap item prices at 4x

### DIFF
--- a/worlds/alttp/Options.py
+++ b/worlds/alttp/Options.py
@@ -95,7 +95,7 @@ class ShopPriceModifier(Range):
     """Percentage modifier for shuffled item prices in shops"""
     range_start = 0
     default = 100
-    range_end = 10000
+    range_end = 400
 
 class WorldState(Choice):
     option_standard = 1


### PR DESCRIPTION
I think quadrupled prices will be plenty expensive, and this will stop people who pick "random" from getting 9999 priced items and potentially locking their multiworld behind absurd rupee grinds