### PR TITLE
SC2: dynamically create Beat <mission_name> Events, preventing copy-paste errors

### DIFF
--- a/worlds/sc2wol/Locations.py
+++ b/worlds/sc2wol/Locations.py
@@ -27,12 +27,9 @@ def get_locations(world: Optional[MultiWorld], player: Optional[int]) -> Tuple[L
         LocationData("Liberation Day", "Liberation Day: Fourth Statue", SC2WOL_LOC_ID_OFFSET + 104),
         LocationData("Liberation Day", "Liberation Day: Fifth Statue", SC2WOL_LOC_ID_OFFSET + 105),
         LocationData("Liberation Day", "Liberation Day: Sixth Statue", SC2WOL_LOC_ID_OFFSET + 106),
-        LocationData("Liberation Day", "Beat Liberation Day", None),
         LocationData("The Outlaws", "The Outlaws: Victory", SC2WOL_LOC_ID_OFFSET + 200,
                      lambda state: state._sc2wol_has_common_unit(world, player)),
         LocationData("The Outlaws", "The Outlaws: Rebel Base", SC2WOL_LOC_ID_OFFSET + 201,
-                     lambda state: state._sc2wol_has_common_unit(world, player)),
-        LocationData("The Outlaws", "Beat The Outlaws", None,
                      lambda state: state._sc2wol_has_common_unit(world, player)),
         LocationData("Zero Hour", "Zero Hour: Victory", SC2WOL_LOC_ID_OFFSET + 300,
                      lambda state: state._sc2wol_has_common_unit(world, player)),
@@ -41,8 +38,6 @@ def get_locations(world: Optional[MultiWorld], player: Optional[int]) -> Tuple[L
                      lambda state: state._sc2wol_has_common_unit(world, player)),
         LocationData("Zero Hour", "Zero Hour: Third Group Rescued", SC2WOL_LOC_ID_OFFSET + 303,
                      lambda state: state._sc2wol_has_common_unit(world, player)),
-        LocationData("Zero Hour", "Beat Zero Hour", None,
-                     lambda state: state._sc2wol_has_common_unit(world, player)),
         LocationData("Evacuation", "Evacuation: Victory", SC2WOL_LOC_ID_OFFSET + 400,
                      lambda state: state._sc2wol_has_anti_air(world, player)),
         LocationData("Evacuation", "Evacuation: First Chysalis", SC2WOL_LOC_ID_OFFSET + 401),
@@ -50,16 +45,11 @@ def get_locations(world: Optional[MultiWorld], player: Optional[int]) -> Tuple[L
                      lambda state: state._sc2wol_has_common_unit(world, player)),
         LocationData("Evacuation", "Evacuation: Third Chysalis", SC2WOL_LOC_ID_OFFSET + 403,
                      lambda state: state._sc2wol_has_common_unit(world, player)),
-        LocationData("Evacuation", "Beat Evacuation", None,
-                     lambda state: state._sc2wol_has_common_unit(world, player) and
-                                   state._sc2wol_has_competent_anti_air(world, player)),
         LocationData("Outbreak", "Outbreak: Victory", SC2WOL_LOC_ID_OFFSET + 500,
                      lambda state: state._sc2wol_has_common_unit(world, player) or state.has("Reaper", player)),
         LocationData("Outbreak", "Outbreak: Left Infestor", SC2WOL_LOC_ID_OFFSET + 501,
                      lambda state: state._sc2wol_has_common_unit(world, player) or state.has("Reaper", player)),
         LocationData("Outbreak", "Outbreak: Right Infestor", SC2WOL_LOC_ID_OFFSET + 502,
-                     lambda state: state._sc2wol_has_common_unit(world, player) or state.has("Reaper", player)),
-        LocationData("Outbreak", "Beat Outbreak", None,
                      lambda state: state._sc2wol_has_common_unit(world, player) or state.has("Reaper", player)),
         LocationData("Safe Haven", "Safe Haven: Victory", SC2WOL_LOC_ID_OFFSET + 600,
                      lambda state: state._sc2wol_has_common_unit(world, player) and
@@ -71,9 +61,6 @@ def get_locations(world: Optional[MultiWorld], player: Optional[int]) -> Tuple[L
                      lambda state: state._sc2wol_has_common_unit(world, player) and
                                    state._sc2wol_has_competent_anti_air(world, player)),
         LocationData("Safe Haven", "Safe Haven: South Nexus", SC2WOL_LOC_ID_OFFSET + 603,
-                     lambda state: state._sc2wol_has_common_unit(world, player) and
-                                   state._sc2wol_has_competent_anti_air(world, player)),
-        LocationData("Safe Haven", "Beat Safe Haven", None,
                      lambda state: state._sc2wol_has_common_unit(world, player) and
                                    state._sc2wol_has_competent_anti_air(world, player)),
         LocationData("Haven's Fall", "Haven's Fall: Victory", SC2WOL_LOC_ID_OFFSET + 700,
@@ -88,9 +75,6 @@ def get_locations(world: Optional[MultiWorld], player: Optional[int]) -> Tuple[L
         LocationData("Haven's Fall", "Haven's Fall: South Hive", SC2WOL_LOC_ID_OFFSET + 703,
                      lambda state: state._sc2wol_has_common_unit(world, player) and
                                    state._sc2wol_has_competent_anti_air(world, player)),
-        LocationData("Haven's Fall", "Beat Haven's Fall", None,
-                     lambda state: state._sc2wol_has_common_unit(world, player) and
-                                   state._sc2wol_has_competent_anti_air(world, player)),
         LocationData("Smash and Grab", "Smash and Grab: Victory", SC2WOL_LOC_ID_OFFSET + 800,
                      lambda state: state._sc2wol_has_common_unit(world, player) and
                                    state._sc2wol_has_competent_anti_air(world, player)),
@@ -99,9 +83,6 @@ def get_locations(world: Optional[MultiWorld], player: Optional[int]) -> Tuple[L
         LocationData("Smash and Grab", "Smash and Grab: Third Relic", SC2WOL_LOC_ID_OFFSET + 803,
                      lambda state: state._sc2wol_has_common_unit(world, player)),
         LocationData("Smash and Grab", "Smash and Grab: Fourth Relic", SC2WOL_LOC_ID_OFFSET + 804,
-                     lambda state: state._sc2wol_has_common_unit(world, player) and
-                                   state._sc2wol_has_anti_air(world, player)),
-        LocationData("Smash and Grab", "Beat Smash and Grab", None,
                      lambda state: state._sc2wol_has_common_unit(world, player) and
                                    state._sc2wol_has_anti_air(world, player)),
         LocationData("The Dig", "The Dig: Victory", SC2WOL_LOC_ID_OFFSET + 900,
@@ -114,10 +95,6 @@ def get_locations(world: Optional[MultiWorld], player: Optional[int]) -> Tuple[L
                      lambda state: state._sc2wol_has_common_unit(world, player)),
         LocationData("The Dig", "The Dig: Right Cliff Relic", SC2WOL_LOC_ID_OFFSET + 903,
                      lambda state: state._sc2wol_has_common_unit(world, player)),
-        LocationData("The Dig", "Beat The Dig", None,
-                     lambda state: state._sc2wol_has_common_unit(world, player) and
-                                   state._sc2wol_has_anti_air(world, player) and
-                                   state._sc2wol_has_heavy_defense(world, player)),
         LocationData("The Moebius Factor", "The Moebius Factor: Victory", SC2WOL_LOC_ID_OFFSET + 1000,
                      lambda state: state._sc2wol_has_air(world, player) and state._sc2wol_has_anti_air(world, player)),
         LocationData("The Moebius Factor", "The Moebius Factor: South Rescue", SC2WOL_LOC_ID_OFFSET + 1003,
@@ -132,8 +109,6 @@ def get_locations(world: Optional[MultiWorld], player: Optional[int]) -> Tuple[L
                      lambda state: state._sc2wol_able_to_rescue(world, player)),
         LocationData("The Moebius Factor", "The Moebius Factor: Brutalisk", SC2WOL_LOC_ID_OFFSET + 1008,
                      lambda state: state._sc2wol_has_air(world, player)),
-        LocationData("The Moebius Factor", "Beat The Moebius Factor", None,
-                     lambda state: state._sc2wol_has_air(world, player)),
         LocationData("Supernova", "Supernova: Victory", SC2WOL_LOC_ID_OFFSET + 1100,
                      lambda state: state._sc2wol_beats_protoss_deathball(world, player)),
         LocationData("Supernova", "Supernova: West Relic", SC2WOL_LOC_ID_OFFSET + 1101),
@@ -141,8 +116,6 @@ def get_locations(world: Optional[MultiWorld], player: Optional[int]) -> Tuple[L
         LocationData("Supernova", "Supernova: South Relic", SC2WOL_LOC_ID_OFFSET + 1103,
                      lambda state: state._sc2wol_beats_protoss_deathball(world, player)),
         LocationData("Supernova", "Supernova: East Relic", SC2WOL_LOC_ID_OFFSET + 1104,
-                     lambda state: state._sc2wol_beats_protoss_deathball(world, player)),
-        LocationData("Supernova", "Beat Supernova", None,
                      lambda state: state._sc2wol_beats_protoss_deathball(world, player)),
         LocationData("Maw of the Void", "Maw of the Void: Victory", SC2WOL_LOC_ID_OFFSET + 1200,
                      lambda state: state.has('Battlecruiser', player) or
@@ -170,18 +143,11 @@ def get_locations(world: Optional[MultiWorld], player: Optional[int]) -> Tuple[L
                                    state._sc2wol_has_air(world, player) and
                                    state._sc2wol_has_competent_anti_air(world, player) and
                                    state.has('Science Vessel', player)),
-        LocationData("Maw of the Void", "Beat Maw of the Void", None,
-                     lambda state: state.has('Battlecruiser', player) or
-                                   state._sc2wol_has_air(world, player) and
-                                   state._sc2wol_has_competent_anti_air(world, player) and
-                                   state.has('Science Vessel', player)),
         LocationData("Devil's Playground", "Devil's Playground: Victory", SC2WOL_LOC_ID_OFFSET + 1300,
                      lambda state: state._sc2wol_has_anti_air(world, player) and (
                              state._sc2wol_has_common_unit(world, player) or state.has("Reaper", player))),
         LocationData("Devil's Playground", "Devil's Playground: Tosh's Miners", SC2WOL_LOC_ID_OFFSET + 1301),
         LocationData("Devil's Playground", "Devil's Playground: Brutalisk", SC2WOL_LOC_ID_OFFSET + 1302,
-                     lambda state: state._sc2wol_has_common_unit(world, player) or state.has("Reaper", player)),
-        LocationData("Devil's Playground", "Beat Devil's Playground", None,
                      lambda state: state._sc2wol_has_common_unit(world, player) or state.has("Reaper", player)),
         LocationData("Welcome to the Jungle", "Welcome to the Jungle: Victory", SC2WOL_LOC_ID_OFFSET + 1400,
                      lambda state: state._sc2wol_has_common_unit(world, player) and
@@ -193,28 +159,21 @@ def get_locations(world: Optional[MultiWorld], player: Optional[int]) -> Tuple[L
         LocationData("Welcome to the Jungle", "Welcome to the Jungle: North-East Relic", SC2WOL_LOC_ID_OFFSET + 1403,
                      lambda state: state._sc2wol_has_common_unit(world, player) and
                                    state._sc2wol_has_competent_anti_air(world, player)),
-        LocationData("Welcome to the Jungle", "Beat Welcome to the Jungle", None,
-                     lambda state: state._sc2wol_has_common_unit(world, player) and
-                                   state._sc2wol_has_competent_anti_air(world, player)),
         LocationData("Breakout", "Breakout: Victory", SC2WOL_LOC_ID_OFFSET + 1500),
         LocationData("Breakout", "Breakout: Diamondback Prison", SC2WOL_LOC_ID_OFFSET + 1501),
         LocationData("Breakout", "Breakout: Siegetank Prison", SC2WOL_LOC_ID_OFFSET + 1502),
-        LocationData("Breakout", "Beat Breakout", None),
         LocationData("Ghost of a Chance", "Ghost of a Chance: Victory", SC2WOL_LOC_ID_OFFSET + 1600),
         LocationData("Ghost of a Chance", "Ghost of a Chance: Terrazine Tank", SC2WOL_LOC_ID_OFFSET + 1601),
         LocationData("Ghost of a Chance", "Ghost of a Chance: Jorium Stockpile", SC2WOL_LOC_ID_OFFSET + 1602),
         LocationData("Ghost of a Chance", "Ghost of a Chance: First Island Spectres", SC2WOL_LOC_ID_OFFSET + 1603),
         LocationData("Ghost of a Chance", "Ghost of a Chance: Second Island Spectres", SC2WOL_LOC_ID_OFFSET + 1604),
         LocationData("Ghost of a Chance", "Ghost of a Chance: Third Island Spectres", SC2WOL_LOC_ID_OFFSET + 1605),
-        LocationData("Ghost of a Chance", "Beat Ghost of a Chance", None),
         LocationData("The Great Train Robbery", "The Great Train Robbery: Victory", SC2WOL_LOC_ID_OFFSET + 1700,
                      lambda state: state._sc2wol_has_train_killers(world, player) and
                                    state._sc2wol_has_anti_air(world, player)),
         LocationData("The Great Train Robbery", "The Great Train Robbery: North Defiler", SC2WOL_LOC_ID_OFFSET + 1701),
         LocationData("The Great Train Robbery", "The Great Train Robbery: Mid Defiler", SC2WOL_LOC_ID_OFFSET + 1702),
         LocationData("The Great Train Robbery", "The Great Train Robbery: South Defiler", SC2WOL_LOC_ID_OFFSET + 1703),
-        LocationData("The Great Train Robbery", "Beat The Great Train Robbery", None,
-                     lambda state: state._sc2wol_has_train_killers(world, player)),
         LocationData("Cutthroat", "Cutthroat: Victory", SC2WOL_LOC_ID_OFFSET + 1800,
                      lambda state: state._sc2wol_has_common_unit(world, player)),
         LocationData("Cutthroat", "Cutthroat: Mira Han", SC2WOL_LOC_ID_OFFSET + 1801,
@@ -223,8 +182,6 @@ def get_locations(world: Optional[MultiWorld], player: Optional[int]) -> Tuple[L
                      lambda state: state._sc2wol_has_common_unit(world, player)),
         LocationData("Cutthroat", "Cutthroat: Mid Relic", SC2WOL_LOC_ID_OFFSET + 1803),
         LocationData("Cutthroat", "Cutthroat: Southwest Relic", SC2WOL_LOC_ID_OFFSET + 1804,
-                     lambda state: state._sc2wol_has_common_unit(world, player)),
-        LocationData("Cutthroat", "Beat Cutthroat", None,
                      lambda state: state._sc2wol_has_common_unit(world, player)),
         LocationData("Engine of Destruction", "Engine of Destruction: Victory", SC2WOL_LOC_ID_OFFSET + 1900,
                      lambda state: state._sc2wol_has_competent_anti_air(world, player)),
@@ -239,9 +196,6 @@ def get_locations(world: Optional[MultiWorld], player: Optional[int]) -> Tuple[L
         LocationData("Engine of Destruction", "Engine of Destruction: Southeast Devourer", SC2WOL_LOC_ID_OFFSET + 1905,
                      lambda state: state._sc2wol_has_competent_anti_air(world, player) and
                                    state._sc2wol_has_common_unit(world, player) or state.has('Wraith', player)),
-        LocationData("Engine of Destruction", "Beat Engine of Destruction", None,
-                     lambda state: state._sc2wol_has_competent_anti_air(world, player) and
-                                   state._sc2wol_has_common_unit(world, player) or state.has('Wraith', player)),
         LocationData("Media Blitz", "Media Blitz: Victory", SC2WOL_LOC_ID_OFFSET + 2000,
                      lambda state: state._sc2wol_has_competent_comp(world, player)),
         LocationData("Media Blitz", "Media Blitz: Tower 1", SC2WOL_LOC_ID_OFFSET + 2001,
@@ -251,8 +205,6 @@ def get_locations(world: Optional[MultiWorld], player: Optional[int]) -> Tuple[L
         LocationData("Media Blitz", "Media Blitz: Tower 3", SC2WOL_LOC_ID_OFFSET + 2003,
                      lambda state: state._sc2wol_has_competent_comp(world, player)),
         LocationData("Media Blitz", "Media Blitz: Science Facility", SC2WOL_LOC_ID_OFFSET + 2004),
-        LocationData("Media Blitz", "Beat Media Blitz", None,
-                     lambda state: state._sc2wol_has_competent_comp(world, player)),
         LocationData("Piercing the Shroud", "Piercing the Shroud: Victory", SC2WOL_LOC_ID_OFFSET + 2100,
                      lambda state: state.has_any({'Combat Shield (Marine)', 'Stabilizer Medpacks (Medic)'}, player)),
         LocationData("Piercing the Shroud", "Piercing the Shroud: Holding Cell Relic", SC2WOL_LOC_ID_OFFSET + 2101),
@@ -264,44 +216,34 @@ def get_locations(world: Optional[MultiWorld], player: Optional[int]) -> Tuple[L
                      lambda state: state.has_any({'Combat Shield (Marine)', 'Stabilizer Medpacks (Medic)'}, player)),
         LocationData("Piercing the Shroud", "Piercing the Shroud: Brutalisk ", SC2WOL_LOC_ID_OFFSET + 2105,
                      lambda state: state.has_any({'Combat Shield (Marine)', 'Stabilizer Medpacks (Medic)'}, player)),
-        LocationData("Piercing the Shroud", "Beat Piercing the Shroud", None,
-                     lambda state: state.has_any({'Combat Shield (Marine)', 'Stabilizer Medpacks (Medic)'}, player)),
         LocationData("Whispers of Doom", "Whispers of Doom: Victory", SC2WOL_LOC_ID_OFFSET + 2200),
         LocationData("Whispers of Doom", "Whispers of Doom: First Hatchery", SC2WOL_LOC_ID_OFFSET + 2201),
         LocationData("Whispers of Doom", "Whispers of Doom: Second Hatchery", SC2WOL_LOC_ID_OFFSET + 2202),
         LocationData("Whispers of Doom", "Whispers of Doom: Third Hatchery", SC2WOL_LOC_ID_OFFSET + 2203),
-        LocationData("Whispers of Doom", "Beat Whispers of Doom", None),
         LocationData("A Sinister Turn", "A Sinister Turn: Victory", SC2WOL_LOC_ID_OFFSET + 2300,
                      lambda state: state._sc2wol_has_protoss_medium_units(world, player)),
         LocationData("A Sinister Turn", "A Sinister Turn: Robotics Facility", SC2WOL_LOC_ID_OFFSET + 2301),
         LocationData("A Sinister Turn", "A Sinister Turn: Dark Shrine", SC2WOL_LOC_ID_OFFSET + 2302),
         LocationData("A Sinister Turn", "A Sinister Turn: Templar Archives", SC2WOL_LOC_ID_OFFSET + 2303,
                      lambda state: state._sc2wol_has_protoss_common_units(world, player)),
-        LocationData("A Sinister Turn", "Beat A Sinister Turn", None,
-                     lambda state: state._sc2wol_has_protoss_medium_units(world, player)),
         LocationData("Echoes of the Future", "Echoes of the Future: Victory", SC2WOL_LOC_ID_OFFSET + 2400,
                      lambda state: state._sc2wol_has_protoss_medium_units(world, player)),
         LocationData("Echoes of the Future", "Echoes of the Future: Close Obelisk", SC2WOL_LOC_ID_OFFSET + 2401),
         LocationData("Echoes of the Future", "Echoes of the Future: West Obelisk", SC2WOL_LOC_ID_OFFSET + 2402,
                      lambda state: state._sc2wol_has_protoss_common_units(world, player)),
-        LocationData("Echoes of the Future", "Beat Echoes of the Future", None,
-                     lambda state: state._sc2wol_has_protoss_medium_units(world, player)),
         LocationData("In Utter Darkness", "In Utter Darkness: Defeat", SC2WOL_LOC_ID_OFFSET + 2500),
         LocationData("In Utter Darkness", "In Utter Darkness: Protoss Archive", SC2WOL_LOC_ID_OFFSET + 2501,
                      lambda state: state._sc2wol_has_protoss_medium_units(world, player)),
         LocationData("In Utter Darkness", "In Utter Darkness: Kills", SC2WOL_LOC_ID_OFFSET + 2502,
                      lambda state: state._sc2wol_has_protoss_common_units(world, player)),
-        LocationData("In Utter Darkness", "Beat In Utter Darkness", None),
         LocationData("Gates of Hell", "Gates of Hell: Victory", SC2WOL_LOC_ID_OFFSET + 2600,
                      lambda state: state._sc2wol_has_competent_comp(world, player)),
         LocationData("Gates of Hell", "Gates of Hell: Large Army", SC2WOL_LOC_ID_OFFSET + 2601,
                      lambda state: state._sc2wol_has_competent_comp(world, player)),
-        LocationData("Gates of Hell", "Beat Gates of Hell", None),
         LocationData("Belly of the Beast", "Belly of the Beast: Victory", SC2WOL_LOC_ID_OFFSET + 2700),
         LocationData("Belly of the Beast", "Belly of the Beast: First Charge", SC2WOL_LOC_ID_OFFSET + 2701),
         LocationData("Belly of the Beast", "Belly of the Beast: Second Charge", SC2WOL_LOC_ID_OFFSET + 2702),
         LocationData("Belly of the Beast", "Belly of the Beast: Third Charge", SC2WOL_LOC_ID_OFFSET + 2703),
-        LocationData("Belly of the Beast", "Beat Belly of the Beast", None),
         LocationData("Shatter the Sky", "Shatter the Sky: Victory", SC2WOL_LOC_ID_OFFSET + 2800,
                      lambda state: state._sc2wol_has_competent_comp(world, player)),
         LocationData("Shatter the Sky", "Shatter the Sky: Close Coolant Tower", SC2WOL_LOC_ID_OFFSET + 2801,
@@ -314,9 +256,15 @@ def get_locations(world: Optional[MultiWorld], player: Optional[int]) -> Tuple[L
                      lambda state: state._sc2wol_has_competent_comp(world, player)),
         LocationData("Shatter the Sky", "Shatter the Sky: Leviathan", SC2WOL_LOC_ID_OFFSET + 2805,
                      lambda state: state._sc2wol_has_competent_comp(world, player)),
-        LocationData("Shatter the Sky", "Beat Shatter the Sky", None,
-                     lambda state: state._sc2wol_has_competent_comp(world, player)),
         LocationData("All-In", "All-In: Victory", None)
     ]
 
-    return tuple(location_table)
+    beat_events = []
+
+    for location_data in location_table:
+        if location_data.name.endswith((": Victory", ": Defeat")):
+            beat_events.append(
+                location_data._replace(name="Beat " + location_data.name.rsplit(": ", 1)[0], code=None)
+            )
+
+    return tuple(location_table + beat_events)

--- a/worlds/sc2wol/Locations.py
+++ b/worlds/sc2wol/Locations.py
@@ -39,7 +39,8 @@ def get_locations(world: Optional[MultiWorld], player: Optional[int]) -> Tuple[L
         LocationData("Zero Hour", "Zero Hour: Third Group Rescued", SC2WOL_LOC_ID_OFFSET + 303,
                      lambda state: state._sc2wol_has_common_unit(world, player)),
         LocationData("Evacuation", "Evacuation: Victory", SC2WOL_LOC_ID_OFFSET + 400,
-                     lambda state: state._sc2wol_has_anti_air(world, player)),
+                     lambda state: state._sc2wol_has_common_unit(world, player) and
+                                   state._sc2wol_has_competent_anti_air(world, player)),
         LocationData("Evacuation", "Evacuation: First Chysalis", SC2WOL_LOC_ID_OFFSET + 401),
         LocationData("Evacuation", "Evacuation: Second Chysalis", SC2WOL_LOC_ID_OFFSET + 402,
                      lambda state: state._sc2wol_has_common_unit(world, player)),
@@ -184,7 +185,8 @@ def get_locations(world: Optional[MultiWorld], player: Optional[int]) -> Tuple[L
         LocationData("Cutthroat", "Cutthroat: Southwest Relic", SC2WOL_LOC_ID_OFFSET + 1804,
                      lambda state: state._sc2wol_has_common_unit(world, player)),
         LocationData("Engine of Destruction", "Engine of Destruction: Victory", SC2WOL_LOC_ID_OFFSET + 1900,
-                     lambda state: state._sc2wol_has_competent_anti_air(world, player)),
+                     lambda state: state._sc2wol_has_competent_anti_air(world, player) and
+                                   state._sc2wol_has_common_unit(world, player) or state.has('Wraith', player)),
         LocationData("Engine of Destruction", "Engine of Destruction: Odin", SC2WOL_LOC_ID_OFFSET + 1901),
         LocationData("Engine of Destruction", "Engine of Destruction: Loki", SC2WOL_LOC_ID_OFFSET + 1902,
                      lambda state: state._sc2wol_has_competent_anti_air(world, player) and


### PR DESCRIPTION


Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?
Victory and Beat conditions diverged in some instances due to needing to be updated in two places, despite them being the same "check".

## How was this tested?
running Generate a few times and peeking at spoiler.

@TheCondor07 