### PR TITLE
Utils: lazy decimal import

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -11,7 +11,6 @@ import io
 import collections
 import importlib
 import logging
-import decimal
 from yaml import load, load_all, dump, SafeLoader
 
 try:
@@ -507,6 +506,7 @@ def chaining_prefix(index: int, labels: typing.Tuple[str]) -> str:
 # noinspection PyPep8Naming
 def format_SI_prefix(value, power=1000, power_labels=("", "k", "M", "G", "T", "P", "E", "Z", "Y")) -> str:
     """Formats a value into a value + metric/si prefix. More info at https://en.wikipedia.org/wiki/Metric_prefix"""
+    import decimal
     n = 0
     value = decimal.Decimal(value)
     limit = power - decimal.Decimal("0.005")


### PR DESCRIPTION
decimal is kinda big, there is no noticable difference in performance and the import is unused by webhost's customserver

decimal.pyc - 342 bytes - imports either _decimal.so or _pydecimal.pyc
_decimal.*.so - 307KB - actually loaded

making a difference in idle malloc of ~300K just to hold the module ready.

to be clear:
the 300KB are not what we actually save, it's the upper bound of the potential. We import enough other stuff, that the real savings are ~~40KB~~ 160KB per process from what I can tell.