### PR TITLE
WebHost: Allow "random" to be default option for toggles and choices.

### DIFF
--- a/WebHostLib/options.py
+++ b/WebHostLib/options.py
@@ -89,6 +89,9 @@ def create():
                     "value": "random",
                 })
 
+                if option.default == "random":
+                    this_option["defaultValue"] = "random"
+
             elif hasattr(option, "range_start") and hasattr(option, "range_end"):
                 game_options[option_name] = {
                     "type": "range",

--- a/WebHostLib/options.py
+++ b/WebHostLib/options.py
@@ -97,7 +97,8 @@ def create():
                     "type": "range",
                     "displayName": option.display_name if hasattr(option, "display_name") else option_name,
                     "description": option.__doc__ if option.__doc__ else "Please document me!",
-                    "defaultValue": option.default if hasattr(option, "default") else option.range_start,
+                    "defaultValue": option.default if hasattr(
+                        option, "default") and option.default != "random" else option.range_start,
                     "min": option.range_start,
                     "max": option.range_end,
                 }

--- a/WebHostLib/templates/options.yaml
+++ b/WebHostLib/templates/options.yaml
@@ -48,7 +48,7 @@ requires:
     {%- endfor -%}
     {% if option.default == "random" %}
     random: 50
-    {% endif %}
+    {%- endif -%}
     {%- else %}
     {{ yaml_dump(default_converter(option.default)) | indent(4, first=False) }}
   {%- endif -%}

--- a/WebHostLib/templates/options.yaml
+++ b/WebHostLib/templates/options.yaml
@@ -46,6 +46,9 @@ requires:
     {%- for suboption_option_id, sub_option_name in option.name_lookup.items() %}
     {{ sub_option_name }}: {% if suboption_option_id == option.default %}50{% else %}0{% endif %}
     {%- endfor -%}
+    {% if option.default == "random" %}
+    random: 50
+    {% endif %}
     {%- else %}
     {{ yaml_dump(default_converter(option.default)) | indent(4, first=False) }}
   {%- endif -%}

--- a/worlds/rogue-legacy/Options.py
+++ b/worlds/rogue-legacy/Options.py
@@ -12,7 +12,7 @@ class StartingGender(Choice):
     option_lady = 1
     alias_male = 0
     alias_female = 1
-    default = 0
+    default = "random"
 
 
 class StartingClass(Choice):


### PR DESCRIPTION
Makes some changes to the WebHost to allow game implementations to define `"random"` as the default value for Choice-derived or Toggle-derived options and sets it as the default on Game Settings pages. Also adds it as the default option in the template files.

Example from Rogue Legacy Options.py:
```py
class StartingGender(Choice):
    """
    Determines the gender of your initial 'Sir Lee' character.
    """
    display_name = "Starting Gender"
    option_sir = 0
    option_lady = 1
    alias_male = 0
    alias_female = 1
    default = "random"
```

What the default option looks like on the Settings Page:
![image](https://user-images.githubusercontent.com/11338376/173198827-30e12ee5-17ac-4e6b-95b5-22e5d7f0b9fd.png)

What the default options look like in the Template file:
```yaml
Rogue Legacy:
  starting_gender: # 
    #    Determines the gender of your initial 'Sir Lee' character.
    #    
    sir: 0
    lady: 0
    random: 50
```
![image](https://user-images.githubusercontent.com/11338376/173198881-f8723a0f-89c3-4e2b-bc20-2ffe5c858353.png)

Also works on the weighted settings page:
![image](https://user-images.githubusercontent.com/11338376/173199022-4cdb927b-190f-474d-ba79-b16e11d76617.png)
