### PR TITLE
[Core] Item plando improvements

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -361,7 +361,7 @@ class MultiWorld():
         except KeyError as e:
             raise KeyError('No such dungeon %s for player %d' % (dungeonname, player)) from e
 
-    def get_all_state(self, use_cache: bool) -> CollectionState:
+    def get_all_state(self, use_cache: bool, sweep: bool=False) -> CollectionState:
         cached = getattr(self, "_all_state", None)
         if use_cache and cached:
             return cached.copy()
@@ -374,7 +374,8 @@ class MultiWorld():
             subworld = self.worlds[player]
             for item in subworld.get_pre_fill_items():
                 subworld.collect(ret, item)
-        ret.sweep_for_events()
+        if sweep:
+            ret.sweep_for_events()
 
         if use_cache:
             self._all_state = ret

--- a/test/general/TestReachability.py
+++ b/test/general/TestReachability.py
@@ -16,7 +16,7 @@ class TestBase(unittest.TestCase):
                 with self.subTest("Game", game=game_name):
                     world = setup_default_world(world_type)
                     excluded = world.exclude_locations[1].value
-                    state = world.get_all_state(False)
+                    state = world.get_all_state(False, sweep=True)
                     for location in world.get_locations():
                         if location.name not in excluded:
                             with self.subTest("Location should be reached", location=location):

--- a/worlds/alttp/__init__.py
+++ b/worlds/alttp/__init__.py
@@ -323,6 +323,8 @@ class ALTTPWorld(World):
         player = self.player
         all_state = world.get_all_state(use_cache=True)
         crystals = [self.create_item(name) for name in ['Red Pendant', 'Blue Pendant', 'Green Pendant', 'Crystal 1', 'Crystal 2', 'Crystal 3', 'Crystal 4', 'Crystal 7', 'Crystal 5', 'Crystal 6']]
+        for crystal in crystals:
+            all_state.remove(crystal)
         crystal_locations = [world.get_location('Turtle Rock - Prize', player),
                              world.get_location('Eastern Palace - Prize', player),
                              world.get_location('Desert Palace - Prize', player),
@@ -524,6 +526,10 @@ class ALTTPWorld(World):
                     for item in dungeon.all_items:
                         if item.name in self.dungeon_local_item_names:
                             res.append(item)
+        res += [self.create_item(name) for name in
+                    ['Red Pendant', 'Blue Pendant', 'Green Pendant', 'Crystal 1', 'Crystal 2', 'Crystal 3', 'Crystal 4',
+                     'Crystal 7', 'Crystal 5', 'Crystal 6']]
+
         return res
 
 

--- a/worlds/oot/EntranceShuffle.py
+++ b/worlds/oot/EntranceShuffle.py
@@ -373,7 +373,7 @@ def shuffle_random_entrances(ootworld):
     player = ootworld.player
 
     # Gather locations to keep reachable for validation
-    all_state = world.get_all_state(use_cache=True)
+    all_state = world.get_all_state(use_cache=True, sweep=True)
     locations_to_ensure_reachable = {loc for loc in world.get_reachable_locations(all_state, player) if not (loc.type == 'Drop' or (loc.type == 'Event' and 'Subrule' in loc.name))}
 
     # Set entrance data for all entrances
@@ -545,7 +545,7 @@ def shuffle_random_entrances(ootworld):
             logging.getLogger('').error(f'Root Exit: {exit} -> {exit.connected_region}')
         logging.getLogger('').error(f'Root has too many entrances left after shuffling entrances')
     # Game is beatable
-    new_all_state = world.get_all_state(use_cache=False)
+    new_all_state = world.get_all_state(use_cache=False, sweep=True)
     if not world.has_beaten_game(new_all_state, player):
         raise EntranceShuffleError('Cannot beat game')
     # Validate world
@@ -672,7 +672,7 @@ def split_entrances_by_requirements(ootworld, entrances_to_split, assumed_entran
         if entrance.connected_region:
             original_connected_regions[entrance] = entrance.disconnect()
 
-    all_state = world.get_all_state(use_cache=False)
+    all_state = world.get_all_state(use_cache=False, sweep=True)
 
     restrictive_entrances = []
     soft_entrances = []

--- a/worlds/oot/Rules.py
+++ b/worlds/oot/Rules.py
@@ -216,7 +216,7 @@ def set_entrances_based_rules(ootworld):
     if ootworld.multiworld.accessibility == 'beatable': 
         return
 
-    all_state = ootworld.multiworld.get_all_state(False)
+    all_state = ootworld.multiworld.get_all_state(False, sweep=True)
 
     for location in filter(lambda location: location.type == 'Shop', ootworld.get_locations()):
         # If a shop is not reachable as adult, it can't have Goron Tunic or Zora Tunic as child can't buy these

--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -595,7 +595,7 @@ class OOTWorld(World):
 
         # Kill unreachable events that can't be gotten even with all items
         # Make sure to only kill actual internal events, not in-game "events"
-        all_state = self.multiworld.get_all_state(False)
+        all_state = self.multiworld.get_all_state(False, sweep=True)
         all_locations = self.get_locations()
         reachable = self.multiworld.get_reachable_locations(all_state, self.player)
         unreachable = [loc for loc in all_locations if
@@ -1119,7 +1119,7 @@ class OOTWorld(World):
     # Specifically ensures that only real items are gotten, not any events.
     # In particular, ensures that Time Travel needs to be found.
     def get_state_with_complete_itempool(self):
-        all_state = self.multiworld.get_all_state(use_cache=False)
+        all_state = self.multiworld.get_all_state(use_cache=False, sweep=True)
         # Remove event progression items
         for item, player in all_state.prog_items:
             if player == self.player and (item not in item_table or (item_table[item][2] is None and item_table[item][0] != 'DungeonReward')):


### PR DESCRIPTION
## What is this fixing or adding?
Item plando improvements:
* places plando blocks using `fill_restrictive` so they are placed intelligently
* adds `early_locations` and `non_early_locations` as special location group names to allow selecting all sphere 1 or all non-sphere 1 locations for the given world(s)

Adds parameter to `get_all_state` to indicate whether to `sweep_for_events` (default off) as if this is done it collects all plando'd items into the all_state. If this is then passed to `fill_restrictive`, those items will always be considered collected during this fill. This parameter is left off for all current calls to it except in the AllStateCanReachEverything unit test, and in OoT for any purpose other than to pass it into `fill_restrictive`.

Adds LTTP dungeon prizes to `get_pre_fill_items` and removes them from state before dungeon prize placement. This will allow prizes to be collected into the all_state for item plando so that e.g., Master Sword Pedestal can be plando'd into.

It might also be a good idea to add a parameter to `get_all_state` for whether to collect items from `get_pre_fill_items` or not, for calls to it that take place after pre-fill.

This also removes the `from_pool` option, as I don't think items not existing from the pool should not be added during item plando, and we should have a different method of modifying the item pool.

Still needs documentation. Looking for feedback before I get to that.

## How was this tested?
I've done some testing but more should be done, especially with OoT.

## If this makes graphical changes, please attach screenshots.
