### PR TITLE
Core: change how required versions work, deprecate IgnoreGame

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -596,7 +596,7 @@ if __name__ == '__main__':
 
     class TextContext(CommonContext):
         tags = {"AP", "IgnoreGame", "TextOnly"}
-        game = "Archipelago"
+        game = ""  # empty matches any game since 0.3.2
         items_handling = 0  # don't receive any NetworkItems
 
         async def server_auth(self, password_requested: bool = False):

--- a/Main.py
+++ b/Main.py
@@ -326,11 +326,13 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
                 slot_data = {}
                 client_versions = {}
                 games = {}
-                minimum_versions = {"server": (0, 2, 4), "clients": client_versions}
+                minimum_versions = {"server": AutoWorld.World.required_server_version, "clients": client_versions}
                 slot_info = {}
                 names = [[name for player, name in sorted(world.player_name.items())]]
                 for slot in world.player_ids:
-                    client_versions[slot] = world.worlds[slot].get_required_client_version()
+                    player_world: AutoWorld.World = world.worlds[slot]
+                    minimum_versions["server"] = max(minimum_versions["server"], player_world.required_server_version)
+                    client_versions[slot] = player_world.required_client_version
                     games[slot] = world.game[slot]
                     slot_info[slot] = NetUtils.NetworkSlot(names[0][slot - 1], world.game[slot],
                                                            world.player_types[slot])

--- a/docs/api.md
+++ b/docs/api.md
@@ -398,7 +398,7 @@ The world has to provide the following things for generation
   `self.world.get_filled_locations(self.player)` will filter for this world.
   `item.player` can be used to see if it's a local item.
 
-In addition the following methods can be implemented
+In addition, the following methods and properties can be implemented
 
 * `def generate_early(self)`
   called per player before any items or locations are created. You can set
@@ -418,11 +418,9 @@ In addition the following methods can be implemented
   before, during and after the regular fill process, before `generate_output`.
 * `fill_slot_data` and `modify_multidata` can be used to modify the data that
   will be used by the server to host the MultiWorld.
-* `def get_required_client_version(self)`
-  can return a tuple of 3 ints to make sure the client is compatible to this
-  world (e.g. item IDs) when connecting.
-  Always use `return max((x,y,z), super().get_required_client_version())`
-  to catch updates in the lower layers that break compatibility.
+* `required_client_version: Tuple(int, int, int)`
+  Client version as tuple of 3 ints to make sure the client is compatible to
+  this world (e.g. implements all required features) when connecting.
 
 #### generate_early
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -398,7 +398,7 @@ The world has to provide the following things for generation
   `self.world.get_filled_locations(self.player)` will filter for this world.
   `item.player` can be used to see if it's a local item.
 
-In addition, the following methods and properties can be implemented
+In addition, the following methods can be implemented and attributes can be set
 
 * `def generate_early(self)`
   called per player before any items or locations are created. You can set

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -583,13 +583,13 @@ GameData is a **dict** but contains these keys and values. It's broken out into 
 ### Tags
 Tags are represented as a list of strings, the common Client tags follow:
 
