### PR TITLE
WebHost: Fixed game order by title

### DIFF
--- a/WebHostLib/misc.py
+++ b/WebHostLib/misc.py
@@ -69,10 +69,6 @@ def tutorial(game, file, lang):
 
 @app.route('/tutorial/')
 def tutorial_landing():
-    worlds = {}
-    for game, world in AutoWorldRegister.world_types.items():
-        if not world.hidden:
-            worlds[game] = world
     return render_template("tutorialLanding.html")
 
 

--- a/WebHostLib/templates/siteMap.html
+++ b/WebHostLib/templates/siteMap.html
@@ -31,14 +31,14 @@
 
         <h2>Game Info Pages</h2>
         <ul>
-            {% for game in games %}
+            {% for game in games | title_sorted %}
                 <li><a href="{{ url_for('game_info', game=game, lang='en') }}">{{ game }}</a></li>
             {% endfor %}
         </ul>
 
         <h2>Game Settings Pages</h2>
         <ul>
-            {% for game in games %}
+            {% for game in games | title_sorted %}
                 <li><a href="{{ url_for('player_settings', game=game) }}">{{ game }}</a></li>
             {% endfor %}
         </ul>


### PR DESCRIPTION
## What is this fixing or adding?
Game lists should now be sorted by title everywhere, and no-longer be sorted by world folder name

## How was this tested?
locally running the webhost with trail & error

## If this makes graphical changes, please attach screenshots.
![image](https://user-images.githubusercontent.com/5691920/209435951-cbf3c4b8-46f2-45c1-bfce-e9d7e0071789.png)
