### PR TITLE
Save game options with server save data

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -416,6 +416,7 @@ class Context:
             "received_items": self.received_items,
             "hints_used": dict(self.hints_used),
             "hints": dict(self.hints),
+            "hint_cost": self.hint_cost,
             "location_checks": dict(self.location_checks),
             "name_aliases": self.name_aliases,
             "client_game_state": dict(self.client_game_state),
@@ -461,6 +462,9 @@ class Context:
              in savedata["client_activity_timers"]})
         self.location_checks.update(savedata["location_checks"])
         self.random.setstate(savedata["random_state"])
+
+        if "hint_cost" in savedata:
+            self.hint_cost = savedata["hint_cost"]
 
         if "stored_data" in savedata:
             self.stored_data = savedata["stored_data"]

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -416,7 +416,6 @@ class Context:
             "received_items": self.received_items,
             "hints_used": dict(self.hints_used),
             "hints": dict(self.hints),
-            "hint_cost": self.hint_cost,
             "location_checks": dict(self.location_checks),
             "name_aliases": self.name_aliases,
             "client_game_state": dict(self.client_game_state),
@@ -425,7 +424,12 @@ class Context:
             "client_connection_timers": tuple(
                 (key, value.timestamp()) for key, value in self.client_connection_timers.items()),
             "random_state": self.random.getstate(),
-            "stored_data": self.stored_data
+            "stored_data": self.stored_data,
+            "game_options": {"hint_cost": self.hint_cost, "location_check_points": self.location_check_points,
+                             "server_password": self.server_password, "password": self.password, "forfeit_mode":
+                             self.forfeit_mode, "remaining_mode": self.remaining_mode, "collect_mode":
+                             self.collect_mode, "item_cheat": self.item_cheat, "compatibility": self.compatibility}
+
         }
 
         return d
@@ -463,8 +467,16 @@ class Context:
         self.location_checks.update(savedata["location_checks"])
         self.random.setstate(savedata["random_state"])
 
-        if "hint_cost" in savedata:
-            self.hint_cost = savedata["hint_cost"]
+        if "game_options" in savedata:
+            self.hint_cost = savedata["game_options"]["hint_cost"]
+            self.location_check_points = savedata["game_options"]["location_check_points"]
+            self.server_password = savedata["game_options"]["server_password"]
+            self.password = savedata["game_options"]["password"]
+            self.forfeit_mode = savedata["game_options"]["forfeit_mode"]
+            self.remaining_mode = savedata["game_options"]["remaining_mode"]
+            self.collect_mode = savedata["game_options"]["collect_mode"]
+            self.item_cheat = savedata["game_options"]["item_cheat"]
+            self.compatibility = savedata["game_options"]["compatibility"]
 
         if "stored_data" in savedata:
             self.stored_data = savedata["stored_data"]


### PR DESCRIPTION
I've started many an async game with my siblings after forgetting to go over my host.yaml settings and started with unwanted settings, and find after the server shuts down due to inactivity every night (or I restart after fixing bugs with other things I'm working on) the options are reset to the initial host.yaml settings.

This will save any changes to game options so that they will not reset after restarting.