### PR TITLE
core: have common client only update games in remote package

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -345,6 +345,8 @@ class CommonContext:
         cache_package = Utils.persistent_load().get("datapackage", {}).get("games", {})
         needed_updates: typing.Set[str] = set()
         for game in relevant_games:
+            if game not in remote_datepackage_versions:
+                continue
             remote_version: int = remote_datepackage_versions[game]
 
             if remote_version == 0:  # custom datapackage for this game


### PR DESCRIPTION
## What is this fixing or adding?
If the common client has games in its data package that the remote data package doesn't you get an invalid key error

## How was this tested?
https://archipelago.gg/seed/aw0ruAJGRSG7zfPCj3KOlQ
