### PR TITLE
TLOZ: Code Cleanup

### DIFF
--- a/worlds/tloz/ItemPool.py
+++ b/worlds/tloz/ItemPool.py
@@ -1,5 +1,6 @@
 from BaseClasses import ItemClassification
 from .Locations import level_locations, all_level_locations, standard_level_locations, shop_locations
+from .Options import TriforceLocations, StartingPosition
 
 # Swords are in starting_weapons
 overworld_items = {
@@ -92,10 +93,11 @@ def get_pool_core(world):
 
     # Starting Weapon
     starting_weapon = random.choice(starting_weapons)
-    if world.multiworld.StartingPosition[world.player] == 0:
+    if world.multiworld.StartingPosition[world.player] == StartingPosition.option_safe:
         placed_items[starting_weapon_locations[0]] = starting_weapon
-    elif world.multiworld.StartingPosition[world.player] in [1, 2]:
-        if world.multiworld.StartingPosition[world.player] == 2:
+    elif world.multiworld.StartingPosition[world.player] in \
+            [StartingPosition.option_unsafe, StartingPosition.option_dangerous]:
+        if world.multiworld.StartingPosition[world.player] == StartingPosition.option_dangerous:
             for location in dangerous_weapon_locations:
                 if world.multiworld.ExpandedPool[world.player] or "Drop" not in location:
                     starting_weapon_locations.append(location)
@@ -115,9 +117,9 @@ def get_pool_core(world):
         possible_level_locations = [location for location in standard_level_locations
                                     if location not in level_locations[8]]
     for level in range(1, 9):
-        if world.multiworld.TriforceLocations[world.player] == 0:
+        if world.multiworld.TriforceLocations[world.player] == TriforceLocations.option_vanilla:
             placed_items[f"Level {level} Triforce"] = fragment
-        elif world.multiworld.TriforceLocations[world.player] == 1:
+        elif world.multiworld.TriforceLocations[world.player] == TriforceLocations.option_dungeons:
             placed_items[possible_level_locations.pop(random.randint(0, len(possible_level_locations) - 1))] = fragment
         else:
             pool.append(fragment)

--- a/worlds/tloz/Locations.py
+++ b/worlds/tloz/Locations.py
@@ -87,16 +87,9 @@ level_locations = [
     ]
 ]
 
-all_level_locations = []
-for level in level_locations:
-    for location in level:
-        all_level_locations.append(location)
+all_level_locations = [location for level in level_locations for location in level]
 
