### PR TITLE
AppImage: provide LD_LIBRARY_PATH

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -289,6 +289,7 @@ tmp="${{exe#*/}}"
 if [ ! "${{#tmp}}" -lt "${{#exe}}" ]; then
     exe="{default_exe.parent}/$exe"
 fi
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$APPDIR/{default_exe.parent}/lib"
 $APPDIR/$exe "$@"
 """)
         launcher_filename.chmod(0o755)


### PR DESCRIPTION
this fixes libssl1.1 not being found on Linux distributions that only have libssl3 - we include libssl1.1.x, but it's not being picked up by the _ssl module without changing environment variables.