### PR TITLE
CI: sni update to v0.0.88 and fix build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ name: Build
 on: workflow_dispatch
 
 env:
-  SNI_VERSION: v0.0.84
+  SNI_VERSION: v0.0.88
   ENEMIZER_VERSION: 7.1
   APPIMAGETOOL_VERSION: 13
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,9 +78,10 @@ jobs:
       - name: Build
         run: |
           # pygobject is an optional dependency for kivy that's not in requirements
-          "${{ env.PYTHON }}" -m pip install --upgrade pip virtualenv PyGObject setuptools
+          # charset-normalizer was somehow incomplete in the github runner
           "${{ env.PYTHON }}" -m venv venv
           source venv/bin/activate
+          "${{ env.PYTHON }}" -m pip install --upgrade pip PyGObject setuptools charset-normalizer
           pip install -r requirements.txt
           python setup.py build_exe --yes bdist_appimage --yes
           echo -e "setup.py build output:\n `ls build`"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,9 +65,10 @@ jobs:
       - name: Build
         run: |
           # pygobject is an optional dependency for kivy that's not in requirements
-          "${{ env.PYTHON }}" -m pip install --upgrade pip virtualenv PyGObject setuptools
+          # charset-normalizer was somehow incomplete in the github runner
           "${{ env.PYTHON }}" -m venv venv
           source venv/bin/activate
+          "${{ env.PYTHON }}" -m pip install --upgrade pip PyGObject setuptools charset-normalizer
           pip install -r requirements.txt
           python setup.py build --yes bdist_appimage --yes
           echo -e "setup.py build output:\n `ls build`"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
       - '*.*.*'
 
 env:
-  SNI_VERSION: v0.0.84
+  SNI_VERSION: v0.0.88
   ENEMIZER_VERSION: 7.1
   APPIMAGETOOL_VERSION: 13
 


### PR DESCRIPTION
Re build fix: this will now install more stuff in the venv, and then later downgrade `charset-normalizer` for `aiohttp`. Not sure if the fix is updating the venv ahead of time, or "priming" then venv with a good charset-normalizer, but it definitely works now.

As a side note: the linux build currently does not work because dkc3 and smw do relative imports outside of their root, but that's unrelated to this change.