### PR TITLE
CommonClient & SNIClient: Fixes for reconnecting

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -44,15 +44,17 @@ class ClientCommandProcessor(CommandProcessor):
 
     def _cmd_connect(self, address: str = "") -> bool:
         """Connect to a MultiWorld Server"""
-        self.ctx.server_address = None
-        self.ctx.username = None
+        if address:
+            self.ctx.server_address = None
+            self.ctx.username = None
+        elif not self.ctx.server_address:
+            self.output("Please specify an address.")
+            return False
         async_start(self.ctx.connect(address if address else None), name="connecting")
         return True
 
     def _cmd_disconnect(self) -> bool:
         """Disconnect from a MultiWorld Server"""
-        self.ctx.server_address = None
-        self.ctx.username = None
         async_start(self.ctx.disconnect(), name="disconnecting")
         return True
 
@@ -144,6 +146,8 @@ class CommonContext:
     input_task: typing.Optional["asyncio.Task[None]"] = None
     keep_alive_task: typing.Optional["asyncio.Task[None]"] = None
     server_task: typing.Optional["asyncio.Task[None]"] = None
+    autoreconnect_task: typing.Optional["asyncio.Task[None]"] = None
+    disconnected_intentionally: bool = False
     server: typing.Optional[Endpoint] = None
     server_version: Version = Version(0, 0, 0)
     current_energy_link_value: int = 0  # to display in UI, gets set by server
@@ -173,7 +177,9 @@ class CommonContext:
 
     # internals
     # current message box through kvui
-    _messagebox = None
+    _messagebox: typing.Optional["kvui.MessageBox"] = None
+    # message box reporting a loss of connection
+    _messagebox_connection_loss: typing.Optional["kvui.MessageBox"] = None
 
     def __init__(self, server_address: typing.Optional[str], password: typing.Optional[str]) -> None:
         # server state
@@ -255,7 +261,11 @@ class CommonContext:
             "remaining": "disabled",
         }
 
-    async def disconnect(self):
+    async def disconnect(self, allow_autoreconnect: bool = False):
+        if not allow_autoreconnect:
+            self.disconnected_intentionally = True
+            if self.cancel_autoreconnect():
+                logger.info("Cancelled auto-reconnect.")
         if self.server and not self.server.socket.closed:
             await self.server.socket.close()
         if self.server_task is not None:
@@ -313,6 +323,13 @@ class CommonContext:
         await self.disconnect()
         self.server_task = asyncio.create_task(server_loop(self, address), name="server loop")
 
+    def cancel_autoreconnect(self) -> bool:
+        if self.autoreconnect_task:
+            self.autoreconnect_task.cancel()
+            self.autoreconnect_task = None
+            return True
+        return False
+
     def slot_concerns_self(self, slot) -> bool:
         if slot == self.slot:
             return True
@@ -357,6 +374,7 @@ class CommonContext:
     async def shutdown(self):
         self.server_address = ""
         self.username = None
+        self.cancel_autoreconnect()
         if self.server and not self.server.socket.closed:
             await self.server.socket.close()
         if self.server_task:
@@ -450,10 +468,10 @@ class CommonContext:
         if old_tags != self.tags and self.server and not self.server.socket.closed:
             await self.send_msgs([{"cmd": "ConnectUpdate", "tags": self.tags}])
 
-    def gui_error(self, title: str, text: typing.Union[Exception, str]):
+    def gui_error(self, title: str, text: typing.Union[Exception, str]) -> typing.Optional["kvui.MessageBox"]:
         """Displays an error messagebox"""
         if not self.ui:
-            return
+            return None
         title = title or "Error"
         from kvui import MessageBox
         if self._messagebox:
@@ -470,6 +488,13 @@ class CommonContext:
         # display error
         self._messagebox = MessageBox(title, text, error=True)
         self._messagebox.open()
+        return self._messagebox
+
+    def _handle_connection_loss(self, msg: str) -> None:
+        """Helper for logging and displaying a loss of connection. Must be called from an except block."""
+        exc_info = sys.exc_info()
+        logger.exception(msg, exc_info=exc_info, extra={'compact_gui': True})
+        self._messagebox_connection_loss = self.gui_error(msg, exc_info[1])
 
     def run_gui(self):
         """Import kivy UI system and start running it as self.ui_task."""
@@ -519,6 +544,11 @@ async def server_loop(ctx: CommonContext, address: typing.Optional[str] = None) 
         logger.info('Please connect to an Archipelago server.')
         return
 
+    ctx.cancel_autoreconnect()
+    if ctx._messagebox_connection_loss:
+        ctx._messagebox_connection_loss.dismiss()
+        ctx._messagebox_connection_loss = None
+
     address = f"ws://{address}" if "://" not in address \
         else address.replace("archipelago://", "ws://")
 
