### PR TITLE
AutoWorld: optional version requirement system

### DIFF
--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -32,7 +32,7 @@ class AutoWorldRegister(type):
             if version_tuple > dct["highest_archipelago_version"]:
                 raise WorldVersionIncompatible(
                     f"World {name} for {dct.get('game', None)} "
-                    f"supports Archipelago up to {dct['required_archipelago_version']}, but this is {version_tuple}")
+                    f"supports Archipelago up to {dct['highest_archipelago_version']}, but this is {version_tuple}")
         if "web" in dct:
             assert isinstance(dct["web"], WebWorld), "WebWorld has to be instantiated."
         # filter out any events


### PR DESCRIPTION
## What is this fixing or adding?
optional version requirement system

potentially a better path is to treat these as proper python packages and use importlib and co. mechanisms for versioning instead. 
That interface seems to currently be in flux however, so I'm not sure if we want to attach to that.

## How was this tested?
a bit with the Factorio world
