### PR TITLE
[Core] Fix forbid_important_item_rule

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -235,7 +235,7 @@ def inaccessible_location_rules(world: MultiWorld, state: CollectionState, locat
     unreachable_locations = [location for location in locations if not location.can_reach(maximum_exploration_state)]
     if unreachable_locations:
         def forbid_important_item_rule(item: Item):
-            return not (item.classification & 0b0011) and world.accessibility[item.player] != 'minimal'
+            return not ((item.classification & 0b0011) and world.accessibility[item.player] != 'minimal')
 
         for location in unreachable_locations:
             add_item_rule(location, forbid_important_item_rule)


### PR DESCRIPTION
## What is this fixing or adding?

Adds parenthesis to forbid_important_item_rule so that the two things are evaluated together instead of `not` only applying to the first

## How was this tested?

generated same seed with and without and determined item placement was different, confirming the intended effect of the old statement was not being achieved

## If this makes graphical changes, please attach screenshots.
