### PR TITLE
Overcooked 2: Revert OC2Level world references to be named correctly, optimize location scouting.

### DIFF
--- a/worlds/overcooked2/Overcooked2Levels.py
+++ b/worlds/overcooked2/Overcooked2Levels.py
@@ -159,7 +159,7 @@ class Overcooked2Level:
     sublevel: int
 
     def __init__(self):
-        self.multiworld = Overcooked2GameWorld.ONE
+        self.world = Overcooked2GameWorld.ONE
         self.sublevel = 0
 
     def __iter__(self):
@@ -167,21 +167,21 @@ class Overcooked2Level:
 
     def __next__(self):
         self.sublevel += 1
-        if self.sublevel > self.multiworld.sublevel_count:
-            if self.multiworld == Overcooked2GameWorld.KEVIN:
+        if self.sublevel > self.world.sublevel_count:
+            if self.world == Overcooked2GameWorld.KEVIN:
                 raise StopIteration
-            self.multiworld = Overcooked2GameWorld(self.multiworld.value + 1)
+            self.world = Overcooked2GameWorld(self.world.value + 1)
             self.sublevel = 1
 
         return self
 
     @property
     def level_id(self) -> int:
-        return self.multiworld.base_id + (self.sublevel - 1)
+        return self.world.base_id + (self.sublevel - 1)
 
     @property
     def level_name(self) -> str:
-        return self.multiworld.as_str + "-" + str(self.sublevel)
+        return self.world.as_str + "-" + str(self.sublevel)
 
     @property
     def location_name_item(self) -> str:

--- a/worlds/overcooked2/__init__.py
+++ b/worlds/overcooked2/__init__.py
@@ -376,17 +376,14 @@ class Overcooked2World(World):
 
         # Place Items at Level Completion Screens (local only)
         on_level_completed: Dict[str, list[Dict[str, str]]] = dict()
-        regions = self.multiworld.get_regions(self.player)
-        for region in regions:
-            for location in region.locations:
-                if location.item is None:
-                    continue
-                if location.item.code is None:
-                    continue  # it's an event
-                if location.item.player != self.player:
-                    continue  # not for us
-                level_id = str(oc2_location_name_to_id[location.name])
-                on_level_completed[level_id] = [item_to_unlock_event(location.item.name)]
+        locations = self.multiworld.get_filled_locations(self.player)
+        for location in locations:
+            if location.item.code is None:
+                continue  # it's an event
+            if location.item.player != self.player:
+                continue  # not for us
+            level_id = str(oc2_location_name_to_id[location.name])
+            on_level_completed[level_id] = [item_to_unlock_event(location.item.name)]
 
         # Put it all together
         star_threshold_scale = self.options["StarThresholdScale"] / 100


### PR DESCRIPTION
## What is this fixing or adding?
Revert an accidental change from the Multiworld rename and optimize the slot_data location scouting. Can this be done with client side scouting instead? Another suggested change is that location IDs currently range from 1-44 and it'd be much better to have a base offset in that dictionary definition, but likely requires client change. @toasterparty :)

## How was this tested?
Generated and played some OC2