### PR TITLE
HK: fix ExtraShopSlots crash

### DIFF
--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -318,14 +318,15 @@ class HKWorld(World):
             if not self.multiworld.EggShopSlots[self.player].value:  # No eggshop, so don't place items there
                 shops.remove('Egg_Shop')
 
-            for _ in range(additional_shop_items):
-                shop = self.multiworld.random.choice(shops)
-                loc = self.create_location(shop)
-                unfilled_locations += 1
-                if len(self.created_multi_locations[shop]) >= 16:
-                    shops.remove(shop)
-                    if not shops:
-                        break
+            if shops:
+                for _ in range(additional_shop_items):
+                    shop = self.multiworld.random.choice(shops)
+                    loc = self.create_location(shop)
+                    unfilled_locations += 1
+                    if len(self.created_multi_locations[shop]) >= 16:
+                        shops.remove(shop)
+                        if not shops:
+                            break
 
         # Create filler items, if needed
         if item_count < unfilled_locations:


### PR DESCRIPTION
## What is this fixing or adding?
If all shop slot options in Hollow Knight are set to 16 and the ExtraShopSlots option is set to a nonzero value, then generation would crash due to trying to find a shop which didn't already have maximum locations. This fixes the crash by checking if there are any open slots before trying to find a shop to add a slot to.

## How was this tested?
Created yaml with above settings; crashes without commit, generates with commit. 