### PR TITLE
Main: Fill: more opportunities for swapping

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -82,13 +82,14 @@ def fill_restrictive(world: MultiWorld, base_state: CollectionState, locations: 
 
                     location.item = None
                     placed_item.location = None
-                    swap_state = sweep_from_pool(base_state)
+                    swap_state = sweep_from_pool(base_state, [placed_item])
+                    # swap_state assumes we can collect placed item before item_to_place
                     if (not single_player_placement or location.player == item_to_place.player) \
                             and location.can_fill(swap_state, item_to_place, perform_access_check):
 
-                        # Verify that placing this item won't reduce available locations
+                        # Verify that placing this item won't reduce available locations, which could happen with rules
+                        # that want to not have both items. Left in until removal is proven useful.
                         prev_state = swap_state.copy()
-                        prev_state.collect(placed_item)
                         prev_loc_count = len(
                             world.get_reachable_locations(prev_state))
 


### PR DESCRIPTION
## What is this fixing or adding?

The current swap algorithm fails in certain scenarios. This change makes the swap assume it can place the
item-to-be-swapped-out in an earlier location so that it attempts the swap even if the swap itself does not improve
accessibility.


## How was this tested?

By running ap-roller on a bunch of yamls.

ItemLink was not tested.

Per-player priority/excluded was not tested.


## Failure comparison

Random options, no local/non-local items, accessibility: items or location (not minimal).

| Game     | Seeds | Main | PR |
|:-------- | -----:| ----:| --:|
| Alttp    |   400 |   [^1] 9% | unchanged |
| Raft[^2] |   400 |        0% | unchanged |
| SA2B     |   400 |        1% | 0% |
| SM       |   400 |  [^3] 37% | 27% |
| SMZ3     |   600 | [^3] high | unchanged |
| SoE.41   |  1400 |        0% | unchanged |
| SoE.42   |  1400 |   [^4] 4% | 0% |
| TS       |   400 |        0% | unchanged |

In addition, local/non-local was tested with SoE.41 Energy Core Fragments and Alttp Triforce Pieces and failures rate was unchanged.

Difference in average runtime of successful runs is in noise.


[^1]: assert failures in place_item due to max_exploration_state vs. world.state
[^2]: not all available options were tested
[^3]: failure rate is pretty high on current main, have not checked why, seems to depend on options and total player count
[^4]: failure rate depends on difficulty option
