### PR TITLE
multiserver: allow `!release` as an alias for `!forfeit`

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1132,7 +1132,7 @@ class ClientMessageProcessor(CommonCommandProcessor):
             return True
         elif "disabled" in self.ctx.forfeit_mode:
             self.output(
-                "Sorry, client itemreleasing has been disabled on this server. You can ask the server admin for a /release")
+                "Sorry, client item releasing has been disabled on this server. You can ask the server admin for a /release")
             return False
         else:  # is auto or goal
             if self.ctx.client_game_state[self.client.team, self.client.slot] == ClientStatus.CLIENT_GOAL:

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -766,7 +766,7 @@ def update_checked_locations(ctx: Context, team: int, slot: int):
 def forfeit_player(ctx: Context, team: int, slot: int):
     """register any locations that are in the multidata"""
     all_locations = set(ctx.locations[slot])
-    ctx.notify_all("%s (Team #%d) has forfeited" % (ctx.player_names[(team, slot)], team + 1))
+    ctx.notify_all("%s (Team #%d) has released all items in their world" % (ctx.player_names[(team, slot)], team + 1))
     register_location_checks(ctx, team, slot, all_locations)
     update_checked_locations(ctx, team, slot)
 
@@ -779,7 +779,7 @@ def collect_player(ctx: Context, team: int, slot: int, is_group: bool = False):
             if values[1] == slot:
                 all_locations[source_slot].add(location_id)
 
-    ctx.notify_all("%s (Team #%d) has collected" % (ctx.player_names[(team, slot)], team + 1))
+    ctx.notify_all("%s (Team #%d) has collected their items from other worlds" % (ctx.player_names[(team, slot)], team + 1))
     for source_player, location_ids in all_locations.items():
         register_location_checks(ctx, team, source_player, location_ids, count_activity=False)
         update_checked_locations(ctx, team, source_player)
@@ -1117,6 +1117,10 @@ class ClientMessageProcessor(CommonCommandProcessor):
         """Get status information about your team."""
         self.output(get_status_string(self.ctx, self.client.team))
         return True
+
+    def _cmd_release(self) -> bool:
+        """Sends remaining items in your world to their recipients"""
+        return self._cmd_forfeit()
 
     def _cmd_forfeit(self) -> bool:
         """Surrender and send your remaining items out to their recipients"""

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -766,7 +766,7 @@ def update_checked_locations(ctx: Context, team: int, slot: int):
 def forfeit_player(ctx: Context, team: int, slot: int):
     """register any locations that are in the multidata"""
     all_locations = set(ctx.locations[slot])
-    ctx.notify_all("%s (Team #%d) has released all items in their world" % (ctx.player_names[(team, slot)], team + 1))
+    ctx.notify_all("%s (Team #%d) has released all remaining items from their world." % (ctx.player_names[(team, slot)], team + 1))
     register_location_checks(ctx, team, slot, all_locations)
     update_checked_locations(ctx, team, slot)
 
@@ -779,7 +779,7 @@ def collect_player(ctx: Context, team: int, slot: int, is_group: bool = False):
             if values[1] == slot:
                 all_locations[source_slot].add(location_id)
 
-    ctx.notify_all("%s (Team #%d) has collected their items from other worlds" % (ctx.player_names[(team, slot)], team + 1))
+    ctx.notify_all("%s (Team #%d) has collected their items from other worlds." % (ctx.player_names[(team, slot)], team + 1))
     for source_player, location_ids in all_locations.items():
         register_location_checks(ctx, team, source_player, location_ids, count_activity=False)
         update_checked_locations(ctx, team, source_player)
@@ -1106,7 +1106,7 @@ class ClientMessageProcessor(CommonCommandProcessor):
         return self.ctx.commandprocessor(command)
 
     def _cmd_players(self) -> bool:
-        """Get information about connected and missing players"""
+        """Get information about connected and missing players."""
         if len(self.ctx.player_names) < 10:
             self.ctx.notify_all(get_players_string(self.ctx))
         else:
@@ -1119,11 +1119,11 @@ class ClientMessageProcessor(CommonCommandProcessor):
         return True
 
     def _cmd_release(self) -> bool:
