### PR TITLE
lufia2ac: fix mismatched exits/parent region

### DIFF
--- a/worlds/lufia2ac/__init__.py
+++ b/worlds/lufia2ac/__init__.py
@@ -133,7 +133,7 @@ class L2ACWorld(World):
         self.multiworld.regions.append(menu)
 
         ancient_dungeon = Region("AncientDungeon", RegionType.Generic, "Ancient Dungeon", self.player, self.multiworld)
-        ancient_dungeon.exits.append(Entrance(self.player, "FinalFloorEntrance", menu))
+        ancient_dungeon.exits.append(Entrance(self.player, "FinalFloorEntrance", ancient_dungeon))
         item_count: int = self.blue_chest_count
         if self.shuffle_capsule_monsters:
             item_count += len(self.item_name_groups["Capsule monsters"])


### PR DESCRIPTION
## What is this fixing or adding?

Fixes an entrance whose parent region did not coincide with the region that it was an exit from.

## How was this tested?

https://github.com/ArchipelagoMW/Archipelago/pull/1442
