### PR TITLE
The Witness: Logic fix (unbeatable seed)

### DIFF
--- a/worlds/witness/WitnessLogic.txt
+++ b/worlds/witness/WitnessLogic.txt
@@ -765,7 +765,9 @@ Inside Mountain Second Layer (Inside Mountain) - Inside Mountain Second Layer Li
 158430 - 0x09FD8 (Color Cycle 5) - 0x09FD7 - Color Cycle & RGB & Squares & Colored Squares & Symmetry & Colored Dots
 Door - 0x09FFB (Staircase Near) - 0x09FD8
 
-Inside Mountain Second Layer Blue Bridge (Inside Mountain) - Inside Mountain Second Layer Beyond Bridge - TrueOneWay - Inside Mountain Second Layer Elevator Room - 0x09EDD:
+Inside Mountain Second Layer Blue Bridge (Inside Mountain) - Inside Mountain Second Layer Beyond Bridge - TrueOneWay - Inside Mountain Second Layer At Door - TrueOneWay:
+
+Inside Mountain Second Layer At Door (Inside Mountain) - Inside Mountain Second Layer Elevator Room - 0x09EDD:
 Door - 0x09EDD (Door to Elevator) - 0x09ED8 & 0x09E86
 
 Inside Mountain Second Layer Light Bridge Room Near (Inside Mountain):


### PR DESCRIPTION
An unbeatable seed was reported where because of faulty region connections/definitions, the logic (in door randomizer) thought you could go backwards through the mountain all the way up to Same Solution Set & Light Bridge Controller 3, which is impossible (you can only go up to Elevator Discard). 

This is the fix for it