### PR TITLE
HK: Extra randomize options

### DIFF
--- a/worlds/hk/Options.py
+++ b/worlds/hk/Options.py
@@ -111,13 +111,30 @@ default_on = {
 }
 
 no_shuffle = {
-    "RandomizeGrubs",
-    "RandomizeRancidEggs",
-    "RandomizeMimics",
+    # "RandomizeGrubs",
+    # "RandomizeRancidEggs",
+    # "RandomizeMimics",
+    # "RandomizeMaskShards",
+    # "RandomizeVesselFragments",
+    # "RandomizeCharmNotches",
+    # "RandomizePaleOre",
+    # "RandomizeGrimmkinFlames",
+}
+
+no_logic = {
     "RandomizeMaskShards",
-    "RandomizeVesselFragments",
-    "RandomizeCharmNotches",
-    "RandomizePaleOre",
+    "RandomizeGeoChests",
+    "RandomizeJunkPits",
+    "RandomizeRelics",
+    "RandomizeArcaneEggs",
+    "RandomizeMimics",
+    #"RandomizeMaps", # Quill is labelled an advancement item?
+    "RandomizeLifebloodCocoons",
+    #"RandomizeJournals", # Hunter's Journal is an advancement item?
+    "RandomizeGeoRocks",
+    "RandomizeBossGeo",
+    "RandomizeSoulTotems",
+    "RandomizeLoreTablets"
 }
 
 # not supported at this time
@@ -129,16 +146,6 @@ disabled = {
 }
 
 
-class RandomizeOptionsWithShuffle(Choice):
-    option_off = 0
-    option_on = 1
-    option_priority = 2
-    option_exclude = 3
-    option_shuffle = -1
-    alias_true = 1
-    alias_false = 0
-
-
 class RandomizeOptions(Choice):
     option_off = 0
     option_on = 1
@@ -146,6 +153,10 @@ class RandomizeOptions(Choice):
     option_exclude = 3
     alias_true = 1
     alias_false = 0
+
+
+class RandomizeOptionsWithShuffle(RandomizeOptions):
+    option_shuffle = 4
 
 
 hollow_knight_randomize_options: typing.Dict[str, type(Option)] = {}

--- a/worlds/hk/Options.py
+++ b/worlds/hk/Options.py
@@ -110,6 +110,16 @@ default_on = {
     "RandomizeRelics"
 }
 
