### PR TITLE
alttp: add item rules for prize locations

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -706,6 +706,8 @@ def distribute_planned(world: MultiWorld) -> None:
 
     # TODO: remove. Preferably by implementing key drop
     from worlds.alttp.Regions import key_drop_data
+    # TODO: remove. Preferably by implementing prize plando
+    from worlds.alttp.SubClasses import ALttPLocation
     world_name_lookup = world.world_name_lookup
 
     block_value = typing.Union[typing.List[str], typing.Dict[str, typing.Any], str]
@@ -851,8 +853,13 @@ def distribute_planned(world: MultiWorld) -> None:
                 item = world.worlds[player].create_item(item_name)
                 for location in reversed(candidates):
                     if location in key_drop_data:
-                        warn(
-                            f"Can't place '{item_name}' at '{placement.location}', as key drop shuffle locations are not supported yet.")
+                        warn(f"Can't place '{item_name}' at '{location}', as "
+                             "key drop shuffle locations are not supported yet.",
+                             placement["force"])
+                        continue
+                    if isinstance(location, ALttPLocation) and location.crystal:
+                        warn(f"Can't place '{item_name}' at '{location}', as prize locations are not supported yet.",
+                             placement["force"])
                         continue
                     if not location.item:
                         if location.item_rule(item):

--- a/Fill.py
+++ b/Fill.py
@@ -706,8 +706,6 @@ def distribute_planned(world: MultiWorld) -> None:
 
     # TODO: remove. Preferably by implementing key drop
     from worlds.alttp.Regions import key_drop_data
-    # TODO: remove. Preferably by implementing prize plando
-    from worlds.alttp.SubClasses import ALttPLocation
     world_name_lookup = world.world_name_lookup
 
     block_value = typing.Union[typing.List[str], typing.Dict[str, typing.Any], str]
@@ -853,13 +851,8 @@ def distribute_planned(world: MultiWorld) -> None:
                 item = world.worlds[player].create_item(item_name)
                 for location in reversed(candidates):
                     if location in key_drop_data:
-                        warn(f"Can't place '{item_name}' at '{location}', as "
-                             "key drop shuffle locations are not supported yet.",
-                             placement["force"])
-                        continue
-                    if isinstance(location, ALttPLocation) and location.crystal:
-                        warn(f"Can't place '{item_name}' at '{location}', as prize locations are not supported yet.",
-                             placement["force"])
+                        warn(
+                            f"Can't place '{item_name}' at '{placement.location}', as key drop shuffle locations are not supported yet.")
                         continue
                     if not location.item:
                         if location.item_rule(item):

--- a/worlds/alttp/Rules.py
+++ b/worlds/alttp/Rules.py
@@ -1,9 +1,12 @@
 import collections
 import logging
+from typing import Iterator, Set
+
 from worlds.alttp import OverworldGlitchRules
 from BaseClasses import RegionType, MultiWorld, Entrance
-from worlds.alttp.Items import ItemFactory, progression_items, item_name_groups
+from worlds.alttp.Items import ItemFactory, progression_items, item_name_groups, item_table
 from worlds.alttp.OverworldGlitchRules import overworld_glitches_rules, no_logic_rules
+from worlds.alttp.Regions import location_table
 from worlds.alttp.UnderworldGlitchRules import underworld_glitches_rules
 from worlds.alttp.Bosses import GanonDefeatRule
 from worlds.generic.Rules import set_rule, add_rule, forbid_item, add_item_rule, item_in_locations, \
@@ -176,6 +179,14 @@ def dungeon_boss_rules(world, player):
 def global_rules(world, player):
     # ganon can only carry triforce
     add_item_rule(world.get_location('Ganon', player), lambda item: item.name == 'Triforce' and item.player == player)
+    # dungeon prizes can only be crystals/pendants
+    crystals_and_pendants: Set[str] = \
+        {item for item, item_data in item_table.items() if item_data.type == "Crystal"}
+    prize_locations: Iterator[str] = \
+        (locations for locations, location_data in location_table.items() if location_data[2] == True)
+    for prize_location in prize_locations:
+        add_item_rule(world.get_location(prize_location, player),
+                      lambda item: item.name in crystals_and_pendants and item.player == player)
     # determines which S&Q locations are available - hide from paths since it isn't an in-game location
     world.get_region('Menu', player).can_reach_private = lambda state: True
     for exit in world.get_region('Menu', player).exits:

--- a/worlds/alttp/test/items/TestPrizes.py
+++ b/worlds/alttp/test/items/TestPrizes.py
@@ -1,0 +1,39 @@
+from typing import List
+
+from BaseClasses import Item, Location
+from test.TestBase import WorldTestBase
+
+
+class TestPrizes(WorldTestBase):
+    game = "A Link to the Past"
+
+    def test_item_rules(self):
+        prize_locations: List[Location] = [
+            self.multiworld.get_location("Eastern Palace - Prize", 1),
+            self.multiworld.get_location("Desert Palace - Prize", 1),
+            self.multiworld.get_location("Tower of Hera - Prize", 1),
+            self.multiworld.get_location("Palace of Darkness - Prize", 1),
+            self.multiworld.get_location("Swamp Palace - Prize", 1),
+            self.multiworld.get_location("Thieves\' Town - Prize", 1),
+            self.multiworld.get_location("Skull Woods - Prize", 1),
+            self.multiworld.get_location("Ice Palace - Prize", 1),
+            self.multiworld.get_location("Misery Mire - Prize", 1),
+            self.multiworld.get_location("Turtle Rock - Prize", 1),
+        ]
+        prize_items: List[Item] = [
+            self.get_item_by_name("Green Pendant"),
+            self.get_item_by_name("Blue Pendant"),
+            self.get_item_by_name("Red Pendant"),
+            self.get_item_by_name("Crystal 1"),
+            self.get_item_by_name("Crystal 2"),
+            self.get_item_by_name("Crystal 3"),
+            self.get_item_by_name("Crystal 4"),
+            self.get_item_by_name("Crystal 5"),
+            self.get_item_by_name("Crystal 6"),
+            self.get_item_by_name("Crystal 7"),
+        ]
+
+        for item in self.multiworld.get_items():
+            for prize_location in prize_locations:
+                self.assertEqual(item in prize_items, prize_location.item_rule(item),
+                                 f"{item} must {'' if item in prize_items else 'not '}be allowed in {prize_location}.")


### PR DESCRIPTION
## What is this fixing or adding?

Originally reported in https://discord.com/channels/731205301247803413/1061996715625947256:
When using items plando without specifying an explicit list of target locations, all locations in the target world will be considered (this seems to be a bit of a semi-hidden feature in itself). However, a problem arises when any item ends up being placed in an ALttP dungeon prize location, as this causes a crash during ROM output. (And wouldn't be supported by the ALttP ASM anyway.)

~~The proposed solution is to ignore all ALttP dungeon prizes when going through plando location candidates.~~
The proposed solution is to add item rules that allow only crystals/pendants for ALttP dungeon prize locations.

~~This PR also tries to fix an existing, similar exclusion, where the present code was faulty (accessing a nonexistant property and omitting a required arg.)~~

## How was this tested?

Generate with item plando enabled, using the yamls from [Players.zip](https://github.com/ArchipelagoMW/Archipelago/files/10407903/Players.zip) and seed 97547315898807837995.
Causes an exception on main, but not on this branch. (There is still an unfilled location even with this fix, but that problem seems unrelated.)
