### PR TITLE
LTTP: Ice Rod Hunt boss shuffle fix

### DIFF
--- a/worlds/alttp/ItemPool.py
+++ b/worlds/alttp/ItemPool.py
@@ -250,8 +250,8 @@ def generate_itempool(world):
         world.push_item(loc, ItemFactory('Triforce Piece', player), False)
         world.treasure_hunt_count[player] = 1
         if world.boss_shuffle[player] != 'none':
-            if 'turtle rock-' not in world.boss_shuffle[player]:
-                world.boss_shuffle[player] = f'Turtle Rock-Trinexx;{world.boss_shuffle[player]}'
+            if 'turtle rock-' not in world.boss_shuffle[player].bosses:
+                world.boss_shuffle[player].bosses = f'Turtle Rock-Trinexx;{world.boss_shuffle[player].bosses}'
             else:
                 logging.warning(f'Cannot guarantee that Trinexx is the boss of Turtle Rock for player {player}')
         loc.event = True


### PR DESCRIPTION
## What is this fixing or adding?
Fixes a crash when generating with Boss Shuffle and Ice Rod Hunt

## How was this tested?
Generating and observing no crash