### PR TITLE
Created the Dark Souls 3 client, with the /id [locationName] command

### DIFF
--- a/DarkSouls3Client.py
+++ b/DarkSouls3Client.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import asyncio
+import copy
+import ctypes
+import logging
+import multiprocessing
+import os.path
+import re
+import sys
+import typing
+import queue
+from pathlib import Path
+
+# CommonClient import first to trigger ModuleUpdater
+from CommonClient import CommonContext, server_loop, ClientCommandProcessor, gui_enabled, get_base_parser
+from MultiServer import mark_raw
+from Utils import init_logging, is_windows
+
+if __name__ == "__main__":
+    init_logging("DarkSoulsClient", exception_logger="Client")
+
+logger = logging.getLogger("Client")
+darksouls_logger = logging.getLogger("DarkSouls3")
+
+import nest_asyncio
+import colorama
+from NetUtils import RawJSONtoTextParser
+from worlds import network_data_package
+
+nest_asyncio.apply()
+max_bonus: int = 8
+victory_modulo: int = 100
+
+
+class DarkSouls3ClientProcessor(ClientCommandProcessor):
+    ctx: DS3Context
+
+    @mark_raw
+    def _cmd_id(self, name: str = "") -> bool:
+        """Gets the id of a specific location on the current client version"""
+        ds3_game = network_data_package["games"]["Dark Souls III"]
+        ds3_location_ids = ds3_game["location_name_to_id"]
+        ds3_item_ids = ds3_game["item_name_to_id"]
+
+        if name in ds3_location_ids:
+            id = ds3_location_ids[name]
+            self.output(name + " is a location with ID [" + str(id) + "] on the current version")
+            return True
+
+        if name in ds3_item_ids:
+            id = ds3_item_ids[name]
+            self.output(name + " is an item with ID [" + str(id) + "] on the current version")
+            return True
+
+        self.output("Could not find a location or item by the name of '" + name + "'")
+        return False
+
+
+class DS3Context(CommonContext):
+    command_processor = DarkSouls3ClientProcessor
+    game = "Dark Souls III"
+
+    def __init__(self, *args, **kwargs):
+        super(DS3Context, self).__init__(*args, **kwargs)
+        self.raw_text_parser = RawJSONtoTextParser(self)
+
+    async def server_auth(self, password_requested: bool = False):
+        if password_requested and not self.password:
+            await super(DS3Context, self).server_auth(password_requested)
+        await self.get_username()
+        await self.send_connect()
+
+    def run_gui(self):
+        super(DS3Context, self).run_gui()
+        self.ui.base_title = "Archipelago Dark Souls III Client"
+
+
+async def main():
+    multiprocessing.freeze_support()
+    parser = get_base_parser()
+    parser.add_argument('--name', default=None, help="Slot Name to connect as.")
+    args = parser.parse_args()
+
+    ctx = DS3Context(args.connect, args.password)
+    ctx.auth = args.name
+    if ctx.server_task is None:
+        ctx.server_task = asyncio.create_task(server_loop(ctx), name="ServerLoop")
+
+    if gui_enabled:
+        ctx.run_gui()
+    ctx.run_cli()
+
+    await ctx.exit_event.wait()
+
+    await ctx.shutdown()
+
+
+if __name__ == '__main__':
+    colorama.init()
+    asyncio.run(main())
+    colorama.deinit()

