### PR TITLE
Ocarina of Time updates

### DIFF
--- a/worlds/oot/Items.py
+++ b/worlds/oot/Items.py
@@ -33,6 +33,7 @@ class OOTItem(Item):
         self.looks_like_item = None
         self.price = special.get('price', None) if special else None
         self.internal = False
+        self.trap = name == 'Ice Trap'
         if force_not_advancement:
             self.never_exclude = True
     

--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -274,6 +274,9 @@ class OOTWorld(World):
             # Both two-handed swords can be required in glitch logic, so only consider them nonprogression in glitchless
             self.nonadvancement_items.add('Biggoron Sword')
             self.nonadvancement_items.add('Giants Knife')
+            if getattr(self, 'logic_water_central_gs_fw', False):
+                # Farore's Wind skippable if not used for this logic trick in Water Temple
+                self.nonadvancement_items.add('Farores Wind')
   
     def load_regions_from_json(self, file_path):
         region_json = read_json(file_path)

--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -274,7 +274,7 @@ class OOTWorld(World):
             # Both two-handed swords can be required in glitch logic, so only consider them nonprogression in glitchless
             self.nonadvancement_items.add('Biggoron Sword')
             self.nonadvancement_items.add('Giants Knife')
-            if getattr(self, 'logic_water_central_gs_fw', False):
+            if not getattr(self, 'logic_water_central_gs_fw', False):
                 # Farore's Wind skippable if not used for this logic trick in Water Temple
                 self.nonadvancement_items.add('Farores Wind')
   

--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -159,6 +159,9 @@ class OOTWorld(World):
         # Closed forest and adult start are not compatible; closed forest takes priority
         if self.open_forest == 'closed':
             self.starting_age = 'child'
+            # These ER options force closed forest to become closed deku
+            if (self.shuffle_interior_entrances == 'all' or self.shuffle_overworld_entrances or self.warp_songs or self.spawn_positions):
+                self.open_forest = 'closed_deku'
 
         # Skip child zelda and shuffle egg are not compatible; skip-zelda takes priority
         if self.skip_child_zelda:

--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -847,7 +847,7 @@ class OOTWorld(World):
                         if loc.player in barren_hint_players:
                             hint_area = get_hint_area(loc)
                             items_by_region[loc.player][hint_area]['weight'] += 1
-                            if loc.item.advancement:
+                            if loc.item.advancement or loc.item.never_exclude:
                                 items_by_region[loc.player][hint_area]['is_barren'] = False
                         if loc.player in woth_hint_players and loc.item.advancement:
                             # Skip item at location and see if game is still beatable


### PR DESCRIPTION
- ER options now affect closed forest correctly
- ER generation rate improved when spawn positions are randomized
- Ice traps now considered trap items internally
- Hints now consider regions containing nonexcluded items to be not barren
- Farore's Wind made a nonexcluded item if the relevant trick is off (instead of always progression)