### PR TITLE
Multiserver: rename all references to forfeit and deprecate it

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -593,9 +593,9 @@ class Context:
         if "auto" in self.collect_mode:
             collect_player(self, client.team, client.slot)
         if "auto" in self.release_mode:
-            forfeit_player(self, client.team, client.slot)
+            release_player(self, client.team, client.slot)
         elif self.forced_auto_forfeits[self.games[client.slot]]:
-            forfeit_player(self, client.team, client.slot)
+            release_player(self, client.team, client.slot)
         self.save()  # save goal completion flag
 
 
@@ -829,7 +829,7 @@ def update_checked_locations(ctx: Context, team: int, slot: int):
                   [{"cmd": "RoomUpdate", "checked_locations": get_checked_checks(ctx, team, slot)}])
 
 
-def forfeit_player(ctx: Context, team: int, slot: int):
+def release_player(ctx: Context, team: int, slot: int):
     """register any locations that are in the multidata"""
     all_locations = set(ctx.locations[slot])
     ctx.notify_all("%s (Team #%d) has released all remaining items from their world." % (ctx.player_names[(team, slot)], team + 1))
@@ -1194,10 +1194,10 @@ class ClientMessageProcessor(CommonCommandProcessor):
     def _cmd_release(self) -> bool:
         """Sends remaining items in your world to their recipients."""
         if self.ctx.allow_forfeits.get((self.client.team, self.client.slot), False):
-            forfeit_player(self.ctx, self.client.team, self.client.slot)
+            release_player(self.ctx, self.client.team, self.client.slot)
             return True
         if "enabled" in self.ctx.release_mode:
-            forfeit_player(self.ctx, self.client.team, self.client.slot)
+            release_player(self.ctx, self.client.team, self.client.slot)
             return True
         elif "disabled" in self.ctx.release_mode:
             self.output("Sorry, client item releasing has been disabled on this server. "
@@ -1205,7 +1205,7 @@ class ClientMessageProcessor(CommonCommandProcessor):
             return False
         else:  # is auto or goal
             if self.ctx.client_game_state[self.client.team, self.client.slot] == ClientStatus.CLIENT_GOAL:
-                forfeit_player(self.ctx, self.client.team, self.client.slot)
+                release_player(self.ctx, self.client.team, self.client.slot)
                 return True
             else:
                 self.output(
@@ -1838,7 +1838,7 @@ class ServerCommandProcessor(CommonCommandProcessor):
         player = self.resolve_player(player_name)
         if player:
             team, slot, _ = player
-            forfeit_player(self.ctx, team, slot)
+            release_player(self.ctx, team, slot)
             return True
 
         self.output(f"Could not find player {player_name} to release")

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -109,6 +109,7 @@ class Context:
                       "location_check_points": int,
                       "server_password": str,
                       "password": str,
+                      "forfeit_mode": str,  # TODO remove around 0.4
                       "release_mode": str,
                       "remaining_mode": str,
                       "collect_mode": str,
@@ -488,9 +489,10 @@ class Context:
             "group_collected": dict(self.group_collected),
             "stored_data": self.stored_data,
             "game_options": {"hint_cost": self.hint_cost, "location_check_points": self.location_check_points,
-                             "server_password": self.server_password, "password": self.password, "release_mode":
-                             self.release_mode, "remaining_mode": self.remaining_mode, "collect_mode":
-                             self.collect_mode, "item_cheat": self.item_cheat, "compatibility": self.compatibility}
+                             "server_password": self.server_password, "password": self.password,
+                             "forfeit_mode": self.release_mode, "release_mode": self.release_mode,  # TODO remove forfeit_mode around 0.4
+                             "remaining_mode": self.remaining_mode, "collect_mode": self.collect_mode,
+                             "item_cheat": self.item_cheat, "compatibility": self.compatibility}
 
         }
 
