### PR TITLE
Timespinner: Fixed Dry lake serene oddity

### DIFF
--- a/worlds/timespinner/Options.py
+++ b/worlds/timespinner/Options.py
@@ -357,7 +357,7 @@ class RisingTidesOverrides(OptionDict):
         "CastleBasement": { "Dry": 66, "Flooded": 17, "FloodedWithSavePointAvailable": 17 },
         "CastleCourtyard": { "Dry": 67, "Flooded": 33 },
         "LakeDesolation": { "Dry": 67, "Flooded": 33 },
-        "LakeSerene": { "Dry": 67, "Flooded": 33 },
+        "LakeSerene": { "Dry": 33, "Flooded": 67 },
     }
 
 

--- a/worlds/timespinner/PreCalculatedWeights.py
+++ b/worlds/timespinner/PreCalculatedWeights.py
@@ -93,9 +93,12 @@ class PreCalculatedWeights:
 
         default_weights: Dict[str, Dict[str, int]] = timespinner_options["RisingTidesOverrides"].default
 
-        for key, weights in default_weights.items():
-            if not key in weights_overrides_option:
-                weights_overrides_option[key] = weights
+        if not weights_overrides_option:
+            weights_overrides_option = default_weights
+        else:
+            for key, weights in default_weights.items():
+                if not key in weights_overrides_option:
+                    weights_overrides_option[key] = weights
 
         return weights_overrides_option 
 

--- a/worlds/timespinner/PreCalculatedWeights.py
+++ b/worlds/timespinner/PreCalculatedWeights.py
@@ -1,7 +1,6 @@
 from typing import Tuple, Dict, Union
 from BaseClasses import MultiWorld
-from .Options import is_option_enabled, get_option_value
-
+from .Options import timespinner_options, is_option_enabled, get_option_value
 
 class PreCalculatedWeights:
     pyramid_keys_unlock: str
@@ -24,21 +23,22 @@ class PreCalculatedWeights:
         weights_overrrides: Dict[str, Union[str, Dict[str, int]]] = self.get_flood_weights_overrides(world, player)
 
         self.flood_basement, self.flood_basement_high = \
-            self.roll_flood_setting_with_available_save(world, player, weights_overrrides, "CastleBasement")
-        self.flood_xarion = self.roll_flood_setting(world, player, weights_overrrides, "Xarion")
-        self.flood_maw = self.roll_flood_setting(world, player, weights_overrrides, "Maw")
-        self.flood_pyramid_shaft = self.roll_flood_setting(world, player, weights_overrrides, "AncientPyramidShaft")
-        self.flood_pyramid_back = self.roll_flood_setting(world, player, weights_overrrides, "Sandman")
-        self.flood_moat = self.roll_flood_setting(world, player, weights_overrrides, "CastleMoat")
-        self.flood_courtyard = self.roll_flood_setting(world, player, weights_overrrides, "CastleCourtyard")
-        self.flood_lake_desolation = self.roll_flood_setting(world, player, weights_overrrides, "LakeDesolation")
-        self.dry_lake_serene = self.roll_flood_setting(world, player, weights_overrrides, "LakeSerene")
+            self.roll_flood_setting(world, player, weights_overrrides, "CastleBasement")
+        self.flood_xarion, _ = self.roll_flood_setting(world, player, weights_overrrides, "Xarion")
+        self.flood_maw, _ = self.roll_flood_setting(world, player, weights_overrrides, "Maw")
+        self.flood_pyramid_shaft, _ = self.roll_flood_setting(world, player, weights_overrrides, "AncientPyramidShaft")
+        self.flood_pyramid_back, _ = self.roll_flood_setting(world, player, weights_overrrides, "Sandman")
+        self.flood_moat, _ = self.roll_flood_setting(world, player, weights_overrrides, "CastleMoat")
+        self.flood_courtyard, _ = self.roll_flood_setting(world, player, weights_overrrides, "CastleCourtyard")
+        self.flood_lake_desolation, _ = self.roll_flood_setting(world, player, weights_overrrides, "LakeDesolation")
+        flood_lake_serene, _ = self.roll_flood_setting(world, player, weights_overrrides, "LakeSerene")
+        self.dry_lake_serene = not flood_lake_serene 
 
         self.pyramid_keys_unlock, self.present_key_unlock, self.past_key_unlock, self.time_key_unlock = \
