### PR TITLE
Factorio: fix automation-level tech costs before automation

### DIFF
--- a/worlds/factorio/__init__.py
+++ b/worlds/factorio/__init__.py
@@ -452,7 +452,7 @@ class FactorioScienceLocation(FactorioLocation):
 
     # Factorio technology properties:
     ingredients: typing.Dict[str, int]
-    count: int
+    count: int = 0
 
     def __init__(self, player: int, name: str, address: int, parent: Region):
         super(FactorioScienceLocation, self).__init__(player, name, address, parent)
@@ -464,8 +464,6 @@ class FactorioScienceLocation(FactorioLocation):
         for complexity in range(self.complexity):
             if parent.multiworld.tech_cost_mix[self.player] > parent.multiworld.random.randint(0, 99):
                 self.ingredients[Factorio.ordered_science_packs[complexity]] = 1
-        self.count = parent.multiworld.random.randint(parent.multiworld.min_tech_cost[self.player],
-                                                      parent.multiworld.max_tech_cost[self.player])
 
     @property
     def factorio_ingredients(self) -> typing.List[typing.Tuple[str, int]]:

--- a/worlds/factorio/__init__.py
+++ b/worlds/factorio/__init__.py
@@ -198,6 +198,10 @@ class Factorio(World):
                     self.multiworld.itempool.append(tech_item)
                 else:
                     loc = cost_sorted_locations[index]
+                    if index >= 0:
+                        # beginning techs - limit cost to 10
+                        # as automation is not achievable yet and hand-crafting for hours is not fun gameplay
+                        loc.count = min(loc.count, 10)
                     loc.place_locked_item(tech_item)
                     loc.revealed = True
 


### PR DESCRIPTION
## What is this fixing or adding?
 prevents automation-1 and logistics-1 costing more than 10 red science, which just becomes tedious without them
 Factory without Factory

## How was this tested/ If this makes graphical changes, please attach screenshots.
![image](https://user-images.githubusercontent.com/3189725/213944041-70cf4aae-ad2d-46da-a025-ba043126596c.png)
![image](https://user-images.githubusercontent.com/3189725/213944047-94817078-58e4-4984-b8bd-d921e599db79.png)
![image](https://user-images.githubusercontent.com/3189725/213944054-0476cf35-db65-49af-9918-7a2b1ac04d40.png)
