### PR TITLE
SC2: Added Difficulty Override to Client

### DIFF
--- a/Starcraft2Client.py
+++ b/Starcraft2Client.py
@@ -42,7 +42,6 @@ class StarcraftClientProcessor(ClientCommandProcessor):
         """Overrides the current difficulty set for the seed.  Takes the argument casual, normal, hard, or brutal"""
         options = difficulty.split()
         num_options = len(options)
-        set_difficulty = True
         difficulty_choice = options[0].lower()
 
         if num_options > 0:
@@ -55,19 +54,22 @@ class StarcraftClientProcessor(ClientCommandProcessor):
             elif difficulty_choice == "brutal":
                 self.ctx.difficulty_override = 3
             else:
-                sc2_logger.info("Unable to parse difficulty '" + options[0] + "'")
-                set_difficulty = False
+                self.output("Unable to parse difficulty '" + options[0] + "'")
+                return False
 
-            if set_difficulty:
-                sc2_logger.info("Difficulty set to " + options[0])
+            self.output("Difficulty set to " + options[0])
+            return True
+
         else:
-            sc2_logger.info("Difficulty needs to be specified in the command.")
+            self.output("Difficulty needs to be specified in the command.")
+            return False
 
     def _cmd_disable_mission_check(self) -> bool:
         """Disables the check to see if a mission is available to play.  Meant for co-op runs where one player can play
         the next mission in a chain the other player is doing."""
         self.ctx.missions_unlocked = True
         sc2_logger.info("Mission check has been disabled")
+        return True
 
     def _cmd_play(self, mission_id: str = "") -> bool:
         """Start a Starcraft 2 mission"""
@@ -83,6 +85,7 @@ class StarcraftClientProcessor(ClientCommandProcessor):
         else:
             sc2_logger.info(
                 "Mission ID needs to be specified.  Use /unfinished or /available to view ids for available missions.")
+            return False
 
         return True
 

--- a/Starcraft2Client.py
+++ b/Starcraft2Client.py
@@ -38,6 +38,25 @@ nest_asyncio.apply()
 class StarcraftClientProcessor(ClientCommandProcessor):
     ctx: SC2Context
 
+    def _cmd_difficulty(self, difficulty: str = "") -> bool:
+        """Overrides the current difficulty set for the seed.  Takes the argument casual, normal, hard, or brutal"""
+        options = difficulty.split()
+        num_options = len(options)
+
+        if num_options > 0:
+            if options[0] == "Casual" or "casual":
+                self.ctx.difficulty_override = 0
+            elif options[0] == "Normal" or "normal":
+                self.ctx.difficulty_override = 1
+            elif options[0] == "Hard" or "hard":
+                self.ctx.difficulty_override = 2
+            elif options[0] == "Brutal" or "brutal":
+                self.ctx.difficulty_override = 3
+            else:
+                sc2_logger.info("Unable to parse difficulty '" + options[0] + "'")
+        else:
+            sc2_logger.info("Difficulty needs to be specified in the command.")
+
     def _cmd_disable_mission_check(self) -> bool:
         """Disables the check to see if a mission is available to play.  Meant for co-op runs where one player can play
         the next mission in a chain the other player is doing."""
@@ -91,6 +110,7 @@ class SC2Context(CommonContext):
     missions_unlocked = False
     current_tooltip = None
     last_loc_list = None
+    difficulty_override = -1
 
     async def server_auth(self, password_requested: bool = False):
         if password_requested and not self.password:
@@ -450,7 +470,10 @@ class ArchipelagoBot(sc2.bot_ai.BotAI):
         game_state = 0
         if iteration == 0:
             start_items = calculate_items(self.ctx.items_received)
