### PR TITLE
 Fix wrong message when loading apsave

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -439,8 +439,9 @@ class Context:
         self.location_checks.update(savedata["location_checks"])
         if "random_state" in savedata:
             self.random.setstate(savedata["random_state"])
-        logging.info(f'Loaded save file with {sum([len(p) for p in self.received_items.values()])} received items '
-                     f'for {len(self.received_items)} players')
+        # count items and slots from lists for item_handling = remote
+        logging.info(f'Loaded save file with {sum([len(v) for k,v in self.received_items.items() if k[2]])} received items '
+                         f'for {sum(k[2] for k in self.received_items)} players')
 
     # rest
 


### PR DESCRIPTION
from doubling received_items that happened when moving from world-based to client-based remote_items

Basing this solely on received_items gives the most accurate message regarding what was in the save (ignoring what was in multidata).