### PR TITLE
Docs: Update Pokemon and OoT setup guides

### DIFF
--- a/worlds/oot/docs/setup_en.md
+++ b/worlds/oot/docs/setup_en.md
@@ -19,7 +19,7 @@ As we are using Bizhawk, this guide is only applicable to Windows and Linux syst
 Once Bizhawk has been installed, open Bizhawk and change the following settings:
 
 - Go to Config > Customize. Switch to the Advanced tab, then switch the Lua Core from "NLua+KopiLua" to
-  "Lua+LuaInterface". This is required for the Lua script to function correctly.
+  "Lua+LuaInterface". Then restart Bizhawk. This is required for the Lua script to function correctly.
   **NOTE: Even if "Lua+LuaInterface" is already selected, toggle between the two options and reselect it. Fresh installs** 
   **of newer versions of Bizhawk have a tendency to show "Lua+LuaInterface" as the default selected option but still load** 
   **"NLua+KopiLua" until this step is done.**

--- a/worlds/pokemon_rb/docs/setup_en.md
+++ b/worlds/pokemon_rb/docs/setup_en.md
@@ -23,6 +23,11 @@ As we are using Bizhawk, this guide is only applicable to Windows and Linux syst
 
 Once Bizhawk has been installed, open Bizhawk and change the following settings:
 
+- Go to Config > Customize. Switch to the Advanced tab, then switch the Lua Core from "NLua+KopiLua" to
+  "Lua+LuaInterface". Then restart Bizhawk. This is required for the Lua script to function correctly.
+  **NOTE: Even if "Lua+LuaInterface" is already selected, toggle between the two options and reselect it. Fresh installs** 
+  **of newer versions of Bizhawk have a tendency to show "Lua+LuaInterface" as the default selected option but still load** 
+  **"NLua+KopiLua" until this step is done.**
 - Under Config > Customize > Advanced, make sure the box for AutoSaveRAM is checked, and click the 5s button.
   This reduces the possibility of losing save data in emulator crashes.
 - Under Config > Customize, check the "Run in background" box. This will prevent disconnecting from the client while


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?
- Pokemon guide was missing a point about changing the Lua option in Bizhawk.
- The same point in the OoT guide was missing a step about restarting Bizhawk after changing the Lua option, so updated that as well.

## How was this tested?
no need. just updated text in docs.

## If this makes graphical changes, please attach screenshots.
