### PR TITLE
Docs/Subnautica: Updated console instructions, misc clarifications

### DIFF
--- a/worlds/subnautica/docs/setup_en.md
+++ b/worlds/subnautica/docs/setup_en.md
@@ -35,18 +35,18 @@ Warning: Currently it is not checked whether a loaded savegame belongs to the mu
 ## Console Commands
 
 The mod adds the following console commands:
- - `say` sends the text following it to Archipelago as a chat message. ! is not an allowed character, use / instead.
- - `silent` toggles Archipelago chat messages appearing.
+ - `say` sends the text following it to Archipelago as a chat message.
+   - `!` is not an allowed character, use `/` in its place. For example, to use the [`!hint` command](/tutorial/Archipelago/commands/en#remote-commands), type `say /hint`.
+ - `silent` toggles Archipelago messages appearing.
  - `deathlink` toggles death link.
 
-To enable the console in Subnautica, press `F3` and `F8`, then uncheck "Disable Console" in the top left. Press `F3` and `F8` again to close the menus.
-To enter a console command, press `Enter`.
+To enable the console in Subnautica, press `Shift+Enter`.
 
 ## Known Issues
 
 - Do not attempt playing vanilla saves while the mod is installed, as the mod will override the scan information of the savegame.
 - When exiting to the main menu the mod's state is not properly reset. Loading a savegame from here will break various things.
-  If you want to reload a save it is recommended you restart the game entirely.
+  If you want to reload a save it is recommended you relaunch the game entirely.
 - Attempting to load a savegame containing no longer valid connection information without entering valid information on the main menu will hang on the loading screen.
 
 ## Troubleshooting

--- a/worlds/subnautica/docs/setup_en.md
+++ b/worlds/subnautica/docs/setup_en.md
@@ -38,6 +38,7 @@ The mod adds the following console commands:
  - `say` sends the text following it to Archipelago as a chat message.
    - `!` is not an allowed character, use `/` in its place. For example, to use the [`!hint` command](/tutorial/Archipelago/commands/en#remote-commands), type `say /hint`.
  - `silent` toggles Archipelago messages appearing.
+ - `tracker` rotates through the possible settings for the in-game tracker that displays the closest uncollected location.
  - `deathlink` toggles death link.
 
 To enable the console in Subnautica, press `Shift+Enter`.


### PR DESCRIPTION
## What is this fixing or adding?
* The steps required to enable/open the console in Subnautica have changed in the recent big update. This updates the instructions.
* Added example for how to use `!hint`.
* Misc rewording for clarification.

## Notes
* I don't know whether we are supporting the old Subnautica version at all. If we are, we should probably keep the old console enabling instructions, and also add a remark somewhere that we support both.
* I haven't added the upcoming `tracker` command. If Berserker wants, he or I can roll it into this PR.