### PR TITLE
Fix lowercase letter in link leading to 404

### DIFF
--- a/WebHostLib/static/assets/tutorial/Archipelago/advanced_settings_en.md
+++ b/WebHostLib/static/assets/tutorial/Archipelago/advanced_settings_en.md
@@ -90,7 +90,7 @@ games you want settings for.
 
     * `triggers` is one of the more advanced options that allows you to create conditional adjustments. You can read
       more triggers in the triggers guide. Triggers
-      guide: [Archipelago Triggers Guide](/tutorial/archipelago/triggers/en)
+      guide: [Archipelago Triggers Guide](/tutorial/Archipelago/triggers/en)
 
 ### Game Options
 
@@ -107,7 +107,7 @@ Currently, these options are `start_inventory`, `start_hints`, `local_items`, `n
 , `exclude_locations`, and various plando options.
 
 See the plando guide for more info on plando options. Plando
-guide: [Archipelago Plando Guide](/tutorial/archipelago/plando/en)
+guide: [Archipelago Plando Guide](/tutorial/Archipelago/plando/en)
 
 * `start_inventory` will give any items defined here to you at the beginning of your game. The format for this must be
   the name as it appears in the game files and the amount you would like to start with. For example `Rupees(5): 6` which

--- a/WebHostLib/static/assets/tutorial/Archipelago/triggers_en.md
+++ b/WebHostLib/static/assets/tutorial/Archipelago/triggers_en.md
@@ -15,7 +15,7 @@ YAML: [Mercenary Mode YAML on GitHub](https://github.com/alwaysintreble/Archipel
 
 For more information on plando you can reference the general plando guide or the Link to the Past plando guide.
 
-General plando guide: [Archipelago Plando Guide](/tutorial/archipelago/plando/en)
+General plando guide: [Archipelago Plando Guide](/tutorial/Archipelago/plando/en)
 
 Link to the Past plando guide: [LttP Plando Guide](/tutorial/zelda3/plando/en)
 

--- a/WebHostLib/static/assets/tutorial/ChecksFinder/checksfinder_en.md
+++ b/WebHostLib/static/assets/tutorial/ChecksFinder/checksfinder_en.md
@@ -12,7 +12,7 @@
 ### What is a YAML file and why do I need one?
 
 See the guide on setting up a basic YAML at the Archipelago setup
-guide: [Basic Multiworld Setup Guide](/tutorial/archipelago/setup/en)
+guide: [Basic Multiworld Setup Guide](/tutorial/Archipelago/setup/en)
 
 ### Where do I get a YAML file?
 

--- a/WebHostLib/static/assets/tutorial/Final Fantasy/multiworld_en.md
+++ b/WebHostLib/static/assets/tutorial/Final Fantasy/multiworld_en.md
@@ -39,7 +39,7 @@ It should download two files. One is the `*.nes` file which your emulator will r
 required by Archipelago.gg
 
 At this point you are ready to join the multiworld. If you are uncertain on how to generate, host or join a multiworld
-please refer to the [game agnostic setup guide](/tutorial/archipelago/setup/en).
+please refer to the [game agnostic setup guide](/tutorial/Archipelago/setup/en).
 
 ## Running the Client Program and Connecting to the Server
 
@@ -70,5 +70,5 @@ NES at any time by running `/nes`
 
 ### Other Client Commands
 
-All other commands may be found on the [Archipelago Server and Client Commands Guide](/tutorial/archipelago/commands/en)
+All other commands may be found on the [Archipelago Server and Client Commands Guide](/tutorial/Archipelago/commands/en)
 .

--- a/WebHostLib/static/assets/tutorial/Minecraft/minecraft_en.md
+++ b/WebHostLib/static/assets/tutorial/Minecraft/minecraft_en.md
@@ -12,7 +12,7 @@
 ### What is a YAML file and why do I need one?
 
 See the guide on setting up a basic YAML at the Archipelago setup
-guide: [Basic Multiworld Setup Guide](/tutorial/archipelago/setup/en)
+guide: [Basic Multiworld Setup Guide](/tutorial/Archipelago/setup/en)
 
 ### Where do I get a YAML file?
 

--- a/WebHostLib/static/assets/tutorial/SMZ3/multiworld_en.md
+++ b/WebHostLib/static/assets/tutorial/SMZ3/multiworld_en.md
@@ -39,7 +39,7 @@
 ### What is a config file and why do I need one?
 
 See the guide on setting up a basic YAML at the Archipelago setup
-guide: [Basic Multiworld Setup Guide](/tutorial/archipelago/setup/en)
+guide: [Basic Multiworld Setup Guide](/tutorial/Archipelago/setup/en)
 
 ### Where do I get a config file?
 

--- a/WebHostLib/static/assets/tutorial/Secret of Evermore/multiworld_en.md
+++ b/WebHostLib/static/assets/tutorial/Secret of Evermore/multiworld_en.md
@@ -19,7 +19,7 @@
 ### What is a config file and why do I need one?
 
 See the guide on setting up a basic YAML at the Archipelago setup
-guide: [Basic Multiworld Setup Guide](/tutorial/archipelago/setup/en)
+guide: [Basic Multiworld Setup Guide](/tutorial/Archipelago/setup/en)
 
 ### Where do I get a config file?
 
@@ -142,4 +142,4 @@ change to green. Congratulations on successfully joining a multiworld game!
 ## Hosting a MultiWorld game
 
 The recommended way to host a game is to use our hosting service on the [seed generation page](/generate). Or check out
-the Archipelago website guide for more information: [Archipelago Website Guide](/tutorial/archipelago/using_website/en)
+the Archipelago website guide for more information: [Archipelago Website Guide](/tutorial/Archipelago/using_website/en)

--- a/WebHostLib/static/assets/tutorial/Super Metroid/multiworld_en.md
+++ b/WebHostLib/static/assets/tutorial/Super Metroid/multiworld_en.md
@@ -42,7 +42,7 @@
 ### What is a config file and why do I need one?
 
 See the guide on setting up a basic YAML at the Archipelago setup
-guide: [Basic Multiworld Setup Guide](/tutorial/archipelago/setup/en)
+guide: [Basic Multiworld Setup Guide](/tutorial/Archipelago/setup/en)
 
 ### Where do I get a config file?
 


### PR DESCRIPTION
The lowercase `a` in the link in this Markdown file leads to a 404.  This fixes the link.  Thanks to CelestialPanda for the heads up.