### PR TITLE
WebHost: Tweaks to search on tracker pages

### DIFF
--- a/WebHostLib/static/assets/tracker.js
+++ b/WebHostLib/static/assets/tracker.js
@@ -18,7 +18,8 @@ window.addEventListener('load', () => {
         info: false,
         dom: "t",
         stateSave: true,
-        stateSaveCallback: function(settings,data) {
+        stateSaveCallback: function(settings, data) {
+            delete data.search;
             localStorage.setItem(`DataTables_${settings.sInstance}_/tracker`, JSON.stringify(data));
         },
         stateLoadCallback: function(settings) {
@@ -70,10 +71,35 @@ window.addEventListener('load', () => {
         // the tbody and render two separate tables.
     });
 
-    document.getElementById('search').addEventListener('keyup', (event) => {
-        tables.search(event.target.value);
-        console.info(tables.search());
+    const searchBox = document.getElementById("search");
+    searchBox.value = tables.search();
+    const doSearch = () => {
+        tables.search(searchBox.value);
         tables.draw();
+    };
+    searchBox.addEventListener("keyup", doSearch);
+    window.addEventListener("keydown", (event) => {
+        if (event.ctrlKey && !event.altKey && !event.shiftKey && event.key === "f") {
+            searchBox.focus();
+            searchBox.select();
+            event.preventDefault();
+        }
+        if (!event.ctrlKey && !event.altKey && event.key.length === 1 && document.activeElement !== searchBox) {
+            searchBox.focus();
+            searchBox.select();
+            if (event.key === "/")
+                event.preventDefault();
+        }
+        if (!event.ctrlKey && !event.altKey && !event.shiftKey && event.key === "Escape") {
+            if (searchBox.value !== "") {
+                searchBox.value = "";
+                doSearch();
+            }
+            searchBox.blur();
+            if (!document.getElementById("tables-container"))
+                window.scroll(0, 0);
+            event.preventDefault();
+        }
     });
 
     const update = () => {


### PR DESCRIPTION
## What is this fixing or adding?
A few quality of life tweaks for the generic tracker pages:
* Pressing `Ctrl+F` or `/` now focuses the search box.
* Typing anywhere now automatically focuses the search box.
* Pressing `Escape` now clears the search and scrolls to the top.

## Points of Deliberation
* Should the standard browser search be suppressed on `Ctrl+F`/`/`?
  * I decided for it, because:
    * I want to use people's muscle memory to show them our search function.
    * I feel like the DataTables search is superior to the browser search in most circumstances.
    * One can still access the standard browser search with `F3` and `Ctrl+G`.
* Should the search filter be restored when the page is loaded?
  * There are two obvious restoration sources: (Note that the search terms obtained from these sources are not necessarily the same.)
    1. Browsers keep textbox contents on `F5` and navigation (but not on `Ctrl+F5` or when opening a fresh tab).
    2. DataTables can load the last search term from local storage (#1145).
  * For now, I have opted to always clear the search on page load with this rationale:
    * Opening a tracker with an active search filter may confuse some users.
    * Refreshing using `F5` is not a use case due to automatic refreshes.

## How was this tested?
Locally, in Firefox and Chrome, with the various search hotkeys as well as Firefox's "Search for text when you start typing" setting.
