### PR TITLE
ALTTP: Updates to setup documents

### DIFF
--- a/worlds/alttp/docs/multiworld_de.md
+++ b/worlds/alttp/docs/multiworld_de.md
@@ -83,7 +83,7 @@ tun.
 
 Wenn du an einem MultiWorld-Spiel teilnehmen möchtest, wirst du in der Regel vom Host nach deiner YAML-Datei gefragt.
 Sobald du diese weitergegeben hast, wird der Host einen Link bereitstellen, wo du deinen Patch oder eine .zip-Datei mit
-allen Patches herunterladen kannst. Die Patch-Datei hat immer die Endung `.apbp`.
+allen Patches herunterladen kannst. Die Patch-Datei hat immer die Endung `.aplttp`.
 
 ### Mit dem Client verbinden
 

--- a/worlds/alttp/docs/multiworld_en.md
+++ b/worlds/alttp/docs/multiworld_en.md
@@ -66,7 +66,7 @@ If you would like to validate your config file to make sure it works, you may do
 
 When you join a multiworld game, you will be asked to provide your config file to whoever is hosting. Once that is done,
 the host will provide you with either a link to download your patch file, or with a zip file containing everyone's patch
-files. Your patch file should have a `.apbp` extension.
+files. Your patch file should have a `.aplttp` extension.
 
 Put your patch file on your desktop or somewhere convenient, and double click it. This should automatically launch the
 client, and will also create your ROM in the same place as your patch file.

--- a/worlds/alttp/docs/multiworld_es.md
+++ b/worlds/alttp/docs/multiworld_es.md
@@ -99,7 +99,7 @@ Si quieres validar que tu fichero YAML para asegurarte que funciona correctament
 
 Cuando te unes a una partida multiworld, debes proveer tu fichero YAML a quien sea el creador de la partida. Una vez
 este hecho, el creador te devolverá un enlace para descargar el parche o un fichero zip conteniendo todos los ficheros
-de parche de la partida Tu fichero de parche debe tener la extensión `.bmbp`.
+de parche de la partida Tu fichero de parche debe tener la extensión `.aplttp`.
 
 Pon tu fichero de parche en el escritorio o en algún sitio conveniente, y haz doble click. Esto debería ejecutar
 automáticamente el cliente, y ademas creara la rom en el mismo directorio donde este el fichero de parche.

--- a/worlds/alttp/docs/multiworld_fr.md
+++ b/worlds/alttp/docs/multiworld_fr.md
@@ -99,7 +99,7 @@ Si vous voulez valider votre fichier YAML pour être sûr qu'il fonctionne, vous
 
 Quand vous rejoignez un multiworld, il vous sera demandé de fournir votre fichier YAML à celui qui héberge la partie ou
 s'occupe de la génération. Une fois cela fait, l'hôte vous fournira soit un lien pour télécharger votre patch, soit un
-fichier `.zip` contenant les patchs de tous les joueurs. Votre patch devrait avoir l'extension `.bmbp`.
+fichier `.zip` contenant les patchs de tous les joueurs. Votre patch devrait avoir l'extension `.aplttp`.
 
 Placez votre patch sur votre bureau ou dans un dossier simple d'accès, et double-cliquez dessus. Cela devrait lancer
 automatiquement le client, et devrait créer la ROM dans le même dossier que votre patch.


### PR DESCRIPTION
Docs reference `.bmbp` or `.apbp` instead of `.aplttp`. Updated those references.

Also remove references to Z3 and SNC in English doc, thanks @alwaysintreble 
~~Best of luck with the other langs~~