### PR TITLE
WebHost: Fixed scrolling to anchors

### DIFF
--- a/WebHostLib/static/assets/faq.js
+++ b/WebHostLib/static/assets/faq.js
@@ -27,10 +27,10 @@ window.addEventListener('load', () => {
 
         // Reset the id of all header divs to something nicer
         for (const header of document.querySelectorAll('h1, h2, h3, h4, h5, h6')) {
-            const headerId = header.innerText.replaceAll(' ', '-').toLowerCase()
+            const headerId = header.innerText.replace(/\s+/g, '-').toLowerCase();
             header.setAttribute('id', headerId);
             header.addEventListener('click', () => {
-                window.location.hash = '#' + headerId;
+                window.location.hash = `#${headerId}`;
                 header.scrollIntoView();
             });
         }

--- a/WebHostLib/static/assets/faq.js
+++ b/WebHostLib/static/assets/faq.js
@@ -26,23 +26,16 @@ window.addEventListener('load', () => {
         adjustHeaderWidth();
 
         // Reset the id of all header divs to something nicer
-        const headers = Array.from(document.querySelectorAll('h1, h2, h3, h4, h5, h6'));
-        const scrollTargetIndex = window.location.href.search(/#[A-z0-9-_]*$/);
-        for (let i=0; i < headers.length; i++){
-            const headerId = headers[i].innerText.replace(/[ ]/g,'-').toLowerCase()
-            headers[i].setAttribute('id', headerId);
-            headers[i].addEventListener('click', () =>
-                window.location.href = window.location.href.substring(0, scrollTargetIndex) + `#${headerId}`);
+        for (const header of document.querySelectorAll('h1, h2, h3, h4, h5, h6')) {
+            const headerId = header.innerText.replaceAll(' ', '-').toLowerCase()
+            header.setAttribute('id', headerId);
+            header.addEventListener('click', () => window.location.hash = '#' + headerId);
         }
 
         // Manually scroll the user to the appropriate header if anchor navigation is used
-        if (scrollTargetIndex > -1) {
-            try{
-                const scrollTarget = window.location.href.substring(scrollTargetIndex + 1);
-                document.getElementById(scrollTarget).scrollIntoView({ behavior: "smooth" });
-            } catch(error) {
-                console.error(error);
-            }
+        if (window.location.hash) {
+            const scrollTarget = document.getElementById(window.location.hash.substring(1));
+            scrollTarget?.scrollIntoView({ behavior: "smooth" });
         }
     }).catch((error) => {
         console.error(error);

--- a/WebHostLib/static/assets/faq.js
+++ b/WebHostLib/static/assets/faq.js
@@ -29,13 +29,16 @@ window.addEventListener('load', () => {
         for (const header of document.querySelectorAll('h1, h2, h3, h4, h5, h6')) {
             const headerId = header.innerText.replaceAll(' ', '-').toLowerCase()
             header.setAttribute('id', headerId);
-            header.addEventListener('click', () => window.location.hash = '#' + headerId);
+            header.addEventListener('click', () => {
+                window.location.hash = '#' + headerId;
+                header.scrollIntoView();
+            });
         }
 
         // Manually scroll the user to the appropriate header if anchor navigation is used
         if (window.location.hash) {
             const scrollTarget = document.getElementById(window.location.hash.substring(1));
-            scrollTarget?.scrollIntoView({ behavior: "smooth" });
+            scrollTarget?.scrollIntoView();
         }
     }).catch((error) => {
         console.error(error);

--- a/WebHostLib/static/assets/faq.js
+++ b/WebHostLib/static/assets/faq.js
@@ -36,10 +36,12 @@ window.addEventListener('load', () => {
         }
 
         // Manually scroll the user to the appropriate header if anchor navigation is used
-        if (window.location.hash) {
-            const scrollTarget = document.getElementById(window.location.hash.substring(1));
-            scrollTarget?.scrollIntoView();
-        }
+        document.fonts.ready.finally(() => {
+            if (window.location.hash) {
+                const scrollTarget = document.getElementById(window.location.hash.substring(1));
+                scrollTarget?.scrollIntoView();
+            }
+        });
     }).catch((error) => {
         console.error(error);
         tutorialWrapper.innerHTML =

--- a/WebHostLib/static/assets/gameInfo.js
+++ b/WebHostLib/static/assets/gameInfo.js
@@ -27,10 +27,10 @@ window.addEventListener('load', () => {
 
         // Reset the id of all header divs to something nicer
         for (const header of document.querySelectorAll('h1, h2, h3, h4, h5, h6')) {
-            const headerId = header.innerText.replaceAll(' ', '-').toLowerCase()
+            const headerId = header.innerText.replace(/\s+/g, '-').toLowerCase();
             header.setAttribute('id', headerId);
             header.addEventListener('click', () => {
-                window.location.hash = '#' + headerId;
+                window.location.hash = `#${headerId}`;
                 header.scrollIntoView();
             });
         }

--- a/WebHostLib/static/assets/gameInfo.js
+++ b/WebHostLib/static/assets/gameInfo.js
@@ -26,23 +26,16 @@ window.addEventListener('load', () => {
         adjustHeaderWidth();
 
         // Reset the id of all header divs to something nicer
-        const headers = Array.from(document.querySelectorAll('h1, h2, h3, h4, h5, h6'));
-        const scrollTargetIndex = window.location.href.search(/#[A-z0-9-_]*$/);
-        for (let i=0; i < headers.length; i++){
-            const headerId = headers[i].innerText.replace(/[ ]/g,'-').toLowerCase()
-            headers[i].setAttribute('id', headerId);
-            headers[i].addEventListener('click', () =>
-                window.location.href = window.location.href.substring(0, scrollTargetIndex) + `#${headerId}`);
+        for (const header of document.querySelectorAll('h1, h2, h3, h4, h5, h6')) {
+            const headerId = header.innerText.replaceAll(' ', '-').toLowerCase()
+            header.setAttribute('id', headerId);
+            header.addEventListener('click', () => window.location.hash = '#' + headerId);
         }
 
         // Manually scroll the user to the appropriate header if anchor navigation is used
-        if (scrollTargetIndex > -1) {
-            try{
-                const scrollTarget = window.location.href.substring(scrollTargetIndex + 1);
-                document.getElementById(scrollTarget).scrollIntoView({ behavior: "smooth" });
-            } catch(error) {
-                console.error(error);
-            }
+        if (window.location.hash) {
+            const scrollTarget = document.getElementById(window.location.hash.substring(1));
+            scrollTarget?.scrollIntoView({ behavior: "smooth" });
         }
     }).catch((error) => {
         console.error(error);

--- a/WebHostLib/static/assets/gameInfo.js
+++ b/WebHostLib/static/assets/gameInfo.js
@@ -36,10 +36,12 @@ window.addEventListener('load', () => {
         }
 
         // Manually scroll the user to the appropriate header if anchor navigation is used
-        if (window.location.hash) {
-            const scrollTarget = document.getElementById(window.location.hash.substring(1));
-            scrollTarget?.scrollIntoView();
-        }
+        document.fonts.ready.finally(() => {
+            if (window.location.hash) {
+                const scrollTarget = document.getElementById(window.location.hash.substring(1));
+                scrollTarget?.scrollIntoView();
+            }
+        });
     }).catch((error) => {
         console.error(error);
         gameInfo.innerHTML =

--- a/WebHostLib/static/assets/gameInfo.js
+++ b/WebHostLib/static/assets/gameInfo.js
@@ -29,13 +29,16 @@ window.addEventListener('load', () => {
         for (const header of document.querySelectorAll('h1, h2, h3, h4, h5, h6')) {
             const headerId = header.innerText.replaceAll(' ', '-').toLowerCase()
             header.setAttribute('id', headerId);
-            header.addEventListener('click', () => window.location.hash = '#' + headerId);
+            header.addEventListener('click', () => {
+                window.location.hash = '#' + headerId;
+                header.scrollIntoView();
+            });
         }
 
         // Manually scroll the user to the appropriate header if anchor navigation is used
         if (window.location.hash) {
             const scrollTarget = document.getElementById(window.location.hash.substring(1));
-            scrollTarget?.scrollIntoView({ behavior: "smooth" });
+            scrollTarget?.scrollIntoView();
         }
     }).catch((error) => {
         console.error(error);

--- a/WebHostLib/static/assets/glossary.js
+++ b/WebHostLib/static/assets/glossary.js
@@ -27,10 +27,10 @@ window.addEventListener('load', () => {
 
         // Reset the id of all header divs to something nicer
         for (const header of document.querySelectorAll('h1, h2, h3, h4, h5, h6')) {
-            const headerId = header.innerText.replaceAll(' ', '-').toLowerCase()
+            const headerId = header.innerText.replace(/\s+/g, '-').toLowerCase();
             header.setAttribute('id', headerId);
             header.addEventListener('click', () => {
-                window.location.hash = '#' + headerId;
+                window.location.hash = `#${headerId}`;
                 header.scrollIntoView();
             });
         }

--- a/WebHostLib/static/assets/glossary.js
+++ b/WebHostLib/static/assets/glossary.js
@@ -26,23 +26,16 @@ window.addEventListener('load', () => {
         adjustHeaderWidth();
 
         // Reset the id of all header divs to something nicer
-        const headers = Array.from(document.querySelectorAll('h1, h2, h3, h4, h5, h6'));
-        const scrollTargetIndex = window.location.href.search(/#[A-z0-9-_]*$/);
-        for (let i=0; i < headers.length; i++){
-            const headerId = headers[i].innerText.replace(/[ ]/g,'-').toLowerCase()
-            headers[i].setAttribute('id', headerId);
-            headers[i].addEventListener('click', () =>
-                window.location.href = window.location.href.substring(0, scrollTargetIndex) + `#${headerId}`);
+        for (const header of document.querySelectorAll('h1, h2, h3, h4, h5, h6')) {
+            const headerId = header.innerText.replaceAll(' ', '-').toLowerCase()
+            header.setAttribute('id', headerId);
+            header.addEventListener('click', () => window.location.hash = '#' + headerId);
         }
 
         // Manually scroll the user to the appropriate header if anchor navigation is used
-        if (scrollTargetIndex > -1) {
-            try{
-                const scrollTarget = window.location.href.substring(scrollTargetIndex + 1);
-                document.getElementById(scrollTarget).scrollIntoView({ behavior: "smooth" });
-            } catch(error) {
-                console.error(error);
-            }
+        if (window.location.hash) {
+            const scrollTarget = document.getElementById(window.location.hash.substring(1));
+            scrollTarget?.scrollIntoView({ behavior: "smooth" });
         }
     }).catch((error) => {
         console.error(error);

--- a/WebHostLib/static/assets/glossary.js
+++ b/WebHostLib/static/assets/glossary.js
@@ -29,13 +29,16 @@ window.addEventListener('load', () => {
         for (const header of document.querySelectorAll('h1, h2, h3, h4, h5, h6')) {
             const headerId = header.innerText.replaceAll(' ', '-').toLowerCase()
             header.setAttribute('id', headerId);
-            header.addEventListener('click', () => window.location.hash = '#' + headerId);
+            header.addEventListener('click', () => {
+                window.location.hash = '#' + headerId;
+                header.scrollIntoView();
+            });
         }
 
         // Manually scroll the user to the appropriate header if anchor navigation is used
         if (window.location.hash) {
             const scrollTarget = document.getElementById(window.location.hash.substring(1));
-            scrollTarget?.scrollIntoView({ behavior: "smooth" });
+            scrollTarget?.scrollIntoView();
         }
     }).catch((error) => {
         console.error(error);

--- a/WebHostLib/static/assets/glossary.js
+++ b/WebHostLib/static/assets/glossary.js
@@ -36,10 +36,12 @@ window.addEventListener('load', () => {
         }
 
         // Manually scroll the user to the appropriate header if anchor navigation is used
-        if (window.location.hash) {
-            const scrollTarget = document.getElementById(window.location.hash.substring(1));
-            scrollTarget?.scrollIntoView();
-        }
+        document.fonts.ready.finally(() => {
+            if (window.location.hash) {
+                const scrollTarget = document.getElementById(window.location.hash.substring(1));
+                scrollTarget?.scrollIntoView();
+            }
+        });
     }).catch((error) => {
         console.error(error);
         tutorialWrapper.innerHTML =

--- a/WebHostLib/static/assets/tutorial.js
+++ b/WebHostLib/static/assets/tutorial.js
@@ -43,10 +43,12 @@ window.addEventListener('load', () => {
         }
 
         // Manually scroll the user to the appropriate header if anchor navigation is used
-        if (window.location.hash) {
-            const scrollTarget = document.getElementById(window.location.hash.substring(1));
-            scrollTarget?.scrollIntoView();
-        }
+        document.fonts.ready.finally(() => {
+            if (window.location.hash) {
+                const scrollTarget = document.getElementById(window.location.hash.substring(1));
+                scrollTarget?.scrollIntoView();
+            }
+        });
     }).catch((error) => {
         console.error(error);
         tutorialWrapper.innerHTML =

--- a/WebHostLib/static/assets/tutorial.js
+++ b/WebHostLib/static/assets/tutorial.js
@@ -36,13 +36,16 @@ window.addEventListener('load', () => {
         for (const header of document.querySelectorAll('h1, h2, h3, h4, h5, h6')) {
             const headerId = header.innerText.replaceAll(' ', '-').toLowerCase()
             header.setAttribute('id', headerId);
-            header.addEventListener('click', () => window.location.hash = '#' + headerId);
+            header.addEventListener('click', () => {
+                window.location.hash = '#' + headerId;
+                header.scrollIntoView();
+            });
         }
 
         // Manually scroll the user to the appropriate header if anchor navigation is used
         if (window.location.hash) {
             const scrollTarget = document.getElementById(window.location.hash.substring(1));
-            scrollTarget?.scrollIntoView({ behavior: "smooth" });
+            scrollTarget?.scrollIntoView();
         }
     }).catch((error) => {
         console.error(error);

--- a/WebHostLib/static/assets/tutorial.js
+++ b/WebHostLib/static/assets/tutorial.js
@@ -33,23 +33,16 @@ window.addEventListener('load', () => {
         }
 
         // Reset the id of all header divs to something nicer
-        const headers = Array.from(document.querySelectorAll('h1, h2, h3, h4, h5, h6'));
-        const scrollTargetIndex = window.location.href.search(/#[A-z0-9-_]*$/);
-        for (let i=0; i < headers.length; i++){
-            const headerId = headers[i].innerText.replace(/[ ]/g,'-').toLowerCase()
-            headers[i].setAttribute('id', headerId);
-            headers[i].addEventListener('click', () =>
-                window.location.href = window.location.href.substring(0, scrollTargetIndex) + `#${headerId}`);
+        for (const header of document.querySelectorAll('h1, h2, h3, h4, h5, h6')) {
+            const headerId = header.innerText.replaceAll(' ', '-').toLowerCase()
+            header.setAttribute('id', headerId);
+            header.addEventListener('click', () => window.location.hash = '#' + headerId);
         }
 
         // Manually scroll the user to the appropriate header if anchor navigation is used
-        if (scrollTargetIndex > -1) {
-            try{
-                const scrollTarget = window.location.href.substring(scrollTargetIndex + 1);
-                document.getElementById(scrollTarget).scrollIntoView({ behavior: "smooth" });
-            } catch(error) {
-                console.error(error);
-            }
+        if (window.location.hash) {
+            const scrollTarget = document.getElementById(window.location.hash.substring(1));
+            scrollTarget?.scrollIntoView({ behavior: "smooth" });
         }
     }).catch((error) => {
         console.error(error);

--- a/WebHostLib/static/assets/tutorial.js
+++ b/WebHostLib/static/assets/tutorial.js
@@ -34,10 +34,10 @@ window.addEventListener('load', () => {
 
         // Reset the id of all header divs to something nicer
         for (const header of document.querySelectorAll('h1, h2, h3, h4, h5, h6')) {
-            const headerId = header.innerText.replaceAll(' ', '-').toLowerCase()
+            const headerId = header.innerText.replace(/\s+/g, '-').toLowerCase();
             header.setAttribute('id', headerId);
             header.addEventListener('click', () => {
-                window.location.hash = '#' + headerId;
+                window.location.hash = `#${headerId}`;
                 header.scrollIntoView();
             });
         }

--- a/WebHostLib/static/styles/themes/base.css
+++ b/WebHostLib/static/styles/themes/base.css
@@ -1,5 +1,7 @@
 html{
     padding-top: 110px;
+    scroll-padding-top: 100px;
+    scroll-behavior: smooth;
 }
 
 #base-header{


### PR DESCRIPTION
## What is this fixing?
Anchors are used to mark a specific spot in a longer page as part of the URL. Consider the following URL:

> [https://archipelago.gg/faq/en/#what-happens-if-a-person-has-to-leave-early?](https://archipelago.gg/faq/en/#what-happens-if-a-person-has-to-leave-early?)

Opening the page using that URL should automatically jump to the section specified by the anchor. However, currently sometimes it doesn't work, and when it does, the start of the section is obscured by the clouds of the header. The same problem occurs when clicking on a heading, which updates the anchor in your URL bar and scrolls it so far to the top that it is obscured by the clouds.

This PR fixes these problems. It also modernizes the code a little bit (for-each loops, `window.location.hash` instead of character juggling with `window.location.href`).

## How was this tested?
I ran a local web host and tested opening pages with anchors, clicking on headings, editing the anchor in the URL bar (which jumps to an anchor without reloading the page), and pressing the back/forward buttons on my mouse. Tested in Firefox, Chrome and Edge.

Here are some URLs for you to try:
- [http://localhost/faq/en/#what-happens-if-a-person-has-to-leave-early?](http://localhost/faq/en/#what-happens-if-a-person-has-to-leave-early?)
- http://localhost/glossary/en/#logic
- http://localhost/tutorial/Super%20Mario%20World/setup/en#bizhawk
- http://localhost/tutorial/Archipelago/advanced_settings/en#random-numbers
- [http://localhost/games/Super%20Mario%20World/info/en#what-does-randomization-do-to-this-game?](http://localhost/games/Super%20Mario%20World/info/en#what-does-randomization-do-to-this-game?)

## Known Issues
- In Firefox only, and only when opening a tab with an anchor in the background, the browser ignores the scroll command and shows the top of the page when the tab is activated. I am currently out of ideas on why this happens and what a good workaround would be.