### PR TITLE
Server: Implement !hint_all command

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1330,7 +1330,7 @@ class ClientMessageProcessor(CommonCommandProcessor):
             self.output("Cheating is disabled.")
             return False
 
-    def get_hints(self, input_text: str, for_location: bool = False) -> bool:
+    def get_hints(self, input_text: str, for_location: bool = False, hint_all: bool = False) -> bool:
         points_available = get_client_points(self.ctx, self.client)
         cost = self.ctx.get_hint_cost(self.client.slot)
 
@@ -1401,7 +1401,10 @@ class ClientMessageProcessor(CommonCommandProcessor):
                 if not not_found_hints:  # everything's been found, no need to pay
                     can_pay = 1000
                 elif cost:
-                    can_pay = int((points_available // cost) > 0)  # limit to 1 new hint per call
+                    if hint_all:
+                        can_pay = int(points_available // cost)
+                    else:
+                        can_pay = int((points_available // cost) > 0)  # limit to 1 new hint per call
                 else:
                     can_pay = 1000
 
@@ -1452,12 +1455,20 @@ class ClientMessageProcessor(CommonCommandProcessor):
         If hint costs are on, this will only give you one new result,
         you can rerun the command to get more in that case."""
         return self.get_hints(item_name)
+    
+    @mark_raw
+    def _cmd_hint_all(self, item_name: str = "") -> bool:
+        """Use !hint_all {item_name},
+        for example !hint Lamp to get a spoiler peek for that item.
+        If hint costs are on, this will give you every result that
+        you can afford to pay for."""
+        return self.get_hints(item_name, hint_all=True)
 
     @mark_raw
     def _cmd_hint_location(self, location: str = "") -> bool:
         """Use !hint_location {location_name},
         for example !hint_location atomic-bomb to get a spoiler peek for that location."""
-        return self.get_hints(location, True)
+        return self.get_hints(location, for_location=True)
 
 
 def get_checked_checks(ctx: Context, team: int, slot: int) -> typing.List[int]:


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?

Adds a !hint_all {item_name} command.

## How was this tested?

Created a game, forfeited a slot,  ran !hint_all on various items until the player could afford no more items.

## If this makes graphical changes, please attach screenshots.

Prior to !hint_all,  the player would of had to spam the !hint command to get everything they could pay for.
![image](https://user-images.githubusercontent.com/79097/201445916-58082ad2-2db8-4216-8327-a68d17966bc8.png)

With !hint_all, the player only needs to run the command one time for each item the player wishes to get all the available instance of the item not yet found.
![image](https://user-images.githubusercontent.com/79097/201446017-88a7e229-2ad9-4c0c-9a9b-6b2637dcf5ea.png)
