### PR TITLE
Factorio: Added commands for checking energy link from CLI and in game

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -146,7 +146,7 @@ class CommonContext:
     server_task: typing.Optional["asyncio.Task[None]"] = None
     server: typing.Optional[Endpoint] = None
     server_version: Version = Version(0, 0, 0)
-    current_energy_link_value: int = 0  # to display in UI, gets set by server
+    current_energy_link_value: typing.Optional[int] = None  # to display in UI, gets set by server
 
     last_death_link: float = time.time()  # last send/received death link on AP layer
 

--- a/worlds/factorio/data/mod_template/control.lua
+++ b/worlds/factorio/data/mod_template/control.lua
@@ -598,6 +598,10 @@ commands.add_command("ap-energylink", "Used by the Archipelago client to manage 
     global.forcedata[force].energy = global.forcedata[force].energy + change
 end)
 
+commands.add_command("energy-link", "Print the status of the Archipelago energy link.", function(call)
+    log("Player command energy-link") -- notifies client
+end)
+
 commands.add_command("toggle-ap-send-filter", "Toggle filtering of item sends that get displayed in-game to only those that involve you.", function(call)
     log("Player command toggle-ap-send-filter") -- notifies client
 end)


### PR DESCRIPTION
## The Problem
The amount of energy stored in the energy link is only visible in the FactorioClient GUI. This means that players running FactorioClient without GUI and players connecting to a remote AP Factorio server have no way of seeing this value.

## What is this adding?
Two commands that print the current status of the energy link:
- `/energy_link` in FactorioClient
- `/energy-link` in game

## Deliberations
- Energy link seems to be mostly implemented in a way that would allow sharing energy between different games, not just Factorio, but I implemented `/energy_link` as part of FactorioClient, rather than baking it into CommonClient. My main reasons are:
  - It's currently tricky to have a CommonClient command appear in the `/help` listing only for certain games. I deemed showing `/energy_link` in all CommonClient based clients to sow more confusion than it's worth.
  - The generalized energy link thing is a mostly theoretic thing for now anyway. (until Satisfactory implements energy link?)
  - It's really not that hard to generalize it later.

## How was this tested?
Locally, using MultiServer and a single FactorioClient.

## How pretty is it?
This pretty:
![in-game screenshot](https://user-images.githubusercontent.com/57289227/199605717-4a104ed2-b5ed-4d26-b645-3a04c0d5286c.png)

## Bonus Changes
- Added a missing `$`.