### PR TITLE
CI: use build_exe in automated build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools
           pip install -r requirements.txt
-          python setup.py build --yes
+          python setup.py build_exe --yes
           $NAME="$(ls build)".Split('.',2)[1]
           $ZIP_NAME="Archipelago_$NAME.7z"
           echo "ZIP_NAME=$ZIP_NAME" >> $Env:GITHUB_ENV
@@ -82,7 +82,7 @@ jobs:
           "${{ env.PYTHON }}" -m venv venv
           source venv/bin/activate
           pip install -r requirements.txt
-          python setup.py build --yes bdist_appimage --yes
+          python setup.py build_exe --yes bdist_appimage --yes
           echo -e "setup.py build output:\n `ls build`"
           echo -e "setup.py dist output:\n `ls dist`"
           cd dist && export APPIMAGE_NAME="`ls *.AppImage`" && cd ..


### PR DESCRIPTION
## What is this fixing or adding?

`build` changed on Windows a while back, breaking the automated build. Fixing by switching to `build_exe` instead.

## How was this tested?

https://github.com/ArchipelagoMW/Archipelago/actions/runs/3347236556