### PR TITLE
Core: recache all locations before locality rules

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -122,6 +122,10 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
     logger.info('Creating Items.')
     AutoWorld.call_all(world, "create_items")
 
+    # All worlds should have finished creating all regions, locations, and entrances.
+    # Recache to ensure that they are all visible for locality rules.
+    world._recache()
+
     logger.info('Calculating Access Rules.')
 
     for player in world.player_ids:


### PR DESCRIPTION
Fixes a bug where locality rules would not be set properly on some locations (first discovered in Hollow Knight) due to no recache being triggered between their creation and `locality_rules` being called.