### PR TITLE
Fixed Oculus Ring from showing up on tracker

### DIFF
--- a/WebHostLib/templates/timespinnerTracker.html
+++ b/WebHostLib/templates/timespinnerTracker.html
@@ -41,7 +41,7 @@
                     <td></td>
                 {% endif %}    
                 <td><img src="{{ icons['Elevator Keycard'] }}" class="{{ 'acquired' if 'Elevator Keycard' in acquired_items }}" title="Elevator Keycard" /></td>
-                {% if 'FacebookMode' in options %}
+                {% if 'EyeSpy' in options %}
                     <td><img src="{{ icons['Oculus Ring'] }}" class="{{ 'acquired' if 'Oculus Ring' in acquired_items }}" title="Oculus Ring" /></td>
                 {% else %}
                     <td></td>


### PR DESCRIPTION
## What is this fixing or adding?
Oculus ring didnt show up on web tracker anymore even if the flag was enabled, the flag was called 'FacebookMode' is now called 'EyeSpy'

## How was this tested?
Poorly

