### PR TITLE
Core: allow `Region`s to have a `progress_type` which marks unfilled locations after pre_fill

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -999,6 +999,10 @@ class Region:
         for entrance in self.entrances:  # BFS might be better here, trying DFS for now.
             return entrance.parent_region.get_connecting_entrance(is_main_entrance)
 
+    def exclude_locations(self) -> None:
+        for loc in [loc for loc in self.locations if not loc.item]:
+            loc.progress_type = LocationProgressType.EXCLUDED
+
     def __repr__(self):
         return self.__str__()
 
@@ -1045,6 +1049,7 @@ class Entrance:
 
 
 class Dungeon(object):
+    excluded: bool = False
     def __init__(self, name: str, regions: List[Region], big_key: Item, small_keys: List[Item],
                  dungeon_items: List[Item], player: int):
         self.name = name

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -959,7 +959,7 @@ class Region:
     locations: List[Location]
     dungeon: Optional[Dungeon] = None
     shop: Optional = None
-    excluded: bool = False
+    progress_type: LocationProgressType
 
     # LttP specific. TODO: move to a LttPRegion
     # will be set after making connections.
@@ -999,9 +999,9 @@ class Region:
         for entrance in self.entrances:  # BFS might be better here, trying DFS for now.
             return entrance.parent_region.get_connecting_entrance(is_main_entrance)
 
-    def exclude_locations(self) -> None:
+    def set_progress_type(self) -> None:
         for loc in [loc for loc in self.locations if not loc.item]:
-            loc.progress_type = LocationProgressType.EXCLUDED
+            loc.progress_type = self.progress_type
 
     def __repr__(self):
         return self.__str__()
@@ -1049,7 +1049,6 @@ class Entrance:
 
 
 class Dungeon(object):
-    excluded: bool = False
     def __init__(self, name: str, regions: List[Region], big_key: Item, small_keys: List[Item],
                  dungeon_items: List[Item], player: int):
         self.name = name

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -959,6 +959,7 @@ class Region:
     locations: List[Location]
     dungeon: Optional[Dungeon] = None
     shop: Optional = None
+    excluded: bool = False
 
     # LttP specific. TODO: move to a LttPRegion
     # will be set after making connections.

--- a/Main.py
+++ b/Main.py
@@ -239,6 +239,16 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
 
     AutoWorld.call_all(world, "pre_fill")
 
+    def exclude_regions(regions: List[Region]) -> None:
+        def exclude_region(region: Region) -> None:
+            for loc in [location for location in region.locations if not location.item]:
+                loc.progress_type = LocationProgressType.EXCLUDED
+
+        for reg in regions:
+            exclude_region(reg)
+
+    exclude_regions([reg for reg in world.get_regions() if reg.excluded])
+
     logger.info(f'Filling the world with {len(world.itempool)} items.')
 
     if world.algorithm == 'flood':

--- a/Main.py
+++ b/Main.py
@@ -240,8 +240,8 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
     AutoWorld.call_all(world, "pre_fill")
 
     for reg in world.get_regions():
-        if reg.excluded:
-            reg.exclude_locations()
+        if getattr(reg, "progress_type", None):
+            reg.set_progress_type()
 
     logger.info(f'Filling the world with {len(world.itempool)} items.')
 

--- a/Main.py
+++ b/Main.py
@@ -239,15 +239,9 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
 
     AutoWorld.call_all(world, "pre_fill")
 
-    def exclude_regions(regions: List[Region]) -> None:
-        def exclude_region(region: Region) -> None:
-            for loc in [location for location in region.locations if not location.item]:
-                loc.progress_type = LocationProgressType.EXCLUDED
-
-        for reg in regions:
-            exclude_region(reg)
-
-    exclude_regions([reg for reg in world.get_regions() if reg.excluded])
+    for reg in world.get_regions():
+        if reg.excluded:
+            reg.exclude_locations()
 
     logger.info(f'Filling the world with {len(world.itempool)} items.')
 

