### PR TITLE
WebHost: sort game list case-insensitively again

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -619,7 +619,7 @@ def title_sorted(data: typing.Sequence, key=None, ignore: typing.Set = frozenset
     def sorter(element: str) -> str:
         parts = element.split(maxsplit=1)
         if parts[0].lower() in ignore:
-            return parts[1]
+            return parts[1].lower()
         else:
-            return element
+            return element.lower()
     return sorted(data, key=lambda i: sorter(key(i)) if key else sorter(i))

--- a/WebHost.py
+++ b/WebHost.py
@@ -104,7 +104,7 @@ def create_ordered_tutorials_file() -> typing.List[typing.Dict[str, typing.Any]]
         for games in data:
             if 'Archipelago' in games['gameTitle']:
                 generic_data = data.pop(data.index(games))
-        sorted_data = [generic_data] + Utils.title_sorted(data, key=lambda entry: entry["gameTitle"].lower())
+        sorted_data = [generic_data] + Utils.title_sorted(data, key=lambda entry: entry["gameTitle"])
         json.dump(sorted_data, json_target, indent=2, ensure_ascii=False)
     return sorted_data
 

--- a/WebHostLib/templates/supportedGames.html
+++ b/WebHostLib/templates/supportedGames.html
@@ -1,7 +1,7 @@
 {% extends 'pageWrapper.html' %}
 
 {% block head %}
-    <title>Player Settings</title>
+    <title>Supported Games</title>
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename="styles/markdown.css") }}" />
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename="styles/supportedGames.css") }}" />
 {% endblock %}


### PR DESCRIPTION
## What is this fixing or adding?

- Case-insensitive sort of the game list on some webpages was broken by #883. Reason being that Jinja, unlike python, has default case insensitive sort, which we were using prior to that PR. Case sensitivity was accidentally introduced to Jinja's sorting of the **Supported Games** list by writing a custom sort function
- Fix preserves title sort while bringing back case insensitive sort.
- Also made the Supported Games page `<title>` more relevant to its content and match how you navigate there.

## How was this tested?

- Diffed the webpage text of `/games` and `/tutorial` before and after. The only effect was sorting SMZ3 correctly again in `/games`.