### PR TITLE
Docs: Updated Sudoku docs now we use standalone deployment

### DIFF
--- a/worlds/bk_sudoku/docs/setup_en.md
+++ b/worlds/bk_sudoku/docs/setup_en.md
@@ -2,7 +2,7 @@
 
 ## Required Software
 - [Bk Sudoku](https://github.com/Jarno458/sudoku)
-- [.Net 6](https://docs.microsoft.com/en-us/dotnet/core/install/windows?tabs=net60)
+- Windows 8 or higher
 
 ## General Concept
 


### PR DESCRIPTION
## What is this fixing or adding?
Updated the docs to nolonger require .net6 to be installed, as BK sudoku switched to a standalone executable

## How was this tested?
Poorly