--- a/Options.py
+++ b/Options.py
@@ -720,7 +720,9 @@ class VerifyKeys:
         if cls.valid_keys:
             data = set(data)
             dataset = set(word.casefold() for word in data) if cls.valid_keys_casefold else set(data)
-            extra = dataset - cls.valid_keys
+            valid_keys = {valid_key.casefold() for valid_key in cls.valid_keys} if cls.valid_keys_casefold\
+                else cls.valid_keys
+            extra = dataset - valid_keys
             if extra:
                 raise Exception(f"Found unexpected key {', '.join(extra)} in {cls}. "
                                 f"Allowed keys: {cls.valid_keys}.")

--- a/worlds/alttp/Dungeons.py
+++ b/worlds/alttp/Dungeons.py
@@ -1,6 +1,6 @@
 import typing
 
-from BaseClasses import Dungeon
+from BaseClasses import Dungeon, MultiWorld, Item
 from worlds.alttp.Bosses import BossFactory
 from Fill import fill_restrictive
 from worlds.alttp.Items import ItemFactory
@@ -20,7 +20,7 @@ def create_dungeons(multiworld: MultiWorld, player: int):
                      big_key: typing.Optional[Item], small_keys: typing.Union[Item, typing.List[Item]],
                      dungeon_items: typing.Union[Item, typing.List[Item]]) -> Dungeon:
         dungeon = Dungeon(name, dungeon_regions, big_key,
-                          [] if world.smallkey_shuffle[player] == smallkey_shuffle.option_universal else small_keys,
+                          [] if multiworld.smallkey_shuffle[player] == smallkey_shuffle.option_universal else small_keys,
                           dungeon_items, player)
         dungeon.excluded = name in excluded_dungeons
         for item in dungeon.all_items:
@@ -91,7 +91,7 @@ def create_dungeons(multiworld: MultiWorld, player: int):
                       ItemFactory(['Small Key (Turtle Rock)'] * 4, player),
                       ItemFactory(['Map (Turtle Rock)', 'Compass (Turtle Rock)'], player))
 
-    if world.mode[player] != 'inverted':
+    if multiworld.mode[player] != 'inverted':
         AT = make_dungeon('Agahnims Tower', 'Agahnim', ['Agahnims Tower', 'Agahnim 1'], None,
                           ItemFactory(['Small Key (Agahnims Tower)'] * 2, player), [])
         GT = make_dungeon('Ganons Tower', 'Agahnim2',
@@ -119,7 +119,7 @@ def create_dungeons(multiworld: MultiWorld, player: int):
     GT.bosses['top'] = BossFactory('Moldorm', player)
 
     for dungeon in [ES, EP, DP, ToH, AT, PoD, TT, SW, SP, IP, MM, TR, GT]:
-        world.dungeons[dungeon.name, dungeon.player] = dungeon
+        multiworld.dungeons[dungeon.name, dungeon.player] = dungeon
 
 
 def get_dungeon_item_pool(world) -> typing.List:

--- a/worlds/alttp/Options.py
+++ b/worlds/alttp/Options.py
@@ -1,7 +1,7 @@
 import typing
 
 from BaseClasses import MultiWorld
-from Options import Choice, Range, Option, Toggle, DefaultOnToggle, DeathLink, TextChoice, PlandoBosses
+from Options import Choice, Range, Option, Toggle, DefaultOnToggle, DeathLink, TextChoice, PlandoBosses, OptionList
 
 
 class Logic(Choice):
@@ -381,6 +381,37 @@ class BeemizerRange(Range):
     range_end = 100
 
 
+class ExcludeDungeons(OptionList):
+    """Listed dungeons will have all locations marked as excluded after key logic resolves. Pendants and Crystals may
+    still be required."""
+    display_name = "Excluded Dungeons"
+    valid_keys = {
+        "Hyrule Castle",
+        "Eastern Palace",
+        "Desert Palace",
+        "Tower of Hera",
+        "Palace of Darkness",
+        "Thieves Town",
+        "Skull Woods",
+        "Swamp Palace",
+        "Ice Palace",
+        "Misery Mire",
+        "Turtle Rock",
+        "Agahnims Tower",
+        "Ganons Tower"
+    }
+    valid_keys_casefold = True
+
+    @property
+    def inverted_names(self) -> typing.List[str]:
+        inverted_excluded_names = self.value.copy()
+        if "Agahnims Tower" in self.value:
+            inverted_excluded_names[self.value.index("Agahnims Tower")] = "Inverted Agahnims Tower"
+        if "Ganons Tower" in self.value:
+            inverted_excluded_names[self.value.index("Ganons Tower")] = "Inverted Ganons Tower"
+        return inverted_excluded_names
+
+
 class BeemizerTotalChance(BeemizerRange):
     """Percentage chance for each junk-fill item (rupees, bombs, arrows) to be
     replaced with either a bee swarm trap or a single bottle-filling bee."""
@@ -441,5 +472,6 @@ alttp_options: typing.Dict[str, type(Option)] = {
     "beemizer_total_chance": BeemizerTotalChance,
     "beemizer_trap_chance": BeemizerTrapChance,
     "death_link": DeathLink,
-    "allow_collect": AllowCollect
+    "allow_collect": AllowCollect,
+    "excluded_dungeons": ExcludeDungeons,
 }

--- a/worlds/alttp/Options.py
+++ b/worlds/alttp/Options.py
@@ -402,6 +402,12 @@ class ExcludeDungeons(OptionList):
     }
     valid_keys_casefold = True
 