-        """Sends remaining items in your world to their recipients"""
+        """Sends remaining items in your world to their recipients."""
         return self._cmd_forfeit()
 
     def _cmd_forfeit(self) -> bool:
-        """Surrender and send your remaining items out to their recipients"""
+        """Surrender and send your remaining items out to their recipients. Use release in the future."""
         if self.ctx.allow_forfeits.get((self.client.team, self.client.slot), False):
             forfeit_player(self.ctx, self.client.team, self.client.slot)
             return True
@@ -1132,7 +1132,7 @@ class ClientMessageProcessor(CommonCommandProcessor):
             return True
         elif "disabled" in self.ctx.forfeit_mode:
             self.output(
-                "Sorry, client forfeiting has been disabled on this server. You can ask the server admin for a /forfeit")
+                "Sorry, client itemreleasing has been disabled on this server. You can ask the server admin for a /release")
             return False
         else:  # is auto or goal
             if self.ctx.client_game_state[self.client.team, self.client.slot] == ClientStatus.CLIENT_GOAL:
@@ -1140,8 +1140,8 @@ class ClientMessageProcessor(CommonCommandProcessor):
                 return True
             else:
                 self.output(
-                    "Sorry, client forfeiting requires you to have beaten the game on this server."
-                    " You can ask the server admin for a /forfeit")
+                    "Sorry, client item releasing requires you to have beaten the game on this server."
+                    " You can ask the server admin for a /release")
                 return False
 
     def _cmd_collect(self) -> bool:
@@ -1703,42 +1703,47 @@ class ServerCommandProcessor(CommonCommandProcessor):
         return False
 
     @mark_raw
+    def _cmd_release(self, player_name: str) -> bool:
+        """Send out the remaining items from a player to their intended recipients."""
+        return self._cmd_forfeit(player_name)
+
+    @mark_raw
     def _cmd_forfeit(self, player_name: str) -> bool:
-        """Send out the remaining items from a player to their intended recipients"""
+        """Send out the remaining items from a player to their intended recipients."""
         seeked_player = player_name.lower()
         for (team, slot), name in self.ctx.player_names.items():
             if name.lower() == seeked_player:
                 forfeit_player(self.ctx, team, slot)
                 return True
 
-        self.output(f"Could not find player {player_name} to forfeit")
+        self.output(f"Could not find player {player_name} to release")
         return False
 
     @mark_raw
     def _cmd_allow_forfeit(self, player_name: str) -> bool:
-        """Allow the specified player to use the !forfeit command"""
+        """Allow the specified player to use the !release command."""
         seeked_player = player_name.lower()
         for (team, slot), name in self.ctx.player_names.items():
             if name.lower() == seeked_player:
                 self.ctx.allow_forfeits[(team, slot)] = True
-                self.output(f"Player {player_name} is now allowed to use the !forfeit command at any time.")
+                self.output(f"Player {player_name} is now allowed to use the !release command at any time.")
                 return True
 
-        self.output(f"Could not find player {player_name} to allow the !forfeit command for.")
+        self.output(f"Could not find player {player_name} to allow the !release command for.")
         return False
 
     @mark_raw
     def _cmd_forbid_forfeit(self, player_name: str) -> bool:
-        """"Disallow the specified player from using the !forfeit command"""
+        """"Disallow the specified player from using the !release command."""
         seeked_player = player_name.lower()
         for (team, slot), name in self.ctx.player_names.items():
             if name.lower() == seeked_player:
                 self.ctx.allow_forfeits[(team, slot)] = False
                 self.output(
-                    f"Player {player_name} has to follow the server restrictions on use of the !forfeit command.")
+                    f"Player {player_name} has to follow the server restrictions on use of the !release command.")
                 return True
 
-        self.output(f"Could not find player {player_name} to forbid the !forfeit command for.")
+        self.output(f"Could not find player {player_name} to forbid the !release command for.")
         return False
 
     def _cmd_send_multiple(self, amount: typing.Union[int, str], player_name: str, *item_name: str) -> bool:


### PR DESCRIPTION
literally just a new command to act as a new call for forfeit. Changed the output text when someone releases and collects from/to the multiworld to be more clear.