### PR TITLE
Factorio: mapgen update

### DIFF
--- a/worlds/factorio/Options.py
+++ b/worlds/factorio/Options.py
@@ -272,11 +272,12 @@ class FactorioWorldGen(OptionDict):
                 "richness": FloatRange(0, 6)
             },
             Optional("property_expression_names"): Schema({
-                "control-setting:moisture:bias": FloatRange(-0.5, 0.5),
-                "control-setting:moisture:frequency:multiplier": FloatRange(0.166, 6),
-                "control-setting:aux:bias": FloatRange(-0.5, 0.5),
-                "control-setting:aux:frequency:multiplier": FloatRange(0.166, 6)
-            }, ignore_extra_keys=True)
+                Optional("control-setting:moisture:bias"): FloatRange(-0.5, 0.5),
+                Optional("control-setting:moisture:frequency:multiplier"): FloatRange(0.166, 6),
+                Optional("control-setting:aux:bias"): FloatRange(-0.5, 0.5),
+                Optional("control-setting:aux:frequency:multiplier"): FloatRange(0.166, 6),
+                Optional(str): object  # allow overriding all properties
+            }),
         },
         "advanced": {
             Optional("pollution"): {

--- a/worlds/factorio/Options.py
+++ b/worlds/factorio/Options.py
@@ -262,6 +262,8 @@ class FactorioWorldGen(OptionDict):
                 }
             },
             Optional("seed"): Or(None, And(int, lambda n: n >= 0)),
+            Optional("width"): And(int, lambda n: n >= 0),
+            Optional("height"): And(int, lambda n: n >= 0),
             Optional("starting_area"): FloatRange(0.166, 6),
             Optional("peaceful_mode"): LuaBool,
             Optional("cliff_settings"): {


### PR DESCRIPTION
* With `width` and `height` all keys for 'basic' map gen should be defined now. (No reason to allow arbitrary keys.)
* Remove all limitations from `property_expression_names` because it has a lot of "sub keys" that could could also be extended through other mods.

As a side-note, setting `basic.cliff_settings.cliff_elevation_0 = 99` seems to already (mostly?) disable cliffs; no need to go into property expressions.