### PR TITLE
The Witness: Death Link + Small bug fixes

### DIFF
--- a/worlds/witness/Options.py
+++ b/worlds/witness/Options.py
@@ -159,7 +159,7 @@ class HintAmount(Range):
 
 
 class DeathLink(Toggle):
-    """If on: Whenever you fail a puzzle (with some exceptions), everyone dies.
+    """If on: Whenever you fail a puzzle (with some exceptions), everyone who is also on Death Link dies.
     The effect of a "death" in The Witness is a Power Surge."""
     display_name = "Death Link"
 

--- a/worlds/witness/Options.py
+++ b/worlds/witness/Options.py
@@ -158,6 +158,12 @@ class HintAmount(Range):
     default = 10
 
 
+class DeathLink(Toggle):
+    """If on: Whenever you fail a puzzle (with some exceptions), everyone dies.
+    The effect of a "death" in The Witness is a Power Surge."""
+    display_name = "Death Link"
+
+
 the_witness_options: Dict[str, type] = {
     "puzzle_randomization": PuzzleRandomization,
     "shuffle_symbols": ShuffleSymbols,
@@ -176,6 +182,7 @@ the_witness_options: Dict[str, type] = {
     "trap_percentage": TrapPercentage,
     "puzzle_skip_amount": PuzzleSkipAmount,
     "hint_amount": HintAmount,
+    "death_link": DeathLink,
 }
 
 

--- a/worlds/witness/WitnessLogic.txt
+++ b/worlds/witness/WitnessLogic.txt
@@ -14,7 +14,7 @@ Tutorial (Tutorial) - Outside Tutorial - 0x03629:
 158005 - 0x0A3B5 (Back Left) - True - True
 158006 - 0x0A3B2 (Back Right) - True - True
 158007 - 0x03629 (Gate Open) - 0x002C2 & 0x0A3B5 & 0x0A3B2 - True
-158008 - 0x03505 (Gate Close) - 0x2FAF6 - True
+158008 - 0x03505 (Gate Close) - 0x2FAF6 & 0x03629 - True
 158009 - 0x0C335 (Pillar) - True - Triangles
 158010 - 0x0C373 (Patio Floor) - 0x0C335 - Dots
 159512 - 0x33530 (Cloud EP) - True - True

--- a/worlds/witness/WitnessLogicExpert.txt
+++ b/worlds/witness/WitnessLogicExpert.txt
@@ -14,7 +14,7 @@ Tutorial (Tutorial) - Outside Tutorial - True:
 158005 - 0x0A3B5 (Back Left) - True - Dots & Full Dots
 158006 - 0x0A3B2 (Back Right) - True - Dots & Full Dots
 158007 - 0x03629 (Gate Open) - 0x002C2 - Symmetry & Dots
-158008 - 0x03505 (Gate Close) - 0x2FAF6 - False
+158008 - 0x03505 (Gate Close) - 0x2FAF6 & 0x03629 - False
 158009 - 0x0C335 (Pillar) - True - Triangles
 158010 - 0x0C373 (Patio Floor) - 0x0C335 - Dots
 159512 - 0x33530 (Cloud EP) - True - True

--- a/worlds/witness/WitnessLogicVanilla.txt
+++ b/worlds/witness/WitnessLogicVanilla.txt
@@ -14,7 +14,7 @@ Tutorial (Tutorial) - Outside Tutorial - 0x03629:
 158005 - 0x0A3B5 (Back Left) - True - True
 158006 - 0x0A3B2 (Back Right) - True - True
 158007 - 0x03629 (Gate Open) - 0x002C2 & 0x0A3B5 & 0x0A3B2 - True
-158008 - 0x03505 (Gate Close) - 0x2FAF6 - True
+158008 - 0x03505 (Gate Close) - 0x2FAF6 & 0x03629 - True
 158009 - 0x0C335 (Pillar) - True - Triangles - True
 158010 - 0x0C373 (Patio Floor) - 0x0C335 - Dots
 159512 - 0x33530 (Cloud EP) - True - True

--- a/worlds/witness/__init__.py
+++ b/worlds/witness/__init__.py
@@ -67,7 +67,7 @@ class WitnessWorld(World):
             'progressive_item_lists': self.items.MULTI_LISTS_BY_CODE,
             'obelisk_side_id_to_EPs': self.static_logic.OBELISK_SIDE_ID_TO_EP_HEXES,
             'precompleted_puzzles': {int(h, 16) for h in self.player_logic.PRECOMPLETED_LOCATIONS},
-            'ep_to_name': self.static_logic.EP_ID_TO_NAME,
+            'entity_to_name': self.static_logic.ENTITY_ID_TO_NAME,
         }
 
     def generate_early(self):

--- a/worlds/witness/docs/setup_en.md
+++ b/worlds/witness/docs/setup_en.md
@@ -3,7 +3,7 @@
 ## Required Software
 
 - [The Witness for 64-bit Windows (e.g. Steam version)](https://store.steampowered.com/app/210970/The_Witness/)
-- [The Witness Archipelago Randomizer](https://github.com/NewSoupVi/The-Witness-Randomizer-for-Archipelago/releases)
+- [The Witness Archipelago Randomizer](https://github.com/NewSoupVi/The-Witness-Randomizer-for-Archipelago/releases/latest)
 
 ## Optional Software
 
@@ -14,7 +14,7 @@
 
 1. Launch The Witness
 2. Start a fresh save
-3. Launch [The Witness Archipelago Randomizer](https://github.com/NewSoupVi/The-Witness-Randomizer-for-Archipelago)
+3. Launch [The Witness Archipelago Randomizer](https://github.com/NewSoupVi/The-Witness-Randomizer-for-Archipelago/releases/latest)
 4. Enter the Archipelago address, slot name and password
 5. Press "Connect"
 6. Enjoy!
@@ -23,7 +23,7 @@ To continue an earlier game:
 
 1. Launch The Witness
 2. Load the save you last played this world on, if it's not the one you loaded into automatically
-3. Launch [The Witness Archipelago Randomizer](https://github.com/NewSoupVi/The-Witness-Randomizer-for-Archipelago)
+3. Launch [The Witness Archipelago Randomizer](https://github.com/NewSoupVi/The-Witness-Randomizer-for-Archipelago/releases/latest)
 4. Press "Load Credentials" (or type them in manually)
 5. Press "Connect"
 

--- a/worlds/witness/locations.py
+++ b/worlds/witness/locations.py
@@ -387,6 +387,9 @@ class StaticWitnessLocations:
         "Mountain Floor 2 Near Row 5",
         "Mountain Floor 2 Far Row 6",
 
+        "Mountain Floor 2 Light Bridge Controller Near",
+        "Mountain Floor 2 Light Bridge Controller Far",
+
         "Mountain Bottom Floor Yellow Bridge EP",
         "Mountain Bottom Floor Blue Bridge EP",
         "Mountain Floor 2 Pink Bridge EP",

--- a/worlds/witness/static_logic.py
+++ b/worlds/witness/static_logic.py
@@ -81,8 +81,6 @@ class StaticWitnessLogicObj:
                     full_check_name = check_name
                 elif "EP" in check_name:
                     location_type = "EP"
-
-                    self.EP_ID_TO_NAME[check_hex] = full_check_name
                 else:
                     location_type = "General"
 
@@ -114,6 +112,8 @@ class StaticWitnessLogicObj:
                     "panelType": location_type
                 }
 
+                self.ENTITY_ID_TO_NAME[check_hex] = full_check_name
+
                 self.CHECKS_BY_NAME[self.CHECKS_BY_HEX[check_hex]["checkName"]] = self.CHECKS_BY_HEX[check_hex]
                 self.STATIC_DEPENDENT_REQUIREMENTS_BY_HEX[check_hex] = requirement
 
@@ -132,7 +132,7 @@ class StaticWitnessLogicObj:
 
         self.EP_TO_OBELISK_SIDE = dict()
 
-        self.EP_ID_TO_NAME = dict()
+        self.ENTITY_ID_TO_NAME = dict()
 
         self.read_logic_file(file_path)
 
@@ -159,7 +159,7 @@ class StaticWitnessLogic:
 
     EP_TO_OBELISK_SIDE = dict()
 
-    EP_ID_TO_NAME = dict()
+    ENTITY_ID_TO_NAME = dict()
 
     def parse_items(self):
         """
@@ -235,4 +235,4 @@ class StaticWitnessLogic:
 
         self.EP_TO_OBELISK_SIDE.update(self.sigma_normal.EP_TO_OBELISK_SIDE)
 
-        self.EP_ID_TO_NAME.update(self.sigma_normal.EP_ID_TO_NAME)
+        self.ENTITY_ID_TO_NAME.update(self.sigma_normal.ENTITY_ID_TO_NAME)


### PR DESCRIPTION
Death Link option has been added.

To facilitate the client showing the "cause" of death, slot_data now contains a dict from all entity IDs to their canonical AP names, rather than just EP names.

A new beta client has been released accordingly.

(I accidentally named one of the commits after the changes to the client, that's why the commit names are weird, oops)