### PR TITLE
Timespinner: Make RisingTidesOverrides consistent with normal yaml behaviour.

### DIFF
--- a/worlds/timespinner/Options.py
+++ b/worlds/timespinner/Options.py
@@ -1,7 +1,7 @@
 from typing import Dict, Union, List
 from BaseClasses import MultiWorld
 from Options import Toggle, DefaultOnToggle, DeathLink, Choice, Range, Option, OptionDict, OptionList
-from schema import Schema, And, Optional
+from schema import Schema, And, Optional, Or
 
 
 class StartWithJewelryBox(Toggle):
@@ -312,43 +312,43 @@ class RisingTidesOverrides(OptionDict):
     """Odds for specific areas to be flooded or drained, only has effect when RisingTides is on.
     Areas that are not specified will roll with the default 33% chance of getting flooded or drained"""
     schema = Schema({
-        Optional("Xarion"): { 
+        Optional("Xarion"): Or(And({
             "Dry": And(int, lambda n: n >= 0), 
             "Flooded": And(int, lambda n: n >= 0)
-        },
-        Optional("Maw"): { 
+        }, lambda d: any(v > 0 for v in d.values())), "Dry", "Flooded"),
+        Optional("Maw"): Or(And({
             "Dry": And(int, lambda n: n >= 0), 
             "Flooded": And(int, lambda n: n >= 0)
-        },
-        Optional("AncientPyramidShaft"): { 
+        }, lambda d: any(v > 0 for v in d.values())), "Dry", "Flooded"),
+        Optional("AncientPyramidShaft"): Or(And({
             "Dry": And(int, lambda n: n >= 0), 
             "Flooded": And(int, lambda n: n >= 0)
-        },
-        Optional("Sandman"): { 
+        }, lambda d: any(v > 0 for v in d.values())), "Dry", "Flooded"),
+        Optional("Sandman"): Or(And({
             "Dry": And(int, lambda n: n >= 0), 
             "Flooded": And(int, lambda n: n >= 0)
-        },
-        Optional("CastleMoat"): { 
+        }, lambda d: any(v > 0 for v in d.values())), "Dry", "Flooded"),
+        Optional("CastleMoat"): Or(And({
             "Dry": And(int, lambda n: n >= 0), 
             "Flooded": And(int, lambda n: n >= 0)
-        },
-        Optional("CastleBasement"): { 
+        }, lambda d: any(v > 0 for v in d.values())), "Dry", "Flooded"),
+        Optional("CastleBasement"): Or(And({
             "Dry": And(int, lambda n: n >= 0), 
             "FloodedWithSavePointAvailable": And(int, lambda n: n >= 0), 
             "Flooded": And(int, lambda n: n >= 0) 
-        },
-        Optional("CastleCourtyard"): { 
+        }, lambda d: any(v > 0 for v in d.values())), "Dry", "FloodedWithSavePointAvailable", "Flooded"),
+        Optional("CastleCourtyard"): Or(And({
             "Dry": And(int, lambda n: n >= 0), 
             "Flooded": And(int, lambda n: n >= 0)
-        },
-        Optional("LakeDesolation"): { 
+        }, lambda d: any(v > 0 for v in d.values())), "Dry", "Flooded"),
+        Optional("LakeDesolation"): Or(And({
             "Dry": And(int, lambda n: n >= 0), 
             "Flooded": And(int, lambda n: n >= 0)
-        },
-        Optional("LakeSerene"): { 
+        }, lambda d: any(v > 0 for v in d.values())), "Dry", "Flooded"),
+        Optional("LakeSerene"): Or(And({
             "Dry": And(int, lambda n: n >= 0), 
             "Flooded": And(int, lambda n: n >= 0)
-        }
+        }, lambda d: any(v > 0 for v in d.values())), "Dry", "Flooded")
     })
     display_name = "Rising Tides Overrides"
     default = {

--- a/worlds/timespinner/Options.py
+++ b/worlds/timespinner/Options.py
@@ -308,47 +308,44 @@ class RisingTides(Toggle):
     display_name = "Rising Tides"
 
 
+def rising_tide_option(location: str, with_save_point_option: bool = False) -> Dict[Optional, Or]:
+    if with_save_point_option:
+        return {
+            Optional(location): Or(
+                And({
+                    Optional("Dry"): And(int, lambda n: n >= 0),
+                    Optional("Flooded"): And(int, lambda n: n >= 0),
+                    Optional("FloodedWithSavePointAvailable"): And(int, lambda n: n >= 0)
+                }, lambda d: any(v > 0 for v in d.values())),
+                "Dry",
+                "Flooded",
+                "FloodedWithSavePointAvailable")
+        }
+    else:
+        return {
+            Optional(location): Or(
+                And({
+                    Optional("Dry"): And(int, lambda n: n >= 0),
+                    Optional("Flooded"): And(int, lambda n: n >= 0)
+                }, lambda d: any(v > 0 for v in d.values())),
+                "Dry",
+                "Flooded")
+        }
+
+
 class RisingTidesOverrides(OptionDict):
     """Odds for specific areas to be flooded or drained, only has effect when RisingTides is on.
     Areas that are not specified will roll with the default 33% chance of getting flooded or drained"""
     schema = Schema({
-        Optional("Xarion"): Or(And({
-            Optional("Dry"): And(int, lambda n: n >= 0), 
-            Optional("Flooded"): And(int, lambda n: n >= 0)
-        }, lambda d: any(v > 0 for v in d.values())), "Dry", "Flooded"),
-        Optional("Maw"): Or(And({
-            Optional("Dry"): And(int, lambda n: n >= 0), 
-            Optional("Flooded"): And(int, lambda n: n >= 0)
-        }, lambda d: any(v > 0 for v in d.values())), "Dry", "Flooded"),
-        Optional("AncientPyramidShaft"): Or(And({
-            Optional("Dry"): And(int, lambda n: n >= 0), 
-            Optional("Flooded"): And(int, lambda n: n >= 0)
-        }, lambda d: any(v > 0 for v in d.values())), "Dry", "Flooded"),
-        Optional("Sandman"): Or(And({
-            Optional("Dry"): And(int, lambda n: n >= 0), 
-            Optional("Flooded"): And(int, lambda n: n >= 0)
-        }, lambda d: any(v > 0 for v in d.values())), "Dry", "Flooded"),
-        Optional("CastleMoat"): Or(And({
-            Optional("Dry"): And(int, lambda n: n >= 0), 
-            Optional("Flooded"): And(int, lambda n: n >= 0)
-        }, lambda d: any(v > 0 for v in d.values())), "Dry", "Flooded"),
-        Optional("CastleBasement"): Or(And({
-            Optional("Dry"): And(int, lambda n: n >= 0), 
-            Optional("FloodedWithSavePointAvailable"): And(int, lambda n: n >= 0), 
-            Optional("Flooded"): And(int, lambda n: n >= 0) 
-        }, lambda d: any(v > 0 for v in d.values())), "Dry", "FloodedWithSavePointAvailable", "Flooded"),
-        Optional("CastleCourtyard"): Or(And({
-            Optional("Dry"): And(int, lambda n: n >= 0), 
-            Optional("Flooded"): And(int, lambda n: n >= 0)
-        }, lambda d: any(v > 0 for v in d.values())), "Dry", "Flooded"),
-        Optional("LakeDesolation"): Or(And({
-            Optional("Dry"): And(int, lambda n: n >= 0), 
-            Optional("Flooded"): And(int, lambda n: n >= 0)
-        }, lambda d: any(v > 0 for v in d.values())), "Dry", "Flooded"),
-        Optional("LakeSerene"): Or(And({
-            Optional("Dry"): And(int, lambda n: n >= 0), 
-            Optional("Flooded"): And(int, lambda n: n >= 0)
-        }, lambda d: any(v > 0 for v in d.values())), "Dry", "Flooded")
+        **rising_tide_option("Xarion"),
+        **rising_tide_option("Maw"),
+        **rising_tide_option("AncientPyramidShaft"),
+        **rising_tide_option("Sandman"),
+        **rising_tide_option("CastleMoat"),
+        **rising_tide_option("CastleBasement", with_save_point_option=True),
+        **rising_tide_option("CastleCourtyard"),
+        **rising_tide_option("LakeDesolation"),
+        **rising_tide_option("LakeSerene")
     })
     display_name = "Rising Tides Overrides"
     default = {

--- a/worlds/timespinner/Options.py
+++ b/worlds/timespinner/Options.py
@@ -313,41 +313,41 @@ class RisingTidesOverrides(OptionDict):
     Areas that are not specified will roll with the default 33% chance of getting flooded or drained"""
     schema = Schema({
         Optional("Xarion"): Or(And({
-            "Dry": And(int, lambda n: n >= 0), 
-            "Flooded": And(int, lambda n: n >= 0)
+            Optional("Dry"): And(int, lambda n: n >= 0), 
+            Optional("Flooded"): And(int, lambda n: n >= 0)
         }, lambda d: any(v > 0 for v in d.values())), "Dry", "Flooded"),
         Optional("Maw"): Or(And({
-            "Dry": And(int, lambda n: n >= 0), 
-            "Flooded": And(int, lambda n: n >= 0)
+            Optional("Dry"): And(int, lambda n: n >= 0), 
+            Optional("Flooded"): And(int, lambda n: n >= 0)
         }, lambda d: any(v > 0 for v in d.values())), "Dry", "Flooded"),
         Optional("AncientPyramidShaft"): Or(And({
-            "Dry": And(int, lambda n: n >= 0), 
-            "Flooded": And(int, lambda n: n >= 0)
+            Optional("Dry"): And(int, lambda n: n >= 0), 
+            Optional("Flooded"): And(int, lambda n: n >= 0)
         }, lambda d: any(v > 0 for v in d.values())), "Dry", "Flooded"),
         Optional("Sandman"): Or(And({
-            "Dry": And(int, lambda n: n >= 0), 
-            "Flooded": And(int, lambda n: n >= 0)
+            Optional("Dry"): And(int, lambda n: n >= 0), 
+            Optional("Flooded"): And(int, lambda n: n >= 0)
         }, lambda d: any(v > 0 for v in d.values())), "Dry", "Flooded"),
         Optional("CastleMoat"): Or(And({
-            "Dry": And(int, lambda n: n >= 0), 
-            "Flooded": And(int, lambda n: n >= 0)
+            Optional("Dry"): And(int, lambda n: n >= 0), 
+            Optional("Flooded"): And(int, lambda n: n >= 0)
         }, lambda d: any(v > 0 for v in d.values())), "Dry", "Flooded"),
         Optional("CastleBasement"): Or(And({
-            "Dry": And(int, lambda n: n >= 0), 
-            "FloodedWithSavePointAvailable": And(int, lambda n: n >= 0), 
-            "Flooded": And(int, lambda n: n >= 0) 
+            Optional("Dry"): And(int, lambda n: n >= 0), 
+            Optional("FloodedWithSavePointAvailable"): And(int, lambda n: n >= 0), 
+            Optional("Flooded"): And(int, lambda n: n >= 0) 
         }, lambda d: any(v > 0 for v in d.values())), "Dry", "FloodedWithSavePointAvailable", "Flooded"),
         Optional("CastleCourtyard"): Or(And({
-            "Dry": And(int, lambda n: n >= 0), 
-            "Flooded": And(int, lambda n: n >= 0)
+            Optional("Dry"): And(int, lambda n: n >= 0), 
+            Optional("Flooded"): And(int, lambda n: n >= 0)
         }, lambda d: any(v > 0 for v in d.values())), "Dry", "Flooded"),
         Optional("LakeDesolation"): Or(And({
-            "Dry": And(int, lambda n: n >= 0), 
-            "Flooded": And(int, lambda n: n >= 0)
+            Optional("Dry"): And(int, lambda n: n >= 0), 
+            Optional("Flooded"): And(int, lambda n: n >= 0)
         }, lambda d: any(v > 0 for v in d.values())), "Dry", "Flooded"),
         Optional("LakeSerene"): Or(And({
-            "Dry": And(int, lambda n: n >= 0), 
-            "Flooded": And(int, lambda n: n >= 0)
+            Optional("Dry"): And(int, lambda n: n >= 0), 
+            Optional("Flooded"): And(int, lambda n: n >= 0)
         }, lambda d: any(v > 0 for v in d.values())), "Dry", "Flooded")
     })
     display_name = "Rising Tides Overrides"

--- a/worlds/timespinner/PreCalculatedWeights.py
+++ b/worlds/timespinner/PreCalculatedWeights.py
@@ -21,7 +21,7 @@ class PreCalculatedWeights:
     dry_lake_serene: bool
 
     def __init__(self, world: MultiWorld, player: int):
-        weights_overrrides: Dict[str, Dict[str, int]] = self.get_flood_weights_overrides(world, player)
+        weights_overrrides: Dict[str, Union[str, Dict[str, int]]] = self.get_flood_weights_overrides(world, player)
 
         self.flood_basement, self.flood_basement_high = \
             self.roll_flood_setting_with_available_save(world, player, weights_overrrides, "CastleBasement")
@@ -87,8 +87,8 @@ class PreCalculatedWeights:
         )
 
     @staticmethod
-    def get_flood_weights_overrides( world: MultiWorld, player: int) -> Dict[str, int]:
-        weights_overrides_option: Union[int, Dict[str, Dict[str, int]]] = \
+    def get_flood_weights_overrides( world: MultiWorld, player: int) -> Dict[str, Union[str, Dict[str, int]]]:
+        weights_overrides_option: Union[int, Dict[str, Union[str, Dict[str, int]]]] = \
             get_option_value(world, player, "RisingTidesOverrides")
 
         if weights_overrides_option == 0:
@@ -97,26 +97,32 @@ class PreCalculatedWeights:
             return weights_overrides_option 
 
     @staticmethod
-    def roll_flood_setting(world: MultiWorld, player: int, weights: Dict[str, Dict[str, int]], key: str) -> bool:
+    def roll_flood_setting(world: MultiWorld, player: int, weights: Dict[str, Union[Dict[str, int], str]], key: str) -> bool:
         if not world or not is_option_enabled(world, player, "RisingTides"):
             return False
 
         weights = weights[key] if key in weights else { "Dry": 67, "Flooded": 33 }
 
-        result: str = world.random.choices(list(weights.keys()), weights=list(map(int, weights.values())))[0]
+        if isinstance(weights, dict):
+            result: str = world.random.choices(list(weights.keys()), weights=list(map(int, weights.values())))[0]
+        else:
+            result: str = weights
 
         return result == "Flooded"
 
     @staticmethod
     def roll_flood_setting_with_available_save(world: MultiWorld, player: int,
-                                               weights: Dict[str, Dict[str, int]], key: str) -> Tuple[bool, bool]:
+                                               weights: Dict[str, Union[Dict[str, int], str]], key: str) -> Tuple[bool, bool]:
 
         if not world or not is_option_enabled(world, player, "RisingTides"):
             return False, False
 
         weights = weights[key] if key in weights else {"Dry": 66, "Flooded": 17, "FloodedWithSavePointAvailable": 17}
 
-        result: str = world.random.choices(list(weights.keys()), weights=list(map(int, weights.values())))[0]
+        if isinstance(weights, dict):
+            result: str = world.random.choices(list(weights.keys()), weights=list(map(int, weights.values())))[0]
+        else:
+            result: str = weights
         
         if result == "Dry":
             return False, False


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?

Allow different ways of specifying RisingTidesOverrides.
In the case of dictionary specification, verify that at least one of the weighted options is greater than zero for each of the options.

## How was this tested?

Rolling different yamls, and verifying that I get the expected errors for bad input.


## If this makes graphical changes, please attach screenshots.

![image](https://user-images.githubusercontent.com/79097/220203430-30e16700-7b11-480e-87bb-601512e3a44e.png)

