### PR TITLE
CommonClient: Fix address pre-selection

### DIFF
--- a/kvui.py
+++ b/kvui.py
@@ -392,11 +392,13 @@ class GameManager(App):
         Clock.schedule_interval(self.update_texts, 1 / 30)
         self.container.add_widget(self.grid)
 
+        # If the address contains a port, select it; otherwise, select the host.
+        s = self.server_connect_bar.text
+        host_start = s.find("@") + 1
+        ipv6_end = s.find("]", host_start) + 1
+        port_start = s.find(":", ipv6_end if ipv6_end > 0 else host_start) + 1
         self.server_connect_bar.focus = True
-        self.server_connect_bar.select_text(
-            self.server_connect_bar.text.find(":") + 1,
-            len(self.server_connect_bar.text)
-        )
+        self.server_connect_bar.select_text(port_start if port_start > 0 else host_start, len(s))
 
         return self.container
 


### PR DESCRIPTION
## What is this fixing?
In #1139 I added a QoL feature that makes CommonClient pre-select the port portion of the address on startup. I simply used `str.find(":")` to determine the port portion, which fails when the address contains other colons than the one separating the port.

This PR ensures the following cases are now handled correctly:
* The address has a username&password component (such as `Berserker:hunter2@archipelago.gg:50695`).
* An IPv6 address is specified (such as `[2001:4860:4860::8888]:38281`).

Additionally, the logic is extended to select the host portion if no port is present.

## How was this tested?
With various strings of all combinations of username&password component present ⨯ IPv6 address ⨯ port present.