### PR TITLE
The Witness: More Puzzle Skips, Softlock Fix

### DIFF
--- a/worlds/witness/Options.py
+++ b/worlds/witness/Options.py
@@ -112,8 +112,8 @@ class PuzzleSkipAmount(Range):
     Works on most panels in the game - The only big exception is The Challenge."""
     display_name = "Puzzle Skips"
     range_start = 0
-    range_end = 20
-    default = 5
+    range_end = 30
+    default = 10
 
 
 class HintAmount(Range):

--- a/worlds/witness/WitnessItems.txt
+++ b/worlds/witness/WitnessItems.txt
@@ -58,7 +58,7 @@ Doors:
 1190 - Swamp Entry (Panel) - 0x0056E
 1192 - Swamp Sliding Bridge (Panel) - 0x00609,0x18488
 1195 - Swamp Rotating Bridge (Panel) - 0x181F5
-1197 - Swamp Maze Control (Panel) - 0x17C0A
+1197 - Swamp Maze Control (Panel) - 0x17C0A,0x17E07
 1310 - Boat - 0x17CDF,0x17CC8,0x17CA6,0x09DB8,0x17C95,0x0A054
 
 1400 - Caves Mountain Shortcut (Door) - 0x2D73F

--- a/worlds/witness/WitnessLogic.txt
+++ b/worlds/witness/WitnessLogic.txt
@@ -927,6 +927,6 @@ Elevator (Mountain Final Room):
 158533 - 0x3C114 (Elevator Entry Right) - 0x3D9A6 | 0x3D9A7 - True
 158534 - 0x3D9AA (Back Wall Left) - 0x3D9A6 | 0x3D9A7 - True
 158535 - 0x3D9A8 (Back Wall Right) - 0x3D9A6 | 0x3D9A7 - True
-158536 - 0x3D9A9 (Elevator Start) - 0x3D9AA | 0x3D9A8 - True
+158536 - 0x3D9A9 (Elevator Start) - 0x3D9AA & 7 Lasers | 0x3D9A8 & 7 Lasers - True
 
 Boat (Boat) - Main Island - TrueOneWay - Swamp Near Boat - TrueOneWay - Treehouse Entry Area - TrueOneWay - Quarry Boathouse Behind Staircase - TrueOneWay - Inside Glass Factory Behind Back Wall - TrueOneWay:

--- a/worlds/witness/WitnessLogicExpert.txt
+++ b/worlds/witness/WitnessLogicExpert.txt
@@ -927,6 +927,6 @@ Elevator (Mountain Final Room):
 158533 - 0x3C114 (Elevator Entry Right) - 0x3D9A6 | 0x3D9A7 - True
 158534 - 0x3D9AA (Back Wall Left) - 0x3D9A6 | 0x3D9A7 - True
 158535 - 0x3D9A8 (Back Wall Right) - 0x3D9A6 | 0x3D9A7 - True
-158536 - 0x3D9A9 (Elevator Start) - 0x3D9AA | 0x3D9A8 - True
+158536 - 0x3D9A9 (Elevator Start) - 0x3D9AA & 7 Lasers | 0x3D9A8 & 7 Lasers - True
 
 Boat (Boat) - Main Island - TrueOneWay - Swamp Near Boat - TrueOneWay - Treehouse Entry Area - TrueOneWay - Quarry Boathouse Behind Staircase - TrueOneWay - Inside Glass Factory Behind Back Wall - TrueOneWay:


### PR DESCRIPTION
**Changes:**

Allow for more Puzzle Skips and also raise the default.

Puzzle Skips have been rebalanced client-side to be more consistent in value across the board, making me feel like it's now fine to allow more of them.

(Examples: Instead of one Puzzle Skip bypassing the entirety of Metapuzzle, you can now individually skip the small puzzles of Metapuzzle, which will show you the correct shape to use. And then only if all 4 small puzzles are skipped, you can use a 5th skip to fully skip Metapuzzle. On the flipside, it is now possible to use 2 Puzzle Skips to skip the Quarry Laser panel even if you haven't beaten either side of the Quarry. I plan to do more interesting things with PSs in the future)

-

Also made the Elevator Start panel logically require shortbox (usually 7) lasers in preparation to lock it behind that in the client.

**Fixes:**

Small fix concerning a client-side softlock (The "Swamp Maze Control" item did not lock the far-side maze panel, which meant you could go backwards through the maze, then "unsolve" that panel in a way that makes it no longer visible. The reason this requires a server-side fix is that the info on which panels to lock behind each item is stored in slot_data)