### PR TITLE
[Pokémon R/B] Account for webhost seed names

### DIFF
--- a/PokemonClient.py
+++ b/PokemonClient.py
@@ -170,12 +170,12 @@ async def gb_sync_task(ctx: GBContext):
                     data_decoded = json.loads(data.decode())
                     #print(data_decoded)
 
-                    if ctx.seed_name and ctx.seed_name != bytes(data_decoded['seedName']).decode():
+                    if ctx.seed_name and ctx.seed_name != bytes(data_decoded['seedName'])[-20:].decode():
                         msg = "The server is running a different multiworld than your client is. (invalid seed_name)"
                         logger.info(msg, extra={'compact_gui': True})
                         ctx.gui_error('Error', msg)
                         error_status = CONNECTION_RESET_STATUS
-                    ctx.seed_name = bytes(data_decoded['seedName']).decode()
+                    ctx.seed_name = bytes(data_decoded['seedName']).decode()[-20:]
                     if not ctx.auth:
                         ctx.auth = ''.join([chr(i) for i in data_decoded['playerName'] if i != 0])
                         if ctx.auth == '':

--- a/worlds/pokemon_rb/rom.py
+++ b/worlds/pokemon_rb/rom.py
@@ -557,7 +557,7 @@ def generate_output(self, output_directory: str):
     write_bytes(data, self.rival_name, rom_addresses['Rival_Name'])
 
     write_bytes(data, basemd5.digest(), 0xFFCC)
-    write_bytes(data, self.world.seed_name.encode(), 0xFFDC)
+    write_bytes(data, self.world.seed_name[-20:].encode(), 0xFFDC)
     write_bytes(data, self.world.player_name[self.player].encode(), 0xFFF0)
 
 


### PR DESCRIPTION
## What is this fixing or adding?
As I was unaware that the seed name is prepended with a "W" when generated via the web host, I was counting on it always being 20 characters. Result is rom ends up without 20th character of seed name, and PokemonClient errors out due to mismatch with server. Rather than move things around, I am just changing it to read only the last 20 characters of the seed name.

## How was this tested?
I'm not able to test this without kicking people off an async game I just started on my web host. This will be a draft until I or someone else confirms it works as intended.