### PR TITLE
FF1: fix FF1Client messaging and scoped lua messaging with printjson

### DIFF
--- a/FF1Client.py
+++ b/FF1Client.py
@@ -74,11 +74,13 @@ class FF1Context(CommonContext):
             msg = args['text']
             if ': !' not in msg:
                 self._set_message(msg, SYSTEM_MESSAGE_ID)
-        elif cmd == "ReceivedItems":
-            msg = f"Received {', '.join([self.item_names[item.item] for item in args['items']])}"
-            self._set_message(msg, SYSTEM_MESSAGE_ID)
 
     def on_print_json(self, args: dict):
+        if self.ui:
+            self.ui.print_json(copy.deepcopy(args["data"]))
+        else:
+            text = self.jsontotextparser(copy.deepcopy(args["data"]))
+            logger.info(text)
         relevant = args.get("type", None) in {"Hint", "ItemSend"}
         if relevant:
             item = args["item"]


### PR DESCRIPTION
Corrects the issue causing the client and lua messaging not displaying properly after the printjson changes

Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?
Corrects the issue where no messages were being displayed in the FF1Client and still keeps the scoping of only relevant information displaying in the lua messages in the emulator.

## How was this tested?
Tested locally against several multiworlds with other games, hinting, item send/receiving, forfeit/collects, etc. up to seed completion, behaves as expected similar to prior to the printjson changes but also with the scoped lua messages now.

## If this makes graphical changes, please attach screenshots.
