### PR TITLE
Subnautica: Fix `creature_scan_logic: removed` allowing Cuddlefish

### DIFF
--- a/worlds/subnautica/Creatures.py
+++ b/worlds/subnautica/Creatures.py
@@ -118,8 +118,8 @@ class Definitions:
         return [name for name in self.all_creatures_presorted if name not in aggressive or name in hatchable]
 
     @functools.cached_property
-    def all_creatures_presorted_without_aggressive(self) -> List[str]:
-        return [name for name in self.all_creatures_presorted if name not in aggressive]
+    def all_creatures_presorted_without_aggressive_and_containment(self) -> List[str]:
+        return [name for name in self.all_creatures_presorted if name not in aggressive and name not in containment]
 
 # only singleton needed
 Definitions: Definitions = Definitions()

--- a/worlds/subnautica/Options.py
+++ b/worlds/subnautica/Options.py
@@ -60,7 +60,7 @@ class AggressiveScanLogic(Choice):
 
     def get_pool(self) -> typing.List[str]:
         if self == self.option_removed:
-            return Definitions.all_creatures_presorted_without_aggressive
+            return Definitions.all_creatures_presorted_without_aggressive_and_containment
         elif self == self.option_stasis:
             return Definitions.all_creatures_presorted_without_containment
         elif self == self.option_containment:


### PR DESCRIPTION
This bug was reported by Oneup#7856 on Discord on October 27th.

## What is this fixing?
The setting `creature_scan_logic: removed` erroneously put the Cuddlefish in the creature scan pool.

## How was this tested?
Generated a few seeds with `creature_scan_logic: removed` and checked the spoiler logs.