### PR TITLE
WebHost: fix local_path on python 3.8

### DIFF
--- a/WebHost.py
+++ b/WebHost.py
@@ -12,7 +12,7 @@ ModuleUpdate.update()
 # in case app gets imported by something like gunicorn
 import Utils
 
-Utils.local_path.cached_path = os.path.dirname(__file__) or "."
+Utils.local_path.cached_path = os.path.dirname(__file__) or "."  # py3.8 is not abs. remove "." when dropping 3.8
 
 from WebHostLib import register, app as raw_app
 from waitress import serve

--- a/WebHost.py
+++ b/WebHost.py
@@ -12,7 +12,7 @@ ModuleUpdate.update()
 # in case app gets imported by something like gunicorn
 import Utils
 
-Utils.local_path.cached_path = os.path.dirname(__file__)
+Utils.local_path.cached_path = os.path.dirname(__file__) or "."
 
 from WebHostLib import register, app as raw_app
 from waitress import serve


### PR DESCRIPTION
`__file__` is relative in 3.8, so `os.path.dirname(__file__)` ends up being an empty string breaking calls to `local_path()` (without arguments)

(an alternative solution would be to do `dirname(abspath(__file__))`, but I think this fix is simpler (and not required once we drop 3.8))