### PR TITLE
Zillion: fix name data overflow

### DIFF
--- a/worlds/zillion/requirements.txt
+++ b/worlds/zillion/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/beauxq/zilliandomizer@23d938daa5aaeaa3ec2255c50f2729b33a9e7f87#egg=zilliandomizer==0.5.1
+git+https://github.com/beauxq/zilliandomizer@cd6a940ad7b585c75a560b91468d6b9eee030559#egg=zilliandomizer==0.5.2


### PR DESCRIPTION
## What is this fixing or adding?

This fixes a bug where putting too many player names for remote items in the rom would overflow to corrupt other data in the rom.

(This bug was discovered with the recent 1200 world async. 100 names was enough to make it overflow.)

## How was this tested?

generated a game with 120 player names for remote items and verified it was playable

completed a 3-player multiworld
