### PR TITLE
Pokemon Red and Blue: Updates to trap weights and tracker support

### DIFF
--- a/worlds/pokemon_rb/__init__.py
+++ b/worlds/pokemon_rb/__init__.py
@@ -349,6 +349,7 @@ class PokemonRedBlueWorld(World):
             "elite_four_condition": self.multiworld.elite_four_condition[self.player].value,
             "victory_road_condition": self.multiworld.victory_road_condition[self.player].value,
             "viridian_gym_condition": self.multiworld.viridian_gym_condition[self.player].value,
+            "cerulean_cave_condition": self.multiworld.cerulean_cave_condition[self.player].value,
             "free_fly_map": self.fly_map_code,
             "extra_badges": self.extra_badges,
             "type_chart": self.type_chart,

--- a/worlds/pokemon_rb/__init__.py
+++ b/worlds/pokemon_rb/__init__.py
@@ -190,9 +190,9 @@ class PokemonRedBlueWorld(World):
                 item = self.create_filler()
             else:
                 item = self.create_item(location.original_item)
-                combinedtraps = self.multiworld.poison_trap_weight[self.player].value + self.multiworld.fire_trap_weight[self.player].value + self.multiworld.paralyze_trap_weight[self.player].value + self.multiworld.ice_trap_weight[self.player].value
+                combined_traps = self.multiworld.poison_trap_weight[self.player].value + self.multiworld.fire_trap_weight[self.player].value + self.multiworld.paralyze_trap_weight[self.player].value + self.multiworld.ice_trap_weight[self.player].value
                 if (item.classification == ItemClassification.filler and self.multiworld.random.randint(1, 100)
-                        <= self.multiworld.trap_percentage[self.player].value and combinedtraps != 0):
+                        <= self.multiworld.trap_percentage[self.player].value and combined_traps != 0):
                     item = self.create_item(self.select_trap())
             if location.event:
                 self.multiworld.get_location(location.name, self.player).place_locked_item(item)

--- a/worlds/pokemon_rb/__init__.py
+++ b/worlds/pokemon_rb/__init__.py
@@ -190,8 +190,9 @@ class PokemonRedBlueWorld(World):
                 item = self.create_filler()
             else:
                 item = self.create_item(location.original_item)
+                combinedtraps = self.multiworld.poison_trap_weight[self.player].value + self.multiworld.fire_trap_weight[self.player].value + self.multiworld.paralyze_trap_weight[self.player].value + self.multiworld.ice_trap_weight[self.player].value
                 if (item.classification == ItemClassification.filler and self.multiworld.random.randint(1, 100)
-                        <= self.multiworld.trap_percentage[self.player].value):
+                        <= self.multiworld.trap_percentage[self.player].value and combinedtraps != 0):
                     item = self.create_item(self.select_trap())
             if location.event:
                 self.multiworld.get_location(location.name, self.player).place_locked_item(item)

--- a/worlds/pokemon_rb/options.py
+++ b/worlds/pokemon_rb/options.py
@@ -518,6 +518,7 @@ class TrapWeight(Choice):
     option_low = 1
     option_medium = 3
     option_high = 5
+    option_disabled = 0
     default = 3
 
 
@@ -539,7 +540,6 @@ class ParalyzeTrapWeight(TrapWeight):
 class IceTrapWeight(TrapWeight):
     """Weights for Ice Traps. These apply the Ice status to all your party members. Don't forget to buy Ice Heals!"""
     display_name = "Ice Trap Weight"
-    option_disabled = 0
     default = 0
 
 


### PR DESCRIPTION
## What is this fixing or adding?
Added `cerulean_cave_condition` to the `fill_slot_data` function to allow poptracker to auto-update the number required
Moved `option_disabled = 0` to the TrapWeight class to allow any trap in Red and Blue to be disabled
Added a contingency to traps such that if all are disabled, it won't give traps,

## How was this tested?
Running `Generate.py` to create a seed with all traps disabled but a `trap_percentage` greater than 0. Then posting the seed onto the online branch to check poptracker sees the new tag