-| Name | Notes |
-| ----- | ---- |
-| AP | Signifies that this client is a reference client, its usefulness is mostly in debugging to compare client behaviours more easily. |
-| IgnoreGame | Tells the server to ignore the "game" attribute in the [Connect](#Connect) packet. |
-| DeathLink | Client participates in the DeathLink mechanic, therefore will send and receive DeathLink bounce packets |
-| Tracker | Tells the server that this client is actually a Tracker, will refuse new locations from this client and send all items as if they were remote items. |
-| TextOnly | Tells the server that this client will not send locations and does not want to receive items. |
+| Name       | Notes                                                                                                                                                                                                              |
+|------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| AP         | Signifies that this client is a reference client, its usefulness is mostly in debugging to compare client behaviours more easily.                                                                                  |
+| IgnoreGame | Deprecated. See Tracker and TextOnly. Tells the server to ignore the "game" attribute in the [Connect](#Connect) packet.                                                                                           |
+| DeathLink  | Client participates in the DeathLink mechanic, therefore will send and receive DeathLink bounce packets                                                                                                            |
+| Tracker    | Tells the server that this client will not send locations and is actually a Tracker. When specified and used with empty or null `game` in [Connect](#connect), game and game's version validation will be skipped. |
+| TextOnly   | Tells the server that this client will not send locations and is intended for chat. When specified and used with empty or null `game` in [Connect](#connect), game and game's version validation will be skipped.  |
 
 ### DeathLink
 A special kind of Bounce packet that can be supported by any AP game. It targets the tag "DeathLink" and carries the following data:

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -27,9 +27,9 @@ class AutoWorldRegister(type):
         dct["location_names"] = frozenset(dct["location_name_to_id"])
         dct["all_item_and_group_names"] = frozenset(dct["item_names"] | set(dct.get("item_name_groups", {})))
 
-        # move away from required_client_version function
+        # move away from get_required_client_version function
         if "game" in dct:
-            assert "get_required_client_version" not in dct, f"{name}: required_client_version is a property now"
+            assert "get_required_client_version" not in dct, f"{name}: required_client_version is an attribute now"
         # set minimum required_client_version from bases
         if "required_client_version" in dct and bases:
             for base in bases:

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -27,6 +27,15 @@ class AutoWorldRegister(type):
         dct["location_names"] = frozenset(dct["location_name_to_id"])
         dct["all_item_and_group_names"] = frozenset(dct["item_names"] | set(dct.get("item_name_groups", {})))
 
+        # move away from required_client_version function
+        if "game" in dct:
+            assert "get_required_client_version" not in dct, f"{name}: required_client_version is a property now"
+        # set minimum required_client_version from bases
+        if "required_client_version" in dct and bases:
+            for base in bases:
+                if "required_client_version" in base.__dict__:
+                    dct["required_client_version"] = max(dct["required_client_version"], base.required_client_version)
+
         # construct class
         new_class = super().__new__(cls, name, bases, dct)
         if "game" in dct:
@@ -105,6 +114,14 @@ class World(metaclass=AutoWorldRegister):
     # While this is set to 0 in *any* AutoWorld, the entire DataPackage is considered in testing mode and will be
     # retrieved by clients on every connection.
     data_version: int = 1
+
+    # override this if changes to a world break forward-compatibility of the client
+    # The base version of (0, 1, 6) is provided for backwards compatibility and does *not* need to be updated in the
+    # future. Protocol level compatibility check moved to MultiServer.min_client_version.
+    required_client_version: Tuple[int, int, int] = (0, 1, 6)
+
+    # update this if the resulting multidata breaks forward-compatibility of the server
+    required_server_version: Tuple[int, int, int] = (0, 2, 4)
 
     hint_blacklist: Set[str] = frozenset()  # any names that should not be hintable
 
@@ -190,9 +207,6 @@ class World(metaclass=AutoWorldRegister):
     def modify_multidata(self, multidata: dict):
         """For deeper modification of server multidata."""
         pass
-
-    def get_required_client_version(self) -> Tuple[int, int, int]:
-        return 0, 1, 6
 
     # Spoiler writing is optional, these may not get called.
     def write_spoiler_header(self, spoiler_handle: TextIO):

--- a/worlds/alttp/__init__.py
+++ b/worlds/alttp/__init__.py
@@ -43,6 +43,7 @@ class ALTTPWorld(World):
     data_version = 8
     remote_items: bool = False
     remote_start_inventory: bool = False
+    required_client_version = (0, 3, 2)
 
     set_rules = set_rules
 
@@ -323,9 +324,6 @@ class ALTTPWorld(World):
         if rom_name:
             new_name = base64.b64encode(bytes(self.rom_name)).decode()
             multidata["connect_names"][new_name] = multidata["connect_names"][self.world.player_name[self.player]]
-
-    def get_required_client_version(self) -> tuple:
-        return max((0, 3, 2), super(ALTTPWorld, self).get_required_client_version())
 
     def create_item(self, name: str) -> Item:
         return ALttPItem(name, self.player, **as_dict_item_table[name])

--- a/worlds/factorio/__init__.py
+++ b/worlds/factorio/__init__.py
@@ -42,7 +42,7 @@ class Factorio(World):
         "Progressive": set(progressive_tech_table.values()),
     }
     data_version = 5
-    required_client_version = (0, 2, 6)
+    required_client_version = (0, 3, 0)
 
     def __init__(self, world, player: int):
         super(Factorio, self).__init__(world, player)

--- a/worlds/factorio/__init__.py
+++ b/worlds/factorio/__init__.py
@@ -42,6 +42,7 @@ class Factorio(World):
         "Progressive": set(progressive_tech_table.values()),
     }
     data_version = 5
+    required_client_version = (0, 2, 6)
 
     def __init__(self, world, player: int):
         super(Factorio, self).__init__(world, player)
@@ -178,9 +179,6 @@ class Factorio(World):
                         return item_name
 
         return super(Factorio, self).collect_item(state, item, remove)
-
-    def get_required_client_version(self) -> tuple:
-        return max((0, 2, 6), super(Factorio, self).get_required_client_version())
 
     options = factorio_options
 

--- a/worlds/meritous/__init__.py
+++ b/worlds/meritous/__init__.py
@@ -32,6 +32,9 @@ class MeritousWorld(World):
     data_version = 2
     forced_auto_forfeit = False
 
+    # NOTE: Remember to change this before this game goes live
+    required_client_version = (0, 2, 4)
+
     options = meritous_options
 
     def __init__(self, world: MultiWorld, player: int):
@@ -149,10 +152,6 @@ class MeritousWorld(World):
         else:
             self.world.completion_condition[self.player] = lambda state: state.has(
                 "Full Victory", self.player)
-
-    def get_required_client_version(self) -> tuple:
-        # NOTE: Remember to change this before this game goes live
-        return max((0, 2, 4), super(MeritousWorld, self).get_required_client_version())
 
     def fill_slot_data(self) -> dict:
         return {

--- a/worlds/raft/__init__.py
+++ b/worlds/raft/__init__.py
@@ -27,6 +27,7 @@ class RaftWorld(World):
     options = raft_options
 
     data_version = 1
+    required_client_version = (0, 2, 0)
 
     def generate_basic(self):
         minRPSpecified = self.world.minimum_resource_pack_amount[self.player].value
@@ -111,9 +112,6 @@ class RaftWorld(World):
 
         return super(RaftWorld, self).collect_item(state, item, remove)
 
-    def get_required_client_version(self) -> typing.Tuple[int, int, int]:
-        return max((0, 2, 0), super(RaftWorld, self).get_required_client_version())
-    
     def pre_fill(self):
         if self.world.island_frequency_locations[self.player] == 0:
             self.setLocationItem("Radio Tower Frequency to Vasagatan", "Vasagatan Frequency")

--- a/worlds/rogue-legacy/__init__.py
+++ b/worlds/rogue-legacy/__init__.py
@@ -21,6 +21,7 @@ class LegacyWorld(World):
     options = legacy_options
     topology_present = False
     data_version = 3
+    required_client_version = (0, 2, 3)
 
     item_name_to_id = {name: data.code for name, data in item_table.items()}
     location_name_to_id = location_table
@@ -53,9 +54,6 @@ class LegacyWorld(World):
     def _create_items(self, name: str):
         data = item_table[name]
         return [self.create_item(name)] * data.quantity
-
-    def get_required_client_version(self) -> typing.Tuple[int, int, int]:
-        return max((0, 2, 3), super(LegacyWorld, self).get_required_client_version())
 
     def fill_slot_data(self) -> dict:
         slot_data = self._get_slot_data()

--- a/worlds/sm/__init__.py
+++ b/worlds/sm/__init__.py
@@ -69,6 +69,10 @@ class SMWorld(World):
     remote_items: bool = False
     remote_start_inventory: bool = False
 
+    # changes to client DeathLink handling for 0.2.1
+    # changes to client Remote Item handling for 0.2.6
+    required_client_version = (0, 2, 6)
+
     itemManager: ItemManager
 
     locations = {}
@@ -166,11 +170,6 @@ class SMWorld(World):
     def create_regions(self):
         create_locations(self, self.player)
         create_regions(self, self.world, self.player)
-
-    def get_required_client_version(self):
-        # changes to client DeathLink handling for 0.2.1
-        # changes to client Remote Item handling for 0.2.6
-        return max(super(SMWorld, self).get_required_client_version(), (0, 2, 6))
 
     def getWord(self, w):
         return (w & 0x00FF, (w & 0xFF00) >> 8)

--- a/worlds/smz3/__init__.py
+++ b/worlds/smz3/__init__.py
@@ -51,6 +51,9 @@ class SMZ3World(World):
     remote_items: bool = False
     remote_start_inventory: bool = False
 
+    # first added for 0.2.6
+    required_client_version = (0, 2, 6)
+
     def __init__(self, world: MultiWorld, player: int):
         self.rom_name_available_event = threading.Event()
         self.locations = {}
@@ -134,10 +137,6 @@ class SMZ3World(World):
             exit = Entrance(self.player, 'Menu' + "->" + region.Name, startRegion)
             startRegion.exits.append(exit)
             exit.connect(currentRegion)
-
-    def get_required_client_version(self):
-        # first added for 0.2.6
-        return max(super(SMZ3World, self).get_required_client_version(), (0, 2, 6))
 
     def apply_sm_custom_sprite(self):
         itemSprites = ["off_world_prog_item.bin", "off_world_item.bin"]

--- a/worlds/soe/__init__.py
+++ b/worlds/soe/__init__.py
@@ -147,6 +147,7 @@ class SoEWorld(World):
     remote_items = False
     data_version = 2
     web = SoEWebWorld()
+    required_client_version = (0, 2, 6)
 
     item_name_to_id, item_id_to_raw = _get_item_mapping()
     location_name_to_id, location_id_to_raw = _get_location_mapping()
@@ -320,10 +321,6 @@ class SoEWorld(World):
         if self.connect_name and self.connect_name != self.world.player_name[self.player]:
             payload = multidata["connect_names"][self.world.player_name[self.player]]
             multidata["connect_names"][self.connect_name] = payload
-
-    def get_required_client_version(self):
-        return max((0, 2, 6), super(SoEWorld, self).get_required_client_version())
-
 
 class SoEItem(Item):
     game: str = "Secret of Evermore"

--- a/worlds/subnautica/__init__.py
+++ b/worlds/subnautica/__init__.py
@@ -28,6 +28,7 @@ class SubnauticaWorld(World):
     options = options
 
     data_version = 2
+    required_client_version = (0, 1, 9)
 
     def generate_basic(self):
         # Link regions
@@ -76,10 +77,6 @@ class SubnauticaWorld(World):
     def create_item(self, name: str) -> Item:
         item = lookup_name_to_item[name]
         return SubnauticaItem(name, item["progression"], item["id"], player=self.player)
-
-    def get_required_client_version(self) -> typing.Tuple[int, int, int]:
-        return max((0, 1, 9), super(SubnauticaWorld, self).get_required_client_version())
-
 
 def create_region(world: MultiWorld, player: int, name: str, locations=None, exits=None):
     ret = Region(name, None, name, player)


### PR DESCRIPTION
* `AutoWorld.World`s can set required_server_version and required_client_version properties. Drop `get_required_client_version()`.
* `MultiServer` will set an absolute minimum client version based on its capability (protocol level).
* `IgnoreVersion` tag is replaced by using `Tracker` or `TextOnly` with empty or null `game`.
* Ignoring game will also ignore game's required_client_version (and fall back to server capability).