### PR TITLE
Add options to generate page

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1060,7 +1060,10 @@ class ClientMessageProcessor(CommonCommandProcessor):
 
     @mark_raw
     def _cmd_admin(self, command: str = ""):
-        """Allow remote administration of the multiworld server"""
+        """Allow remote administration of the multiworld server
+        Usage: "!admin login <password>" in order to log in to the remote interface.
+        Once logged in, you can then use "!admin <command>" to issue commands.
+        If you need further help once logged in.  use "!admin /help" """
 
         output = f"!admin {command}"
         if output.lower().startswith(

--- a/WebHostLib/api/generate.py
+++ b/WebHostLib/api/generate.py
@@ -45,7 +45,7 @@ def generate_api():
                     "detail": app.config["MAX_ROLL"]}, 409
         meta = get_meta(meta_options_source)
         meta["race"] = race
-        results, gen_options = roll_options(options)
+        results, gen_options = roll_options(options, meta["plando_options"])
         if any(type(result) == str for result in results.values()):
             return {"text": str(results),
                     "detail": results}, 400

--- a/WebHostLib/check.py
+++ b/WebHostLib/check.py
@@ -62,7 +62,7 @@ def get_yaml_data(file) -> Union[Dict[str, str], str]:
     return options
 
 
-def roll_options(options: Dict[str, Union[dict, str]]) -> Tuple[Dict[str, Union[str, bool]], Dict[str, dict]]:
+def roll_options(options: Dict[str, Union[dict, str]], plando_options: set = {"bosses", "items", "connections", "texts"}) -> Tuple[Dict[str, Union[str, bool]], Dict[str, dict]]:
     results = {}
     rolled_results = {}
     for filename, text in options.items():
@@ -77,11 +77,11 @@ def roll_options(options: Dict[str, Union[dict, str]]) -> Tuple[Dict[str, Union[
             try:
                 if len(yaml_datas) == 1:
                     rolled_results[filename] = roll_settings(yaml_datas[0],
-                                        plando_options={"bosses", "items", "connections", "texts"})
+                                        plando_options=plando_options)
                 else:
                     for i, yaml_data in enumerate(yaml_datas):
                         rolled_results[f"{filename}/{i + 1}"] = roll_settings(yaml_data,
-                                                         plando_options={"bosses", "items", "connections", "texts"})
+                                                         plando_options=plando_options)
             except Exception as e:
                 results[filename] = f"Failed to generate mystery in {filename}: {e}"
             else:

--- a/WebHostLib/generate.py
+++ b/WebHostLib/generate.py
@@ -27,6 +27,7 @@ def get_meta(options_source: dict) -> dict:
         "forfeit_mode": options_source.get("forfeit_mode", "goal"),
         "remaining_mode": options_source.get("forfeit_mode", "disabled"),
         "collect_mode": options_source.get("collect_mode", "disabled"),
+        "item_cheat": bool(int(options_source.get("item_cheat", 1)))
     }
     return meta
 

--- a/WebHostLib/generate.py
+++ b/WebHostLib/generate.py
@@ -27,7 +27,8 @@ def get_meta(options_source: dict) -> dict:
         "forfeit_mode": options_source.get("forfeit_mode", "goal"),
         "remaining_mode": options_source.get("forfeit_mode", "disabled"),
         "collect_mode": options_source.get("collect_mode", "disabled"),
-        "item_cheat": bool(int(options_source.get("item_cheat", 1)))
+        "item_cheat": bool(int(options_source.get("item_cheat", 1))),
+        "server_password": options_source.get("server_password", None)
     }
     return meta
 

--- a/WebHostLib/generate.py
+++ b/WebHostLib/generate.py
@@ -22,13 +22,23 @@ from .upload import upload_zip_to_db
 
 
 def get_meta(options_source: dict) -> dict:
+    plando_options = {
+        options_source.get("plando_bosses", ""),
+        options_source.get("plando_items", ""),
+        options_source.get("plando_connections", ""),
+        options_source.get("plando_texts", "")
+    }
+    plando_options -= {""}
+    print(plando_options)
+    print(options_source)
     meta = {
         "hint_cost": int(options_source.get("hint_cost", 10)),
         "forfeit_mode": options_source.get("forfeit_mode", "goal"),
         "remaining_mode": options_source.get("forfeit_mode", "disabled"),
         "collect_mode": options_source.get("collect_mode", "disabled"),
         "item_cheat": bool(int(options_source.get("item_cheat", 1))),
-        "server_password": options_source.get("server_password", None)
+        "server_password": options_source.get("server_password", None),
+        "plando_options": plando_options
     }
     return meta
 
