### PR TITLE
Move remote_items and _start_inventory from world to client

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -118,6 +118,7 @@ class CommonContext():
     game = None
     ui = None
     keep_alive_task = None
+    items_handling: typing.Optional[int] = None
 
     def __init__(self, server_address, password):
         # server state
@@ -247,9 +248,9 @@ class CommonContext():
 
     async def send_connect(self, **kwargs):
         payload = {
-            "cmd": 'Connect',
+            'cmd': 'Connect',
             'password': self.password, 'name': self.auth, 'version': Utils.version_tuple,
-            'tags': self.tags,
+            'tags': self.tags, 'items_handling': self.items_handling,
             'uuid': Utils.get_unique_identifier(), 'game': self.game
         }
         if kwargs:
@@ -469,6 +470,8 @@ async def process_server_cmd(ctx: CommonContext, args: dict):
             logger.error('Invalid password')
             ctx.password = None
             await ctx.server_auth(True)
+        elif 'InvalidItemsHandling' in errors:
+            raise Exception('The item handling flags requested by the client are not supported')
         elif errors:
             raise Exception("Unknown connection errors: " + str(errors))
         else:
@@ -589,6 +592,7 @@ if __name__ == '__main__':
     class TextContext(CommonContext):
         tags = {"AP", "IgnoreGame", "TextOnly"}
         game = "Archipelago"
+        items_handling = 0  # don't receive any NetworkItems
 
         async def server_auth(self, password_requested: bool = False):
             if password_requested and not self.password:

--- a/FF1Client.py
+++ b/FF1Client.py
@@ -30,6 +30,9 @@ class FF1CommandProcessor(ClientCommandProcessor):
 
 
 class FF1Context(CommonContext):
+    command_processor = FF1CommandProcessor
+    items_handling = 0b111  # full remote
+
     def __init__(self, server_address, password):
         super().__init__(server_address, password)
         self.nes_streams: (StreamReader, StreamWriter) = None
@@ -39,8 +42,6 @@ class FF1Context(CommonContext):
         self.nes_status = CONNECTION_INITIAL_STATUS
         self.game = 'Final Fantasy'
         self.awaiting_rom = False
-
-    command_processor = FF1CommandProcessor
 
     async def server_auth(self, password_requested: bool = False):
         if password_requested and not self.password:

--- a/FactorioClient.py
+++ b/FactorioClient.py
@@ -49,6 +49,7 @@ class FactorioCommandProcessor(ClientCommandProcessor):
 class FactorioContext(CommonContext):
     command_processor = FactorioCommandProcessor
     game = "Factorio"
+    items_handling = 0b111  # full remote
 
     # updated by spinup server
     mod_version: Utils.Version = Utils.Version(0, 0, 0)

--- a/SNIClient.py
+++ b/SNIClient.py
@@ -102,6 +102,7 @@ class LttPCommandProcessor(ClientCommandProcessor):
 class Context(CommonContext):
     command_processor = LttPCommandProcessor
     game = "A Link to the Past"
+    items_handling = None  # set in game_watcher
 
     def __init__(self, snes_address, server_address, password):
         super(Context, self).__init__(server_address, password)
@@ -901,8 +902,10 @@ async def game_watcher(ctx: Context):
                 continue
             elif game_name == b"SM":
                 ctx.game = GAME_SM
+                ctx.items_handling = 0b001  # full local
             else:
                 ctx.game = GAME_ALTTP
