### PR TITLE
MultiServer: Remove `forced_auto_forfeit`

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -135,7 +135,6 @@ class Context:
     item_name_groups: typing.Dict[str, typing.Dict[str, typing.Set[str]]]
     location_names: typing.Dict[int, str] = Utils.KeyedDefaultDict(lambda code: f'Unknown location (ID:{code})')
     all_item_and_group_names: typing.Dict[str, typing.Set[str]]
-    forced_auto_forfeits: typing.Dict[str, bool]
     non_hintable_names: typing.Dict[str, typing.Set[str]]
 
     def __init__(self, host: str, port: int, server_password: str, password: str, location_check_points: int,
@@ -205,7 +204,6 @@ class Context:
         self.gamespackage = {}
         self.item_name_groups = {}
         self.all_item_and_group_names = {}
-        self.forced_auto_forfeits = collections.defaultdict(lambda: False)
         self.non_hintable_names = collections.defaultdict(frozenset)
 
         self._load_game_data()
@@ -218,7 +216,6 @@ class Context:
         self.item_name_groups = {world_name: world.item_name_groups for world_name, world in
                                  worlds.AutoWorldRegister.world_types.items()}
         for world_name, world in worlds.AutoWorldRegister.world_types.items():
-            self.forced_auto_forfeits[world_name] = world.forced_auto_forfeit
             self.non_hintable_names[world_name] = world.hint_blacklist
 
     def _init_game_data(self):
@@ -318,7 +315,7 @@ class Context:
         if not client.auth:
             return
         if client.version >= print_command_compatability_threshold:
-            async_start(self.send_msgs(client, 
+            async_start(self.send_msgs(client,
                 [{"cmd": "PrintJSON", "data": [{ "text": text }]} for text in texts]))
         else:
             async_start(self.send_msgs(client, [{"cmd": "Print", "text": text} for text in texts]))
@@ -661,8 +658,6 @@ class Context:
         if "auto" in self.collect_mode:
             collect_player(self, client.team, client.slot)
         if "auto" in self.release_mode:
-            release_player(self, client.team, client.slot)
-        elif self.forced_auto_forfeits[self.games[client.slot]]:
             release_player(self, client.team, client.slot)
         self.save()  # save goal completion flag
 

--- a/WebHostLib/customserver.py
+++ b/WebHostLib/customserver.py
@@ -12,12 +12,12 @@ import threading
 import time
 
 import websockets
-from pony.orm import db_session, commit, select
+from pony.orm import commit, db_session, select
 
 import Utils
-from MultiServer import Context, server, auto_shutdown, ServerCommandProcessor, ClientMessageProcessor
-from Utils import get_public_ipv4, get_public_ipv6, restricted_loads, cache_argsless
-from .models import Room, Command, db
+from MultiServer import ClientMessageProcessor, Context, ServerCommandProcessor, auto_shutdown, server
+from Utils import cache_argsless, get_public_ipv4, get_public_ipv6, restricted_loads
+from .models import Command, Room, db
 
 
 class CustomClientMessageProcessor(ClientMessageProcessor):
@@ -66,7 +66,6 @@ class WebHostContext(Context):
     def _load_game_data(self):
         for key, value in self.static_server_data.items():
             setattr(self, key, value)
-        self.forced_auto_forfeits = collections.defaultdict(lambda: False, self.forced_auto_forfeits)
         self.non_hintable_names = collections.defaultdict(frozenset, self.non_hintable_names)
 
     def listen_to_db_commands(self):
@@ -126,7 +125,6 @@ def get_random_port():
 def get_static_server_data() -> dict:
     import worlds
     data = {
-        "forced_auto_forfeits": {},
         "non_hintable_names": {},
         "gamespackage": worlds.network_data_package["games"],
         "item_name_groups": {world_name: world.item_name_groups for world_name, world in
@@ -134,7 +132,6 @@ def get_static_server_data() -> dict:
     }
 
     for world_name, world in worlds.AutoWorldRegister.world_types.items():
-        data["forced_auto_forfeits"][world_name] = world.forced_auto_forfeit
         data["non_hintable_names"][world_name] = world.hint_blacklist
 
     return data

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -109,10 +109,10 @@ def call_stage(multiworld: "MultiWorld", method_name: str, *args: Any) -> None:
 
 class WebWorld:
     """Webhost integration"""
-    
+
     settings_page: Union[bool, str] = True
     """display a settings page. Can be a link to a specific page or external tool."""
-    
+
     game_info_languages: List[str] = ['en']
     """docs folder will be scanned for game info pages using this list in the format '{language}_{game_name}.md'"""
 
@@ -159,10 +159,6 @@ class World(metaclass=AutoWorldRegister):
     required_server_version: Tuple[int, int, int] = (0, 2, 4)
 
     hint_blacklist: ClassVar[FrozenSet[str]] = frozenset()  # any names that should not be hintable
-
-    # For games where after a victory it is impossible to go back in and get additional/remaining Locations checked.
-    # this forces forfeit:  auto for those games.
-    forced_auto_forfeit: bool = False
 
     # Hide World Type from various views. Does not remove functionality.
     hidden: ClassVar[bool] = False

--- a/worlds/ror2/__init__.py
+++ b/worlds/ror2/__init__.py
@@ -1,12 +1,12 @@
 import string
 from typing import Dict, List
-from .Items import RiskOfRainItem, item_table, item_pool_weights
-from .Locations import RiskOfRainLocation, item_pickups
-from .Rules import set_rules
 
-from BaseClasses import Region, RegionType, Entrance, Item, ItemClassification, MultiWorld, Tutorial
-from .Options import ror2_options, ItemWeights
-from worlds.AutoWorld import World, WebWorld
+from BaseClasses import Entrance, Item, ItemClassification, MultiWorld, Region, RegionType, Tutorial
+from worlds.AutoWorld import WebWorld, World
+from .Items import RiskOfRainItem, item_pool_weights, item_table
+from .Locations import RiskOfRainLocation, item_pickups
+from .Options import ItemWeights, ror2_options
+from .Rules import set_rules
 
 client_version = 1
 
@@ -36,7 +36,6 @@ class RiskOfRainWorld(World):
     location_name_to_id = item_pickups
 
     data_version = 4
-    forced_auto_forfeit = True
     web = RiskOfWeb()
     total_revivals: int
 

--- a/worlds/spire/__init__.py
+++ b/worlds/spire/__init__.py
@@ -1,12 +1,12 @@
 import string
 
-from BaseClasses import Item, MultiWorld, Region, Location, Entrance, Tutorial, ItemClassification, RegionType
-from .Items import item_table, item_pool, event_item_pairs
+from BaseClasses import Entrance, Item, ItemClassification, Location, MultiWorld, Region, RegionType, Tutorial
+from .Items import event_item_pairs, item_pool, item_table
 from .Locations import location_table
+from .Options import spire_options
 from .Regions import create_regions
 from .Rules import set_rules
-from ..AutoWorld import World, WebWorld
-from .Options import spire_options
+from ..AutoWorld import WebWorld, World
 
 
 class SpireWeb(WebWorld):
@@ -35,8 +35,6 @@ class SpireWorld(World):
 
     item_name_to_id = {name: data.code for name, data in item_table.items()}
     location_name_to_id = location_table
-
-    forced_auto_forfeit = True
 
     def _get_slot_data(self):
         return {


### PR DESCRIPTION
## What is this fixing or adding?
Completely remove `forced_auto_forfeit` as the only 2 worlds that used it, "Risk of Rain 2" and "Slay the Spire", no longer depend on it.

## How was this tested?
Ran tests and removed all references to `forced_auto_forfeit`.

## If this makes graphical changes, please attach screenshots.
N/A