### PR TITLE
remove limit of 1000 Yotta-Joule in EnergyLink

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -12,6 +12,7 @@ import io
 import collections
 import importlib
 import logging
+import decimal
 
 if typing.TYPE_CHECKING:
     from tkinter import Tk

--- a/Utils.py
+++ b/Utils.py
@@ -494,17 +494,24 @@ class VersionException(Exception):
     pass
 
 
+def chaining_prefix(index: int, labels: typing.Tuple[str]) -> str:
+    text = ""
+    max_label = len(labels) - 1
+    while index > max_label:
+        text += labels[-1]
+        index -= max_label
+    return labels[index] + text
+
+
 # noinspection PyPep8Naming
 def format_SI_prefix(value, power=1000, power_labels=('', 'k', 'M', 'G', 'T', "P", "E", "Z", "Y")) -> str:
     n = 0
-
-    while value > power:
+    value = decimal.Decimal(value)
+    while value >= power:
         value /= power
         n += 1
-    if type(value) == int:
-        return f"{value} {power_labels[n]}"
-    else:
-        return f"{value:0.3f} {power_labels[n]}"
+
+    return f"{value.quantize(decimal.Decimal('1.00'))} {chaining_prefix(n, power_labels)}"
 
 
 def get_fuzzy_ratio(word1: str, word2: str) -> float:

--- a/Utils.py
+++ b/Utils.py
@@ -506,6 +506,7 @@ def chaining_prefix(index: int, labels: typing.Tuple[str]) -> str:
 
 # noinspection PyPep8Naming
 def format_SI_prefix(value, power=1000, power_labels=('', 'k', 'M', 'G', 'T', "P", "E", "Z", "Y")) -> str:
+    """Formats a value into a value + metric/si prefix. More info at https://en.wikipedia.org/wiki/Metric_prefix"""
     n = 0
     value = decimal.Decimal(value)
     while value >= power:


### PR DESCRIPTION
format_SI_prefix would break trying to find the next label after Yotta. Any such weakness is now removed. Also converted to use of Decimal to unify float and int handling for convenience.