### PR TITLE
[Pokémon Red and Blue] Fix location name in rules

### DIFF
--- a/worlds/pokemon_rb/rules.py
+++ b/worlds/pokemon_rb/rules.py
@@ -101,7 +101,7 @@ def set_rules(world, player):
         "S.S. Anne B1F - Hidden Item Under Pillow": lambda state: state.pokemon_rb_can_get_hidden_items(player),
         "Route 10 - Hidden Item Behind Rock Tunnel Entrance Cuttable Tree": lambda
             state: state.pokemon_rb_can_get_hidden_items(player),
-        "Route 10 - Hidden Item Rock": lambda state: state.pokemon_rb_can_get_hidden_items(player),
+        "Route 10 - Hidden Item Bush": lambda state: state.pokemon_rb_can_get_hidden_items(player),
         "Rocket Hideout B1F - Hidden Item Pot Plant": lambda state: state.pokemon_rb_can_get_hidden_items(player),
         "Rocket Hideout B3F - Hidden Item Near East Item": lambda state: state.pokemon_rb_can_get_hidden_items(player),
         "Rocket Hideout B4F - Hidden Item Behind Giovanni": lambda state: state.pokemon_rb_can_get_hidden_items(player),


### PR DESCRIPTION
## What is this fixing or adding?
A late change to location names was made, and one was missed in rules.py. I had tested these changes by generating a default yaml, and failed to realize this would not include hidden items 

## How was this tested?
Describing this code change to Figment who made this change and reported that generation was able to proceed past the rule setting phase without error

## If this makes graphical changes, please attach screenshots.
