### PR TITLE
Zillion: fix unreproducible seeds

### DIFF
--- a/test/worlds/zillion/TestReproducibleRandom.py
+++ b/test/worlds/zillion/TestReproducibleRandom.py
@@ -1,0 +1,29 @@
+from typing import cast
+from test.worlds.zillion import ZillionTestBase
+
+from worlds.zillion import ZillionWorld
+
+
+class SeedTest(ZillionTestBase):
+    auto_construct = False
+
+    def test_reproduce_seed(self) -> None:
+        self.world_setup(42)
+        z_world = cast(ZillionWorld, self.world.worlds[1])
+        r = z_world.zz_system.randomizer
+        assert r
+        randomized_requirements_first = tuple(
+            location.req.gun
+            for location in r.locations.values()
+        )
+
+        self.world_setup(42)
+        z_world = cast(ZillionWorld, self.world.worlds[1])
+        r = z_world.zz_system.randomizer
+        assert r
+        randomized_requirements_second = tuple(
+            location.req.gun
+            for location in r.locations.values()
+        )
+
+        assert randomized_requirements_first == randomized_requirements_second

--- a/worlds/zillion/__init__.py
+++ b/worlds/zillion/__init__.py
@@ -133,6 +133,7 @@ class ZillionWorld(World):
             self.zz_system.make_patcher(rom_dir_name)
             self.zz_system.make_randomizer(zz_op)
 
+            self.zz_system.seed(self.world.seed)
             self.zz_system.make_map()
 
         # just in case the options changed anything (I don't think they do)

--- a/worlds/zillion/requirements.txt
+++ b/worlds/zillion/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/beauxq/zilliandomizer@c97298ecb1bca58c3dd3376a1e1609fad53788cf#egg=zilliandomizer==0.4.5
+git+https://github.com/beauxq/zilliandomizer@10549a126b3293595ddb6816b896c1f88ce344c5#egg=zilliandomizer==0.4.6


### PR DESCRIPTION
Zillion seeds weren't reproducing.

## What is this fixing or adding?

Seeds now reproduce.

The package update also has some minor logic fixes.

## How was this tested?

a unit test that failed without this fix
