### PR TITLE
WebHost: Fix DataTables local storage keys

### DIFF
--- a/WebHostLib/static/assets/tracker.js
+++ b/WebHostLib/static/assets/tracker.js
@@ -18,6 +18,12 @@ window.addEventListener('load', () => {
         info: false,
         dom: "t",
         stateSave: true,
+        stateSaveCallback: function(settings,data) {
+            localStorage.setItem(`DataTables_${settings.sInstance}_/tracker`, JSON.stringify(data));
+        },
+        stateLoadCallback: function(settings) {
+            return JSON.parse(localStorage.getItem(`DataTables_${settings.sInstance}_/tracker`));
+        },
         columnDefs: [
             {
                 targets: 'hours',

--- a/WebHostLib/templates/checkResult.html
+++ b/WebHostLib/templates/checkResult.html
@@ -12,7 +12,7 @@
         <div id="check-result" class="grass-island">
             <h1>Verification Results</h1>
             <p>The results of your requested file check are below.</p>
-            <table class="table autodatatable">
+            <table id="results-table" class="table autodatatable">
                 <thead>
                     <tr>
                         <th>File</th>

--- a/WebHostLib/templates/genericTracker.html
+++ b/WebHostLib/templates/genericTracker.html
@@ -15,7 +15,7 @@
             <span class="info">This tracker will automatically update itself periodically.</span>
         </div>
             <div class="table-wrapper">
-                <table class="table non-unique-item-table">
+                <table id="received-table" class="table non-unique-item-table">
                     <thead>
                         <tr>
                             <th>Item</th>
@@ -37,7 +37,7 @@
                 </table>
             </div>
             <div class="table-wrapper">
-                <table class="table non-unique-item-table">
+                <table id="locations-table" class="table non-unique-item-table">
                     <thead>
                     <tr>
                         <th>Location</th>

--- a/WebHostLib/templates/tracker.html
+++ b/WebHostLib/templates/tracker.html
@@ -25,7 +25,7 @@
         <div id="tables-container">
             {% for team, players in inventory.items() %}
                 <div class="table-wrapper">
-                    <table class="table unique-item-table">
+                    <table id="inventory-table" class="table unique-item-table">
                         <thead>
                         <tr>
                             <th>#</th>
@@ -78,7 +78,7 @@
 
             {% for team, players in checks_done.items() %}
                 <div class="table-wrapper">
-                    <table class="table non-unique-item-table">
+                    <table id="checks-table" class="table non-unique-item-table">
                         <thead>
                             <tr>
                                 <th rowspan="2">#</th>
@@ -153,7 +153,7 @@
             {% endfor %}
             {% for team, hints in hints.items() %}
                 <div class="table-wrapper">
-                    <table class="table non-unique-item-table" data-order='[[5, "asc"], [0, "asc"]]'>
+                    <table id="hints-table" class="table non-unique-item-table" data-order='[[5, "asc"], [0, "asc"]]'>
                         <thead>
                         <tr>
                             <th>Finder</th>


### PR DESCRIPTION
## What is this fixing or adding?
This PR should put the other PR (#1145) in go mode. It adds DOM IDs to all relevant tables and adds the discussed snippet for unifying the settings of all tracker pages.

## How was this tested?
Mildly. On localhost with all the different tracker pages, checking the local storage display of the browser.