### PR TITLE
WebHost: add checks percent done column to tracker

### DIFF
--- a/WebHostLib/templates/tracker.html
+++ b/WebHostLib/templates/tracker.html
@@ -98,6 +98,7 @@
                                         <th colspan="{{ colspan }}" class="center-column">{{ area }}</th>
                                     {%- endif -%}
                                 {%- endfor -%}
+                                <th rowspan="2" class="center-column">&percnt;</th>
                                 <th rowspan="2" class="center-column hours">Last<br>Activity</th>
                             </tr>
                             <tr>
@@ -140,6 +141,7 @@
                                             <td class="center-column">{% if inventory[team][player][big_key_ids[area]] %}✔️{% endif %}</td>
                                         {%- endif -%}
                                     {%- endfor -%}
+                                    <td class="center-column">{{ percent_total_checks_done[team][player] }}</td>
                                     {%- if activity_timers[(team, player)] -%}
                                         <td class="center-column">{{ activity_timers[(team, player)].total_seconds() }}</td>
                                     {%- else -%}

--- a/WebHostLib/tracker.py
+++ b/WebHostLib/tracker.py
@@ -1232,6 +1232,11 @@ def getTracker(tracker: UUID):
                                 for playernumber in range(1, len(team) + 1) if playernumber not in groups}
                    for teamnumber, team in enumerate(names)}
 
+    percent_total_checks_done = {teamnumber: {playernumber: 0
+                                for playernumber in range(1, len(team) + 1) if playernumber not in groups}
+                    for teamnumber, team in enumerate(names)}
+
+    
     hints = {team: set() for team in range(len(names))}
     if room.multisave:
         multisave = restricted_loads(room.multisave)
@@ -1259,6 +1264,7 @@ def getTracker(tracker: UUID):
                 attribute_item(inventory, team, recipient, item)
             checks_done[team][player][player_location_to_area[player][location]] += 1
             checks_done[team][player]["Total"] += 1
+        percent_total_checks_done[team][player] = int(checks_done[team][player]["Total"] / seed_checks_in_area[player]["Total"] * 100) if seed_checks_in_area[player]["Total"] else 100
 
     for (team, player), game_state in multisave.get("client_game_state", {}).items():
         if player in groups:
@@ -1303,8 +1309,8 @@ def getTracker(tracker: UUID):
     return render_template("tracker.html", inventory=inventory, get_item_name_from_id=lookup_any_item_id_to_name,
                            lookup_id_to_name=Items.lookup_id_to_name, player_names=player_names,
                            tracking_names=tracking_names, tracking_ids=tracking_ids, room=room, icons=alttp_icons,
-                           multi_items=multi_items, checks_done=checks_done, ordered_areas=ordered_areas,
-                           checks_in_area=seed_checks_in_area, activity_timers=activity_timers,
+                           multi_items=multi_items, checks_done=checks_done, percent_total_checks_done=percent_total_checks_done,
+                           ordered_areas=ordered_areas, checks_in_area=seed_checks_in_area, activity_timers=activity_timers,
                            key_locations=group_key_locations, small_key_ids=small_key_ids, big_key_ids=big_key_ids,
                            video=video, big_key_locations=group_big_key_locations,
                            hints=hints, long_player_names=long_player_names)


### PR DESCRIPTION
## What is this fixing or adding?
Add a column to the general tracker to display a percentage of checks completed in each seed. In response to games having different numbers of total checks, this allows players to see a normalized value to compare progress between them.

## How was this tested?
Ran webhost from source. Created seed with two different games. Completed different amounts of progress in each game. Verified percentage column displayed correct style formatting and correct values. Created second seed with two copies of same game. Forfeited one seed to confirm 100 percent completion displayed correctly.

## If this makes graphical changes, please attach screenshots.
![archipelago-trackerPercentColumn1](https://user-images.githubusercontent.com/36623732/211181163-1eb6f45b-c91a-4829-99ce-fb2582525eff.png)
![archipelago-trackerPercentColumn2](https://user-images.githubusercontent.com/36623732/211181167-81f2d268-157a-41a5-be14-691d49d368e7.PNG)