### PR TITLE
Generate: fix windows support

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -216,7 +216,7 @@ def main(args=None, callback=ERmain):
 
 def read_weights_yaml(path):
     try:
-        if urllib.parse.urlparse(path).scheme:
+        if urllib.parse.urlparse(path).scheme == 'https':
             yaml = str(urllib.request.urlopen(path).read(), "utf-8")
         else:
             with open(path, 'rb') as f:

--- a/Generate.py
+++ b/Generate.py
@@ -216,7 +216,7 @@ def main(args=None, callback=ERmain):
 
 def read_weights_yaml(path):
     try:
-        if urllib.parse.urlparse(path).scheme == 'https':
+        if urllib.parse.urlparse(path).scheme in ('https', 'file'):
             yaml = str(urllib.request.urlopen(path).read(), "utf-8")
         else:
             with open(path, 'rb') as f:


### PR DESCRIPTION
Makes absolute paths for yamls work
This breaks downloads of http:// and ftp://, but nobody should use that

Sorry for breaking that. Someone tested on windows, but i guess not Generate.exe :S