@@ -698,6 +700,7 @@ async def on_client_connected(ctx: Context, client: Client):
 
 def get_permissions(ctx) -> typing.Dict[str, Permission]:
     return {
+        "forfeit": Permission.from_text(ctx.release_mode),  # TODO remove around 0.4
         "release": Permission.from_text(ctx.release_mode),
         "remaining": Permission.from_text(ctx.remaining_mode),
         "collect": Permission.from_text(ctx.collect_mode)
@@ -1984,7 +1987,7 @@ class ServerCommandProcessor(CommonCommandProcessor):
                     return input_text
             setattr(self.ctx, option_name, attrtype(option))
             self.output(f"Set option {option_name} to {getattr(self.ctx, option_name)}")
-            if option_name in {"release_mode", "remaining_mode", "collect_mode"}:
+            if option_name in {"forfeit_mode", "release_mode", "remaining_mode", "collect_mode"}:  # TODO remove forfeit_mode with 0.4
                 self.ctx.broadcast_all([{"cmd": "RoomUpdate", 'permissions': get_permissions(self.ctx)}])
             elif option_name in {"hint_cost", "location_check_points"}:
                 self.ctx.broadcast_all([{"cmd": "RoomUpdate", option_name: getattr(self.ctx, option_name)}])

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -164,7 +164,7 @@ class Context:
         self.location_check_points = location_check_points
         self.hints_used = collections.defaultdict(int)
         self.hints: typing.Dict[team_slot, typing.Set[NetUtils.Hint]] = collections.defaultdict(set)
-        self.forfeit_mode: str = forfeit_mode
+        self.release_mode: str = forfeit_mode
         self.remaining_mode: str = remaining_mode
         self.collect_mode: str = collect_mode
         self.item_cheat = item_cheat
@@ -489,7 +489,7 @@ class Context:
             "stored_data": self.stored_data,
             "game_options": {"hint_cost": self.hint_cost, "location_check_points": self.location_check_points,
                              "server_password": self.server_password, "password": self.password, "release_mode":
-                             self.forfeit_mode, "remaining_mode": self.remaining_mode, "collect_mode":
+                             self.release_mode, "remaining_mode": self.remaining_mode, "collect_mode":
                              self.collect_mode, "item_cheat": self.item_cheat, "compatibility": self.compatibility}
 
         }
@@ -521,7 +521,7 @@ class Context:
             self.location_check_points = savedata["game_options"]["location_check_points"]
             self.server_password = savedata["game_options"]["server_password"]
             self.password = savedata["game_options"]["password"]
-            self.forfeit_mode = savedata["game_options"]["release_mode"]
+            self.release_mode = savedata["game_options"]["release_mode"]
             self.remaining_mode = savedata["game_options"]["remaining_mode"]
             self.collect_mode = savedata["game_options"]["collect_mode"]
             self.item_cheat = savedata["game_options"]["item_cheat"]
@@ -590,7 +590,7 @@ class Context:
         self.notify_all(finished_msg)
         if "auto" in self.collect_mode:
             collect_player(self, client.team, client.slot)
-        if "auto" in self.forfeit_mode:
+        if "auto" in self.release_mode:
             forfeit_player(self, client.team, client.slot)
         elif self.forced_auto_forfeits[self.games[client.slot]]:
             forfeit_player(self, client.team, client.slot)
@@ -698,7 +698,7 @@ async def on_client_connected(ctx: Context, client: Client):
 
 def get_permissions(ctx) -> typing.Dict[str, Permission]:
     return {
-        "forfeit": Permission.from_text(ctx.forfeit_mode),
+        "release": Permission.from_text(ctx.release_mode),
         "remaining": Permission.from_text(ctx.remaining_mode),
         "collect": Permission.from_text(ctx.collect_mode)
     }
@@ -1193,10 +1193,10 @@ class ClientMessageProcessor(CommonCommandProcessor):
         if self.ctx.allow_forfeits.get((self.client.team, self.client.slot), False):
             forfeit_player(self.ctx, self.client.team, self.client.slot)
             return True
-        if "enabled" in self.ctx.forfeit_mode:
+        if "enabled" in self.ctx.release_mode:
             forfeit_player(self.ctx, self.client.team, self.client.slot)
             return True
-        elif "disabled" in self.ctx.forfeit_mode:
+        elif "disabled" in self.ctx.release_mode:
             self.output("Sorry, client item releasing has been disabled on this server. "
                         "You can ask the server admin for a /release")
             return False
@@ -2110,7 +2110,7 @@ async def main(args: argparse.Namespace):
     Utils.init_logging("Server", loglevel=args.loglevel.lower())
 
     ctx = Context(args.host, args.port, args.server_password, args.password, args.location_check_points,
-                  args.hint_cost, not args.disable_item_cheat, args.forfeit_mode, args.collect_mode,
+                  args.hint_cost, not args.disable_item_cheat, args.release_mode, args.collect_mode,
                   args.remaining_mode,
                   args.auto_shutdown, args.compatibility, args.log_network)
     data_filename = args.multidata

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1210,11 +1210,6 @@ class ClientMessageProcessor(CommonCommandProcessor):
                     " You can ask the server admin for a /release")
                 return False
 
-    def _cmd_forfeit(self) -> None:
-        """Deprecated. Please use release instead."""
-        self.output(
-            "!forfeit has been deprecated. Please use !release instead.")
-
     def _cmd_collect(self) -> bool:
         """Send your remaining items to yourself"""
         if "enabled" in self.ctx.collect_mode:
