### PR TITLE
[Core] Fix priority location handling in accessibility corrections

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -232,13 +232,14 @@ def accessibility_corrections(world: MultiWorld, state: CollectionState, locatio
             if location in state.events:
                 state.events.remove(location)
             locations.append(location)
-
-    if pool:
+    if pool and locations:
+        locations.sort(key=lambda loc: loc.progress_type != LocationProgressType.PRIORITY)
         fill_restrictive(world, state, locations, pool)
 
 
 def inaccessible_location_rules(world: MultiWorld, state: CollectionState, locations):
-    maximum_exploration_state = sweep_from_pool(state, [])
+    maximum_exploration_state = state.copy()
+    maximum_exploration_state.sweep_for_events()
     unreachable_locations = [location for location in locations if not location.can_reach(maximum_exploration_state)]
     if unreachable_locations:
         def forbid_important_item_rule(item: Item):
@@ -285,15 +286,10 @@ def distribute_items_restrictive(world: MultiWorld) -> None:
         nonlocal lock_later
         lock_later.append(location)
 
-    # "priority fill"
-    fill_restrictive(world, world.state, prioritylocations, progitempool, swap=False, on_place=mark_for_locking)
-    accessibility_corrections(world, world.state, prioritylocations, progitempool)
-
-    for location in lock_later:
-        location.locked = True
-    del mark_for_locking, lock_later
-
     if prioritylocations:
+        # "priority fill"
+        fill_restrictive(world, world.state, prioritylocations, progitempool, swap=False, on_place=mark_for_locking)
+        accessibility_corrections(world, world.state, prioritylocations, progitempool)
         defaultlocations = prioritylocations + defaultlocations
 
     if progitempool:
@@ -303,6 +299,10 @@ def distribute_items_restrictive(world: MultiWorld) -> None:
             raise FillError(
                 f'Not enough locations for progress items. There are {len(progitempool)} more items than locations')
         accessibility_corrections(world, world.state, defaultlocations)
+
+    for location in lock_later:
+        location.locked = True
+    del mark_for_locking, lock_later
 
     inaccessible_location_rules(world, world.state, defaultlocations)
 

--- a/Fill.py
+++ b/Fill.py
@@ -238,8 +238,7 @@ def accessibility_corrections(world: MultiWorld, state: CollectionState, locatio
 
 
 def inaccessible_location_rules(world: MultiWorld, state: CollectionState, locations):
-    maximum_exploration_state = state.copy()
-    maximum_exploration_state.sweep_for_events()
+    maximum_exploration_state = sweep_from_pool(state)
     unreachable_locations = [location for location in locations if not location.can_reach(maximum_exploration_state)]
     if unreachable_locations:
         def forbid_important_item_rule(item: Item):

--- a/Fill.py
+++ b/Fill.py
@@ -301,7 +301,8 @@ def distribute_items_restrictive(world: MultiWorld) -> None:
         accessibility_corrections(world, world.state, defaultlocations)
 
     for location in lock_later:
-        location.locked = True
+        if location.item:
+            location.locked = True
     del mark_for_locking, lock_later
 
     inaccessible_location_rules(world, world.state, defaultlocations)


### PR DESCRIPTION
## What is this fixing or adding?
Fixes an issue where inaccessible items placed during main prog item fill could make items placed into priority locations inaccessible. Accomplishes this by waiting until after prog item fill to lock priority locations. 

Other changes:
* Put priority fill into an `if` block as I noticed `accessibillity corrections` wasting a few seconds on a small multiworld when there were no priority locations
* Since inaccessible locations may be emptied after prog item fill, I sort locations to move priority locations to the front of the line before re-filling in `accessibility_corrections`. I first tried pulling out priority locations and running `fill_restrictive` with just them, but that function will put out warnings that items failed to place if it ends with items and locations left over. We could change this so it won't do that check for this particular fill, but I'm fairly certain that sorting the location pool should work just as well, since every time an item selected for placement it checks location in the order they're passed in, so if anything can fill the emptied priority locations, they will.
* call `sweep_for_events` instead of `sweep_from_pool(state, [])` as this is all that will be accomplished by this call anyways

These changes *will* allow for priority locations to end up with junk items, but only if they had an item for a player with `items` or `locations` accessibility and the location would not have been accessible, and no items pulled during `accessibility_corrections` are able to be placed in them.

## How was this tested?
Generated the yamls sent to me by @black-sliver with the seed number he indicated to ensure this correctly moves the inaccessible item and succeeds generation. 