### PR TITLE
MultiServer: Don't leak info about what exists or not if player can't afford the hint

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1332,6 +1332,8 @@ class ClientMessageProcessor(CommonCommandProcessor):
 
     def get_hints(self, input_text: str, for_location: bool = False) -> bool:
         points_available = get_client_points(self.ctx, self.client)
+        cost = self.ctx.get_hint_cost(self.client.slot)
+
         if not input_text:
             hints = {hint.re_check(self.ctx, self.client.team) for hint in
                      self.ctx.hints[self.client.team, self.client.slot]}
@@ -1386,7 +1388,6 @@ class ClientMessageProcessor(CommonCommandProcessor):
                 return False
 
         if hints:
-            cost = self.ctx.get_hint_cost(self.client.slot)
             new_hints = set(hints) - self.ctx.hints[self.client.team, self.client.slot]
             old_hints = set(hints) - new_hints
             if old_hints:
@@ -1436,7 +1437,12 @@ class ClientMessageProcessor(CommonCommandProcessor):
                 return True
 
         else:
-            self.output("Nothing found. Item/Location may not exist.")
+            if points_available >= cost:
+                self.output("Nothing found. Item/Location may not exist.")
+            else:
+                self.output(f"You can't afford the hint. "
+                            f"You have {points_available} points and need at least "
+                            f"{self.ctx.get_hint_cost(self.client.slot)}.")
             return False
 
     @mark_raw


### PR DESCRIPTION
Changes the way the hint system works, so that if there is a hint cost, a player can no longer right at the start of the game do for example,  !hint master sword,  !hint power glove, !hint mirror shield,  in order to find out if their items are progressive or not, in the case where the player decided to use grouped random.  If you can't afford to pay for the hint,  then the only messages a player will get besides not being able to pay,  is general error messages, like "did you mean x (69% sure)"

The following screenshot shows an example, in the case of zillion, I have a random starting character, so a player might do !hint JJ, !hint Apple, !hint Champ,  to find out what their starting character is before the game has started.  By giving the same can't afford the hint message in all cases, this is no longer possible.
![image](https://user-images.githubusercontent.com/79097/198276266-22893358-8ec7-4e02-ae8f-fee681e62274.png)

This was the result before this change was implemented.  In this case, it revealed even before !hint Champ, that the starting character was Champ.
![image](https://user-images.githubusercontent.com/79097/198277110-ab7c3d4c-a81d-4c6f-8c04-4a9c4244c4ba.png)

