### PR TITLE
Factorio: add option "ramping tech cost"

### DIFF
--- a/worlds/factorio/Options.py
+++ b/worlds/factorio/Options.py
@@ -69,6 +69,13 @@ class TechCostMix(Range):
     default = 70
 
 
+class RampingTechCosts(Toggle):
+    """Forces the amount of Science Packs required to ramp up with the highest involved Pack. Average is preserved.
+    For example:
+    off: Automation (red)/Logistics (green) sciences can range from 1 to 1000 Science Packs,
+    on: Automation (red) ranges to ~500 packs and Logistics (green) from ~500 to 1000 Science Packs"""
+
+
 class Silo(Choice):
     """Ingredients to craft rocket silo or auto-place if set to spawn."""
     display_name = "Rocket Silo"
@@ -372,6 +379,7 @@ factorio_options: typing.Dict[str, type(Option)] = {
     "min_tech_cost": MinTechCost,
     "max_tech_cost": MaxTechCost,
     "tech_cost_mix": TechCostMix,
+    "ramping_tech_cost": RampingTechCosts,
     "silo": Silo,
     "satellite": Satellite,
     "free_samples": FreeSamples,

--- a/worlds/factorio/Options.py
+++ b/worlds/factorio/Options.py
@@ -74,6 +74,7 @@ class RampingTechCosts(Toggle):
     For example:
     off: Automation (red)/Logistics (green) sciences can range from 1 to 1000 Science Packs,
     on: Automation (red) ranges to ~500 packs and Logistics (green) from ~500 to 1000 Science Packs"""
+    display_name = "Ramping Tech Costs"
 
 
 class Silo(Choice):

--- a/worlds/factorio/Options.py
+++ b/worlds/factorio/Options.py
@@ -379,7 +379,7 @@ factorio_options: typing.Dict[str, type(Option)] = {
     "min_tech_cost": MinTechCost,
     "max_tech_cost": MaxTechCost,
     "tech_cost_mix": TechCostMix,
-    "ramping_tech_cost": RampingTechCosts,
+    "ramping_tech_costs": RampingTechCosts,
     "silo": Silo,
     "satellite": Satellite,
     "free_samples": FreeSamples,

--- a/worlds/factorio/__init__.py
+++ b/worlds/factorio/__init__.py
@@ -99,7 +99,13 @@ class Factorio(World):
                           for loc_name in location_names]
         rand_values = sorted(random.randint(self.multiworld.min_tech_cost[self.player],
                                             self.multiworld.max_tech_cost[self.player]) for _ in self.locations)
-        for i, location in enumerate(sorted(self.locations, key=lambda loc: loc.rel_cost)):
+        if self.multiworld.ramping_tech_costs[self.player]:
+            def sorter(loc: FactorioScienceLocation):
+                return loc.complexity, loc.rel_cost
+        else:
+            def sorter(loc: FactorioScienceLocation):
+                return loc.rel_cost
+        for i, location in enumerate(sorted(self.locations, key=sorter)):
             location.count = rand_values[i]
         del rand_values
         nauvis.locations.extend(self.locations)


### PR DESCRIPTION
## What is this fixing or adding?
adds ramping tech cost as an option

## How was this tested?
By loading it up in Factorio

## If this makes graphical changes, please attach screenshots.
Taken from 1-10000 cost with ramping on.
![image](https://user-images.githubusercontent.com/3189725/213945368-f365191c-647a-40eb-96fc-ea84c5769d81.png)
![image](https://user-images.githubusercontent.com/3189725/213945376-bbb33899-41f4-433c-9d47-5309593ff6b3.png)
![image](https://user-images.githubusercontent.com/3189725/213945383-b29724b5-e363-469a-8295-be097f1a45c3.png)
![image](https://user-images.githubusercontent.com/3189725/213945397-0848c483-4b25-4aac-8304-61c348053ae2.png)
