### PR TITLE
Docs: Zillion: RetroArch core and `early_items` recommendation.

### DIFF
--- a/worlds/zillion/docs/setup_en.md
+++ b/worlds/zillion/docs/setup_en.md
@@ -15,7 +15,9 @@
 RetroArch 1.9.x will not work, as it is older than 1.10.3.
 
 1. Enter the RetroArch main menu screen.
-2. Go to Main Menu --> Online Updater --> Core Downloader. Scroll down and install "Sega - MS/GG (SMS Plus GX)".
+2. Go to Main Menu --> Online Updater --> Core Downloader. Scroll down and install one of these cores:
+   - "Sega - MS/GG (SMS Plus GX)"
+   - "Sega - MS/GG/MD/CD (Genesis Plus GX)
 3. Go to Settings --> User Interface. Set "Show Advanced Settings" to ON.
 4. Go to Settings --> Network. Set "Network Commands" to ON. (It is found below Request Device 16.) Leave the default
    Network Command Port at 55355.
@@ -63,7 +65,7 @@ If you would like to validate your config file to make sure it works, you may do
     - Windows
        - Double-click on your patch file.
    The Zillion Client will launch automatically, and create your ROM in the location of the patch file.
-6. Open the ROM in RetroArch using the core "SMS Plus GX".
+6. Open the ROM in RetroArch using the core "SMS Plus GX" or "Genesis Plus GX".
     - For a single player game, any emulator (or a Sega Master System) can be used, but there are additional features with RetroArch and the Zillion Client.
        - If you press reset or restore a save state and return to the surface in the game, the Zillion Client will keep open all the doors that you have opened.
 
@@ -80,7 +82,7 @@ If you would like to validate your config file to make sure it works, you may do
     - This should automatically launch the client, and will also create your ROM in the same place as your patch file.
 3. Connect to the client.
     - Use RetroArch to open the ROM that was generated.
-    - Be sure to select the **SMS Plus GX** core. This core will allow external tools to read RAM data.
+    - Be sure to select the **SMS Plus GX** core or the **Genesis Plus GX** core. These cores will allow external tools to read RAM data.
 4. Connect to the Archipelago Server.
     - The patch file which launched your client should have automatically connected you to the AP Server. There are a few reasons this may not happen however, including if the game is hosted on the website but was generated elsewhere. If the client window shows "Server Status: Not Connected", simply ask the host for the address of the server, and copy/paste it into the "Server" input field then press enter.
     - The client will attempt to reconnect to the new server address, and should momentarily show "Server Status: Connected".

--- a/worlds/zillion/docs/setup_en.md
+++ b/worlds/zillion/docs/setup_en.md
@@ -49,6 +49,15 @@ guide: [Basic Multiworld Setup Guide](/tutorial/Archipelago/setup/en)
 The [player settings page](/games/Zillion/player-settings) on the website allows you to configure your personal settings and export a config file from
 them.
 
+### Advanced settings
+
+The [advanced settings page](/tutorial/Archipelago/advanced_settings/en) describes more options you can put in your configuration file.
+ - A recommended setting for Zillion is:
+```
+  early_items:
+    Scope: 1
+```
+
 ### Verifying your config file
 
 If you would like to validate your config file to make sure it works, you may do so on the [YAML Validator page](/mysterycheck).

--- a/worlds/zillion/options.py
+++ b/worlds/zillion/options.py
@@ -26,11 +26,6 @@ class ZillionContinues(SpecialRange):
     }
 
 
-class ZillionEarlyScope(Toggle):
-    """ whether to make sure there is a scope available early """
-    display_name = "early scope"
-
-
 class ZillionFloppyReq(Range):
     """ how many floppy disks are required """
     range_start = 0
@@ -227,7 +222,6 @@ class ZillionRoomGen(Toggle):
 
 zillion_options: Dict[str, AssembleOptions] = {
     "continues": ZillionContinues,
-    # "early_scope": ZillionEarlyScope,  # TODO: implement
     "floppy_req": ZillionFloppyReq,
     "gun_levels": ZillionGunLevels,
     "jump_levels": ZillionJumpLevels,
@@ -371,7 +365,7 @@ def validate(world: "MultiWorld", p: int) -> "Tuple[ZzOptions, Counter[str]]":
         floppy_req.value,
         wo.continues[p].value,
         wo.randomize_alarms[p].value,
-        False,  # wo.early_scope[p].value,
+        False,  # early scope can be done with AP early_items
         True,  # balance defense
         starting_cards.value,
         bool(room_gen.value)


### PR DESCRIPTION
I found that the RetroArch core I have been using has not been updated in more than 10 years, and the author is telling people to go to a different one instead. So I did a game with that one and it works.

Also, since `early_items` is implemented, I wanted to include a recommendation to use it in the setup guide.