-            difficulty = calc_difficulty(self.ctx.difficulty)
+            if self.ctx.difficulty_override >= 0:
+                difficulty = calc_difficulty(self.ctx.difficulty_override)
+            else:
+                difficulty = calc_difficulty(self.ctx.difficulty)
             await self.chat_send("ArchipelagoLoad {} {} {} {} {} {} {} {} {} {} {} {} {}".format(
                 difficulty,
                 start_items[0], start_items[1], start_items[2], start_items[3], start_items[4],

--- a/Starcraft2Client.py
+++ b/Starcraft2Client.py
@@ -45,13 +45,13 @@ class StarcraftClientProcessor(ClientCommandProcessor):
         set_difficulty = True
 
         if num_options > 0:
-            if options[0] == "Casual" or "casual":
+            if options[0].lower == "casual":
                 self.ctx.difficulty_override = 0
-            elif options[0] == "Normal" or "normal":
+            elif options[0].lower == "normal":
                 self.ctx.difficulty_override = 1
-            elif options[0] == "Hard" or "hard":
+            elif options[0].lower == "hard":
                 self.ctx.difficulty_override = 2
-            elif options[0] == "Brutal" or "brutal":
+            elif options[0].lower == "brutal":
                 self.ctx.difficulty_override = 3
             else:
                 sc2_logger.info("Unable to parse difficulty '" + options[0] + "'")

--- a/Starcraft2Client.py
+++ b/Starcraft2Client.py
@@ -43,16 +43,16 @@ class StarcraftClientProcessor(ClientCommandProcessor):
         options = difficulty.split()
         num_options = len(options)
         set_difficulty = True
-        difficulty = options[0].lower
+        difficulty_choice = options[0].lower
 
         if num_options > 0:
-            if difficulty == "casual":
+            if difficulty_choice == "casual":
                 self.ctx.difficulty_override = 0
-            elif difficulty == "normal":
+            elif difficulty_choice == "normal":
                 self.ctx.difficulty_override = 1
-            elif difficulty == "hard":
+            elif difficulty_choice == "hard":
                 self.ctx.difficulty_override = 2
-            elif difficulty == "brutal":
+            elif difficulty_choice == "brutal":
                 self.ctx.difficulty_override = 3
             else:
                 sc2_logger.info("Unable to parse difficulty '" + options[0] + "'")

--- a/Starcraft2Client.py
+++ b/Starcraft2Client.py
@@ -42,6 +42,7 @@ class StarcraftClientProcessor(ClientCommandProcessor):
         """Overrides the current difficulty set for the seed.  Takes the argument casual, normal, hard, or brutal"""
         options = difficulty.split()
         num_options = len(options)
+        set_difficulty = True
 
         if num_options > 0:
             if options[0] == "Casual" or "casual":
@@ -54,6 +55,10 @@ class StarcraftClientProcessor(ClientCommandProcessor):
                 self.ctx.difficulty_override = 3
             else:
                 sc2_logger.info("Unable to parse difficulty '" + options[0] + "'")
+                set_difficulty = False
+
+            if set_difficulty:
+                sc2_logger.info("Difficulty set to " + options[0])
         else:
             sc2_logger.info("Difficulty needs to be specified in the command.")
 

--- a/Starcraft2Client.py
+++ b/Starcraft2Client.py
@@ -43,7 +43,7 @@ class StarcraftClientProcessor(ClientCommandProcessor):
         options = difficulty.split()
         num_options = len(options)
         set_difficulty = True
-        difficulty_choice = options[0].lower
+        difficulty_choice = options[0].lower()
 
         if num_options > 0:
             if difficulty_choice == "casual":

--- a/Starcraft2Client.py
+++ b/Starcraft2Client.py
@@ -43,15 +43,16 @@ class StarcraftClientProcessor(ClientCommandProcessor):
         options = difficulty.split()
         num_options = len(options)
         set_difficulty = True
+        difficulty = options[0].lower
 
         if num_options > 0:
-            if options[0].lower == "casual":
+            if difficulty == "casual":
                 self.ctx.difficulty_override = 0
-            elif options[0].lower == "normal":
+            elif difficulty == "normal":
                 self.ctx.difficulty_override = 1
-            elif options[0].lower == "hard":
+            elif difficulty == "hard":
                 self.ctx.difficulty_override = 2
-            elif options[0].lower == "brutal":
+            elif difficulty == "brutal":
                 self.ctx.difficulty_override = 3
             else:
                 sc2_logger.info("Unable to parse difficulty '" + options[0] + "'")


### PR DESCRIPTION
Simple command to the client override the difficulty of a missions in a certain seed.  Is not persistent and is local only, will only have the override until the client is closed