### PR TITLE
Witness: More bug fixes

### DIFF
--- a/worlds/witness/__init__.py
+++ b/worlds/witness/__init__.py
@@ -65,8 +65,12 @@ class WitnessWorld(World):
         if not (is_option_enabled(self.world, self.player, "shuffle_symbols")
                 or get_option_value(self.world, self.player, "shuffle_doors")
                 or is_option_enabled(self.world, self.player, "shuffle_lasers")):
-            warning("This Witness world doesn't have any progression items. Please turn on Symbol Shuffle, Door"
-                    " Shuffle or Laser Shuffle if that doesn't seem right.")
+            if self.world.players == 1:
+                warning("This Witness world doesn't have any progression items. Please turn on Symbol Shuffle, Door"
+                        " Shuffle or Laser Shuffle if that doesn't seem right.")
+            else:
+                raise Exception("This Witness world doesn't have any progression items. Please turn on Symbol Shuffle,"
+                                " Door Shuffle or Laser Shuffle.")
 
         self.player_logic = WitnessPlayerLogic(self.world, self.player)
         self.locat = WitnessPlayerLocations(self.world, self.player, self.player_logic)

--- a/worlds/witness/__init__.py
+++ b/worlds/witness/__init__.py
@@ -13,6 +13,7 @@ from .rules import set_rules
 from .regions import WitnessRegions
 from .Options import is_option_enabled, the_witness_options, get_option_value
 from .utils import best_junk_to_add_based_on_weights
+from logging import warning
 
 
 class WitnessWebWorld(WebWorld):
@@ -63,8 +64,8 @@ class WitnessWorld(World):
         if not (is_option_enabled(self.world, self.player, "shuffle_symbols")
                 or get_option_value(self.world, self.player, "shuffle_doors")
                 or is_option_enabled(self.world, self.player, "shuffle_lasers")):
-            raise Exception("This Witness world doesn't have any progression items. Please turn on Symbol Shuffle, Door"
-                            " Shuffle or Laser Shuffle")
+            warning("This Witness world doesn't have any progression items. Please turn on Symbol Shuffle, Door"
+                    " Shuffle or Laser Shuffle if that doesn't seem right.")
 
         self.player_logic = WitnessPlayerLogic(self.world, self.player)
         self.locat = WitnessPlayerLocations(self.world, self.player, self.player_logic)

--- a/worlds/witness/__init__.py
+++ b/worlds/witness/__init__.py
@@ -57,7 +57,8 @@ class WitnessWorld(World):
             'panelhex_to_id': self.locat.CHECK_PANELHEX_TO_ID,
             'item_id_to_door_hexes': self.items.ITEM_ID_TO_DOOR_HEX,
             'door_hexes': self.items.DOORS,
-            'symbols_not_in_the_game': self.items.SYMBOLS_NOT_IN_THE_GAME
+            'symbols_not_in_the_game': self.items.SYMBOLS_NOT_IN_THE_GAME,
+            'disabled_panels': self.player_logic.COMPLETELY_DISABLED_CHECKS,
         }
 
     def generate_early(self):

--- a/worlds/witness/locations.py
+++ b/worlds/witness/locations.py
@@ -277,6 +277,8 @@ class WitnessPlayerLocations:
         if not is_option_enabled(world, player, "shuffle_postgame"):
             self.CHECK_LOCATIONS -= postgame
 
