### PR TITLE
WebHost: Detect confusion of settings zip and seed zip

### DIFF
--- a/WebHostLib/api/generate.py
+++ b/WebHostLib/api/generate.py
@@ -2,7 +2,7 @@ import json
 import pickle
 from uuid import UUID
 
-from flask import request, session, url_for
+from flask import request, session, url_for, Markup
 from pony.orm import commit
 
 from WebHostLib import app
@@ -21,7 +21,7 @@ def generate_api():
         if 'file' in request.files:
             file = request.files['file']
             options = get_yaml_data(file)
-            if type(options) == str:
+            if isinstance(options, (str, Markup)):
                 return {"text": options}, 400
             if "race" in request.form:
                 race = bool(0 if request.form["race"] in {"false"} else int(request.form["race"]))

--- a/WebHostLib/api/generate.py
+++ b/WebHostLib/api/generate.py
@@ -21,7 +21,9 @@ def generate_api():
         if 'file' in request.files:
             file = request.files['file']
             options = get_yaml_data(file)
-            if isinstance(options, (str, Markup)):
+            if isinstance(options, Markup):
+                return {"text": options.striptags()}, 400
+            if isinstance(options, str):
                 return {"text": options}, 400
             if "race" in request.form:
                 race = bool(0 if request.form["race"] in {"false"} else int(request.form["race"]))

--- a/WebHostLib/check.py
+++ b/WebHostLib/check.py
@@ -25,7 +25,7 @@ def check():
         else:
             file = request.files['file']
             options = get_yaml_data(file)
-            if isinstance(options, (str, Markup)):
+            if isinstance(options, str):
                 flash(options)
             else:
                 results, _ = roll_options(options)

--- a/WebHostLib/check.py
+++ b/WebHostLib/check.py
@@ -1,7 +1,7 @@
 import zipfile
 from typing import *
 
-from flask import request, flash, redirect, url_for, render_template
+from flask import request, flash, redirect, url_for, render_template, Markup
 
 from WebHostLib import app
 
@@ -25,7 +25,7 @@ def check():
         else:
             file = request.files['file']
             options = get_yaml_data(file)
-            if type(options) == str:
+            if isinstance(options, (str, Markup)):
                 flash(options)
             else:
                 results, _ = roll_options(options)
@@ -38,7 +38,7 @@ def mysterycheck():
     return redirect(url_for("check"), 301)
 
 
-def get_yaml_data(file) -> Union[Dict[str, str], str]:
+def get_yaml_data(file) -> Union[Dict[str, str], str, Markup]:
     options = {}
     # if user does not select file, browser also
     # submit an empty part without filename
@@ -49,6 +49,10 @@ def get_yaml_data(file) -> Union[Dict[str, str], str]:
 
             with zipfile.ZipFile(file, 'r') as zfile:
                 infolist = zfile.infolist()
+
+                if any(file.filename.endswith(".archipelago") for file in infolist):
+                    return Markup("Error: Your .zip file contains an .archipelago file. "
+                                 'Did you mean to <a href="/uploads">host a game</a>?')
 
                 for file in infolist:
                     if file.filename.endswith(banned_zip_contents):

--- a/WebHostLib/generate.py
+++ b/WebHostLib/generate.py
@@ -8,7 +8,7 @@ import concurrent.futures
 from collections import Counter
 from typing import Dict, Optional, Any
 
-from flask import request, flash, redirect, url_for, session, render_template, Markup
+from flask import request, flash, redirect, url_for, session, render_template
 from pony.orm import commit, db_session
 
 from BaseClasses import seeddigits, get_seed
@@ -52,7 +52,7 @@ def generate(race=False):
         else:
             file = request.files['file']
             options = get_yaml_data(file)
-            if isinstance(options, (str, Markup)):
+            if isinstance(options, str):
                 flash(options)
             else:
                 meta = get_meta(request.form)

--- a/WebHostLib/generate.py
+++ b/WebHostLib/generate.py
@@ -8,7 +8,7 @@ import concurrent.futures
 from collections import Counter
 from typing import Dict, Optional, Any
 
-from flask import request, flash, redirect, url_for, session, render_template
+from flask import request, flash, redirect, url_for, session, render_template, Markup
 from pony.orm import commit, db_session
 
 from BaseClasses import seeddigits, get_seed
@@ -52,7 +52,7 @@ def generate(race=False):
         else:
             file = request.files['file']
             options = get_yaml_data(file)
-            if type(options) == str:
+            if isinstance(options, (str, Markup)):
                 flash(options)
             else:
                 meta = get_meta(request.form)

--- a/WebHostLib/static/styles/globalStyles.css
+++ b/WebHostLib/static/styles/globalStyles.css
@@ -105,6 +105,9 @@ h5, h6{
     margin-bottom: 20px;
     background-color: #ffff00;
 }
+.user-message a{
+    color: #ff7700;
+}
 
 .interactive{
     color: #ffef00;

--- a/WebHostLib/upload.py
+++ b/WebHostLib/upload.py
@@ -5,7 +5,7 @@ import uuid
 import zipfile
 from io import BytesIO
 
-from flask import request, flash, redirect, url_for, session, render_template
+from flask import request, flash, redirect, url_for, session, render_template, Markup
 from pony.orm import flush, select
 
 import MultiServer
@@ -22,6 +22,10 @@ def upload_zip_to_db(zfile: zipfile.ZipFile, owner=None, meta={"race": False}, s
     if not owner:
         owner = session["_id"]
     infolist = zfile.infolist()
+    if all(file.filename.endswith((".yaml", ".yml")) or file.is_dir() for file in infolist):
+        flash(Markup("Error: Your .zip file only contains .yaml files. "
+                     'Did you mean to <a href="/generate">generate a game</a>?'))
+        return
     slots: typing.Set[Slot] = set()
     spoiler = ""
     multidata = None


### PR DESCRIPTION
## Context
The website accepts two different kinds of zip files on two not entirely dissimilar pages, both part of common workflows for setting up a game:
- A *settings zip* serves to bundle a set of player settings YAML files for upload to `/generate` (or `/check`).
- A *seed zip* serves to bundle the various output files of a seed generation, which may be uploaded to `/uploads` to host a room on the web host.

## The Problem
When you accidentally upload a seed zip to the `/generate` or `/check` pages you get a cryptic error message, because the spoiler log is parsed as a settings file. I have observed one instance of this causing a newbie to seek tech support in the Discord.
Example:
![problem](https://user-images.githubusercontent.com/57289227/201166717-4713c4cb-6e0c-4f3a-8684-cf40331bac58.png)

## What is this fixing or adding?
This adds rudimentary checks to `/generate` and `/check` to reject seed zips, and to `/uploads` to reject settings zips. A helpful error message is displayed with a link to the correct page.

The `/api/generate` endpoint is also affected, but as far as I can tell, the feature to upload zip files to it is both unused and undocumented.

## How was this tested?
Local webhost, uploading both wrong and correct files to all the changed endpoints except for `/api/generate`.

## Graphical Changes
The new error messages look like this:
![solution1](https://user-images.githubusercontent.com/57289227/201166779-70854425-5124-41f1-ae5f-1f42947b79f2.png)
![solution2](https://user-images.githubusercontent.com/57289227/201166793-1fc03aae-0cd4-4a10-9175-d66c7324d830.png)

## Why are `.txt` files read as settings files in the first place?
¯\\\_(ツ)\_/¯