### PR TITLE
SMW & DKC3: Ship as `.apworld`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,8 @@ apworlds: set = {
     "Subnautica",
     "Factorio",
     "Rogue Legacy",
+    "Donkey Kong Country 3",
+    "Super Mario World",
 }
 
 if os.path.exists("X:/pw.txt"):


### PR DESCRIPTION
## What is this fixing or adding?
SMW and DKC3 have been successfully tested as `.apworld`s, so ship them as such.

## How was this tested?
Local tests of both games as `.apworld`

## If this makes graphical changes, please attach screenshots.
