### PR TITLE
Factorio: Detect if more than one AP factorio mod is loaded.

### DIFF
--- a/worlds/factorio/data/mod_template/settings.lua
+++ b/worlds/factorio/data/mod_template/settings.lua
@@ -1,3 +1,21 @@
+-- Find out if more than one AP mod is loaded, and if so, error out.
+function mod_is_AP(str)
+    -- lua string.match is way more restrictive than regex. Regex would be "^AP-\d{20}-P[1-9]\d*-.+$"
+	local result = string.match(str, "^AP%-%d%d%d%d%d%d%d%d%d%d%d%d%d%d%d%d%d%d%d%d%-P[1-9]%d-%-.+$")
+	if result ~= nil then
+		log("Archipelago Mod: " .. result .. " is loaded.")
+	end
+	return result ~= nil
+end
+local ap_mod_count = 0
+for name, _ in pairs(mods) do
+    if mod_is_AP(name) then
+        ap_mod_count = ap_mod_count + 1
+        if ap_mod_count > 1 then
+            error("More than one Archipelago Factorio mod is loaded.")
+        end
+    end
+end
 data:extend({
     {
         type = "bool-setting",

--- a/worlds/factorio/data/mod_template/settings.lua
+++ b/worlds/factorio/data/mod_template/settings.lua
@@ -1,7 +1,7 @@
 -- Find out if more than one AP mod is loaded, and if so, error out.
 function mod_is_AP(str)
-    -- lua string.match is way more restrictive than regex. Regex would be "^AP-\d{20}-P[1-9]\d*-.+$"
-	local result = string.match(str, "^AP%-%d%d%d%d%d%d%d%d%d%d%d%d%d%d%d%d%d%d%d%d%-P[1-9]%d-%-.+$")
+    -- lua string.match is way more restrictive than regex. Regex would be "^AP-W?\d{20}-P[1-9]\d*-.+$"
+	local result = string.match(str, "^AP%-W?%d%d%d%d%d%d%d%d%d%d%d%d%d%d%d%d%d%d%d%d%-P[1-9]%d-%-.+$")
 	if result ~= nil then
 		log("Archipelago Mod: " .. result .. " is loaded.")
 	end


### PR DESCRIPTION
Rather than having to wait for the client to load up all the way to the first time it attempts to reach control phase to find out that it borked because more than one factorio AP mod attempted to define the exact same command functions,  best catch this during the earliest phase possible.

This is what that looks like in the factorio client.
![image](https://user-images.githubusercontent.com/79097/186334126-4a73408d-986f-4c6f-b45d-d4ba06d0e4b4.png)

If at least one of the mod instances has this change, it will catch all the instances whether or not the change is present. (as shown in the following image.)
![image](https://user-images.githubusercontent.com/79097/186334683-32df7195-dcc6-4e7a-b8d5-a08fc4890e94.png)

And no error if one and only one factorio AP mod is loaded.
![image](https://user-images.githubusercontent.com/79097/186335058-c62f46b4-e835-4793-a181-d440214aeca3.png)

