### PR TITLE
Core: make player name case-insensitive

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -233,8 +233,8 @@ def main(args=None, callback=ERmain):
         else:
             raise RuntimeError(f'No weights specified for player {player}')
 
-    if len(set(erargs.name.values())) != len(erargs.name):
-        raise Exception(f"Names have to be unique. Names: {Counter(erargs.name.values())}")
+    if len(set(name.lower() for name in erargs.name.values())) != len(erargs.name):
+        raise Exception(f"Names have to be unique. Names: {Counter(name.lower() for name in erargs.name.values())}")
 
     if args.yaml_output:
         import yaml
@@ -317,11 +317,11 @@ class SafeDict(dict):
 
 
 def handle_name(name: str, player: int, name_counter: Counter):
-    name_counter[name] += 1
+    name_counter[name.lower()] += 1
+    number = name_counter[name.lower()]
     new_name = "%".join([x.replace("%number%", "{number}").replace("%player%", "{player}") for x in name.split("%%")])
-    new_name = string.Formatter().vformat(new_name, (), SafeDict(number=name_counter[name],
-                                                                 NUMBER=(name_counter[name] if name_counter[
-                                                                                                   name] > 1 else ''),
+    new_name = string.Formatter().vformat(new_name, (), SafeDict(number=number,
+                                                                 NUMBER=(number if number > 1 else ''),
                                                                  player=player,
                                                                  PLAYER=(player if player > 1 else '')))
     new_name = new_name.strip()[:16]

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1804,6 +1804,7 @@ class ServerCommandProcessor(CommonCommandProcessor):
 
     def resolve_player(self, input_name: str) -> typing.Optional[typing.Tuple[int, int, str]]:
         """ returns (team, slot, player name) """
+        # TODO: clean up once we disallow multidata < 0.3.6, which has CI unique names
         # first match case
         for (team, slot), name in self.ctx.player_names.items():
             if name == input_name:


### PR DESCRIPTION
## What is this fixing or adding?

Make player names case insensitive from Generator's point of view.
Note: this also makes Player{NUMBER} and Player{number} use the same counter, which was not the case previously.

## How was this tested?
Bunch of yamls with the same name in different variations.