### PR TITLE
core: properly declare from_any as an abstract classmethod

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -79,9 +79,6 @@ class AssembleOptions(abc.ABCMeta):
 
         return super(AssembleOptions, mcs).__new__(mcs, name, bases, attrs)
 
-    @abc.abstractclassmethod
-    def from_any(cls, value: typing.Any) -> "Option[typing.Any]": ...
-
 
 T = typing.TypeVar('T')
 
@@ -129,8 +126,9 @@ class Option(typing.Generic[T], metaclass=AssembleOptions):
         return bool(self.value)
 
     @classmethod
+    @abc.abstractmethod
     def from_any(cls, data: typing.Any) -> Option[T]:
-        raise NotImplementedError
+        ...
 
     if typing.TYPE_CHECKING:
         from Generate import PlandoOptions
@@ -168,7 +166,7 @@ class FreeText(Option):
         return value
 
 
-class NumericOption(Option[int], numbers.Integral):
+class NumericOption(Option[int], numbers.Integral, abc.ABC):
     default = 0
     # note: some of the `typing.Any`` here is a result of unresolved issue in python standards
     # `int` is not a `numbers.Integral` according to the official typestubs


### PR DESCRIPTION
## What is this fixing or adding?

Currently the method `from_any` is declared as an abstract classmethod on the class `AssembleOptions`, but this is incorrect.
`AssembleOptions` itself is not an ABC to begin with (it actually is a metaclass for defining ABCs).

Instead, this PR moves the declaration of the abstract classmethod to the ABC whose metaclass is `AssembleOptions`, i.e., the class `Option`.


## If this makes graphical changes, please attach screenshots.

Honestly, the main reason this PR exists is because it ensures that PyCharm no longer points out that *subclasses* of `AssembleOptions` are incomplete because they do not implement `from_any`.
(We actually want to enforce this for *instances* of `AssembleOptions`, which is what this PR does.)

Before:
![image](https://user-images.githubusercontent.com/109771707/215876647-66739087-05ed-439c-9e82-ee52395d98c2.png)

After:
![image](https://user-images.githubusercontent.com/109771707/215876676-5b0b1148-d8ec-48aa-b876-ccd22896ac77.png)


## How was this tested?

```python
class OptionWithoutFromAny(Option[str]):
    pass

OptionWithoutFromAny()
```
Before: Nothing
After: "TypeError: Can't instantiate abstract class OptionWithoutFromAny with abstract methods from_any"