### PR TITLE
[Pokemon R/B] Allow 0 exp setting and add logic rule to Cinnabar Gym

### DIFF
--- a/worlds/pokemon_rb/logic.py
+++ b/worlds/pokemon_rb/logic.py
@@ -80,3 +80,8 @@ class PokemonLogic(LogicMixin):
         return (self.can_reach('Mt Moon 1F - Southwest Item', 'Location', player) and
                 self.can_reach('Cinnabar Island - Lab Scientist', 'Location', player) and len(
             [item for item in ["Dome Fossil", "Helix Fossil", "Old Amber"] if self.has(item, player)]) >= count)
+
+    def pokemon_rb_cinnabar_gym(self, player):
+        # ensures higher level Pokémon are obtainable before Cinnabar Gym is in logic
+        return ((not self.multiworld.extra_key_items[player]) or self.has("Mansion Key", player)
+                or self.has("Oak's Parcel", player) or self.pokemon_rb_can_surf(player))

--- a/worlds/pokemon_rb/logic.py
+++ b/worlds/pokemon_rb/logic.py
@@ -83,5 +83,10 @@ class PokemonLogic(LogicMixin):
 
     def pokemon_rb_cinnabar_gym(self, player):
         # ensures higher level Pokémon are obtainable before Cinnabar Gym is in logic
-        return ((not self.multiworld.extra_key_items[player]) or self.has("Mansion Key", player)
-                or self.has("Oak's Parcel", player) or self.pokemon_rb_can_surf(player))
+        return ((self.multiworld.old_man[player] != "vanilla") or (not self.multiworld.extra_key_items[player]) or
+                self.has("Mansion Key", player) or self.has("Oak's Parcel", player) or self.pokemon_rb_can_surf(player))
+
+    def pokemon_rb_dojo(self, player):
+        # ensures higher level Pokémon are obtainable before Fighting Dojo is in logic
+        return (self.pokemon_rb_can_pass_guards(player) or self.has("Oak's Parcel", player) or
+                self.pokemon_rb_can_surf(player))

--- a/worlds/pokemon_rb/options.py
+++ b/worlds/pokemon_rb/options.py
@@ -199,7 +199,7 @@ class OaksAidRt15(Range):
 class ExpModifier(SpecialRange):
     """Modifier for EXP gained. When specifying a number, exp is multiplied by this amount and divided by 16."""
     display_name = "Exp Modifier"
-    range_start = 1
+    range_start = 0
     range_end = 255
     default = 16
     special_range_names = {

--- a/worlds/pokemon_rb/regions.py
+++ b/worlds/pokemon_rb/regions.py
@@ -248,7 +248,7 @@ def create_regions(multiworld: MultiWorld, player: int):
     connect(multiworld, player, "Viridian City", "Viridian City North", lambda state: state.has("Oak's Parcel", player) or state.multiworld.old_man[player].value == 2 or state.pokemon_rb_can_cut(player))
     connect(multiworld, player, "Route 3", "Mt Moon 1F", one_way=True)
     connect(multiworld, player, "Route 11", "Route 11 East", lambda state: state.pokemon_rb_can_strength(player))
-    connect(multiworld, player, "Cinnabar Island", "Cinnabar Gym", lambda state: state.has("Secret Key", player), one_way=True)
+    connect(multiworld, player, "Cinnabar Island", "Cinnabar Gym", lambda state: state.has("Secret Key", player) and state.pokemon_rb_cinnabar_gym(player), one_way=True)
     connect(multiworld, player, "Cinnabar Island", "Pokemon Mansion 1F", lambda state: state.has("Mansion Key", player) or not state.multiworld.extra_key_items[player].value, one_way=True)
     connect(multiworld, player, "Seafoam Islands 1F", "Seafoam Islands B1F", one_way=True)
     connect(multiworld, player, "Seafoam Islands B1F", "Seafoam Islands B2F", one_way=True)

--- a/worlds/pokemon_rb/regions.py
+++ b/worlds/pokemon_rb/regions.py
@@ -190,7 +190,7 @@ def create_regions(multiworld: MultiWorld, player: int):
     connect(multiworld, player, "Pokemon Tower 6F", "Pokemon Tower 7F", lambda state: state.has("Silph Scope", player))
     connect(multiworld, player, "Cerulean City", "Route 5")
     connect(multiworld, player, "Route 5", "Saffron City", lambda state: state.pokemon_rb_can_pass_guards(player))
-    connect(multiworld, player, "Saffron City", "Fighting Dojo", one_way=True)
+    connect(multiworld, player, "Saffron City", "Fighting Dojo", lambda state: state.pokemon_rb_dojo(player), one_way=True)
     connect(multiworld, player, "Route 5", "Underground Tunnel North-South")
     connect(multiworld, player, "Route 6", "Underground Tunnel North-South")
     connect(multiworld, player, "Route 6", "Saffron City", lambda state: state.pokemon_rb_can_pass_guards(player))


### PR DESCRIPTION
## What is this fixing or adding?
Allow setting exp modifier to 0%, and add logic rules to Cinnabar Gym and Fighting Dojo to ensure higher level Pokémon are catchable

## How was this tested?
Generating with plando and set seeds with logic rules in place and without, to ensure it would not force you to fly to Cinnabar Gym and fight Blaine or to Saffron and fight in the Dojo before being able to reach any catchable Pokémon beyond sphere 1