### PR TITLE
Subnautica: fix considers items firing wrong

### DIFF
--- a/worlds/subnautica/Rules.py
+++ b/worlds/subnautica/Rules.py
@@ -152,7 +152,7 @@ def has_ultra_glide_fins(state: "CollectionState", player: int) -> bool:
 def get_max_swim_depth(state: "CollectionState", player: int) -> int:
     swim_rule: SwimRule = state.multiworld.swim_rule[player]
     depth: int = swim_rule.base_depth
-    if swim_rule == swim_rule.consider_items:
+    if swim_rule.consider_items:
         if has_seaglide(state, player):
             if has_ultra_high_capacity_tank(state, player):
                 depth += 350  # It's about 800m. Give some room


### PR DESCRIPTION
## What is this fixing or adding?
fix swim_rule 0 (easy) always considers items
`0 == False -> True`
also fix considers items actually working, as 3 or 4 or `5 == True -> False`

Basically this behaviour matrix was by accident in effect:
```
easy -> easy_items
normal -> normal
hard -> hard
easy_items -> easy
normal_items -> normal
hard_items -> hard
```

## How was this tested?
a quick look at a spoiler
