### PR TITLE
Implement get_filler_item_name for various games

### DIFF
--- a/worlds/alttp/__init__.py
+++ b/worlds/alttp/__init__.py
@@ -8,7 +8,7 @@ from BaseClasses import Item, CollectionState
 from .SubClasses import ALttPItem
 from ..AutoWorld import World, LogicMixin
 from .Options import alttp_options, smallkey_shuffle
-from .Items import as_dict_item_table, item_name_groups, item_table
+from .Items import as_dict_item_table, item_name_groups, item_table, GetBeemizerItem
 from .Regions import lookup_name_to_id, create_regions, mark_light_world_regions
 from .Rules import set_rules
 from .ItemPool import generate_itempool, difficulties
@@ -396,7 +396,16 @@ class ALTTPWorld(World):
                     trash_count -= 1
 
     def get_filler_item_name(self) -> str:
-        return "Rupees (5)"  # temporary
+        if self.world.goal[self.player] == "icerodhunt":
+            item = "Nothing"
+        else:
+            extras_list = difficulties[self.world.difficulty[self.player]].extras[0] \
+            + difficulties[self.world.difficulty[self.player]].extras[1] \
+            + difficulties[self.world.difficulty[self.player]].extras[2] \
+            + difficulties[self.world.difficulty[self.player]].extras[3] \
+            + difficulties[self.world.difficulty[self.player]].extras[4]
+            item = self.world.random.choice(extras_list)
+        return GetBeemizerItem(self.world, self.player, item)
 
     def get_pre_fill_items(self):
         res = []

--- a/worlds/alttp/__init__.py
+++ b/worlds/alttp/__init__.py
@@ -17,6 +17,7 @@ from .Dungeons import create_dungeons
 from .Rom import LocalRom, patch_rom, patch_race_rom, patch_enemizer, apply_rom_settings, get_hash_string, \
     get_base_rom_path, LttPDeltaPatch
 import Patch
+from itertools import chain
 
 from .InvertedRegions import create_inverted_regions, mark_dark_world_regions
 from .EntranceShuffle import link_entrances, link_inverted_entrances, plando_connect
@@ -399,12 +400,7 @@ class ALTTPWorld(World):
         if self.world.goal[self.player] == "icerodhunt":
             item = "Nothing"
         else:
-            extras_list = difficulties[self.world.difficulty[self.player]].extras[0] \
-            + difficulties[self.world.difficulty[self.player]].extras[1] \
-            + difficulties[self.world.difficulty[self.player]].extras[2] \
-            + difficulties[self.world.difficulty[self.player]].extras[3] \
-            + difficulties[self.world.difficulty[self.player]].extras[4]
-            item = self.world.random.choice(extras_list)
+            item = self.world.random.choice(chain(difficulties[self.world.difficulty[self.player]].extras[0:5]))
         return GetBeemizerItem(self.world, self.player, item)
 
     def get_pre_fill_items(self):

--- a/worlds/archipidle/__init__.py
+++ b/worlds/archipidle/__init__.py
@@ -62,6 +62,8 @@ class ArchipIDLEWorld(World):
         self.world.get_entrance('Entrance to IDLE Zone', self.player)\
             .connect(self.world.get_region('IDLE Zone', self.player))
 
+    def get_filler_item_name(self) -> str:
+        return self.world.random.choice(item_table)
 
 def create_region(world: MultiWorld, player: int, name: str, locations=None, exits=None):
     region = Region(name, None, name, player)

--- a/worlds/ff1/__init__.py
+++ b/worlds/ff1/__init__.py
@@ -104,7 +104,7 @@ class FF1World(World):
         return slot_data
 
     def get_filler_item_name(self) -> str:
-        return self.world.random.choice(["Heal", "Heal", "Pure", "Soft"])
+        return self.world.random.choice(["Heal", "Pure", "Soft", "Tent", "Cabin", "House"])
 
 def get_options(world: MultiWorld, name: str, player: int):
     return getattr(world, name, None)[player].value

--- a/worlds/ff1/__init__.py
+++ b/worlds/ff1/__init__.py
@@ -103,6 +103,8 @@ class FF1World(World):
 
         return slot_data
 
+    def get_filler_item_name(self) -> str:
+        return self.world.random.choice(["Heal", "Heal", "Pure", "Soft"])
 
 def get_options(world: MultiWorld, name: str, player: int):
     return getattr(world, name, None)[player].value

