### PR TITLE
Better UX, AppImage and setup.py

### DIFF
--- a/Launcher.py
+++ b/Launcher.py
@@ -20,7 +20,6 @@ from Utils import is_frozen, user_path, local_path, init_logging, open_filename,
 from shutil import which
 import shlex
 from enum import Enum, auto
-import logging
 
 
 def open_host_yaml():
@@ -38,22 +37,16 @@ def open_host_yaml():
 
 
 def open_patch():
+    suffixes = []
+    for c in components:
+        if isfile(get_exe(c)[-1]):
+            suffixes += c.file_identifier.suffixes if c.type == Type.CLIENT and \
+                                                      isinstance(c.file_identifier, SuffixIdentifier) else []
     try:
-        import tkinter
-        import tkinter.filedialog
+        filename = open_filename('Select patch', (('Patches', suffixes),))
     except Exception as e:
-        logging.error("Could not load tkinter, which is likely not installed. "
-                      "This attempt was made because Launcher.open_patch was used.")
-        raise e
+        messagebox('Error', str(e), error=True)
     else:
-        root = tkinter.Tk()
-        root.withdraw()
-        suffixes = []
-        for c in components:
-            if isfile(get_exe(c)[-1]):
-                suffixes += c.file_identifier.suffixes if c.type == Type.CLIENT and \
-                                                          isinstance(c.file_identifier, SuffixIdentifier) else []
-        filename = tkinter.filedialog.askopenfilename(filetypes=(('Patches', ' '.join(suffixes)),))
         file, _, component = identify(filename)
         if file and component:
             launch([*get_exe(component), file], component.cli)

--- a/Launcher.py
+++ b/Launcher.py
@@ -15,16 +15,12 @@ import sys
 from typing import Iterable, Sequence, Callable, Union, Optional
 import subprocess
 import itertools
-from Utils import is_frozen, user_path, local_path, init_logging
+from Utils import is_frozen, user_path, local_path, init_logging, open_filename, messagebox,\
+    is_windows, is_macos, is_linux
 from shutil import which
 import shlex
 from enum import Enum, auto
 import logging
-
-
-is_linux = sys.platform.startswith('linux')
-is_macos = sys.platform == 'darwin'
-is_windows = sys.platform in ("win32", "cygwin", "msys")
 
 
 def open_host_yaml():

--- a/MinecraftClient.py
+++ b/MinecraftClient.py
@@ -13,12 +13,12 @@ import logging
 import requests
 
 import Utils
+from Utils import is_windows
 
 atexit.register(input, "Press enter to exit.")
 
 # 1 or more digits followed by m or g, then optional b
 max_heap_re = re.compile(r"^\d+[mMgG][bB]?$")
-is_windows = sys.platform in ("win32", "cygwin", "msys")
 
 
 def prompt_yes_no(prompt):

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1945,18 +1945,8 @@ async def main(args: argparse.Namespace):
 
     try:
         if not data_filename:
-            try:
-                import tkinter
-                import tkinter.filedialog
-            except Exception as e:
-                logging.error("Could not load tkinter, which is likely not installed. "
-                              "This attempt was made because no .archipelago file was provided as argument. "
-                              "Either provide a file or ensure the tkinter package is installed.")
-                raise e
-            else:
-                root = tkinter.Tk()
-                root.withdraw()
-                data_filename = tkinter.filedialog.askopenfilename(filetypes=(("Multiworld data", "*.archipelago *.zip"),))
+            filetypes = (("Multiworld data", (".archipelago", ".zip")),)
+            data_filename = Utils.open_filename("Select multiworld data", filetypes)
 
         ctx.load(data_filename, args.use_embedded_options)
 

--- a/Utils.py
+++ b/Utils.py
@@ -519,3 +519,30 @@ def get_fuzzy_results(input_word: str, wordlist: typing.Sequence[str], limit: ty
                 reverse=True)[0:limit]
         )
     )
+
+
+def messagebox(title: str, text: str, error: bool = False) -> None:
+    def is_kivy_running():
+        if 'kivy' in sys.modules:
+            from kivy.app import App
+            return App.get_running_app() is not None
+        return False
+
+    if is_kivy_running():
+        from kvui import MessageBox
+        MessageBox(title, text, error).open()
+        return
+
+    # fall back to tk
+    try:
+        import tkinter
+        from tkinter.messagebox import showerror, showinfo
+    except Exception as e:
+        logging.error('Could not load tkinter, which is likely not installed. '
+                      f'This attempt was made because messagebox was used for "{title}".')
+        raise e
+    else:
+        root = tkinter.Tk()
+        root.withdraw()
+        showerror(title, text) if error else showinfo(title, text)
+        root.update()

--- a/Utils.py
+++ b/Utils.py
@@ -32,6 +32,10 @@ class Version(typing.NamedTuple):
 __version__ = "0.3.2"
 version_tuple = tuplize_version(__version__)
 
+is_linux = sys.platform.startswith('linux')
+is_macos = sys.platform == 'darwin'
+is_windows = sys.platform in ("win32", "cygwin", "msys")
+
 import jellyfish
 from yaml import load, load_all, dump, SafeLoader
 

