### PR TITLE
Docs, Sudoku: Hints will no-longer duplicate

### DIFF
--- a/worlds/bk_sudoku/docs/en_Sudoku.md
+++ b/worlds/bk_sudoku/docs/en_Sudoku.md
@@ -6,7 +6,7 @@ BK Sudoku is not a typical Archipelago game; instead, it is a generic Sudoku cli
 
 ## What hints are unlocked?
 
-After completing a Sudoku puzzle, the game will unlock 1 random hint for an unchecked location in the slot you are connected to. It is possible to hint a location that was previously hinted for using the !hint command.
+After completing a Sudoku puzzle, the game will unlock 1 random hint for an unchecked location in the slot you are connected to.
 
 ## Where is the settings page?
 


### PR DESCRIPTION
## What is this fixing or adding?
Updated docs to match latest release of client where hints no-longer yield duplicated results due to the implementation of the hints api

## How was this tested?
just here in the github ui
