### PR TITLE
config: Use valid default enemizer_path on Linux (and Windows)

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -255,7 +255,7 @@ def get_default_options() -> dict:
         },
         "generator": {
             "teams": 1,
-            "enemizer_path": os.path.join("EnemizerCLI", "EnemizerCLI.Core.exe"),
+            "enemizer_path": os.path.join("EnemizerCLI", "EnemizerCLI.Core"),
             "player_files_path": "Players",
             "players": 0,
             "weights_file_path": "weights.yaml",

--- a/host.yaml
+++ b/host.yaml
@@ -56,7 +56,7 @@ server_options:
 # Options for Generation
 generator:
   # Location of your Enemizer CLI, available here: https://github.com/Ijwu/Enemizer/releases
-  enemizer_path: "EnemizerCLI/EnemizerCLI.Core.exe"
+  enemizer_path: "EnemizerCLI/EnemizerCLI.Core" # + ".exe" is implied on Windows
   # Folder from which the player yaml files are pulled from
   player_files_path: "Players"
   #amount of players, 0 to infer from player files

--- a/setup.py
+++ b/setup.py
@@ -219,7 +219,6 @@ class BuildExeCommand(cx_Freeze.dist.build_exe):
             host_yaml = self.buildfolder / 'host.yaml'
             with host_yaml.open('r+b') as f:
                 data = f.read()
-                data = data.replace(b'EnemizerCLI.Core.exe', b'EnemizerCLI.Core')
                 data = data.replace(b'factorio\\\\bin\\\\x64\\\\factorio', b'factorio/bin/x64/factorio')
                 f.seek(0, os.SEEK_SET)
                 f.write(data)


### PR DESCRIPTION
After extracting the latest Enemizer release to the expected path (EnemizerCLI in the root),
Generate.py runs into the following exception on Linux:

`Exception: Enemizer not found at /home/p/archipelago/EnemizerCLI/EnemizerCLI.Core.exe, please install it.Such as https://github.com/Ijwu/Enemizer/releases`

This is because the default value of enemizer_path is `"EnemizerCLI/EnemizerCLI.Core.exe"`.
Removing the ".exe" from this default value works on both Linux and Windows, since `subprocess.Popen`, like a cmd prompt, accepts an exe path string that omits the final ".exe"

Notes:
- Custom configs will continue working (".exe" is fine on Windows).
- worlds/alttp/Rom.py is already set up to check for {enemizer_path} OR {enemizer_path}.exe on Windows.