--- a/kvui.py
+++ b/kvui.py
@@ -38,6 +38,7 @@ from kivy.uix.behaviors import FocusBehavior
 from kivy.uix.recycleboxlayout import RecycleBoxLayout
 from kivy.uix.recycleview.layout import LayoutSelectionBehavior
 from kivy.animation import Animation
+from kivy.uix.popup import Popup
 
 fade_in_animation = Animation(opacity=0, duration=0) + Animation(opacity=1, duration=0.25)
 
@@ -266,6 +267,25 @@ class ConnectBarTextInput(TextInput):
     def insert_text(self, substring, from_undo=False):
         s = substring.replace('\n', '').replace('\r', '')
         return super(ConnectBarTextInput, self).insert_text(s, from_undo=from_undo)
+
+
+class MessageBox(Popup):
+    class MessageBoxLabel(Label):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self._label.refresh()
+            self.size = self._label.texture.size
+            if self.width + 50 > Window.width:
+                self.text_size[0] = Window.width - 50
+                self._label.refresh()
+                self.size = self._label.texture.size
+
+    def __init__(self, title, text, error=False, **kwargs):
+        label = MessageBox.MessageBoxLabel(text=text)
+        separator_color = [217 / 255, 129 / 255, 122 / 255, 1.] if error else [47 / 255., 167 / 255., 212 / 255, 1.]
+        super().__init__(title=title, content=label, size_hint=(None, None), width=max(100, int(label.width)+40),
+                         separator_color=separator_color, **kwargs)
+        self.height += max(0, label.height - 18)
 
 
 class GameManager(App):

--- a/setup.py
+++ b/setup.py
@@ -267,7 +267,7 @@ match="${{1#--executable=}}"
 if [ "${{#match}}" -lt "${{#1}}" ]; then
     exe="$match"
     shift
-elif [ "$1" == "-executable" ] || [ "$1" == "--executable" ]; then
+elif [ "$1" = "-executable" ] || [ "$1" = "--executable" ]; then
     exe="$2"
     shift; shift
 fi
@@ -355,7 +355,7 @@ cx_Freeze.setup(
             "optimize": 1,
             "build_exe": buildfolder,
             "extra_data": extra_data,
-            "bin_includes": [] if is_windows else ["libffi.so"]
+            "bin_includes": [] if is_windows else ["libffi.so", "libcrypt.so"]
         },
         "bdist_appimage": {
            "build_folder": buildfolder,

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from Launcher import components, icon_paths
 # This is a bit jank. We need cx-Freeze to be able to run anything from this script, so install it
 import subprocess
 import pkg_resources
-requirement = 'cx-Freeze>=6.10'
+requirement = 'cx-Freeze>=6.11'
 try:
     pkg_resources.require(requirement)
     import cx_Freeze
@@ -67,7 +67,7 @@ def _threaded_hash(filepath):
 
 
 # cx_Freeze's build command runs other commands. Override to accept --yes and store that.
-class BuildCommand(cx_Freeze.dist.build):
+class BuildCommand(cx_Freeze.command.build.Build):
     user_options = [
         ('yes', 'y', 'Answer "yes" to all questions.'),
     ]
@@ -84,8 +84,8 @@ class BuildCommand(cx_Freeze.dist.build):
 
 
 # Override cx_Freeze's build_exe command for pre and post build steps
-class BuildExeCommand(cx_Freeze.dist.build_exe):
-    user_options = cx_Freeze.dist.build_exe.user_options + [
+class BuildExeCommand(cx_Freeze.command.build_exe.BuildEXE):
+    user_options = cx_Freeze.command.build_exe.BuildEXE.user_options + [
         ('yes', 'y', 'Answer "yes" to all questions.'),
         ('extra-data=', None, 'Additional files to add.'),
     ]

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from hashlib import sha3_512
 import base64
 import datetime
-from Utils import version_tuple
+from Utils import version_tuple, is_windows
 from collections.abc import Iterable
 import typing
 import setuptools
@@ -39,7 +39,6 @@ else:
 arch_folder = "exe.{platform}-{version}".format(platform=sysconfig.get_platform(),
                                                 version=sysconfig.get_python_version())
 buildfolder = Path("build", arch_folder)
-is_windows = sys.platform in ("win32", "cygwin", "msys")
 
 
 # see Launcher.py on how to add scripts to setup.py


### PR DESCRIPTION
Sorry to merge 3 things into one PR

* cx_Freeze 6.11 requires changes to the build commands. Because of the `>=6.10` we had previously this will break current setup.py, which is required to use/test the AppImage. Commit# 1e28a3d replaces commit# f9b12b5
* Better AppImage compatibility:
  * the start script did not work for Linux flavours with a shell that is strictly posix compliant
  * we now package one more library, that may be too different between build and user OS
* Better UX for Launcher.py and MultiServer.py:
  * kvui.MessageBox: this is required to show errors in Launcher.py. I also added a messagebox function to Utils.py that either uses kivy or falls back to tkinter, so we can use a single function call and get nice UX
  * Utils.open_filename: tk does not look native on Linux, so we default to zenity and kdialog now, which are the "command line dialog helpers" for Gnome and KDE respectively. This also removes tk boiler plate from where it is called.