### PR TITLE
[OC2] Relax Horde Logic for Horde H-8 and Winter H-4

### DIFF
--- a/worlds/overcooked2/Logic.py
+++ b/worlds/overcooked2/Logic.py
@@ -3055,7 +3055,8 @@ level_logic = {
     "Horde H-8": (
         (  # 1-star
             {  # Exclusive
-
+                "Coin Purse",
+                "Calmer Unbread"
             },
             horde_logic,
         ),
@@ -3467,7 +3468,8 @@ level_logic = {
     "Winter H-4": (
         (  # 1-star
             {  # Exclusive
-
+                "Coin Purse",
+                "Calmer Unbread"
             },
             horde_logic,
         ),


### PR DESCRIPTION
## What is this fixing or adding?
Horde logic used to be blanketed over all horde levels, but these two levels are significantly harder without the horde specific items. Require both horde items before logical access to these levels.

## How was this tested?
`python -m pytest ./worlds/overcooked2/test/TestOvercooked2.py`
