### PR TITLE
Block collection of Sahasrahlah.

### DIFF
--- a/SNIClient.py
+++ b/SNIClient.py
@@ -530,7 +530,8 @@ boss_locations = {Regions.lookup_name_to_id[name] for name in {'Eastern Palace -
                                                                            "Thieves' Town - Boss",
                                                                            'Ice Palace - Boss',
                                                                            'Misery Mire - Boss',
-                                                                           'Turtle Rock - Boss'}}
+                                                                           'Turtle Rock - Boss',
+                                                                           'Sahasrahla'}}
 
 location_table_uw_id = {Regions.lookup_name_to_id[name]: data for name, data in location_table_uw.items()}
 
@@ -974,8 +975,9 @@ async def track_locations(ctx: Context, roomid, roomdata):
             for location_id, mask in location_table_npc_id.items():
                 if npc_value & mask != 0 and location_id not in ctx.locations_checked:
                     new_check(location_id)
-                if ctx.allow_collect and location_id in ctx.checked_locations and location_id not in ctx.locations_checked \
-                        and location_id in ctx.locations_info and ctx.locations_info[location_id].player != ctx.slot:
+                if ctx.allow_collect and location_id not in boss_locations and location_id in ctx.checked_locations \
+                        and location_id not in ctx.locations_checked and location_id in ctx.locations_info \
+                        and ctx.locations_info[location_id].player != ctx.slot:
                     npc_value |= mask
                     npc_value_changed = True
             if npc_value_changed:


### PR DESCRIPTION
Since it is impossible to determine which dungeon to reveal, like it is impossible to determine which prize to auto-collect if the boss itself was collected, without reading the rom,  I have to block collection of Sahasrahlah like I do with blocking of boss items.