### PR TITLE
Tests: test that exits to `Regions` are the parents of the `Entrance`

### DIFF
--- a/test/general/TestImplemented.py
+++ b/test/general/TestImplemented.py
@@ -7,16 +7,16 @@ from . import setup_default_world
 class TestImplemented(unittest.TestCase):
     def testCompletionCondition(self):
         """Ensure a completion condition is set that has requirements."""
-        for gamename, world_type in AutoWorldRegister.world_types.items():
-            if not world_type.hidden and gamename not in {"ArchipIDLE", "Final Fantasy", "Sudoku"}:
-                with self.subTest(gamename):
+        for game_name, world_type in AutoWorldRegister.world_types.items():
+            if not world_type.hidden and game_name not in {"ArchipIDLE", "Final Fantasy", "Sudoku"}:
+                with self.subTest(game_name):
                     multiworld = setup_default_world(world_type)
                     self.assertFalse(multiworld.completion_condition[1](multiworld.state))
 
     def testEntranceParents(self):
         """Tests that the parents of created Entrances match the exiting Region."""
         for game_name, world_type in AutoWorldRegister.world_types.items():
-            if not world_type.hidden and game_name not in {"ArchipIDLE", "Final Fantasy", "Sudoku"}:
+            if not world_type.hidden and game_name not in {"Final Fantasy"}:
                 with self.subTest(game_name):
                     multiworld = setup_default_world(world_type)
                     for region in multiworld.regions:

--- a/test/general/TestImplemented.py
+++ b/test/general/TestImplemented.py
@@ -10,5 +10,15 @@ class TestImplemented(unittest.TestCase):
         for gamename, world_type in AutoWorldRegister.world_types.items():
             if not world_type.hidden and gamename not in {"ArchipIDLE", "Final Fantasy", "Sudoku"}:
                 with self.subTest(gamename):
-                    world = setup_default_world(world_type)
-                    self.assertFalse(world.completion_condition[1](world.state))
+                    multiworld = setup_default_world(world_type)
+                    self.assertFalse(multiworld.completion_condition[1](multiworld.state))
+
+    def testEntranceParents(self):
+        """Tests that the parents of created Entrances match the exiting Region."""
+        for game_name, world_type in AutoWorldRegister.world_types.items():
+            if not world_type.hidden and game_name not in {"ArchipIDLE", "Final Fantasy", "Sudoku"}:
+                with self.subTest(game_name):
+                    multiworld = setup_default_world(world_type)
+                    for region in multiworld.regions:
+                        for exit in region.exits:
+                            self.assertEqual(exit.parent_region, region)

--- a/test/general/TestReachability.py
+++ b/test/general/TestReachability.py
@@ -12,7 +12,7 @@ class TestBase(unittest.TestCase):
     def testAllStateCanReachEverything(self):
         for game_name, world_type in AutoWorldRegister.world_types.items():
             # Final Fantasy logic is controlled by finalfantasyrandomizer.com
-            if game_name != "Ori and the Blind Forest" and game_name != "Final Fantasy":  # TODO: fix Ori Logic
+            if game_name not in {"Ori and the Blind Forest", "Final Fantasy"}:  # TODO: fix Ori Logic
                 with self.subTest("Game", game=game_name):
                     world = setup_default_world(world_type)
                     excluded = world.exclude_locations[1].value


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?
Title

## How was this tested?
It's a test

## If this makes graphical changes, please attach screenshots.
