### PR TITLE
Factorio: Add optional filtering for item sends displayed in-game

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -312,6 +312,12 @@ class CommonContext:
             return self.slot in self.slot_info[slot].group_members
         return False
 
+    def is_uninteresting_item_send(self, print_json_packet: dict) -> bool:
+        """Helper function for filtering out ItemSend prints that do not concern the local player."""
+        return print_json_packet.get("type", "") == "ItemSend" \
+            and not self.slot_concerns_self(print_json_packet["receiving"]) \
+            and not self.slot_concerns_self(print_json_packet["item"].player)
+
     def on_print(self, args: dict):
         logger.info(args["text"])
 

--- a/FactorioClient.py
+++ b/FactorioClient.py
@@ -91,10 +91,7 @@ class FactorioContext(CommonContext):
 
     def on_print_json(self, args: dict):
         if self.rcon_client:
-            is_uninteresting_item_send = args.get("type", "") == "ItemSend" \
-                                         and not self.slot_concerns_self(args["receiving"]) \
-                                         and not self.slot_concerns_self(args["item"].player)
-            if not self.filter_item_sends or not is_uninteresting_item_send:
+            if not self.filter_item_sends or not self.is_uninteresting_item_send(args):
                 text = self.factorio_json_text_parser(copy.deepcopy(args["data"]))
                 self.print_to_game(text)
         super(FactorioContext, self).on_print_json(args)

--- a/FactorioClient.py
+++ b/FactorioClient.py
@@ -92,7 +92,8 @@ class FactorioContext(CommonContext):
     def on_print_json(self, args: dict):
         if self.rcon_client:
             is_uninteresting_item_send: bool = args.get("type", "") == "ItemSend" \
-                                               and args["receiving"] != self.slot and args["item"].player != self.slot
+                                               and not self.slot_concerns_self(args["receiving"]) \
+                                               and not self.slot_concerns_self(args["item"].player)
             if not self.filter_item_sends or not is_uninteresting_item_send:
                 text = self.factorio_json_text_parser(copy.deepcopy(args["data"]))
                 self.print_to_game(text)

--- a/FactorioClient.py
+++ b/FactorioClient.py
@@ -91,9 +91,9 @@ class FactorioContext(CommonContext):
 
     def on_print_json(self, args: dict):
         if self.rcon_client:
-            is_uninteresting_item_send: bool = args.get("type", "") == "ItemSend" \
-                                               and not self.slot_concerns_self(args["receiving"]) \
-                                               and not self.slot_concerns_self(args["item"].player)
+            is_uninteresting_item_send = args.get("type", "") == "ItemSend" \
+                                         and not self.slot_concerns_self(args["receiving"]) \
+                                         and not self.slot_concerns_self(args["item"].player)
             if not self.filter_item_sends or not is_uninteresting_item_send:
                 text = self.factorio_json_text_parser(copy.deepcopy(args["data"]))
                 self.print_to_game(text)
@@ -135,7 +135,6 @@ class FactorioContext(CommonContext):
 
     def toggle_filter_item_sends(self) -> None:
         self.filter_item_sends = not self.filter_item_sends
-        announcement: str
         if self.filter_item_sends:
             announcement = "Item sends are now filtered."
         else:
@@ -441,7 +440,7 @@ if __name__ == '__main__':
         server_settings = os.path.abspath(server_settings)
     if not isinstance(options["factorio_options"]["filter_item_sends"], bool):
         logging.warning(f"Warning: Option filter_item_sends should be a bool.")
-    initial_filter_item_sends: bool = bool(options["factorio_options"]["filter_item_sends"])
+    initial_filter_item_sends = bool(options["factorio_options"]["filter_item_sends"])
 
     if not os.path.exists(os.path.dirname(executable)):
         raise FileNotFoundError(f"Path {os.path.dirname(executable)} does not exist or could not be accessed.")

--- a/Utils.py
+++ b/Utils.py
@@ -231,6 +231,7 @@ def get_default_options() -> OptionsType:
         },
         "factorio_options": {
             "executable": os.path.join("factorio", "bin", "x64", "factorio"),
+            "filter_item_sends": False,
         },
         "sni_options": {
             "sni": "SNI",

--- a/host.yaml
+++ b/host.yaml
@@ -99,6 +99,8 @@ factorio_options:
   executable: "factorio/bin/x64/factorio"
   # by default, no settings are loaded if this file does not exist.  If this file does exist, then it will be used.
   # server_settings: "factorio\\data\\server-settings.json"
+  # Whether to filter item send messages displayed in-game to only those that involve you.
+  filter_item_sends: false
 minecraft_options: 
   forge_directory: "Minecraft Forge server"
   max_heap_size: "2G"

--- a/worlds/factorio/data/mod_template/control.lua
+++ b/worlds/factorio/data/mod_template/control.lua
@@ -596,5 +596,9 @@ commands.add_command("ap-energylink", "Used by the Archipelago client to manage 
     global.forcedata[force].energy = global.forcedata[force].energy + change
 end)
 
+commands.add_command("toggle-ap-send-filter", "Toggle filtering of item sends that get displayed in-game to only those that involve you.", function(call)
+    log("Player command toggle-ap-send-filter") -- notifies client
+end)
+
 -- data
 progressive_technologies = {{ dict_to_lua(progressive_technology_table) }}

--- a/worlds/factorio/docs/setup_en.md
+++ b/worlds/factorio/docs/setup_en.md
@@ -141,6 +141,18 @@ you can also issue the `!help` command to learn about additional commands like `
 4. Provide your IP address to anyone you want to join your game, and have them follow the steps for
    "Connecting to Someone Else's Factorio Game" above.
 
+## Other Settings
+
+- By default, all item sends are displayed in-game. In larger async seeds this may become overly spammy.
+  To hide all item sends that are not to or from your factory, do one of the following:
+  - Type `/toggle-ap-send-filter` in-game
+  - Type `/toggle_send_filter` in the Archipelago Client
+  - In your `host.yaml` set
+    ```
+    factorio_options:
+      filter_item_sends: true
+    ```
+
 ## Troubleshooting
 
 In case any problems should occur, the Archipelago Client will create a file `FactorioClient.txt` in the `/logs`. The


### PR DESCRIPTION
## What is this fixing or adding?
In light of the pain caused by the in-game spam in the big async, this PR adds a toggle to filter the item sends being displayed in-game down to only those involving the local factory (items sent from or to that factory). It defaults to off, but can be enabled by any of a `host.yaml` setting, a FactorioClient command and a Factorio client in-game command.

Note that this filter does not affect what is displayed in FactorioClient.

## How was this tested?
I tested this locally using a modded MultiServer.py to send randomly generated ItemSend messages to a FactorioClient & Factorio client instance.

## Other PRs
This feature is technically independent of #1068, but the toggling commands and settings are implemented in exactly the same way. Minor merge conflict resolving will be required if both PRs are approved.
