### PR TITLE
Clients: don't use stdin when loading steam overlay

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -17,6 +17,7 @@ from MultiServer import CommandProcessor
 from NetUtils import Endpoint, decode, NetworkItem, encode, JSONtoTextParser, ClientStatus, Permission
 from Utils import Version, stream_input
 from worlds import network_data_package, AutoWorldRegister
+import os
 
 logger = logging.getLogger("Client")
 
@@ -617,13 +618,16 @@ if __name__ == '__main__':
         ctx = TextContext(args.connect, args.password)
         ctx.server_task = asyncio.create_task(server_loop(ctx), name="server loop")
         input_task = None
+        steam_overlay = False
+
         if gui_enabled:
             from kvui import TextManager
             ctx.ui = TextManager(ctx)
             ui_task = asyncio.create_task(ctx.ui.async_run(), name="UI")
+            steam_overlay = 'gameoverlayrenderer' in os.environ.get('LD_PRELOAD', '')
         else:
             ui_task = None
-        if sys.stdin:
+        if sys.stdin and not steam_overlay:  # steam overlay breaks when starting console_loop
             input_task = asyncio.create_task(console_loop(ctx), name="Input")
         await ctx.exit_event.wait()
 


### PR DESCRIPTION
Don't run the `console_loop` task when steam overlay is being used because it would freeze steam on Linux (and possibly Mac).

Explanation: steam uses the LD_PRELOAD environment variable to force-load DLLs that overwrite OpenGL functions, so that as soon as an OpenGL context is created steam can activate its overlay. This seems to be broken when a a thread waits on stdin, so we detect that "gameoverlayrenderer" (the name of the DLL) was preloaded and disable said task.