### PR TITLE
WebHost/Core: Defer creating slots that have patch files until after multidata is loaded and remove redundant code.

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -308,10 +308,7 @@ class MultiWorld():
 
     def get_out_file_name_base(self, player: int) -> str:
         """ the base name (without file extension) for each player's output file for a seed """
-        return f"AP_{self.seed_name}_P{player}" \
-            + (f"_{self.get_file_safe_player_name(player).replace(' ', '_')}"
-               if (self.player_name[player] != f"Player{player}")
-               else '')
+        return f"AP_{self.seed_name}_P{player}_{self.get_file_safe_player_name(player).replace(' ', '_')}"
 
     def initialize_regions(self, regions=None):
         for region in regions if regions else self.regions:

--- a/WebHostLib/upload.py
+++ b/WebHostLib/upload.py
@@ -65,7 +65,7 @@ def upload_zip_to_db(zfile: zipfile.ZipFile, owner=None, meta={"race": False}, s
             data = zfile.open(file, "r").read()
             files[int(slot_id[1:])] = data
 
-        # All other patch files using the standard MultiWorld.get_out_file_name_base method
+        # All other files using the standard MultiWorld.get_out_file_name_base method
         else:
             _, _, slot_id, *_ = file.filename.split('.')[0].split('_', 3)
             data = zfile.open(file, "r").read()

--- a/WebHostLib/upload.py
+++ b/WebHostLib/upload.py
@@ -15,7 +15,7 @@ from worlds.Files import AutoPatchRegister
 from . import app
 from .models import Seed, Room, Slot
 
-banned_zip_contents = (".sfc",)
+banned_zip_contents = (".sfc", ".z64", ".n64", ".sms", ".gb")
 
 
 def upload_zip_to_db(zfile: zipfile.ZipFile, owner=None, meta={"race": False}, sid=None):
@@ -24,69 +24,28 @@ def upload_zip_to_db(zfile: zipfile.ZipFile, owner=None, meta={"race": False}, s
     infolist = zfile.infolist()
     slots: typing.Set[Slot] = set()
     spoiler = ""
+    patches = {}
     multidata = None
+
+    # Load files.
     for file in infolist:
         handler = AutoPatchRegister.get_handler(file.filename)
         if file.filename.endswith(banned_zip_contents):
             return "Uploaded data contained a rom file, which is likely to contain copyrighted material. " \
                    "Your file was deleted."
+
+        # AP Container
         elif handler:
-            raw = zfile.open(file, "r").read()
-            patch = handler(BytesIO(raw))
-            patch.read()
-            slots.add(Slot(data=raw,
-                           player_name=patch.player_name,
-                           player_id=patch.player,
-                           game=patch.game))
-
-        elif file.filename.endswith(".apmc"):
             data = zfile.open(file, "r").read()
-            metadata = json.loads(base64.b64decode(data).decode("utf-8"))
-            slots.add(Slot(data=data,
-                           player_name=metadata["player_name"],
-                           player_id=metadata["player_id"],
-                           game="Minecraft"))
+            patch = handler(BytesIO(data))
+            patch.read()
+            patches[patch.player] = data
 
-        elif file.filename.endswith(".apv6"):
-            # TODO: Don't omit the player name in Multiworld.get_out_file_name_base so this "fix" can be removed.
-            _, seed_name, slot_id, *slot_name = file.filename.split('.')[0].split('_', 3)
-            slot_name = slot_name[0] if slot_name else f"Player{slot_id[1:]}"
-            slots.add(Slot(data=zfile.open(file, "r").read(), player_name=slot_name,
-                           player_id=int(slot_id[1:]), game="VVVVVV"))
-
-        elif file.filename.endswith(".apsm64ex"):
-            # TODO: Don't omit the player name in Multiworld.get_out_file_name_base so this "fix" can be removed.
-            _, seed_name, slot_id, *slot_name = file.filename.split('.')[0].split('_', 3)
-            slot_name = slot_name[0] if slot_name else f"Player{slot_id[1:]}"
-            slots.add(Slot(data=zfile.open(file, "r").read(), player_name=slot_name,
-                           player_id=int(slot_id[1:]), game="Super Mario 64"))
-
-        elif file.filename.endswith(".zip"):
-            # Factorio mods need a specific name or they do not function
-            # TODO: Don't omit the player name in Multiworld.get_out_file_name_base so this "fix" can be removed.
-            _, seed_name, slot_id, *slot_name = file.filename.rsplit("_", 1)[0].split("-", 3)
-            slot_name = slot_name[0] if slot_name else f"Player{slot_id[1:]}"
-            slots.add(Slot(data=zfile.open(file, "r").read(), player_name=slot_name,
-                           player_id=int(slot_id[1:]), game="Factorio"))
-
-        elif file.filename.endswith(".apz5"):
-            # .apz5 must be named specifically since they don't contain any metadata
-            # TODO: Don't omit the player name in Multiworld.get_out_file_name_base so this "fix" can be removed.
-            _, seed_name, slot_id, *slot_name = file.filename.split('.')[0].split('_', 3)
-            slot_name = slot_name[0] if slot_name else f"Player{slot_id[1:]}"
-            slots.add(Slot(data=zfile.open(file, "r").read(), player_name=slot_name,
-                           player_id=int(slot_id[1:]), game="Ocarina of Time"))
-
-        elif file.filename.endswith(".json"):
-            # TODO: Don't omit the player name in Multiworld.get_out_file_name_base so this "fix" can be removed.
-            _, seed_name, slot_id, *slot_name = file.filename.split('.')[0].split('-', 3)
-            slot_name = slot_name[0] if slot_name else f"Player{slot_id[1:]}"
-            slots.add(Slot(data=zfile.open(file, "r").read(), player_name=slot_name,
-                           player_id=int(slot_id[1:]), game="Dark Souls III"))
-
+        # Spoiler
         elif file.filename.endswith(".txt"):
             spoiler = zfile.open(file, "r").read().decode("utf-8-sig")
 
+        # Multi-data
         elif file.filename.endswith(".archipelago"):
             try:
                 multidata = zfile.open(file).read()
@@ -94,17 +53,36 @@ def upload_zip_to_db(zfile: zipfile.ZipFile, owner=None, meta={"race": False}, s
                 flash("Could not load multidata. File may be corrupted or incompatible.")
                 multidata = None
 
+        # Minecraft
+        elif file.filename.endswith(".apmc"):
+            data = zfile.open(file, "r").read()
+            metadata = json.loads(base64.b64decode(data).decode("utf-8"))
+            patches[metadata["player_id"]] = data
+
+        # Factorio
+        elif file.filename.endswith(".zip"):
+            _, _, slot_id, *_ = file.filename.split('_')[0].split('-', 3)
+            data = zfile.open(file, "r").read()
+            patches[int(slot_id[1:])] = data
+
+        # All other patch files using the standard MultiWorld.get_out_file_name_base method
+        else:
+            _, _, slot_id, *_ = file.filename.split('.')[0].split('_', 3)
+            data = zfile.open(file, "r").read()
+            patches[int(slot_id[1:])] = data
+
+    # Load multi data.
     if multidata:
         decompressed_multidata = MultiServer.Context.decompress(multidata)
         if "slot_info" in decompressed_multidata:
-            player_names = {slot.player_name for slot in slots}
-            leftover_names: typing.Dict[int, NetworkSlot] = {
-                slot_id: slot_info for slot_id, slot_info in decompressed_multidata["slot_info"].items()
-                if slot_info.name not in player_names and slot_info.type != SlotType.group}
-            newslots = [(Slot(data=None, player_name=slot_info.name, player_id=slot, game=slot_info.game))
-                        for slot, slot_info in leftover_names.items()]
-            for slot in newslots:
-                slots.add(slot)
+            for slot, slot_info in decompressed_multidata["slot_info"].items():
+                # Ignore Player Groups (e.g. item links)
+                if slot_info.type == SlotType.group:
+                    continue
+                slots.add(Slot(data=patches.get(slot, None),
+                               player_name=slot_info.name,
+                               player_id=slot,
+                               game=slot_info.game))
 
             flush()  # commit slots
 

--- a/WebHostLib/upload.py
+++ b/WebHostLib/upload.py
@@ -24,7 +24,7 @@ def upload_zip_to_db(zfile: zipfile.ZipFile, owner=None, meta={"race": False}, s
     infolist = zfile.infolist()
     slots: typing.Set[Slot] = set()
     spoiler = ""
-    patches = {}
+    files = {}
     multidata = None
 
     # Load files.
@@ -39,7 +39,7 @@ def upload_zip_to_db(zfile: zipfile.ZipFile, owner=None, meta={"race": False}, s
             data = zfile.open(file, "r").read()
             patch = handler(BytesIO(data))
             patch.read()
-            patches[patch.player] = data
+            files[patch.player] = data
 
         # Spoiler
         elif file.filename.endswith(".txt"):
@@ -57,19 +57,19 @@ def upload_zip_to_db(zfile: zipfile.ZipFile, owner=None, meta={"race": False}, s
         elif file.filename.endswith(".apmc"):
             data = zfile.open(file, "r").read()
             metadata = json.loads(base64.b64decode(data).decode("utf-8"))
-            patches[metadata["player_id"]] = data
+            files[metadata["player_id"]] = data
 
         # Factorio
         elif file.filename.endswith(".zip"):
             _, _, slot_id, *_ = file.filename.split('_')[0].split('-', 3)
             data = zfile.open(file, "r").read()
-            patches[int(slot_id[1:])] = data
+            files[int(slot_id[1:])] = data
 
         # All other patch files using the standard MultiWorld.get_out_file_name_base method
         else:
             _, _, slot_id, *_ = file.filename.split('.')[0].split('_', 3)
             data = zfile.open(file, "r").read()
-            patches[int(slot_id[1:])] = data
+            files[int(slot_id[1:])] = data
 
     # Load multi data.
     if multidata:
@@ -79,7 +79,7 @@ def upload_zip_to_db(zfile: zipfile.ZipFile, owner=None, meta={"race": False}, s
                 # Ignore Player Groups (e.g. item links)
                 if slot_info.type == SlotType.group:
                     continue
-                slots.add(Slot(data=patches.get(slot, None),
+                slots.add(Slot(data=files.get(slot, None),
                                player_name=slot_info.name,
                                player_id=slot,
                                game=slot_info.game))

--- a/WebHostLib/upload.py
+++ b/WebHostLib/upload.py
@@ -50,14 +50,14 @@ def upload_zip_to_db(zfile: zipfile.ZipFile, owner=None, meta={"race": False}, s
         elif file.filename.endswith(".apv6"):
             # TODO: Don't omit the player name in Multiworld.get_out_file_name_base so this "fix" can be removed.
             _, seed_name, slot_id, *slot_name = file.filename.split('.')[0].split('_', 3)
-            slot_name = "".join(slot_name) or f"Player{slot_id[1:]}"
+            slot_name = slot_name[0] if slot_name else f"Player{slot_id[1:]}"
             slots.add(Slot(data=zfile.open(file, "r").read(), player_name=slot_name,
                            player_id=int(slot_id[1:]), game="VVVVVV"))
 
         elif file.filename.endswith(".apsm64ex"):
             # TODO: Don't omit the player name in Multiworld.get_out_file_name_base so this "fix" can be removed.
             _, seed_name, slot_id, *slot_name = file.filename.split('.')[0].split('_', 3)
-            slot_name = "".join(slot_name) or f"Player{slot_id[1:]}"
+            slot_name = slot_name[0] if slot_name else f"Player{slot_id[1:]}"
             slots.add(Slot(data=zfile.open(file, "r").read(), player_name=slot_name,
                            player_id=int(slot_id[1:]), game="Super Mario 64"))
 
@@ -65,7 +65,7 @@ def upload_zip_to_db(zfile: zipfile.ZipFile, owner=None, meta={"race": False}, s
             # Factorio mods need a specific name or they do not function
             # TODO: Don't omit the player name in Multiworld.get_out_file_name_base so this "fix" can be removed.
             _, seed_name, slot_id, *slot_name = file.filename.rsplit("_", 1)[0].split("-", 3)
-            slot_name = "".join(slot_name) or f"Player{slot_id[1:]}"
+            slot_name = slot_name[0] if slot_name else f"Player{slot_id[1:]}"
             slots.add(Slot(data=zfile.open(file, "r").read(), player_name=slot_name,
                            player_id=int(slot_id[1:]), game="Factorio"))
 
@@ -73,14 +73,14 @@ def upload_zip_to_db(zfile: zipfile.ZipFile, owner=None, meta={"race": False}, s
             # .apz5 must be named specifically since they don't contain any metadata
             # TODO: Don't omit the player name in Multiworld.get_out_file_name_base so this "fix" can be removed.
             _, seed_name, slot_id, *slot_name = file.filename.split('.')[0].split('_', 3)
-            slot_name = "".join(slot_name) or f"Player{slot_id[1:]}"
+            slot_name = slot_name[0] if slot_name else f"Player{slot_id[1:]}"
             slots.add(Slot(data=zfile.open(file, "r").read(), player_name=slot_name,
                            player_id=int(slot_id[1:]), game="Ocarina of Time"))
 
         elif file.filename.endswith(".json"):
             # TODO: Don't omit the player name in Multiworld.get_out_file_name_base so this "fix" can be removed.
             _, seed_name, slot_id, *slot_name = file.filename.split('.')[0].split('-', 3)
-            slot_name = "".join(slot_name) or f"Player{slot_id[1:]}"
+            slot_name = slot_name[0] if slot_name else f"Player{slot_id[1:]}"
             slots.add(Slot(data=zfile.open(file, "r").read(), player_name=slot_name,
                            player_id=int(slot_id[1:]), game="Dark Souls III"))
 

--- a/WebHostLib/upload.py
+++ b/WebHostLib/upload.py
@@ -48,29 +48,39 @@ def upload_zip_to_db(zfile: zipfile.ZipFile, owner=None, meta={"race": False}, s
                            game="Minecraft"))
 
         elif file.filename.endswith(".apv6"):
-            _, seed_name, slot_id, slot_name = file.filename.split('.')[0].split('_', 3)
+            # TODO: Don't omit the player name in Multiworld.get_out_file_name_base so this "fix" can be removed.
+            _, seed_name, slot_id, *slot_name = file.filename.split('.')[0].split('_', 3)
+            slot_name = "".join(slot_name) or f"Player{slot_id[1:]}"
             slots.add(Slot(data=zfile.open(file, "r").read(), player_name=slot_name,
                            player_id=int(slot_id[1:]), game="VVVVVV"))
 
         elif file.filename.endswith(".apsm64ex"):
-            _, seed_name, slot_id, slot_name = file.filename.split('.')[0].split('_', 3)
+            # TODO: Don't omit the player name in Multiworld.get_out_file_name_base so this "fix" can be removed.
+            _, seed_name, slot_id, *slot_name = file.filename.split('.')[0].split('_', 3)
+            slot_name = "".join(slot_name) or f"Player{slot_id[1:]}"
             slots.add(Slot(data=zfile.open(file, "r").read(), player_name=slot_name,
                            player_id=int(slot_id[1:]), game="Super Mario 64"))
 
         elif file.filename.endswith(".zip"):
             # Factorio mods need a specific name or they do not function
-            _, seed_name, slot_id, slot_name = file.filename.rsplit("_", 1)[0].split("-", 3)
+            # TODO: Don't omit the player name in Multiworld.get_out_file_name_base so this "fix" can be removed.
+            _, seed_name, slot_id, *slot_name = file.filename.rsplit("_", 1)[0].split("-", 3)
+            slot_name = "".join(slot_name) or f"Player{slot_id[1:]}"
             slots.add(Slot(data=zfile.open(file, "r").read(), player_name=slot_name,
                            player_id=int(slot_id[1:]), game="Factorio"))
 
         elif file.filename.endswith(".apz5"):
             # .apz5 must be named specifically since they don't contain any metadata
-            _, seed_name, slot_id, slot_name = file.filename.split('.')[0].split('_', 3)
+            # TODO: Don't omit the player name in Multiworld.get_out_file_name_base so this "fix" can be removed.
+            _, seed_name, slot_id, *slot_name = file.filename.split('.')[0].split('_', 3)
+            slot_name = "".join(slot_name) or f"Player{slot_id[1:]}"
             slots.add(Slot(data=zfile.open(file, "r").read(), player_name=slot_name,
                            player_id=int(slot_id[1:]), game="Ocarina of Time"))
 
         elif file.filename.endswith(".json"):
-            _, seed_name, slot_id, slot_name = file.filename.split('.')[0].split('-', 3)
+            # TODO: Don't omit the player name in Multiworld.get_out_file_name_base so this "fix" can be removed.
+            _, seed_name, slot_id, *slot_name = file.filename.split('.')[0].split('-', 3)
+            slot_name = "".join(slot_name) or f"Player{slot_id[1:]}"
             slots.add(Slot(data=zfile.open(file, "r").read(), player_name=slot_name,
                            player_id=int(slot_id[1:]), game="Dark Souls III"))
 


### PR DESCRIPTION
There is a method in BaseClasses.py: `MultiWorld.get_out_file_name_base` that does not append the player name to the final patch output file if the player name matches the format: `Player{slot_number}`. This does cause any issues in Generation or even when running the Server, but during upload in WebHost, WebHost tries to search for the player name in the file name and fails to do so, causing a 500 error.

![image](https://user-images.githubusercontent.com/11338376/202915845-3cf2e0e2-e5e2-471a-bae4-60ccb93d81f6.png)
```
Traceback (most recent call last):
  File "C:\Users\Phar\Projects\Archipelago\.venv\lib\site-packages\flask\app.py", line 2525, in wsgi_app
    response = self.full_dispatch_request()
  File "C:\Users\Phar\Projects\Archipelago\.venv\lib\site-packages\flask\app.py", line 1822, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "C:\Users\Phar\Projects\Archipelago\.venv\lib\site-packages\flask\app.py", line 1820, in full_dispatch_request
    rv = self.dispatch_request()
  File "C:\Users\Phar\Projects\Archipelago\.venv\lib\site-packages\flask\app.py", line 1796, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "C:\Users\Phar\Projects\Archipelago\WebHostLib\upload.py", line 127, in uploads
    res = upload_zip_to_db(zfile)
  File "C:\Users\Phar\Projects\Archipelago\WebHostLib\upload.py", line 56, in upload_zip_to_db
    _, seed_name, slot_id, slot_name = file.filename.split('.')[0].split('_', 3)
ValueError: not enough values to unpack (expected 4, got 3)
```

~~The permanent solution is to adjust `MultiWorld.get_out_file_name_base` to always add that information (or even better, move away from having slot info in the name and using the AP container format pls), but those solutions will require a new generator client to be sent out if anyone is rolling locally which may be a pain since 0.3.6 just came out.~~

~~This is a temporary solution to allow a quick hot-patch to the WebHost to infer the name based on player number if it's missing in the file name of the patch file, so if anyone is generating using an old generator, it can still upload without the 500 error.~~

~~This "hot-fix" portions should be removed before next release as the issue should be completely solved from the adjustment to `MultiWorld.get_out_file_name_base`.~~

**Edit**: While working on this, I found a better solution that will also fix another issue referenced in this discord thread: https://discord.com/channels/731205301247803413/1043915360220479528

In addition to the change in `MultiWorld.get_out_file_name_base`, I've also refactored the `upload_zip_to_db` function with the following algorithm changes:

First, it still goes through all the files and if any patch files are present, but it will pull only the slot number from the file name (since that wasn't affected by the earlier issue), and adds the read patch data to a dict for later. Once all the files are read, the multidata is decompressed and loaded, it will then go through each slot and create a slot with the information in the multidata. If a slot has a patch file in the patches dict, it will link them together in this stage.

Since most games use the `MultiWorld.get_out_file_name_base` function, I've also removed the duplicated code and just have a final else clause for parsing that data. The only exceptions are Minecraft and Factorio because their file naming conventions are slightly different, but hopefully they can be removed once moved to an AP container format.

## What is this fixing or adding?
See giant wall of text above.

## How was this tested?
Ran a few test generations on release 0.3.6 with the issue present. Then uploaded the output to WebHost and confirmed it no longer fails to parse player names from the file name if it is missing, and creates the room without issue.

See attached files for example .zips that would fail on 0.3.6, but no longer fail on this PR's WebHost.

[AP_59550798954284179230.zip](https://github.com/ArchipelagoMW/Archipelago/files/10050289/AP_59550798954284179230.zip) [ Single SM64 ]
[AP_24891978875502332646.zip](https://github.com/ArchipelagoMW/Archipelago/files/10050290/AP_24891978875502332646.zip) [ Multiple Patch File Worlds ]
[AP_32681958483069524592.zip](https://github.com/ArchipelagoMW/Archipelago/files/10050481/AP_32681958483069524592.zip) [ Weird Naming ]
[AP_79957322348280977406.zip](https://github.com/ArchipelagoMW/Archipelago/files/10050502/AP_79957322348280977406.zip) [ Item Links ]

## If this makes graphical changes, please attach screenshots.
N/A
