### PR TITLE
Tracker: get game names from slot_info instead of `multidata["games"]` and render custom game names on generic tracker

### DIFF
--- a/WebHostLib/tracker.py
+++ b/WebHostLib/tracker.py
@@ -83,8 +83,10 @@ def get_alttp_id(item_name):
     return Items.item_table[item_name][2]
 
 
-app.jinja_env.filters["location_name"] = lambda location: lookup_any_location_id_to_name.get(location, location)
-app.jinja_env.filters['item_name'] = lambda id: lookup_any_item_id_to_name.get(id, id)
+lookup_custom_location_id_to_name = {}
+lookup_custom_item_id_to_name = {}
+app.jinja_env.filters["location_name"] = lambda location: lookup_any_location_id_to_name.get(location, lookup_custom_location_id_to_name.get(location, location))
+app.jinja_env.filters['item_name'] = lambda id: lookup_any_item_id_to_name.get(id, lookup_custom_item_id_to_name.get(id, id))
 
 links = {"Bow": "Progressive Bow",
          "Silver Arrows": "Progressive Bow",
@@ -264,6 +266,11 @@ def get_static_room_data(room: Room):
         groups = {slot: slot_info.group_members for slot, slot_info in multidata["slot_info"].items()
                   if slot_info.type == SlotType.group}
     seed_checks_in_area = checks_in_area.copy()
+
+    for game in games.values():
+        if game in multidata["datapackage"]:
+            lookup_custom_location_id_to_name.update({id: name for name, id in multidata["datapackage"][game]["location_name_to_id"].items()})
+            lookup_custom_item_id_to_name.update({id: name for name, id in multidata["datapackage"][game]["item_name_to_id"].items()})
 
     use_door_tracker = False
     if "tags" in multidata:

--- a/WebHostLib/tracker.py
+++ b/WebHostLib/tracker.py
@@ -263,12 +263,16 @@ def get_static_room_data(room: Room):
         games = {slot: slot_info.game for slot, slot_info in multidata["slot_info"].items()}
         groups = {slot: slot_info.group_members for slot, slot_info in multidata["slot_info"].items()
                   if slot_info.type == SlotType.group}
-    seed_checks_in_area = checks_in_area.copy()
 
-    for game in games.values():
-        if game in multidata["datapackage"]:
-            lookup_any_location_id_to_name.update({id: name for name, id in multidata["datapackage"][game]["location_name_to_id"].items()})
-            lookup_any_item_id_to_name.update({id: name for name, id in multidata["datapackage"][game]["item_name_to_id"].items()})
+        for game in games.values():
+            if game in multidata["datapackage"]:
+                lookup_any_location_id_to_name.update(
+                    {id: name for name, id in multidata["datapackage"][game]["location_name_to_id"].items()})
+                lookup_any_item_id_to_name.update(
+                    {id: name for name, id in multidata["datapackage"][game]["item_name_to_id"].items()})
+    elif "games" in multidata:
+        games = multidata["games"]
+    seed_checks_in_area = checks_in_area.copy()
 
     use_door_tracker = False
     if "tags" in multidata:

--- a/WebHostLib/tracker.py
+++ b/WebHostLib/tracker.py
@@ -83,10 +83,8 @@ def get_alttp_id(item_name):
     return Items.item_table[item_name][2]
 
 
-lookup_custom_location_id_to_name = {}
-lookup_custom_item_id_to_name = {}
-app.jinja_env.filters["location_name"] = lambda location: lookup_any_location_id_to_name.get(location, lookup_custom_location_id_to_name.get(location, location))
-app.jinja_env.filters['item_name'] = lambda id: lookup_any_item_id_to_name.get(id, lookup_custom_item_id_to_name.get(id, id))
+app.jinja_env.filters["location_name"] = lambda location: lookup_any_location_id_to_name.get(location, location)
+app.jinja_env.filters['item_name'] = lambda id: lookup_any_item_id_to_name.get(id, id)
 
 links = {"Bow": "Progressive Bow",
          "Silver Arrows": "Progressive Bow",
@@ -269,8 +267,8 @@ def get_static_room_data(room: Room):
 
     for game in games.values():
         if game in multidata["datapackage"]:
-            lookup_custom_location_id_to_name.update({id: name for name, id in multidata["datapackage"][game]["location_name_to_id"].items()})
-            lookup_custom_item_id_to_name.update({id: name for name, id in multidata["datapackage"][game]["item_name_to_id"].items()})
+            lookup_any_location_id_to_name.update({id: name for name, id in multidata["datapackage"][game]["location_name_to_id"].items()})
+            lookup_any_item_id_to_name.update({id: name for name, id in multidata["datapackage"][game]["item_name_to_id"].items()})
 
     use_door_tracker = False
     if "tags" in multidata:

--- a/WebHostLib/tracker.py
+++ b/WebHostLib/tracker.py
@@ -260,6 +260,7 @@ def get_static_room_data(room: Room):
     names: Dict[int, Dict[int, str]] = multidata["names"]
     groups = {}
     if "slot_info" in multidata:
+        games = {slot: slot_info.game for slot, slot_info in multidata["slot_info"].items()}
         groups = {slot: slot_info.group_members for slot, slot_info in multidata["slot_info"].items()
                   if slot_info.type == SlotType.group}
     seed_checks_in_area = checks_in_area.copy()
@@ -282,7 +283,7 @@ def get_static_room_data(room: Room):
                                if playernumber not in groups}
     saving_second = get_saving_second(multidata["seed_name"])
     result = locations, names, use_door_tracker, player_checks_in_area, player_location_to_area, \
-             multidata["precollected_items"], multidata["games"], multidata["slot_data"], groups, saving_second
+             multidata["precollected_items"], games, multidata["slot_data"], groups, saving_second
     _multidata_cache[room.seed.id] = result
     return result
 

--- a/WebHostLib/tracker.py
+++ b/WebHostLib/tracker.py
@@ -6,7 +6,7 @@ from uuid import UUID
 
 import jinja2
 from flask import render_template
-from jinja2 import pass_context
+from jinja2 import pass_context, runtime
 from werkzeug.exceptions import abort
 
 from MultiServer import Context, get_saving_second
@@ -1222,14 +1222,14 @@ def __renderGenericTracker(multisave: Dict[str, Any], room: Room, locations: Dic
         player_received_items[networkItem.item] = order_index
 
     @pass_context
-    def get_location_name(context: Dict, loc: int) -> str:
-        custom_locations = context["custom_locations"]
-        return collections.ChainMap(lookup_any_location_id_to_name, custom_locations).get(loc, loc)
+    def get_location_name(context: runtime.Context, loc: int) -> str:
+        context_locations = context.get("custom_locations", {})
+        return collections.ChainMap(lookup_any_location_id_to_name, context_locations).get(loc, loc)
 
     @pass_context
-    def get_item_name(context: Dict, item: int) -> str:
-        custom_items = context["custom_items"]
-        return collections.ChainMap(lookup_any_item_id_to_name, custom_items).get(item, item)
+    def get_item_name(context: runtime.Context, item: int) -> str:
+        context_items = context.get("custom_items", {})
+        return collections.ChainMap(lookup_any_item_id_to_name, context_items).get(item, item)
 
     app.jinja_env.filters["location_name"] = get_location_name
     app.jinja_env.filters["item_name"] = get_item_name


### PR DESCRIPTION
## What is this fixing or adding?
https://discord.com/channels/731205301247803413/731214280439103580/1075228226399502366

## How was this tested?
ran webhost locally and opened the multitracker

## If this makes graphical changes, please attach screenshots.
