### PR TITLE
Fix webgen for ladx

### DIFF
--- a/worlds/ladx/__init__.py
+++ b/worlds/ladx/__init__.py
@@ -394,7 +394,7 @@ class LinksAwakeningWorld(World):
             args,
             self.laxdr_options,
             self.player_options,
-            bytes.fromhex(self.multiworld.seed_name),
+            bytes.fromhex(self.multiworld.seed_name[-20:]),
             self.ladxr_logic,
             rnd=self.multiworld.per_slot_randoms[self.player],
             player_name=name_for_rom,
@@ -411,7 +411,7 @@ class LinksAwakeningWorld(World):
             os.unlink(rompath)
 
     def generate_multi_key(self):
-        return bytes.fromhex(self.multiworld.seed_name) + self.player.to_bytes(2, 'big')
+        return bytes.fromhex(self.multiworld.seed_name[-20:]) + self.player.to_bytes(2, 'big')
 
     def modify_multidata(self, multidata: dict):
         multi_key = binascii.hexlify(self.generate_multi_key()).decode()


### PR DESCRIPTION
## What is this fixing or adding?
Webgen prepends "W" to the seed_name. This patch only takes the last 20 bytes of the seed_name - pokemon had to do the same thing, this is likely going to be a common patch for gameboy/RA based games due to the limited space in bank 0.

## How was this tested?
Ran local webhost, it genned and I was able to connect

## If this makes graphical changes, please attach screenshots.
