### PR TITLE
CI: run unittests on macos

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -23,6 +23,8 @@ jobs:
             os: windows-latest
           - python: {version: '3.10'}  # current
             os: windows-latest
+          - python: {version: '3.10'}  # current
+            os: macos-latest
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
## What is this fixing or adding?

Adding macos to the unittest matrix to see if all dependencies work on macos (they should.)

## How was this tested?

We'll see once this fails or succeeds
