### PR TITLE
Rogue Legacy: Fix early vendors and architect... again.

### DIFF
--- a/worlds/rogue_legacy/Rules.py
+++ b/worlds/rogue_legacy/Rules.py
@@ -1,4 +1,4 @@
-from BaseClasses import MultiWorld, CollectionState
+from BaseClasses import CollectionState, MultiWorld
 
 
 def get_upgrade_total(multiworld: MultiWorld, player: int) -> int:
@@ -20,7 +20,7 @@ def has_upgrade_amount(state: CollectionState, player: int, amount: int) -> bool
 
 
 def has_upgrades_percentage(state: CollectionState, player: int, percentage: float) -> bool:
-    return has_upgrade_amount(state, player, get_upgrade_total(state.multiworld, player) * (round(percentage) // 100))
+    return has_upgrade_amount(state, player, round(get_upgrade_total(state.multiworld, player) * (percentage / 100)))
 
 
 def has_movement_rune(state: CollectionState, player: int) -> bool:


### PR DESCRIPTION
## What is this fixing or adding?
Early vendors and early architect can place items anywhere instead of the first local sphere, because some math was terrible in a rule (basically always returned `True`).

This fixes that.

## How was this tested?
Ran before:
![image](https://user-images.githubusercontent.com/11338376/210244549-4e16a8fe-653c-4e67-8fa1-1529fdd330b7.png)

Ran after:
![image](https://user-images.githubusercontent.com/11338376/210244576-5084d449-f16c-4dc4-b2b2-419f73cc5717.png)

## If this makes graphical changes, please attach screenshots.
N/A