### PR TITLE
v6,sm64ex: Use standard Death Link option name

### DIFF
--- a/worlds/sm64ex/Options.py
+++ b/worlds/sm64ex/Options.py
@@ -45,6 +45,6 @@ sm64_options: typing.Dict[str,type(Option)] = {
     "StrictCannonRequirements": StrictCannonRequirements,
     "StarsToFinish": StarsToFinish,
     "ExtraStars": ExtraStars,
-    "DeathLink": DeathLink,
+    "death_link": DeathLink,
     "BuddyChecks": BuddyChecks,
 } 

--- a/worlds/sm64ex/__init__.py
+++ b/worlds/sm64ex/__init__.py
@@ -111,7 +111,7 @@ class SM64World(World):
         return {
             "AreaRando": self.area_connections,
             "StarsToFinish": self.world.StarsToFinish[self.player].value,
-            "DeathLink": self.world.DeathLink[self.player].value,
+            "DeathLink": self.world.death_link[self.player].value,
         }
 
     def generate_output(self, output_directory: str):

--- a/worlds/v6/Options.py
+++ b/worlds/v6/Options.py
@@ -30,6 +30,6 @@ v6_options: typing.Dict[str,type(Option)] = {
     "AreaRandomizer": AreaRandomizer,
     "DoorCost": DoorCost,
     "AreaCostRandomizer": AreaCostRandomizer,
-    "DeathLink": DeathLink,
+    "death_link": DeathLink,
     "DeathLinkAmnesty": DeathLinkAmnesty
 }

--- a/worlds/v6/__init__.py
+++ b/worlds/v6/__init__.py
@@ -71,7 +71,7 @@ class V6World(World):
             "AreaRando": self.area_connections,
             "DoorCost": self.world.DoorCost[self.player].value,
             "AreaCostRando": self.area_cost_map,
-            "DeathLink": self.world.DeathLink[self.player].value,
+            "DeathLink": self.world.death_link[self.player].value,
             "DeathLink_Amnesty": self.world.DeathLinkAmnesty[self.player].value
         }
 


### PR DESCRIPTION
I was asked a while ago whether or not I was OK with this change, but I guess whoever asked never implemented it.