### PR TITLE
OoT: prevent glitched + mq dungeons

### DIFF
--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -190,7 +190,11 @@ class OOTWorld(World):
 
         # Determine which dungeons are MQ
         # Possible future plan: allow user to pick which dungeons are MQ
-        mq_dungeons = self.world.random.sample(dungeon_table, self.mq_dungeons)
+        if self.logic_rules == 'glitchless':
+            mq_dungeons = self.world.random.sample(dungeon_table, self.mq_dungeons)
+        else:
+            self.mq_dungeons = 0
+            mq_dungeons = []
         self.dungeon_mq = {item['name']: (item in mq_dungeons) for item in dungeon_table}
 
         # Determine tricks in logic


### PR DESCRIPTION
## What is this fixing or adding?
It turns out that glitched logic and MQ dungeons are not compatible. This is something that I missed when adding MQ functionality originally, so this never actually worked anyway. On ootrandomizer this is also forbidden, so we'll forbid it here too.
A big rewrite for glitched logic is in the works, so once that's done I'll port it over and we should get glitched+MQ with it.