### PR TITLE
BaseClasses: make ItemClassification properties faster

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1191,19 +1191,19 @@ class Item:
 
     @property
     def advancement(self) -> bool:
-        return bool(self.classification & ItemClassification.progression)
+        return ItemClassification.progression in self.classification
 
     @property
     def skip_in_prog_balancing(self) -> bool:
-        return self.classification == ItemClassification.progression_skip_balancing
+        return ItemClassification.progression_skip_balancing in self.classification
 
     @property
     def useful(self) -> bool:
-        return bool(self.classification & ItemClassification.useful)
+        return ItemClassification.useful in self.classification
 
     @property
     def trap(self) -> bool:
-        return bool(self.classification & ItemClassification.trap)
+        return ItemClassification.trap in self.classification
 
     @property
     def flags(self) -> int:


### PR DESCRIPTION
```py
test = ItemClassification.progression_skip_balancing
import timeit
print(timeit.timeit("ItemClassification.progression in test", globals=globals()))
print(timeit.timeit("bool(test & ItemClassification.progression)", globals=globals()))
```

```
0.3143199998885393
1.2014224999584258
```