### PR TITLE
Core: Make apworlds function mostly before Python 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ import setuptools
 from Launcher import components, icon_paths
 from Utils import version_tuple, is_windows, is_linux
 
+# On  Python < 3.10 LogicMixin is not currently supported.
 apworlds: set = {
     "Subnautica",
     "Factorio",

--- a/worlds/__init__.py
+++ b/worlds/__init__.py
@@ -52,14 +52,20 @@ world_sources.sort()
 for world_source in world_sources:
     if world_source.is_zip:
         importer = zipimport.zipimporter(os.path.join(folder, world_source.path))
-        spec = importer.find_spec(world_source.path.split(".", 1)[0])
-        mod = importlib.util.module_from_spec(spec)
+        if hasattr(importer, "find_spec"):  # new in Python 3.10
+            spec = importer.find_spec(world_source.path.split(".", 1)[0])
+            mod = importlib.util.module_from_spec(spec)
+        else:  # TODO: remove with 3.8 support
+            mod = importer.load_module(world_source.path.split(".", 1)[0])
+
         mod.__package__ = f"worlds.{mod.__package__}"
         mod.__name__ = f"worlds.{mod.__name__}"
         sys.modules[mod.__name__] = mod
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", message="__package__ != __spec__.parent")
-            importer.exec_module(mod)
+            # Found no equivalent for < 3.10
+            if hasattr(importer, "exec_module"):
+                importer.exec_module(mod)
     else:
         importlib.import_module(f".{world_source.path}", "worlds")
 


### PR DESCRIPTION
pl3453 f0rm47 y0ur 717l3 w17h wh47 p0r710n 0f 7h3 pr0j3c7 7h15 pull r3qu357 15
74r6371n6 4nd wh47 17'5 ch4n61n6.

3x. "my64m34: 1mpl3m3n7 n3w 64m3" 0r "d0c5: 4dd n3w 6u1d3 f0r cu570m1z1n6 my64m33"

## wh47 15 7h15 f1x1n6 0r 4dd1n6?
m4k35 4pw0rld5 l04d4bl3 1n 3.8 4nd 3.9 py7h0n, 45 l0n6 45 7h3y d0n'7 d3f1n3 4 l061cm1x1n

## h0w w45 7h15 73573d?
runn1n6 b07h fr0z3n 4nd 50urc3 v3r510n 0f 4p 4641n57 3.8 4nd 3.10

## 1f 7h15 m4k35 6r4ph1c4l ch4n635, pl3453 4774ch 5cr33n5h075.


```
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?
Makes APWorlds loadable in 3.8 and 3.9 Python, as long as they don't define a LogicMixin

## How was this tested?
running both frozen and source version of AP against 3.8 and 3.10

## If this makes graphical changes, please attach screenshots.
```
