### PR TITLE
OoT: make Bottles and Adult Trade Item hintable groups

### DIFF
--- a/test/general/TestItems.py
+++ b/test/general/TestItems.py
@@ -19,6 +19,8 @@ class TestBase(unittest.TestCase):
         exclusion_dict = {
             "A Link to the Past":
                 {"Pendants", "Crystals"},
+            "Ocarina of Time":
+                {"medallions", "stones", "rewards", "logic_bottles"},
             "Starcraft 2 Wings of Liberty":
                 {"Missions"},
         }

--- a/worlds/oot/Rules.py
+++ b/worlds/oot/Rules.py
@@ -22,7 +22,7 @@ class OOTLogic(LogicMixin):
         return self.has_group("rewards", player, count)
 
     def _oot_has_bottle(self, player): 
-        return self.has_group("bottles", player)
+        return self.has_group("logic_bottles", player)
 
     # Used for fall damage and other situations where damage is unavoidable
     def _oot_can_live_dmg(self, player, hearts):

--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -110,6 +110,29 @@ class OOTWorld(World):
 
     required_client_version = (0, 3, 2)
 
+    item_name_groups = {
+        # internal groups
+        "medallions": {"Light Medallion", "Forest Medallion", "Fire Medallion",
+            "Water Medallion", "Shadow Medallion", "Spirit Medallion"},
+        "stones": {"Kokiri Emerald", "Goron Ruby", "Zora Sapphire"},
+        "rewards": {"Light Medallion", "Forest Medallion", "Fire Medallion",
+            "Water Medallion", "Shadow Medallion", "Spirit Medallion",
+            "Kokiri Emerald", "Goron Ruby", "Zora Sapphire"},
+        "logic_bottles": {"Bottle", "Bottle with Milk", "Deliver Letter",
+            "Sell Big Poe", "Bottle with Red Potion", "Bottle with Green Potion", 
+            "Bottle with Blue Potion", "Bottle with Fairy", "Bottle with Fish", 
+            "Bottle with Blue Fire", "Bottle with Bugs", "Bottle with Poe"},
+
+        # hint groups
+        "Bottles": {"Bottle", "Bottle with Milk", "Rutos Letter",
+            "Bottle with Big Poe", "Bottle with Red Potion", "Bottle with Green Potion", 
+            "Bottle with Blue Potion", "Bottle with Fairy", "Bottle with Fish", 
+            "Bottle with Blue Fire", "Bottle with Bugs", "Bottle with Poe"},
+        "Adult Trade Item": {"Pocket Egg", "Pocket Cucco", "Odd Mushroom",
+            "Odd Potion", "Poachers Saw", "Broken Sword", "Prescription",
+            "Eyeball Frog", "Eyedrops", "Claim Check"}
+    }
+
     def __init__(self, world, player):
         self.hint_data_available = threading.Event()
         super(OOTWorld, self).__init__(world, player)
@@ -140,19 +163,6 @@ class OOTWorld(World):
         self.songs_as_items = False
         self.file_hash = [self.multiworld.random.randint(0, 31) for i in range(5)]
         self.connect_name = ''.join(self.multiworld.random.choices(printable, k=16))
-
-        self.item_name_groups = {
-            "medallions": {"Light Medallion", "Forest Medallion", "Fire Medallion", "Water Medallion",
-                           "Shadow Medallion", "Spirit Medallion"},
-            "stones": {"Kokiri Emerald", "Goron Ruby", "Zora Sapphire"},
-            "rewards": {"Light Medallion", "Forest Medallion", "Fire Medallion", "Water Medallion", "Shadow Medallion",
-                        "Spirit Medallion", \
-                        "Kokiri Emerald", "Goron Ruby", "Zora Sapphire"},
-            "bottles": {"Bottle", "Bottle with Milk", "Deliver Letter", "Sell Big Poe", "Bottle with Red Potion",
-                        "Bottle with Green Potion", \
-                        "Bottle with Blue Potion", "Bottle with Fairy", "Bottle with Fish", "Bottle with Blue Fire",
-                        "Bottle with Bugs", "Bottle with Poe"}
-        }
 
         # Incompatible option handling
         # ER and glitched logic are not compatible; glitched takes priority


### PR DESCRIPTION
## What is this fixing or adding?
in title. Fixes longstanding issue of bottles not being hintable, and adds a new set because I realized it could be useful for those who randomize it. 

## How was this tested?
generate game, server hint for the two groups, returns items correctly