### PR TITLE
[OC2] Colored Ramp Button Items

### DIFF
--- a/worlds/overcooked2/Items.py
+++ b/worlds/overcooked2/Items.py
@@ -54,7 +54,7 @@ item_table: Dict[str, ItemData] = {
     "Yellow Ramp"                   : ItemData(oc2_base_id + 39),
     "Blue Ramp"                     : ItemData(oc2_base_id + 40),
     "Pink Ramp"                     : ItemData(oc2_base_id + 41),
-    "Grey Ramp"                     : ItemData(oc2_base_id + 42),
+    "Dark Green Ramp"               : ItemData(oc2_base_id + 42),
     "Red Ramp"                      : ItemData(oc2_base_id + 43),
     "Purple Ramp"                   : ItemData(oc2_base_id + 44),
 }
@@ -94,7 +94,7 @@ item_name_to_config_name = {
     "Yellow Ramp"                   : "DisableYellowRampButton"        ,
     "Blue Ramp"                     : "DisableBlueRampButton"          ,
     "Pink Ramp"                     : "DisablePinkRampButton"          ,
-    "Grey Ramp"                     : "DisableGreyRampButton"          ,
+    "Dark Green Ramp"                     : "DisableGreyRampButton"          ,
     "Red Ramp"                      : "DisableRedRampButton"           ,
     "Purple Ramp"                   : "DisablePurpleRampButton"        ,
     "Calmer Unbread"                : "AggressiveHorde"                ,

--- a/worlds/overcooked2/Items.py
+++ b/worlds/overcooked2/Items.py
@@ -57,6 +57,7 @@ item_table: Dict[str, ItemData] = {
     "Dark Green Ramp"               : ItemData(oc2_base_id + 42),
     "Red Ramp"                      : ItemData(oc2_base_id + 43),
     "Purple Ramp"                   : ItemData(oc2_base_id + 44),
+    "Emote Wheel"                   : ItemData(oc2_base_id + 45),
 }
 
 item_frequencies = {
@@ -68,9 +69,12 @@ item_frequencies = {
 
     # Unused items
     "Ramp Button": 0,
+    "Cooking Emote" : 0,
+    "Curse Emote" : 0,
     "Serving Emote" : 0,
-    "Preparing Emote": 0,
+    "Preparing Emote" : 0,
     "Washing Up Emote": 0,
+    "Ok Emote": 0,
 }
 
 item_name_to_config_name = {
@@ -94,7 +98,7 @@ item_name_to_config_name = {
     "Yellow Ramp"                   : "DisableYellowRampButton"        ,
     "Blue Ramp"                     : "DisableBlueRampButton"          ,
     "Pink Ramp"                     : "DisablePinkRampButton"          ,
-    "Dark Green Ramp"                     : "DisableGreyRampButton"          ,
+    "Dark Green Ramp"               : "DisableGreyRampButton"          ,
     "Red Ramp"                      : "DisableRedRampButton"           ,
     "Purple Ramp"                   : "DisablePurpleRampButton"        ,
     "Calmer Unbread"                : "AggressiveHorde"                ,
@@ -150,6 +154,8 @@ def item_to_unlock_event(item_name: str) -> Dict[str, str]:
         kevin_num = int(item_name.split("-")[-1])
         action = "UNLOCK_LEVEL"
         payload = str(kevin_num + 36)
+    elif item_name == "Emote Wheel":
+        action = "UNLOCK_EMOTES"
     elif "Emote" in item_name:
         action = "UNLOCK_EMOTE"
         payload = str(item_table[item_name].code - item_table["Cooking Emote"].code)

--- a/worlds/overcooked2/Items.py
+++ b/worlds/overcooked2/Items.py
@@ -50,6 +50,13 @@ item_table: Dict[str, ItemData] = {
     "Ramp Button"                   : ItemData(oc2_base_id + 35),
     "Bonus Star"                    : ItemData(oc2_base_id + 36),
     "Calmer Unbread"                : ItemData(oc2_base_id + 37),
+    "Green Ramp"                    : ItemData(oc2_base_id + 38),
+    "Yellow Ramp"                   : ItemData(oc2_base_id + 39),
+    "Blue Ramp"                     : ItemData(oc2_base_id + 40),
+    "Pink Ramp"                     : ItemData(oc2_base_id + 41),
+    "Grey Ramp"                     : ItemData(oc2_base_id + 42),
+    "Red Ramp"                      : ItemData(oc2_base_id + 43),
+    "Purple Ramp"                   : ItemData(oc2_base_id + 44),
 }
 
 item_frequencies = {
@@ -58,28 +65,40 @@ item_frequencies = {
     "Order Lookahead": 2,
     "Progressive Dash": 2,
     "Bonus Star": 0,  # Filler Item
-    # default: 1
+
+    # Unused items
+    "Ramp Button": 0,
+    "Serving Emote" : 0,
+    "Preparing Emote": 0,
+    "Washing Up Emote": 0,
 }
 
 item_name_to_config_name = {
-    "Wood"                         : "DisableWood"                   ,
-    "Coal Bucket"                  : "DisableCoal"                   ,
-    "Spare Plate"                  : "DisableOnePlate"               ,
-    "Fire Extinguisher"            : "DisableFireExtinguisher"       ,
-    "Bellows"                      : "DisableBellows"                ,
-    "Clean Dishes"                 : "PlatesStartDirty"              ,
-    "Control Stick Batteries"      : "DisableControlStick"           ,
-    "Wok Wheels"                   : "DisableWokDrag"                ,
-    "Dish Scrubber"                : "WashTimeMultiplier"            ,
-    "Burn Leniency"                : "BurnSpeedMultiplier"           ,
-    "Sharp Knife"                  : "ChoppingTimeScale"             ,
-    "Lightweight Backpack"         : "BackpackMovementScale"         ,
-    "Faster Respawn Time"          : "RespawnTime"                   ,
-    "Faster Condiment/Drink Switch": "CarnivalDispenserRefactoryTime",
-    "Guest Patience"               : "CustomOrderLifetime"           ,
-    "Ramp Button"                  : "DisableRampButton"             ,
-    "Calmer Unbread"               : "AggressiveHorde"               ,
-    "Coin Purse"                   : "DisableEarnHordeMoney"         ,
+    "Wood"                          : "DisableWood"                    ,
+    "Coal Bucket"                   : "DisableCoal"                    ,
+    "Spare Plate"                   : "DisableOnePlate"                ,
+    "Fire Extinguisher"             : "DisableFireExtinguisher"        ,
+    "Bellows"                       : "DisableBellows"                 ,
+    "Clean Dishes"                  : "PlatesStartDirty"               ,
+    "Control Stick Batteries"       : "DisableControlStick"            ,
+    "Wok Wheels"                    : "DisableWokDrag"                 ,
+    "Dish Scrubber"                 : "WashTimeMultiplier"             ,
+    "Burn Leniency"                 : "BurnSpeedMultiplier"            ,
+    "Sharp Knife"                   : "ChoppingTimeScale"              ,
+    "Lightweight Backpack"          : "BackpackMovementScale"          ,
+    "Faster Respawn Time"           : "RespawnTime"                    ,
+    "Faster Condiment/Drink Switch" : "CarnivalDispenserRefactoryTime" ,
+    "Guest Patience"                : "CustomOrderLifetime"            ,
+    "Ramp Button"                   : "DisableRampButton"              ,
+    "Green Ramp"                    : "DisableGreenRampButton"         ,
+    "Yellow Ramp"                   : "DisableYellowRampButton"        ,
+    "Blue Ramp"                     : "DisableBlueRampButton"          ,
+    "Pink Ramp"                     : "DisablePinkRampButton"          ,
+    "Grey Ramp"                     : "DisableGreyRampButton"          ,
+    "Red Ramp"                      : "DisableRedRampButton"           ,
+    "Purple Ramp"                   : "DisablePurpleRampButton"        ,
+    "Calmer Unbread"                : "AggressiveHorde"                ,
+    "Coin Purse"                    : "DisableEarnHordeMoney"          ,
 }
 
 vanilla_values = {
@@ -101,6 +120,13 @@ vanilla_values = {
     "CustomOrderLifetime": 100.0,
     "AggressiveHorde": False,
     "DisableEarnHordeMoney": False,
+    "DisableGreenRampButton" : False,
+    "DisableYellowRampButton" : False,
+    "DisableBlueRampButton" : False,
+    "DisablePinkRampButton" : False,
+    "DisableGreyRampButton" : False,
+    "DisableRedRampButton" : False,
+    "DisablePurpleRampButton" : False,
 }
 
 item_id_to_name: Dict[int, str] = {

--- a/worlds/overcooked2/Logic.py
+++ b/worlds/overcooked2/Logic.py
@@ -229,7 +229,7 @@ ramp_logic = {
     "5-2": (["Purple"], []),
     "6-1": (["Pink"], []),
     "6-2": (["Red", "Purple"], ["5-1"]),  # 5-1 spawns blue button, blue button gets you to red button
-    "Kevin-1": (["Grey"], []),
+    "Kevin-1": (["Dark Green"], []),
     "Kevin-7": (["Purple"], ["5-1"]), # 5-1 spawns blue button,
                                     # press blue button,
                                     # climb blue ramp,

--- a/worlds/overcooked2/Logic.py
+++ b/worlds/overcooked2/Logic.py
@@ -8,12 +8,15 @@ def has_requirements_for_level_access(state: CollectionState, level_name: str, p
                                       required_star_count: int, player: int) -> bool:
     # Check if the ramps in the overworld are set correctly
     if level_name in ramp_logic:
-        if not state.has("Ramp Button", player):
-            return False  # need the item to use ramps
+        (ramp_reqs, level_reqs) = ramp_logic[level_name]
 
-        for req in ramp_logic[level_name]:
+        for req in level_reqs:
             if not state.has(req + " Level Complete", player):
                 return False  # This level needs another to be beaten first
+
+        for req in ramp_reqs:
+            if not state.has(req + " Ramp", player):
+                return False  # The player doesn't have the pre-requisite ramp button
 
     # Kevin Levels Need to have the corresponding items
     if level_name.startswith("K"):
@@ -78,7 +81,7 @@ def is_item_progression(item_name, level_mapping, include_kevin):
     if item_name.endswith("Emote"):
         return False
 
-    if "Kevin" in item_name or item_name in ["Ramp Button"]:
+    if "Kevin" in item_name or "Ramp" in item_name:
         return True  # always progression
 
     def item_in_logic(shortname, _item_name):
@@ -216,23 +219,23 @@ def is_completable_no_items(level: Overcooked2GenericLevel) -> bool:
 #
 # If empty, a ramp is required to access, but the ramp button is garunteed accessible
 #
-# If populated, a ramp is required to access and the button requires all levels in the
+# If populated, ramp(s) are required to access and the button requires all levels in the
 # list to be compelted before it can be pressed
 #
 ramp_logic = {
-    "1-5": [],
-    "2-2": [],
-    "3-1": [],
-    "5-2": [],
-    "6-1": [],
-    "6-2": ["5-1"],  # 5-1 spawns blue button, blue button gets you to red button
-    "Kevin-1": [],
-    "Kevin-7": ["5-1"],  # 5-1 spawns blue button,
-                         # press blue button,
-                         # climb blue ramp,
-                         # jump the gap,
-                         # climb wood ramps
-    "Kevin-8": ["5-1", "6-2"],  # Same as above, but 6-2 spawns the ramp to K8
+    "1-5": (["Yellow"], []),
+    "2-2": (["Green"], []),
+    "3-1": (["Blue"], []),
+    "5-2": (["Purple"], []),
+    "6-1": (["Pink"], []),
+    "6-2": (["Red", "Purple"], ["5-1"]),  # 5-1 spawns blue button, blue button gets you to red button
+    "Kevin-1": (["Grey"], []),
+    "Kevin-7": (["Purple"], ["5-1"]), # 5-1 spawns blue button,
+                                    # press blue button,
+                                    # climb blue ramp,
+                                    # jump the gap,
+                                    # climb wood ramps
+    "Kevin-8": (["Red", "Blue"], ["5-1", "6-2"]),  # Same as above, but 6-2 spawns the ramp to K8
 }
 
 horde_logic = {  # Additive

--- a/worlds/overcooked2/__init__.py
+++ b/worlds/overcooked2/__init__.py
@@ -256,7 +256,16 @@ class Overcooked2World(World):
         # useful = list()
         # filler = list()
         # progression = list()
-        for item_name in item_table:
+        for item_name in item_table:            
+            if item_name in item_frequencies:
+                freq = item_frequencies[item_name]
+            else:
+                freq = 1
+            
+            if freq <= 0:
+                # not used
+                continue
+
             if not self.options["ShuffleLevelOrder"] and item_name in ITEMS_TO_EXCLUDE_IF_NO_DLC:
                 # skip DLC items if no DLC
                 continue
@@ -282,15 +291,10 @@ class Overcooked2World(World):
                     # filler.append(item_name)
                     classification = ItemClassification.filler
 
-            if item_name in item_frequencies:
-                freq = item_frequencies[item_name]
-
-                while freq > 0:
-                    self.itempool.append(self.create_item(item_name, classification))
-                    classification = ItemClassification.useful  # only the first progressive item can be progression
-                    freq -= 1
-            else:
+            while freq > 0:
                 self.itempool.append(self.create_item(item_name, classification))
+                classification = ItemClassification.useful  # only the first progressive item can be progression
+                freq -= 1
 
         # print(f"progression: {progression}")
         # print(f"useful: {useful}")
@@ -439,7 +443,7 @@ class Overcooked2World(World):
             "DisableCatch": True,
             "DisableControlStick": True,
             "DisableWokDrag": True,
-            "DisableRampButton": True,
+            # "DisableRampButton": True,
             "WashTimeMultiplier": 1.4,
             "BurnSpeedMultiplier": 1.43,
             "MaxOrdersOnScreenOffset": -2,
@@ -448,7 +452,7 @@ class Overcooked2World(World):
             "RespawnTime": 10.0,
             "CarnivalDispenserRefactoryTime": 4.0,
             "LevelUnlockRequirements": level_unlock_requirements,
-            "LockedEmotes": [0, 1, 2, 3, 4, 5],
+            "LockedEmotes": [0, 1, 5],
             "StarOffset": 0,
             "AggressiveHorde": True,
             "DisableEarnHordeMoney": True,

--- a/worlds/overcooked2/__init__.py
+++ b/worlds/overcooked2/__init__.py
@@ -459,7 +459,7 @@ class Overcooked2World(World):
             "RespawnTime": 10.0,
             "CarnivalDispenserRefactoryTime": 4.0,
             "LevelUnlockRequirements": level_unlock_requirements,
-            "LockedEmotes": [0, 1, 5],
+            "LockedEmotes": [0, 1, 2, 3, 4, 5],
             "StarOffset": 0,
             "AggressiveHorde": True,
             "DisableEarnHordeMoney": True,

--- a/worlds/overcooked2/__init__.py
+++ b/worlds/overcooked2/__init__.py
@@ -46,7 +46,7 @@ class Overcooked2World(World):
 
     game = "Overcooked! 2"
     web = Overcooked2Web()
-    required_client_version = (0, 3, 7)
+    required_client_version = (0, 3, 8)
     option_definitions = overcooked_options
     topology_present: bool = False
     data_version = 3

--- a/worlds/overcooked2/__init__.py
+++ b/worlds/overcooked2/__init__.py
@@ -49,7 +49,7 @@ class Overcooked2World(World):
     required_client_version = (0, 3, 7)
     option_definitions = overcooked_options
     topology_present: bool = False
-    data_version = 2
+    data_version = 3
 
     item_name_to_id = item_name_to_id
     item_id_to_name = item_id_to_name
@@ -443,7 +443,14 @@ class Overcooked2World(World):
             "DisableCatch": True,
             "DisableControlStick": True,
             "DisableWokDrag": True,
-            # "DisableRampButton": True,
+            # "DisableRampButton": True, # Unused
+            "DisableGreenRampButton" : True,
+            "DisableYellowRampButton" : True,
+            "DisableBlueRampButton" : True,
+            "DisablePinkRampButton" : True,
+            "DisableGreyRampButton" : True,
+            "DisableRedRampButton" : True,
+            "DisablePurpleRampButton" : True,
             "WashTimeMultiplier": 1.4,
             "BurnSpeedMultiplier": 1.43,
             "MaxOrdersOnScreenOffset": -2,

--- a/worlds/overcooked2/docs/en_Overcooked! 2.md
+++ b/worlds/overcooked2/docs/en_Overcooked! 2.md
@@ -52,7 +52,7 @@ The following items were invented for Randomizer:
 
 ### Overworld
 - Unlock Kevin Level (x8)
-- Ramp Button
+- Ramp Buttons (x7)
 - Bonus Star (Filler Item*)
 
 **Note: Bonus star count varies with settings*

--- a/worlds/overcooked2/test/TestOvercooked2.py
+++ b/worlds/overcooked2/test/TestOvercooked2.py
@@ -17,7 +17,7 @@ class Overcooked2Test(unittest.TestCase):
         for item_name in item_table.keys():
             item: Item = item_table[item_name]
             self.assertGreaterEqual(item.code, oc2_base_id, "Overcooked Item ID out of range")
-            self.assertLessEqual(item.code, item_table["Calmer Unbread"].code, "Overcooked Item ID out of range")
+            self.assertLessEqual(item.code, item_table["Purple Ramp"].code, "Overcooked Item ID out of range")
 
             if previous_item is not None:
                 self.assertEqual(item.code, previous_item + 1,
@@ -31,7 +31,7 @@ class Overcooked2Test(unittest.TestCase):
             self.assertIn(item_name, item_table.keys(), "Unexpected Overcooked Item in item_frequencies")
 
         for item_name in item_name_to_config_name.keys():
-            self.assertIn(item_name, item_table.keys(), "Unexpected Overcooked Item in config mapping")
+            self.assertIn(item_name, item_table.keys(), "Unexpected config in item-config mapping")
 
         for config_name in item_name_to_config_name.values():
             self.assertIn(config_name, vanilla_values.keys(), "Unexpected Overcooked Item in default config mapping")

--- a/worlds/overcooked2/test/TestOvercooked2.py
+++ b/worlds/overcooked2/test/TestOvercooked2.py
@@ -17,7 +17,7 @@ class Overcooked2Test(unittest.TestCase):
         for item_name in item_table.keys():
             item: Item = item_table[item_name]
             self.assertGreaterEqual(item.code, oc2_base_id, "Overcooked Item ID out of range")
-            self.assertLessEqual(item.code, item_table["Purple Ramp"].code, "Overcooked Item ID out of range")
+            self.assertLessEqual(item.code, item_table["Emote Wheel"].code, "Overcooked Item ID out of range")
 
             if previous_item is not None:
                 self.assertEqual(item.code, previous_item + 1,


### PR DESCRIPTION
## What is this fixing or adding?

Before: 1 item activates all 4
After: 7 items activate 7 buttons, creating more divergent routes

Also, I consolidated the 6 filler emotes into a single "Emote Wheel" item to make space in the item pool.

I bumped my data version and min AP version to indicate this change.

The corresponding oc2-modding update is **v1.6.0**

## How was this tested?
Played a few local seeds. If I add more features in this version, then I'll probably ping for a beta test to clear the cumulative changes from any regression doubt.