### PR TITLE
CommonClient: Some GUI polish

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -297,6 +297,8 @@ class CommonContext:
         await self.send_msgs([payload])
 
     async def console_input(self) -> str:
+        if self.ui:
+            self.ui.focus_textinput()
         self.input_requests += 1
         return await self.input_queue.get()
 

--- a/CommonClient.py
+++ b/CommonClient.py
@@ -235,9 +235,9 @@ class CommonContext:
             return len(self.checked_locations | self.missing_locations)
 
     async def connection_closed(self):
-        self.reset_server_state()
         if self.server and self.server.socket is not None:
             await self.server.socket.close()
+        self.reset_server_state()
 
     def reset_server_state(self):
         self.auth = None

--- a/data/client.kv
+++ b/data/client.kv
@@ -15,6 +15,8 @@
 <UILog>:
     viewclass: 'SelectableLabel'
     scroll_y: 0
+    scroll_type: ["content", "bars"]
+    bar_width: dp(12)
     effect_cls: "ScrollEffect"
     SelectableRecycleBoxLayout:
         default_size: None, dp(20)

--- a/kvui.py
+++ b/kvui.py
@@ -446,6 +446,10 @@ class GameManager(App):
         self.log_panels["Archipelago"].on_message_markup(text)
         self.log_panels["All"].on_message_markup(text)
 
+    def focus_textinput(self):
+        if hasattr(self, "textinput"):
+            self.textinput.focus = True
+
     def update_address_bar(self, text: str):
         if hasattr(self, "server_connect_bar"):
             self.server_connect_bar.text = text

--- a/kvui.py
+++ b/kvui.py
@@ -402,10 +402,12 @@ class GameManager(App):
                          f" | Connected to: {self.ctx.server_address} " \
                          f"{'.'.join(str(e) for e in self.ctx.server_version)}"
             self.server_connect_button.text = "Disconnect"
+            self.server_connect_bar.readonly = True
             self.progressbar.max = len(self.ctx.checked_locations) + len(self.ctx.missing_locations)
             self.progressbar.value = len(self.ctx.checked_locations)
         else:
             self.server_connect_button.text = "Connect"
+            self.server_connect_bar.readonly = False
             self.title = self.base_title + " " + Utils.__version__
             self.progressbar.value = 0
 

--- a/kvui.py
+++ b/kvui.py
@@ -334,7 +334,7 @@ class GameManager(App):
         # top part
         server_label = ServerLabel()
         self.connect_layout.add_widget(server_label)
-        self.server_connect_bar = ConnectBarTextInput(text=self.ctx.suggested_address or "archipelago.gg", size_hint_y=None,
+        self.server_connect_bar = ConnectBarTextInput(text=self.ctx.suggested_address or "archipelago.gg:", size_hint_y=None,
                                                       height=30, multiline=False, write_tab=False)
         self.server_connect_bar.bind(on_text_validate=self.connect_button_action)
         self.connect_layout.add_widget(self.server_connect_bar)
@@ -385,6 +385,13 @@ class GameManager(App):
         self.commandprocessor("/help")
         Clock.schedule_interval(self.update_texts, 1 / 30)
         self.container.add_widget(self.grid)
+
+        self.server_connect_bar.focus = True
+        self.server_connect_bar.select_text(
+            self.server_connect_bar.text.find(":") + 1,
+            len(self.server_connect_bar.text)
+        )
+
         return self.container
 
     def update_texts(self, dt):

--- a/kvui.py
+++ b/kvui.py
@@ -336,7 +336,10 @@ class GameManager(App):
         self.connect_layout.add_widget(server_label)
         self.server_connect_bar = ConnectBarTextInput(text=self.ctx.suggested_address or "archipelago.gg:", size_hint_y=None,
                                                       height=30, multiline=False, write_tab=False)
-        self.server_connect_bar.bind(on_text_validate=self.connect_button_action)
+        def connect_bar_validate(sender):
+            if not self.ctx.server:
+                self.connect_button_action(sender)
+        self.server_connect_bar.bind(on_text_validate=connect_bar_validate)
         self.connect_layout.add_widget(self.server_connect_bar)
         self.server_connect_button = Button(text="Connect", size=(100, 30), size_hint_y=None, size_hint_x=None)
         self.server_connect_button.bind(on_press=self.connect_button_action)

--- a/kvui.py
+++ b/kvui.py
@@ -377,12 +377,7 @@ class GameManager(App):
         bottom_layout.add_widget(info_button)
         self.textinput = TextInput(size_hint_y=None, height=30, multiline=False, write_tab=False)
         self.textinput.bind(on_text_validate=self.on_message)
-
-        def text_focus(event):
-            """Needs to be set via delay, as unfocusing happens after on_message"""
-            self.textinput.focus = True
-
-        self.textinput.text_focus = text_focus
+        self.textinput.text_validate_unfocus = False
         bottom_layout.add_widget(self.textinput)
         self.grid.add_widget(bottom_layout)
         self.commandprocessor("/help")
@@ -447,8 +442,6 @@ class GameManager(App):
                 self.ctx.input_queue.put_nowait(input_text)
             elif input_text:
                 self.commandprocessor(input_text)
-
-            Clock.schedule_once(textinput.text_focus)
 
         except Exception as e:
             logging.getLogger("Client").exception(e)

--- a/kvui.py
+++ b/kvui.py
@@ -334,7 +334,7 @@ class GameManager(App):
         # top part
         server_label = ServerLabel()
         self.connect_layout.add_widget(server_label)
-        self.server_connect_bar = ConnectBarTextInput(text=self.ctx.server_address or "archipelago.gg", size_hint_y=None,
+        self.server_connect_bar = ConnectBarTextInput(text=self.ctx.suggested_address or "archipelago.gg", size_hint_y=None,
                                                       height=30, multiline=False, write_tab=False)
         self.server_connect_bar.bind(on_text_validate=self.connect_button_action)
         self.connect_layout.add_widget(self.server_connect_bar)


### PR DESCRIPTION
## What is this fixing or adding?
A bunch of small fixes and improvements for CommonClient:
- Focus the text field when requesting input.
- Store and prefill the last server address. It is stored in `_persistent_storage.yaml` and is thus global to all CommonClient derivatives in the install. It is only stored upon a successful connect.
- Focus the address bar upon start and select the port portion. (If the last server address does not have a port component, the entire address is selected.) This means, if the last address is correct, you can simply hit Enter after starting the client to reconnect.
- Don't allow editing of the address while connected.
- Don't make pressing Enter in the address bar disconnect you.
- Use `TextInput.text_validate_unfocus` over the current jank workaround.
- Fixed the ~10 second hang when quitting after a failed handshake. (To reproduce: Attempt connecting to a valid server with the TextClient, but enter an invalid slot name. Then close the window.)
- Made the scrollbar wider and interactable.

Each of these is contained within its own independent commit, for ease of review and in case you want to pick and choose.

## How was this tested?
Locally, as TextClient, SNIClient, FactorioClient, and OoTClient.

## What about this might be controversial?
I changed the default server address from `archipelago.gg` to `archipelago.gg:`, which puts the cursor behind the colon instead of selecting the entire thing. Note that this only affects the first start of a CommonClient for an install, as afterwards the last used address is prefilled instead. Also note that entering `archipelago.gg:` as is works and uses the default port.

## Other imaginable concerns
In the clients which immediately start an emulator you don't get a good opportunity to hit Enter to connect before the emulator window takes focus. Worse, if you are used to seeing `archipelago.gg` in the address bar before connecting, since the address is now prefilled, you may forget to connect.