### PR TITLE
OOT: set default for adult trade start if the set is empty

### DIFF
--- a/worlds/oot/Options.py
+++ b/worlds/oot/Options.py
@@ -1045,6 +1045,11 @@ class AdultTradeStart(OptionSet):
         "Claim Check",
     }
 
+    def __init__(self, value: typing.Iterable[str]):
+        if not value:
+            value = self.default
+        super().__init__(value)
+
 
 itempool_options: typing.Dict[str, type(Option)] = {
     "item_pool_value": ItemPoolValue, 


### PR DESCRIPTION
## What is this fixing or adding?
title

## How was this tested?
debugged with a yaml with an empty list for the option