@@ -46,10 +56,9 @@ def generate(race=False):
             if type(options) == str:
                 flash(options)
             else:
-                results, gen_options = roll_options(options)
-                # get form data -> server settings
                 meta = get_meta(request.form)
                 meta["race"] = race
+                results, gen_options = roll_options(options, meta["plando_options"])
 
                 if race:
                     meta["item_cheat"] = False
@@ -91,6 +100,8 @@ def gen_game(gen_options, meta: TypeOptional[Dict[str, object]] = None, owner=No
     meta.setdefault("hint_cost", 10)
     race = meta.get("race", False)
     del (meta["race"])
+    plando_options = meta.get("plando", {"bosses", "items", "connections", "texts"})
+    del (meta["plando_options"])
     try:
         target = tempfile.TemporaryDirectory()
         playercount = len(gen_options)
@@ -110,6 +121,7 @@ def gen_game(gen_options, meta: TypeOptional[Dict[str, object]] = None, owner=No
         erargs.outputname = seedname
         erargs.outputpath = target.name
         erargs.teams = 1
+        erargs.plando_options = ", ".join(plando_options)
 
         name_counter = Counter()
         for player, (playerfile, settings) in enumerate(gen_options.items(), 1):

--- a/WebHostLib/generate.py
+++ b/WebHostLib/generate.py
@@ -29,8 +29,7 @@ def get_meta(options_source: dict) -> dict:
         options_source.get("plando_texts", "")
     }
     plando_options -= {""}
-    print(plando_options)
-    print(options_source)
+
     meta = {
         "hint_cost": int(options_source.get("hint_cost", 10)),
         "forfeit_mode": options_source.get("forfeit_mode", "goal"),

--- a/WebHostLib/static/styles/generate.css
+++ b/WebHostLib/static/styles/generate.css
@@ -6,7 +6,7 @@
 }
 
 #generate-game{
-    width: 700px;
+    width: 990px;
     min-height: 360px;
     text-align: center;
 }
@@ -25,9 +25,26 @@
     margin-bottom: 1rem;
 }
 
+#generate-game-tables-container{
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: space-around;
+}
+
+.table-wrapper select {
+    width: 200px;
+}
+
+.table-wrapper input:not([type]){
+    width: 200px;
+}
+
 #generate-game-form-wrapper table td{
     text-align: left;
     padding-right: 0.5rem;
+    vertical-align: top;
+    width: 230px;
 }
 
 #generate-form-button-row{

--- a/WebHostLib/templates/generate.html
+++ b/WebHostLib/templates/generate.html
@@ -121,15 +121,7 @@
                                     <label for="server_password">Server Password:</label>
                                     <span
                                         class="interactive"
-                                        data-tooltip="Allows for issuing of server console commands from any text client.">(?)
-                                    </span>
-                                    <span
-                                        class="interactive"
-                                        data-tooltip="Use !admin login <password> to login.">(?)
-                                    </span>
-                                    <span
-                                        class="interactive"
-                                        data-tooltip="Use !admin </server command> to issue commands to the server.">(?)
+                                        data-tooltip="Allows for issuing of server console commands from any text client or in-game client using the !admin command.">(?)
                                     </span>
                                 </td>
                                 <td>

--- a/WebHostLib/templates/generate.html
+++ b/WebHostLib/templates/generate.html
@@ -87,9 +87,13 @@
                                 </td>
                                 <td>
                                     <select name="remaining_mode" id="remaining_mode">
-                                        <option value="disabled">Disabled</option>
-                                        <option value="goal">Allow !remaining after goal completion</option>
-                                        <option value="enabled">Manual !remaining</option>
+                                        {% if race -%}
+                                            <option value="disabled">Disabled in Race mode</option>
+                                        {%- else -%}
+                                            <option value="disabled">Disabled</option>
+                                            <option value="goal">Allow !remaining after goal completion</option>
+                                            <option value="enabled">Manual !remaining</option>
+                                        {%- endif -%}
                                     </select>
                                 </td>
                             </tr>
