### PR TITLE
SC2: Add helpful feedback when failing to locate SC2

### DIFF
--- a/Starcraft2Client.py
+++ b/Starcraft2Client.py
@@ -795,9 +795,10 @@ def check_game_install_path() -> bool:
         if content:
             try:
                 base = re.search(r" = (.*)Versions", content).group(1)
-            except AttributeError as exc:
-                raise RuntimeError(f"We found {einfo}, but it was empty. Run SC2 through the Blizzard launcher, then "
-                                   f"try again.") from exc
+            except AttributeError:
+                sc2_logger.warning(f"We found {einfo}, but it was empty. Run SC2 through the Blizzard launcher, then "
+                                   f"try again.")
+                return False
             if os.path.exists(base):
                 executable = sc2.paths.latest_executeble(Path(base).expanduser() / "Versions")
 
@@ -814,7 +815,7 @@ def check_game_install_path() -> bool:
             else:
                 sc2_logger.warning(f"{einfo} pointed to {base}, but we could not find an SC2 install there.")
     else:
-        sc2_logger.warning(f"Couldn't find {einfo}. Run SC2 through the Blizzard launcher, then try again."
+        sc2_logger.warning(f"Couldn't find {einfo}. Run SC2 through the Blizzard launcher, then try again. "
                            f"If that fails, please run /set_path with your SC2 install directory.")
     return False
 

--- a/Starcraft2Client.py
+++ b/Starcraft2Client.py
@@ -796,7 +796,7 @@ def check_game_install_path() -> bool:
             try:
                 base = re.search(r" = (.*)Versions", content).group(1)
             except AttributeError:
-                sc2_logger.warning(f"We found {einfo}, but it was empty. Run SC2 through the Blizzard launcher, then "
+                sc2_logger.warning(f"Found {einfo}, but it was empty. Run SC2 through the Blizzard launcher, then "
                                    f"try again.")
                 return False
             if os.path.exists(base):

--- a/Starcraft2Client.py
+++ b/Starcraft2Client.py
@@ -793,7 +793,11 @@ def check_game_install_path() -> bool:
         with open(einfo) as f:
             content = f.read()
         if content:
-            base = re.search(r" = (.*)Versions", content).group(1)
+            try:
+                base = re.search(r" = (.*)Versions", content).group(1)
+            except AttributeError as exc:
+                raise RuntimeError(f"We found {einfo}, but it was empty. Run SC2 through the Blizzard launcher, then "
+                                   f"try again.") from exc
             if os.path.exists(base):
                 executable = sc2.paths.latest_executeble(Path(base).expanduser() / "Versions")
 
@@ -810,7 +814,8 @@ def check_game_install_path() -> bool:
             else:
                 sc2_logger.warning(f"{einfo} pointed to {base}, but we could not find an SC2 install there.")
     else:
-        sc2_logger.warning(f"Couldn't find {einfo}. Please run /set_path with your SC2 install directory.")
+        sc2_logger.warning(f"Couldn't find {einfo}. Run SC2 through the Blizzard launcher, then try again."
+                           f"If that fails, please run /set_path with your SC2 install directory.")
     return False
 
 


### PR DESCRIPTION
## What is this fixing or adding?
- The client now knows what to do and say if `ExecuteInfo.txt` exists, but is empty.
- If `ExecuteInfo.txt` is missing or empty, the user is now instructed to run SC2 through the Blizzard launcher, then try again.

## How was this tested?
Manually edited/deleted `ExecuteInfo.txt`, then ran `Starcraft2Client.py` on Windows 10 and tried to connect.

## Other info
Originally, I was going to have the client raise a RuntimeError when `ExecuteInfo.txt` is empty, but that would have been inconsistent with how it handles other cases (like the file being missing, or being unable to find the executable it points to). I preferred raising the error, personally, because it's louder, puts the proposed solution front-and-center on the user's screen, forces the connection to fail so the user can retry as suggested without closing the client, and still prints to the log, but I didn't want to rock the boat. I'd be happy to make a separate PR out of that.