### PR TITLE
Webhost: Bandaid fix for OptionList and OptionSet on Weighted Settings

### DIFF
--- a/WebHostLib/options.py
+++ b/WebHostLib/options.py
@@ -140,14 +140,14 @@ def create():
                     "description": get_html_doc(option),
                 }
 
-            elif issubclass(option, Options.OptionList) or issubclass(option, Options.OptionSet):
-                if option.valid_keys:
-                    game_options[option_name] = {
-                        "type": "custom-list",
-                        "displayName": option.display_name if hasattr(option, "display_name") else option_name,
-                        "description": get_html_doc(option),
-                        "options": list(option.valid_keys),
-                    }
+            # elif issubclass(option, Options.OptionList) or issubclass(option, Options.OptionSet):
+            #     if option.valid_keys:
+            #         game_options[option_name] = {
+            #             "type": "custom-list",
+            #             "displayName": option.display_name if hasattr(option, "display_name") else option_name,
+            #             "description": get_html_doc(option),
+            #             "options": list(option.valid_keys),
+            #         }
 
             else:
                 logging.debug(f"{option} not exported to Web Settings.")


### PR DESCRIPTION
## What is this fixing or adding?
remove check for OptionList and OptionSet since they aren't handled properly and cause bugs. They always put out empty arrays, ignoring defaults, which breaks option assumptions.

## How was this tested?
Looked at the weighted settings page and exported a file.