+no_shuffle = {
+    "RandomizeGrubs",
+    "RandomizeRancidEggs",
+    "RandomizeMimics",
+    "RandomizeMaskShards",
+    "RandomizeVesselFragments",
+    "RandomizeCharmNotches",
+    "RandomizePaleOre",
+}
+
 # not supported at this time
 disabled = {
     "RandomizeFocus",
@@ -117,6 +127,26 @@ disabled = {
     "RandomizeMimics",
     "RandomizeNail",
 }
+
+
+class RandomizeOptionsWithShuffle(Choice):
+    option_off = 0
+    option_on = 1
+    option_priority = 2
+    option_exclude = 3
+    option_shuffle = -1
+    alias_true = 1
+    alias_false = 0
+
+
+class RandomizeOptions(Choice):
+    option_off = 0
+    option_on = 1
+    option_priority = 2
+    option_exclude = 3
+    alias_true = 1
+    alias_false = 0
+
 
 hollow_knight_randomize_options: typing.Dict[str, type(Option)] = {}
 
@@ -127,10 +157,21 @@ for option_name, option_data in pool_options.items():
     if option_name in disabled:
         extra_data["__doc__"] = "Disabled Option. Not implemented."
         option = type(option_name, (Disabled,), extra_data)
-    if option_name in default_on:
-        option = type(option_name, (DefaultOnToggle,), extra_data)
     else:
-        option = type(option_name, (Toggle,), extra_data)
+        extra_data["__doc__"] +=\
+            "\r\nOn fully randomizes these locations. Off leaves them in their original locations.\r\n\
+Priority and Exclude fully randomize these locations and add them to priority_locations or exclude_locations, respectively."
+        if option_name not in no_shuffle:
+            extra_data["__doc__"] += "\r\nShuffle will shuffle these items across only these locations"
+    if option_name in default_on:
+        extra_data['default'] = 1
+    else:
+        extra_data['default'] = 0
+    extra_data['display_name'] = option_name[0:9] + ' ' + option_name[9:]
+    if option_name in no_shuffle:
+        option = type(option_name, (RandomizeOptions,), extra_data)
+    else:
+        option = type(option_name, (RandomizeOptionsWithShuffle,), extra_data)
     globals()[option.__name__] = option
     hollow_knight_randomize_options[option.__name__] = option
 

--- a/worlds/hk/Options.py
+++ b/worlds/hk/Options.py
@@ -110,33 +110,6 @@ default_on = {
     "RandomizeRelics"
 }
 
-no_shuffle = {
-    # "RandomizeGrubs",
-    # "RandomizeRancidEggs",
-    # "RandomizeMimics",
-    # "RandomizeMaskShards",
-    # "RandomizeVesselFragments",
-    # "RandomizeCharmNotches",
-    # "RandomizePaleOre",
-    # "RandomizeGrimmkinFlames",
-}
-
-no_logic = {
-    "RandomizeMaskShards",
-    "RandomizeGeoChests",
-    "RandomizeJunkPits",
-    "RandomizeRelics",
-    "RandomizeArcaneEggs",
-    "RandomizeMimics",
-    #"RandomizeMaps", # Quill is labelled an advancement item?
-    "RandomizeLifebloodCocoons",
-    #"RandomizeJournals", # Hunter's Journal is an advancement item?
-    "RandomizeGeoRocks",
-    "RandomizeBossGeo",
-    "RandomizeSoulTotems",
-    "RandomizeLoreTablets"
-}
-
 # not supported at this time
 disabled = {
     "RandomizeFocus",
@@ -155,10 +128,6 @@ class RandomizeOptions(Choice):
     alias_false = 0
 
 
-class RandomizeOptionsWithShuffle(RandomizeOptions):
-    option_shuffle = 4
-
-
 hollow_knight_randomize_options: typing.Dict[str, type(Option)] = {}
 
 for option_name, option_data in pool_options.items():
@@ -172,17 +141,12 @@ for option_name, option_data in pool_options.items():
         extra_data["__doc__"] +=\
             "\r\nOn fully randomizes these locations. Off leaves them in their original locations.\r\n\
 Priority and Exclude fully randomize these locations and add them to priority_locations or exclude_locations, respectively."
-        if option_name not in no_shuffle:
-            extra_data["__doc__"] += "\r\nShuffle will shuffle these items across only these locations"
     if option_name in default_on:
         extra_data['default'] = 1
     else:
         extra_data['default'] = 0
     extra_data['display_name'] = option_name[0:9] + ' ' + option_name[9:]
-    if option_name in no_shuffle:
-        option = type(option_name, (RandomizeOptions,), extra_data)
-    else:
-        option = type(option_name, (RandomizeOptionsWithShuffle,), extra_data)
+    option = type(option_name, (RandomizeOptions,), extra_data)
     globals()[option.__name__] = option
     hollow_knight_randomize_options[option.__name__] = option
 

--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -206,6 +206,8 @@ class HKWorld(World):
             geo_replace.add("Shade_Soul")
             geo_replace.add("Descending_Dark")
 
+        location_types = {1: LocationProgressType.DEFAULT, 2: LocationProgressType.PRIORITY, 3:
+                          LocationProgressType.EXCLUDED}
         wp_exclusions = self.white_palace_exclusions()
         for option_key, option in hollow_knight_randomize_options.items():
             option_choice = getattr(self.world, option_key)[self.player]
@@ -221,9 +223,7 @@ class HKWorld(World):
                         self.world.push_precollected(item)
                     else:
                         pool.append(item)
-                        self.create_location(location_name).progress_type = LocationProgressType.PRIORITY if \
-                        option_choice == 2 else LocationProgressType.EXCLUDED if option_choice == 3 else \
-                        LocationProgressType.DEFAULT
+                        self.create_location(location_name).progress_type = location_types[option_choice]
             # elif option_key not in logicless_options:
             else:
                 for item_name, location_name in zip(option.items, option.locations):


### PR DESCRIPTION
Item randomization options gain new choices:
Priority and Exclude: randomize them but add all the locations to priority_locations or exclude_locations, respectively.
~Shuffle (only for options that randomize more than 1 item ID): shuffles items from this category into this category's locations~ could not get this to work
