### PR TITLE
Factorio: Add explicit support for factory-levels mod.

### DIFF
--- a/worlds/factorio/Mod.py
+++ b/worlds/factorio/Mod.py
@@ -34,7 +34,8 @@ base_info = {
     "factorio_version": "1.1",
     "dependencies": [
         "base >= 1.1.0",
-        "? science-not-invited"
+        "? science-not-invited",
+        "? factory-levels"
     ]
 }
 

--- a/worlds/factorio/data/mod/info.json
+++ b/worlds/factorio/data/mod/info.json
@@ -8,6 +8,7 @@
     "factorio_version": "1.1",
     "dependencies": [
 	  "base >= 1.1.0",
-	  "? science-not-invited"
+	  "? science-not-invited",
+      "? factory-levels"
 	]
 }

--- a/worlds/factorio/data/mod/info.json
+++ b/worlds/factorio/data/mod/info.json
@@ -7,8 +7,8 @@
     "description": "Integration client for the Archipelago Randomizer",
     "factorio_version": "1.1",
     "dependencies": [
-	  "base >= 1.1.0",
-	  "? science-not-invited",
+      "base >= 1.1.0",
+      "? science-not-invited",
       "? factory-levels"
-	]
+    ]
 }

--- a/worlds/factorio/data/mod_template/data-final-fixes.lua
+++ b/worlds/factorio/data/mod_template/data-final-fixes.lua
@@ -183,6 +183,18 @@ end
 data.raw["assembling-machine"]["assembling-machine-1"].crafting_categories = table.deepcopy(data.raw["assembling-machine"]["assembling-machine-3"].crafting_categories)
 data.raw["assembling-machine"]["assembling-machine-2"].crafting_categories = table.deepcopy(data.raw["assembling-machine"]["assembling-machine-3"].crafting_categories)
 data.raw["assembling-machine"]["assembling-machine-1"].fluid_boxes = table.deepcopy(data.raw["assembling-machine"]["assembling-machine-2"].fluid_boxes)
+if mods["factory-levels"] then
+    -- Factory-Levels allows the assembling machines to get faster (and depending on settings), more productive at crafting products, the more the
+    -- assembling machine crafts the product.  If the machine crafts enough, it may auto-upgrade to the next tier.
+    for i = 1, 25, 1 do
+        data.raw["assembling-machine"]["assembling-machine-1-level-" .. i].crafting_categories = table.deepcopy(data.raw["assembling-machine"]["assembling-machine-3"].crafting_categories)
+        data.raw["assembling-machine"]["assembling-machine-1-level-" .. i].fluid_boxes = table.deepcopy(data.raw["assembling-machine"]["assembling-machine-2"].fluid_boxes)
+    end
+    for i = 1, 50, 1 do
+        data.raw["assembling-machine"]["assembling-machine-2-level-" .. i].crafting_categories = table.deepcopy(data.raw["assembling-machine"]["assembling-machine-3"].crafting_categories)
+    end
+end
+
 data.raw["ammo"]["artillery-shell"].stack_size = 10
 
 {# each randomized tech gets set to be invisible, with new nodes added that trigger those #}


### PR DESCRIPTION
[Factory Levels](https://mods.factorio.com/mod/factory-levels) allows for some of the machines to level up and get faster and more productive, based on the number of products crafted by the machines.  If a machine levels up enough, it may even upgrade to the next tier automatically, in the cases where the machine can be upgraded in place.

The main thing here is that the fluid box and crafting categories needed to be copied to ALL 25 levels of assembling-machine-1.
