### PR TITLE
CI: update ubuntu to 20.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,8 +53,8 @@ jobs:
           path: dist/${{ env.ZIP_NAME }}
           retention-days: 7  # keep for 7 days, should be enough
 
-  build-ubuntu1804:
-    runs-on: ubuntu-18.04
+  build-ubuntu2004:
+    runs-on: ubuntu-20.04
     steps:
       # - copy code below to release.yml -
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,8 @@ jobs:
   # build-release-windows: # this is done by hand because of signing
   # build-release-macos: # LF volunteer
 
-  build-release-ubuntu1804:
-    runs-on: ubuntu-18.04
+  build-release-ubuntu2004:
+    runs-on: ubuntu-20.04
     steps:
       - name: Set env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV


### PR DESCRIPTION
18.04 will not be supported starting 2023-04-01

Merge as late as possible. Getting the old libc into the next release would be nice.