### PR TITLE
Core: convert mixture of Plando Options and Settings into just Options

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -48,7 +48,7 @@ class MultiWorld():
     precollected_items: Dict[int, List[Item]]
     state: CollectionState
 
-    plando_settings: PlandoSettings
+    plando_options: PlandoOptions
     accessibility: Dict[int, Options.Accessibility]
     early_items: Dict[int, Dict[str, int]]
     local_early_items: Dict[int, Dict[str, int]]
@@ -161,7 +161,7 @@ class MultiWorld():
         self.custom_data = {}
         self.worlds = {}
         self.slot_seeds = {}
-        self.plando_settings = PlandoSettings.none
+        self.plando_options = PlandoOptions.none
 
     def get_all_ids(self) -> Tuple[int, ...]:
         return self.player_ids + tuple(self.groups)
@@ -1560,7 +1560,7 @@ class Spoiler():
                     Utils.__version__, self.multiworld.seed))
             outfile.write('Filling Algorithm:               %s\n' % self.multiworld.algorithm)
             outfile.write('Players:                         %d\n' % self.multiworld.players)
-            outfile.write(f'Plando Options:                  {self.multiworld.plando_settings}\n')
+            outfile.write(f'Plando Options:                  {self.multiworld.plando_options}\n')
             AutoWorld.call_stage(self.multiworld, "write_spoiler_header", outfile)
 
             for player in range(1, self.multiworld.players + 1):
@@ -1677,7 +1677,7 @@ class Tutorial(NamedTuple):
     authors: List[str]
 
 
-class PlandoSettings(IntFlag):
+class PlandoOptions(IntFlag):
     none = 0b0000
     items = 0b0001
     connections = 0b0010
@@ -1685,7 +1685,7 @@ class PlandoSettings(IntFlag):
     bosses = 0b1000
 
     @classmethod
-    def from_option_string(cls, option_string: str) -> PlandoSettings:
+    def from_option_string(cls, option_string: str) -> PlandoOptions:
         result = cls(0)
         for part in option_string.split(","):
             part = part.strip().lower()
@@ -1694,14 +1694,14 @@ class PlandoSettings(IntFlag):
         return result
 
     @classmethod
-    def from_set(cls, option_set: Set[str]) -> PlandoSettings:
+    def from_set(cls, option_set: Set[str]) -> PlandoOptions:
         result = cls(0)
         for part in option_set:
             result = cls._handle_part(part, result)
         return result
 
     @classmethod
-    def _handle_part(cls, part: str, base: PlandoSettings) -> PlandoSettings:
+    def _handle_part(cls, part: str, base: PlandoOptions) -> PlandoOptions:
         try:
             part = cls[part]
         except Exception as e:
@@ -1712,7 +1712,7 @@ class PlandoSettings(IntFlag):
 
     def __str__(self) -> str:
         if self.value:
-            return ", ".join(flag.name for flag in PlandoSettings if self.value & flag.value)
+            return ", ".join(flag.name for flag in PlandoOptions if self.value & flag.value)
         return "None"
 
 

--- a/Generate.py
+++ b/Generate.py
@@ -20,7 +20,7 @@ from worlds.generic import PlandoConnection
 from Utils import parse_yamls, version_tuple, __version__, tuplize_version, get_options, user_path
 from worlds.alttp.EntranceRandomizer import parse_arguments
 from Main import main as ERmain
-from BaseClasses import seeddigits, get_seed, PlandoSettings
+from BaseClasses import seeddigits, get_seed, PlandoOptions
 import Options
 from worlds.alttp.Text import TextTable
 from worlds.AutoWorld import AutoWorldRegister
@@ -61,7 +61,7 @@ def mystery_argparse():
         args.weights_file_path = os.path.join(args.player_files_path, args.weights_file_path)
     if not os.path.isabs(args.meta_file_path):
         args.meta_file_path = os.path.join(args.player_files_path, args.meta_file_path)
-    args.plando: PlandoSettings = PlandoSettings.from_option_string(args.plando)
+    args.plando: PlandoOptions = PlandoOptions.from_option_string(args.plando)
     return args, options
 
 
@@ -134,7 +134,7 @@ def main(args=None, callback=ERmain):
                         f"A mix is also permitted.")
     erargs = parse_arguments(['--multi', str(args.multi)])
     erargs.seed = seed
