### PR TITLE
Pokémon R/B: Add Revive to better_shops

### DIFF
--- a/worlds/pokemon_rb/rom.py
+++ b/worlds/pokemon_rb/rom.py
@@ -505,9 +505,9 @@ def generate_output(self, output_directory: str):
         inventory = ["Poke Ball", "Great Ball", "Ultra Ball"]
         if self.multiworld.better_shops[self.player].value == 2:
             inventory.append("Master Ball")
-        inventory += ["Potion", "Super Potion", "Hyper Potion", "Max Potion", "Full Restore", "Antidote", "Awakening",
-                      "Burn Heal", "Ice Heal", "Paralyze Heal", "Full Heal", "Repel", "Super Repel", "Max Repel",
-                      "Escape Rope"]
+        inventory += ["Potion", "Super Potion", "Hyper Potion", "Max Potion", "Full Restore", "Revive", "Antidote",
+                      "Awakening", "Burn Heal", "Ice Heal", "Paralyze Heal", "Full Heal", "Repel", "Super Repel",
+                      "Max Repel", "Escape Rope"]
         shop_data = bytearray([0xFE, len(inventory)])
         shop_data += bytearray([item_table[item].id - 172000000 for item in inventory])
         shop_data.append(0xFF)


### PR DESCRIPTION
## What is this fixing or adding?
Adds revives to the shops modified by the better_shops option, left out by an oversight

## How was this tested?
Generating, checking shops to make sure Revive is present and there are no apparent issues with shops.

## If this makes graphical changes, please attach screenshots.
