### PR TITLE
Witness Emergency hotfix: Game-breaking bug

### DIFF
--- a/worlds/witness/locations.py
+++ b/worlds/witness/locations.py
@@ -130,7 +130,7 @@ class StaticWitnessLocations:
         "Inside Mountain Physically Obstructed 3",
         "Inside Mountain Angled Inside Trash 2",
         "Inside Mountain Color Cycle 5",
-        "Inside Mountain Same Solution 6",
+        # "Inside Mountain Same Solution 6",
         "Inside Mountain Elevator Discard",
         "Inside Mountain Giant Puzzle",
     }


### PR DESCRIPTION
We discovered a bug with the client that can completely softlock you out of completing the game if you "do a check the wrong way".

For now, we'll take this location out of the game, and then discuss how we can put it back in safely at a later point.