-standard_level_locations = []
-for level in level_locations:
-    for location in level:
-        if "Drop" not in location:
-            standard_level_locations.append(location)
+standard_level_locations = [location for level in level_locations for location in level if "Drop" not in location]
 
 shop_locations = [
     "Arrow Shop Item Left", "Arrow Shop Item Middle", "Arrow Shop Item Right",
@@ -190,7 +183,6 @@ floor_location_game_offsets_early = {
 }
 
 floor_location_game_ids_early = {}
-floor_location_game_ids_late = {}
 for key, value in floor_location_game_offsets_early.items():
     floor_location_game_ids_early[key] = value + Rom.first_quest_dungeon_items_early
 
@@ -254,6 +246,7 @@ floor_location_game_offsets_late = {
     "Level 9 Rupee Drop (Gels East)": 0x26
 }
 
+floor_location_game_ids_late = {}
 for key, value in floor_location_game_offsets_late.items():
     floor_location_game_ids_late[key] = value + Rom.first_quest_dungeon_items_late
 

--- a/worlds/tloz/Options.py
+++ b/worlds/tloz/Options.py
@@ -3,7 +3,7 @@ from Options import Option, DefaultOnToggle, Choice
 
 
 class ExpandedPool(DefaultOnToggle):
-    """Puts room clear drops into the pool of items and locations."""
+    """Puts room clear drops and take any caves into the pool of items and locations."""
     display_name = "Expanded Item Pool"
 
 

--- a/worlds/tloz/Rules.py
+++ b/worlds/tloz/Rules.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 from ..generic.Rules import add_rule
 from .Locations import food_locations, shop_locations
 from .ItemPool import dangerous_weapon_locations
+from .Options import StartingPosition
 
 if TYPE_CHECKING:
     from . import TLoZWorld
@@ -22,7 +23,8 @@ def set_rules(tloz_world: "TLoZWorld"):
     # No dungeons without weapons except for the dangerous weapon locations if we're dangerous, no unsafe dungeons
     for i, level in enumerate(tloz_world.levels[1:10]):
         for location in level.locations:
-            if world.StartingPosition[player] < 1 or location.name not in dangerous_weapon_locations:
+            if world.StartingPosition[player] < StartingPosition.option_dangerous \
+                    or location.name not in dangerous_weapon_locations:
                 add_rule(world.get_location(location.name, player),
                          lambda state: state.has_group("weapons", player))
             if i > 0:  # Don't need an extra heart for Level 1
@@ -107,18 +109,17 @@ def set_rules(tloz_world: "TLoZWorld"):
             add_rule(world.get_location(location, player),
                      lambda state: state.has("Stepladder", player))
 
-    if world.StartingPosition[player] != 2:
-        # Don't allow Take Any Items until we can actually get in one
-        if world.ExpandedPool[player]:
-            add_rule(world.get_location("Take Any Item Left", player),
-                     lambda state: state.has_group("candles", player) or
-                                   state.has("Raft", player))
-            add_rule(world.get_location("Take Any Item Middle", player),
-                     lambda state: state.has_group("candles", player) or
-                                   state.has("Raft", player))
-            add_rule(world.get_location("Take Any Item Right", player),
-                     lambda state: state.has_group("candles", player) or
-                                   state.has("Raft", player))
+    # Don't allow Take Any Items until we can actually get in one
+    if world.ExpandedPool[player]:
+        add_rule(world.get_location("Take Any Item Left", player),
+                 lambda state: state.has_group("candles", player) or
+                               state.has("Raft", player))
+        add_rule(world.get_location("Take Any Item Middle", player),
+                 lambda state: state.has_group("candles", player) or
+                               state.has("Raft", player))
+        add_rule(world.get_location("Take Any Item Right", player),
+                 lambda state: state.has_group("candles", player) or
+                               state.has("Raft", player))
     for location in tloz_world.levels[4].locations:
         add_rule(world.get_location(location.name, player),
                  lambda state: state.has("Raft", player) or state.has("Recorder", player))

--- a/worlds/tloz/__init__.py
+++ b/worlds/tloz/__init__.py
@@ -14,7 +14,7 @@ from .Locations import location_table, level_locations, major_locations, shop_lo
     standard_level_locations, shop_price_location_ids, secret_money_ids, location_ids, food_locations
 from .Options import tloz_options
 from .Rom import TLoZDeltaPatch, get_base_rom_path, first_quest_dungeon_items_early, first_quest_dungeon_items_late
-from  .Rules import set_rules
+from .Rules import set_rules
 from worlds.AutoWorld import World, WebWorld
 from worlds.generic.Rules import add_rule
 
@@ -134,6 +134,11 @@ class TLoZWorld(World):
         self.multiworld.regions.append(menu)
         self.multiworld.regions.append(overworld)
 
+    def create_items(self):
+        # refer to ItemPool.py
+        generate_itempool(self)
+
+    # refer to Rules.py
     set_rules = set_rules
 
     def generate_basic(self):
@@ -144,9 +149,7 @@ class TLoZWorld(World):
         self.multiworld.get_location("Zelda", self.player).place_locked_item(self.create_event("Rescued Zelda!"))
         add_rule(self.multiworld.get_location("Zelda", self.player),
                  lambda state: ganon in state.locations_checked)
-
         self.multiworld.completion_condition[self.player] = lambda state: state.has("Rescued Zelda!", self.player)
-        generate_itempool(self)
 
     def apply_base_patch(self, rom):
         # The base patch source is on a different repo, so here's the summary of changes:


### PR DESCRIPTION
## What is this fixing or adding?
Addressed some of the comments left by @alwaysintreble in the original PR, and a few things I came across
- consolidated declaration and population of level location lists
- moved floor_location_game_ids_late declaration for consistency
- moved generate_itempool to create_items, where it belongs
- mention that expanded pool includes take any caves in the option description again
- removed unnecessary StartingPosition check regarding Take Any Caves (leftover from older StartingPosition behavior I believe)
- use proper comparisons to option keys instead of hardcoded ints

## How was this tested?
some test generations and some debugging stepthroughs to make sure behaviors still worked as intended and items are being placed as they should

## If this makes graphical changes, please attach screenshots.
N/A