### PR TITLE
SC2: add anti air to Devil's Playground Victory

### DIFF
--- a/worlds/sc2wol/Locations.py
+++ b/worlds/sc2wol/Locations.py
@@ -176,7 +176,8 @@ def get_locations(world: Optional[MultiWorld], player: Optional[int]) -> Tuple[L
                                    state._sc2wol_has_competent_anti_air(world, player) and
                                    state.has('Science Vessel', player)),
         LocationData("Devil's Playground", "Devil's Playground: Victory", SC2WOL_LOC_ID_OFFSET + 1300,
-                     lambda state: state._sc2wol_has_common_unit(world, player) or state.has("Reaper", player)),
+                     lambda state: state._sc2wol_has_anti_air(world, player) and (
+                             state._sc2wol_has_common_unit(world, player) or state.has("Reaper", player))),
         LocationData("Devil's Playground", "Devil's Playground: Tosh's Miners", SC2WOL_LOC_ID_OFFSET + 1301),
         LocationData("Devil's Playground", "Devil's Playground: Brutalisk", SC2WOL_LOC_ID_OFFSET + 1302,
                      lambda state: state._sc2wol_has_common_unit(world, player) or state.has("Reaper", player)),


### PR DESCRIPTION
People seem to be on the mission long enough to get attacked by Mutalisks, so Victory should require anti air.
Optional Objectives are doable quite comfortably before Mutalisks show up, allowing the anti-air to be on them for later in the mission.