### PR TITLE
Network: implement read_only datastore keys: hints and slot_data

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -134,6 +134,7 @@ class CommonContext:
     tags: typing.Set[str] = {"AP"}
     game: typing.Optional[str] = None
     items_handling: typing.Optional[int] = None
+    want_slot_data: bool = True  # should slot_data be retrieved via Connect
 
     # datapackage
     # Contents in flux until connection to server is made, to download correct data for this multiworld.
@@ -309,7 +310,7 @@ class CommonContext:
             'cmd': 'Connect',
             'password': self.password, 'name': self.auth, 'version': Utils.version_tuple,
             'tags': self.tags, 'items_handling': self.items_handling,
-            'uuid': Utils.get_unique_identifier(), 'game': self.game
+            'uuid': Utils.get_unique_identifier(), 'game': self.game, "slot_data": self.want_slot_data,
         }
         if kwargs:
             payload.update(kwargs)
@@ -801,6 +802,7 @@ if __name__ == '__main__':
         tags = {"AP", "IgnoreGame", "TextOnly"}
         game = ""  # empty matches any game since 0.3.2
         items_handling = 0b111  # receive all items for /received
+        want_slot_data = False  # Can't use game specific slot_data
 
         async def server_auth(self, password_requested: bool = False):
             if password_requested and not self.password:

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1719,7 +1719,7 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
             args["cmd"] = "Retrieved"
             keys = args["keys"]
             args["keys"] = {
-                key: ctx.read_data.get(key[5:], lambda: None)() if key.startswith("_read") else
+                key: ctx.read_data.get(key[6:], lambda: None)() if key.startswith("_read_") else
                      ctx.stored_data.get(key, None)
                 for key in keys
             }

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -598,7 +598,7 @@ class Context:
     def notify_hints(self, team: int, hints: typing.List[NetUtils.Hint], only_new: bool = False):
         """Send and remember hints."""
         if only_new:
-            hints = [hint for hint in hints if hint not in ctx.hints[team, hint.finding_player]]
+            hints = [hint for hint in hints if hint not in self.hints[team, hint.finding_player]]
         if not hints:
             return
         new_hint_events: typing.Set[int] = set()

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -646,7 +646,7 @@ class Context:
         self.save()  # save goal completion flag
 
     def on_new_hint(self, team: int, slot: int):
-        key: str = f"hints_{team}_{slot}"
+        key: str = f"_read_hints_{team}_{slot}"
         targets: typing.Set[Client] = set(self.stored_data_notification_clients[key])
         if targets:
             self.broadcast(targets, [{"cmd": "SetReply", "key": key, "value": self.hints[team, slot]}])

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -361,7 +361,7 @@ class Context:
                 self.clients[team][player] = []
                 self.player_names[team, player] = name
                 self.player_name_lookup[name] = team, player
-                self.read_data[f"_hints_{team}_{player}"] = lambda local_team=team, local_player=player: \
+                self.read_data[f"hints_{team}_{player}"] = lambda local_team=team, local_player=player: \
                     list(self.get_rechecked_hints(local_team, local_player))
         self.seed_name = decoded_obj["seed_name"]
         self.random.seed(self.seed_name)

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -646,7 +646,7 @@ class Context:
         self.save()  # save goal completion flag
 
     def on_new_hint(self, team: int, slot: int):
-        key: str = f"_send_{team}_{slot}"
+        key: str = f"hints_{team}_{slot}"
         targets: typing.Set[Client] = set(self.stored_data_notification_clients[key])
         if targets:
             self.broadcast(targets, [{"cmd": "SetReply", "key": key, "value": self.hints[team, slot]}])

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1726,7 +1726,7 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
             await ctx.send_msgs(client, [args])
 
         elif cmd == "Set":
-            if "key" not in args or args["key"].startswith("_read") or \
+            if "key" not in args or args["key"].startswith("_read_") or \
                     "operations" not in args or not type(args["operations"]) == list:
                 await ctx.send_msgs(client, [{'cmd': 'InvalidPacket', "type": "arguments",
                                               "text": 'Set', "original_cmd": cmd}])

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -371,7 +371,7 @@ class Context:
         self.locations = decoded_obj['locations']
         self.slot_data = decoded_obj['slot_data']
         for slot, data in self.slot_data.items():
-            self.read_data["_slot_data"] = lambda: data
+            self.read_data[f"slot_data_{slot}"] = lambda data=data: data
         self.er_hint_data = {int(player): {int(address): name for address, name in loc_data.items()}
                              for player, loc_data in decoded_obj["er_hint_data"].items()}
 

--- a/Utils.py
+++ b/Utils.py
@@ -677,7 +677,7 @@ def read_snes_rom(stream: BinaryIO, strip_header: bool = True) -> bytearray:
 _faf_tasks: "Set[asyncio.Task[None]]" = set()
 
 
