### PR TITLE
SMW: Add link to Tracker in setup guide

### DIFF
--- a/worlds/smw/docs/setup_en.md
+++ b/worlds/smw/docs/setup_en.md
@@ -14,6 +14,11 @@
       compatible hardware
 - Your legally obtained Super Mario World ROM file, probably named `Super Mario World (USA).sfc`
 
+## Optional Software
+- Super Mario World Tracker
+	- PopTracker from: [PopTracker Releases Page](https://github.com/black-sliver/PopTracker/releases/)
+	- Super Mario World Archipelago PopTracker pack from: [SMW AP Tracker Releases Page](https://github.com/PoryGone/SMW_AP_Tracker/releases/)
+
 ## Installation Procedures
 
 ### Windows Setup


### PR DESCRIPTION
## What is this fixing or adding?
Adding a link to the SMW Tracker to the SMW Setup Guide.

## How was this tested?
I clicked the link.

## If this makes graphical changes, please attach screenshots.
![image](https://user-images.githubusercontent.com/98504756/200090828-50fb6588-cf4e-4ead-81cd-50061cd9536b.png)
