### PR TITLE
docs: fix 2 URLs

### DIFF
--- a/worlds/alttp/docs/multiworld_es.md
+++ b/worlds/alttp/docs/multiworld_es.md
@@ -144,7 +144,8 @@ Sólo hay que segiur estos pasos una vez.
 2. Ve a Ajustes --> Interfaz de usario. Configura "Mostrar ajustes avanzados" en ON.
 3. Ve a Ajustes --> Red. Configura "Comandos de red" en ON. (Se encuentra bajo Request Device 16.) Deja en 55355 (el
    default) el Puerto de comandos de red.
-![Captura de pantalla del ajuste Comandos de red](/static/assets/tutorial/retroarch-network-commands-en.png)
+
+![Captura de pantalla del ajuste Comandos de red](/static/generated/docs/A%20Link%20to%20the%20Past/retroarch-network-commands-en.png)
 4. Ve a Menú principal --> Actualizador en línea --> Descargador de núcleos. Desplázate y selecciona "Nintendo - SNES /
    SFC (bsnes-mercury Performance)".
 

--- a/worlds/smz3/docs/multiworld_en.md
+++ b/worlds/smz3/docs/multiworld_en.md
@@ -10,9 +10,8 @@
     - An emulator capable of connecting to SNI such as:
         - snes9x Multitroid
           from: [snes9x Multitroid Download](https://drive.google.com/drive/folders/1_ej-pwWtCAHYXIrvs5Hro16A1s9Hi3Jz),
-        - BizHawk from: [BizHawk Website](http://tasvideos.org/BizHawk.html)
-        - RetroArch 1.10.3 or newer from: [RetroArch BuildBot Website](https://buildbot.libretro.com/) - nightly builds
-          are required until 1.10.3 is released. Or,
+        - BizHawk from: [BizHawk Website](http://tasvideos.org/BizHawk.html), or
+        - RetroArch 1.10.3 or newer from: [RetroArch Website](https://retroarch.com?page=platforms). Or,
     - An SD2SNES, FXPak Pro ([FXPak Pro Store Page](https://krikzz.com/store/home/54-fxpak-pro.html)), or other
       compatible hardware
 - Your legally obtained Super Metroid ROM file, probably named `Super Metroid (Japan, USA).sfc` and


### PR DESCRIPTION
The path of the image embedded in LTTP ES language setup guide was not changed when both files were moved in #455 . If any other non-English docs have embeds, those might be worth checking over.

By convenient opportunity I've also removed the mention of RetroArch nightly builds from the SMZ3 setup guide, because RA 1.10.3 was released with the fix for AP SMZ3.