### PR TITLE
AutoWorld: make is_zip a property

### DIFF
--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -14,6 +14,10 @@ if TYPE_CHECKING:
 class AutoWorldRegister(type):
     world_types: Dict[str, type(World)] = {}
 
+    @property
+    def is_zip(cls: World):
+        return ".apworld" in cls.__file__
+
     def __new__(mcs, name: str, bases: Tuple[type, ...], dct: Dict[str, Any]) -> AutoWorldRegister:
         if "web" in dct:
             assert isinstance(dct["web"], WebWorld), "WebWorld has to be instantiated."
@@ -48,7 +52,6 @@ class AutoWorldRegister(type):
                 raise RuntimeError(f"""Game {dct["game"]} already registered.""")
             AutoWorldRegister.world_types[dct["game"]] = new_class
         new_class.__file__ = sys.modules[new_class.__module__].__file__
-        new_class.is_zip = ".apworld" in new_class.__file__
         return new_class
 
 

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -189,17 +189,17 @@ class World(metaclass=AutoWorldRegister):
         self.world = world
         self.player = player
 
-    def __getattr__(self, key):
-        if key == "is_zip":
+    def __getattr__(self, name):
+        if name == "is_zip":
             return type(self).is_zip
         raise AttributeError
 
-    def __setattr__(self, key, value):
-        if key == "is_zip":
+    def __setattr__(self, name, value):
+        if name == "is_zip":
             type(self).is_zip = value
-        elif key == "__file__":
-            raise AttributeError("Can't set attribute '__file__'")
-        self.__dict__[key] = value
+        elif name == "__file__":
+            raise AttributeError("can't set attribute '__file__'")
+        super().__setattr__(name, value)
 
     # overridable methods that get called by Main.py, sorted by execution order
     # can also be implemented as a classmethod and called "stage_<original_name>",

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -189,6 +189,18 @@ class World(metaclass=AutoWorldRegister):
         self.world = world
         self.player = player
 
+    def __getattr__(self, key):
+        if key == "is_zip":
+            return type(self).is_zip
+        raise AttributeError
+
+    def __setattr__(self, key, value):
+        if key == "is_zip":
+            type(self).is_zip = value
+        elif key == "__file__":
+            raise AttributeError("Can't set attribute '__file__'")
+        self.__dict__[key] = value
+
     # overridable methods that get called by Main.py, sorted by execution order
     # can also be implemented as a classmethod and called "stage_<original_name>",
     # in that case the MultiWorld object is passed as an argument and it gets called once for the entire multiworld.


### PR DESCRIPTION
```python
>>> from worlds.AutoWorld import AutoWorldRegister
>>> AutoWorldRegister.world_types["Secret of Evermore"].is_zip
False
>>> AutoWorldRegister.world_types["Secret of Evermore"].is_zip = True
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: can't set attribute 'is_zip'
```
```python
>>> AutoWorldRegister.world_types["Secret of Evermore"](None, 1).is_zip
False
>>> AutoWorldRegister.world_types["Secret of Evermore"](None, 1).is_zip = True
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "worlds/AutoWorld.py", line 199, in __setattr__
    type(self).is_zip = value
AttributeError: can't set attribute 'is_zip'
>>> AutoWorldRegister.world_types["Secret of Evermore"].__file__ = 'test'
>>> AutoWorldRegister.world_types["Secret of Evermore"](None, 1).__file__ = 'test'
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "worlds/AutoWorld.py", line 201, in __setattr__
    raise AttributeError("Can't set attribute '__file__'")
AttributeError: Can't set attribute '__file__'
```