+    def __init__(self, value: typing.List[str]):
+        super(ExcludeDungeons, self).__init__(value)
+        titled_names = [name.lower().title() for name in value]
+        for index in range(len(titled_names)):
+            self.value[index] = titled_names[index].replace("Of", "of")
+
     @property
     def inverted_names(self) -> typing.List[str]:
         inverted_excluded_names = self.value.copy()

--- a/worlds/alttp/__init__.py
+++ b/worlds/alttp/__init__.py
@@ -246,7 +246,6 @@ class ALTTPWorld(World):
             world.register_indirect_condition(world.get_region(region_name, player),
                                               world.get_entrance(entrance_name, player))
 
-
     def collect_item(self, state: CollectionState, item: Item, remove=False):
         item_name = item.name
         if item_name.startswith('Progressive '):

--- a/worlds/alttp/test/options/TestExcludeDungeons.py
+++ b/worlds/alttp/test/options/TestExcludeDungeons.py
@@ -1,0 +1,53 @@
+from BaseClasses import LocationProgressType
+from . import LTTPOptionsTestBase
+
+
+class ExcludeDungeonsTest(LTTPOptionsTestBase):
+    options = {
+        "excluded_dungeons": ["Hyrule Castle", "Agahnims Tower", "pAlaCe Of DaRkneSs"]
+    }
+    dungeon_names = ["Hyrule Castle", "Agahnims Tower", "Palace of Darkness"]
+
+    def testCaseInsensitivity(self):
+        self.assertEqual(self.dungeon_names,
+                         self.multiworld.excluded_dungeons[1].value)
+
+    def testDungeonsExcluded(self):
+        excluded_dungeons = [self.multiworld.get_dungeon(dungeon_name, 1) for dungeon_name in self.dungeon_names]
+        for dungeon in excluded_dungeons:
+            with self.subTest("dungeon excluded", dungeon=dungeon.name):
+                self.assertTrue(dungeon.progress_type == LocationProgressType.EXCLUDED)
+
+        excluded_regions = [region for dungeon in excluded_dungeons for region in dungeon.regions]
+        for region in excluded_regions:
+            with self.subTest("region excluded", region=region.name):
+                self.assertTrue(region.progress_type == LocationProgressType.EXCLUDED)
+            region.set_progress_type()
+            for loc in region.locations:
+                if not loc.item:
+                    with self.subTest("location excluded", location=loc.name):
+                        self.assertTrue(loc.progress_type == LocationProgressType.EXCLUDED)
+
+
+class ExcludeInvertedDungeonsTest(LTTPOptionsTestBase):
+    options = {
+        "mode": "inverted",
+        "excluded_dungeons": ["Hyrule Castle", "Agahnims Tower", "Ganons Tower"]
+    }
+    dungeon_names = ["Hyrule Castle", "Inverted Agahnims Tower", "Inverted Ganons Tower"]
+
+    def testDungeonsExcluded(self):
+        excluded_dungeons = [self.multiworld.get_dungeon(dungeon_name, 1) for dungeon_name in self.dungeon_names]
+        for dungeon in excluded_dungeons:
+            with self.subTest("dungeon excluded", dungeon=dungeon.name):
+                self.assertTrue(dungeon.progress_type == LocationProgressType.EXCLUDED)
+
+        excluded_regions = [region for dungeon in excluded_dungeons for region in dungeon.regions]
+        for region in excluded_regions:
+            with self.subTest("region excluded", region=region.name):
+                self.assertTrue(region.progress_type == LocationProgressType.EXCLUDED)
+            region.set_progress_type()
+            for loc in region.locations:
+                if not loc.item:
+                    with self.subTest("location excluded", location=loc.name):
+                        self.assertTrue(loc.progress_type == LocationProgressType.EXCLUDED)

