### PR TITLE
Witness Hotfixes

### DIFF
--- a/worlds/witness/WitnessItems.txt
+++ b/worlds/witness/WitnessItems.txt
@@ -17,5 +17,5 @@ Boosts:
 500 - Speed Boost
 
 Traps:
-600 - Slowness Trap
-610 - Power Surge Trap
+600 - Slowness
+610 - Power Surge

--- a/worlds/witness/locations.py
+++ b/worlds/witness/locations.py
@@ -122,7 +122,6 @@ class StaticWitnessLocations:
         "Treehouse Right Orange Bridge 12",
         "Treehouse Laser",
 
-        "Mountaintop Trap Door Triple Exit",
         "Mountaintop Discard",
         "Mountaintop Vault Box",
 

--- a/worlds/witness/locations.py
+++ b/worlds/witness/locations.py
@@ -150,8 +150,6 @@ class StaticWitnessLocations:
     }
 
     HARD_LOCATIONS = {
-        "Tutorial Gate Close",
-
         "Inside Mountain Secret Area Dot Grid Triangles 4",
         "Inside Mountain Secret Area Symmetry Triangles",
         "Inside Mountain Secret Area Stars & Squares and Triangles 2",

--- a/worlds/witness/locations.py
+++ b/worlds/witness/locations.py
@@ -51,7 +51,6 @@ class StaticWitnessLocations:
         "Quarry Mill Eraser and Dots 6",
         "Quarry Mill Eraser and Squares 8",
         "Quarry Mill Small Squares & Dots & and Eraser",
-        "Quarry Mill Big Squares & Dots & and Eraser",
         "Quarry Boathouse Intro Shapers",
         "Quarry Boathouse Eraser and Shapers 5",
         "Quarry Boathouse Stars & Eraser & and Shapers 2",
@@ -140,6 +139,7 @@ class StaticWitnessLocations:
     UNCOMMON_LOCATIONS = {
         "Mountaintop River Shape",
         "Tutorial Patio Floor",
+        "Quarry Mill Big Squares & Dots & and Eraser",
         "Theater Tutorial Video",
         "Theater Desert Video",
         "Theater Jungle Video",


### PR DESCRIPTION
1. Junk items weren't generating correctly due to a naming discrepancy. This is now fixed.
2. Small oversight: A difficult optional panel was in the "general" category, which is supposed to only include required and/or easy puzzles.
3. Jarno made a major addition to the client which needs a change in generation to not break things. Specifically, it requires that the location list includes no panels where using multiple solutions on that same panel is *required* in some way.