--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -307,16 +307,6 @@ class HKWorld(World):
         assert 0 < i < 18, "limited number of multi location IDs reserved."
         return f"{base}_{i}"
 
-    def get_filler_item_name(self) -> str:
-        return self.world.random.choice(["Geo_Rock-Default", "Geo_Rock-Deepnest", "Geo_Rock-Abyss",
-                                         "Geo_Rock-GreenPath01", "Geo_Rock-Outskirts", "Geo_Rock-GreenPath02",
-                                         "Geo_Rock-Fung01", "Geo_Rock-Fung02", "Geo_Rock-City", "Geo_Rock-Hive",
-                                         "Geo_Rock-Mine", "Geo_Rock-Grave02", "Geo_Rock-Grave01", "One_Geo",
-                                         "Lumafly_Escape", "Soul_Refill", "Soul_Totem-A", "Soul_Totem-B",
-                                         "Soul_Totem-C", "Soul_Totem-D", "Soul_Totem-E", "Soul_Totem-F", "Soul_Totem-G",
-                                         "Geo_Chest-Junk_Pit_1", "Geo_Chest-Junk_Pit_2", "Geo_Chest-Junk_Pit_3",
-                                         "Geo_Chest-Junk_Pit_5"])
-
 
 def create_region(world: MultiWorld, player: int, name: str, location_names=None, exits=None) -> Region:
     ret = Region(name, RegionType.Generic, name, player)

--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -308,7 +308,15 @@ class HKWorld(World):
         return f"{base}_{i}"
 
     def get_filler_item_name(self) -> str:
-        return "Geo_Rock-Default"
+        return self.world.random.choice(["Geo_Rock-Default", "Geo_Rock-Deepnest", "Geo_Rock-Abyss",
+                                         "Geo_Rock-GreenPath01", "Geo_Rock-Outskirts", "Geo_Rock-GreenPath02",
+                                         "Geo_Rock-Fung01", "Geo_Rock-Fung02", "Geo_Rock-City", "Geo_Rock-Hive",
+                                         "Geo_Rock-Mine", "Geo_Rock-Grave02", "Geo_Rock-Grave01", "One_Geo",
+                                         "Lumafly_Escape", "Soul_Refill", "Soul_Totem-A", "Soul_Totem-B",
+                                         "Soul_Totem-C", "Soul_Totem-D", "Soul_Totem-E", "Soul_Totem-F", "Soul_Totem-G",
+                                         "Geo_Chest-Junk_Pit_1", "Geo_Chest-Junk_Pit_2", "Geo_Chest-Junk_Pit_3",
+                                         "Geo_Chest-Junk_Pit_5"])
+
 
 def create_region(world: MultiWorld, player: int, name: str, location_names=None, exits=None) -> Region:
     ret = Region(name, RegionType.Generic, name, player)

--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -307,6 +307,8 @@ class HKWorld(World):
         assert 0 < i < 18, "limited number of multi location IDs reserved."
         return f"{base}_{i}"
 
+    def get_filler_item_name(self) -> str:
+        return "Geo_Rock-Default"
 
 def create_region(world: MultiWorld, player: int, name: str, location_names=None, exits=None) -> Region:
     ret = Region(name, RegionType.Generic, name, player)

--- a/worlds/minecraft/__init__.py
+++ b/worlds/minecraft/__init__.py
@@ -101,6 +101,9 @@ class MinecraftWorld(World):
 
         self.world.itempool += itempool
 
+    def get_filler_item_name(self) -> str:
+        return self.world.random.choices(list(junk_weights.keys()), weights=list(junk_weights.values()))[0]
+
     def set_rules(self):
         set_advancement_rules(self.world, self.player)
         set_completion_rules(self.world, self.player)

--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -985,4 +985,4 @@ class OOTWorld(World):
         return all_state
 
     def get_filler_item_name(self) -> str:
-        return get_junk_item(count=1)[0]
+        return get_junk_item(count=1, pool=get_junk_pool(self))[0]

--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -983,3 +983,6 @@ class OOTWorld(World):
         all_state.stale[self.player] = True
 
         return all_state
+
+    def get_filler_item_name(self) -> str:
+        return get_junk_item(count=1)[0]

--- a/worlds/rogue-legacy/__init__.py
+++ b/worlds/rogue-legacy/__init__.py
@@ -149,6 +149,9 @@ class LegacyWorld(World):
 
         self.world.itempool += itempool
 