@@ -103,8 +107,12 @@
                                 </td>
                                 <td>
                                     <select name="item_cheat" id="item_cheat">
-                                        <option value="1">Enabled</option>
-                                        <option value="0">Disabled</option>
+                                        {% if race -%}
+                                            <option value="0">Disabled in Race mode</option>
+                                        {%- else -%}
+                                            <option value="1">Enabled</option>
+                                            <option value="0">Disabled</option>
+                                        {%- endif -%}
                                     </select>
                                 </td>
                             </tr>

--- a/WebHostLib/templates/generate.html
+++ b/WebHostLib/templates/generate.html
@@ -128,6 +128,17 @@
                                     <input type="text" id="server_password" name="server_password">
                                 </td>
                             </tr>
+                            <tr>
+                                <td>
+                                    <label for="plando_options">Plando Options:</label>
+                                </td>
+                                <td>
+                                    <input type="checkbox" name="plando_bosses" value="bosses" checked><label for="plando_bosses">Bosses</label><br>
+                                    <input type="checkbox" name="plando_items" value="items" checked><label for="plando_items">Items</label><br>
+                                    <input type="checkbox" name="plando_connections" value="connections" checked><label for="plando_connections">Connections</label><br>
+                                    <input type="checkbox" name="plando_texts" value="texts" checked><label for="plando_texts">Text</label>
+                                </td>
+                            </tr>
 
                             <tr>
                                 <td>

--- a/WebHostLib/templates/generate.html
+++ b/WebHostLib/templates/generate.html
@@ -35,132 +35,153 @@
             </p>
             <div id="generate-game-form-wrapper">
                 <form id="generate-game-form" method="post" enctype="multipart/form-data">
