### PR TITLE
Pokemon R/B: Version 3 final touches

### DIFF
--- a/worlds/pokemon_rb/__init__.py
+++ b/worlds/pokemon_rb/__init__.py
@@ -289,8 +289,10 @@ class PokemonRedBlueWorld(World):
 
         if self.multiworld.old_man[self.player] == "early_parcel":
             self.multiworld.local_early_items[self.player]["Oak's Parcel"] = 1
-            for location in [self.multiworld.get_location(f"Pokedex - {mon}", self.player) for mon in poke_data.pokemon_data.keys()]:
-                add_item_rule(location, lambda item: item.name != "Oak's Parcel" or item.player != self.player)
+            if self.multiworld.dexsanity[self.player]:
+                for location in [self.multiworld.get_location(f"Pokedex - {mon}", self.player)
+                                 for mon in poke_data.pokemon_data.keys()]:
+                    add_item_rule(location, lambda item: item.name != "Oak's Parcel" or item.player != self.player)
 
         if not self.multiworld.badgesanity[self.player].value:
             self.multiworld.non_local_items[self.player].value -= self.item_name_groups["Badges"]

--- a/worlds/pokemon_rb/__init__.py
+++ b/worlds/pokemon_rb/__init__.py
@@ -287,8 +287,10 @@ class PokemonRedBlueWorld(World):
             else:
                 break
 
-        if self.multiworld.old_man[self.player].value == 1:
+        if self.multiworld.old_man[self.player] == "early_parcel":
             self.multiworld.local_early_items[self.player]["Oak's Parcel"] = 1
+            for location in [self.multiworld.get_location(f"Pokedex - {mon}", self.player) for mon in poke_data.pokemon_data.keys()]:
+                add_item_rule(location, lambda item: item.name != "Oak's Parcel" or item.player != self.player)
 
         if not self.multiworld.badgesanity[self.player].value:
             self.multiworld.non_local_items[self.player].value -= self.item_name_groups["Badges"]

--- a/worlds/pokemon_rb/locations.py
+++ b/worlds/pokemon_rb/locations.py
@@ -753,8 +753,9 @@ location_data = [
     LocationData("Celadon Game Corner", "Hidden Item at End of Horizontal Machine Row (Coin Case)", "20 Coins", rom_addresses["Hidden_Item_Game_Corner_10"], Hidden(63), inclusion=hidden_items),
     LocationData("Celadon Game Corner", "Hidden Item in Front of Horizontal Machine Row (Coin Case)", "100 Coins", rom_addresses["Hidden_Item_Game_Corner_11"], Hidden(64), inclusion=hidden_items),
 
-    *[LocationData("Pokedex", mon, None, rom_addresses["Dexsanity_Items"] + i, DexSanityFlag(i),
-                   type="Item", inclusion=dexsanity) for (mon, i) in zip(pokemon_data.keys(), range(0, 152))],
+    *[LocationData("Pokedex", mon, ball, rom_addresses["Dexsanity_Items"] + i, DexSanityFlag(i), type="Item",
+                   inclusion=dexsanity) for (mon, i, ball) in zip(pokemon_data.keys(), range(0, 152),
+                                                                  ["Poke Ball", "Great Ball", "Ultra Ball"]* 51)],
 
     LocationData("Indigo Plateau", "Become Champion", "Become Champion", event=True),
     LocationData("Pokemon Tower 7F", "Fuji Saved", "Fuji Saved", event=True),


### PR DESCRIPTION
## What is this fixing or adding?
If early_parcel is chosen and Dexsanity is on, do not allow the Parcel on dexsanity locations. There are no repeatable sources of income to fund Pokéball purchases before getting the Parcel and you could have to catch 20 Pokémon before finding the one that gives the Parcel.

Items added to pool when Dexsanity is enabled are changed from "any random filler" to Poké Balls, Great Balls, and Ultra Balls, as it can end up being quite expensive to purchase all the balls needed to catch every Pokémon.

## How was this tested?
Generated a seed on main where Oak's Parcel was at a Dexsanity location, used same seed number with this branch and Oak's Parcel moved to the Route 1 Free Sample Man. Also observed many Poké Ball items in the pool.