### PR TITLE
kvui: limit UI side logs to by default 1000 messages

### DIFF
--- a/data/client.kv
+++ b/data/client.kv
@@ -30,6 +30,8 @@
     font_size: dp(20)
     markup: True
 <UILog>:
+    messages: 1000 # amount of messages stored in client logs.
+    cols: 1
     viewclass: 'SelectableLabel'
     scroll_y: 0
     scroll_type: ["content", "bars"]

--- a/kvui.py
+++ b/kvui.py
@@ -508,7 +508,7 @@ class LogtoUI(logging.Handler):
 
 
 class UILog(RecycleView):
-    cols = 1
+    messages: typing.ClassVar[int]  # comes from kv file
 
     def __init__(self, *loggers_to_handle, **kwargs):
         super(UILog, self).__init__(**kwargs)
@@ -518,9 +518,15 @@ class UILog(RecycleView):
 
     def on_log(self, record: str) -> None:
         self.data.append({"text": escape_markup(record)})
+        self.clean_old()
 
     def on_message_markup(self, text):
         self.data.append({"text": text})
+        self.clean_old()
+
+    def clean_old(self):
+        if len(self.data) > self.messages:
+            self.data.pop(0)
 
     def fix_heights(self):
         """Workaround fix for divergent texture and layout heights"""


### PR DESCRIPTION
## What is this fixing or adding?
 limit UI side logs to by default 1000 messages

## How was this tested?
by setting it to 1 and watching every message on the async delete the last one.