+                ctx.items_handling = 0b001  # full local
 
             rom = await snes_read(ctx, SM_ROMNAME_START if ctx.game == GAME_SM else ROMNAME_START, ROMNAME_SIZE)
             if rom is None or rom == bytes([0] * ROMNAME_SIZE):

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -230,7 +230,7 @@ Sent by the client to initiate a connection to an Archipelago game session.
 Many, if not all, other packets require a successfully authenticated client. This is described in more detail in [Archipelago Connection Handshake](#Archipelago-Connection-Handshake).
 
 ### ConnectUpdate
-Update arguments from the Connect package, currently only updating tags and item_handling is supported.
+Update arguments from the Connect package, currently only updating tags and items_handling is supported.
 
 #### Arguments
 | Name | Type | Notes |

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -221,10 +221,11 @@ Sent by the client to initiate a connection to an Archipelago game session.
 #### items_handling flags
 | Value | Meaning |
 | ----- | ------- |
+| 0b000 | No ReceivedItems is sent to you, ever. |
 | 0b001 | Indicates you get items sent from other worlds. |
 | 0b010 | Indicates you get items sent from your own world. Requires 0b001 to be set. |
 | 0b100 | Indicates you get your starting inventory sent. Requires 0b001 to be set. |
-| null  | Null or undefined loads settings from world definition for backwards compatibility. This is deprecated.
+| null  | Null or undefined loads settings from world definition for backwards compatibility. This is deprecated. |
 
 #### Authentication
 Many, if not all, other packets require a successfully authenticated client. This is described in more detail in [Archipelago Connection Handshake](#Archipelago-Connection-Handshake).

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -99,13 +99,14 @@ Sent to clients when the server refuses connection. This is sent during the init
 #### Arguments
 | Name | Type | Notes |
 | ---- | ---- | ----- |
-| errors | list\[str\] | Optional. When provided, should contain any one of: `InvalidSlot`, `InvalidGame`, `SlotAlreadyTaken`, `IncompatibleVersion`, or `InvalidPassword`. |
+| errors | list\[str\] | Optional. When provided, should contain any one of: `InvalidSlot`, `InvalidGame`, `SlotAlreadyTaken`, `IncompatibleVersion`, `InvalidPassword`, or `InvalidItemsHandling`. |
 
 InvalidSlot indicates that the sent 'name' field did not match any auth entry on the server.
 InvalidGame indicates that a correctly named slot was found, but the game for it mismatched.
 SlotAlreadyTaken indicates a connection with a different uuid is already established.
 IncompatibleVersion indicates a version mismatch.
 InvalidPassword indicates the wrong, or no password when it was required, was sent.
+InvalidItemsHandling indicates a wrong value type or flag combination was sent.
 
 ### Connected
 Sent to clients when the connection handshake is successfully completed.
@@ -214,17 +215,27 @@ Sent by the client to initiate a connection to an Archipelago game session.
 | name | str | The player name for this client. |
 | uuid | str | Unique identifier for player client. |
 | version | [NetworkVersion](#NetworkVersion) | An object representing the Archipelago version this client supports. |
+| items_handling | int | Flags configuring which items should be sent by the server. Read below for individual flags.
 | tags | list\[str\] | Denotes special features or capabilities that the sender is capable of. [Tags](#Tags) |
+
+#### items_handling flags
+| Value | Meaning |
+| ----- | ------- |
+| 0b001 | Indicates you get items sent from other worlds. |
+| 0b010 | Indicates you get items sent from your own world. Requires 0b001 to be set. |
+| 0b100 | Indicates you get your starting inventory sent. Requires 0b001 to be set. |
+| null  | Null or undefined loads settings from world definition for backwards compatibility. This is deprecated.
 
 #### Authentication
 Many, if not all, other packets require a successfully authenticated client. This is described in more detail in [Archipelago Connection Handshake](#Archipelago-Connection-Handshake).
 
 ### ConnectUpdate
-Update arguments from the Connect package, currently only updating tags is supported.
+Update arguments from the Connect package, currently only updating tags and item_handling is supported.
 
 #### Arguments
 | Name | Type | Notes |
 | ---- | ---- | ----- |
+| items_handling | int | Flags configuring which items should be sent by the server.
 | tags | list\[str\] | Denotes special features or capabilities that the sender is capable of. [Tags](#Tags) |
 
 ### Sync


### PR DESCRIPTION
* adds new Connect and ConnectUpdate argument `items_handling: int`. Passing `null` or not sending it loads them from multidata, which is set by world for backwards-compatibility, but is deprecated.
* adds new ConnectionRefused reason `InvalidItemsHandling`