### PR TITLE
[SM64] Separate Entrance Shuffle pools option and MIPS cost option improvement

### DIFF
--- a/worlds/sm64ex/Options.py
+++ b/worlds/sm64ex/Options.py
@@ -46,7 +46,7 @@ class MIPS1Cost(Range):
 
 
 class MIPS2Cost(Range):
-    """How many stars are required to spawn MIPS the secound time. Must be bigger or equal MIPS1Cost"""
+    """How many stars are required to spawn MIPS the second time."""
     range_start = 0
     range_end = 80
     default = 50
@@ -73,6 +73,7 @@ class AreaRandomizer(Choice):
     option_Off = 0
     option_Courses_Only = 1
     option_Courses_and_Secrets = 2
+    option_Courses_and_Secrets_Separate = 3
 
 
 class BuddyChecks(Toggle):

--- a/worlds/sm64ex/Options.py
+++ b/worlds/sm64ex/Options.py
@@ -72,8 +72,8 @@ class AreaRandomizer(Choice):
     display_name = "Entrance Randomizer"
     option_Off = 0
     option_Courses_Only = 1
-    option_Courses_and_Secrets = 2
-    option_Courses_and_Secrets_Separate = 3
+    option_Courses_and_Secrets_Separate = 2
+    option_Courses_and_Secrets = 3
 
 
 class BuddyChecks(Toggle):

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -16,8 +16,13 @@ def set_rules(world, player: int, area_connections):
     if world.AreaRandomizer[player].value >= 1: # Some randomization is happening, randomize Courses
         entrance_ids = list(range(len(sm64paintings)))
         world.random.shuffle(entrance_ids)
-        entrance_ids = entrance_ids + list(range(len(sm64paintings), len(sm64paintings) + len(sm64secrets)))
-    if world.AreaRandomizer[player].value == 2: # Secret Regions as well
+        if world.AreaRandomizer[player].value == 3: # Shuffle Secret Regions only among themselves
+            secret_entrance_ids = list(range(len(sm64paintings), len(sm64paintings) + len(sm64secrets)))
+            world.random.shuffle(secret_entrance_ids)
+            entrance_ids += secret_entrance_ids
+        else:
+            entrance_ids += list(range(len(sm64paintings), len(sm64paintings) + len(sm64secrets)))
+    if world.AreaRandomizer[player].value == 2: # Shuffle Secret Regions with courses
         world.random.shuffle(entrance_ids)
         # Guarantee first entrance is a course
         swaplist = list(range(len(entrance_ids)))
@@ -117,7 +122,7 @@ def set_rules(world, player: int, area_connections):
     add_rule(world.get_location("Toad (Third Floor)", player), lambda state: state.can_reach("Third Floor", 'Region', player) and state.has("Power Star", player, 35))
 
     if world.MIPS1Cost[player].value > world.MIPS2Cost[player].value:
-        world.MIPS2Cost[player].value = world.MIPS1Cost[player].value
+        (world.MIPS2Cost[player].value, world.MIPS1Cost[player].value) = (world.MIPS1Cost[player].value, world.MIPS2Cost[player].value)
     add_rule(world.get_location("MIPS 1", player), lambda state: state.can_reach("Basement", 'Region', player) and state.has("Power Star", player, world.MIPS1Cost[player].value))
     add_rule(world.get_location("MIPS 2", player), lambda state: state.can_reach("Basement", 'Region', player) and state.has("Power Star", player, world.MIPS2Cost[player].value))
 

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -13,16 +13,14 @@ def set_rules(world, player: int, area_connections):
     destination_regions = list(range(13)) + [12,13,14] + list(range(15,15+len(sm64secrets))) # Two instances of Destination Course THI. Past normal course idx are secret regions
     if world.AreaRandomizer[player].value == 0:
         entrance_ids = list(range(len(sm64paintings + sm64secrets)))
-    if world.AreaRandomizer[player].value >= 1: # Some randomization is happening, randomize Courses
+    if world.AreaRandomizer[player].value >= 1:  # Some randomization is happening, randomize Courses
         entrance_ids = list(range(len(sm64paintings)))
         world.random.shuffle(entrance_ids)
-        if world.AreaRandomizer[player].value == 3: # Shuffle Secret Regions only among themselves
-            secret_entrance_ids = list(range(len(sm64paintings), len(sm64paintings) + len(sm64secrets)))
+        secret_entrance_ids = list(range(len(sm64paintings), len(sm64paintings) + len(sm64secrets)))
+        if world.AreaRandomizer[player].value == 2:  # Randomize Secrets as well
             world.random.shuffle(secret_entrance_ids)
-            entrance_ids += secret_entrance_ids
-        else:
-            entrance_ids += list(range(len(sm64paintings), len(sm64paintings) + len(sm64secrets)))
-    if world.AreaRandomizer[player].value == 2: # Shuffle Secret Regions with courses
+        entrance_ids += secret_entrance_ids
+    if world.AreaRandomizer[player].value == 3:  # Shuffle Secret Regions with courses
         world.random.shuffle(entrance_ids)
         # Guarantee first entrance is a course
         swaplist = list(range(len(entrance_ids)))

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -11,16 +11,14 @@ def fix_reg(entrance_ids, reg, invalidspot, swaplist, world):
 
 def set_rules(world, player: int, area_connections):
     destination_regions = list(range(13)) + [12,13,14] + list(range(15,15+len(sm64secrets))) # Two instances of Destination Course THI. Past normal course idx are secret regions
-    if world.AreaRandomizer[player].value == 0:
-        entrance_ids = list(range(len(sm64paintings + sm64secrets)))
+    secret_entrance_ids = list(range(len(sm64paintings), len(sm64paintings) + len(sm64secrets)))
+    course_entrance_ids = list(range(len(sm64paintings)))
     if world.AreaRandomizer[player].value >= 1:  # Some randomization is happening, randomize Courses
-        entrance_ids = list(range(len(sm64paintings)))
-        world.random.shuffle(entrance_ids)
-        secret_entrance_ids = list(range(len(sm64paintings), len(sm64paintings) + len(sm64secrets)))
-        if world.AreaRandomizer[player].value == 2:  # Randomize Secrets as well
-            world.random.shuffle(secret_entrance_ids)
-        entrance_ids += secret_entrance_ids
-    if world.AreaRandomizer[player].value == 3:  # Shuffle Secret Regions with courses
+        world.random.shuffle(course_entrance_ids)
+    if world.AreaRandomizer[player].value == 2:  # Randomize Secrets as well
+        world.random.shuffle(secret_entrance_ids)
+    entrance_ids = course_entrance_ids + secret_entrance_ids
+    if world.AreaRandomizer[player].value == 3:  # Randomize Courses and Secrets in one pool
         world.random.shuffle(entrance_ids)
         # Guarantee first entrance is a course
         swaplist = list(range(len(entrance_ids)))


### PR DESCRIPTION
## What is this fixing or adding?

* Adds an option to split courses and secret areas into separate pools for randomization
* If MIPS1Cost is greater than MIPS2Cost, swap the costs instead of setting MIPS2Cost to MIPS1Cost

## How was this tested?

Generating and observing intended effects in the spoiler logs

@N00byKing 