### PR TITLE
SMW & DKC3: Remove relative imports

### DIFF
--- a/worlds/dkc3/Rules.py
+++ b/worlds/dkc3/Rules.py
@@ -2,8 +2,8 @@ import math
 
 from BaseClasses import MultiWorld
 from .Names import LocationName, ItemName
-from ..AutoWorld import LogicMixin
-from ..generic.Rules import add_rule, set_rule
+from worlds.AutoWorld import LogicMixin
+from worlds.generic.Rules import add_rule, set_rule
 
 
 def set_rules(world: MultiWorld, player: int):

--- a/worlds/dkc3/__init__.py
+++ b/worlds/dkc3/__init__.py
@@ -12,7 +12,7 @@ from .Levels import level_list
 from .Rules import set_rules
 from .Names import ItemName, LocationName
 from .Client import DKC3SNIClient
-from ..AutoWorld import WebWorld, World
+from worlds.AutoWorld import WebWorld, World
 from .Rom import LocalRom, patch_rom, get_base_rom_path, DKC3DeltaPatch
 import Patch
 

--- a/worlds/smw/Regions.py
+++ b/worlds/smw/Regions.py
@@ -4,7 +4,7 @@ from BaseClasses import MultiWorld, Region, Entrance
 from .Locations import SMWLocation
 from .Levels import level_info_dict
 from .Names import LocationName, ItemName
-from ..generic.Rules import add_rule, set_rule
+from worlds.generic.Rules import add_rule, set_rule
 
 
 def create_regions(world, player: int, active_locations):

--- a/worlds/smw/Rules.py
+++ b/worlds/smw/Rules.py
@@ -2,8 +2,8 @@ import math
 
 from BaseClasses import MultiWorld
 from .Names import LocationName, ItemName
-from ..AutoWorld import LogicMixin
-from ..generic.Rules import add_rule, set_rule
+from worlds.AutoWorld import LogicMixin
+from worlds.generic.Rules import add_rule, set_rule
 
 
 def set_rules(world: MultiWorld, player: int):

--- a/worlds/smw/__init__.py
+++ b/worlds/smw/__init__.py
@@ -10,10 +10,10 @@ from .Options import smw_options
 from .Regions import create_regions, connect_regions
 from .Levels import full_level_list, generate_level_list, location_id_to_level_id
 from .Rules import set_rules
-from ..generic.Rules import add_rule, exclusion_rules
+from worlds.generic.Rules import add_rule, exclusion_rules
 from .Names import ItemName, LocationName
 from .Client import SMWSNIClient
-from ..AutoWorld import WebWorld, World
+from worlds.AutoWorld import WebWorld, World
 from .Rom import LocalRom, patch_rom, get_base_rom_path, SMWDeltaPatch
 
 


### PR DESCRIPTION
## What is this fixing or adding?
No longer use out-of-world relative imports in SMW or DKC3 worlds, to prevent runtime errors with `.apworld`s.

## How was this tested?
- Generated several seeds of each game, with varying settings which would interact with the relative imports.
- Run `setup.py` and test generating and opening clients for multiple games, verifying there are no errors with at any point.

## If this makes graphical changes, please attach screenshots.
N/A