-    erargs.plando_settings = args.plando
+    erargs.plando_options = args.plando
     erargs.glitch_triforce = options["generator"]["glitch_triforce_room"]
     erargs.spoiler = args.spoiler
     erargs.race = args.race
@@ -408,7 +408,7 @@ def roll_triggers(weights: dict, triggers: list) -> dict:
     return weights
 
 
-def handle_option(ret: argparse.Namespace, game_weights: dict, option_key: str, option: type(Options.Option), plando_options: PlandoSettings):
+def handle_option(ret: argparse.Namespace, game_weights: dict, option_key: str, option: type(Options.Option), plando_options: PlandoOptions):
     if option_key in game_weights:
         try:
             if not option.supports_weighting:
@@ -424,7 +424,7 @@ def handle_option(ret: argparse.Namespace, game_weights: dict, option_key: str, 
         setattr(ret, option_key, option.from_any(option.default))  # call the from_any here to support default "random"
 
 
-def roll_settings(weights: dict, plando_options: PlandoSettings = PlandoSettings.bosses):
+def roll_settings(weights: dict, plando_options: PlandoOptions = PlandoOptions.bosses):
     if "linked_options" in weights:
         weights = roll_linked_options(weights)
 
@@ -437,7 +437,7 @@ def roll_settings(weights: dict, plando_options: PlandoSettings = PlandoSettings
         if tuplize_version(version) > version_tuple:
             raise Exception(f"Settings reports required version of generator is at least {version}, "
                             f"however generator is of version {__version__}")
-        required_plando_options = PlandoSettings.from_option_string(requirements.get("plando", ""))
+        required_plando_options = PlandoOptions.from_option_string(requirements.get("plando", ""))
         if required_plando_options not in plando_options:
             if required_plando_options:
                 raise Exception(f"Settings reports required plando module {str(required_plando_options)}, "
@@ -471,12 +471,12 @@ def roll_settings(weights: dict, plando_options: PlandoSettings = PlandoSettings
             if option_key not in world_type.option_definitions and \
                     (option_key not in Options.common_options or option_key in game_weights):
                 handle_option(ret, game_weights, option_key, option, plando_options)
-        if PlandoSettings.items in plando_options:
+        if PlandoOptions.items in plando_options:
             ret.plando_items = game_weights.get("plando_items", [])
         if ret.game == "Minecraft" or ret.game == "Ocarina of Time":
             # bad hardcoded behavior to make this work for now
             ret.plando_connections = []
-            if PlandoSettings.connections in plando_options:
+            if PlandoOptions.connections in plando_options:
                 options = game_weights.get("plando_connections", [])
                 for placement in options:
                     if roll_percentage(get_choice("percentage", placement, 100)):
@@ -591,7 +591,7 @@ def roll_alttp_settings(ret: argparse.Namespace, weights, plando_options):
             raise Exception(f"unknown Medallion {medallion} for {'misery mire' if index == 0 else 'turtle rock'}")
 
     ret.plando_texts = {}
-    if PlandoSettings.texts in plando_options:
+    if PlandoOptions.texts in plando_options:
         tt = TextTable()
         tt.removeUnwantedText()
         options = weights.get("plando_texts", [])
@@ -603,7 +603,7 @@ def roll_alttp_settings(ret: argparse.Namespace, weights, plando_options):
                 ret.plando_texts[at] = str(get_choice_legacy("text", placement))
 
     ret.plando_connections = []
-    if PlandoSettings.connections in plando_options:
+    if PlandoOptions.connections in plando_options:
         options = weights.get("plando_connections", [])
         for placement in options:
             if roll_percentage(get_choice_legacy("percentage", placement, 100)):

--- a/Main.py
+++ b/Main.py
@@ -38,7 +38,7 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
 
     logger = logging.getLogger()
     world.set_seed(seed, args.race, str(args.outputname if args.outputname else world.seed))
-    world.plando_settings = args.plando_settings
+    world.plando_options = args.plando_options
 
     world.shuffle = args.shuffle.copy()
     world.logic = args.logic.copy()

--- a/Options.py
+++ b/Options.py
@@ -133,10 +133,10 @@ class Option(typing.Generic[T], metaclass=AssembleOptions):
         raise NotImplementedError
 
     if typing.TYPE_CHECKING:
-        from Generate import PlandoSettings
+        from Generate import PlandoOptions
         from worlds.AutoWorld import World
 
-        def verify(self, world: World, player_name: str, plando_options: PlandoSettings) -> None:
+        def verify(self, world: World, player_name: str, plando_options: PlandoOptions) -> None:
             pass
     else:
         def verify(self, *args, **kwargs) -> None:
@@ -578,8 +578,8 @@ class PlandoBosses(TextChoice, metaclass=BossMeta):
     def verify(self, world, player_name: str, plando_options) -> None:
         if isinstance(self.value, int):
             return
-        from Generate import PlandoSettings
-        if not(PlandoSettings.bosses & plando_options):
+        from Generate import PlandoOptions
+        if not(PlandoOptions.bosses & plando_options):
             import logging
             # plando is disabled but plando options were given so pull the option and change it to an int
             option = self.value.split(";")[-1]

--- a/WebHostLib/check.py
+++ b/WebHostLib/check.py
@@ -12,7 +12,7 @@ def allowed_file(filename):
     return filename.endswith(('.txt', ".yaml", ".zip"))
 
 
-from Generate import roll_settings, PlandoSettings
+from Generate import roll_settings, PlandoOptions
 from Utils import parse_yamls
 
 
@@ -69,7 +69,7 @@ def get_yaml_data(file) -> Union[Dict[str, str], str, Markup]:
 def roll_options(options: Dict[str, Union[dict, str]],
                  plando_options: Set[str] = frozenset({"bosses", "items", "connections", "texts"})) -> \
         Tuple[Dict[str, Union[str, bool]], Dict[str, dict]]:
-    plando_options = PlandoSettings.from_set(set(plando_options))
+    plando_options = PlandoOptions.from_set(set(plando_options))
     results = {}
     rolled_results = {}
     for filename, text in options.items():

--- a/WebHostLib/generate.py
+++ b/WebHostLib/generate.py
@@ -12,7 +12,7 @@ from flask import request, flash, redirect, url_for, session, render_template
 from pony.orm import commit, db_session
 
 from BaseClasses import seeddigits, get_seed
-from Generate import handle_name, PlandoSettings
+from Generate import handle_name, PlandoOptions
 from Main import main as ERmain
 from Utils import __version__
 from WebHostLib import app
@@ -119,7 +119,7 @@ def gen_game(gen_options: dict, meta: Optional[Dict[str, Any]] = None, owner=Non
         erargs.outputname = seedname
         erargs.outputpath = target.name
         erargs.teams = 1
-        erargs.plando_options = PlandoSettings.from_set(meta.setdefault("plando_options",
+        erargs.plando_options = PlandoOptions.from_set(meta.setdefault("plando_options",
                                                                         {"bosses", "items", "connections", "texts"}))
 
         name_counter = Counter()

--- a/worlds/alttp/test/options/TestPlandoBosses.py
+++ b/worlds/alttp/test/options/TestPlandoBosses.py
@@ -113,8 +113,8 @@ class TestPlandoBosses(unittest.TestCase):
         """Test automatic singularity mode"""
         self.assertIn(";singularity", MultiBosses.from_any("b2").value)
 
-    def testPlandoSettings(self):
-        """Test that plando settings verification works"""
+    def testPlandoOptions(self):
+        """Test that plando options verification works"""
         plandoed_string = "l1-b2;l2-b1"
         mixed_string = "l1-b2;shuffle"
         regular_string = "shuffle"
@@ -123,14 +123,14 @@ class TestPlandoBosses(unittest.TestCase):
         regular = MultiBosses.from_any(regular_string)
 
         # plando should work with boss plando
-        plandoed.verify(None, "Player", Generate.PlandoSettings.bosses)
+        plandoed.verify(None, "Player", Generate.PlandoOptions.bosses)
         self.assertTrue(plandoed.value.startswith(plandoed_string))
         # plando should fall back to default without boss plando
-        plandoed.verify(None, "Player", Generate.PlandoSettings.items)
+        plandoed.verify(None, "Player", Generate.PlandoOptions.items)
         self.assertEqual(plandoed, MultiBosses.option_vanilla)
         # mixed should fall back to mode
-        mixed.verify(None, "Player", Generate.PlandoSettings.items)  # should produce a warning and still work
+        mixed.verify(None, "Player", Generate.PlandoOptions.items)  # should produce a warning and still work
         self.assertEqual(mixed, MultiBosses.option_shuffle)
         # mode stuff should just work
-        regular.verify(None, "Player", Generate.PlandoSettings.items)
+        regular.verify(None, "Player", Generate.PlandoOptions.items)
         self.assertEqual(regular, MultiBosses.option_shuffle)

--- a/worlds/sm/variaRandomizer/rando/RandoSettings.py
+++ b/worlds/sm/variaRandomizer/rando/RandoSettings.py
@@ -10,7 +10,7 @@ from rando.ItemLocContainer import ItemLocation
 # Holds settings not related to graph layout.
 class RandoSettings(object):
     def __init__(self, maxDiff, progSpeed, progDiff, qty, restrictions,
-                 superFun, runtimeLimit_s, plandoSettings, minDiff):
+                 superFun, runtimeLimit_s, PlandoOptions, minDiff):
         self.progSpeed = progSpeed.lower()
         self.progDiff = progDiff.lower()
         self.maxDiff = maxDiff
@@ -20,7 +20,7 @@ class RandoSettings(object):
         self.runtimeLimit_s = runtimeLimit_s
         if self.runtimeLimit_s <= 0:
             self.runtimeLimit_s = sys.maxsize
-        self.plandoSettings = plandoSettings
+        self.PlandoOptions = PlandoOptions
         self.minDiff = minDiff
 
     def getSuperFun(self):
@@ -30,7 +30,7 @@ class RandoSettings(object):
         self.superFun = superFun[:]
 
     def isPlandoRando(self):
-        return self.plandoSettings is not None
+        return self.PlandoOptions is not None
 
     def getItemManager(self, smbm, nLocs):
         if not self.isPlandoRando():
@@ -43,20 +43,20 @@ class RandoSettings(object):
             return None
         exclude = {'alreadyPlacedItems': defaultdict(int), 'forbiddenItems': []}
         # locsItems is a dict {'loc name': 'item type'}
-        for locName,itemType in self.plandoSettings["locsItems"].items():
+        for locName,itemType in self.PlandoOptions["locsItems"].items():
             if not any(loc.Name == locName for loc in locations):
                 continue
             exclude['alreadyPlacedItems'][itemType] += 1
             exclude['alreadyPlacedItems']['total'] += 1
 
-        exclude['forbiddenItems'] = self.plandoSettings['forbiddenItems']
+        exclude['forbiddenItems'] = self.PlandoOptions['forbiddenItems']
 
         return exclude
 
     def collectAlreadyPlacedItemLocations(self, container):
         if not self.isPlandoRando():
             return
-        for locName,itemType in self.plandoSettings["locsItems"].items():
+        for locName,itemType in self.PlandoOptions["locsItems"].items():
             if not any(loc.Name == locName for loc in container.unusedLocations):
                 continue
             item = container.getNextItemInPool(itemType)

--- a/worlds/sm/variaRandomizer/randomizer.py
+++ b/worlds/sm/variaRandomizer/randomizer.py
@@ -621,7 +621,7 @@ class VariaRandomizer:
         self.ctrlDict = { getattr(ctrl, button) : button for button in ctrlButton }
         args.moonWalk = ctrl.Moonwalk
 
-        plandoSettings = None
+        PlandoOptions = None
         if args.plandoRando is not None:
             forceArg('progressionSpeed', 'speedrun', "'Progression Speed' forced to speedrun")
             progSpeed = 'speedrun'
@@ -632,10 +632,10 @@ class VariaRandomizer:
             args.plandoRando = json.loads(args.plandoRando)
             RomPatches.ActivePatches[self.player] = args.plandoRando["patches"]
             DoorsManager.unserialize(args.plandoRando["doors"])
-            plandoSettings = {"locsItems": args.plandoRando['locsItems'], "forbiddenItems": args.plandoRando['forbiddenItems']}
+            PlandoOptions = {"locsItems": args.plandoRando['locsItems'], "forbiddenItems": args.plandoRando['forbiddenItems']}
         randoSettings = RandoSettings(self.maxDifficulty, progSpeed, progDiff, qty,
                                     restrictions, args.superFun, args.runtimeLimit_s,
-                                    plandoSettings, minDifficulty)
+                                    PlandoOptions, minDifficulty)
 
         # print some parameters for jm's stats
         if args.jm == True:


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?
convert mixture of Plando Options and Settings into just Options
also this
![image](https://user-images.githubusercontent.com/3189725/212955640-59b28aa7-1fa1-43d4-80b4-9a29cbb75c75.png)

## How was this tested?
running generation on webhost and generate.py

## If this makes graphical changes, please attach screenshots.
