### PR TITLE
Increase contrast of SM tracker

### DIFF
--- a/WebHostLib/static/styles/supermetroidTracker.css
+++ b/WebHostLib/static/styles/supermetroidTracker.css
@@ -54,7 +54,7 @@
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
     background-color: #546E7A;
-    color: #000000;
+    color: #ffffff;
     padding: 0 3px 3px;
     font-size: 14px;
     cursor: default;
@@ -101,4 +101,8 @@
 
 .hide {
     display: none;
+}
+
+body {
+    background-color: #000000;
 }


### PR DESCRIPTION
Improve accessibility by changing text to white and page background to black.

Original contrast ratio was 3.88, and new contrast ratio is 5.4