### PR TITLE
Main: compress world type output log

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -86,12 +86,12 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
     numlength = 8
     for name, cls in AutoWorld.AutoWorldRegister.world_types.items():
         if not cls.hidden:
-            logger.info(f"  {name:{longest_name}}: {len(cls.item_names):3} Items | "
-                        f"{len(cls.location_names):3} Locations")
-            logger.info(f"   Item IDs: {min(cls.item_id_to_name):{numlength}} - "
-                        f"{max(cls.item_id_to_name):{numlength}} | "
-                        f"Location IDs: {min(cls.location_id_to_name):{numlength}} - "
-                        f"{max(cls.location_id_to_name):{numlength}}")
+            logger.info(f"  {name:{longest_name}}: {len(cls.item_names):3} "
+                        f"Items (IDs: {min(cls.item_id_to_name):{numlength}} - "
+                        f"{max(cls.item_id_to_name):{numlength}}) | "
+                        f"{len(cls.location_names):3} "
+                        f"Locations (IDs: {min(cls.location_id_to_name):{numlength}} - "
+                        f"{max(cls.location_id_to_name):{numlength}})")
 
     AutoWorld.call_stage(world, "assert_generate")
 


### PR DESCRIPTION
From: 
```
Found World Types:
  A Link to the Past      : 144 Items | 287 Locations
   Item IDs:        2 -      180 | Location IDs:    59758 -  4194341
  ArchipIDLE              : 300 Items | 100 Locations
   Item IDs:     9000 -     9299 | Location IDs:     9000 -     9099
  ChecksFinder            :   3 Items |  25 Locations
   Item IDs:    80000 -    80002 | Location IDs:    81000 -    81024
  Factorio                : 222 Items | 183 Locations
   Item IDs:   131070 -   131292 | Location IDs:   131072 -   131254
  Final Fantasy           : 192 Items | 255 Locations
   Item IDs:      256 -      498 | Location IDs:      257 -      767
  Hollow Knight           : 249 Items | 740 Locations
   Item IDs: 16777216 - 16777464 | Location IDs: 16777216 - 16777955
  Meritous                :  23 Items | 104 Locations
   Item IDs:   593000 -   593022 | Location IDs:   593000 -   593103
  Minecraft               :  45 Items | 103 Locations
   Item IDs:    45000 -    45100 | Location IDs:    42000 -    42102
  Ocarina of Time         : 148 Items | 663 Locations               
   Item IDs:    66001 -    66202 | Location IDs:    67010 -    67673
  Raft                    : 228 Items | 116 Locations               
   Item IDs:    47001 -    47228 | Location IDs:    48001 -    48117
  Rogue Legacy            :  76 Items | 844 Locations               
   Item IDs:    90000 -    90097 | Location IDs:    91000 -    92259
  Risk of Rain 2          :  11 Items | 500 Locations               
   Item IDs:    37001 -    37011 | Location IDs:    37006 -    37505
  Sonic Adventure 2 Battle:  30 Items | 193 Locations               
   Item IDs: 16711680 - 16711709 | Location IDs: 16711680 - 16711880
  Super Metroid           :  30 Items | 105 Locations               
   Item IDs:    83000 -    83037 | Location IDs:    82000 -    82260
  Super Mario 64          :  18 Items | 135 Locations               
   Item IDs:  3626000 -  3626214 | Location IDs:  3626000 -  3626214
  SMZ3                    : 147 Items | 316 Locations               
   Item IDs:    84000 -    84223 | Location IDs:    85000 -    85510
  Secret of Evermore      : 155 Items | 337 Locations               
   Item IDs:    64000 -    64904 | Location IDs:    64000 -    64384
  Slay the Spire          :   4 Items |  31 Locations               
   Item IDs:     8000 -     8003 | Location IDs:    19001 -    22003
  Subnautica              :  81 Items | 130 Locations               
   Item IDs:    35000 -    35080 | Location IDs:    33000 -    33129
  Timespinner             : 181 Items | 212 Locations               
   Item IDs:  1337000 -  1337249 | Location IDs:  1337000 -  1337249
  VVVVVV                  :  20 Items |  20 Locations               
   Item IDs:  2515000 -  2515019 | Location IDs:  2515000 -  2515019
  The Witness             :  16 Items | 583 Locations
   Item IDs:   158000 -   158610 | Location IDs:   158000 -   158712
```
to:
```
Found World Types:
  A Link to the Past      : 144 Items (IDs:        2 -      180) | 287 Locations (IDs:    59758 -  4194341)
  ArchipIDLE              : 300 Items (IDs:     9000 -     9299) | 100 Locations (IDs:     9000 -     9099)
  ChecksFinder            :   3 Items (IDs:    80000 -    80002) |  25 Locations (IDs:    81000 -    81024)
  Factorio                : 222 Items (IDs:   131070 -   131292) | 183 Locations (IDs:   131072 -   131254)
  Final Fantasy           : 192 Items (IDs:      256 -      498) | 255 Locations (IDs:      257 -      767)
  Hollow Knight           : 249 Items (IDs: 16777216 - 16777464) | 740 Locations (IDs: 16777216 - 16777955)
  Meritous                :  23 Items (IDs:   593000 -   593022) | 104 Locations (IDs:   593000 -   593103)
  Minecraft               :  45 Items (IDs:    45000 -    45100) | 103 Locations (IDs:    42000 -    42102)
  Ocarina of Time         : 148 Items (IDs:    66001 -    66202) | 663 Locations (IDs:    67010 -    67673)
  Raft                    : 228 Items (IDs:    47001 -    47228) | 116 Locations (IDs:    48001 -    48117)
  Rogue Legacy            :  76 Items (IDs:    90000 -    90097) | 844 Locations (IDs:    91000 -    92259)
  Risk of Rain 2          :  11 Items (IDs:    37001 -    37011) | 500 Locations (IDs:    37006 -    37505)
  Sonic Adventure 2 Battle:  30 Items (IDs: 16711680 - 16711709) | 193 Locations (IDs: 16711680 - 16711880)
  Super Metroid           :  30 Items (IDs:    83000 -    83037) | 105 Locations (IDs:    82000 -    82260)
  Super Mario 64          :  18 Items (IDs:  3626000 -  3626214) | 135 Locations (IDs:  3626000 -  3626214)
  SMZ3                    : 147 Items (IDs:    84000 -    84223) | 316 Locations (IDs:    85000 -    85510)
  Secret of Evermore      : 155 Items (IDs:    64000 -    64904) | 337 Locations (IDs:    64000 -    64384)
  Slay the Spire          :   4 Items (IDs:     8000 -     8003) |  31 Locations (IDs:    19001 -    22003)
  Subnautica              :  81 Items (IDs:    35000 -    35080) | 130 Locations (IDs:    33000 -    33129)
  Timespinner             : 181 Items (IDs:  1337000 -  1337249) | 212 Locations (IDs:  1337000 -  1337249)
  VVVVVV                  :  20 Items (IDs:  2515000 -  2515019) |  20 Locations (IDs:  2515000 -  2515019)
  The Witness             :  16 Items (IDs:   158000 -   158610) | 583 Locations (IDs:   158000 -   158712)
```
Which gives 107 characters per line, which is still below the recommended limit of 120