### PR TITLE
Docs: Retrieved packet when information doesn't exist

### DIFF
--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -234,6 +234,8 @@ Sent to clients as a response the a [Get](#Get) package.
 | ---- | ---- | ----- |
 | keys | dict\[str\, any] | A key-value collection containing all the values for the keys requested in the [Get](#Get) package. |
 
+If a requested key was not present in the server's data, the associated value will be `null`.
+
 Additional arguments added to the [Get](#Get) package that triggered this [Retrieved](#Retrieved) will also be passed along.
 
 ### SetReply


### PR DESCRIPTION
## What is this fixing or adding?

I had to look in the code to find out what happens when I `Get` a key that doesn't exist on the server.
This puts it in the documentation.
