### PR TITLE
SC2: Added command to automatically print unlocks to a text file

### DIFF
--- a/Starcraft2Client.py
+++ b/Starcraft2Client.py
@@ -362,6 +362,8 @@ class SC2Context(CommonContext):
         await super(SC2Context, self).shutdown()
         if self.sc2_run_task:
             self.sc2_run_task.cancel()
+        if self.print_unlocks_task:
+            self.print_unlocks_task.cancel()
 
     def play_mission(self, mission_id):
         if self.missions_unlocked or \


### PR DESCRIPTION
This command was requested by a streamer.  What it does is every 1 second updates a text file called SC2Unlocks.txt with a comma separated list of all items received in a run.  Its main purpose is to allow stream overlays the ability to read items received in a run so that a streamer can make a custom stream overlay for unlocks.