--- a/worlds/alttp/test/options/TestOpenPyramid.py
+++ b/worlds/alttp/test/options/TestOpenPyramid.py
@@ -1,12 +1,8 @@
-from test.TestBase import WorldTestBase
+from . import LTTPOptionsTestBase
 from ...Items import ItemFactory
 
 
-class PyramidTestBase(WorldTestBase):
-    game = "A Link to the Past"
-
-
-class OpenPyramidTest(PyramidTestBase):
+class OpenPyramidTest(LTTPOptionsTestBase):
     options = {
         "open_pyramid": "open"
     }
@@ -17,7 +13,7 @@ class OpenPyramidTest(PyramidTestBase):
         self.assertTrue(self.can_reach_entrance("Pyramid Hole"))
 
 
-class GoalPyramidTest(PyramidTestBase):
+class GoalPyramidTest(LTTPOptionsTestBase):
     options = {
         "open_pyramid": "goal"
     }

--- a/worlds/alttp/test/options/__init__.py
+++ b/worlds/alttp/test/options/__init__.py
@@ -1,0 +1,33 @@
+from argparse import Namespace
+
+from BaseClasses import MultiWorld
+from test.TestBase import WorldTestBase, gen_steps
+from worlds import AutoWorldRegister
+from worlds.AutoWorld import call_all
+
+
+class LTTPOptionsTestBase(WorldTestBase):
+    game = "A Link to the Past"
+
+    def setUp(self) -> None:
+        for option in self.options:
+            if option not in AutoWorldRegister.world_types[self.game].option_definitions:
+                self.setup_lttp_multiworld()
+                break
+        else:
+            super().setUp()
+
+    def setup_lttp_multiworld(self):
+        self.multiworld = MultiWorld(1)
+        self.multiworld.game[1] = self.game
+        self.multiworld.player_name = {1: "Tester"}
+        args = Namespace()
+        for name, option in AutoWorldRegister.world_types[self.game].option_definitions.items():
+            setattr(args, name, {1: option.from_any(self.options.get(name, getattr(option, "default")))})
+        self.multiworld.set_options(args)
+        self.multiworld.set_default_common_options()
+        for name, option in {name: option for name, option in self.options.items()
+                             if name not in AutoWorldRegister.world_types[self.game].option_definitions}.items():
+            setattr(self.multiworld, name, {1: option})
+        for step in gen_steps:
+            call_all(self.multiworld, step)


### PR DESCRIPTION
## What is this fixing or adding?
Title. Added an `excluded_dungeons` option to LTTP which marks all the regions in each dungeon with `LocationProgressType.EXCLUDED`.

## How was this tested?
Ran the tests, mostly. Needs practical testing still.
