### PR TITLE
LTTP: make the enemizer check a property and only check for it once instead of per world

### DIFF
--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -189,7 +189,7 @@ class World(metaclass=AutoWorldRegister):
     # in that case the MultiWorld object is passed as an argument and it gets called once for the entire multiworld.
     # An example of this can be found in alttp as stage_pre_fill
     @classmethod
-    def stage_assert_generate(cls, multiworld: MultiWorld) -> None:
+    def assert_generate(cls) -> None:
         """Checks that a game is capable of generating, usually checks for some base file like a ROM.
         Not run for unittests since they don't produce output"""
         pass

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -189,7 +189,7 @@ class World(metaclass=AutoWorldRegister):
     # in that case the MultiWorld object is passed as an argument and it gets called once for the entire multiworld.
     # An example of this can be found in alttp as stage_pre_fill
     @classmethod
-    def assert_generate(cls) -> None:
+    def stage_assert_generate(cls, multiworld: MultiWorld) -> None:
         """Checks that a game is capable of generating, usually checks for some base file like a ROM.
         Not run for unittests since they don't produce output"""
         pass

--- a/worlds/alttp/Rom.py
+++ b/worlds/alttp/Rom.py
@@ -20,7 +20,7 @@ import concurrent.futures
 import bsdiff4
 from typing import Optional, List
 
-from BaseClasses import CollectionState, Region, Location
+from BaseClasses import CollectionState, Region, Location, MultiWorld
 from worlds.alttp.Shops import ShopType, ShopPriceType
 from worlds.alttp.Dungeons import dungeon_music_addresses
 from worlds.alttp.Regions import location_table, old_location_address_to_new_location_address
@@ -765,7 +765,7 @@ def get_nonnative_item_sprite(item: str) -> int:
     # https://discord.com/channels/731205301247803413/827141303330406408/852102450822905886
 
 
-def patch_rom(world, rom, player, enemized):
+def patch_rom(world: MultiWorld, rom: LocalRom, player: int, enemized: bool):
     local_random = world.per_slot_randoms[player]
 
     # patch items

--- a/worlds/alttp/__init__.py
+++ b/worlds/alttp/__init__.py
@@ -372,19 +372,19 @@ class ALTTPWorld(World):
         ShopSlotFill(world)
 
     @property
-    def use_enemizer(self):
+    def use_enemizer(self) -> bool:
         world = self.multiworld
         player = self.player
-        return (world.boss_shuffle[player] or world.enemy_shuffle[player]
-                or world.enemy_health[player] != 'default' or world.enemy_damage[player] != 'default'
-                or world.pot_shuffle[player] or world.bush_shuffle[player]
-                or world.killable_thieves[player])
+        return bool(world.boss_shuffle[player] or world.enemy_shuffle[player]
+                    or world.enemy_health[player] != 'default' or world.enemy_damage[player] != 'default'
+                    or world.pot_shuffle[player] or world.bush_shuffle[player]
+                    or world.killable_thieves[player])
 
     def generate_output(self, output_directory: str):
         world = self.multiworld
         player = self.player
         try:
-            use_enemizer = self.use_enemizer()
+            use_enemizer = self.use_enemizer
 
             rom = LocalRom(get_base_rom_path())
 

--- a/worlds/alttp/__init__.py
+++ b/worlds/alttp/__init__.py
@@ -5,7 +5,7 @@ import threading
 import typing
 
 import Utils
-from BaseClasses import Item, CollectionState, Tutorial
+from BaseClasses import Item, CollectionState, Tutorial, MultiWorld
 from .Dungeons import create_dungeons
 from .EntranceShuffle import link_entrances, link_inverted_entrances, plando_connect, \
     indirect_connections, indirect_connections_inverted, indirect_connections_not_inverted
@@ -151,16 +151,18 @@ class ALTTPWorld(World):
         super(ALTTPWorld, self).__init__(*args, **kwargs)
 
     @classmethod
-    def stage_assert_generate(cls, world):
+    def stage_assert_generate(cls, world: MultiWorld):
         rom_file = get_base_rom_path()
         if not os.path.exists(rom_file):
             raise FileNotFoundError(rom_file)
         if world.is_race:
             import xxtea
+        for player in world.get_game_players(cls.game):
+            if world.worlds[player].use_enemizer:
+                check_enemizer(world.worlds[player].enemizer_path)
+                break
 
     def generate_early(self):
-        if self.use_enemizer():
-            check_enemizer(self.enemizer_path)
 
         player = self.player
         world = self.multiworld
@@ -369,6 +371,7 @@ class ALTTPWorld(World):
     def stage_post_fill(cls, world):
         ShopSlotFill(world)
 
+    @property
     def use_enemizer(self):
         world = self.multiworld
         player = self.player

--- a/worlds/alttp/__init__.py
+++ b/worlds/alttp/__init__.py
@@ -151,15 +151,15 @@ class ALTTPWorld(World):
         super(ALTTPWorld, self).__init__(*args, **kwargs)
 
     @classmethod
-    def stage_assert_generate(cls, world: MultiWorld):
+    def stage_assert_generate(cls, multiworld: MultiWorld):
         rom_file = get_base_rom_path()
         if not os.path.exists(rom_file):
             raise FileNotFoundError(rom_file)
-        if world.is_race:
+        if multiworld.is_race:
             import xxtea
-        for player in world.get_game_players(cls.game):
-            if world.worlds[player].use_enemizer:
-                check_enemizer(world.worlds[player].enemizer_path)
+        for player in multiworld.get_game_players(cls.game):
+            if multiworld.worlds[player].use_enemizer:
+                check_enemizer(multiworld.worlds[player].enemizer_path)
                 break
 
     def generate_early(self):


### PR DESCRIPTION
## What is this fixing or adding?
Moved lttp's enemizer check to stage_assert_generate and made the `LTTPWorld.use_enemizer` check a property and have it break once it finds the first lttp player that needs enemizer and checks for it, both giving a slight performance boost.

## How was this tested?
Generated with every world except zillion and lufia2. Generated with boss shuffle both with and without enemizer in AP

## If this makes graphical changes, please attach screenshots.