-            self.get_pyramid_keys_unlock(world, player, self.flood_maw)
+            self.get_pyramid_keys_unlocks(world, player, self.flood_maw)
 
-
-    def get_pyramid_keys_unlock(self, world: MultiWorld, player: int, is_maw_flooded: bool) -> Tuple[str, str, str, str]:
+    @staticmethod
+    def get_pyramid_keys_unlocks(world: MultiWorld, player: int, is_maw_flooded: bool) -> Tuple[str, str, str, str]:
         present_teleportation_gates: Tuple[str, ...] = (
             "GateKittyBoss",
             "GateLeftLibrary",
@@ -87,37 +87,26 @@ class PreCalculatedWeights:
         )
 
     @staticmethod
-    def get_flood_weights_overrides( world: MultiWorld, player: int) -> Dict[str, Union[str, Dict[str, int]]]:
+    def get_flood_weights_overrides(world: MultiWorld, player: int) -> Dict[str, Union[str, Dict[str, int]]]:
         weights_overrides_option: Union[int, Dict[str, Union[str, Dict[str, int]]]] = \
             get_option_value(world, player, "RisingTidesOverrides")
 
-        if weights_overrides_option == 0:
-            return {}
-        else:
-            return weights_overrides_option 
+        default_weights: Dict[str, Dict[str, int]] = timespinner_options["RisingTidesOverrides"].default
+
+        for key, weights in default_weights.items():
+            if not key in weights_overrides_option:
+                weights_overrides_option[key] = weights
+
+        return weights_overrides_option 
 
     @staticmethod
-    def roll_flood_setting(world: MultiWorld, player: int, weights: Dict[str, Union[Dict[str, int], str]], key: str) -> bool:
-        if not world or not is_option_enabled(world, player, "RisingTides"):
-            return False
-
-        weights = weights[key] if key in weights else { "Dry": 67, "Flooded": 33 }
-
-        if isinstance(weights, dict):
-            result: str = world.random.choices(list(weights.keys()), weights=list(map(int, weights.values())))[0]
-        else:
-            result: str = weights
-
-        return result == "Flooded"
-
-    @staticmethod
-    def roll_flood_setting_with_available_save(world: MultiWorld, player: int,
-                                               weights: Dict[str, Union[Dict[str, int], str]], key: str) -> Tuple[bool, bool]:
+    def roll_flood_setting(world: MultiWorld, player: int,
+            all_weights: Dict[str, Union[Dict[str, int], str]], key: str) -> Tuple[bool, bool]:
 
         if not world or not is_option_enabled(world, player, "RisingTides"):
             return False, False
 
-        weights = weights[key] if key in weights else {"Dry": 66, "Flooded": 17, "FloodedWithSavePointAvailable": 17}
+        weights: Union[Dict[str, int], str] = all_weights[key]
 
         if isinstance(weights, dict):
             result: str = world.random.choices(list(weights.keys()), weights=list(map(int, weights.values())))[0]
@@ -127,6 +116,6 @@ class PreCalculatedWeights:
         if result == "Dry":
             return False, False
         elif result == "Flooded":
-            return True, False
-        elif result == "FloodedWithSavePointAvailable":
             return True, True
+        elif result == "FloodedWithSavePointAvailable":
+            return True, False

--- a/worlds/timespinner/__init__.py
+++ b/worlds/timespinner/__init__.py
@@ -144,8 +144,8 @@ class TimespinnerWorld(World):
                 flooded_areas.append("Castle Courtyard")
             if self.precalculated_weights.flood_lake_desolation:
                 flooded_areas.append("Lake Desolation")
-            if self.precalculated_weights.dry_lake_serene:
-                flooded_areas.append("Dry Lake Serene")
+            if not self.precalculated_weights.dry_lake_serene:
+                flooded_areas.append("Lake Serene")
 
             if len(flooded_areas) == 0:
                 flooded_areas_string: str = "None"


### PR DESCRIPTION
## What is this fixing or adding?
The `RisingTidesOverrides` for `LakeSerene` was an oddity as rolling `Flooded` caused it to be `Dry` and vice versa
Also refactored the `PreCalculatedWeights` to reduce code duplication

## How was this tested?
Local generations + loaded up a few tests seed for confirmation
