### PR TITLE
core: allow game to be overridden by meta.yaml

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -193,7 +193,8 @@ def main(args=None, callback=ERmain):
                         if category_name is None:
                             if key == "game":
                                 yaml[key] = option
-                                yaml.setdefault(option, {})
+                                if option not in yaml:
+                                    raise KeyError(f"Meta: Game: {key} does not exist in {yaml}.")
                                 continue
                             for category in yaml:
                                 if key in Options.common_options and category in AutoWorldRegister.world_types:

--- a/Generate.py
+++ b/Generate.py
@@ -5,7 +5,7 @@ import logging
 import random
 import urllib.request
 import urllib.parse
-from typing import Set, Dict, Tuple, Callable, Any, Union
+from typing import Set, Dict, Tuple, Callable, Any, Union, Optional
 import os
 from collections import Counter, ChainMap
 import string
@@ -374,7 +374,7 @@ def update_weights(weights: dict, new_weights: dict, type: str, name: str) -> di
     return weights
 
 
-def roll_meta_option(option_key, game: str, category_dict: Dict) -> Any:
+def roll_meta_option(option_key: str, game: Optional[str], category_dict: Dict) -> Any:
     if not game:
         return get_choice(option_key, category_dict)
     if game in AutoWorldRegister.world_types:
@@ -393,7 +393,7 @@ def roll_meta_option(option_key, game: str, category_dict: Dict) -> Any:
                           "misery_mire_medallion", "turtle_rock_medallion", "sprite_pool", "sprite",
                           "random_sprite_on_event"}:
             return get_choice(option_key, category_dict)
-    raise Exception(f"Error generating meta option {option_key} for {game}.")
+    raise ValueError(f"Error generating meta option {option_key} for {game}.")
 
 
 def roll_linked_options(weights: dict) -> dict:

--- a/Generate.py
+++ b/Generate.py
@@ -186,17 +186,22 @@ def main(args=None, callback=ERmain):
         for category_name, category_dict in meta_weights.items():
             for key in category_dict:
                 option = roll_meta_option(key, category_name, category_dict)
-                if option is not None:
-                    for path in weights_cache:
-                        for yaml in weights_cache[path]:
-                            if category_name is None:
-                                for category in yaml:
-                                    if category in AutoWorldRegister.world_types and key in Options.common_options:
-                                        yaml[category][key] = option
-                            elif category_name not in yaml:
-                                logging.warning(f"Meta: Category {category_name} is not present in {path}.")
-                            else:
-                                yaml[category_name][key] = option
+                if option is None:
+                    continue
+                for path in weights_cache:
+                    for yaml in weights_cache[path]:
+                        if category_name is None:
+                            if key == "game":
+                                yaml[key] = option
+                                yaml.setdefault(option, {})
+                                continue
+                            for category in yaml:
+                                if key in Options.common_options and category in AutoWorldRegister.world_types:
+                                    yaml[category][key] = option
+                        elif category_name not in yaml:
+                            logging.warning(f"Meta: Category {category_name} is not present in {path}.")
+                        else:
+                            yaml[category_name][key] = option
 
     player_path_cache = {}
     for player in range(1, args.multi + 1):


### PR DESCRIPTION
## What is this fixing or adding?
title

## How was this tested?
tested by creating a meta file with 
```
meta_description: test
null:
  game: Hollow Knight
```

and a Factorio yaml
