### PR TITLE
Core: default distribute Factorio and Subnautica as .apworld

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,7 @@ Output Logs/
 /freeze_requirements.txt
 /Archipelago.zip
 /setup.ini
-
+/installdelete.iss
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/inno_setup.iss
+++ b/inno_setup.iss
@@ -152,6 +152,7 @@ Type: dirifempty; Name: "{app}"
 [InstallDelete]
 Type: files; Name: "{app}\ArchipelagoLttPClient.exe"
 Type: filesandordirs; Name: "{app}\lib\worlds\rogue-legacy*"
+#include "installdelete.iss"
 
 [Registry]
 

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ import shutil
 import sys
 import sysconfig
 import platform
+import zipfile
 from pathlib import Path
 from hashlib import sha3_512
 import base64
@@ -13,6 +14,11 @@ import typing
 import setuptools
 from Launcher import components, icon_paths
 
+
+apworlds: set = {
+    "Subnautica",
+    "Factorio",
+}
 
 # This is a bit jank. We need cx-Freeze to be able to run anything from this script, so install it
 import subprocess
@@ -185,11 +191,26 @@ class BuildExeCommand(cx_Freeze.command.build_exe.BuildEXE):
         from WebHostLib.options import create
         create()
         from worlds.AutoWorld import AutoWorldRegister
+        assert not apworlds - set(AutoWorldRegister.world_types), "Unknown world designated for .apworld"
+        folders_to_remove: typing.List[str] = []
         for worldname, worldtype in AutoWorldRegister.world_types.items():
             if not worldtype.hidden:
                 file_name = worldname+".yaml"
                 shutil.copyfile(os.path.join("WebHostLib", "static", "generated", "configs", file_name),
                                 self.buildfolder / "Players" / "Templates" / file_name)
+            if worldname in apworlds:
+                file_name = os.path.split(os.path.dirname(worldtype.__file__))[1]
+                world_directory = self.libfolder / "worlds" / file_name
+                # this method creates an apworld that cannot be moved to a different OS or minor python version,
+                # which should be ok
+                with zipfile.ZipFile(self.libfolder / "worlds" / (file_name + ".apworld"), "x", zipfile.ZIP_DEFLATED,
+                                     compresslevel=9) as zf:
+                    entry: os.DirEntry
+                    for path in world_directory.rglob("*.*"):
+                        relative_path = os.path.join(*path.parts[path.parts.index("worlds")+1:])
+                        zf.write(path, relative_path)
+                    folders_to_remove.append(file_name)
+                shutil.rmtree(world_directory)
         shutil.copyfile("meta.yaml", self.buildfolder / "Players" / "Templates" / "meta.yaml")
         # TODO: fix LttP options one day
         shutil.copyfile("playerSettings.yaml", self.buildfolder / "Players" / "Templates" / "A Link to the Past.yaml")
@@ -218,9 +239,13 @@ class BuildExeCommand(cx_Freeze.command.build_exe.BuildEXE):
         self.create_manifest()
 
         if is_windows:
+            # Inno setup stuff
             with open("setup.ini", "w") as f:
                 min_supported_windows = "6.2.9200" if sys.version_info > (3, 9) else "6.0.6000"
                 f.write(f"[Data]\nsource_path={self.buildfolder}\nmin_windows={min_supported_windows}\n")
+            with open("installdelete.iss", "w") as f:
+                f.writelines("Type: filesandordirs; Name: \"{app}\\lib\\worlds\\"+world_directory+"\"\n"
+                             for world_directory in folders_to_remove)
         else:
             # make sure extra programs are executable
             enemizer_exe = self.buildfolder / 'EnemizerCLI/EnemizerCLI.Core'


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?
distribute Factorio and Subnautica as .apworld

## How was this tested?
on py 3.10 win10 through to launching an inno installed AP

## If this makes graphical changes, please attach screenshots.
