### PR TITLE
Core: Check for show_in_spoiler

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1464,7 +1464,7 @@ class Spoiler():
             AutoWorld.call_all(self.multiworld, "write_spoiler", outfile)
 
             locations = [(str(location), str(location.item) if location.item is not None else "Nothing")
-                              for location in self.multiworld.get_locations()]
+                              for location in self.multiworld.get_locations() if location.show_in_spoiler]
             outfile.write('\n\nLocations:\n\n')
             outfile.write('\n'.join(
                 ['%s: %s' % (location, item) for location, item in locations]))


### PR DESCRIPTION
## What is this fixing or adding?
#1467 removed all checks for `show_in_spoiler` and it is ignored. This adds a check back in so that locations with this flag are not written to the spoiler log.


## How was this tested?
Generating and observing the spoiler