### PR TITLE
WebHost: Fix `OptionDict`s that define `valid_keys` from outputting as `[]` on Weighted Settings export.

### DIFF
--- a/WebHostLib/options.py
+++ b/WebHostLib/options.py
@@ -110,7 +110,7 @@ def create():
                 if option.default == "random":
                     this_option["defaultValue"] = "random"
 
-            elif hasattr(option, "range_start") and hasattr(option, "range_end"):
+            elif issubclass(option, Options.Range):
                 game_options[option_name] = {
                     "type": "range",
                     "displayName": option.display_name if hasattr(option, "display_name") else option_name,
@@ -121,7 +121,7 @@ def create():
                     "max": option.range_end,
                 }
 
-                if hasattr(option, "special_range_names"):
+                if issubclass(option, Options.SpecialRange):
                     game_options[option_name]["type"] = 'special_range'
                     game_options[option_name]["value_names"] = {}
                     for key, val in option.special_range_names.items():
@@ -141,7 +141,7 @@ def create():
                     "description": option.__doc__ if option.__doc__ else "Please document me!",
                 }
 
-            elif hasattr(option, "valid_keys"):
+            elif issubclass(option, Options.OptionList) or issubclass(option, Options.OptionSet):
                 if option.valid_keys:
                     game_options[option_name] = {
                         "type": "custom-list",

--- a/WebHostLib/static/assets/weighted-settings.js
+++ b/WebHostLib/static/assets/weighted-settings.js
@@ -91,7 +91,6 @@ const createDefaultSettings = (settingData) => {
           case 'locations-list':
           case 'custom-list':
             newSettings[game][gameSetting] = [];
-            console.log(`Setting ${game} ${setting.type} ${gameSetting} to [].`);
             break;
 
           default:

--- a/WebHostLib/static/assets/weighted-settings.js
+++ b/WebHostLib/static/assets/weighted-settings.js
@@ -91,6 +91,7 @@ const createDefaultSettings = (settingData) => {
           case 'locations-list':
           case 'custom-list':
             newSettings[game][gameSetting] = [];
+            console.log(`Setting ${game} ${setting.type} ${gameSetting} to [].`);
             break;
 
           default:


### PR DESCRIPTION
Now it doesn't output anything... just like all the other `OptionDict`s. Also some more explicit checking of types rather than if they just contain an attribute.