### PR TITLE
Webhost: allow webhost to be run with game with missing docs folder

### DIFF
--- a/WebHost.py
+++ b/WebHost.py
@@ -71,9 +71,12 @@ def create_ordered_tutorials_file() -> typing.List[typing.Dict[str, typing.Any]]
                         zf.extract(zfile, target_path)
         else:
             source_path = Utils.local_path(os.path.dirname(world.__file__), "docs")
-            files = os.listdir(source_path)
-            for file in files:
-                shutil.copyfile(Utils.local_path(source_path, file), Utils.local_path(target_path, file))
+            if os.path.exists(source_path):
+                files = os.listdir(source_path)
+                for file in files:
+                    shutil.copyfile(Utils.local_path(source_path, file), Utils.local_path(target_path, file))
+            else:
+                logging.warning(f"{game} is missing a docs folder!")
 
         # build a json tutorial dict per game
         game_data = {'gameTitle': game, 'tutorials': []}


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?
I'm lazy and don't want to put a docs folder in my game until it's finished ok? Still throws a warning to the user and the tests will still fail in this use case.

## How was this tested?
I was able to run webhost without it crashing for me :)

## If this makes graphical changes, please attach screenshots.
