### PR TITLE
SNES games: use JPN as abbreviation for Japan/Japanese

### DIFF
--- a/LttPAdjuster.py
+++ b/LttPAdjuster.py
@@ -47,7 +47,7 @@ def main():
 
     parser.add_argument('rom', nargs="?", default='AP_LttP.sfc', help='Path to an ALttP rom to adjust.')
     parser.add_argument('--baserom', default='Zelda no Densetsu - Kamigami no Triforce (Japan).sfc',
-                        help='Path to an ALttP JAP(1.0) rom to use as a base.')
+                        help='Path to an ALttP Japan(1.0) rom to use as a base.')
     parser.add_argument('--loglevel', default='info', const='info', nargs='?',
                         choices=['error', 'info', 'warning', 'debug'], help='Select level of logging for output.')
     parser.add_argument('--menuspeed', default='normal', const='normal', nargs='?',

--- a/Patch.py
+++ b/Patch.py
@@ -178,14 +178,14 @@ preferred_endings = {
 
 def generate_yaml(patch: bytes, metadata: Optional[dict] = None, game: str = GAME_ALTTP) -> bytes:
     if game == GAME_ALTTP:
-        from worlds.alttp.Rom import JAP10HASH as HASH
+        from worlds.alttp.Rom import LTTPJPN10HASH as HASH
     elif game == GAME_SM:
-        from worlds.sm.Rom import JAP10HASH as HASH
+        from worlds.sm.Rom import SMJUHASH as HASH
     elif game == GAME_SOE:
         from worlds.soe.Patch import USHASH as HASH
     elif game == GAME_SMZ3:
-        from worlds.alttp.Rom import JAP10HASH as ALTTPHASH
-        from worlds.sm.Rom import JAP10HASH as SMHASH
+        from worlds.alttp.Rom import LTTPJPN10HASH as ALTTPHASH
+        from worlds.sm.Rom import SMJUHASH as SMHASH
         HASH = ALTTPHASH + SMHASH
     else:
         raise RuntimeError(f"Selected game {game} for base rom not found.")

--- a/worlds/alttp/Rom.py
+++ b/worlds/alttp/Rom.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import Utils
 from Patch import read_rom
 
-JAP10HASH = '03a63945398191337e896e5771f77173'
+LTTPJPN10HASH = '03a63945398191337e896e5771f77173'
 RANDOMIZERBASEHASH = '9952c2a3ec1b421e408df0d20c8f0c7f'
 ROM_PLAYER_LIMIT = 255
 
@@ -2890,7 +2890,7 @@ hash_alphabet = [
 
 
 class LttPDeltaPatch(Patch.APDeltaPatch):
-    hash = JAP10HASH
+    hash = LTTPJPN10HASH
     game = "A Link to the Past"
     patch_file_ending = ".aplttp"
 
@@ -2907,8 +2907,8 @@ def get_base_rom_bytes(file_name: str = "") -> bytes:
 
         basemd5 = hashlib.md5()
         basemd5.update(base_rom_bytes)
-        if JAP10HASH != basemd5.hexdigest():
-            raise Exception('Supplied Base Rom does not match known MD5 for JAP(1.0) release. '
+        if LTTPJPN10HASH != basemd5.hexdigest():
+            raise Exception('Supplied Base Rom does not match known MD5 for Japan(1.0) release. '
                             'Get the correct game and version, then dump it')
         get_base_rom_bytes.base_rom_bytes = base_rom_bytes
     return base_rom_bytes

--- a/worlds/sm/Rom.py
+++ b/worlds/sm/Rom.py
@@ -4,12 +4,12 @@ import os
 import Utils
 from Patch import read_rom, APDeltaPatch
 
-JAP10HASH = '21f3e98df4780ee1c667b84e57d88675'
+SMJUHASH = '21f3e98df4780ee1c667b84e57d88675'
 ROM_PLAYER_LIMIT = 65535
 
 
 class SMDeltaPatch(APDeltaPatch):
-    hash = JAP10HASH
+    hash = SMJUHASH
     game = "Super Metroid"
     patch_file_ending = ".apsm"
 
@@ -26,8 +26,8 @@ def get_base_rom_bytes(file_name: str = "") -> bytes:
 
         basemd5 = hashlib.md5()
         basemd5.update(base_rom_bytes)
-        if JAP10HASH != basemd5.hexdigest():
-            raise Exception('Supplied Base Rom does not match known MD5 for JAP(1.0) release. '
+        if SMJUHASH != basemd5.hexdigest():
+            raise Exception('Supplied Base Rom does not match known MD5 for Japan+US release. '
                             'Get the correct game and version, then dump it')
         get_base_rom_bytes.base_rom_bytes = base_rom_bytes
     return base_rom_bytes

--- a/worlds/smz3/Rom.py
+++ b/worlds/smz3/Rom.py
@@ -4,8 +4,8 @@ import os
 import Utils
 from Patch import read_rom, APDeltaPatch
 
-SMJAP10HASH = '21f3e98df4780ee1c667b84e57d88675'
-LTTPJAP10HASH = '03a63945398191337e896e5771f77173'
+SMJUHASH = '21f3e98df4780ee1c667b84e57d88675'
+LTTPJPN10HASH = '03a63945398191337e896e5771f77173'
 ROM_PLAYER_LIMIT = 256
 
 
@@ -27,16 +27,16 @@ def get_base_rom_bytes() -> bytes:
 
         basemd5 = hashlib.md5()
         basemd5.update(sm_base_rom_bytes)
-        if SMJAP10HASH != basemd5.hexdigest():
-            raise Exception('Supplied Base Rom does not match known MD5 for SM JAP(1.0) release. '
+        if SMJUHASH != basemd5.hexdigest():
+            raise Exception('Supplied Base Rom does not match known MD5 for SM Japan+US release. '
                             'Get the correct game and version, then dump it')
         lttp_file_name = get_lttp_base_rom_path()
         lttp_base_rom_bytes = bytes(read_rom(open(lttp_file_name, "rb")))
 
         basemd5 = hashlib.md5()
         basemd5.update(lttp_base_rom_bytes)
-        if LTTPJAP10HASH != basemd5.hexdigest():
-            raise Exception('Supplied Base Rom does not match known MD5 for LttP JAP(1.0) release. '
+        if LTTPJPN10HASH != basemd5.hexdigest():
+            raise Exception('Supplied Base Rom does not match known MD5 for LttP Japan(1.0) release. '
                             'Get the correct game and version, then dump it')
 
         get_base_rom_bytes.base_rom_bytes = bytes(combine_smz3_rom(sm_base_rom_bytes, lttp_base_rom_bytes))


### PR DESCRIPTION
Removes term considered offensive from error messages & variable names.

Tested rolling a SM+Z3+SMZ3 multi & genning world roms by running SNIClient on the resulting world patchfiles.