### PR TITLE
Ocarina of Time 0.3.7 hotfixes

### DIFF
--- a/worlds/oot/Options.py
+++ b/worlds/oot/Options.py
@@ -899,11 +899,11 @@ class HintDistribution(Choice):
     display_name = "Hint Distribution"
     option_balanced = 0
     option_ddr = 1
-    option_league = 2
-    option_mw3 = 3
+    # option_league = 2
+    # option_mw3 = 3
     option_scrubs = 4
     option_strong = 5
-    option_tournament = 6
+    # option_tournament = 6
     option_useless = 7
     option_very_strong = 8
     option_async = 9

--- a/worlds/oot/Patches.py
+++ b/worlds/oot/Patches.py
@@ -82,7 +82,7 @@ def patch_rom(world, rom):
     # Load Triforce model into a file
     triforce_obj_file = File({ 'Name': 'object_gi_triforce' })
     triforce_obj_file.copy(rom)
-    with open(data_path('triforce.zobj'), 'rb') as stream:
+    with open(data_path('Triforce.zobj'), 'rb') as stream:
         obj_data = stream.read()
         rom.write_bytes(triforce_obj_file.start, obj_data)
         triforce_obj_file.end = triforce_obj_file.start + len(obj_data)

--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -943,13 +943,15 @@ class OOTWorld(World):
 
             outfile_name = self.multiworld.get_out_file_name_base(self.player)
             rom = Rom(file=get_options()['oot_options']['rom_file'])
-            if self.hints != 'none':
-                buildWorldGossipHints(self)
-            # try:
-            patch_rom(self, rom)
-            # except Exception as e:
-            #     print(e)
-            patch_cosmetics(self, rom)
+            try:
+                if self.hints != 'none':
+                    buildWorldGossipHints(self)
+                patch_rom(self, rom)
+                patch_cosmetics(self, rom)
+            except Exception as e:
+                raise e
+            finally:
+                self.collectible_flags_available.set()
             rom.update_header()
             patch_data = create_patch_file(rom)
             rom.restore()

--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -949,6 +949,7 @@ class OOTWorld(World):
                 patch_rom(self, rom)
                 patch_cosmetics(self, rom)
             except Exception as e:
+                logger.error(e)
                 raise e
             finally:
                 self.collectible_flags_available.set()


### PR DESCRIPTION
## What is this fixing or adding?
- Since multiprocessing and exceptions apparently don't interact well, any exceptions in `generate_output` are handled more gracefully now. The event is always set as well, so the process will no longer hang on an exception there.
- The triforce object file was renamed in 7.0. I didn't change the filename in the code, so it would crash on non-Windows systems.
- Some hint distributions just crash, so I'm temporarily removing them. It will take a while to port the relevant functionality and I'd rather not hold up the next version release.