### PR TITLE
HK: Bugfix shop requirements to be >= rather than >.

### DIFF
--- a/worlds/hk/Rules.py
+++ b/worlds/hk/Rules.py
@@ -27,7 +27,7 @@ def set_shop_prices(hk_world):
     for shop, unit in hk_world.shops.items():
         for i in range(1, 1 + hk_world.created_multi_locations[shop]):
             loc = hk_world.world.get_location(f"{shop}_{i}", hk_world.player)
-            add_rule(loc, lambda state, unit=units[unit], cost=loc.cost: state.count(unit, player) > cost)
+            add_rule(loc, lambda state, unit=units[unit], cost=loc.cost: state.count(unit, player) >= cost)
 
 
 def set_rules(hk_world):

--- a/worlds/hk/templates/RulesTemplate.pyt
+++ b/worlds/hk/templates/RulesTemplate.pyt
@@ -25,7 +25,7 @@ def set_shop_prices(hk_world):
     for shop, unit in hk_world.shops.items():
         for i in range(1, 1 + hk_world.created_multi_locations[shop]):
             loc = hk_world.world.get_location(f"{shop}_{i}", hk_world.player)
-            add_rule(loc, lambda state, unit=units[unit], cost=loc.cost: state.count(unit, player) > cost)
+            add_rule(loc, lambda state, unit=units[unit], cost=loc.cost: state.count(unit, player) >= cost)
 
 
 def set_rules(hk_world):


### PR DESCRIPTION
This was causing off-by-one errors, which were problematic if e.g. a Grubfather slot wanted all 46 grubs.