### PR TITLE
WebHost: Fixed some document titles

### DIFF
--- a/WebHostLib/static/assets/tutorial.js
+++ b/WebHostLib/static/assets/tutorial.js
@@ -27,6 +27,11 @@ window.addEventListener('load', () => {
         tutorialWrapper.innerHTML += (new showdown.Converter()).makeHtml(results);
         adjustHeaderWidth();
 
+        const title = document.querySelector('h1')
+        if (title) {
+            document.title = title.textContent;
+        }
+
         // Reset the id of all header divs to something nicer
         const headers = Array.from(document.querySelectorAll('h1, h2, h3, h4, h5, h6'));
         const scrollTargetIndex = window.location.href.search(/#[A-z0-9-_]*$/);

--- a/WebHostLib/templates/check.html
+++ b/WebHostLib/templates/check.html
@@ -1,7 +1,6 @@
 {% extends 'pageWrapper.html' %}
 
 {% block head %}
-    {{ super() }}
     <title>Mystery Check Result</title>
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename="styles/check.css") }}" />
     <script type="application/ecmascript" src="{{ url_for('static', filename="assets/check.js") }}"></script>

--- a/WebHostLib/templates/generate.html
+++ b/WebHostLib/templates/generate.html
@@ -1,7 +1,6 @@
 {% extends 'pageWrapper.html' %}
 
 {% block head %}
-    {{ super() }}
     <title>Generate Game</title>
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename="styles/generate.css") }}" />
     <script type="application/ecmascript" src="{{ url_for('static', filename="assets/generate.js") }}"></script>

--- a/WebHostLib/templates/hostGame.html
+++ b/WebHostLib/templates/hostGame.html
@@ -1,7 +1,6 @@
 {% extends 'pageWrapper.html' %}
 
 {% block head %}
-    {{ super() }}
     <title>Upload Multidata</title>
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename="styles/hostGame.css") }}" />
     <script type="application/ecmascript" src="{{ url_for('static', filename="assets/hostGame.js") }}"></script>

--- a/WebHostLib/templates/startPlaying.html
+++ b/WebHostLib/templates/startPlaying.html
@@ -1,7 +1,6 @@
 {% extends 'pageWrapper.html' %}
 
 {% block head %}
-    {{ super() }}
     <title>Start Playing</title>
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename="styles/startPlaying.css") }}" />
 {% endblock %}


### PR DESCRIPTION
## What is this fixing or adding?
I noticed many pages used the default document title of "Archipelago", for example:
- https://archipelago.gg/start-playing
- https://archipelago.gg/tutorial/Archipelago/plando/en
- https://archipelago.gg/tutorial/Factorio/setup/en

These changes fix some obvious mistakes where multiple `<title>` tags are being set and extends the tutorial loading JavaScript to attempt to take a title from the loaded markdown.

## How was this tested?
I ran a local web host, opened these URLs in my browser and confirmed the document title to be better than before:
- http://localhost/start-playing
- http://localhost/generate
- http://localhost/uploads
- http://localhost/check
- http://localhost/tutorial/Archipelago/advanced_settings/en
- http://localhost/tutorial/Factorio/setup/en
- etc

## Graphical changes
![more_web_document_titles](https://user-images.githubusercontent.com/57289227/192996457-28674825-d2c7-4dc3-8c26-9b702aef8d7f.png)
