### PR TITLE
Update Minecraft and OoT to new patch format

### DIFF
--- a/worlds/oot/Patches.py
+++ b/worlds/oot/Patches.py
@@ -2,6 +2,8 @@ import struct
 import itertools
 import re
 import zlib
+import zipfile
+import os
 from collections import defaultdict
 from functools import partial
 
@@ -16,6 +18,18 @@ from .Messages import read_messages, update_message_by_id, read_shop_items, upda
 from .MQ import patch_files, File, update_dmadata, insert_space, add_relocations
 from .SaveContext import SaveContext
 from .TextBox import character_table, NORMAL_LINE_WIDTH
+
+from Patch import APContainer
+
+
+class OOTContainer(APContainer):
+    game = "Ocarina of Time"
+
+    def write_contents(self, opened_zipfile: zipfile.ZipFile):
+        zpf = self.path[:-5] + '.zpf'  # cut off .apz5, replace with .zpf
+        print(zpf)
+        opened_zipfile.write(zpf, os.path.basename(zpf))
+        super(OOTContainer, self).write_contents(opened_zipfile)  # write manifest
 
 
 # "Spoiler" argument deleted; can probably be replaced with calls to world.world

--- a/worlds/oot/Patches.py
+++ b/worlds/oot/Patches.py
@@ -25,10 +25,13 @@ from Patch import APContainer
 class OOTContainer(APContainer):
     game = "Ocarina of Time"
 
+    def __init__(self, player=None, player_name="", server="", path_noext=""):
+        container_path = path_noext + ".apz5"
+        self.zpf_path  = path_noext + ".zpf"
+        super(OOTContainer, self).__init__(container_path, player, player_name, server)
+
     def write_contents(self, opened_zipfile: zipfile.ZipFile):
-        zpf = self.path[:-5] + '.zpf'  # cut off .apz5, replace with .zpf
-        print(zpf)
-        opened_zipfile.write(zpf, os.path.basename(zpf))
+        opened_zipfile.write(self.zpf_path, os.path.basename(self.zpf_path))
         super(OOTContainer, self).write_contents(opened_zipfile)  # write manifest
 
 

--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -786,11 +786,11 @@ class OOTWorld(World):
             rom.restore()
 
             # Put zpf in apz5 container, then clear patch file
-            apz5 = OOTContainer(path=outfile_path + '.apz5',
-                player=self.player,
-                player_name=player_name)
+            apz5 = OOTContainer(player=self.player,
+                player_name=player_name,
+                path_noext=outfile_path)
             apz5.write()
-            os.remove(outfile_path + '.zpf')
+            os.remove(apz5.zpf_path)
 
             # Write entrances to spoiler log
             all_entrances = self.get_shuffled_entrances()


### PR DESCRIPTION
`.apmc` files are now containers with only `archipelago.json`, with all information located there.
`.apz5` files are now containers with a `.zpf` file; the `.zpf` is what was previously an `.apz5` file.