### PR TITLE
The Messenger: docs improvement

### DIFF
--- a/worlds/messenger/docs/en_The Messenger.md
+++ b/worlds/messenger/docs/en_The Messenger.md
@@ -1,7 +1,7 @@
 # The Messenger
 
 ## Quick Links
-- [Setup](../../../../games/The%20Messenger/setup/en)
+- [Setup](../../../../tutorial/The%20Messenger/setup/en)
 - [Settings Page](../../../../games/The%20Messenger/player-settings)
 - [Courier Github](https://github.com/Brokemia/Courier)
 - [The Messenger Randomizer Github](https://github.com/minous27/TheMessengerRandomizerMod)
@@ -48,25 +48,23 @@ for it. The groups you can use for The Messenger are:
 ## Other changes
 
 * The player can return to the Tower of Time HQ at any point by selecting the button from the options menu
-    * This can cause issues if used at specific times. Current known:
-        * During Boss fights
-        * After Courage Note collection (Corrupted Future chase)
-            * This is currently an expected action in logic. If you do need to teleport during this chase sequence, it
-is recommended to quit to title and reload the save
+  * This can cause issues if used at specific times. Current known:
+    * During Boss fights
+      * After Courage Note collection (Corrupted Future chase)
+        * This is currently an expected action in logic. If you do need to teleport during this chase sequence, it
+        is recommended to quit to title and reload the save
 * After reaching ninja village a teleport option is added to the menu to reach it quickly
 * Toggle Windmill Shuriken button is added to option menu once the item is received
 
 ## Currently known issues
 * Necro cutscene will sometimes not play correctly, but will still reward the item
 * Ruxxtin Coffin cutscene will sometimes not play correctly, but will still reward the item
-* If you receive the Fairy Bottle while in Quillshroom Marsh, The Decurse Queen cutscene will not play
+* If you receive the Fairy Bottle while in Quillshroom Marsh, The Decurse Queen cutscene will not play. You can exit
+to Searing Crags and re-enter to get it to play correctly.
 * If you defeat Barma'thazël, the cutscene afterward will not play correctly since that is what normally transitions
 you to 2nd quest. The game will not kill you if you fall here, so you can teleport to HQ at any point after defeating him.
 * Sometimes upon teleporting back to HQ, Ninja will run left and enter a different portal than the one entered by the
 player.
-* If playing the game in non-english, sometimes the text entry menus will say "What is your name?" in local language
-instead of the correct text. This can be fixed by going into the game options and selecting your language in the menu.
-It does not need to be changed to something else and back.
 * Text entry menus don't accept controller input
 
 ## What do I do if I have a problem?

--- a/worlds/messenger/docs/en_The Messenger.md
+++ b/worlds/messenger/docs/en_The Messenger.md
@@ -52,7 +52,7 @@ for it. The groups you can use for The Messenger are:
     * During Boss fights
       * After Courage Note collection (Corrupted Future chase)
         * This is currently an expected action in logic. If you do need to teleport during this chase sequence, it
-        is recommended to quit to title and reload the save
+          is recommended to quit to title and reload the save
 * After reaching ninja village a teleport option is added to the menu to reach it quickly
 * Toggle Windmill Shuriken button is added to option menu once the item is received
 
@@ -60,11 +60,11 @@ for it. The groups you can use for The Messenger are:
 * Necro cutscene will sometimes not play correctly, but will still reward the item
 * Ruxxtin Coffin cutscene will sometimes not play correctly, but will still reward the item
 * If you receive the Fairy Bottle while in Quillshroom Marsh, The Decurse Queen cutscene will not play. You can exit
-to Searing Crags and re-enter to get it to play correctly.
+  to Searing Crags and re-enter to get it to play correctly.
 * If you defeat Barma'thazël, the cutscene afterward will not play correctly since that is what normally transitions
-you to 2nd quest. The game will not kill you if you fall here, so you can teleport to HQ at any point after defeating him.
+  you to 2nd quest. The game will not kill you if you fall here, so you can teleport to HQ at any point after defeating him.
 * Sometimes upon teleporting back to HQ, Ninja will run left and enter a different portal than the one entered by the
-player.
+  player.
 * Text entry menus don't accept controller input
 
 ## What do I do if I have a problem?

--- a/worlds/messenger/docs/en_The Messenger.md
+++ b/worlds/messenger/docs/en_The Messenger.md
@@ -50,9 +50,9 @@ for it. The groups you can use for The Messenger are:
 * The player can return to the Tower of Time HQ at any point by selecting the button from the options menu
   * This can cause issues if used at specific times. Current known:
     * During Boss fights
-      * After Courage Note collection (Corrupted Future chase)
-        * This is currently an expected action in logic. If you do need to teleport during this chase sequence, it
-          is recommended to quit to title and reload the save
+    * After Courage Note collection (Corrupted Future chase)
+      * This is currently an expected action in logic. If you do need to teleport during this chase sequence, it
+        is recommended to quit to title and reload the save
 * After reaching ninja village a teleport option is added to the menu to reach it quickly
 * Toggle Windmill Shuriken button is added to option menu once the item is received
 

--- a/worlds/messenger/docs/setup_en.md
+++ b/worlds/messenger/docs/setup_en.md
@@ -31,12 +31,12 @@
 2. Navigate to `Options > Third Party Mod Options`
 3. Select `Reset Randomizer File Slots`
    * This will set up all of your save slots with new randomizer save files. You can have up to 3 randomizer files at a
-time, but must do this step again to start new runs afterwards.
+     time, but must do this step again to start new runs afterwards.
 4. Enter connection info using the relevant option buttons
    * **The game is limited to alphanumerical characters and `-` so when entering the host name replace `.` with ` ` and
-ensure that your player name when generating a settings file follows these constrictions**
+     ensure that your player name when generating a settings file follows these constrictions**
    * This defaults to `archipelago.gg` and does not need to be manually changed if connecting to a game hosted on the
-website.
+     website.
 5. Select the `Connect to Archipelago` button
 6. Navigate to save file selection
 7. Select a new valid randomizer save

--- a/worlds/messenger/docs/setup_en.md
+++ b/worlds/messenger/docs/setup_en.md
@@ -13,7 +13,7 @@
 1. Download and install Courier Mod Loader using the instructions on the release page
    * [Latest release is currently 0.7.1](https://github.com/Brokemia/Courier/releases)
 2. Download and install the randomizer mod
-   1. Download the latest [TheMessengerRandomizer.zip](https://github.com/minous27/TheMessengerRandomizerMod/releases)
+   1. Download the latest TheMessengerRandomizer.zip from the [The Messenger Randomizer Mod releases page](https://github.com/minous27/TheMessengerRandomizerMod/releases)
    2. Extract the zip file to `TheMessenger/Mods/` of your game's install location
    3. Optionally, Backup your save game
      * On Windows

--- a/worlds/messenger/docs/setup_en.md
+++ b/worlds/messenger/docs/setup_en.md
@@ -1,31 +1,29 @@
 # The Messenger Randomizer Setup Guide
 
 ## Quick Links
-- [Main Page](../../../../games/The%20Messenger/info/en)
+- [Game Info](../../../../games/The%20Messenger/info/en)
 - [Settings Page](../../../../games/The%20Messenger/player-settings)
 - [Courier Github](https://github.com/Brokemia/Courier)
 - [The Messenger Randomizer Github](https://github.com/minous27/TheMessengerRandomizerMod)
 - [Jacksonbird8237's Item Tracker](https://github.com/Jacksonbird8237/TheMessengerItemTracker)
 - [PopTracker Pack](https://github.com/alwaysintreble/TheMessengerTrackPack)
 
-## Required Software
-
-- [The Messenger](https://store.steampowered.com/app/764790/The_Messenger/)
-  - Only Steam version is currently supported.
-- [Courier Mod Loader](https://github.com/Brokemia/Courier/releases)
-- [The Messenger Randomizer Mod](https://github.com/minous27/TheMessengerRandomizerMod/releases)
-
 ## Installation
 
 1. Download and install Courier Mod Loader using the instructions on the release page
+   * [Latest release is currently 0.7.1](https://github.com/Brokemia/Courier/releases)
 2. Download and install the randomizer mod
-     * Download the latest `TheMessengerRandomizer.zip`
-     * Extract the zip file to `TheMessenger/Mods/` of your game's install location
-     * Optionally, Backup your save game
+   1. Download the latest [TheMessengerRandomizer.zip](https://github.com/minous27/TheMessengerRandomizerMod/releases)
+   2. Extract the zip file to `TheMessenger/Mods/` of your game's install location
+   3. Optionally, Backup your save game
+     * On Windows
        1. Press `Windows Key + R` to open run
        2. Type `%appdata%` to access AppData
        3. Navigate to `AppData/locallow/SabotageStudios/The Messenger`
        4. Rename `SaveGame.txt` to any name of your choice
+     * On Linux
+       1. Navigate to `steamapps/compatdata/764790/pfx/drive_c/users/steamuser/AppData/LocalLow/Sabotage Studio/The Messenger`
+       2. Rename `SaveGame.txt` to any name of your choice
 
 ## Joining a MultiWorld Game
 


### PR DESCRIPTION
## What is this fixing or adding?
Made the tutorial a bit clearer and added file path for linux users. Removed an issue that was fixed in a newer courier release. Fixed a bad link.

## How was this tested?
Reading and clicking the links