### PR TITLE
Core, WebHost: Add the possibility to configure steps in range options

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -589,6 +589,7 @@ class PlandoBosses(TextChoice, metaclass=BossMeta):
 class Range(NumericOption):
     range_start = 0
     range_end = 1
+    step = 1
 
     def __init__(self, value: int):
         if value < self.range_start:

--- a/WebHostLib/options.py
+++ b/WebHostLib/options.py
@@ -118,6 +118,7 @@ def create():
                         option, "default") and option.default != "random" else option.range_start,
                     "min": option.range_start,
                     "max": option.range_end,
+                    "step": option.step,
                 }
 
                 if issubclass(option, Options.SpecialRange):

--- a/WebHostLib/static/assets/player-settings.js
+++ b/WebHostLib/static/assets/player-settings.js
@@ -166,6 +166,7 @@ const buildOptionsTable = (settings, romOpts = false) => {
         range.setAttribute('data-key', setting);
         range.setAttribute('min', settings[setting].min);
         range.setAttribute('max', settings[setting].max);
+        range.setAttribute('step', settings[setting].step);
         range.value = currentSettings[gameName][setting];
         range.addEventListener('change', (event) => {
           document.getElementById(`${setting}-value`).innerText = event.target.value;
@@ -229,6 +230,7 @@ const buildOptionsTable = (settings, romOpts = false) => {
         specialRange.setAttribute('data-key', setting);
         specialRange.setAttribute('min', settings[setting].min);
         specialRange.setAttribute('max', settings[setting].max);
+        specialRange.setAttribute('step', settings[setting].step);
         specialRange.value = currentSettings[gameName][setting];
 
         // Build rage value element


### PR DESCRIPTION
## What is this fixing or adding?
Adding the possibility to configure steps when using Range and SpecialRange options. It's not taken into account during randomization, only used by the WebHost for yaml generation.

## How was this tested?
I used the steps with some options, it works well! It also does not affect ranges where it's not configured, since the default is 1. 

## If this makes graphical changes, please attach screenshots.

Demo with Stardew Valley configs: 

![slider-step](https://user-images.githubusercontent.com/16137441/210127383-807ac39b-93d6-4d64-b77b-afd2bcaad493.gif)
