### PR TITLE
Core: Add MultiServer command to check a specific location

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1905,7 +1905,7 @@ class ServerCommandProcessor(CommonCommandProcessor):
         """Sends an item to the specified player"""
         return self._cmd_send_multiple(1, player_name, *item_name)
 
-    def _cmd_check_location(self, player_name: str, *location_name: str) -> bool:
+    def _cmd_send_location(self, player_name: str, *location_name: str) -> bool:
         """Send out item from a player's location as though they checked it"""
         seeked_player, usable, response = get_intended_text(player_name, self.ctx.player_names.values())
         if usable:
@@ -1918,7 +1918,7 @@ class ServerCommandProcessor(CommonCommandProcessor):
             elif self.ctx.location_names_for_game(game) is not None:
                 location, usable, response = get_intended_text(full_name, self.ctx.location_names_for_game(game))
             else:
-                self.output("Can't look up location for unknown game. Check by ID instead.")
+                self.output("Can't look up location for unknown game. Send by ID instead.")
                 return False
 
             if usable:

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1905,6 +1905,37 @@ class ServerCommandProcessor(CommonCommandProcessor):
         """Sends an item to the specified player"""
         return self._cmd_send_multiple(1, player_name, *item_name)
 
+    def _cmd_check_location(self, player_name: str, *location_name: str) -> bool:
+        """Send out item from a player's location as though they checked it"""
+        seeked_player, usable, response = get_intended_text(player_name, self.ctx.player_names.values())
+        if usable:
+            team, slot = self.ctx.player_name_lookup[seeked_player]
+            game = self.ctx.games[slot]
+            full_name = " ".join(location_name)
+
+            if full_name.isnumeric():
+                location, usable, response = int(full_name), True, None
+            elif self.ctx.location_names_for_game(game) is not None:
+                location, usable, response = get_intended_text(full_name, self.ctx.location_names_for_game(game))
+            else:
+                self.output("Can't look up location for unknown game. Check by ID instead.")
+                return False
+
+            if usable:
+                if isinstance(location, int):
+                    register_location_checks(self.ctx, team, slot, [location])
+                else:
+                    seeked_location: int = self.ctx.location_names_for_game(self.ctx.games[slot])[location]
+                    register_location_checks(self.ctx, team, slot, [seeked_location])
+                return True
+            else:
+                self.output(response)
+                return False
+
+        else:
+            self.output(response)
+            return False
+
     def _cmd_hint(self, player_name: str, *item_name: str) -> bool:
         """Send out a hint for a player's item to their team"""
         seeked_player, usable, response = get_intended_text(player_name, self.ctx.player_names.values())

--- a/worlds/generic/docs/commands_en.md
+++ b/worlds/generic/docs/commands_en.md
@@ -92,6 +92,6 @@ including the exclamation point.
 - `/forbid_forfeit <player name>` Bars the given player from using the `!forfeit` command.
 - `/send <player name> <item name>` Grants the given player the specified item.
 - `/send_multiple <amount> <player name> <item name>` Grants the given player the stated amount of the specified item.
-- `/check_location <player name> <item name>` Send out the given location for the specified player as if the player checked it
+- `/check_location <player name> <location name>` Send out the given location for the specified player as if the player checked it
 - `/hint <player name> <item or location name>` Send out a hint for the given item or location for the specified player.
 - `/option <option name> <option value>` Set a server option. For a list of options, use the `/options` command.

--- a/worlds/generic/docs/commands_en.md
+++ b/worlds/generic/docs/commands_en.md
@@ -92,6 +92,6 @@ including the exclamation point.
 - `/forbid_forfeit <player name>` Bars the given player from using the `!forfeit` command.
 - `/send <player name> <item name>` Grants the given player the specified item.
 - `/send_multiple <amount> <player name> <item name>` Grants the given player the stated amount of the specified item.
-- `/check_location <player name> <location name>` Send out the given location for the specified player as if the player checked it
+- `/send_location <player name> <location name>` Send out the given location for the specified player as if the player checked it
 - `/hint <player name> <item or location name>` Send out a hint for the given item or location for the specified player.
 - `/option <option name> <option value>` Set a server option. For a list of options, use the `/options` command.

--- a/worlds/generic/docs/commands_en.md
+++ b/worlds/generic/docs/commands_en.md
@@ -92,5 +92,6 @@ including the exclamation point.
 - `/forbid_forfeit <player name>` Bars the given player from using the `!forfeit` command.
 - `/send <player name> <item name>` Grants the given player the specified item.
 - `/send_multiple <amount> <player name> <item name>` Grants the given player the stated amount of the specified item.
+- `/check_location <player name> <item name>` Send out the given location for the specified player as if the player checked it
 - `/hint <player name> <item or location name>` Send out a hint for the given item or location for the specified player.
 - `/option <option name> <option value>` Set a server option. For a list of options, use the `/options` command.


### PR DESCRIPTION
## What is this fixing or adding?
I've definitely found in development that there were times I wished I could check a specific location from the server, in order to test various game behaviors. This is now possible.

Ex:
```
/send_location Pory_SMW Donut Plains 4 - Normal Exit
```

## How was this tested?
I spun up `MultiServer.py` hosting a seed with a few games, and checked locations in each of several games. Also attempted intentional typos to verify the typo detection.

## If this makes graphical changes, please attach screenshots.
![image](https://user-images.githubusercontent.com/98504756/202310675-68916d6c-7e83-4dee-9155-bb4019733f40.png)


I'm not attached to the name of the command or any of the messaging returned to the players in fail states, please suggest if you have better wording