### PR TITLE
Break out of fill loop if locations is empty

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -46,7 +46,7 @@ def fill_restrictive(world: MultiWorld, base_state: CollectionState, locations: 
             if not locations:
                 unplaced_items += items_to_place
                 break
-            item_to_place = items_to_place.pop()
+            item_to_place = items_to_place.pop(0)
 
             spot_to_fill: typing.Optional[Location] = None
             if world.accessibility[item_to_place.player] == 'minimal':

--- a/Fill.py
+++ b/Fill.py
@@ -43,12 +43,15 @@ def fill_restrictive(world: MultiWorld, base_state: CollectionState, locations: 
         has_beaten_game = world.has_beaten_game(maximum_exploration_state)
 
         while items_to_place:
+            # if we have run out of locations to fill,break out of this loop
             if not locations:
                 unplaced_items += items_to_place
                 break
             item_to_place = items_to_place.pop(0)
 
             spot_to_fill: typing.Optional[Location] = None
+
+            # if minimal accessibility, only check whether location is reachable if game not beatable
             if world.accessibility[item_to_place.player] == 'minimal':
                 perform_access_check = not world.has_beaten_game(maximum_exploration_state,
                                                                  item_to_place.player) \
@@ -59,7 +62,7 @@ def fill_restrictive(world: MultiWorld, base_state: CollectionState, locations: 
             for i, location in enumerate(locations):
                 if (not single_player_placement or location.player == item_to_place.player) \
                         and location.can_fill(maximum_exploration_state, item_to_place, perform_access_check):
-                    # poping by index is faster than removing by content,
+                    # popping by index is faster than removing by content,
                     spot_to_fill = locations.pop(i)
                     # skipping a scan for the element
                     break

--- a/Fill.py
+++ b/Fill.py
@@ -42,7 +42,12 @@ def fill_restrictive(world: MultiWorld, base_state: CollectionState, locations: 
 
         has_beaten_game = world.has_beaten_game(maximum_exploration_state)
 
-        for item_to_place in items_to_place:
+        while items_to_place:
+            if not locations:
+                unplaced_items += items_to_place
+                break
+            item_to_place = items_to_place.pop()
+
             spot_to_fill: typing.Optional[Location] = None
             if world.accessibility[item_to_place.player] == 'minimal':
                 perform_access_check = not world.has_beaten_game(maximum_exploration_state,


### PR DESCRIPTION
fill_restrictive pops out one item per player, then goes into a loop trying to place them. If the locations sent into fill_restrictive are exhausted, it will continue trying to fill all the remaining items popped out, and will start trying to swap out previously placed items.

I don't think this was an issue before priority_locations was introduced, as fill_restrictive was expected to never run out of locations. But this can be expected to be a regular occurrence now.

I observed this loop going on for quite some time for a multiworld of just 30 games. I imagine generating an async of 400+ games could lose a lot of time over this.