### PR TITLE
kivy: allow user-defined text colors in data/client.kv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ Output Logs/
 /Archipelago.zip
 /setup.ini
 /installdelete.iss
+/data/user.kv
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/data/client.kv
+++ b/data/client.kv
@@ -56,3 +56,16 @@
             rectangle: self.x-2, self.y-2, self.width+4, self.height+4
 <ServerToolTip>:
     pos_hint: {'center_y': 0.5, 'center_x': 0.5}
+<TextColors>:
+    # Hex-format RGB colors used in clients. Resets after an update/install, backup your changes if needed.
+    black: "000000"
+    red: "EE0000"
+    green: "00FF7F"  # typically a location
+    yellow: "FAFAD2"  # typically other slots/players
+    blue: "6495ED"  # typically extra info (such as entrance)
+    magenta: "EE00EE"  # typically your slot/player
+    cyan: "00EEEE"  # typically regular item
+    slateblue: "6D8BE8"  # typically useful item
+    plum: "AF99EF"  # typically progression item
+    salmon: "FA8072"  # typically trap item
+    white: "FFFFFF"

--- a/data/client.kv
+++ b/data/client.kv
@@ -57,7 +57,9 @@
 <ServerToolTip>:
     pos_hint: {'center_y': 0.5, 'center_x': 0.5}
 <TextColors>:
-    # Hex-format RGB colors used in clients. Resets after an update/install, backup your changes if needed.
+    # Hex-format RGB colors used in clients. Resets after an update/install.
+    # To avoid, you can copy the TextColors section into a new "user.kv" next to this file
+    # and it will read from there instead.
     black: "000000"
     red: "EE0000"
     green: "00FF7F"  # typically a location

--- a/data/client.kv
+++ b/data/client.kv
@@ -1,4 +1,21 @@
-<TabbedPanel>
+<TextColors>:
+    # Hex-format RGB colors used in clients. Resets after an update/install.
+    # To avoid, you can copy the TextColors section into a new "user.kv" next to this file
+    # and it will read from there instead.
+    black: "000000"
+    red: "EE0000"
+    green: "00FF7F"  # typically a location
+    yellow: "FAFAD2"  # typically other slots/players
+    blue: "6495ED"  # typically extra info (such as entrance)
+    magenta: "EE00EE"  # typically your slot/player
+    cyan: "00EEEE"  # typically regular item
+    slateblue: "6D8BE8"  # typically useful item
+    plum: "AF99EF"  # typically progression item
+    salmon: "FA8072"  # typically trap item
+    white: "FFFFFF"  # not used, if you want to change the generic text color change color in Label
+<Label>:
+    color: "FFFFFF"
+<TabbedPanel>:
     tab_width: root.width / app.tab_count
 <SelectableLabel>:
     canvas.before:
@@ -56,18 +73,3 @@
             rectangle: self.x-2, self.y-2, self.width+4, self.height+4
 <ServerToolTip>:
     pos_hint: {'center_y': 0.5, 'center_x': 0.5}
-<TextColors>:
-    # Hex-format RGB colors used in clients. Resets after an update/install.
-    # To avoid, you can copy the TextColors section into a new "user.kv" next to this file
-    # and it will read from there instead.
-    black: "000000"
-    red: "EE0000"
-    green: "00FF7F"  # typically a location
-    yellow: "FAFAD2"  # typically other slots/players
-    blue: "6495ED"  # typically extra info (such as entrance)
-    magenta: "EE00EE"  # typically your slot/player
-    cyan: "00EEEE"  # typically regular item
-    slateblue: "6D8BE8"  # typically useful item
-    plum: "AF99EF"  # typically progression item
-    salmon: "FA8072"  # typically trap item
-    white: "FFFFFF"

--- a/kvui.py
+++ b/kvui.py
@@ -18,14 +18,14 @@ Config.set("input", "mouse", "mouse,disable_multitouch")
 Config.set('kivy', 'exit_on_escape', '0')
 Config.set('graphics', 'multisamples', '0')  # multisamples crash old intel drivers
 
-from kivy.app import App
+from kivy.app import App, Widget
 from kivy.core.window import Window
 from kivy.core.clipboard import Clipboard
 from kivy.core.text.markup import MarkupLabel
 from kivy.base import ExceptionHandler, ExceptionManager
 from kivy.clock import Clock
 from kivy.factory import Factory
-from kivy.properties import BooleanProperty, ObjectProperty
+from kivy.properties import BooleanProperty, ObjectProperty, DictProperty
 from kivy.uix.button import Button
 from kivy.uix.gridlayout import GridLayout
 from kivy.uix.layout import Layout
@@ -538,6 +538,19 @@ class E(ExceptionHandler):
 
 
 class KivyJSONtoTextParser(JSONtoTextParser):
+    # dummy class to absorb kvlang definitions
+    class TextColors(Widget):
+        pass
+
+    def __init__(self, *args, **kwargs):
+        # we grab the color definitions from the .kv file, then overwrite the JSONtoTextParser default entries
+        colors = self.TextColors()
+        color_codes = self.color_codes.copy()
+        for name, code in color_codes.items():
+            color_codes[name] = getattr(colors, name, code)
+        self.color_codes = color_codes
+        super().__init__(*args, **kwargs)
+
     def __call__(self, *args, **kwargs):
         self.ref_count = 0
         return super(KivyJSONtoTextParser, self).__call__(*args, **kwargs)

--- a/kvui.py
+++ b/kvui.py
@@ -600,3 +600,8 @@ class KivyJSONtoTextParser(JSONtoTextParser):
 ExceptionManager.add_handler(E())
 
 Builder.load_file(Utils.local_path("data", "client.kv"))
+user_file = Utils.local_path("data", "user.kv")
+if os.path.exists(user_file):
+    logging.info("Loading user.kv into builder.")
+    Builder.load_file(user_file)
+

--- a/kvui.py
+++ b/kvui.py
@@ -1,7 +1,6 @@
 import os
 import logging
 import typing
-import asyncio
 
 os.environ["KIVY_NO_CONSOLELOG"] = "1"
 os.environ["KIVY_NO_FILELOG"] = "1"
@@ -18,14 +17,15 @@ Config.set("input", "mouse", "mouse,disable_multitouch")
 Config.set('kivy', 'exit_on_escape', '0')
 Config.set('graphics', 'multisamples', '0')  # multisamples crash old intel drivers
 
-from kivy.app import App, Widget
+from kivy.app import App
 from kivy.core.window import Window
 from kivy.core.clipboard import Clipboard
 from kivy.core.text.markup import MarkupLabel
 from kivy.base import ExceptionHandler, ExceptionManager
 from kivy.clock import Clock
 from kivy.factory import Factory
-from kivy.properties import BooleanProperty, ObjectProperty, DictProperty
+from kivy.properties import BooleanProperty, ObjectProperty
+from kivy.uix.widget import Widget
 from kivy.uix.button import Button
 from kivy.uix.gridlayout import GridLayout
 from kivy.uix.layout import Layout


### PR DESCRIPTION
## What is this fixing or adding?
allow user-defined text colors in data/client.kv

## How was this tested?
![image](https://user-images.githubusercontent.com/3189725/216164273-3c4017ab-4e21-4e71-bc09-2f9f9df8a855.png)


## If this makes graphical changes, please attach screenshots.
![image](https://user-images.githubusercontent.com/3189725/216164282-7204a54c-97ae-4e40-972f-bc02aa541aa9.png)
