### PR TITLE
Factorio: Fix a bug with single craft free samples.

### DIFF
--- a/worlds/factorio/data/mod_template/control.lua
+++ b/worlds/factorio/data/mod_template/control.lua
@@ -249,6 +249,10 @@ script.on_event(defines.events.on_player_main_inventory_changed, update_player_e
 
 function add_samples(force, name, count)
     local function add_to_table(t)
+        if count <= 0 then
+			-- Fixes a bug with single craft, if a recipe gives 0 of a given item.
+			return
+		end
         t[name] = (t[name] or 0) + count
     end
     -- Add to global table of earned samples for future new players


### PR DESCRIPTION
Found a bug where if a recipe gives 0 of an item, then the mod can crash, if the recipe was unlocked in single craft mode.  (it dies at can_insert(stack)).

Found this bug while testing a standalone version of free samples, and of course, I needed to back port this bug fix here.