### PR TITLE
MultiServer: fix case sensitivity in server commands

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1809,31 +1809,17 @@ class ServerCommandProcessor(CommonCommandProcessor):
         for (team, slot), name in self.ctx.player_names.items():
             if name == input_name:
                 return team, slot, name
-        
-        @dataclass
-        class TSNC:
-            """ team, slot, name, (count without case) """
-            team: int
-            slot: int
-            name: str
-            count: int = 1
 
         # if no case-sensitive match, then match without case only if there's only 1 match
-        lowered_data: typing.Dict[str, TSNC] = {}
+        input_lower = input_name.lower()
+        match: typing.Optional[typing.Tuple[int, int, str]] = None
         for (team, slot), name in self.ctx.player_names.items():
             lowered = name.lower()
-            if lowered in lowered_data:
-                lowered_data[lowered].count += 1
-            else:
-                lowered_data[lowered] = TSNC(team, slot, name)
-
-        input_lower = input_name.lower()
-        if input_lower in lowered_data and lowered_data[input_lower].count == 1:
-            match = lowered_data[input_lower]
-            return match.team, match.slot, match.name
-
-        # else no case match and no unique match without case
-        return None
+            if lowered == input_lower:
+                if match:
+                    return None  # ambiguous input_name
+                match = (team, slot, name)
+        return match
 
     @mark_raw
     def _cmd_collect(self, player_name: str) -> bool:

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-from dataclasses import dataclass
 import functools
 import logging
 import zlib

--- a/test/programs/TestMultiServer.py
+++ b/test/programs/TestMultiServer.py
@@ -1,0 +1,37 @@
+import unittest
+from MultiServer import Context, ServerCommandProcessor
+
+
+class TestResolvePlayerName(unittest.TestCase):
+    def test_resolve(self) -> None:
+        p = ServerCommandProcessor(Context("", 0, "", "", 0, 0, False))
+        p.ctx.player_names = {
+            (1, 1): "aBc",
+            (1, 2): "abC",
+        }
+        assert not p.resolve_player("abc"), "ambiguous name entry shouldn't resolve to player"
+        assert not p.resolve_player("Abc"), "ambiguous name entry shouldn't resolve to player"
+        assert p.resolve_player("aBc") == (1, 1, "aBc"), "matching case resolve"
+        assert p.resolve_player("abC") == (1, 2, "abC"), "matching case resolve"
+        assert not p.resolve_player("aB"), "partial name shouldn't resolve to player"
+        assert not p.resolve_player("abCD"), "incorrect name shouldn't resolve to player"
+
+        p.ctx.player_names = {
+            (1, 1): "abc",
+            (1, 2): "abC",
+        }
+        assert p.resolve_player("abc") == (1, 1, "abc"), "matching case resolve"
+        assert not p.resolve_player("Abc"), "ambiguous name entry shouldn't resolve to player"
+        assert not p.resolve_player("aBc"), "ambiguous name entry shouldn't resolve to player"
+        assert p.resolve_player("abC") == (1, 2, "abC"), "matching case resolve"
+
+        p.ctx.player_names = {
+            (1, 1): "abc",
+            (1, 2): "abCD",
+        }
+        assert p.resolve_player("abc") == (1, 1, "abc"), "matching case resolve"
+        assert p.resolve_player("abC") == (1, 1, "abc"), "case insensitive resolves when 1 match"
+        assert p.resolve_player("Abc") == (1, 1, "abc"), "case insensitive resolves when 1 match"
+        assert p.resolve_player("ABC") == (1, 1, "abc"), "case insensitive resolves when 1 match"
+        assert p.resolve_player("abcd") == (1, 2, "abCD"), "case insensitive resolves when 1 match"
+        assert not p.resolve_player("aB"), "partial name shouldn't resolve to player"

--- a/test/programs/TestMultiServer.py
+++ b/test/programs/TestMultiServer.py
@@ -6,32 +6,35 @@ class TestResolvePlayerName(unittest.TestCase):
     def test_resolve(self) -> None:
         p = ServerCommandProcessor(Context("", 0, "", "", 0, 0, False))
         p.ctx.player_names = {
-            (1, 1): "aBc",
-            (1, 2): "abC",
+            (1, 1): "AAA",
+            (1, 2): "aBc",
+            (1, 3): "abC",
         }
         assert not p.resolve_player("abc"), "ambiguous name entry shouldn't resolve to player"
         assert not p.resolve_player("Abc"), "ambiguous name entry shouldn't resolve to player"
-        assert p.resolve_player("aBc") == (1, 1, "aBc"), "matching case resolve"
-        assert p.resolve_player("abC") == (1, 2, "abC"), "matching case resolve"
+        assert p.resolve_player("aBc") == (1, 2, "aBc"), "matching case resolve"
+        assert p.resolve_player("abC") == (1, 3, "abC"), "matching case resolve"
         assert not p.resolve_player("aB"), "partial name shouldn't resolve to player"
         assert not p.resolve_player("abCD"), "incorrect name shouldn't resolve to player"
 
         p.ctx.player_names = {
-            (1, 1): "abc",
-            (1, 2): "abC",
+            (1, 1): "aaa",
+            (1, 2): "abc",
+            (1, 3): "abC",
         }
-        assert p.resolve_player("abc") == (1, 1, "abc"), "matching case resolve"
+        assert p.resolve_player("abc") == (1, 2, "abc"), "matching case resolve"
         assert not p.resolve_player("Abc"), "ambiguous name entry shouldn't resolve to player"
         assert not p.resolve_player("aBc"), "ambiguous name entry shouldn't resolve to player"
-        assert p.resolve_player("abC") == (1, 2, "abC"), "matching case resolve"
+        assert p.resolve_player("abC") == (1, 3, "abC"), "matching case resolve"
 
         p.ctx.player_names = {
-            (1, 1): "abc",
-            (1, 2): "abCD",
+            (1, 1): "AbcdE",
+            (1, 2): "abc",
+            (1, 3): "abCD",
         }
-        assert p.resolve_player("abc") == (1, 1, "abc"), "matching case resolve"
-        assert p.resolve_player("abC") == (1, 1, "abc"), "case insensitive resolves when 1 match"
-        assert p.resolve_player("Abc") == (1, 1, "abc"), "case insensitive resolves when 1 match"
-        assert p.resolve_player("ABC") == (1, 1, "abc"), "case insensitive resolves when 1 match"
-        assert p.resolve_player("abcd") == (1, 2, "abCD"), "case insensitive resolves when 1 match"
+        assert p.resolve_player("abc") == (1, 2, "abc"), "matching case resolve"
+        assert p.resolve_player("abC") == (1, 2, "abc"), "case insensitive resolves when 1 match"
+        assert p.resolve_player("Abc") == (1, 2, "abc"), "case insensitive resolves when 1 match"
+        assert p.resolve_player("ABC") == (1, 2, "abc"), "case insensitive resolves when 1 match"
+        assert p.resolve_player("abcd") == (1, 3, "abCD"), "case insensitive resolves when 1 match"
         assert not p.resolve_player("aB"), "partial name shouldn't resolve to player"


### PR DESCRIPTION
Once upon a time, there was a multiworld seed with a player named "buxnq" and another player named "buxnQ", and some other players. And the host needed to forfeit the items from buxnq's world. So the host used the command `/forfeit buxnq`, and it forfeited buxnQ's items. The host was unable to forfeit buxnq's items.

## What is this fixing or adding?

The server commands first try to match the player name case sensitively.
If there's no case-sensitive match, then they will try to match without matching case (only if it's unamibguous).

## How was this tested?

new unit tests added

generated a game with those names again and tested a few server commands
