### PR TITLE
[SMZ3] Fix Harmless Hellway logic

### DIFF
--- a/worlds/smz3/TotalSMZ3/Regions/Zelda/PalaceOfDarkness.py
+++ b/worlds/smz3/TotalSMZ3/Regions/Zelda/PalaceOfDarkness.py
@@ -29,7 +29,7 @@ class PalaceOfDarkness(Z3Region, IReward):
             Location(self, 256+127, 0x1EA43, LocationType.Regular, "Palace of Darkness - Compass Chest",
                 lambda items: items.KeyPD >= (4 if (items.Hammer and items.Bow and items.Lamp) or config.Keysanity else 3)),
             Location(self, 256+128, 0x1EA46, LocationType.Regular, "Palace of Darkness - Harmless Hellway",
-                lambda items: items.KeyPD >= (4 if (items.Hammer and items.Bow and items.Lamp) or config.Keysanity else 3 if 
+                lambda items: items.KeyPD >= ((4 if (items.Hammer and items.Bow and items.Lamp) or config.Keysanity else 3) if 
                         self.GetLocation("Palace of Darkness - Harmless Hellway").ItemIs(ItemType.KeyPD, self.world) else
                         6 if (items.Hammer and items.Bow and items.Lamp) or config.Keysanity else 5))
                 .AlwaysAllow(lambda item, items: item.Is(ItemType.KeyPD, self.world) and items.KeyPD >= 5),


### PR DESCRIPTION
Per discussion in #bug-reports

Original logic from SMZ3 is:

`
items.KeyPD >= (GetLocation("Palace of Darkness - Harmless Hellway").ItemIs(KeyPD, World) ?
                        (items.Hammer && items.Bow && items.Lamp) || config.Keysanity ? 4 : 3 :
                        (items.Hammer && items.Bow && items.Lamp) || config.Keysanity ? 6 : 5))
`

I believe these parentheses are needed to correctly replicate this logic

@lordlou 