### PR TITLE
Docs/Factorio: Option descriptions, peaceful mode setup

### DIFF
--- a/worlds/factorio/Options.py
+++ b/worlds/factorio/Options.py
@@ -10,7 +10,9 @@ LuaBool = Or(bool, And(int, lambda n: n in (0, 1)))
 
 
 class MaxSciencePack(Choice):
-    """Maximum level of science pack required to complete the game."""
+    """Maximum level of science pack required to complete the game.
+    This also affects the relative cost of silo and satellite recipes if they are randomized.
+    That is the only thing in which the Utility Science Pack and Space Science Pack settings differ."""
     display_name = "Maximum Required Science Pack"
     option_automation_science_pack = 0
     option_logistic_science_pack = 1
@@ -95,7 +97,14 @@ class FreeSamples(Choice):
 
 
 class TechTreeLayout(Choice):
-    """Selects how the tech tree nodes are interwoven."""
+    """Selects how the tech tree nodes are interwoven.
+    Single: No dependencies
+    Diamonds: Several grid graphs (4/9/16 nodes each)
+    Pyramids: Several top halves of diamonds (6/10/15 nodes each)
+    Funnels: Several bottom halves of diamonds (6/10/15 nodes each)
+    Trees: Several trees
+    Choices: A single balanced binary tree
+    """
     display_name = "Technology Tree Layout"
     option_single = 0
     option_small_diamonds = 1
@@ -113,7 +122,11 @@ class TechTreeLayout(Choice):
 
 
 class TechTreeInformation(Choice):
-    """How much information should be displayed in the tech tree."""
+    """How much information should be displayed in the tech tree.
+    None: No indication what a research unlocks
+    Advancement: Indicators which researches unlock items that are considered logical advancements
+    Full: Labels with exact names and recipients of unlocked items
+    """
     display_name = "Technology Tree Information"
     option_none = 0
     option_advancement = 1

--- a/worlds/factorio/Options.py
+++ b/worlds/factorio/Options.py
@@ -125,7 +125,7 @@ class TechTreeInformation(Choice):
     """How much information should be displayed in the tech tree.
     None: No indication what a research unlocks
     Advancement: Indicators which researches unlock items that are considered logical advancements
-    Full: Labels with exact names and recipients of unlocked items
+    Full: Labels with exact names and recipients of unlocked items; all researches are prefilled into the !hint command.
     """
     display_name = "Technology Tree Information"
     option_none = 0

--- a/worlds/factorio/docs/setup_en.md
+++ b/worlds/factorio/docs/setup_en.md
@@ -153,7 +153,8 @@ config .yaml file by including the `world_gen` setting. This setting is currentl
 have to manually create or edit your config file with a text editor of your choice.
 The [template file](/static/generated/configs/Factorio.yaml) is a good starting point and contains the default value of
 the `world_gen` setting. If you already have a config file you may also just copy that setting over from the template.
-Finally, to enable peaceful mode, replace `peaceful_mode: false` with `peaceful_mode: true`.
+To enable peaceful mode, simply replace `peaceful_mode: false` with `peaceful_mode: true`. Finally, use the
+[.yaml checker](/check) to ensure your file is valid.
 
 ### After starting
 If you have already submitted your config file, generated the seed, or even started playing, you can retroactively

--- a/worlds/factorio/docs/setup_en.md
+++ b/worlds/factorio/docs/setup_en.md
@@ -143,6 +143,27 @@ For more information about the commands you can use, see the [Commands Guide](/t
 4. Provide your IP address to anyone you want to join your game, and have them follow the steps for
    "Connecting to Someone Else's Factorio Game" above.
 
+## Enabling Peaceful Mode
+
+By default, peaceful mode is disabled. There are two methods to enable peaceful mode:
+
+### By config file
+You can specify Factorio game settings such as peaceful mode and terrain and resource generation parameters in your
+config .yaml file by including the `world_gen` setting. This setting is currently not supported by the web UI, so you'll
+have to manually create or edit your config file with a text editor of your choice.
+The [template file](/static/generated/configs/Factorio.yaml) is a good starting point and contains the default value of
+the `world_gen` setting. If you already have a config file you may also just copy that setting over from the template.
+Finally, to enable peaceful mode, replace `peaceful_mode: false` with `peaceful_mode: true`.
+
+### After starting
+If you have already submitted your config file, generated the seed, or even started playing, you can retroactively
+enable peaceful mode by entering the following commands into your Archipelago Factorio Client:
+```
+/factorio /c game.surfaces[1].peaceful_mode=true
+/factorio /c game.forces["enemy"].kill_all_units()
+```
+(If this warns you that these commands may disable achievements, you may need to repeat them for them to take effect.)
+
 ## Other Settings
 
 - By default, all item sends are displayed in-game. In larger async seeds this may become overly spammy.

--- a/worlds/factorio/docs/setup_en.md
+++ b/worlds/factorio/docs/setup_en.md
@@ -166,25 +166,29 @@ enable peaceful mode by entering the following commands into your Archipelago Fa
 
 ## Other Settings
 
-- By default, all item sends are displayed in-game. In larger async seeds this may become overly spammy.
-  To hide all item sends that are not to or from your factory, do one of the following:
-  - Type `/toggle-ap-send-filter` in-game
-  - Type `/toggle_send_filter` in the Archipelago Client
-  - In your `host.yaml` set
+### filter_item_sends
+
+By default, all item sends are displayed in-game. In larger async seeds this may become overly spammy.
+To hide all item sends that are not to or from your factory, do one of the following:
+- Type `/toggle-ap-send-filter` in-game
+- Type `/toggle_send_filter` in the Archipelago Client
+- In your `host.yaml` set
 ```
 factorio_options:
   filter_item_sends: true
 ```
-- By default, in-game chat is bridged to Archipelago. If you prefer to be able to speak privately, you can disable this
-  feature by doing one of the following:
-  - Type `/toggle-ap-chat` in-game
-  - Type `/toggle_chat` in the Archipelago Client
-  - In your `host.yaml` set
+
+### bridge_chat_out
+By default, in-game chat is bridged to Archipelago. If you prefer to be able to speak privately, you can disable this
+feature by doing one of the following:
+- Type `/toggle-ap-chat` in-game
+- Type `/toggle_chat` in the Archipelago Client
+- In your `host.yaml` set
 ```
 factorio_options:
   bridge_chat_out: false
 ```
-  Note that this will also disable `!` commands from within the game, and that it will not affect incoming chat.
+Note that this will also disable `!` commands from within the game, and that it will not affect incoming chat.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## What is this fixing or adding?
* Fleshed out lacking option descriptions.
* Added instructions on peaceful mode to the setup guide.
* Added subheadings for each "other setting" in the setup guide.

## How was this tested?
Locally, in Firefox.