--- a/Launcher.py
+++ b/Launcher.py
@@ -151,6 +151,8 @@ components: Iterable[Component] = (
     Component('ChecksFinder Client', 'ChecksFinderClient'),
     # Starcraft 2
     Component('Starcraft 2 Client', 'Starcraft2Client'),
+    # Dark Souls III
+    Component('Dark Souls III Client', 'DarkSouls3Client'),
     # Zillion
     Component('Zillion Client', 'ZillionClient',
               file_identifier=SuffixIdentifier('.apzl')),

--- a/inno_setup.iss
+++ b/inno_setup.iss
@@ -78,6 +78,7 @@ Name: "client/pkmn/red";  Description: "Pokemon Client - Pokemon Red Setup"; Typ
 Name: "client/pkmn/blue"; Description: "Pokemon Client - Pokemon Blue Setup"; Types: full playing; ExtraDiskSpaceRequired: 1048576
 Name: "client/cf";        Description: "ChecksFinder"; Types: full playing
 Name: "client/sc2";       Description: "Starcraft 2"; Types: full playing
+Name: "client/ds3";       Description: "Dark Souls 3"; Types: full playing
 Name: "client/zl";        Description: "Zillion"; Types: full playing
 Name: "client/text";      Description: "Text, to !command and chat"; Types: full playing
 
@@ -112,6 +113,7 @@ Source: "{#source_path}\ArchipelagoFF1Client.exe"; DestDir: "{app}"; Flags: igno
 Source: "{#source_path}\ArchipelagoPokemonClient.exe"; DestDir: "{app}"; Flags: ignoreversion; Components: client/pkmn
 Source: "{#source_path}\ArchipelagoChecksFinderClient.exe"; DestDir: "{app}"; Flags: ignoreversion; Components: client/cf
 Source: "{#source_path}\ArchipelagoStarcraft2Client.exe"; DestDir: "{app}"; Flags: ignoreversion; Components: client/sc2
+Source: "{#source_path}\ArchipelagoDarkSouls3Client.exe"; DestDir: "{app}"; Flags: ignoreversion; Components: client/ds3
 Source: "vc_redist.x64.exe"; DestDir: {tmp}; Flags: deleteafterinstall
 
 [Icons]
@@ -127,6 +129,7 @@ Name: "{group}\{#MyAppName} Final Fantasy 1 Client"; Filename: "{app}\Archipelag
 Name: "{group}\{#MyAppName} Pokemon Client"; Filename: "{app}\ArchipelagoPokemonClient.exe"; Components: client/pkmn
 Name: "{group}\{#MyAppName} ChecksFinder Client"; Filename: "{app}\ArchipelagoChecksFinderClient.exe"; Components: client/cf
 Name: "{group}\{#MyAppName} Starcraft 2 Client"; Filename: "{app}\ArchipelagoStarcraft2Client.exe"; Components: client/sc2
+Name: "{group}\{#MyAppName} Dark Souls III Client"; Filename: "{app}\DarkSouls3Client.exe"; Components: client/ds3
 
 Name: "{commondesktop}\{#MyAppName} Folder"; Filename: "{app}"; Tasks: desktopicon
 Name: "{commondesktop}\{#MyAppName} Server"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon; Components: server
@@ -139,6 +142,7 @@ Name: "{commondesktop}\{#MyAppName} Final Fantasy 1 Client"; Filename: "{app}\Ar
 Name: "{commondesktop}\{#MyAppName} Pokemon Client"; Filename: "{app}\ArchipelagoPokemonClient.exe"; Tasks: desktopicon; Components: client/pkmn
 Name: "{commondesktop}\{#MyAppName} ChecksFinder Client"; Filename: "{app}\ArchipelagoChecksFinderClient.exe"; Tasks: desktopicon; Components: client/cf
 Name: "{commondesktop}\{#MyAppName} Starcraft 2 Client"; Filename: "{app}\ArchipelagoStarcraft2Client.exe"; Tasks: desktopicon; Components: client/sc2
+Name: "{commondesktop}\{#MyAppName} Dark Souls III Client"; Filename: "{app}\ArchipelagoDarkSouls3Client.exe"; Tasks: desktopicon; Components: client/ds3
 
 [Run]
 

--- a/inno_setup.iss
+++ b/inno_setup.iss
@@ -129,7 +129,7 @@ Name: "{group}\{#MyAppName} Final Fantasy 1 Client"; Filename: "{app}\Archipelag
 Name: "{group}\{#MyAppName} Pokemon Client"; Filename: "{app}\ArchipelagoPokemonClient.exe"; Components: client/pkmn
 Name: "{group}\{#MyAppName} ChecksFinder Client"; Filename: "{app}\ArchipelagoChecksFinderClient.exe"; Components: client/cf
 Name: "{group}\{#MyAppName} Starcraft 2 Client"; Filename: "{app}\ArchipelagoStarcraft2Client.exe"; Components: client/sc2
-Name: "{group}\{#MyAppName} Dark Souls III Client"; Filename: "{app}\DarkSouls3Client.exe"; Components: client/ds3
+Name: "{group}\{#MyAppName} Dark Souls III Client"; Filename: "{app}\ArchipelagoDarkSouls3Client.exe"; Components: client/ds3
 
 Name: "{commondesktop}\{#MyAppName} Folder"; Filename: "{app}"; Tasks: desktopicon
 Name: "{commondesktop}\{#MyAppName} Server"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon; Components: server


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "Dark Souls 3: Added a TextClient and an /id command"

## What is this fixing or adding?
The goal of this commit is to add a DarkSoulsClient, which has only the purpose of allowing a user to type /id [name] to get the id of a location or item.
This is because in the latest release, Dark Souls 3 ids have changed. For web-site hosted games that were started on 0.3.5, this means that !hints are now broken.
![image](https://user-images.githubusercontent.com/16685738/202918943-9639fdde-72bc-4db1-b345-dd25fa41b6e8.png)

Some hints will point to the wrong item, and some will provide an id that points to nothing, and only appear as the integer id.
While local id to item mapping can be done using the ds3 installation (there is a json file that helps with that), when the ID maps to an existing item which is not the correct one, there is no easy way to figure out what ID this is supposed to be in other to convert it to a 0.3.5 name.

The new /id command will allow you to map a 0.3.6 name to a 0.3.6 ID, in order to figure out what the ID **should** be, and then map it back to a 0.3.5 name.

While the use case is somewhat limited, the command itself can be useful in the future when any ID-related problems, either through bugs or user error, happen.

## How was this tested?
As this is only a TextClient with no interaction with generation, hosting, or gameplay, only the existing tests have been run, and the client itself has been manually tested.

## If this makes graphical changes, please attach screenshots.
No graphical changes, but here is a screenshot of the command in action
![image](https://user-images.githubusercontent.com/16685738/202919158-407c279b-c16d-4225-a8dc-6bb7073700a1.png)
