### PR TITLE
Fix SNI not launching on upgrade to 0.3.6

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -236,7 +236,7 @@ def get_default_options() -> OptionsType:
             "bridge_chat_out": True,
         },
         "sni_options": {
-            "sni": "SNI",
+            "sni_path": "SNI",
             "snes_rom_start": True,
         },
         "sm_options": {


### PR DESCRIPTION
## What is this fixing or adding?

> **BlackSilver**: sni is not being started from sniclient in the 0.3.6 appimage when you upgrade. reason seems to be that the option was renamed in host.yaml, but the new option does not have a default in Utils.py that's working (it has the wrong name there).
>
> **PoryGone**: Changing the field in Utils.py to match should resolve it

## How was this tested?

Did not test directly (I used a suggested workaround of deleting `host.yaml` instead, which worked)
