### PR TITLE
Factorio: specify rcon version

### DIFF
--- a/worlds/factorio/requirements.txt
+++ b/worlds/factorio/requirements.txt
@@ -1,1 +1,1 @@
-factorio-rcon-py>=1.2.1
+factorio-rcon-py==1.2.1


### PR DESCRIPTION
Addresses bug https://github.com/mark9064/factorio-rcon-py/issues/2 by  specifying working version for now.