### PR TITLE
OoT: heart logic fix

### DIFF
--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -198,6 +198,17 @@ class OOTWorld(World):
         if self.triforce_hunt:
             self.shuffle_ganon_bosskey = 'triforce'
 
+        # Force itempool to higher settings if it doesn't have enough hearts
+        max_required_hearts = 3
+        if self.bridge == 'hearts':
+            max_required_hearts = max(max_required_hearts, self.bridge_hearts)
+        if self.shuffle_ganon_bosskey == 'hearts':
+            max_required_hearts = max(max_required_hearts, self.ganon_bosskey_hearts)
+        if max_required_hearts > 3 and self.item_pool_value == 'minimal':
+            self.item_pool_value = 'scarce'
+        if max_required_hearts > 12 and self.item_pool_value == 'scarce':
+            self.item_pool_value = 'balanced'
+
         # If songs/keys locked to own world by settings, add them to local_items
         local_types = []
         if self.shuffle_song_items != 'any':


### PR DESCRIPTION
If the bridge or ganon bosskey required more hearts than were in the pool, generation crashed.
This forces the item pool to contain sufficiently many hearts to satisfy the logic.
Fixes the bug reported at https://discordapp.com/channels/731205301247803413/1063244398411927564.