### PR TITLE
sm64ex: Adapt area_connections slotdata Format

### DIFF
--- a/worlds/sm64ex/Regions.py
+++ b/worlds/sm64ex/Regions.py
@@ -11,6 +11,8 @@ sm64courses = ["Bob-omb Battlefield", "Whomp's Fortress", "Jolly Roger Bay", "Co
                "Wet-Dry World",
                "Tall, Tall Mountain", "Tiny-Huge Island", "Tick Tock Clock", "Rainbow Ride"]
 
+# sm64paintings is list of strings for quick reference for Painting IDs (NOT warp node IDs!)
+sm64paintings = ["BOB", "WF", "JRB", "CCM", "BBH", "HMC", "LLL", "SSL", "DDD", "SL", "WDW", "TTM", "THI Tiny", "THI Huge", "TTC", "RR"]
 
 def create_regions(world: MultiWorld, player: int):
     regSS = Region("Menu", RegionType.Generic, "Castle Area", player, world)

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -1,40 +1,50 @@
 from ..generic.Rules import add_rule
-from .Regions import connect_regions, sm64courses
+from .Regions import connect_regions, sm64courses, sm64paintings
 
 
 def set_rules(world, player: int, area_connections):
-    courseshuffle = list(range(len(sm64courses)))
+    entrance_ids = list(range(len(sm64paintings)))
+    destination_courses = list(range(13)) + [12,13,14] # Two instances of Destination Course THI
     if world.AreaRandomizer[player]:
-        world.random.shuffle(courseshuffle)
-    area_connections.update({index: value for index, value in enumerate(courseshuffle)})
+        world.random.shuffle(entrance_ids)
+    temp_assign = dict(zip(entrance_ids,destination_courses)) # Used for Rules only
 
-    connect_regions(world, player, "Menu", sm64courses[area_connections[0]])
-    connect_regions(world, player, "Menu", sm64courses[area_connections[1]], lambda state: state.has("Power Star", player, 1))
-    connect_regions(world, player, "Menu", sm64courses[area_connections[2]], lambda state: state.has("Power Star", player, 3))
-    connect_regions(world, player, "Menu", sm64courses[area_connections[3]], lambda state: state.has("Power Star", player, 3))
+    # Destination Format: LVL | AREA with LVL = Course ID, 0-indexed, AREA = Area as used in sm64 code
+    area_connections.update({entrance: (destination_course*10 + 1) for entrance, destination_course in temp_assign.items()})
+    for i in range(len(area_connections)):
+        if (int(area_connections[i]/10) == 12):
+            # Change first occurence of course 12 (THI) to Area 2 (THI Tiny)
+            area_connections[i] = 12*10 + 2
+            break
+
+    connect_regions(world, player, "Menu", sm64courses[temp_assign[0]])
+    connect_regions(world, player, "Menu", sm64courses[temp_assign[1]], lambda state: state.has("Power Star", player, 1))
+    connect_regions(world, player, "Menu", sm64courses[temp_assign[2]], lambda state: state.has("Power Star", player, 3))
+    connect_regions(world, player, "Menu", sm64courses[temp_assign[3]], lambda state: state.has("Power Star", player, 3))
     connect_regions(world, player, "Menu", "Bowser in the Dark World", lambda state: state.has("Power Star", player, world.FirstBowserStarDoorCost[player].value))
-    connect_regions(world, player, "Menu", sm64courses[area_connections[4]], lambda state: state.has("Power Star", player, 12))
+    connect_regions(world, player, "Menu", sm64courses[temp_assign[4]], lambda state: state.has("Power Star", player, 12))
 
     connect_regions(world, player, "Menu", "Basement", lambda state: state.has("Basement Key", player) or state.has("Progressive Key", player, 1))
 
-    connect_regions(world, player, "Basement", sm64courses[area_connections[5]])
-    connect_regions(world, player, "Basement", sm64courses[area_connections[6]])
-    connect_regions(world, player, "Basement", sm64courses[area_connections[7]])
-    connect_regions(world, player, "Basement", sm64courses[area_connections[8]], lambda state: state.has("Power Star", player, world.BasementStarDoorCost[player].value))
+    connect_regions(world, player, "Basement", sm64courses[temp_assign[5]])
+    connect_regions(world, player, "Basement", sm64courses[temp_assign[6]])
+    connect_regions(world, player, "Basement", sm64courses[temp_assign[7]])
+    connect_regions(world, player, "Basement", sm64courses[temp_assign[8]], lambda state: state.has("Power Star", player, world.BasementStarDoorCost[player].value))
     connect_regions(world, player, "Basement", "Bowser in the Fire Sea", lambda state: state.has("Power Star", player, world.BasementStarDoorCost[player].value) and
                                                                                        state.can_reach("DDD: Board Bowser's Sub", 'Location', player))
 
     connect_regions(world, player, "Menu", "Second Floor", lambda state: state.has("Second Floor Key", player) or state.has("Progressive Key", player, 2))
 
