### PR TITLE
SC2Client: Changes to /download_data and feedback

### DIFF
--- a/Starcraft2Client.py
+++ b/Starcraft2Client.py
@@ -120,9 +120,9 @@ class StarcraftClientProcessor(ClientCommandProcessor):
             sc2_logger.warning("When using set_path, you must type the path to your SC2 install directory.")
         return False
 
-    def _cmd_download_data(self, force: bool = False) -> bool:
+    def _cmd_download_data(self) -> bool:
         """Download the most recent release of the necessary files for playing SC2 with
-        Archipelago. force should be True or False. force=True will overwrite your files."""
+        Archipelago. Will overwrite existing files."""
         if "SC2PATH" not in os.environ:
             check_game_install_path()
 
@@ -132,7 +132,8 @@ class StarcraftClientProcessor(ClientCommandProcessor):
         else:
             current_ver = None
 
-        tempzip, version = download_latest_release_zip('TheCondor07', 'Starcraft2ArchipelagoData', current_version=current_ver, force_download=force)
+        tempzip, version = download_latest_release_zip('TheCondor07', 'Starcraft2ArchipelagoData',
+                                                       current_version=current_ver, force_download=True)
 
         if tempzip != '':
             try:

--- a/Starcraft2Client.py
+++ b/Starcraft2Client.py
@@ -195,12 +195,16 @@ class SC2Context(CommonContext):
             self.build_location_to_mission_mapping()
 
             # Looks for the required maps and mods for SC2. Runs check_game_install_path.
-            is_mod_installed_correctly()
+            maps_present = is_mod_installed_correctly()
             if os.path.exists(os.environ["SC2PATH"] + "ArchipelagoSC2Version.txt"):
                 with open(os.environ["SC2PATH"] + "ArchipelagoSC2Version.txt", "r") as f:
                     current_ver = f.read()
                 if is_mod_update_available("TheCondor07", "Starcraft2ArchipelagoData", current_ver):
                     sc2_logger.info("NOTICE: Update for required files found. Run /download_data to install.")
+            elif maps_present:
+                sc2_logger.info("NOTICE: Your map files may be outdated (version number not found). Run /download_data"
+                                "to update them.")
+
 
     def on_print_json(self, args: dict):
         # goes to this world

--- a/Starcraft2Client.py
+++ b/Starcraft2Client.py
@@ -202,7 +202,7 @@ class SC2Context(CommonContext):
                 if is_mod_update_available("TheCondor07", "Starcraft2ArchipelagoData", current_ver):
                     sc2_logger.info("NOTICE: Update for required files found. Run /download_data to install.")
             elif maps_present:
-                sc2_logger.info("NOTICE: Your map files may be outdated (version number not found). Run /download_data"
+                sc2_logger.info("NOTICE: Your map files may be outdated (version number not found). Run /download_data "
                                 "to update them.")
 
 


### PR DESCRIPTION
## What is this fixing or adding?
Old users who have never run the /download_data command in SC2Client do not have a version number for the maps on their system. This PR warns these users that their maps are probably outdated, and that they should run `/download_data`. This should cut back on people having issues with the Safe Haven and Haven's Fall missions.

Also, `/download_data` no longer accepts a parameter called `force`, and will now *always* force a download when run. This is to simplify the user interface; we did have an issue already where someone needed to force a download but didn't understand how to do it.

## How was this tested?
- Deleted version number file on a Windows 10 machine that already had the most recent map files
- Tried to connect to a server (the correct feedback appeared)
- Ran `/download_data` twice with no arguments (the client did the download both times)