### PR TITLE
HK: changes dreamers to skip prog balance

### DIFF
--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -645,6 +645,8 @@ class HKItem(Item):
             classification = ItemClassification.filler
         elif type in ("Mask", "Ore", "Vessel"):
             classification = ItemClassification.useful
+        elif type in ("Dreamer"):
+            classification = ItemClassification.progression_skip_balancing
         elif advancement:
             classification = ItemClassification.progression
         else:

--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -637,7 +637,7 @@ class HKItem(Item):
     def __init__(self, name, advancement, code, type: str, player: int = None):
         if name == "Mimic_Grub":
             classification = ItemClassification.trap
-        elif type in ("Grub", "DreamWarrior", "Root", "Egg"):
+        elif type in ("Grub", "DreamWarrior", "Root", "Egg", "Dreamer"):
             classification = ItemClassification.progression_skip_balancing
         elif type == "Charm" and name not in progression_charms:
             classification = ItemClassification.progression_skip_balancing
@@ -645,8 +645,6 @@ class HKItem(Item):
             classification = ItemClassification.filler
         elif type in ("Mask", "Ore", "Vessel"):
             classification = ItemClassification.useful
-        elif type in ("Dreamer"):
-            classification = ItemClassification.progression_skip_balancing
         elif advancement:
             classification = ItemClassification.progression
         else:


### PR DESCRIPTION

## What is this fixing or adding?
This changes Dreamers to no longer be affected by progression balancing due to it providing very early dreamers in games leading to early infected crossroads and much shorter games in some cases.

## How was this tested?
3 successful generation attempts 

## If this makes graphical changes, please attach screenshots.
