### PR TITLE
FactorioClient: Prevent pipes from breaking on invalid UTF-8

### DIFF
--- a/FactorioClient.py
+++ b/FactorioClient.py
@@ -211,6 +211,8 @@ async def game_watcher(ctx: FactorioContext):
 
 
 def stream_factorio_output(pipe, queue, process):
+    pipe.reconfigure(errors="replace")
+
     def queuer():
         while process.poll() is None:
             text = pipe.readline().strip()


### PR DESCRIPTION
## What is this fixing?
Under certain circumstances the Factorio server outputs invalid UTF-8 on its stdout, which causes FactorioClient's pipe to the Factorio server process to break. FactorioClient prints the following stack trace but continues running:
```
Exception in thread Factorio Output Queue:
Traceback (most recent call last):
  File "C:\Program Files\Python310\lib\threading.py", line 1009, in _bootstrap_inner
    self.run()
  File "C:\Program Files\Python310\lib\threading.py", line 946, in run
    self._target(*self._args, **self._kwargs)
  File "C:\repos\git-archipelago\FactorioClient.py", line 216, in queuer
    text = pipe.readline().strip()
  File "C:\Program Files\Python310\lib\codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xed in position 38: invalid continuation byte
```
Currently, the breaking of this pipe has limited impact on the functioning of FactorioClient as the RCON connection is not affected. The biggest impact is that the join/leave/chat/death messages (from players on the Factorio server) that would usually appear in the Kivy window and FactorioClient's stdout go missing.
However, if one were to implement features again that rely on this pipe, such as #1068 or perhaps a return to the push-based information exchange system (using `FactorioContext.awaiting_bridge`), any invalid UTF-8 would mostly silently break these features until FactorioClient is restarted.

## How is this fixing it?
By setting the error handling of the pipe to `"replace"`, invalid UTF-8 bytes are transparently replaced by the valid Unicode codepoint `U+FFFD REPLACEMENT CHARACTER` ("�").

## When does the Factorio server output invalid UTF-8?
I only stumbled upon one instance so far, namely a Factorio player trying to send Unicode emojis in Factorio chat. When pasted from the clipboard they are automatically removed, but when input directly into the in-game chat box (such as using `Win+.`) they cause the problems described above.
This would probably also be deemed a bug in Factorio, but it doesn't hurt if we catch it here.