### PR TITLE
Fix generation failure for Final Fantasy 1 and Dark Souls 3.

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1202,7 +1202,7 @@ class Item:
         return self.__str__()
 
     def __str__(self) -> str:
-        if self.location:
+        if self.location and self.location.parent_region and self.location.parent_region.world:
             return self.location.parent_region.world.get_name_string_for_object(self)
         return f"{self.name} (Player {self.player})"
 

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -146,7 +146,7 @@ class DarkSouls3World(World):
 
     # For each region, add the associated locations retrieved from the corresponding location_table
     def create_region(self, region_name, location_table) -> Region:
-        new_region = Region(region_name, RegionType.Generic, region_name, self.player)
+        new_region = Region(region_name, RegionType.Generic, region_name, self.player, self.world)
         if location_table:
             for name, address in location_table.items():
                 location = DarkSouls3Location(self.player, name, self.location_name_to_id[name], new_region)

--- a/worlds/ff1/__init__.py
+++ b/worlds/ff1/__init__.py
@@ -54,6 +54,7 @@ class FF1World(World):
         locations = get_options(self.world, 'locations', self.player)
         rules = get_options(self.world, 'rules', self.player)
         menu_region = self.ff1_locations.create_menu_region(self.player, locations, rules)
+        menu_region.world = self.world
         terminated_event = Location(self.player, CHAOS_TERMINATED_EVENT, EventId, menu_region)
         terminated_item = Item(CHAOS_TERMINATED_EVENT, ItemClassification.progression, EventId, self.player)
         terminated_event.place_locked_item(terminated_item)


### PR DESCRIPTION
PR #840 didn't validate that item.location had parent_region, and parent_region having world, and just blindly assumed that the entire chain of self.location.parent_region.world would be valid if self.location itself was valid.

As a consequence, I looked to see what games were broken by #840.