### PR TITLE
Tests: add test to check for typo'd item name group definitions

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1778,7 +1778,8 @@ class ServerCommandProcessor(CommonCommandProcessor):
                 if item in world.item_name_groups:
                     hints = []
                     for item in world.item_name_groups[item]:
-                        hints.extend(collect_hints(self.ctx, team, slot, item))
+                        if item in world.item_name_to_id:  # ensure item has an ID
+                            hints.extend(collect_hints(self.ctx, team, slot, item))
                 else:  # item name
                     hints = collect_hints(self.ctx, team, slot, item)
 

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1276,7 +1276,8 @@ class ClientMessageProcessor(CommonCommandProcessor):
                 elif not for_location and hint_name in world.item_name_groups:  # item group name
                     hints = []
                     for item in world.item_name_groups[hint_name]:
-                        hints.extend(collect_hints(self.ctx, self.client.team, self.client.slot, item))
+                        if item in world.item_name_to_id:  # ensure item has an ID
+                            hints.extend(collect_hints(self.ctx, self.client.team, self.client.slot, item))
                 elif not for_location and hint_name in world.item_names:  # item name
                     hints = collect_hints(self.ctx, self.client.team, self.client.slot, hint_name)
                 else:  # location name

--- a/test/general/TestItems.py
+++ b/test/general/TestItems.py
@@ -10,3 +10,22 @@ class TestBase(unittest.TestCase):
                 with self.subTest("Create Item", item_name=item_name, game_name=game_name):
                     item = proxy_world.create_item(item_name)
                     self.assertEqual(item.name, item_name)
+
+    def testItemNameGroupHasValidItem(self):
+        """Test that all item name groups contain valid items. """
+        # This cannot test for Event names that you may have declared for logic, only sendable Items.
+        # In such a case, you can add your entries to this Exclusion dict. Game Name -> Group Names
+        exclusion_dict = {
+            "A Link to the Past":
+                {"Pendants", "Crystals"},
+            "Starcraft 2 Wings of Liberty":
+                {"Missions"},
+        }
+        for game_name, world_type in AutoWorldRegister.world_types.items():
+            with self.subTest(game_name, game_name=game_name):
+                exclusions = exclusion_dict.get(game_name, frozenset())
+                for group_name, items in world_type.item_name_groups.items():
+                    if group_name not in exclusions:
+                        with self.subTest(group_name, group_name=group_name):
+                            for item in items:
+                                self.assertIn(item, world_type.item_name_to_id)

--- a/worlds/factorio/__init__.py
+++ b/worlds/factorio/__init__.py
@@ -52,7 +52,7 @@ class Factorio(World):
     item_name_to_id = all_items
     location_name_to_id = base_tech_table
     item_name_groups = {
-        "Progressive": set(progressive_tech_table.values()),
+        "Progressive": set(progressive_tech_table.keys()),
     }
     data_version = 5
     required_client_version = (0, 3, 0)


### PR DESCRIPTION
Factorio: item *name* group was pointing to IDs instead.
Server: prevent crash when using Event-filled item name group