### PR TITLE
CI: more filters, update CodeQL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,12 +5,12 @@ name: Build
 on:
   push:
     paths:
-      - '.github/workflows/build.yaml'
+      - '.github/workflows/build.yml'
       - 'setup.py'
       - 'requirements.txt'
   pull_request:
     paths:
-      - '.github/workflows/build.yaml'
+      - '.github/workflows/build.yml'
       - 'setup.py'
       - 'requirements.txt'
   workflow_dispatch:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,7 +45,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +56,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -70,4 +70,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,9 +14,15 @@ name: "CodeQL"
 on:
   push:
     branches: [ main ]
+    paths:
+      - '**.py'
+      - '**.js'
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main ]
+    paths:
+      - '**.py'
+      - '**.js'
   schedule:
     - cron: '44 8 * * 1'
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,12 +17,14 @@ on:
     paths:
       - '**.py'
       - '**.js'
+      - '.github/workflows/codeql-analysis.yml'
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main ]
     paths:
       - '**.py'
       - '**.js'
+      - '.github/workflows/codeql-analysis.yml'
   schedule:
     - cron: '44 8 * * 1'
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,13 @@
 
 name: lint
 
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - '**.py'
+  pull_request:
+    paths:
+      - '**.py'
 
 jobs:
   build:

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -5,17 +5,23 @@ name: unittests
 
 on:
   push:
-    paths-ignore:
-      - 'docs/**'
-      - 'setup.py'
-      - '*.iss'
-      - '.gitignore'
+    paths:
+      - '**'
+      - '!docs/**'
+      - '!setup.py'
+      - '!*.iss'
+      - '!.gitignore'
+      - '!.github'
+      - '.github/workflows/unittests.yml'
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - 'setup.py'
-      - '*.iss'
-      - '.gitignore'
+    paths:
+      - '**'
+      - '!docs/**'
+      - '!setup.py'
+      - '!*.iss'
+      - '!.gitignore'
+      - '!.github'
+      - '.github/workflows/unittests.yml'
 
 jobs:
   build:

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -11,7 +11,7 @@ on:
       - '!setup.py'
       - '!*.iss'
       - '!.gitignore'
-      - '!.github'
+      - '!.github/workflows/**'
       - '.github/workflows/unittests.yml'
   pull_request:
     paths:
@@ -20,7 +20,7 @@ on:
       - '!setup.py'
       - '!*.iss'
       - '!.gitignore'
-      - '!.github'
+      - '!.github/workflows/**'
       - '.github/workflows/unittests.yml'
 
 jobs:


### PR DESCRIPTION
## What is this fixing or adding?

* the previous change had a typo, not always triggering build
* skipping of unittests is a bit more greedy now
* skip lint if no py changed
* skip CodeQL if no py and no js changed (probably good since it's our slowest workflow).
* update CodeQL since `@v1` is unsupported now

## How was this tested?

With what feels like a million branches on my fork :sweat_smile: 