@@ -1845,11 +1840,6 @@ class ServerCommandProcessor(CommonCommandProcessor):
 
         self.output(f"Could not find player {player_name} to release")
         return False
-
-    @mark_raw
-    def _cmd_forfeit(self, player_name: str) -> None:
-        """Deprecated command. Please use release instead"""
-        self.output("This command has been deprecated. Please use /release instead.")
 
     @mark_raw
     def _cmd_allow_release(self, player_name: str) -> bool:

--- a/WebHostLib/generate.py
+++ b/WebHostLib/generate.py
@@ -33,7 +33,7 @@ def get_meta(options_source: dict) -> dict:
 
     server_options = {
         "hint_cost": int(options_source.get("hint_cost", 10)),
-        "forfeit_mode": options_source.get("forfeit_mode", "goal"),
+        "release_mode": options_source.get("release_mode", "goal"),
         "remaining_mode": options_source.get("remaining_mode", "disabled"),
         "collect_mode": options_source.get("collect_mode", "disabled"),
         "item_cheat": bool(int(options_source.get("item_cheat", 1))),

--- a/WebHostLib/templates/generate.html
+++ b/WebHostLib/templates/generate.html
@@ -40,20 +40,20 @@
                             <tbody>
                                 <tr>
                                     <td>
-                                        <label for="forfeit_mode">Forfeit Permission:
-                                            <span class="interactive" data-tooltip="A forfeit releases all remaining items from the locations in your world.">
+                                        <label for="release_mode">Release Permission:
+                                            <span class="interactive" data-tooltip="Permissions on when players are able to release all remaining items from their world.">
                                                 (?)
                                             </span>
                                         </label>
                                     </td>
                                     <td>
-                                        <select name="forfeit_mode" id="forfeit_mode">
+                                        <select name="release_mode" id="forfeit_mode">
                                             <option value="auto">Automatic on goal completion</option>
-                                            <option value="goal">Allow !forfeit after goal completion</option>
+                                            <option value="goal">Allow !release after goal completion</option>
                                             <option value="auto-enabled">
-                                                Automatic on goal completion and manual !forfeit
+                                                Automatic on goal completion and manual !release
                                             </option>
-                                            <option value="enabled">Manual !forfeit</option>
+                                            <option value="enabled">Manual !release</option>
                                             <option value="disabled">Disabled</option>
                                         </select>
                                     </td>
@@ -62,7 +62,7 @@
                                 <tr>
                                     <td>
                                         <label for="collect_mode">Collect Permission:
-                                            <span class="interactive" data-tooltip="A collect releases all of your remaining items to you from across the multiworld.">
+                                            <span class="interactive" data-tooltip="Permissions on when players are able to collect all their remaining items from across the multiworld.">
                                                 (?)
                                             </span>
                                         </label>

--- a/host.yaml
+++ b/host.yaml
@@ -22,14 +22,14 @@ server_options:
   # Relative point cost to receive a hint via !hint for players
   # so for example hint_cost: 20 would mean that for every 20% of available checks, you get the ability to hint, for a total of 5
   hint_cost: 10 # Set to 0 if you want free hints
-  # Forfeit modes
-  # A Forfeit sends out the remaining items *from* a world that forfeits
-  # "disabled" -> clients can't forfeit,
-  # "enabled" -> clients can always forfeit
-  # "auto" -> automatic forfeit on goal completion
-  # "auto-enabled" -> automatic forfeit on goal completion and manual forfeit is also enabled
-  # "goal" -> forfeit is allowed after goal completion
-  forfeit_mode: "goal"
+  # Release modes
+  # A Release sends out the remaining items *from* a world that releases
+  # "disabled" -> clients can't release,
+  # "enabled" -> clients can always release
+  # "auto" -> automatic release on goal completion
+  # "auto-enabled" -> automatic release on goal completion and manual release is also enabled
+  # "goal" -> release is allowed after goal completion
+  release_mode: "goal"
   # Collect modes
   # A Collect sends the remaining items *to* a world that collects
   # "disabled" -> clients can't collect,


### PR DESCRIPTION
## What is this fixing or adding?
Renamed all the host options to use `release_mode` instead

## How was this tested?
Generated and tested all of the commands locally on webhost and on multiserver both as client and as server

## If this makes graphical changes, please attach screenshots.
![Screenshot_62](https://user-images.githubusercontent.com/13184667/202265849-6903b55b-db81-425e-96a9-5122adfb28b6.png)
![Screenshot_63](https://user-images.githubusercontent.com/13184667/202265851-844cb0ff-0603-4c23-b0f9-7a206836d9fa.png)
