### PR TITLE
Zillion: use `Option.current_key`

### DIFF
--- a/worlds/zillion/__init__.py
+++ b/worlds/zillion/__init__.py
@@ -2,13 +2,12 @@ from collections import deque, Counter
 from contextlib import redirect_stdout
 import functools
 import threading
-from typing import Any, Dict, List, Set, Tuple, Optional, cast
+from typing import Any, Dict, List, Literal, Set, Tuple, Optional, cast
 import os
 import logging
 
 from BaseClasses import ItemClassification, LocationProgressType, \
     MultiWorld, Item, CollectionState, Entrance, Tutorial
-from Options import AssembleOptions
 from .logic import cs_to_zz_locs
 from .region import ZillionLocation, ZillionRegion
 from .options import ZillionStartChar, zillion_options, validate
@@ -48,17 +47,17 @@ class ZillionWorld(World):
     game = "Zillion"
     web = ZillionWebWorld()
 
-    option_definitions: Dict[str, AssembleOptions] = zillion_options
-    topology_present: bool = True  # indicate if world type has any meaningful layout/pathing
+    option_definitions = zillion_options
+    topology_present = True  # indicate if world type has any meaningful layout/pathing
 
     # map names to their IDs
-    item_name_to_id: Dict[str, int] = _item_name_to_id
-    location_name_to_id: Dict[str, int] = _loc_name_to_id
+    item_name_to_id = _item_name_to_id
+    location_name_to_id = _loc_name_to_id
 
     # increment this every time something in your world's names/id mappings changes.
     # While this is set to 0 in *any* AutoWorld, the entire DataPackage is considered in testing mode and will be
     # retrieved by clients on every connection.
-    data_version: int = 1
+    data_version = 1
 
     logger: logging.Logger
 
@@ -250,7 +249,7 @@ class ZillionWorld(World):
             if group["game"] == "Zillion":
                 assert "item_pool" in group
                 item_pool = group["item_pool"]
-                to_stay = "JJ"
+                to_stay: Literal['Apple', 'Champ', 'JJ'] = "JJ"
                 if "JJ" in item_pool:
                     assert "players" in group
                     group_players = group["players"]

--- a/worlds/zillion/logic.py
+++ b/worlds/zillion/logic.py
@@ -42,6 +42,7 @@ def item_counts(cs: CollectionState, p: int) -> Tuple[Tuple[str, int], ...]:
 
 
 LogicCacheType = Dict[int, Tuple[_Counter[Tuple[str, int]], FrozenSet[Location]]]
+""" { hash: (cs.prog_items, accessible_locations) } """
 
 
 def cs_to_zz_locs(cs: CollectionState, p: int, zz_r: Randomizer, id_to_zz_item: Dict[int, Item]) -> FrozenSet[Location]:

--- a/worlds/zillion/options.py
+++ b/worlds/zillion/options.py
@@ -276,14 +276,14 @@ def validate(world: "MultiWorld", p: int) -> "Tuple[ZzOptions, Counter[str]]":
     skill = wo.skill[p].value
 
     jump_levels = cast(ZillionJumpLevels, wo.jump_levels[p])
-    jump_option = jump_levels.get_current_option_name().lower()
+    jump_option = jump_levels.current_key
     required_level = char_to_jump["Apple"][cast(ZzVBLR, jump_option)].index(3) + 1
     if skill == 0:
         # because of hp logic on final boss
         required_level = 8
 
     gun_levels = cast(ZillionGunLevels, wo.gun_levels[p])
-    gun_option = gun_levels.get_current_option_name().lower()
+    gun_option = gun_levels.current_key
     guns_required = char_to_gun["Champ"][cast(ZzVBLR, gun_option)].index(3)
 
     floppy_req = cast(ZillionFloppyReq, wo.floppy_req[p])
@@ -347,10 +347,14 @@ def validate(world: "MultiWorld", p: int) -> "Tuple[ZzOptions, Counter[str]]":
 
     # that should be all of the level requirements met
 
+    name_capitalization = {
+        "jj": "JJ",
+        "apple": "Apple",
+        "champ": "Champ",
+    }
+
     start_char = cast(ZillionStartChar, wo.start_char[p])
-    start_char_name = start_char.get_current_option_name()
-    if start_char_name == "Jj":
-        start_char_name = "JJ"
+    start_char_name = name_capitalization[start_char.current_key]
     assert start_char_name in chars
     start_char_name = cast(Chars, start_char_name)
 

--- a/worlds/zillion/region.py
+++ b/worlds/zillion/region.py
@@ -15,7 +15,7 @@ class ZillionRegion(Region):
                  name: str,
                  hint: str,
                  player: int,
-                 multiworld: Optional[MultiWorld] = None) -> None:
+                 multiworld: MultiWorld) -> None:
         super().__init__(name, player, multiworld, hint)
         self.zz_r = zz_r
 


### PR DESCRIPTION
## What is this fixing or adding?

use `Option.current_key` instead of `Option.get_current_option_name()`
and other minor fixes (typing and docstrings)

## How was this tested?

a few generations, a single-player playthrough, and unit tests