### PR TITLE
Adding in error message for FF1 if player name is empty in the ROM

### DIFF
--- a/FF1Client.py
+++ b/FF1Client.py
@@ -187,6 +187,9 @@ async def nes_sync_task(ctx: FF1Context):
                         asyncio.create_task(parse_locations(data_decoded['locations'], ctx, False))
                     if not ctx.auth:
                         ctx.auth = ''.join([chr(i) for i in data_decoded['playerName'] if i != 0])
+                        if ctx.auth == '':
+                            logger.info("Invalid ROM detected. No player name built into the ROM. Please regenerate"
+                                        "the ROM using the same link but adding your slot name")
                         if ctx.awaiting_rom:
                             await ctx.server_auth(False)
                 except asyncio.TimeoutError:


### PR DESCRIPTION
Specifically check for an empty string and give a helpful error message