### PR TITLE
Ocarina of Time: 0.3.7 hotfixes round 2

### DIFF
--- a/worlds/oot/EntranceShuffle.py
+++ b/worlds/oot/EntranceShuffle.py
@@ -480,7 +480,7 @@ def shuffle_random_entrances(ootworld):
     if ootworld.shuffle_dungeon_entrances:
         entrance_pools['Dungeon'] = ootworld.get_shufflable_entrances(type='Dungeon', only_primary=True)
         if ootworld.open_forest == 'closed':
-            entrance_pools['Dungeon'].remove(ootworld.get_entrance('KF Outside Deku Tree -> Deku Tree Lobby', player))
+            entrance_pools['Dungeon'].remove(ootworld.get_entrance('KF Outside Deku Tree -> Deku Tree Lobby'))
         if ootworld.shuffle_special_dungeon_entrances:
             entrance_pools['Dungeon'] += ootworld.get_shufflable_entrances(type='DungeonSpecial', only_primary=True)
         if ootworld.decouple_entrances:
@@ -500,7 +500,7 @@ def shuffle_random_entrances(ootworld):
         exclude_overworld_reverse = ootworld.mix_entrance_pools == 'all' and not ootworld.decouple_entrances
         entrance_pools['Overworld'] = ootworld.get_shufflable_entrances(type='Overworld', only_primary=exclude_overworld_reverse)
         if not ootworld.decouple_entrances:
-            entrance_pools['Overworld'].remove(world.get_entrance('GV Lower Stream -> Lake Hylia', player))
+            entrance_pools['Overworld'].remove(ootworld.get_entrance('GV Lower Stream -> Lake Hylia'))
 
     # Mark shuffled entrances
     for entrance in chain(chain.from_iterable(one_way_entrance_pools.values()), chain.from_iterable(entrance_pools.values())):

--- a/worlds/oot/Items.py
+++ b/worlds/oot/Items.py
@@ -41,7 +41,7 @@ class OOTItem(Item):
             classification = ItemClassification.useful
         elif name == "Ice Trap":
             classification = ItemClassification.trap
-        elif name == 'Gold Skulltula Token':
+        elif name in {'Gold Skulltula Token', 'Triforce Piece'}:
             classification = ItemClassification.progression_skip_balancing
         elif advancement:
             classification = ItemClassification.progression

--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -843,8 +843,11 @@ class OOTWorld(World):
         impa = self.multiworld.get_location("Song from Impa", self.player)
         if self.shuffle_child_trade == 'skip_child_zelda':
             if impa.item is None:
-                item_to_place = self.multiworld.random.choice(
-                    list(item for item in self.multiworld.itempool if item.player == self.player))
+                candidate_items = list(item for item in self.multiworld.itempool if item.player == self.player)
+                if candidate_items:
+                    item_to_place = self.multiworld.random.choice(candidate_items)
+                else:
+                    item_to_place = self.create_item("Recovery Heart")
                 impa.place_locked_item(item_to_place)
                 self.multiworld.itempool.remove(item_to_place)
             # Give items to startinventory

--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -846,10 +846,10 @@ class OOTWorld(World):
                 candidate_items = list(item for item in self.multiworld.itempool if item.player == self.player)
                 if candidate_items:
                     item_to_place = self.multiworld.random.choice(candidate_items)
+                    self.multiworld.itempool.remove(item_to_place)
                 else:
                     item_to_place = self.create_item("Recovery Heart")
                 impa.place_locked_item(item_to_place)
-                self.multiworld.itempool.remove(item_to_place)
             # Give items to startinventory
             self.multiworld.push_precollected(impa.item)
             self.multiworld.push_precollected(self.create_item("Zeldas Letter"))

--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -109,7 +109,7 @@ class OOTWorld(World):
 
     data_version = 3
 
-    required_client_version = (0, 3, 6)
+    required_client_version = (0, 3, 7)
 
     item_name_groups = {
         # internal groups

--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -317,13 +317,14 @@ class OOTWorld(World):
 
         # Determine which dungeons are MQ. Not compatible with glitched logic.
         mq_dungeons = set()
+        all_dungeons = [d['name'] for d in dungeon_table]
         if self.logic_rules != 'glitched':
             if self.mq_dungeons_mode == 'mq':
-                mq_dungeons = dungeon_table.keys()
+                mq_dungeons = all_dungeons
             elif self.mq_dungeons_mode == 'specific':
                 mq_dungeons = self.mq_dungeons_specific
             elif self.mq_dungeons_mode == 'count':
-                mq_dungeons = self.multiworld.random.sample(dungeon_table, self.mq_dungeons_count)
+                mq_dungeons = self.multiworld.random.sample(all_dungeons, self.mq_dungeons_count)
         else:
             self.mq_dungeons_mode = 'count'
             self.mq_dungeons_count = 0


### PR DESCRIPTION
Fixes crash with mq dungeons set to "mq" as well as "count" option not actually working.
Also fixes skip-child-zelda-related crash, although with a sort of clunky solution. 
Non-bugfixes: triforces pieces finally get skipped in progression balancing, 0.3.7 client made required to reduce chance of people not updating.