### PR TITLE
MultiServer: include 'Archipelago' in games, versions and checksums

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -746,6 +746,7 @@ async def on_client_connected(ctx: Context, client: Client):
                                   ctx.name_aliases.get((team, slot), name), name)
                 )
     games = {ctx.games[x] for x in range(1, len(ctx.games) + 1)}
+    games.add("Archipelago")
     await ctx.send_msgs(client, [{
         'cmd': 'RoomInfo',
         'password': bool(ctx.password),


### PR DESCRIPTION
## What is this fixing or adding?
Fixes a bug where Archipelago was missing from datapackage_versions and datapackage_checksums.
Also includes "Archipelago" in games, so it gets picked up by clients instead of having to hard-code it in clients.

## How was this tested?
while updating apclientpp
