### PR TITLE
[Core] fix early items bug

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -294,7 +294,7 @@ def distribute_items_restrictive(world: MultiWorld) -> None:
                             {len(unplaced_early_items)} items early.")
             itempool += unplaced_early_items
 
-        fill_locations += early_locations + early_priority_locations
+        fill_locations += early_locations
         world.random.shuffle(fill_locations)
 
     for item in itempool:


### PR DESCRIPTION
## What is this fixing or adding?
Fixes bug where unfilled early_priority_locations is added to  fill_locations twice

## How was this tested?
generating games with early items and early priority locations and ensuring it does not explode

## If this makes graphical changes, please attach screenshots.
