### PR TITLE
Minecraft fixes

### DIFF
--- a/Launcher.py
+++ b/Launcher.py
@@ -58,9 +58,9 @@ def open_patch():
                 suffixes += c.file_identifier.suffixes if c.type == Type.CLIENT and \
                                                           isinstance(c.file_identifier, SuffixIdentifier) else []
         filename = tkinter.filedialog.askopenfilename(filetypes=(('Patches', ' '.join(suffixes)),))
-        file, component = identify(filename)
+        file, _, component = identify(filename)
         if file and component:
-            subprocess.Popen([*get_exe(component), file])
+            launch([*get_exe(component), file], component.cli)
 
 
 def browse_files():
@@ -165,11 +165,11 @@ icon_paths = {
 
 def identify(path: Union[None, str]):
     if path is None:
-        return None, None
+        return None, None, None
     for component in components:
         if component.handles_file(path):
-            return path, component.script_name
-    return (None, None) if '/' in path or '\\' in path else (None, path)
+            return path, component.script_name, component
+    return (None, None, None) if '/' in path or '\\' in path else (None, path, None)
 
 
 def get_exe(component: Union[str, Component]) -> Optional[Sequence[str]]:
@@ -284,7 +284,7 @@ def main(args: Optional[Union[argparse.Namespace, dict]] = None):
         args = {}
 
     if "Patch|Game|Component" in args:
-        file, component = identify(args["Patch|Game|Component"])
+        file, component, _ = identify(args["Patch|Game|Component"])
         if file:
             args['file'] = file
         if component:

--- a/Launcher.py
+++ b/Launcher.py
@@ -142,7 +142,7 @@ components: Iterable[Component] = (
     # Factorio
     Component('Factorio Client', 'FactorioClient'),
     # Minecraft
-    Component('Minecraft Client', 'MinecraftClient', icon='mcicon',
+    Component('Minecraft Client', 'MinecraftClient', icon='mcicon', cli=True,
               file_identifier=SuffixIdentifier('.apmc')),
     # Ocarina of Time
     Component('OoT Client', 'OoTClient',

--- a/MinecraftClient.py
+++ b/MinecraftClient.py
@@ -211,7 +211,7 @@ def install_forge(directory: str):
                 f.write(resp.content)
             print(f"Installing Forge...")
             argstring = ' '.join([jdk, "-jar", "\"" + forge_install_jar+ "\"", "--installServer", "\"" + directory + "\""])
-            install_process = Popen(argstring)
+            install_process = Popen(argstring, shell=True)
             install_process.wait()
             os.remove(forge_install_jar)
 
@@ -228,7 +228,8 @@ def run_forge_server(forge_dir: str, heap_arg):
         heap_arg = heap_arg[:-1]
     heap_arg = "-Xmx" + heap_arg
 
-    args_file = os.path.join(forge_dir, "libraries", "net", "minecraftforge", "forge", forge_version, "win_args.txt")
+    os_args = "win_args.txt" if is_windows else "unix_args.txt"
+    args_file = os.path.join(forge_dir, "libraries", "net", "minecraftforge", "forge", forge_version, os_args)
     win_args = []
     with open(args_file) as argfile:
         for line in argfile:
@@ -237,7 +238,7 @@ def run_forge_server(forge_dir: str, heap_arg):
     argstring = ' '.join([java_exe, heap_arg] + win_args + ["-nogui"])
     logging.info(f"Running Forge server: {argstring}")
     os.chdir(forge_dir)
-    return Popen(argstring)
+    return Popen(argstring, shell=True)
 
 
 if __name__ == '__main__':
@@ -271,7 +272,10 @@ if __name__ == '__main__':
     if apmc_file is not None and not os.path.isfile(apmc_file):
         raise FileNotFoundError(f"Path {apmc_file} does not exist or could not be accessed.")
     if not os.path.isdir(forge_dir):
-        raise NotADirectoryError(f"Path {forge_dir} does not exist or could not be accessed.")
+        if prompt_yes_no("Did not find forge directory. Download and install forge now?"):
+            install_forge(forge_dir)
+        if not os.path.isdir(forge_dir):
+            raise NotADirectoryError(f"Path {forge_dir} does not exist or could not be accessed.")
     if not max_heap_re.match(max_heap):
         raise Exception(f"Max heap size {max_heap} in incorrect format. Use a number followed by M or G, e.g. 512M or 2G.")
 

--- a/MinecraftClient.py
+++ b/MinecraftClient.py
@@ -211,7 +211,7 @@ def install_forge(directory: str):
                 f.write(resp.content)
             print(f"Installing Forge...")
             argstring = ' '.join([jdk, "-jar", "\"" + forge_install_jar+ "\"", "--installServer", "\"" + directory + "\""])
-            install_process = Popen(argstring, shell=True)
+            install_process = Popen(argstring, shell=not is_windows)
             install_process.wait()
             os.remove(forge_install_jar)
 
@@ -238,7 +238,7 @@ def run_forge_server(forge_dir: str, heap_arg):
     argstring = ' '.join([java_exe, heap_arg] + win_args + ["-nogui"])
     logging.info(f"Running Forge server: {argstring}")
     os.chdir(forge_dir)
-    return Popen(argstring, shell=True)
+    return Popen(argstring, shell=not is_windows)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Added the cli=True that got lost when moving MinecraftClient from setup.py to Launcher.py
* Added some level of non-windows compatibility for MinecraftClient:
  * Launcher: Open terminal when launching cli components from open_patch
  * MinecraftClient: fall back to whatever is defined in `host.yaml: minecraft_options: java` or java in PATH if not windows
  * MinecraftClient: ask the user to install the mod if it's missing (when run without --install)
  * MinecraftClient: added missing `shell=True` - should not break anything on windows, right?

@espeon65536 or @KonoTyran please check if this looks good to you.