### PR TITLE
[LTTP] update template to add all universal AP options

### DIFF
--- a/playerSettings.yaml
+++ b/playerSettings.yaml
@@ -27,17 +27,62 @@ game: # Pick a game to play
   A Link to the Past: 1
 requires:
   version: 0.3.3 # Version of Archipelago required for this yaml to work as expected.
-# Shared Options supported by all games:
-accessibility:
-  items: 0 # Guarantees you will be able to acquire all items, but you may not be able to access all locations
-  locations: 50 # Guarantees you will be able to access all locations, and therefore all items
-  none: 0 # Guarantees only that the game is beatable. You may not be able to access all locations or acquire all items
-progression_balancing: # A system to reduce BK, as in times during which you can't do anything, by moving your items into an earlier access sphere
-  0: 0 # Choose a lower number if you don't mind a longer multiworld, or can glitch/sequence break around missing items.
-  25: 0
-  50: 50 # Make it likely you have stuff to do.
-  99: 0 # Get important items early, and stay at the front of the progression.
 A Link to the Past:
+  progression_balancing:
+    # A system that can move progression earlier, to try and prevent the player from getting stuck and bored early.
+    # A lower setting means more getting stuck. A higher setting means less getting stuck.
+    #
+    # You can define additional values between the minimum and maximum values.
+    # Minimum value is 0
+    # Maximum value is 99
+    random: 0
+    random-low: 0
+    random-high: 0
+    disabled: 0 # equivalent to 0
+    normal: 50 # equivalent to 50
+    extreme: 0 # equivalent to 99
+
+  accessibility:
+    # Set rules for reachability of your items/locations.
+    # Locations: ensure everything can be reached and acquired.
+    # Items: ensure all logically relevant items can be acquired.
+    # Minimal: ensure what is needed to reach your goal can be acquired.
+    locations: 0
+    items: 50
+    minimal: 0
+
+  local_items:
+    # Forces these items to be in their native world.
+    [ ]
+
+  non_local_items:
+    # Forces these items to be outside their native world.
+    [ ]
+
+  start_inventory:
+    # Start with these items.
+    { }
+
+  start_hints:
+    # Start with these item's locations prefilled into the !hint command.
+    [ ]
+
+  start_location_hints:
+    # Start with these locations and their item prefilled into the !hint command
+    [ ]
+
+  exclude_locations:
+    # Prevent these locations from having an important item
+    [ ]
+
+  priority_locations:
+    # Prevent these locations from having an unimportant item
+    [ ]
+
+  item_links:
+    # Share part of your item pool with other players.
+    [ ]
+
   ### Logic Section ###
   glitches_required: # Determine the logic required to complete the seed
     none: 50 # No glitches required


### PR DESCRIPTION
## What is this fixing or adding?
moves prog balancing and accessibility into game section, and adds the rest of the universal AP options to the template yaml

## How was this tested?
ran a couple test gens to make sure i didn't break anything with the defaults

## If this makes graphical changes, please attach screenshots.
n/a