-                    <table>
-                        <tbody>
-                            <tr>
-                                <td>
-                                    <label for="forfeit_mode">Forfeit Permission:</label>
-                                    <span
-                                            class="interactive"
-                                            data-tooltip="A forfeit releases all remaining items from the locations
-                                            in your world.">(?)
-                                    </span>
-                                </td>
-                                <td>
-                                    <select name="forfeit_mode" id="forfeit_mode">
-                                        <option value="auto">Automatic on goal completion</option>
-                                        <option value="goal">Allow !forfeit after goal completion</option>
-                                        <option value="auto-enabled">Automatic on goal completion and manual !forfeit</option>
-                                        <option value="enabled">Manual !forfeit</option>
-                                        <option value="disabled">Disabled</option>
-                                    </select>
-                                </td>
-                            </tr>
-
-                            <tr>
-                                <td>
-                                    <label for="collect_mode">Collect Permission:</label>
-                                    <span
-                                            class="interactive"
-                                            data-tooltip="A collect releases all of your remaining items to you
-                                            from across the multiworld.">(?)
-                                    </span>
-                                </td>
-                                <td>
-                                    <select name="collect_mode" id="collect_mode">
-                                        <option value="goal">Allow !collect after goal completion</option>
-                                        <option value="auto">Automatic on goal completion</option>
-                                        <option value="auto-enabled">Automatic on goal completion and manual !collect</option>
-                                        <option value="enabled">Manual !collect</option>
-                                        <option value="disabled">Disabled</option>
-                                    </select>
-                                </td>
-                            </tr>
-
-                            <tr>
-                                <td>
-                                    <label for="remaining_mode">Remaining Permission:</label>
-                                    <span
-                                            class="interactive"
-                                            data-tooltip="Remaining lists all items still in your world by name only.">(?)
-                                    </span>
-                                </td>
-                                <td>
-                                    <select name="remaining_mode" id="remaining_mode">
-                                        {% if race -%}
-                                            <option value="disabled">Disabled in Race mode</option>
-                                        {%- else -%}
-                                            <option value="disabled">Disabled</option>
-                                            <option value="goal">Allow !remaining after goal completion</option>
-                                            <option value="enabled">Manual !remaining</option>
-                                        {%- endif -%}
-                                    </select>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <label for="item_cheat">Item Cheat:</label>
-                                    <span
-                                            class="interactive"
-                                            data-tooltip="Allows players to use the !getitem command.">(?)
-                                    </span>
-                                </td>
-                                <td>
-                                    <select name="item_cheat" id="item_cheat">
-                                        {% if race -%}
-                                            <option value="0">Disabled in Race mode</option>
-                                        {%- else -%}
-                                            <option value="1">Enabled</option>
-                                            <option value="0">Disabled</option>
-                                        {%- endif -%}
-                                    </select>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <label for="server_password">Server Password:</label>
-                                    <span
-                                        class="interactive"
-                                        data-tooltip="Allows for issuing of server console commands from any text client or in-game client using the !admin command.">(?)
-                                    </span>
-                                </td>
-                                <td>
-                                    <input type="text" id="server_password" name="server_password">
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <label for="plando_options">Plando Options:</label>
-                                </td>
-                                <td>
-                                    <input type="checkbox" name="plando_bosses" value="bosses" checked><label for="plando_bosses">Bosses</label><br>
-                                    <input type="checkbox" name="plando_items" value="items" checked><label for="plando_items">Items</label><br>
-                                    <input type="checkbox" name="plando_connections" value="connections" checked><label for="plando_connections">Connections</label><br>
-                                    <input type="checkbox" name="plando_texts" value="texts" checked><label for="plando_texts">Text</label>
-                                </td>
-                            </tr>
-
-                            <tr>
-                                <td>
-                                    <label for="hint_cost"> Hint Cost:</label>
-                                    <span
-                                            class="interactive"
-                                            data-tooltip="After gathering this many checks, players can !hint <itemname>
-                                            to get the location of that hint item.">(?)
-                                    </span>
-                                </td>
-                                <td>
-                                    <select name="hint_cost" id="hint_cost">
-                                        {% for n in range(0, 110, 5) %}
-                                            <option {% if n == 10 %}selected="selected" {% endif %} value="{{ n }}">
-                                                {% if n > 100 %}Off{% else %}{{ n }}%{% endif %}
+                    <div id="generate-game-tables-container">
+                        <div class="table-wrapper">
+                        <table>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <label for="forfeit_mode">Forfeit Permission:</label>
+                                        <span
+                                                class="interactive"
+                                                data-tooltip="A forfeit releases all remaining items from the locations
+                                                in your world.">(?)
+                                        </span>
+                                    </td>
+                                    <td>
+                                        <select name="forfeit_mode" id="forfeit_mode">
+                                            <option value="auto">Automatic on goal completion</option>
+                                            <option value="goal">Allow !forfeit after goal completion</option>
+                                            <option value="auto-enabled">
+                                                Automatic on goal completion and manual !forfeit
                                             </option>
