### PR TITLE
Generate: don't try to include meta or filler weights file as player

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -154,11 +154,12 @@ def main(args=None, callback=ERmain):
     # sort dict for consistent results across platforms:
     weights_cache = {key: value for key, value in sorted(weights_cache.items())}
     for filename, yaml_data in weights_cache.items():
-        for yaml in yaml_data:
-            print(f"P{player_id} Weights: {filename} >> "
-                  f"{get_choice('description', yaml, 'No description specified')}")
-            player_files[player_id] = filename
-            player_id += 1
+        if filename not in {args.meta_file_path, args.weights_file_path}:
+            for yaml in yaml_data:
+                print(f"P{player_id} Weights: {filename} >> "
+                      f"{get_choice('description', yaml, 'No description specified')}")
+                player_files[player_id] = filename
+                player_id += 1
 
     args.multi = max(player_id - 1, args.multi)
     print(f"Generating for {args.multi} player{'s' if args.multi > 1 else ''}, {seed_name} Seed {seed} with plando: "


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?
Fixes that filler gets included as player, regardless if filler is needed or not. Even if filler is needed, earlier behaviour would have one random filler slot within the group of non-filler slots.

## How was this tested?
Running Generate with 3 and 0 players, with templates posted to discord. Problem was found as Player142 of the Async gen was another copy of the filler.

## If this makes graphical changes, please attach screenshots.