+    def get_filler_item_name(self) -> str:
+        return self.world.random.choice(list(misc_items_table.keys()))
+
     def create_regions(self):
         create_regions(self.world, self.player)
 

--- a/worlds/sm/__init__.py
+++ b/worlds/sm/__init__.py
@@ -501,6 +501,9 @@ class SMWorld(World):
         item = next(x for x in ItemManager.Items.values() if x.Name == name)
         return SMItem(item.Name, True, item.Type, self.item_name_to_id[item.Name], player = self.player)
 
+    def get_filler_item_name(self) -> str:
+        return "Nothing"
+
     def pre_fill(self):
         if (self.variaRando.args.morphPlacement == "early") and next((item for item in self.world.itempool if item.player == self.player and item.name == "Morph Ball"), False):
             viable = []

--- a/worlds/sm/__init__.py
+++ b/worlds/sm/__init__.py
@@ -502,7 +502,19 @@ class SMWorld(World):
         return SMItem(item.Name, True, item.Type, self.item_name_to_id[item.Name], player = self.player)
 
     def get_filler_item_name(self) -> str:
-        return "Nothing"
+        if self.world.random.randint(0, 100) < self.world.minor_qty[self.player].value:
+            power_bombs = self.world.power_bomb_qty[self.player].value
+            missiles = self.world.missile_qty[self.player].value
+            super_missiles = self.world.super_qty[self.player].value
+            roll = self.world.random.randint(1, power_bombs + missiles + super_missiles)
+            if roll <= power_bombs:
+                return "Power Bomb"
+            elif roll <= power_bombs + missiles:
+                return "Missile"
+            else:
+                return "Super Missile"
+        else:
+            return "Nothing"
 
     def pre_fill(self):
         if (self.variaRando.args.morphPlacement == "early") and next((item for item in self.world.itempool if item.player == self.player and item.name == "Morph Ball"), False):

--- a/worlds/sm64ex/__init__.py
+++ b/worlds/sm64ex/__init__.py
@@ -83,6 +83,9 @@ class SM64World(World):
             self.world.get_location("THI: Bob-omb Buddy", self.player).place_locked_item(self.create_item("Cannon Unlock THI"))
             self.world.get_location("RR: Bob-omb Buddy", self.player).place_locked_item(self.create_item("Cannon Unlock RR"))
 
+    def get_filler_item_name(self) -> str:
+        return "1Up Mushroom"
+
     def fill_slot_data(self):
         return {
             "AreaRando": self.area_connections,

--- a/worlds/soe/__init__.py
+++ b/worlds/soe/__init__.py
@@ -322,6 +322,9 @@ class SoEWorld(World):
             payload = multidata["connect_names"][self.world.player_name[self.player]]
             multidata["connect_names"][self.connect_name] = payload
 
+    def get_filler_item_name(self) -> str:
+        return self.world.random.choice(list(self.item_name_groups["Ingredients"]))
+
 class SoEItem(Item):
     game: str = "Secret of Evermore"
 

--- a/worlds/spire/__init__.py
+++ b/worlds/spire/__init__.py
@@ -78,6 +78,9 @@ class SpireWorld(World):
             slot_data[option_name] = int(option.value)
         return slot_data
 
+    def get_filler_item_name(self) -> str:
+        return self.world.random.choice(["Card Draw", "Card Draw", "Card Draw", "Relic", "Relic"])
+
 
 def create_region(world: MultiWorld, player: int, name: str, locations=None, exits=None):
     ret = Region(name, None, name, player)


### PR DESCRIPTION
Implements the get_filler_item_name function for various games. Junk items are determined with the following methods:

ALTTP: From the "extras" lists for the specified item pool difficulty
ArchipIDLE: Any random item
FF1: 50% Heal, 25% Pure, 25% Soft
Hollow Knight: Geo Rock-Default
Minecraft: pulls from the junk weights used to normally fill out the item pool with junk
OoT: results of get_junk_item()
Rogue Legacy: random item from misc_items_table
Super Metroid: Nothing
Super Mario 64: 1Up Mushroom
Secret of Evermore: random item from the Ingredients item name group
Slay the Spire: 60% Card Draw, 40% Relic

I'd be happy to make any adjustments / remove sections if any maintainers, etc do not like these methods