### PR TITLE
WebHost: Add tutorials to sitemap and hide settings link for games without settings

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-from ctypes import Union
 import typing
 import builtins
 import os
@@ -13,7 +12,7 @@ import io
 import collections
 import importlib
 import logging
-from typing import BinaryIO, Coroutine, Optional, Set, Dict, Any
+from typing import BinaryIO, Coroutine, Optional, Set, Dict, Any, Union
 
 from yaml import load, load_all, dump, SafeLoader
 

--- a/Utils.py
+++ b/Utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from ctypes import Union
 import typing
 import builtins
 import os
@@ -12,7 +13,7 @@ import io
 import collections
 import importlib
 import logging
-from typing import BinaryIO, Coroutine, Optional, Set
+from typing import BinaryIO, Coroutine, Optional, Set, Dict, Any
 
 from yaml import load, load_all, dump, SafeLoader
 
@@ -662,7 +663,10 @@ def messagebox(title: str, text: str, error: bool = False) -> None:
 
 def title_sorted(data: typing.Sequence, key=None, ignore: typing.Set = frozenset(("a", "the"))):
     """Sorts a sequence of text ignoring typical articles like "a" or "the" in the beginning."""
-    def sorter(element: str) -> str:
+    def sorter(element: Union[str, Dict[str, Any]]) -> str:
+        if (not isinstance(element, str)):
+            element = element["title"]
+
         parts = element.split(maxsplit=1)
         if parts[0].lower() in ignore:
             return parts[1].lower()

--- a/WebHostLib/misc.py
+++ b/WebHostLib/misc.py
@@ -1,5 +1,7 @@
 import datetime
 import os
+from tkinter import W
+from typing import List
 
 import jinja2.exceptions
 from flask import request, redirect, url_for, render_template, Response, session, abort, send_from_directory
@@ -163,8 +165,9 @@ def get_datapackage():
 @app.route('/index')
 @app.route('/sitemap')
 def get_sitemap():
-    available_games = []
+    available_games: List = []
     for game, world in AutoWorldRegister.world_types.items():
         if not world.hidden:
-            available_games.append(game)
+            has_settings: bool = isinstance(world.web.settings_page, bool) and world.web.settings_page
+            available_games.append({ 'title': game, 'has_settings': has_settings })
     return render_template("siteMap.html", games=available_games)

--- a/WebHostLib/misc.py
+++ b/WebHostLib/misc.py
@@ -1,7 +1,6 @@
 import datetime
 import os
-from tkinter import W
-from typing import List
+from typing import List, Dict, Union
 
 import jinja2.exceptions
 from flask import request, redirect, url_for, render_template, Response, session, abort, send_from_directory
@@ -165,7 +164,7 @@ def get_datapackage():
 @app.route('/index')
 @app.route('/sitemap')
 def get_sitemap():
-    available_games: List = []
+    available_games: List[Dict[str, Union[str, bool]]] = []
     for game, world in AutoWorldRegister.world_types.items():
         if not world.hidden:
             has_settings: bool = isinstance(world.web.settings_page, bool) and world.web.settings_page

--- a/WebHostLib/templates/siteMap.html
+++ b/WebHostLib/templates/siteMap.html
@@ -29,17 +29,30 @@
             <li><a href="/glossary/en">Glossary</a></li>
         </ul>
 
+        <h2>Tutorials</h2>
+        <ul>
+            <li><a href="/tutorial/Archipelago/setup/en">Multiworld Setup Tutorial</a></li>
+            <li><a href="/tutorial/Archipelago/using_website/en">Website User Guide</a></li>
+            <li><a href="/tutorial/Archipelago/mac/en">Setup Guide for Mac</a></li>
+            <li><a href="/tutorial/Archipelago/commands/en">Server and Client Commands</a></li>
+            <li><a href="/tutorial/Archipelago/advanced_settings/en">Advanced YAML Guide</a></li>
+            <li><a href="/tutorial/Archipelago/triggers/en">Triggers Guide</a></li>
+            <li><a href="/tutorial/Archipelago/plando/en">Plando Guide</a></li>
+        </ul>
+
         <h2>Game Info Pages</h2>
         <ul>
             {% for game in games | title_sorted %}
-                <li><a href="{{ url_for('game_info', game=game, lang='en') }}">{{ game }}</a></li>
+                <li><a href="{{ url_for('game_info', game=game['title'], lang='en') }}">{{ game['title'] }}</a></li>
             {% endfor %}
         </ul>
 
         <h2>Game Settings Pages</h2>
         <ul>
             {% for game in games | title_sorted %}
-                <li><a href="{{ url_for('player_settings', game=game) }}">{{ game }}</a></li>
+                {% if game['has_settings'] %}
+                    <li><a href="{{ url_for('player_settings', game=game['title']) }}">{{ game['title'] }}</a></li>
+                {% endif %} 
             {% endfor %}
         </ul>
     </div>


### PR DESCRIPTION
## What is this fixing or adding?
* Sitemap game settings list, nolonger has links to games that dont have a setting page
* Added tutorials to the sitemap for easy access

## How was this tested?
Locally running the webhost

## If this makes graphical changes, please attach screenshots.
![image](https://user-images.githubusercontent.com/5691920/218734701-a8485d10-f847-4e2f-a702-206786cfa05f.png)
![image](https://user-images.githubusercontent.com/5691920/218734928-a05fdfc4-458d-411d-93c1-8ccbf6561456.png)
