### PR TITLE
Test: check that default templates can be parsed into Option objects

### DIFF
--- a/test/webhost/TestFileGeneration.py
+++ b/test/webhost/TestFileGeneration.py
@@ -14,8 +14,19 @@ class TestFileGeneration(unittest.TestCase):
 
     def testOptions(self):
         WebHost.create_options_files()
-        self.assertTrue(os.path.exists(os.path.join(self.correct_path, "static", "generated", "configs")))
+        target = os.path.join(self.correct_path, "static", "generated", "configs")
+        self.assertTrue(os.path.exists(target))
         self.assertFalse(os.path.exists(os.path.join(self.incorrect_path, "static", "generated", "configs")))
+
+        # folder seems fine, so now we try to generate Options based on the default file
+        from WebHostLib.check import roll_options
+        file: os.DirEntry
+        for file in os.scandir(target):
+            if file.is_file() and file.name.endswith(".yaml"):
+                with self.subTest(file=file.name):
+                    with open(file) as f:
+                        for value in roll_options({file.name: f.read()})[0].values():
+                            self.assertTrue(value is True, f"Default Options for template {file.name} cannot be run.")
 
     def testTutorial(self):
         WebHost.create_ordered_tutorials_file()


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?
check that default templates can be parsed into Option objects

## How was this tested?
by running it

## If this makes graphical changes, please attach screenshots.
