### PR TITLE
SC2:  Increment required client version

### DIFF
--- a/worlds/sc2wol/PoolFilter.py
+++ b/worlds/sc2wol/PoolFilter.py
@@ -172,7 +172,7 @@ class ValidInventory:
                         transient_items += items_to_remove
                         for transient_item in transient_items:
                             if transient_item not in inventory and transient_item not in locked_items:
-                                locked_items += transient_item
+                                locked_items.append(transient_item)
                             if transient_item.classification in (ItemClassification.progression, ItemClassification.progression_skip_balancing):
                                 self.logical_inventory.add(transient_item.name)
                         break

--- a/worlds/sc2wol/__init__.py
+++ b/worlds/sc2wol/__init__.py
@@ -46,7 +46,7 @@ class SC2WoLWorld(World):
     mission_req_table = {}
     final_mission_id: int
     victory_item: str
-    required_client_version = 0, 3, 5
+    required_client_version = 0, 3, 6
 
     def __init__(self, world: MultiWorld, player: int):
         super(SC2WoLWorld, self).__init__(world, player)

--- a/worlds/sc2wol/__init__.py
+++ b/worlds/sc2wol/__init__.py
@@ -131,7 +131,7 @@ def get_excluded_items(self: SC2WoLWorld, world: MultiWorld, player: int) -> Set
 def assign_starter_items(world: MultiWorld, player: int, excluded_items: Set[str], locked_locations: List[str]) -> List[Item]:
     non_local_items = world.non_local_items[player].value
     if get_option_value(world, player, "early_unit"):
-        local_basic_unit = tuple(item for item in get_basic_units(world, player) if item not in non_local_items)
+        local_basic_unit = tuple(item for item in get_basic_units(world, player) if item not in non_local_items and item not in excluded_items)
         if not local_basic_unit:
             raise Exception("At least one basic unit must be local")
 


### PR DESCRIPTION
## What is this fixing or adding?

Vestigial fields were removed from slot data, so old clients always crash.  Incremented the required version to 0.3.6.

## How was this tested?

Generated one SC2 world, hosted it on source, and connected to it with a source client.