-    connect_regions(world, player, "Second Floor", sm64courses[area_connections[9]])
-    connect_regions(world, player, "Second Floor", sm64courses[area_connections[10]])
-    connect_regions(world, player, "Second Floor", sm64courses[area_connections[11]])
-    connect_regions(world, player, "Second Floor", sm64courses[area_connections[12]])
+    connect_regions(world, player, "Second Floor", sm64courses[temp_assign[9]])
+    connect_regions(world, player, "Second Floor", sm64courses[temp_assign[10]])
+    connect_regions(world, player, "Second Floor", sm64courses[temp_assign[11]])
+    connect_regions(world, player, "Second Floor", sm64courses[temp_assign[12]]) # THI Tiny
+    connect_regions(world, player, "Second Floor", sm64courses[temp_assign[13]]) # THI Huge
 
     connect_regions(world, player, "Second Floor", "Third Floor", lambda state: state.has("Power Star", player, world.SecondFloorStarDoorCost[player].value))
 
-    connect_regions(world, player, "Third Floor", sm64courses[area_connections[13]])
-    connect_regions(world, player, "Third Floor", sm64courses[area_connections[14]])
+    connect_regions(world, player, "Third Floor", sm64courses[temp_assign[14]])
+    connect_regions(world, player, "Third Floor", sm64courses[temp_assign[15]])
 
     #Special Rules for some Locations
     add_rule(world.get_location("Tower of the Wing Cap Switch", player), lambda state: state.has("Power Star", player, 10))

--- a/worlds/sm64ex/__init__.py
+++ b/worlds/sm64ex/__init__.py
@@ -35,7 +35,7 @@ class SM64World(World):
     location_name_to_id = location_table
 
     data_version = 6
-    client_version = 2
+    required_client_version = (0,3,0)
     
     forced_auto_forfeit = False
 

--- a/worlds/sm64ex/__init__.py
+++ b/worlds/sm64ex/__init__.py
@@ -5,7 +5,7 @@ from .Items import item_table, cannon_item_table, SM64Item
 from .Locations import location_table, SM64Location
 from .Options import sm64_options
 from .Rules import set_rules
-from .Regions import create_regions, sm64courses
+from .Regions import create_regions, sm64courses, sm64paintings
 from BaseClasses import Item, Tutorial, ItemClassification
 from ..AutoWorld import World, WebWorld
 
@@ -54,10 +54,10 @@ class SM64World(World):
         set_rules(self.world, self.player, self.area_connections)
         if self.topology_present:
             # Write area_connections to spoiler log
-            for painting_id, course_id in self.area_connections.items():
+            for painting_id, destination in self.area_connections.items():
                 self.world.spoiler.set_entrance(
-                    sm64courses[painting_id] + " Painting",
-                    sm64courses[course_id],
+                    sm64paintings[painting_id] + " Painting",
+                    sm64courses[destination // 10],
                     'entrance', self.player)
 
     def create_item(self, name: str) -> Item:
@@ -145,8 +145,8 @@ class SM64World(World):
     def modify_multidata(self, multidata):
         if self.topology_present:
             er_hint_data = {}
-            for painting_id, course_id in self.area_connections.items():
-                region = self.world.get_region(sm64courses[course_id], self.player)
+            for painting_id, destination in self.area_connections.items():
+                region = self.world.get_region(sm64courses[destination // 10], self.player)
                 for location in region.locations:
-                    er_hint_data[location.address] = sm64courses[painting_id]
+                    er_hint_data[location.address] = sm64paintings[painting_id]
             multidata['er_hint_data'][self.player] = er_hint_data


### PR DESCRIPTION
Required to fix THI behaviour.

New Behaviour: THI Tiny / Huge are treated as seperate paintings. When randomized, this also means that two seperate painting can lead to each THI instance, and the two original THI paintings can lead to different courses