### PR TITLE
WebHost: Capitalize `SpecialRange` choices in keep consistency with other `Choice` options on settings pages.

### DIFF
--- a/WebHostLib/static/assets/player-settings.js
+++ b/WebHostLib/static/assets/player-settings.js
@@ -205,6 +205,11 @@ const buildOptionsTable = (settings, romOpts = false) => {
           let presetOption = document.createElement('option');
           presetOption.innerText = presetName;
           presetOption.value = settings[setting].value_names[presetName];
+          const words = presetOption.innerText.split("_");
+          for (let i = 0; i < words.length; i++) {
+            words[i] = words[i][0].toUpperCase() + words[i].substring(1);
+          }
+          presetOption.innerText = words.join(" ");
           specialRangeSelect.appendChild(presetOption);
         });
         let customOption = document.createElement('option');


### PR DESCRIPTION
## What is this fixing or adding?
See title and images below.

## How was this tested?
Compared webpages between current site and this branch. Verified that template files and exported setting files were not affected by change, purely just a visual change on website.

## If this makes graphical changes, please attach screenshots.
Before:
![image](https://user-images.githubusercontent.com/11338376/210247567-54fd3964-65e3-471c-b2d6-bc79d8819ba1.png)
![image](https://user-images.githubusercontent.com/11338376/210247596-e1e1577b-d446-4ec2-a6af-724e763e8b3b.png)
![image](https://user-images.githubusercontent.com/11338376/210247611-653ddaef-4db8-4091-85ec-8e77e7a6daa7.png)

After:
![image](https://user-images.githubusercontent.com/11338376/210247648-bd6b4ba6-7477-4108-a36a-72555030c712.png)
![image](https://user-images.githubusercontent.com/11338376/210247663-ae12ab31-8739-4b34-bb21-0e8ba063226b.png)
![image](https://user-images.githubusercontent.com/11338376/210247688-6bb5e24c-3ebd-4729-99ec-0f407490fa23.png)