+        self.CHECK_LOCATIONS.discard(StaticWitnessLogic.CHECKS_BY_HEX[player_logic.VICTORY_LOCATION]["checkName"])
+
         self.CHECK_LOCATIONS = self.CHECK_LOCATIONS - {
             StaticWitnessLogic.CHECKS_BY_HEX[check_hex]["checkName"]
             for check_hex in player_logic.COMPLETELY_DISABLED_CHECKS

--- a/worlds/witness/player_logic.py
+++ b/worlds/witness/player_logic.py
@@ -37,7 +37,7 @@ class WitnessPlayerLogic:
         """
 
         if panel_hex in self.COMPLETELY_DISABLED_CHECKS:
-            return frozenset({frozenset("F")})
+            return frozenset()
 
         check_obj = StaticWitnessLogic.CHECKS_BY_HEX[panel_hex]
 
@@ -76,7 +76,7 @@ class WitnessPlayerLogic:
                 dep_obj = StaticWitnessLogic.CHECKS_BY_HEX.get(option_panel)
 
                 if option_panel in self.COMPLETELY_DISABLED_CHECKS:
-                    new_items = frozenset({frozenset("F")})
+                    new_items = frozenset()
                 elif option_panel in {"7 Lasers", "11 Lasers"}:
                     new_items = frozenset({frozenset([option_panel])})
                 # If a panel turns on when a panel in a different region turns on,

--- a/worlds/witness/player_logic.py
+++ b/worlds/witness/player_logic.py
@@ -36,6 +36,9 @@ class WitnessPlayerLogic:
         Panels outside of the same region will still be checked manually.
         """
 
+        if panel_hex in self.COMPLETELY_DISABLED_CHECKS:
+            return frozenset({frozenset("F")})
+
         check_obj = StaticWitnessLogic.CHECKS_BY_HEX[panel_hex]
 
         these_items = frozenset({frozenset()})
@@ -72,7 +75,9 @@ class WitnessPlayerLogic:
             for option_panel in option:
                 dep_obj = StaticWitnessLogic.CHECKS_BY_HEX.get(option_panel)
 
-                if option_panel in {"7 Lasers", "11 Lasers"}:
+                if option_panel in self.COMPLETELY_DISABLED_CHECKS:
+                    new_items = frozenset({frozenset("F")})
+                elif option_panel in {"7 Lasers", "11 Lasers"}:
                     new_items = frozenset({frozenset([option_panel])})
                 # If a panel turns on when a panel in a different region turns on,
                 # the latter panel will be an "event panel", unless it ends up being
@@ -204,9 +209,11 @@ class WitnessPlayerLogic:
         elif get_option_value(world, player, "victory_condition") == 3:
             self.VICTORY_LOCATION = "0xFFF00"
 
-        self.COMPLETELY_DISABLED_CHECKS.add(
-            self.VICTORY_LOCATION
-        )
+        if get_option_value(world, player, "challenge_lasers") <= 7:
+            adjustment_linesets_in_order.append([
+                "Requirement Changes:",
+                "0xFFF00 - 11 Lasers - True",
+            ])
 
         if is_option_enabled(world, player, "disable_non_randomized_puzzles"):
             adjustment_linesets_in_order.append(get_disable_unrandomized_list())
@@ -356,6 +363,12 @@ class WitnessPlayerLogic:
             "0x2700B": "Open Door to Treehouse Laser House",
             "0x00055": "Orchard Apple Trees 4 Turns On",
             "0x17DDB": "Left Orange Bridge Fully Extended",
+            "0x03535": "Shipwreck Video Pattern Knowledge",
+            "0x03542": "Mountain Video Pattern Knowledge",
+            "0x0339E": "Desert Video Pattern Knowledge",
+            "0x03481": "Tutorial Video Pattern Knowledge",
+            "0x03702": "Jungle Video Pattern Knowledge",
+            "0x0356B": "Challenge Video Pattern Knowledge",
         }
 
         self.ALWAYS_EVENT_NAMES_BY_HEX = {
@@ -371,12 +384,6 @@ class WitnessPlayerLogic:
             "0x0C2B2": "Bunker Laser Activation",
             "0x00BF6": "Swamp Laser Activation",
             "0x028A4": "Treehouse Laser Activation",
-            "0x03535": "Shipwreck Video Pattern Knowledge",
-            "0x03542": "Mountain Video Pattern Knowledge",
-            "0x0339E": "Desert Video Pattern Knowledge",
-            "0x03481": "Tutorial Video Pattern Knowledge",
-            "0x03702": "Jungle Video Pattern Knowledge",
-            "0x0356B": "Challenge Video Pattern Knowledge",
             "0x09F7F": "Mountaintop Trap Door Turns On",
             "0x17C34": "Mountain Access",
         }

--- a/worlds/witness/settings/Disable_Unrandomized.txt
+++ b/worlds/witness/settings/Disable_Unrandomized.txt
@@ -1,15 +1,15 @@
 Event Items:
-Town Tower 4th Door Opens - 0x17CFB,0x3C12B,0x00B8D,0x17CF7
-Monastery Laser Activation - 0x00A5B,0x17CE7,0x17FA9,0x17CA4
+Monastery Laser Activation - 0x00A5B,0x17CE7,0x17FA9
 Bunker Laser Activation - 0x00061,0x17D01,0x17C42
 Shadows Laser Activation - 0x00021,0x17D28,0x17C71
 
 Requirement Changes:
-0x17C65 - 0x00A5B | 0x17CE7 | 0x17FA9 | 0x17CA4
+0x17C65 - 0x00A5B | 0x17CE7 | 0x17FA9
 0x0C2B2 - 0x00061 | 0x17D01 | 0x17C42
 0x181B3 - 0x00021 | 0x17D28 | 0x17C71
 0x28B39 - True - Reflection
 0x17CAB - True - True
+0x2779A - True - 0x17CFB | 0x3C12B | 0x17CF7
 
 Disabled Locations:
 0x03505 (Tutorial Gate Close)
@@ -61,7 +61,7 @@ Disabled Locations:
 0x193AA (Monastery Branch Avoid 2)
 0x193AB (Monastery Branch Follow 1)
 0x193A6 (Monastery Branch Follow 2)
-0x17CA4 (Monastery Laser) - 0x193A6 - True
+0x17CA4 (Monastery Laser)
 0x18590 (Tree Outlines) - True - Symmetry & Environment
 0x28AE3 (Vines Shadows Follow) - 0x18590 - Shadows Follow & Environment
 0x28938 (Four-way Apple Tree) - 0x28AE3 - Environment

--- a/worlds/witness/settings/Disable_Unrandomized.txt
+++ b/worlds/witness/settings/Disable_Unrandomized.txt
@@ -104,3 +104,5 @@ Disabled Locations:
 0x09DE0 (Bunker Laser)
 0x0A079 (Bunker Elevator Control)
 0x0042D (Mountaintop River Shape)
+
+0x17CAA (River Door to Garden Panel)


### PR DESCRIPTION
- Fixed logic for disable_non_randomized (It previously thought you could still use the original activation triggers for lasers)
- Changed Exception for no progression items to a Warning
- Made it so the Mountaintop Box Long solution does not logically require access to the stairs below the box *if* the requirement is set to 7 lasers or lower
- Other small changes