### PR TITLE
Tests: Check for Holes in the Item Pool

### DIFF
--- a/test/general/TestItems.py
+++ b/test/general/TestItems.py
@@ -34,8 +34,8 @@ class TestBase(unittest.TestCase):
     def testItemCountGreaterEqualLocations(self):
         for game_name, world_type in AutoWorldRegister.world_types.items():
 
-            if game_name not in {"Archipelago", "Final Fantasy"}:
-
+            if game_name in {"Final Fantasy"}:
+                continue
             with self.subTest("Game", game=game_name):
                 world = setup_default_world(world_type)
                 location_count = sum(0 if location.event or location.item else 1 for location in world.get_locations())

--- a/test/general/TestItems.py
+++ b/test/general/TestItems.py
@@ -38,10 +38,7 @@ class TestBase(unittest.TestCase):
 
             with self.subTest("Game", game=game_name):
                 world = setup_default_world(world_type)
-                location_count = 0
-                for location in world.get_locations():
-                    if not location.event and location.item is None:  # ignore events and manually placed
-                        location_count += 1
+                location_count = sum(0 if location.event or location.item else 1 for location in world.get_locations())
                 self.assertGreaterEqual(
                     len(world.itempool),
                     location_count,

--- a/test/general/TestItems.py
+++ b/test/general/TestItems.py
@@ -34,7 +34,7 @@ class TestBase(unittest.TestCase):
     def testItemCountGreaterEqualLocations(self):
         for game_name, world_type in AutoWorldRegister.world_types.items():
 
-            if game_name == "Archipelago" or game_name == "Final Fantasy":
+            if game_name not in {"Archipelago", "Final Fantasy"}:
                 continue
 
             with self.subTest("Game", game=game_name):

--- a/test/general/TestItems.py
+++ b/test/general/TestItems.py
@@ -35,7 +35,6 @@ class TestBase(unittest.TestCase):
         for game_name, world_type in AutoWorldRegister.world_types.items():
 
             if game_name not in {"Archipelago", "Final Fantasy"}:
-                continue
 
             with self.subTest("Game", game=game_name):
                 world = setup_default_world(world_type)

--- a/test/general/TestItems.py
+++ b/test/general/TestItems.py
@@ -1,5 +1,6 @@
 import unittest
 from worlds.AutoWorld import AutoWorldRegister
+from . import setup_default_world
 
 
 class TestBase(unittest.TestCase):
@@ -29,3 +30,21 @@ class TestBase(unittest.TestCase):
                         with self.subTest(group_name, group_name=group_name):
                             for item in items:
                                 self.assertIn(item, world_type.item_name_to_id)
+
+    def testItemCountGreaterEqualLocations(self):
+        for game_name, world_type in AutoWorldRegister.world_types.items():
+
+            if game_name == "Archipelago" or game_name == "Final Fantasy":
+                continue
+
+            with self.subTest("Game", game=game_name):
+                world = setup_default_world(world_type)
+                location_count = 0
+                for location in world.get_locations():
+                    if not location.event and location.item is None:  # ignore events and manually placed
+                        location_count += 1
+                self.assertGreaterEqual(
+                    len(world.itempool),
+                    location_count,
+                    f"{game_name} Item count MUST meet or exceede the number of locations",
+                )


### PR DESCRIPTION
This was an implementation requirement that wasn't quite clear to me starting out. Adding a test makes it extremely clear - generation breaks when games don't have enough items in the pool.

Also trying to get a feel for how PRs work around here before my big one.

## How was this tested?
```
python -m pytest .\test\general\TestItems.py
```

First normally, and second, removing a single filler item from my game on my dev branch.