### PR TITLE
Factorio: Fix impossible seeds for rocket-part recipes as well.

### DIFF
--- a/worlds/factorio/__init__.py
+++ b/worlds/factorio/__init__.py
@@ -329,7 +329,7 @@ class Factorio(World):
     def set_custom_recipes(self):
         original_rocket_part = recipes["rocket-part"]
         science_pack_pools = get_science_pack_pools()
-        valid_pool = sorted(science_pack_pools[self.world.max_science_pack[self.player].get_max_pack()])
+        valid_pool = sorted(science_pack_pools[self.world.max_science_pack[self.player].get_max_pack()] & stacking_items)
         self.world.random.shuffle(valid_pool)
         while any([valid_pool[x] in fluids for x in range(3)]):
             self.world.random.shuffle(valid_pool)


### PR DESCRIPTION
Managed to find a seed where the non-stackable spidertron remote ended up in the rocket-part recipe, resulting in that seed being impossible to complete.