### PR TITLE
Fix region_has_shortcuts crash when boss shuffle is on

### DIFF
--- a/worlds/oot/Hints.py
+++ b/worlds/oot/Hints.py
@@ -365,9 +365,9 @@ class HintArea(Enum):
                     return parent_region.alt_hint
                 return parent_region.hint
 
-            spot_queue.extend(list(filter(lambda ent: ent not in already_checked, parent_region.entrances)))
+            spot_queue.extend(filter(lambda ent: ent not in already_checked, parent_region.entrances))
 
-        raise HintAreaNotFound('No hint area could be found for %s [World %d]' % (spot, spot.world.player))
+        raise HintAreaNotFound('No hint area could be found for %s [World %d]' % (spot, spot.player))
 
     @classmethod
     def for_dungeon(cls, dungeon_name: str):

--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -11,7 +11,8 @@ logger = logging.getLogger("Ocarina of Time")
 from .Location import OOTLocation, LocationFactory, location_name_to_id
 from .Entrance import OOTEntrance
 from .EntranceShuffle import shuffle_random_entrances, entrance_shuffle_table, EntranceShuffleError
-from .Hints import HintArea
+from .HintList import getRequiredHints
+from .Hints import HintArea, HintAreaNotFound, hint_dist_keys, get_hint_area, buildWorldGossipHints
 from .Items import OOTItem, item_table, oot_data_to_ap_id, oot_is_item_of_type
 from .ItemPool import generate_itempool, get_junk_item, get_junk_pool
 from .Regions import OOTRegion, TimeOfDay
@@ -26,8 +27,6 @@ from .Rom import Rom
 from .Patches import OoTContainer, patch_rom
 from .N64Patch import create_patch_file
 from .Cosmetics import patch_cosmetics
-from .Hints import hint_dist_keys, get_hint_area, buildWorldGossipHints
-from .HintList import getRequiredHints
 
 from Utils import get_options
 from BaseClasses import MultiWorld, CollectionState, RegionType, Tutorial, LocationProgressType
@@ -1146,9 +1145,11 @@ class OOTWorld(World):
     # Helper functions
     def region_has_shortcuts(self, regionname):
         region = self.get_region(regionname)
-        if not region.dungeon:
-            region = region.entrances[0].parent_region
-        return region.dungeon.name in self.dungeon_shortcuts
+        try:
+            dungeon_name = HintArea.at(region).dungeon_name
+            return dungeon_name in self.dungeon_shortcuts
+        except HintAreaNotFound:
+            return False
 
     def get_shufflable_entrances(self, type=None, only_primary=False):
         return [entrance for entrance in self.multiworld.get_entrances() if (entrance.player == self.player and


### PR DESCRIPTION
## What is this fixing or adding?
Fixes a bug where the region_has_shortcuts function would crash during evaluation if the relevant boss room was not yet connected to a dungeon (e.g. in boss shuffle). Now returns False if unconnected, which is the logically-safe assumption. 
Bug reported at https://discord.com/channels/731205301247803413/1051691924085543003