-                                        {% endfor %}
-                                    </select>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
+                                            <option value="enabled">Manual !forfeit</option>
+                                            <option value="disabled">Disabled</option>
+                                        </select>
+                                    </td>
+                                </tr>
+
+                                <tr>
+                                    <td>
+                                        <label for="collect_mode">Collect Permission:</label>
+                                        <span
+                                                class="interactive"
+                                                data-tooltip="A collect releases all of your remaining items to you
+                                                from across the multiworld.">(?)
+                                        </span>
+                                    </td>
+                                    <td>
+                                        <select name="collect_mode" id="collect_mode">
+                                            <option value="goal">Allow !collect after goal completion</option>
+                                            <option value="auto">Automatic on goal completion</option>
+                                            <option value="auto-enabled">
+                                                Automatic on goal completion and manual !collect
+                                            </option>
+                                            <option value="enabled">Manual !collect</option>
+                                            <option value="disabled">Disabled</option>
+                                        </select>
+                                    </td>
+                                </tr>
+
+                                <tr>
+                                    <td>
+                                        <label for="remaining_mode">Remaining Permission:</label>
+                                        <span
+                                            class="interactive"
+                                            data-tooltip="Remaining lists all items still in your world by name only."
+                                        >(?)
+                                        </span>
+                                    </td>
+                                    <td>
+                                        <select name="remaining_mode" id="remaining_mode">
+                                            {% if race -%}
+                                                <option value="disabled">Disabled in Race mode</option>
+                                            {%- else -%}
+                                                <option value="disabled">Disabled</option>
+                                                <option value="goal">Allow !remaining after goal completion</option>
+                                                <option value="enabled">Manual !remaining</option>
+                                            {%- endif -%}
+                                        </select>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <label for="item_cheat">Item Cheat:</label>
+                                        <span
+                                                class="interactive"
+                                                data-tooltip="Allows players to use the !getitem command.">(?)
+                                        </span>
+                                    </td>
+                                    <td>
+                                        <select name="item_cheat" id="item_cheat">
+                                            {% if race -%}
+                                                <option value="0">Disabled in Race mode</option>
+                                            {%- else -%}
+                                                <option value="1">Enabled</option>
+                                                <option value="0">Disabled</option>
+                                            {%- endif -%}
+                                        </select>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="table-wrapper">
+                            <table>
+                                <tbody>
+                                    <tr>
+                                        <td>
+                                            <label for="hint_cost"> Hint Cost:</label>
+                                            <span
+                                                class="interactive"
+                                                data-tooltip="After gathering this many checks, players can !hint <itemname>
+                                                to get the location of that hint item.">(?)
+                                            </span>
+                                        </td>
+                                        <td>
+                                            <select name="hint_cost" id="hint_cost">
+                                                {% for n in range(0, 110, 5) %}
+                                                    <option {% if n == 10 %}selected="selected" {% endif %} value="{{ n }}">
+                                                        {% if n > 100 %}Off{% else %}{{ n }}%{% endif %}
+                                                    </option>
+                                                {% endfor %}
+                                            </select>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td>
+                                            <label for="server_password">Server Password:</label>
+                                            <span
+                                                class="interactive"
+                                                data-tooltip="Allows for issuing of server console commands from any text client or in-game client using the !admin command.">(?)
+                                            </span>
+                                        </td>
+                                        <td>
+                                            <input id="server_password" name="server_password">
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td>
+                                            <label for="plando_options">Plando Options:</label>
+                                        </td>
+                                        <td>
+                                            <input type="checkbox" name="plando_bosses" value="bosses" checked>
+                                            <label for="plando_bosses">Bosses</label><br>
+
+                                            <input type="checkbox" name="plando_items" value="items" checked>
+                                            <label for="plando_items">Items</label><br>
+
+                                            <input type="checkbox" name="plando_connections" value="connections" checked>
+                                            <label for="plando_connections">Connections</label><br>
+
+                                            <input type="checkbox" name="plando_texts" value="texts" checked>
+                                            <label for="plando_texts">Text</label>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
                     <div id="generate-form-button-row">
                         <input id="file-input" type="file" name="file">
                     </div>

--- a/WebHostLib/templates/generate.html
+++ b/WebHostLib/templates/generate.html
@@ -116,6 +116,26 @@
                                     </select>
                                 </td>
                             </tr>
+                            <tr>
+                                <td>
+                                    <label for="server_password">Server Password:</label>
+                                    <span
+                                        class="interactive"
+                                        data-tooltip="Allows for issuing of server console commands from any text client.">(?)
+                                    </span>
+                                    <span
+                                        class="interactive"
+                                        data-tooltip="Use !admin login <password> to login.">(?)
+                                    </span>
+                                    <span
+                                        class="interactive"
+                                        data-tooltip="Use !admin </server command> to issue commands to the server.">(?)
+                                    </span>
+                                </td>
+                                <td>
+                                    <input type="text" id="server_password" name="server_password">
+                                </td>
+                            </tr>
 
                             <tr>
                                 <td>

--- a/WebHostLib/templates/generate.html
+++ b/WebHostLib/templates/generate.html
@@ -93,6 +93,21 @@
                                     </select>
                                 </td>
                             </tr>
+                            <tr>
+                                <td>
+                                    <label for="item_cheat">Item Cheat:</label>
+                                    <span
+                                            class="interactive"
+                                            data-tooltip="Allows players to use the !getitem command.">(?)
+                                    </span>
+                                </td>
+                                <td>
+                                    <select name="item_cheat" id="item_cheat">
+                                        <option value="1">Enabled</option>
+                                        <option value="0">Disabled</option>
+                                    </select>
+                                </td>
+                            </tr>
 
                             <tr>
                                 <td>


### PR DESCRIPTION
* Add item_cheat control instead of being always enabled.
* add server_password to allow for !admin /server_commands from any text client, therefore allowing server console hand-off to another person.
* Clearly indicate that item_cheat and remaining_mode are disabled in Race mode.