### PR TITLE
Spoiler: Don't double print if world overrides common options

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1280,7 +1280,9 @@ class Spoiler():
                 outfile.write('Game:                            %s\n' % self.multiworld.game[player])
                 for f_option, option in Options.per_game_common_options.items():
                     write_option(f_option, option)
-                options = self.multiworld.worlds[player].option_definitions
+                options = {option_name: option for option_name, option
+                           in self.multiworld.worlds[player].option_definitions.items()
+                           if option_name not in Options.per_game_common_options}
                 if options:
                     for f_option, option in options.items():
                         write_option(f_option, option)

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -2,19 +2,19 @@ from __future__ import annotations
 
 import copy
 import functools
-import json
 import logging
 import random
 import secrets
 import typing  # this can go away when Python 3.8 support is dropped
 from argparse import Namespace
-from collections import OrderedDict, Counter, deque
-from enum import unique, IntEnum, IntFlag
+from collections import OrderedDict, Counter, deque, ChainMap
+from enum import IntEnum, IntFlag
 from typing import List, Dict, Optional, Set, Iterable, Union, Any, Tuple, TypedDict, Callable, NamedTuple
 
 import NetUtils
 import Options
 import Utils
+
 
 class Group(TypedDict, total=False):
     name: str
@@ -1278,14 +1278,11 @@ class Spoiler():
                 if self.multiworld.players > 1:
                     outfile.write('\nPlayer %d: %s\n' % (player, self.multiworld.get_player_name(player)))
                 outfile.write('Game:                            %s\n' % self.multiworld.game[player])
-                for f_option, option in Options.per_game_common_options.items():
+
+                options = ChainMap(Options.per_game_common_options, self.multiworld.worlds[player].option_definitions)
+                for f_option, option in options.items():
                     write_option(f_option, option)
-                options = {option_name: option for option_name, option
-                           in self.multiworld.worlds[player].option_definitions.items()
-                           if option_name not in Options.per_game_common_options}
-                if options:
-                    for f_option, option in options.items():
-                        write_option(f_option, option)
+
                 AutoWorld.call_single(self.multiworld, "write_spoiler_header", player, outfile)
 
             if self.entrances:


### PR DESCRIPTION
## What is this fixing or adding?
Title

## How was this tested?
Generated and looked at the spoiler. Since I override Accessibility in The Messenger it was double printing
