### PR TITLE
Sudoku, Docs: Updated text about duplicated hints

### DIFF
--- a/worlds/bk_sudoku/docs/en_Sudoku.md
+++ b/worlds/bk_sudoku/docs/en_Sudoku.md
@@ -6,7 +6,7 @@ BK Sudoku is not a typical Archipelago game; instead, it is a generic Sudoku cli
 
 ## What hints are unlocked?
 
-After completing a Sudoku puzzle, the game will unlock 1 random hint for an unchecked location in the slot you are connected to. It is possible to hint the same location repeatedly if that location is still unchecked.
+After completing a Sudoku puzzle, the game will unlock 1 random hint for an unchecked location in the slot you are connected to. It is possible to hint a location that was previously hinted for using the !hint command.
 
 ## Where is the settings page?
 


### PR DESCRIPTION
## What is this fixing or adding?
Updating the Sudoku docs to specify it will nolonger hint the same location multiple times

## How was this tested?
Just checked the .md file in github for style and spelling mistakes