### PR TITLE
Portals and items per act distinction

### DIFF
--- a/worlds/spire/Options.py
+++ b/worlds/spire/Options.py
@@ -27,10 +27,29 @@ class HeartRun(Toggle):
     option_true = 1
     option_false = 0
     default = 0
-
+    
+    
+class Portals(Toggle):
+    """Wether or not you want to have act portals enabled. Reach boss chest of previous act to activate it on future runs."""
+    display_name = "Portals"
+    option_true = 1
+    option_false = 0
+    default = 1
+    
+    
+class ItemDistinction(Choice):
+    """Pick how you wish your items to be distributed per act."""
+    display_name = "Item distribution"
+    option_no_distinction = 0
+    option_distinction_per_act = 1
+    option_distinction_with_backlog = 2
+    default = 0
+    
 
 spire_options: typing.Dict[str, type(Option)] = {
     "character": Character,
     "ascension": Ascension,
-    "heart_run": HeartRun
+    "heart_run": HeartRun,
+    "portals": Portals,
+    "item_distinction": ItemDistinction
 }

--- a/worlds/spire/__init__.py
+++ b/worlds/spire/__init__.py
@@ -41,7 +41,9 @@ class SpireWorld(World):
             'seed': "".join(self.multiworld.slot_seeds[self.player].choice(string.ascii_letters) for i in range(16)),
             'character': self.multiworld.character[self.player],
             'ascension': self.multiworld.ascension[self.player],
-            'heart_run': self.multiworld.heart_run[self.player]
+            'heart_run': self.multiworld.heart_run[self.player],
+            'portals': self.multiworld.portals[self.player],
+            'item_distinction': self.multiworld.item_distinction[self.player]
         }
 
     def generate_basic(self):


### PR DESCRIPTION
## What is this fixing or adding?
Option to enable or disable act portals and allowing player to chose how they want their item locations distributed (no distinction, per act or per act with backlog (no orphaned checks))

## How was this tested?

I'm not sure how to test it. Though I don't think it's a significant change to logic.

## If this makes graphical changes, please attach screenshots.
