### PR TITLE
Doc/Tests: item and location names must not be numeric

### DIFF
--- a/docs/world api.md
+++ b/docs/world api.md
@@ -103,8 +103,9 @@ or boss drops for RPG-like games but could also be progress in a research tree.
 
 Each location has a `name` and an `id` (a.k.a. "code" or "address"), is placed
 in a Region and has access rules.
-The name needs to be unique in each game, the ID needs to be unique across all
-games and is best in the same range as the item IDs.
+The name needs to be unique in each game and must not be numeric (has to
+contain least 1 letter or symbol). The ID needs to be unique across all games
+and is best in the same range as the item IDs.
 World-specific IDs are 1 to 2<sup>53</sup>-1, IDs ≤ 0 are global and reserved.
 
 Special locations with ID `None` can hold events.
@@ -120,6 +121,9 @@ Progression items are items which a player may require to progress in
 their world. Progression items will be assigned to locations with higher
 priority and moved around to meet defined rules and accomplish progression
 balancing.
+
+The name needs to be unique in each game, meaning a duplicate item has the
+same ID. Name must not be numeric (has to contain at least 1 letter or symbol).
 
 Special items with ID `None` can mark events (read below).
 

--- a/test/general/TestNames.py
+++ b/test/general/TestNames.py
@@ -1,0 +1,20 @@
+import unittest
+from worlds.AutoWorld import AutoWorldRegister
+
+
+class TestNames(unittest.TestCase):
+    def testItemNamesFormat(self):
+        """Item names must not be all numeric in order to differentiate between ID and name in !hint"""
+        for gamename, world_type in AutoWorldRegister.world_types.items():
+            with self.subTest(game=gamename):
+                for item_name in world_type.item_name_to_id:
+                    self.assertFalse(item_name.isnumeric(),
+                                     f"Item name \"{item_name}\" is invalid. It must not be numeric.")
+
+    def testLocationNameFormat(self):
+        """Location names must not be all numeric in order to differentiate between ID and name in !hint_location"""
+        for gamename, world_type in AutoWorldRegister.world_types.items():
+            with self.subTest(game=gamename):
+                for location_name in world_type.location_name_to_id:
+                    self.assertFalse(location_name.isnumeric(),
+                                     f"Location name \"{location_name}\" is invalid. It must not be numeric.")


### PR DESCRIPTION
## What is this fixing or adding?

In order to differentiate between IDs and names (i.e. for !hint), names must not be numeric.

## How was this tested?

Renamed an item and a location and watched ~~the world burn~~ tests fail.

## If this makes graphical changes, please attach screenshots.

![test-example2](https://user-images.githubusercontent.com/59490463/191181088-b82f0ef9-8c91-4388-a5d8-8b0bcc6423f2.png)
