### PR TITLE
Subnautica: Allow either utility room for progression

### DIFF
--- a/worlds/subnautica/Items.py
+++ b/worlds/subnautica/Items.py
@@ -223,7 +223,7 @@ item_table: Dict[int, ItemDict] = {
             'name': 'Observatory',
             'tech_type': 'BaseObservatory'},
     35053: {'classification': ItemClassification.progression,
-            'count': 2,
+            'count': 1,
             'name': 'Multipurpose Room',
             'tech_type': 'BaseRoom'},
     35054: {'classification': ItemClassification.useful,
@@ -338,12 +338,11 @@ item_table: Dict[int, ItemDict] = {
             'count': 1,
             'name': 'Ultra High Capacity Tank',
             'tech_type': 'HighCapacityTank'},
-    # these currently unlock through some special sauce in Subnautica, unlike any established other
-    # keeping here for later
     35082: {'classification': ItemClassification.progression,
-            'count': 0,
+            'count': 1,
             'name': 'Large Room',
             'tech_type': 'BaseLargeRoom'},
+    # awarded with their rooms, keeping that as-is as they're cosmetic
     35083: {'classification': ItemClassification.filler,
             'count': 0,
             'name': 'Large Room Glass Dome',

--- a/worlds/subnautica/__init__.py
+++ b/worlds/subnautica/__init__.py
@@ -42,7 +42,7 @@ class SubnauticaWorld(World):
     option_definitions = Options.options
 
     data_version = 9
-    required_client_version = (0, 3, 8)
+    required_client_version = (0, 3, 9)
 
     creatures_to_scan: List[str]
 


### PR DESCRIPTION
## What is this fixing or adding?
Vanilla Subnautica gives "Large Room" alongside "Multipurpose Room" always. New client is now released that breaks this bond and makes them independently shuffleable

## How was this tested?
locally so far, posted client and apworld to Subnautica channel.