### PR TITLE
CI: fix automated builds, update SNI and Enemizer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,11 @@ name: Build
 
 on: workflow_dispatch
 
+env:
+  SNI_VERSION: v0.0.84
+  ENEMIZER_VERSION: 7.1
+  APPIMAGETOOL_VERSION: 13
+
 jobs:
   # build-release-macos: # LF volunteer
 
@@ -17,9 +22,9 @@ jobs:
           python-version: '3.8'
       - name: Download run-time dependencies
         run: |
-          Invoke-WebRequest -Uri https://github.com/alttpo/sni/releases/download/v0.0.82/sni-v0.0.82-windows-amd64.zip -OutFile sni.zip
+          Invoke-WebRequest -Uri https://github.com/alttpo/sni/releases/download/${Env:SNI_VERSION}/sni-${Env:SNI_VERSION}-windows-amd64.zip -OutFile sni.zip
           Expand-Archive -Path sni.zip -DestinationPath SNI -Force
-          Invoke-WebRequest -Uri https://github.com/Ijwu/Enemizer/releases/download/7.0.1/win-x64.zip -OutFile enemizer.zip
+          Invoke-WebRequest -Uri https://github.com/Ijwu/Enemizer/releases/download/${Env:ENEMIZER_VERSION}/win-x64.zip -OutFile enemizer.zip
           Expand-Archive -Path enemizer.zip -DestinationPath EnemizerCLI -Force
       - name: Build
         run: |
@@ -43,6 +48,7 @@ jobs:
   build-ubuntu1804:
     runs-on: ubuntu-18.04
     steps:
+      # - copy code below to release.yml -
       - uses: actions/checkout@v2
       - name: Install base dependencies
         run: |
@@ -56,18 +62,18 @@ jobs:
       - name: Install build-time dependencies
         run: |
           echo "PYTHON=python3.9" >> $GITHUB_ENV
-          wget -nv https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-x86_64.AppImage
+          wget -nv https://github.com/AppImage/AppImageKit/releases/download/$APPIMAGETOOL_VERSION/appimagetool-x86_64.AppImage
           chmod a+rx appimagetool-x86_64.AppImage
           ./appimagetool-x86_64.AppImage --appimage-extract
           echo -e '#/bin/sh\n./squashfs-root/AppRun "$@"' > appimagetool
           chmod a+rx appimagetool
       - name: Download run-time dependencies
         run: |
-          wget -nv https://github.com/alttpo/sni/releases/download/v0.0.82/sni-v0.0.82-manylinux2014-amd64.tar.xz
+          wget -nv https://github.com/alttpo/sni/releases/download/$SNI_VERSION/sni-$SNI_VERSION-manylinux2014-amd64.tar.xz
           tar xf sni-*.tar.xz
           rm sni-*.tar.xz
           mv sni-* SNI
-          wget -nv https://github.com/Ijwu/Enemizer/releases/download/7.0.1/ubuntu.16.04-x64.7z
+          wget -nv https://github.com/Ijwu/Enemizer/releases/download/$ENEMIZER_VERSION/ubuntu.16.04-x64.7z
           7za x -oEnemizerCLI/ ubuntu.16.04-x64.7z
       - name: Build
         run: |
@@ -84,6 +90,7 @@ jobs:
           (cd build && DIR_NAME="`ls | grep exe`" && mv "$DIR_NAME" Archipelago && tar -czvf ../dist/$TAR_NAME Archipelago && mv Archipelago "$DIR_NAME")
           echo "APPIMAGE_NAME=$APPIMAGE_NAME" >> $GITHUB_ENV
           echo "TAR_NAME=$TAR_NAME" >> $GITHUB_ENV
+      # - copy code above to release.yml -
       - name: Store AppImage
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,11 @@ on:
     tags:
       - '*.*.*'
 
+env:
+  SNI_VERSION: v0.0.84
+  ENEMIZER_VERSION: 7.1
+  APPIMAGETOOL_VERSION: 13
+
 jobs:
   create-release:
     runs-on: ubuntu-latest
@@ -44,22 +49,23 @@ jobs:
       - name: Install build-time dependencies
         run: |
           echo "PYTHON=python3.9" >> $GITHUB_ENV
-          wget -nv https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-x86_64.AppImage
+          wget -nv https://github.com/AppImage/AppImageKit/releases/download/$APPIMAGETOOL_VERSION/appimagetool-x86_64.AppImage
           chmod a+rx appimagetool-x86_64.AppImage
           ./appimagetool-x86_64.AppImage --appimage-extract
           echo -e '#/bin/sh\n./squashfs-root/AppRun "$@"' > appimagetool
           chmod a+rx appimagetool
       - name: Download run-time dependencies
         run: |
-          wget -nv https://github.com/alttpo/sni/releases/download/v0.0.82/sni-v0.0.82-manylinux2014-amd64.tar.xz
+          wget -nv https://github.com/alttpo/sni/releases/download/$SNI_VERSION/sni-$SNI_VERSION-manylinux2014-amd64.tar.xz
           tar xf sni-*.tar.xz
           rm sni-*.tar.xz
           mv sni-* SNI
-          wget -nv https://github.com/Ijwu/Enemizer/releases/download/7.0.1/ubuntu.16.04-x64.7z
+          wget -nv https://github.com/Ijwu/Enemizer/releases/download/$ENEMIZER_VERSION/ubuntu.16.04-x64.7z
           7za x -oEnemizerCLI/ ubuntu.16.04-x64.7z
       - name: Build
         run: |
-          "${{ env.PYTHON }}" -m pip install --upgrade pip setuptools virtualenv PyGObject  # pygobject should probably move to requirements
+          # pygobject is an optional dependency for kivy that's not in requirements
+          "${{ env.PYTHON }}" -m pip install --upgrade pip virtualenv PyGObject setuptools
           "${{ env.PYTHON }}" -m venv venv
           source venv/bin/activate
           pip install -r requirements.txt

--- a/Launcher.py
+++ b/Launcher.py
@@ -19,8 +19,9 @@ from os.path import isfile
 from shutil import which
 from typing import Iterable, Sequence, Callable, Union, Optional
 
-import ModuleUpdate
-ModuleUpdate.update()
+if __name__ == "__main__":
+    import ModuleUpdate
+    ModuleUpdate.update()
 
 from Utils import is_frozen, user_path, local_path, init_logging, open_filename, messagebox, \
     is_windows, is_macos, is_linux
@@ -69,6 +70,7 @@ def browse_files():
         webbrowser.open(file)
 
 
+# noinspection PyArgumentList
 class Type(Enum):
     TOOL = auto()
     FUNC = auto()  # not a real component


### PR DESCRIPTION
## What is this fixing or adding?

* Launcher.py always running ModuleUpdate breaks setup.py build --yes
* Use env variables in github workflows
* Update SNI and Enemizer versions in github workflows
* Minor cleanup in workflows
* Silence pycharm warning in Launcher.py

## How was this tested?

https://github.com/black-sliver/Archipelago/runs/8179743619
