### PR TITLE
ALttP: remove link_palettes option

### DIFF
--- a/LttPAdjuster.py
+++ b/LttPAdjuster.py
@@ -83,9 +83,9 @@ def main():
     parser.add_argument('--ow_palettes', default='default',
                         choices=['default', 'random', 'blackout', 'puke', 'classic', 'grayscale', 'negative', 'dizzy',
                                  'sick'])
-    parser.add_argument('--link_palettes', default='default',
-                        choices=['default', 'random', 'blackout', 'puke', 'classic', 'grayscale', 'negative', 'dizzy',
-                                 'sick'])
+    # parser.add_argument('--link_palettes', default='default',
+    #                     choices=['default', 'random', 'blackout', 'puke', 'classic', 'grayscale', 'negative', 'dizzy',
+    #                              'sick'])
     parser.add_argument('--shield_palettes', default='default',
                         choices=['default', 'random', 'blackout', 'puke', 'classic', 'grayscale', 'negative', 'dizzy',
                                  'sick'])

--- a/worlds/alttp/Options.py
+++ b/worlds/alttp/Options.py
@@ -282,8 +282,8 @@ class ShieldPalette(Palette):
     display_name = "Shield Palette"
 
 
-class LinkPalette(Palette):
-    display_name = "Link Palette"
+# class LinkPalette(Palette):
+#     display_name = "Link Palette"
 
 
 class HeartBeep(Choice):
@@ -387,7 +387,7 @@ alttp_options: typing.Dict[str, type(Option)] = {
     "hud_palettes": HUDPalette,
     "sword_palettes": SwordPalette,
     "shield_palettes": ShieldPalette,
-    "link_palettes": LinkPalette,
+    # "link_palettes": LinkPalette,
     "heartbeep": HeartBeep,
     "heartcolor": HeartColor,
     "quickswap": QuickSwap,

--- a/worlds/alttp/__init__.py
+++ b/worlds/alttp/__init__.py
@@ -378,7 +378,7 @@ class ALTTPWorld(World):
                 'hud': world.hud_palettes[player],
                 'sword': world.sword_palettes[player],
                 'shield': world.shield_palettes[player],
-                'link': world.link_palettes[player]
+                # 'link': world.link_palettes[player]
             }
             palettes_options = {key: option.current_key for key, option in palettes_options.items()}
 


### PR DESCRIPTION
The `link_palettes` option is disabled because it doesn't work and is also incompatible with `random_sprite_on_event`. However, it's still exposed on the settings page. This simply removes the option from view so that we do not have a nonfunctional setting.