@@ -529,6 +559,9 @@ async def server_loop(ctx: CommonContext, address: typing.Optional[str] = None) 
         ctx.password = server_url.password
     port = server_url.port or 38281
 
+    def reconnect_hint() -> str:
+        return ", type /connect to reconnect" if ctx.server_address else ""
+
     logger.info(f'Connecting to Archipelago server at {address}')
     try:
         socket = await websockets.connect(address, port=port, ping_timeout=None, ping_interval=None)
@@ -538,31 +571,25 @@ async def server_loop(ctx: CommonContext, address: typing.Optional[str] = None) 
         logger.info('Connected')
         ctx.server_address = address
         ctx.current_reconnect_delay = ctx.starting_reconnect_delay
+        ctx.disconnected_intentionally = False
         async for data in ctx.server.socket:
             for msg in decode(data):
                 await process_server_cmd(ctx, msg)
-        logger.warning('Disconnected from multiworld server, type /connect to reconnect')
-    except ConnectionRefusedError as e:
-        msg = 'Connection refused by the server. May not be running Archipelago on that address or port.'
-        logger.exception(msg, extra={'compact_gui': True})
-        ctx.gui_error(msg, e)
-    except websockets.InvalidURI as e:
-        msg = 'Failed to connect to the multiworld server (invalid URI)'
-        logger.exception(msg, extra={'compact_gui': True})
-        ctx.gui_error(msg, e)
-    except OSError as e:
-        msg = 'Failed to connect to the multiworld server'
-        logger.exception(msg, extra={'compact_gui': True})
-        ctx.gui_error(msg, e)
-    except Exception as e:
-        msg = 'Lost connection to the multiworld server, type /connect to reconnect'
-        logger.exception(msg, extra={'compact_gui': True})
-        ctx.gui_error(msg, e)
+        logger.warning(f"Disconnected from multiworld server{reconnect_hint()}")
+    except ConnectionRefusedError:
+        ctx._handle_connection_loss("Connection refused by the server. May not be running Archipelago on that address or port.")
+    except websockets.InvalidURI:
+        ctx._handle_connection_loss("Failed to connect to the multiworld server (invalid URI)")
+    except OSError:
+        ctx._handle_connection_loss("Failed to connect to the multiworld server")
+    except Exception:
+        ctx._handle_connection_loss(f"Lost connection to the multiworld server{reconnect_hint()}")
     finally:
         await ctx.connection_closed()
-        if ctx.server_address:
-            logger.info(f"... reconnecting in {ctx.current_reconnect_delay}s")
-            async_start(server_autoreconnect(ctx), name="server auto reconnect")
+        if ctx.server_address and ctx.username and not ctx.disconnected_intentionally:
+            logger.info(f"... automatically reconnecting in {ctx.current_reconnect_delay} seconds")
+            assert ctx.autoreconnect_task is None
+            ctx.autoreconnect_task = asyncio.create_task(server_autoreconnect(ctx), name="server auto reconnect")
         ctx.current_reconnect_delay *= 2
 
 

--- a/kvui.py
+++ b/kvui.py
@@ -426,7 +426,6 @@ class GameManager(App):
 
     def connect_button_action(self, button):
         if self.ctx.server:
-            self.ctx.server_address = None
             self.ctx.username = None
             async_start(self.ctx.disconnect())
         else:


### PR DESCRIPTION
## What is this fixing?
- Both CommonClient and SNIClient use fire-and-forget auto-reconnect tasks that may fire at unexpected moments.
- CommonClient: The user is prompted to reconnect by typing `/connect`, but the last address and username are always already deleted at that point.
- CommonClient: The connection loss modal popup stays up even if a connection has been reestablished (for example by auto-reconnect).
- SNIClient: The snes auto-reconnect message looks almost exactly the same as the AP auto-reconnect message.

## How was this tested?
I tried out all the features, but I'm sure I didn't cover every single situation, especially with SNIClient. Both more testing and someone carefully reading over the code for gaps in the logic would be great.

## Deliberations
- The module-level function `server_loop` now accesses protected fields and functions of `class CommonContext` directly. I would argue that that is okay as `server_loop` is really a member function at heart. In fact, I would recommend a refactor that makes most module-level functions in CommonClient.py member functions of `class CommonContext`.
  - If you wish to keep `server_loop` separate but still have it not access protected fields/functions, I can slap a bunch of accessors on it. I could also do the big refactor, in this or a separate PR. Let me know.
- I kept the setup where the loss of the SNES connection also causes an AP connection reconnect, but that whole setup seems rather janky and having the `allow_autoreconnect` parameter in `CommonContext.disconnect` just for that setup seems a bit strange.
