### PR TITLE
ModuleUpdate: skip disabled/hidden folders

### DIFF
--- a/ModuleUpdate.py
+++ b/ModuleUpdate.py
@@ -13,8 +13,8 @@ update_ran = getattr(sys, "frozen", False)  # don't run update if environment is
 
 if not update_ran:
     for entry in os.scandir(os.path.join(local_dir, "worlds")):
-        # skip _* (non-world) and .* (disabled) folders
-        if not entry.name.startswith(("_", ".")):
+        # skip .* (hidden / disabled) folders
+        if not entry.name.startswith("."):
             if entry.is_dir():
                 req_file = os.path.join(entry.path, "requirements.txt")
                 if os.path.exists(req_file):

--- a/ModuleUpdate.py
+++ b/ModuleUpdate.py
@@ -13,10 +13,12 @@ update_ran = getattr(sys, "frozen", False)  # don't run update if environment is
 
 if not update_ran:
     for entry in os.scandir(os.path.join(local_dir, "worlds")):
-        if entry.is_dir():
-            req_file = os.path.join(entry.path, "requirements.txt")
-            if os.path.exists(req_file):
-                requirements_files.add(req_file)
+        # skip _* (non-world) and .* (disabled) folders
+        if not entry.name.startswith(("_", ".")):
+            if entry.is_dir():
+                req_file = os.path.join(entry.path, "requirements.txt")
+                if os.path.exists(req_file):
+                    requirements_files.add(req_file)
 
 
 def update_command():


### PR DESCRIPTION
## What is this fixing or adding?

ModuleUpdate.py would scan requirements for worlds that are deliberately excluded from AutoWorld system.

## How was this tested?

By renaming sc2wol to .sc2wol and running ModuleUpdate.py
