### PR TITLE
SC2: Bugfixes for YAML Option Interactions

### DIFF
--- a/worlds/sc2wol/PoolFilter.py
+++ b/worlds/sc2wol/PoolFilter.py
@@ -172,7 +172,7 @@ class ValidInventory:
                         transient_items += items_to_remove
                         for transient_item in transient_items:
                             if transient_item not in inventory and transient_item not in locked_items:
-                                locked_items += transient_item
+                                locked_items.append(transient_item)
                             if transient_item.classification in (ItemClassification.progression, ItemClassification.progression_skip_balancing):
                                 self.logical_inventory.add(transient_item.name)
                         break

--- a/worlds/sc2wol/__init__.py
+++ b/worlds/sc2wol/__init__.py
@@ -131,7 +131,7 @@ def get_excluded_items(self: SC2WoLWorld, world: MultiWorld, player: int) -> Set
 def assign_starter_items(world: MultiWorld, player: int, excluded_items: Set[str], locked_locations: List[str]) -> List[Item]:
     non_local_items = world.non_local_items[player].value
     if get_option_value(world, player, "early_unit"):
-        local_basic_unit = tuple(item for item in get_basic_units(world, player) if item not in non_local_items)
+        local_basic_unit = tuple(item for item in get_basic_units(world, player) if item not in non_local_items and item not in excluded_items)
         if not local_basic_unit:
             raise Exception("At least one basic unit must be local")
 


### PR DESCRIPTION
## What is this fixing or adding?

Early Unit:  Now respects Excluded Items when selecting a random unit.

Units Always Have Upgrades:  Changed removal cascade behavior; now additionally checks to see if an associated item is already locked when attempting to remove, and locks associated items if so.  Occasionally caused issues with starter items in the past, frequently caused issues with yaml-defined Locked Items.

## How was this tested?

Five test generations on five different YAMLs, four of which used reduced settings and one of which used full settings.