### PR TITLE
Hylics 2: fix beatability failures

### DIFF
--- a/worlds/hylics2/__init__.py
+++ b/worlds/hylics2/__init__.py
@@ -76,14 +76,6 @@ class Hylics2World(World):
                 self.start_location = "Shield Facility"
 
     def generate_basic(self):
-        # create location for beating the game and place Victory event there
-        loc = Location(self.player, "Defeat Gibby", None, self.multiworld.get_region("Hylemxylem", self.player))
-        loc.place_locked_item(self.create_event("Victory"))
-        set_rule(loc, lambda state: state._hylics2_has_upper_chamber_key(self.player)
-            and state._hylics2_has_vessel_room_key(self.player))
-        self.multiworld.get_region("Hylemxylem", self.player).locations.append(loc)
-        self.multiworld.completion_condition[self.player] = lambda state: state.has("Victory", self.player)
-
         # create item pool
         pool = []
         
@@ -236,6 +228,14 @@ class Hylics2World(World):
             for i, data in Locations.medallion_location_table.items():
                 region_table[data["region"]].locations\
                     .append(Hylics2Location(self.player, data["name"], i, region_table[data["region"]]))
+
+        # create location for beating the game and place Victory event there
+        loc = Location(self.player, "Defeat Gibby", None, self.multiworld.get_region("Hylemxylem", self.player))
+        loc.place_locked_item(self.create_event("Victory"))
+        set_rule(loc, lambda state: state._hylics2_has_upper_chamber_key(self.player)
+            and state._hylics2_has_vessel_room_key(self.player))
+        self.multiworld.get_region("Hylemxylem", self.player).locations.append(loc)
+        self.multiworld.completion_condition[self.player] = lambda state: state.has("Victory", self.player)
 
 
 class Hylics2Location(Location):


### PR DESCRIPTION
## What is this fixing or adding?
Fixes a generation issue found by @ThePhar where Hylics 2 worlds would not be recognized as beatable because the victory event was created too late, in `generate_basic` rather than `create_regions`. This resulted in the location not being cached, and therefore not retrieved by `get_locations` during `check_accessibility`. 