### PR TITLE
WebHost: Fixed warning ".gitignore dropped, as it has no valid sprite data."

### DIFF
--- a/WebHostLib/lttpsprites.py
+++ b/WebHostLib/lttpsprites.py
@@ -32,7 +32,7 @@ def update_sprites_lttp():
 
     spriteData = []
 
-    for file in (file for file in os.listdir(input_dir) if file != ".gitignore"):
+    for file in (file for file in os.listdir(input_dir) if not file.startswith(".")):
         sprite = Sprite(os.path.join(input_dir, file))
 
         if not sprite.name:

--- a/WebHostLib/lttpsprites.py
+++ b/WebHostLib/lttpsprites.py
@@ -32,7 +32,7 @@ def update_sprites_lttp():
 
     spriteData = []
 
-    for file in os.listdir(input_dir):
+    for file in (file for file in os.listdir(input_dir) if file != ".gitignore"):
         sprite = Sprite(os.path.join(input_dir, file))
 
         if not sprite.name:


### PR DESCRIPTION
## What is this fixing or adding?
Fixed the warning ".gitignore dropped, as it has no valid sprite data." that is logged when starting up the WebHost

## How was this tested?
Just starting the WebHost with the line changed
