### PR TITLE
[Core] improve sweep_for_events efficiency

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -689,14 +689,14 @@ class CollectionState():
     def sweep_for_events(self, key_only: bool = False, locations: Optional[Iterable[Location]] = None) -> None:
         if locations is None:
             locations = self.world.get_filled_locations()
-        new_locations = True
+        reachable_events = True
         # since the loop has a good chance to run more than once, only filter the events once
         locations = {location for location in locations if location.event and
                      not key_only or getattr(location.item, "locked_dungeon_item", False)}
-        while new_locations:
+        while reachable_events:
             reachable_events = {location for location in locations if location.can_reach(self)}
-            new_locations = reachable_events - self.events
-            for event in new_locations:
+            locations -= reachable_events
+            for event in reachable_events:
                 self.events.add(event)
                 assert isinstance(event.item, Item), "tried to collect Event with no Item"
                 self.collect(event.item, True, event)


### PR DESCRIPTION
## What is this fixing or adding?
In `sweep_for_events`, removes locations from the location set after they are reachable, so that we don't run `can_reach` on already-reachable locations unnecessarily

## How was this tested?
Generated a 10 world HK multiworld with 6200 items, on main and on this branch, with a set seed. Generation time was cut from around 450 seconds to 253 seconds, and the .archipelago files output matched exactly.

## If this makes graphical changes, please attach screenshots.
