### PR TITLE
Pokémon R/B: Pokémon Tower Wild Pokemon logic fix

### DIFF
--- a/worlds/pokemon_rb/rules.py
+++ b/worlds/pokemon_rb/rules.py
@@ -125,6 +125,8 @@ def set_rules(world, player):
         "Seafoam Islands B4F - Legendary Pokemon": lambda state: state.pokemon_rb_can_strength(player),
         "Vermilion City - Legendary Pokemon": lambda state: state.pokemon_rb_can_surf(player) and state.has("S.S. Ticket", player),
 
+        **{f"Pokemon Tower {floor}F - Wild Pokemon - {slot}": lambda state: state.has("Silph Scope", player) for floor in range(3, 8) for slot in range(1, 11)},
+
         "Route 2 - Marcel Trade": lambda state: state.can_reach("Route 24 - Wild Pokemon - 6", "Location", player),
         "Underground Tunnel West-East - Spot Trade": lambda state: state.can_reach("Route 24 - Wild Pokemon - 6", "Location", player),
         "Route 11 - Terry Trade": lambda state: state.can_reach("Safari Zone Center - Wild Pokemon - 5", "Location", player),


### PR DESCRIPTION
Had a random moment of realization that I forgot access rules on Pokemon Tower wild Pokémon, which is far more likely to be an issue now with Dexsanity as an option

## What is this fixing or adding?
Adds logical requirement for Silph Scope to catch wild Pokémon in the Pokémon Tower.

## How was this tested?
Generating and following code with breakpoints