### PR TITLE
autoworld: don't load files/folders starting with '.'

### DIFF
--- a/worlds/__init__.py
+++ b/worlds/__init__.py
@@ -28,7 +28,7 @@ world_sources: typing.List[WorldSource] = []
 file: os.DirEntry  # for me (Berserker) at least, PyCharm doesn't seem to infer the type correctly
 for file in os.scandir(folder):
     # prevent loading of __pycache__ and allow _* for non-world folders, disable files/folders starting with "."
-    if not file.name.startswith("_") and not file.name.startswith("."):
+    if not file.name.startswith(("_", ".")):
         if file.is_dir():
             world_sources.append(WorldSource(file.name))
         elif file.is_file() and file.name.endswith(".apworld"):

--- a/worlds/__init__.py
+++ b/worlds/__init__.py
@@ -27,7 +27,8 @@ class WorldSource(typing.NamedTuple):
 world_sources: typing.List[WorldSource] = []
 file: os.DirEntry  # for me (Berserker) at least, PyCharm doesn't seem to infer the type correctly
 for file in os.scandir(folder):
-    if not file.name.startswith("_"):  # prevent explicitly loading __pycache__ and allow _* names for non-world folders
+    # prevent loading of __pycache__ and allow _* for non-world folders, disable files/folders starting with "."
+    if not file.name.startswith("_") and not file.name.startswith("."):
         if file.is_dir():
             world_sources.append(WorldSource(file.name))
         elif file.is_file() and file.name.endswith(".apworld"):


### PR DESCRIPTION
## What is this fixing or adding?

The imports fail if the folder has a '.' in the name, with a somewhat obscure error, and adding a '.' in front of it is what a linux user might expect to use when disabling a world temporarily.

This change makes AutoWorld's automatic imports ignore files and folders that start with ".".

## How was this tested?

ran Generate.py