### PR TITLE
WebHost: Add links to "Setup Guides" in Supported Games page

### DIFF
--- a/WebHostLib/static/assets/tutorialLanding.js
+++ b/WebHostLib/static/assets/tutorialLanding.js
@@ -23,6 +23,7 @@ window.addEventListener('load', () => {
       games.forEach((game) => {
         const gameTitle = document.createElement('h2');
         gameTitle.innerText = game.gameTitle;
+        gameTitle.id = `${encodeURIComponent(game.gameTitle)}`;
         tutorialDiv.appendChild(gameTitle);
 
         game.tutorials.forEach((tutorial) => {
@@ -64,6 +65,16 @@ window.addEventListener('load', () => {
     } catch (error) {
       showError();
       console.error(error);
+    }
+
+    // Check if we are on an anchor when coming in, and scroll to it.
+    const hash = window.location.hash;
+    console.log(hash);
+    if (hash) {
+      const offset = 128;  // To account for navbar banner at top of page.
+      window.scrollTo(0, 0);
+      const rect = document.getElementById(hash.slice(1)).getBoundingClientRect();
+      window.scrollTo(rect.left, rect.top - offset);
     }
   };
   ajax.open('GET', `${window.location.origin}/static/generated/tutorials.json`, true);

--- a/WebHostLib/static/assets/tutorialLanding.js
+++ b/WebHostLib/static/assets/tutorialLanding.js
@@ -69,7 +69,6 @@ window.addEventListener('load', () => {
 
     // Check if we are on an anchor when coming in, and scroll to it.
     const hash = window.location.hash;
-    console.log(hash);
     if (hash) {
       const offset = 128;  // To account for navbar banner at top of page.
       window.scrollTo(0, 0);

--- a/WebHostLib/templates/supportedGames.html
+++ b/WebHostLib/templates/supportedGames.html
@@ -15,10 +15,15 @@
         <p>
             {{ world.__doc__ | default("No description provided.", true) }}<br />
             <a href="{{ url_for("game_info", game=game_name, lang="en") }}">Game Page</a>
+            {% if world.web.tutorials %}
             <span class="link-spacer">|</span>
+            <a href="{{ url_for("tutorial_landing") }}#{{ game_name }}">Setup Guides</a>
+            {% endif %}
             {% if world.web.settings_page is string %}
+            <span class="link-spacer">|</span>
             <a href="{{ world.web.settings_page }}">Settings Page</a>
             {% elif world.web.settings_page %}
+            <span class="link-spacer">|</span>
             <a href="{{ url_for("player_settings", game=game_name) }}">Settings Page</a>
             {% endif %}
             {% if world.web.bug_report_page %}


### PR DESCRIPTION
Adds an anchor tag to each "Game" entry in Setup Guides and scrolls to it from the Games page when clicked. Should help reduce the amount of "How do I set up this game?" questions.

<img width="1086" alt="image" src="https://user-images.githubusercontent.com/11338376/182008875-1a32b185-c7f5-466b-b1c9-c9f14b277776.png">
