### PR TITLE
FF1: Corrected capitalization noverworld items

### DIFF
--- a/worlds/ff1/data/items.json
+++ b/worlds/ff1/data/items.json
@@ -191,6 +191,6 @@
   "Bridge": 488,
   "Canal": 492,
   "Canoe": 498,
-  "Sigil": 499,
-  "Mark": 500
+  "SIGIL": 499,
+  "MARK": 500
 }


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?
Generation fails for Noverworld seeds since yamls from the FF1 website list Sigil and Mark as all caps, which didn't match the items.json for the FF1 world since they are lowercase.

## How was this tested?
Corrected the item.json locally and was able to generate correctly.

## If this makes graphical changes, please attach screenshots.
