### PR TITLE
WebHost: Add tooltip for Plando Options on the Generate page.

### DIFF
--- a/WebHostLib/templates/generate.html
+++ b/WebHostLib/templates/generate.html
@@ -163,6 +163,10 @@
                                     <tr>
                                         <td>
                                             <label for="plando_options">Plando Options:</label>
+                                            <span
+                                                class="interactive"
+                                                data-tooltip="Allows players to plan some of the randomization. See the 'Archipelago Plando Guide' in 'Setup Guides' for more information.">(?)
+                                            </span>
                                         </td>
                                         <td>
                                             <input type="checkbox" name="plando_bosses" value="bosses" checked>


### PR DESCRIPTION
Just a simple, "this is what it does, go see this guide for more info." basically for those not familiar with it, but are curious what it does.

![image](https://user-images.githubusercontent.com/11338376/169727518-2063b9d1-6421-4569-b221-aae6b223d2b5.png)