### PR TITLE
Docs/OoT: Add savestate fix and links to Bizhawk and Logic wiki pages

### DIFF
--- a/worlds/oot/docs/en_Ocarina of Time.md
+++ b/worlds/oot/docs/en_Ocarina of Time.md
@@ -9,7 +9,8 @@ config file.
 
 Items which the player would normally acquire throughout the game have been moved around. Logic remains, so the game is
 always able to be completed, but because of the item shuffle the player may need to access certain areas before they
-would in the vanilla game.
+would in the vanilla game. A list of perhaps non-obvious pieces of logic can be found
+[here](https://wiki.ootrandomizer.com/index.php?title=Logic).
 
 ## What items and locations get shuffled?
 

--- a/worlds/oot/docs/setup_en.md
+++ b/worlds/oot/docs/setup_en.md
@@ -31,11 +31,16 @@ Once Bizhawk has been installed, open Bizhawk and change the following settings:
   to disable most of these, which you can do quickly using `Esc`.
 - If playing with a controller, when you bind controls, disable "P1 A Up", "P1 A Down", "P1 A Left", and "P1 A Right"
   as these interfere with aiming if bound. Set directional input using the Analog tab instead.
+- Under N64 enable "Use Expansion Slot". This is required for savestates to work.
+  (The N64 menu only appears after loading a ROM.)
 
 It is strongly recommended to associate N64 rom extensions (\*.n64, \*.z64) to the Bizhawk we've just installed.
 To do so, we simply have to search any N64 rom we happened to own, right click and select "Open with...", unfold
 the list that appears and select the bottom option "Look for another application", then browse to the Bizhawk folder
 and select EmuHawk.exe.
+
+An alternative Bizhawk setup guide as well as various pieces of troubleshooting advice can be found
+[here](https://wiki.ootrandomizer.com/index.php?title=Bizhawk).
 
 ## Configuring your YAML file
 


### PR DESCRIPTION
## What is this adding?
Adds to the OoT docs:
- How to make savestates work
- A link to https://wiki.ootrandomizer.com/index.php?title=Bizhawk
- A link to https://wiki.ootrandomizer.com/index.php?title=Logic

## How was this tested?
Local webhost instance.