### PR TITLE
ChecksFinder: Linux support via wine

### DIFF
--- a/ChecksFinderClient.py
+++ b/ChecksFinderClient.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 import os
+import sys
 import asyncio
+import shutil
 
 import ModuleUpdate
 ModuleUpdate.update()
@@ -36,11 +38,16 @@ class ChecksFinderContext(CommonContext):
         if "localappdata" in os.environ:
             self.game_communication_path = os.path.expandvars(r"%localappdata%/ChecksFinder")
         else:
-            # not windows. game is an exe so maybe the user wants to use wine? using custom wine dir or default
+            # not windows. game is an exe so let's see if wine might be around to run it
             if "WINEPREFIX" in os.environ:
                 wineprefix = os.environ["WINEPREFIX"]
+            elif shutil.which("wine") or shutil.which("wine-stable"):
+                wineprefix = os.path.expanduser("~/.wine") # default root of wine system data, deep in which is app data
             else:
-                wineprefix = os.path.expanduser("~/.wine")
+                msg = "ChecksFinderClient couldn't detect system type. Unable to infer required game_communication_path"
+                logger.error("Error: " + msg)
+                Utils.messagebox("Error", msg, error=True)
+                sys.exit(1)
             self.game_communication_path = os.path.join(
                 wineprefix,
                 "drive_c",

--- a/ChecksFinderClient.py
+++ b/ChecksFinderClient.py
@@ -36,9 +36,14 @@ class ChecksFinderContext(CommonContext):
         if "localappdata" in os.environ:
             self.game_communication_path = os.path.expandvars(r"%localappdata%/ChecksFinder")
         else:
-            # not windows. game is an exe so maybe the user wants to use wine?
+            # not windows. game is an exe so maybe the user wants to use wine? using custom wine dir or default
+            if "WINEPREFIX" in os.environ:
+                wineprefix = os.environ["WINEPREFIX"]
+            else:
+                wineprefix = os.path.expanduser("~/.wine")
             self.game_communication_path = os.path.join(
-                os.path.expanduser("~/.wine/drive_c"),
+                wineprefix,
+                "drive_c",
                 os.path.expandvars("users/$USER/Local Settings/Application Data/ChecksFinder"))
 
     async def server_auth(self, password_requested: bool = False):


### PR DESCRIPTION
Found ChecksFinder works easily on Linux as long as the client has the correct path.

Existing exe is fine, just run `wine ChecksFinder.exe`