### PR TITLE
Factorio: set useless technologies to be researched from the start

### DIFF
--- a/worlds/factorio/Mod.py
+++ b/worlds/factorio/Mod.py
@@ -13,7 +13,7 @@ import Utils
 import worlds.Files
 from . import Options
 from .Technologies import tech_table, recipes, free_sample_exclusions, progressive_technology_table, \
-    base_tech_table, tech_to_progressive_lookup, fluids
+    base_tech_table, tech_to_progressive_lookup, fluids, useless_technologies
 
 if TYPE_CHECKING:
     from . import Factorio
@@ -135,6 +135,7 @@ def generate_mod(world: "Factorio", output_directory: str):
         "liquids": fluids,
         "goal": multiworld.goal[player].value,
         "energy_link": multiworld.energy_link[player].value,
+        "useless_technologies": useless_technologies,
     }
 
     for factorio_option in Options.factorio_options:

--- a/worlds/factorio/data/mod_template/control.lua
+++ b/worlds/factorio/data/mod_template/control.lua
@@ -112,6 +112,9 @@ function on_force_created(event)
 {%- if silo == 2 %}
     check_spawn_silo(force)
 {%- endif %}
+{%- for tech_name in useless_technologies %}
+    force.technologies.{{ tech_name }}.researched = true
+{%- endfor %}
 end
 script.on_event(defines.events.on_force_created, on_force_created)
 


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?
in normal AP play, nothing.
This sets vanilla technologies that are useless to be hidden and researched, so if any user installed mods happen to refer to these technologies, it will not break those changes.

## How was this tested?
By loading up Factorio and seeing if it gave the desired result.

## If this makes graphical changes, please attach screenshots.
The technologies are completely hidden from the user, so no.