### PR TITLE
Core: Generic excluded fill

### DIFF
--- a/worlds/alttp/Dungeons.py
+++ b/worlds/alttp/Dungeons.py
@@ -162,21 +162,7 @@ def fill_dungeons_restrictive(world):
                                  (5 if (item.player, item.name) in dungeon_specific else 0))
             for item in in_dungeon_items:
                 all_state_base.remove(item)
-            fill_restrictive(world, all_state_base, locations, in_dungeon_items, True, True, allow_partial=True)
-            # partial fill
-            if in_dungeon_items:
-                # check if partial fill is the result of excluded locations, in which case allow dungeon locked items
-                excluded_locations = [
-                    location for location in locations
-                    if location.progress_type == location.progress_type.EXCLUDED and not location.item
-                ]
-                if excluded_locations:
-                    for location in excluded_locations:
-                        location.progress_type = location.progress_type.DEFAULT
-                    fill_restrictive(world, all_state_base, excluded_locations, in_dungeon_items, True, True)
-                    for location in excluded_locations:
-                        if not location.item:
-                            location.progress_type = location.progress_type.EXCLUDED
+            fill_restrictive(world, all_state_base, locations, in_dungeon_items, True, True, allow_excluded=True)
 
 
 dungeon_music_addresses = {'Eastern Palace - Prize': [0x1559A],

--- a/worlds/alttp/Dungeons.py
+++ b/worlds/alttp/Dungeons.py
@@ -7,6 +7,8 @@ from worlds.alttp.Items import ItemFactory
 from worlds.alttp.Regions import lookup_boss_drops
 from worlds.alttp.Options import smallkey_shuffle
 
+if typing.TYPE_CHECKING:
+    from .SubClasses import ALttPLocation
 
 def create_dungeons(world, player):
     def make_dungeon(name, default_boss, dungeon_regions, big_key, small_keys, dungeon_items):
@@ -138,9 +140,10 @@ def fill_dungeons_restrictive(world):
         if in_dungeon_items:
             restricted_players = {player for player, restricted in world.restrict_dungeon_item_on_boss.items() if
                                   restricted}
-            locations = [location for location in get_unfilled_dungeon_locations(world)
-                         # filter boss
-                         if not (location.player in restricted_players and location.name in lookup_boss_drops)]
+            locations: typing.List["ALttPLocation"] = [
+                location for location in get_unfilled_dungeon_locations(world)
+                # filter boss
+                if not (location.player in restricted_players and location.name in lookup_boss_drops)]
             if dungeon_specific:
                 for location in locations:
                     dungeon = location.parent_region.dungeon
@@ -159,7 +162,21 @@ def fill_dungeons_restrictive(world):
                                  (5 if (item.player, item.name) in dungeon_specific else 0))
             for item in in_dungeon_items:
                 all_state_base.remove(item)
-            fill_restrictive(world, all_state_base, locations, in_dungeon_items, True, True)
+            fill_restrictive(world, all_state_base, locations, in_dungeon_items, True, True, allow_partial=True)
+            # partial fill
+            if in_dungeon_items:
+                # check if partial fill is the result of excluded locations, in which case allow dungeon locked items
+                excluded_locations = [
+                    location for location in locations
+                    if location.progress_type == location.progress_type.EXCLUDED and not location.item
+                ]
+                if excluded_locations:
+                    for location in excluded_locations:
+                        location.progress_type = location.progress_type.DEFAULT
+                    fill_restrictive(world, all_state_base, locations, in_dungeon_items, True, True)
+                    for location in excluded_locations:
+                        if not location.item:
+                            location.progress_type = location.progress_type.EXCLUDED
 
 
 dungeon_music_addresses = {'Eastern Palace - Prize': [0x1559A],

--- a/worlds/alttp/Dungeons.py
+++ b/worlds/alttp/Dungeons.py
@@ -173,7 +173,7 @@ def fill_dungeons_restrictive(world):
                 if excluded_locations:
                     for location in excluded_locations:
                         location.progress_type = location.progress_type.DEFAULT
-                    fill_restrictive(world, all_state_base, locations, in_dungeon_items, True, True)
+                    fill_restrictive(world, all_state_base, excluded_locations, in_dungeon_items, True, True)
                     for location in excluded_locations:
                         if not location.item:
                             location.progress_type = location.progress_type.EXCLUDED


### PR DESCRIPTION
## What is this fixing or adding?
adds the ability to have restricted fill retry fill while ignoring excluded locations.
Generalisation of https://github.com/ArchipelagoMW/Archipelago/pull/1503

## How was this tested?
Quite a bit, but only with LttP. I wrote this before https://github.com/ArchipelagoMW/Archipelago/pull/1504, but only finished testing it now.
