### PR TITLE
FF1: Throw exception for Noverworld

### DIFF
--- a/worlds/ff1/__init__.py
+++ b/worlds/ff1/__init__.py
@@ -66,7 +66,10 @@ class FF1World(World):
             def goal_rule_and_shards(state):
                 return goal_rule(state) and state.has("Shard", self.player, 32)
             terminated_event.access_rule = goal_rule_and_shards
-
+        if "MARK" in items.keys():
+            # Fail generation for Noverworld and provide link to old FFR website
+            raise Exception("FFR Noverworld seeds must be generated on an older version of FFR. Please ensure you generated the settings using "
+                            "4-4-0.finalfantasyrandomizer.com")
         menu_region.locations.append(terminated_event)
         self.world.regions += [menu_region]
 


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?
Adds an exception when Noverworld seeds are attempted to be rolled. The workaround is to generate them on an old version of the FFR site.

## How was this tested?
Tested generation on normal seeds successfully, exception is thown on the Noverworld seeds successfully

## If this makes graphical changes, please attach screenshots.
