### PR TITLE
Add bug report link to WebWorld

### DIFF
--- a/WebHostLib/templates/supportedGames.html
+++ b/WebHostLib/templates/supportedGames.html
@@ -23,7 +23,7 @@
             {% endif %}
             {% if world.web.bug_report_page %}
             <span class="link-spacer">|</span>
-            <a href="{{ world.web.bug_report_page }}">Submit a Bug Report with this Game</a>
+            <a href="{{ world.web.bug_report_page }}">Report a Bug</a>
             {% endif %}
         </p>
         {% endfor %}

--- a/WebHostLib/templates/supportedGames.html
+++ b/WebHostLib/templates/supportedGames.html
@@ -21,6 +21,10 @@
             {% elif world.web.settings_page %}
             <a href="{{ url_for("player_settings", game=game_name) }}">Settings Page</a>
             {% endif %}
+            {% if world.web.bug_report_page %}
+            <span class="link-spacer">|</span>
+            <a href="{{ world.web.bug_report_page }}">Bug Report</a>
+            {% endif %}
         </p>
         {% endfor %}
     </div>

--- a/WebHostLib/templates/supportedGames.html
+++ b/WebHostLib/templates/supportedGames.html
@@ -23,7 +23,7 @@
             {% endif %}
             {% if world.web.bug_report_page %}
             <span class="link-spacer">|</span>
-            <a href="{{ world.web.bug_report_page }}">Bug Report</a>
+            <a href="{{ world.web.bug_report_page }}">Submit a Bug Report with this Game</a>
             {% endif %}
         </p>
         {% endfor %}

--- a/docs/api.md
+++ b/docs/api.md
@@ -56,11 +56,16 @@ game.
 ### WebWorld Class
 
 A `WebWorld` class contains specific attributes and methods that can be modified
-for your world specifically on the webhost. At the moment this comprises of `settings_page`
-which can be changed to a link instead of an AP generated settings page, and a `theme` to be used for your game specific AP pages. Available themes:
+for your world specifically on the webhost.
+
+`settings_page` which can be changed to a link instead of an AP generated settings page.
+
+`theme` to be used for your game specific AP pages. Available themes:
 | dirt  | grass (default) | grassFlowers | ice  | jungle  | ocean | partyTime |
 |---|---|---|---|---|---|---|
 | <img src="img/theme_dirt.JPG" width="100"> | <img src="img/theme_grass.JPG" width="100"> | <img src="img/theme_grassFlowers.JPG" width="100"> | <img src="img/theme_ice.JPG" width="100"> | <img src="img/theme_jungle.JPG" width="100"> | <img src="img/theme_ocean.JPG" width="100"> | <img src="img/theme_partyTime.JPG" width="100"> |
+
+`bug_report_page` (optional) can be a link to a bug reporting page, most likely a GitHub issue page, that will be placed by the site to help direct users to report bugs.
 
 ### MultiWorld Object
 

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -94,7 +94,7 @@ class WebWorld:
     theme = "grass"
 
     # display a link to a bug report page, most likely a link to a GitHub issue page.
-    bug_report_page: Union[bool, str] = False
+    bug_report_page: Optional[str]
 
 
 class World(metaclass=AutoWorldRegister):

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -93,6 +93,9 @@ class WebWorld:
     # Available: dirt, grass, grassFlowers, ice, jungle, ocean, partyTime
     theme = "grass"
 
+    # display a link to a bug report page, most likely a link to a GitHub issue page.
+    bug_report_page: Union[bool, str] = False
+
 
 class World(metaclass=AutoWorldRegister):
     """A World object encompasses a game's Items, Locations, Rules and additional data or functionality required.

--- a/worlds/minecraft/__init__.py
+++ b/worlds/minecraft/__init__.py
@@ -19,7 +19,7 @@ minecraft_version = "1.17.1"
 
 class MinecraftWebWorld(WebWorld):
     theme = "jungle"
-    bug_report_page = "https://github.com/KonoTyran/Minecraft_AP_Randomizer/issues"
+    bug_report_page = "https://github.com/KonoTyran/Minecraft_AP_Randomizer/issues/new?assignees=&labels=bug&template=bug_report.yaml&title=%5BBug%5D%3A+Brief+Description+of+bug+here"
 
 
 class MinecraftWorld(World):

--- a/worlds/minecraft/__init__.py
+++ b/worlds/minecraft/__init__.py
@@ -11,10 +11,16 @@ from worlds.generic.Rules import exclusion_rules
 
 from BaseClasses import Region, Entrance, Item
 from .Options import minecraft_options
-from ..AutoWorld import World
+from ..AutoWorld import World, WebWorld
 
 client_version = 7
 minecraft_version = "1.17.1"
+
+
+class MinecraftWebWorld(WebWorld):
+    theme = "jungle"
+    bug_report_page = "https://github.com/KonoTyran/Minecraft_AP_Randomizer/issues"
+
 
 class MinecraftWorld(World):
     """
@@ -26,6 +32,7 @@ class MinecraftWorld(World):
     game: str = "Minecraft"
     options = minecraft_options
     topology_present = True
+    web = MinecraftWebWorld()
 
     item_name_to_id = {name: data.code for name, data in item_table.items()}
     location_name_to_id = {name: data.id for name, data in advancement_table.items()}


### PR DESCRIPTION
added option for a World to supply a bug report URL to the user, most likely a GitHub issue page, but can be any URL.
Added the actual link to the `/games` endpoint. but I am open to suggestions on other places to put it.