### PR TITLE
Item Plando: make world selection deterministic

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -840,8 +840,7 @@ def distribute_planned(world: MultiWorld) -> None:
             maxcount = placement['count']['target']
             from_pool = placement['from_pool']
 
-            candidates = list(location for location in world.get_unfilled_locations_for_players(locations,
-                                                                                                worlds))
+            candidates = list(world.get_unfilled_locations_for_players(locations, sorted(worlds)))
             world.random.shuffle(candidates)
             world.random.shuffle(items)
             count = 0


### PR DESCRIPTION
## What is this fixing or adding?

item plando that selects from multiple worlds uses a set, which may return in different order when rolling the same seed twice

## How was this tested?

by running the new code once and checking if it still gives the same locations as before