### PR TITLE
WebHost: Remove "Wiki" link from footer

### DIFF
--- a/WebHostLib/templates/islandFooter.html
+++ b/WebHostLib/templates/islandFooter.html
@@ -6,8 +6,6 @@
             -
             <a href="https://github.com/ArchipelagoMW/Archipelago">Source Code</a>
             -
-            <a href="https://github.com/ArchipelagoMW/Archipelago/wiki">Wiki</a>
-            -
             <a href="https://github.com/ArchipelagoMW/Archipelago/graphs/contributors">Contributors</a>
             -
             <a href="https://github.com/ArchipelagoMW/Archipelago/issues">Bug Report</a>


### PR DESCRIPTION
GitHub wiki is hardly updated and we prefer developers/users to use the markdown documentation in the docs/ directory anyway, so removed link in footer.

Before:
![image](https://user-images.githubusercontent.com/11338376/185768884-ee6ed846-e20e-4263-a69d-d575eabcaea8.png)

After:
![image](https://user-images.githubusercontent.com/11338376/185768900-fd15a165-8269-4cda-9819-2f531b89d406.png)
