### PR TITLE
Factorio: deterministic locations

### DIFF
--- a/worlds/factorio/__init__.py
+++ b/worlds/factorio/__init__.py
@@ -91,8 +91,9 @@ class Factorio(World):
 
         location_pool = []
 
-        for pack in self.world.max_science_pack[self.player].get_allowed_packs():
+        for pack in sorted(self.world.max_science_pack[self.player].get_allowed_packs()):
             location_pool.extend(location_pools[pack])
+
         location_names = self.world.random.sample(location_pool, location_count)
         self.locations = [FactorioScienceLocation(player, loc_name, self.location_name_to_id[loc_name], nauvis)
                           for loc_name in location_names]
@@ -107,7 +108,7 @@ class Factorio(World):
         event = FactorioItem("Victory", ItemClassification.progression, None, player)
         location.place_locked_item(event)
 
-        for ingredient in self.world.max_science_pack[self.player].get_allowed_packs():
+        for ingredient in sorted(self.world.max_science_pack[self.player].get_allowed_packs()):
             location = FactorioLocation(player, f"Automate {ingredient}", None, nauvis)
             nauvis.locations.append(location)
             event = FactorioItem(f"Automated {ingredient}", ItemClassification.progression, None, player)


### PR DESCRIPTION
## What is this fixing or adding?
Factorio would
* generate different location pool order (and thus different locations)
* generate "automated" events in different order

for the same seed. Fixing this by sorting.

## How was this tested?
```python
        from hashlib import md5
        print(md5(str(nauvis.locations).encode("utf-8")).hexdigest())
```