### PR TITLE
SA2B: Fix uncommon calculation playthrough error where wrong emblem count is passed to rule for final region.

### DIFF
--- a/worlds/sa2b/__init__.py
+++ b/worlds/sa2b/__init__.py
@@ -195,10 +195,10 @@ class SA2BWorld(World):
 
         self.region_emblem_map = dict(zip(shuffled_region_list, emblem_requirement_list))
 
-        connect_regions(self.world, self.player, gates, self.emblems_for_cannons_core, self.gate_bosses)
-
         max_required_emblems = max(max(emblem_requirement_list), self.emblems_for_cannons_core)
         itempool += [self.create_item(ItemName.emblem) for _ in range(max_required_emblems)]
+
+        connect_regions(self.world, self.player, gates, max_required_emblems, self.gate_bosses)
 
         non_required_emblems = (total_emblem_count - max_required_emblems)
         junk_count = math.floor(non_required_emblems * (self.world.junk_fill_percentage[self.player].value / 100.0))


### PR DESCRIPTION
## What is this fixing or adding?

If `emblem_requirement_list` has a value that is greater than `self.emblems_for_cannons_core`, it will connect the region that contains Cannon Core with the wrong requirement, which causes a failure when calculating play-through.

Moved `connect_regions` function to after it calculates the true max required emblems and pass that value into the `connect_regions` function.

## How was this tested?
Generated 100 test 2-player SA2B random-settings seeds on the old branch and it failed 10% of the time.

Made the change and tested 500 new seeds of the same settings. 0 failures.

## If this makes graphical changes, please attach screenshots.
N/A