### PR TITLE
SC2: Updated webhost details page

### DIFF
--- a/worlds/sc2wol/docs/en_Starcraft 2 Wings of Liberty.md
+++ b/worlds/sc2wol/docs/en_Starcraft 2 Wings of Liberty.md
@@ -8,9 +8,7 @@ config file.
 ## What does randomization do to this game?
 
 Items which the player would normally acquire throughout the game have been moved around. Logic remains, so the game is
-always able to be completed, but because of the item shuffle the player may need to access certain areas before they
-would in the vanilla game. All rings and spells are also randomized into those item locations, therefore you can no
-longer craft them at the alchemist
+always able to be completed.  Options exist to also shuffle around the mission order of the campaign.
 
 ## What is the goal of Starcraft 2 when randomized?
 
@@ -20,6 +18,12 @@ The goal remains unchanged. Beat the final mission All In.
 
 Unit unlocks, upgrade unlocks, armory upgrades, laboratory researches, and mercenary unlocks can be shuffled, and all
 bonus objectives, side missions, mission completions are now locations that can contain these items.
+
+## What has been changed from vanilla Starcraft 2?
+
+Some missions have been given more vespene gas available to mine to allow for a wider variety of unit compositions on 
+those missions.  Starports no longer require Factories in order to be built.  In 'A Sinister Turn' and 'Echoes 
+of the Future', you can research protoss air armor and weapon upgrades.
 
 ## Which items can be in another player's world?
 


### PR DESCRIPTION
Removed some Timespinner copy-pasta in the webhost page and added details on what has been changed in the campaign.