### PR TITLE
kvui: always display all tab headers

### DIFF
--- a/data/client.kv
+++ b/data/client.kv
@@ -1,5 +1,5 @@
 <TabbedPanel>
-    tab_width: 200
+    tab_width: root.width / app.tab_count
 <SelectableLabel>:
     canvas.before:
         Color:

--- a/kvui.py
+++ b/kvui.py
@@ -330,6 +330,12 @@ class GameManager(App):
 
         super(GameManager, self).__init__()
 
+    @property
+    def tab_count(self):
+        if hasattr(self, "tabs"):
+            return max(1, len(self.tabs.tab_list))
+        return 1
+
     def build(self) -> Layout:
         self.container = ContainerLayout()
 


### PR DESCRIPTION
## What is this fixing or adding?
always display all tab headers

## How was this tested?
looking at it, mostly SC2 client as it has the Mission Launcher, which is not a logger.

## If this makes graphical changes, please attach screenshots.
From
![image](https://user-images.githubusercontent.com/3189725/213901766-4e7b9f7b-0334-4484-b781-8db78161facf.png)

to
![image](https://user-images.githubusercontent.com/3189725/213901757-a18c069a-beea-40e1-91b4-f341dce79a55.png)
