### PR TITLE
SC2: Switched mission item group to a list comprehension

### DIFF
--- a/worlds/sc2wol/Items.py
+++ b/worlds/sc2wol/Items.py
@@ -1,5 +1,6 @@
 from BaseClasses import Item, ItemClassification
 import typing
+from .MissionTables import vanilla_mission_req_table
 
 
 class ItemData(typing.NamedTuple):
@@ -153,12 +154,7 @@ basic_unit: typing.Tuple[str, ...] = (
 item_name_groups = {}
 for item, data in item_table.items():
     item_name_groups.setdefault(data.type, []).append(item)
-item_name_groups["Missions"] = ["Beat Liberation Day", "Beat The Outlaws", "Beat Zero Hour", "Beat Evacuation",
-                         "None Outbreak", "Beat Safe Haven", "Beat Haven's Fall", "Beat Smash and Grab", "Beat The Dig",
-                         "Beat The Moebius Factor", "Beat Supernova", "Beat Maw of the Void", "Beat Devil's Playground",
-                         "Beat Welcome to the Jungle", "Beat Breakout", "Beat Ghost of a Chance",
-                         "Beat The Great Train Robbery", "Beat Cutthroat", "Beat Engine of Destruction",
-                         "Beat Media Blitz", "Beat Piercing the Shroud"]
+item_name_groups["Missions"] = ["Beat " + mission_name for mission_name in vanilla_mission_req_table]
 
 filler_items: typing.Tuple[str, ...] = (
     '+15 Starting Minerals',


### PR DESCRIPTION
## What is this fixing or adding?

Some of the "Beat Mission" items defined in Items.py were incorrectly named (and they were all manually entered), so they are replaced with a list comprehension that pulls mission names from MissionTables.py.  This fixes a generation error where certain missions could never be recognized as complete, preventing generation from accessing large portions of the campaign.

## How was this tested?

Ran ~100 generations on a generic mission shuffle yaml.