### PR TITLE
MultiServer: swap auto-forfeit with auto-collect order

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -579,12 +579,12 @@ class Context:
         finished_msg = f'{self.get_aliased_name(client.team, client.slot)} (Team #{client.team + 1})' \
                        f' has completed their goal.'
         self.notify_all(finished_msg)
+        if "auto" in self.collect_mode:
+            collect_player(self, client.team, client.slot)
         if "auto" in self.forfeit_mode:
             forfeit_player(self, client.team, client.slot)
         elif self.forced_auto_forfeits[self.games[client.slot]]:
             forfeit_player(self, client.team, client.slot)
-        if "auto" in self.collect_mode:
-            collect_player(self, client.team, client.slot)
 
 
 def notify_hints(ctx: Context, team: int, hints: typing.List[NetUtils.Hint], only_new: bool = False):


### PR DESCRIPTION
That way the forfeit for items for players that are still playing appear last in the log, which is the visible text in at least the py clients.