-def async_start(co: Coroutine[None, None, None], name: Optional[str] = None) -> None:
+def async_start(co: Coroutine[typing.Any, typing.Any, bool], name: Optional[str] = None) -> None:
     """
     Use this to start a task when you don't keep a reference to it or immediately await it,
     to prevent early garbage collection. "fire-and-forget"

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -242,11 +242,11 @@ Additional arguments added to the [Get](#Get) package that triggered this [Retri
 ### SetReply
 Sent to clients in response to a [Set](#Set) package if want_reply was set to true, or if the client has registered to receive updates for a certain key using the [SetNotify](#SetNotify) package. SetReply packages are sent even if a [Set](#Set) package did not alter the value for the key.
 #### Arguments
-| Name | Type | Notes |
-| ---- | ---- | ----- |
-| key | str | The key that was updated. |
-| value | any | The new value for the key. |
-| original_value | any | The value the key had before it was updated. |
+| Name           | Type | Notes                                                                                      |
+|----------------|------|--------------------------------------------------------------------------------------------|
+| key            | str  | The key that was updated.                                                                  |
+| value          | any  | The new value for the key.                                                                 |
+| original_value | any  | The value the key had before it was updated. Not present on "_read" prefixed special keys. |
 
 Additional arguments added to the [Set](#Set) package that triggered this [SetReply](#SetReply) will also be passed along.
 

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -121,15 +121,15 @@ InvalidItemsHandling indicates a wrong value type or flag combination was sent.
 ### Connected
 Sent to clients when the connection handshake is successfully completed.
 #### Arguments
-| Name | Type | Notes |
-| ---- | ---- | ----- |
-| team | int | Your team number. See [NetworkPlayer](#NetworkPlayer) for more info on team number. |
-| slot | int | Your slot number on your team. See [NetworkPlayer](#NetworkPlayer) for more info on the slot number. |
-| players | list\[[NetworkPlayer](#NetworkPlayer)\] | List denoting other players in the multiworld, whether connected or not. |
-| missing_locations | list\[int\] | Contains ids of remaining locations that need to be checked. Useful for trackers, among other things. |
-| checked_locations | list\[int\] | Contains ids of all locations that have been checked. Useful for trackers, among other things. Location ids are in the range of ± 2<sup>53</sup>-1. |
-| slot_data | dict | Contains a json object for slot related data, differs per game. Empty if not required. |
-| slot_info | dict\[int, [NetworkSlot](#NetworkSlot)\] | maps each slot to a [NetworkSlot](#NetworkSlot) information |
+| Name              | Type                                     | Notes                                                                                                                                               |
+|-------------------|------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| team              | int                                      | Your team number. See [NetworkPlayer](#NetworkPlayer) for more info on team number.                                                                 |
+| slot              | int                                      | Your slot number on your team. See [NetworkPlayer](#NetworkPlayer) for more info on the slot number.                                                |
+| players           | list\[[NetworkPlayer](#NetworkPlayer)\]  | List denoting other players in the multiworld, whether connected or not.                                                                            |
+| missing_locations | list\[int\]                              | Contains ids of remaining locations that need to be checked. Useful for trackers, among other things.                                               |
+| checked_locations | list\[int\]                              | Contains ids of all locations that have been checked. Useful for trackers, among other things. Location ids are in the range of ± 2<sup>53</sup>-1. |
+| slot_data         | dict                                     | Contains a json object for slot related data, differs per game. Empty if not required. Not present if slot_data in [Connect](#Connect) is false.    |
+| slot_info         | dict\[int, [NetworkSlot](#NetworkSlot)\] | maps each slot to a [NetworkSlot](#NetworkSlot) information                                                                                         |
 
 ### ReceivedItems
 Sent to clients when they receive an item.
@@ -269,15 +269,16 @@ These packets are sent purely from client to server. They are not accepted by cl
 Sent by the client to initiate a connection to an Archipelago game session.
 
 #### Arguments
-| Name | Type | Notes |
-| ---- | ---- | ----- |
-| password | str | If the game session requires a password, it should be passed here. |
-| game | str | The name of the game the client is playing. Example: `A Link to the Past` |
-| name | str | The player name for this client. |
-| uuid | str | Unique identifier for player client. |
-| version | [NetworkVersion](#NetworkVersion) | An object representing the Archipelago version this client supports. |
-| items_handling | int | Flags configuring which items should be sent by the server. Read below for individual flags. |
-| tags | list\[str\] | Denotes special features or capabilities that the sender is capable of. [Tags](#Tags) |
+| Name           | Type                              | Notes                                                                                        |
+|----------------|-----------------------------------|----------------------------------------------------------------------------------------------|
+| password       | str                               | If the game session requires a password, it should be passed here.                           |
+| game           | str                               | The name of the game the client is playing. Example: `A Link to the Past`                    |
+| name           | str                               | The player name for this client.                                                             |
+| uuid           | str                               | Unique identifier for player client.                                                         |
+| version        | [NetworkVersion](#NetworkVersion) | An object representing the Archipelago version this client supports.                         |
+| items_handling | int                               | Flags configuring which items should be sent by the server. Read below for individual flags. |
+| tags           | list\[str\]                       | Denotes special features or capabilities that the sender is capable of. [Tags](#Tags)        |
+| slot_data      | bool                              | If true, the Connect answer will contain slot_data                                           |
 
 #### items_handling flags
 | Value | Meaning |
@@ -366,15 +367,22 @@ Used to request a single or multiple values from the server's data storage, see 
 | keys | list\[str\] | Keys to retrieve the values for. |
 
 Additional arguments sent in this package will also be added to the [Retrieved](#Retrieved) package it triggers.
+Some special keys exist with specific return data:
+
+| Name                       | Type         | Notes                                        |
+|----------------------------|--------------|----------------------------------------------|
+| \_read_hints_{team}_{slot} | list\[Hint\] | All Hints belonging to the requested Player. |
+| \_read_slot_data_{slot]    | any          | slot_data belonging to the requested slot.   |
+
 
 ### Set
 Used to write data to the server's data storage, that data can then be shared across worlds or just saved for later. Values for keys in the data storage can be retrieved with a [Get](#Get) package, or monitored with a [SetNotify](#SetNotify) package.
 #### Arguments
-| Name | Type | Notes |
-| ------ | ----- | ------ |
-| key | str | The key to manipulate. |
-| default | any | The default value to use in case the key has no value on the server. |
-| want_reply | bool | If true, the server will send a [SetReply](#SetReply) response back to the client. |
+| Name       | Type                                                  | Notes                                                                                                                  |
+|------------|-------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|
+| key        | str                                                   | The key to manipulate. Can never start with "_read".                                                                   |
+| default    | any                                                   | The default value to use in case the key has no value on the server.                                                   |
+| want_reply | bool                                                  | If true, the server will send a [SetReply](#SetReply) response back to the client.                                     |
 | operations | list\[[DataStorageOperation](#DataStorageOperation)\] | Operations to apply to the value, multiple operations can be present and they will be executed in order of appearance. |
 
 Additional arguments sent in this package will also be added to the [SetReply](#SetReply) package it triggers.

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -372,7 +372,7 @@ Some special keys exist with specific return data:
 | Name                       | Type                  | Notes                                        |
 |----------------------------|-----------------------|----------------------------------------------|
 | \_read_hints_{team}_{slot} | list\[[Hint](#Hint)\] | All Hints belonging to the requested Player. |
-| \_read_slot_data_{slot]    | any                   | slot_data belonging to the requested slot.   |
+| \_read_slot_data_{slot}    | any                   | slot_data belonging to the requested slot.   |
 
 
 ### Set

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -369,10 +369,10 @@ Used to request a single or multiple values from the server's data storage, see 
 Additional arguments sent in this package will also be added to the [Retrieved](#Retrieved) package it triggers.
 Some special keys exist with specific return data:
 
-| Name                       | Type         | Notes                                        |
-|----------------------------|--------------|----------------------------------------------|
-| \_read_hints_{team}_{slot} | list\[Hint\] | All Hints belonging to the requested Player. |
-| \_read_slot_data_{slot]    | any          | slot_data belonging to the requested slot.   |
+| Name                       | Type                  | Notes                                        |
+|----------------------------|-----------------------|----------------------------------------------|
+| \_read_hints_{team}_{slot} | list\[[Hint](#Hint)\] | All Hints belonging to the requested Player. |
+| \_read_slot_data_{slot]    | any                   | slot_data belonging to the requested slot.   |
 
 
 ### Set
@@ -597,6 +597,20 @@ class Permission(enum.IntEnum):
     goal = 0b010  # 2, allows manual use after goal completion
     auto = 0b110  # 6, forces use after goal completion, only works for forfeit and collect
     auto_enabled = 0b111  # 7, forces use after goal completion, allows manual use any time
+```
+
+### Hint
+An object representing a Hint.
+```python
+import typing
+class Hint(typing.NamedTuple):
+    receiving_player: int
+    finding_player: int
+    location: int
+    item: int
+    found: bool
+    entrance: str = ""
+    item_flags: int = 0
 ```
 
 ### Data Package Contents


### PR DESCRIPTION
## What is this fixing or adding?
implements _read prefixed datastore keys that can dynamically answer.
This implements  
 * `_read_hints_{team}_{slot}` to get hints of that player
 * `_read_slot_data_{slot}` to get slot_data of that slot

slot_data is now optional. In practice I've seen it be used sometimes only for a client or only for a tracker.
TextClient now skips slot_data download.

## How was this tested?
A bit, with stuff like `asyncio.create_task(self.send_msgs([{"cmd": "Get", "keys": [f"_read_hints_{self.team}_{self.slot}"]}]))` in an on_package callback.
Which returned:
`{'cmd': 'Retrieved', 'keys': {'_read_hints_0_1': [{'receiving_player': 8, 'finding_player': 3, 'location': 91948, 'item': 1604, 'found': False, 'entrance': '', 'item_flags': 2, 'class': 'Hint'}, {'receiving_player': 9, 'finding_player': 1, 'location': 2202, 'item': 1604, 'found': False, 'entrance': '', 'item_flags': 2, 'class': 'Hint'}]}}`

## If this makes graphical changes, please attach screenshots.
