### PR TITLE
SA2B: Fix Gate Region Connections

### DIFF
--- a/worlds/sa2b/Regions.py
+++ b/worlds/sa2b/Regions.py
@@ -873,7 +873,7 @@ def connect_regions(world, player, gates: typing.List[LevelGate], cannon_core_em
 
     gates_len = len(gates)
     if gates_len >= 2:
-        connect(world, player, names, 'Menu', LocationName.gate_1_boss_region,
+        connect(world, player, names, LocationName.gate_0_region, LocationName.gate_1_boss_region,
                 lambda state: (state.has(ItemName.emblem, player, gates[1].gate_emblem_count)))
 
         if gate_bosses[1] == all_gate_bosses_table[king_boom_boo]:
@@ -886,7 +886,7 @@ def connect_regions(world, player, gates: typing.List[LevelGate], cannon_core_em
             connect(world, player, names, LocationName.gate_1_region, shuffleable_regions[gates[1].gate_levels[i]])
 
     if gates_len >= 3:
-        connect(world, player, names, 'Menu', LocationName.gate_2_boss_region,
+        connect(world, player, names, LocationName.gate_1_region, LocationName.gate_2_boss_region,
                 lambda state: (state.has(ItemName.emblem, player, gates[2].gate_emblem_count)))
 
         if gate_bosses[2] == all_gate_bosses_table[king_boom_boo]:
@@ -899,7 +899,7 @@ def connect_regions(world, player, gates: typing.List[LevelGate], cannon_core_em
             connect(world, player, names, LocationName.gate_2_region, shuffleable_regions[gates[2].gate_levels[i]])
 
     if gates_len >= 4:
-        connect(world, player, names, 'Menu', LocationName.gate_3_boss_region,
+        connect(world, player, names, LocationName.gate_2_region, LocationName.gate_3_boss_region,
                 lambda state: (state.has(ItemName.emblem, player, gates[3].gate_emblem_count)))
 
         if gate_bosses[3] == all_gate_bosses_table[king_boom_boo]:
@@ -912,7 +912,7 @@ def connect_regions(world, player, gates: typing.List[LevelGate], cannon_core_em
             connect(world, player, names, LocationName.gate_3_region, shuffleable_regions[gates[3].gate_levels[i]])
 
     if gates_len >= 5:
-        connect(world, player, names, 'Menu', LocationName.gate_4_boss_region,
+        connect(world, player, names, LocationName.gate_3_region, LocationName.gate_4_boss_region,
                 lambda state: (state.has(ItemName.emblem, player, gates[4].gate_emblem_count)))
 
         if gate_bosses[4] == all_gate_bosses_table[king_boom_boo]:
@@ -925,7 +925,7 @@ def connect_regions(world, player, gates: typing.List[LevelGate], cannon_core_em
             connect(world, player, names, LocationName.gate_4_region, shuffleable_regions[gates[4].gate_levels[i]])
 
     if gates_len >= 6:
-        connect(world, player, names, 'Menu', LocationName.gate_5_boss_region,
+        connect(world, player, names, LocationName.gate_4_region, LocationName.gate_5_boss_region,
                 lambda state: (state.has(ItemName.emblem, player, gates[5].gate_emblem_count)))
 
         if gate_bosses[5] == all_gate_bosses_table[king_boom_boo]:


### PR DESCRIPTION
## What is this fixing or adding?
`King Boom Boo` boss can lock progress to subsequent gates, by requiring `Knuckles - Shovel Claws`. The region connections were not accounting for gates past the immediate one locked by said boss, so the `Knuckles - Shovel Claws` could be locked in a later gate, with no means of access.

## How was this tested?
Many generations, verifying access to `Knuckles - Shovel Claws` before `King Boom Boo` in all cases
