### PR TITLE
setup.py: fix setuptools>=61 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           Expand-Archive -Path enemizer.zip -DestinationPath EnemizerCLI -Force
       - name: Build
         run: |
-          python -m pip install --upgrade pip setuptools==60.10.0  # 61 does not work with the current layout
+          python -m pip install --upgrade pip setuptools
           pip install -r requirements.txt
           python setup.py build --yes
           $NAME="$(ls build)".Split('.',2)[1]
@@ -72,7 +72,7 @@ jobs:
       - name: Build
         run: |
           # pygobject is an optional dependency for kivy that's not in requirements
-          "${{ env.PYTHON }}" -m pip install --upgrade pip virtualenv PyGObject setuptools==60.10.0  # setuptools same as windows
+          "${{ env.PYTHON }}" -m pip install --upgrade pip virtualenv PyGObject setuptools
           "${{ env.PYTHON }}" -m venv venv
           source venv/bin/activate
           pip install -r requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -401,6 +401,7 @@ cx_Freeze.setup(
     version=f"{version_tuple.major}.{version_tuple.minor}.{version_tuple.build}",
     description="Archipelago",
     executables=exes,
+    ext_modules=[],  # required to disable auto-discovery with setuptools>=61
     options={
         "build_exe": {
             "packages": ["websockets", "worlds", "kivy"],


### PR DESCRIPTION
Closes ArchipelagoMW/Archipelago#391
As long as we don't provide a pyproject.toml, defining `ext_modules` will disable auto-discovery. Auto-discovery is what triggered the error message we got.

Would be good if someone could validate this on windows with latest setuptools before merging.
Currently cx_freeze has setuptools<=60.10.0 in its requirements, probably because other users ran into the same problem, so the manual steps below are required to test the fix:
1. pip install cx_freeze
2. pip install --upgrade setuptools>61.0.0  # this should give a warning that setuptools is incompatible to cx_freeze
3. pip show cx_freeze setuptools  # should now say 6.11.0 and  62.4.0
4. add `#` in front of line 22 of setup.py to disable downgrade of setuptools
5. run setup.py build