### PR TITLE
Adding damage rando v2 options to timespinner rando

### DIFF
--- a/worlds/timespinner/Options.py
+++ b/worlds/timespinner/Options.py
@@ -1,6 +1,7 @@
 from typing import Dict, Union
 from BaseClasses import MultiWorld
 from Options import Toggle, DefaultOnToggle, DeathLink, Choice, Range, Option, OptionDict
+from schema import Schema, And
 
 class StartWithJewelryBox(Toggle):
     "Start with Jewelry Box unlocked"
@@ -67,6 +68,88 @@ class DamageRando(Choice):
 
 class DamageRandoOverrides(OptionDict):
     "Manual +/-/normal odds for each orb. Put 0 if you don't want a certain nerf or buff to be a possibility."
+    schema = Schema({
+        "Blue": { 
+            "MinusOdds": And(int, lambda n: n >= 0), 
+            "NormalOdds": And(int, lambda n: n >= 0), 
+            "PlusOdds": And(int, lambda n: n >= 0) 
+        },
+        "Blade": { 
+            "MinusOdds": And(int, lambda n: n >= 0), 
+            "NormalOdds": And(int, lambda n: n >= 0), 
+            "PlusOdds": And(int, lambda n: n >= 0) 
+        },
+        "Fire": { 
+            "MinusOdds": And(int, lambda n: n >= 0), 
+            "NormalOdds": And(int, lambda n: n >= 0), 
+            "PlusOdds": And(int, lambda n: n >= 0) 
+        },
+        "Plasma": { 
+            "MinusOdds": And(int, lambda n: n >= 0), 
+            "NormalOdds": And(int, lambda n: n >= 0), 
+            "PlusOdds": And(int, lambda n: n >= 0) 
+        },
+        "Iron": { 
+            "MinusOdds": And(int, lambda n: n >= 0), 
+            "NormalOdds": And(int, lambda n: n >= 0), 
+            "PlusOdds": And(int, lambda n: n >= 0) 
+        },
+        "Ice": { 
+            "MinusOdds": And(int, lambda n: n >= 0), 
+            "NormalOdds": And(int, lambda n: n >= 0), 
+            "PlusOdds": And(int, lambda n: n >= 0) 
+        },
+        "Wind": { 
+            "MinusOdds": And(int, lambda n: n >= 0), 
+            "NormalOdds": And(int, lambda n: n >= 0), 
+            "PlusOdds": And(int, lambda n: n >= 0) 
+        },
+        "Gun": { 
+            "MinusOdds": And(int, lambda n: n >= 0), 
+            "NormalOdds": And(int, lambda n: n >= 0), 
+            "PlusOdds": And(int, lambda n: n >= 0) 
+        },
+        "Umbra": { 
+            "MinusOdds": And(int, lambda n: n >= 0), 
+            "NormalOdds": And(int, lambda n: n >= 0), 
+            "PlusOdds": And(int, lambda n: n >= 0) 
+        },
+        "Empire": { 
+            "MinusOdds": And(int, lambda n: n >= 0), 
+            "NormalOdds": And(int, lambda n: n >= 0), 
+            "PlusOdds": And(int, lambda n: n >= 0) 
+        },
+        "Eye": { 
+            "MinusOdds": And(int, lambda n: n >= 0), 
+            "NormalOdds": And(int, lambda n: n >= 0), 
+            "PlusOdds": And(int, lambda n: n >= 0) 
+        },
+        "Blood": { 
+            "MinusOdds": And(int, lambda n: n >= 0), 
+            "NormalOdds": And(int, lambda n: n >= 0), 
+            "PlusOdds": And(int, lambda n: n >= 0) 
+        },
+        "ForbiddenTome": { 
+            "MinusOdds": And(int, lambda n: n >= 0), 
+            "NormalOdds": And(int, lambda n: n >= 0), 
+            "PlusOdds": And(int, lambda n: n >= 0) 
+        },
+        "Shattered": { 
+            "MinusOdds": And(int, lambda n: n >= 0), 
+            "NormalOdds": And(int, lambda n: n >= 0), 
+            "PlusOdds": And(int, lambda n: n >= 0) 
+        },
+        "Nether": { 
+            "MinusOdds": And(int, lambda n: n >= 0), 
+            "NormalOdds": And(int, lambda n: n >= 0), 
+            "PlusOdds": And(int, lambda n: n >= 0) 
+        },
+        "Radiant": { 
+            "MinusOdds": And(int, lambda n: n >= 0), 
+            "NormalOdds": And(int, lambda n: n >= 0), 
+            "PlusOdds": And(int, lambda n: n >= 0) 
+        },
+    })
     display_name = "Damage Rando Overrides"
     default = {
         "Blue": { "MinusOdds": 1, "NormalOdds": 1, "PlusOdds": 1 },

--- a/worlds/timespinner/Options.py
+++ b/worlds/timespinner/Options.py
@@ -110,6 +110,20 @@ class ShopMultiplier(Range):
     range_end = 10
     default = 1
 
+class LootPool(Choice):
+    """Sets the items that drop from enemies (does not apply to boss reward checks)
+    Vanilla: Drops are the same as the base game
+    Randomized: Each slot of every enemy's drop table is given a random use item or piece of equipment.
+    Empty: Enemies drop nothing."""
+    display_name = "Loot Pool"
+    option_vanilla = 0
+    option_randomized = 1
+    option_empty = 2
+
+class ShowBestiary(Toggle):
+    "All entries in the bestiary are visible, without needing to kill one of a given enemy first"
+    display_name = "Show Bestiary Entries"
+
 # Some options that are available in the timespinner randomizer arent currently implemented
 timespinner_options: Dict[str, Option] = {
     "StartWithJewelryBox": StartWithJewelryBox,
@@ -130,6 +144,8 @@ timespinner_options: Dict[str, Option] = {
     "ShopFill": ShopFill,
     "ShopWarpShards": ShopWarpShards,
     "ShopMultiplier": ShopMultiplier,
+    "LootPool": LootPool,
+    "ShowBestiary": ShowBestiary,
     "DeathLink": DeathLink,
 }
 

--- a/worlds/timespinner/Options.py
+++ b/worlds/timespinner/Options.py
@@ -1,6 +1,6 @@
-from typing import Dict
+from typing import Dict, Union
 from BaseClasses import MultiWorld
-from Options import Toggle, DefaultOnToggle, DeathLink, Choice, Range, Option
+from Options import Toggle, DefaultOnToggle, DeathLink, Choice, Range, Option, OptionDict
 
 class StartWithJewelryBox(Toggle):
     "Start with Jewelry Box unlocked"
@@ -54,9 +54,38 @@ class LoreChecks(Toggle):
     "Memories and journal entries contain items."
     display_name = "Lore Checks"
 
-class DamageRando(Toggle):
-    "Each orb has a high chance of having lower base damage and a low chance of having much higher base damage."
+class DamageRando(Choice):
+    "Randomly nerfs and buffs some orbs and their associated spells as well as some associated rings."
     display_name = "Damage Rando"
+    option_off = 0
+    option_allnerfs = 1
+    option_mostlynerfs = 2
+    option_balanced = 3
+    option_mostlybuffs = 4
+    option_allbuffs = 5
+    option_manual = 6
+
+class DamageRandoOverrides(OptionDict):
+    "Manual +/-/normal odds for each orb. Put 0 if you don't want a certain nerf or buff to be a possibility."
+    display_name = "Damage Rando Overrides"
+    default = {
+        "Blue": { "MinusOdds": 1, "NormalOdds": 1, "PlusOdds": 1 },
+        "Blade": { "MinusOdds": 1, "NormalOdds": 1, "PlusOdds": 1 },
+        "Fire": { "MinusOdds": 1, "NormalOdds": 1, "PlusOdds": 1 },
+        "Plasma": { "MinusOdds": 1, "NormalOdds": 1, "PlusOdds": 1 },
+        "Iron": { "MinusOdds": 1, "NormalOdds": 1, "PlusOdds": 1 },
+        "Ice": { "MinusOdds": 1, "NormalOdds": 1, "PlusOdds": 1 },
+        "Wind": { "MinusOdds": 1, "NormalOdds": 1, "PlusOdds": 1 },
+        "Gun": { "MinusOdds": 1, "NormalOdds": 1, "PlusOdds": 1 },
+        "Umbra": { "MinusOdds": 1, "NormalOdds": 1, "PlusOdds": 1 },
+        "Empire": { "MinusOdds": 1, "NormalOdds": 1, "PlusOdds": 1 },
+        "Eye": { "MinusOdds": 1, "NormalOdds": 1, "PlusOdds": 1 },
+        "Blood": { "MinusOdds": 1, "NormalOdds": 1, "PlusOdds": 1 },
+        "ForbiddenTome": { "MinusOdds": 1, "NormalOdds": 1, "PlusOdds": 1 },
+        "Shattered": { "MinusOdds": 1, "NormalOdds": 1, "PlusOdds": 1 },
+        "Nether": { "MinusOdds": 1, "NormalOdds": 1, "PlusOdds": 1 },
+        "Radiant": { "MinusOdds": 1, "NormalOdds": 1, "PlusOdds": 1 },
+    }
 
 class ShopFill(Choice):
     """Sets the items for sale in Merchant Crow's shops.
@@ -81,20 +110,6 @@ class ShopMultiplier(Range):
     range_end = 10
     default = 1
 
-class LootPool(Choice):
-    """Sets the items that drop from enemies (does not apply to boss reward checks)
-    Vanilla: Drops are the same as the base game
-    Randomized: Each slot of every enemy's drop table is given a random use item or piece of equipment.
-    Empty: Enemies drop nothing."""
-    display_name = "Loot Pool"
-    option_vanilla = 0
-    option_randomized = 1
-    option_empty = 2
-
-class ShowBestiary(Toggle):
-    "All entries in the bestiary are visible, without needing to kill one of a given enemy first"
-    display_name = "Show Bestiary Entries"
-
 # Some options that are available in the timespinner randomizer arent currently implemented
 timespinner_options: Dict[str, Option] = {
     "StartWithJewelryBox": StartWithJewelryBox,
@@ -111,21 +126,19 @@ timespinner_options: Dict[str, Option] = {
     "Cantoran": Cantoran,
     "LoreChecks": LoreChecks,
     "DamageRando": DamageRando,
+    "DamageRandoOverrides": DamageRandoOverrides,
     "ShopFill": ShopFill,
     "ShopWarpShards": ShopWarpShards,
     "ShopMultiplier": ShopMultiplier,
-    "LootPool": LootPool,
-    "ShowBestiary": ShowBestiary,
     "DeathLink": DeathLink,
 }
 
 def is_option_enabled(world: MultiWorld, player: int, name: str) -> bool:
     return get_option_value(world, player, name) > 0
 
-def get_option_value(world: MultiWorld, player: int, name: str) -> int:
+def get_option_value(world: MultiWorld, player: int, name: str) -> Union[int, dict]:
     option = getattr(world, name, None)
-
     if option == None:
         return 0
 
-    return int(option[player].value)
+    return option[player].value


### PR DESCRIPTION
- Added a new Option toggle for Timespinner damage rando -- instead of just on/off there are presets and also "Manual"
- If "Manual" is chosen it reads from the new DamageRandoOverrides attribute, allowing for granular setting of probabilities for each orb to be buffed, nerfed, or unaffected