### PR TITLE
Core: replace assert in push_item by exception

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -389,7 +389,8 @@ class MultiWorld():
         self.state.collect(item, True)
 
     def push_item(self, location: Location, item: Item, collect: bool = True):
-        assert location.can_fill(self.state, item, False), f"Cannot place {item} into {location}."
+        if not location.can_fill(self.state, item, False):
+            raise Exception(f"Cannot place {item} into {location}.")
         location.item = item
         item.location = location
         item.world = self  # try to not have this here anymore and create it with item?


### PR DESCRIPTION
Minimal and SMZ3 fill errors may get past the assert with `-O`. Converting that back to a full exception would correctly report the error without requiring full playthrough.

With the two SMZ3 PRs I could not reproduce the fill crashes, but minimal filling may still crash. I don't want to decide if this should be merged, but in case, this PR should make sure the errors are caught.