### PR TITLE
SC2: Fixed issue in random mission order with some missions being available too early

### DIFF
--- a/worlds/sc2wol/Regions.py
+++ b/worlds/sc2wol/Regions.py
@@ -204,7 +204,7 @@ def create_regions(world: MultiWorld, player: int, locations: Tuple[LocationData
             mission_req_table.update({missions[i]: MissionInfo(
                 vanilla_mission_req_table[missions[i]].id, vanilla_mission_req_table[missions[i]].extra_locations,
                 connections, completion_critical=vanilla_shuffle_order[i].completion_critical,
-                or_requirements=vanilla_shuffle_order[i].or_requirements)})
+                number=vanilla_shuffle_order[i].number, or_requirements=vanilla_shuffle_order[i].or_requirements)})
 
         return mission_req_table
 


### PR DESCRIPTION
Random mission order generation was not properly passing the number property of MissionInfo meaning all missions defaulted assumed that they only needed one mission complete to be available (in addition to the normal mission prerequisite).