### PR TITLE
[SM] Fixed failing testAllStateCanReachEverything

### DIFF
--- a/test/general/TestReachability.py
+++ b/test/general/TestReachability.py
@@ -21,6 +21,13 @@ class TestBase(unittest.TestCase):
             "Lost Woods Mushroom Timeout",  # trade quest starts after this item
             "ZD Eyeball Frog Timeout",  # trade quest starts after this item
             "ZR Top of Waterfall",  # dummy region used for entrance shuffle
+        },
+        # The following SM regions are only used when the corresponding StartLocation option is selected (so not with default settings).
+        # Also, those dont have any entrances as they serve as starting Region (that's why they have to be excluded for testAllStateCanReachEverything).
+        "Super Metroid": {
+            "Ceres",
+            "Gauntlet Top",
+            "Mama Turtle"
         }
     }
 

--- a/worlds/sm/Regions.py
+++ b/worlds/sm/Regions.py
@@ -6,7 +6,7 @@ def create_regions(self, world, player: int):
 
     regions = []
     for accessPoint in Logic.accessPoints:
-        if (not accessPoint.Escape):
+        if not accessPoint.Escape:
             regions.append(create_region(   self, 
                                             world, 
                                             player, 

--- a/worlds/sm/Regions.py
+++ b/worlds/sm/Regions.py
@@ -6,12 +6,13 @@ def create_regions(self, world, player: int):
 
     regions = []
     for accessPoint in Logic.accessPoints:
-        regions.append(create_region(   self, 
-                                        world, 
-                                        player, 
-                                        accessPoint.Name, 
-                                        None,
-                                        [accessPoint.Name + "->" + key for key in accessPoint.intraTransitions.keys()]))
+        if (not accessPoint.Escape):
+            regions.append(create_region(   self, 
+                                            world, 
+                                            player, 
+                                            accessPoint.Name, 
+                                            None,
+                                            [accessPoint.Name + "->" + key for key in accessPoint.intraTransitions.keys()]))
 
     world.regions += regions
 

--- a/worlds/sm/Regions.py
+++ b/worlds/sm/Regions.py
@@ -7,12 +7,12 @@ def create_regions(self, world, player: int):
     regions = []
     for accessPoint in Logic.accessPoints:
         if not accessPoint.Escape:
-            regions.append(create_region(   self, 
-                                            world, 
-                                            player, 
-                                            accessPoint.Name, 
-                                            None,
-                                            [accessPoint.Name + "->" + key for key in accessPoint.intraTransitions.keys()]))
+            regions.append(create_region(self, 
+                                         world, 
+                                         player, 
+                                         accessPoint.Name, 
+                                         None,
+                                         [accessPoint.Name + "->" + key for key in accessPoint.intraTransitions.keys()]))
 
     world.regions += regions
 

--- a/worlds/sm/Rules.py
+++ b/worlds/sm/Rules.py
@@ -36,6 +36,6 @@ def set_rules(world, player):
             add_postAvailable_rule(location, player, value.PostAvailable)
             
     for accessPoint in Logic.accessPoints:
-        if (not accessPoint.Escape):
+        if not accessPoint.Escape:
             for key, value1 in accessPoint.intraTransitions.items():
                 set_entrance_rule(world.get_entrance(accessPoint.Name + "->" + key, player), player, value1)

--- a/worlds/sm/Rules.py
+++ b/worlds/sm/Rules.py
@@ -36,5 +36,6 @@ def set_rules(world, player):
             add_postAvailable_rule(location, player, value.PostAvailable)
             
     for accessPoint in Logic.accessPoints:
-        for key, value1 in accessPoint.intraTransitions.items():
-            set_entrance_rule(world.get_entrance(accessPoint.Name + "->" + key, player), player, value1)
+        if (not accessPoint.Escape):
+            for key, value1 in accessPoint.intraTransitions.items():
+                set_entrance_rule(world.get_entrance(accessPoint.Name + "->" + key, player), player, value1)


### PR DESCRIPTION
- by adding exclusion for Regions used only when corresponding Starting Location is used
- by removing unnecessary VARIA Regions used only for EscapeRando (not supported in AP anyway)