### PR TITLE
LADX: Pass in seed_name and auth separately

### DIFF
--- a/worlds/ladx/LADXR/generator.py
+++ b/worlds/ladx/LADXR/generator.py
@@ -60,7 +60,7 @@ from ..Options import TrendyGame, Palette
 
 
 # Function to generate a final rom, this patches the rom with all required patches
-def generateRom(args, settings, ap_settings, seed, logic, rnd=None, multiworld=None, player_name=None, player_names=[], player_id = 0):
+def generateRom(args, settings, ap_settings, auth, seed_name, logic, rnd=None, multiworld=None, player_name=None, player_names=[], player_id = 0):
     rom = ROMWithTables(args.input_filename)
     rom.player_names = player_names
     pymods = []
@@ -119,7 +119,7 @@ def generateRom(args, settings, ap_settings, seed, logic, rnd=None, multiworld=N
     patches.core.easyColorDungeonAccess(rom)
     patches.owl.removeOwlEvents(rom)
     patches.enemies.fixArmosKnightAsMiniboss(rom)
-    patches.bank3e.addBank3E(rom, seed, player_id, player_names)
+    patches.bank3e.addBank3E(rom, auth, player_id, player_names)
     patches.bank3f.addBank3F(rom)
     patches.bank34.addBank34(rom, item_list)
     patches.core.removeGhost(rom)
@@ -269,7 +269,7 @@ def generateRom(args, settings, ap_settings, seed, logic, rnd=None, multiworld=N
         patches.core.addFrameCounter(rom, len(item_list))
 
     patches.core.warpHome(rom)  # Needs to be done after setting the start location.
-    patches.titleScreen.setRomInfo(rom, binascii.hexlify(seed).decode("ascii").upper(), settings, player_name, player_id)
+    patches.titleScreen.setRomInfo(rom, auth, seed_name, settings, player_name, player_id)
     patches.endscreen.updateEndScreen(rom)
     patches.aesthetics.updateSpriteData(rom)
     if args.doubletrouble:
@@ -411,13 +411,9 @@ def generateRom(args, settings, ap_settings, seed, logic, rnd=None, multiworld=N
                 rom.banks[bank][address + 1] = packed >> 8
 
     SEED_LOCATION = 0x0134
-    SEED_SIZE = 10
-
-    # TODO: pass this in
     # Patch over the title
-    assert(len(seed) == SEED_SIZE)
-    gameid = seed + player_id.to_bytes(2, 'big')
-    rom.patch(0x00, SEED_LOCATION, None, binascii.hexlify(gameid))
+    assert(len(auth) == 12)
+    rom.patch(0x00, SEED_LOCATION, None, binascii.hexlify(auth))
 
 
     for pymod in pymods:

--- a/worlds/ladx/LADXR/patches/titleScreen.py
+++ b/worlds/ladx/LADXR/patches/titleScreen.py
@@ -20,27 +20,22 @@ def _encode(s):
     return result
 
 
-def setRomInfo(rom, seed, settings, player_name, player_id):
-    #try:
-    #    version = subprocess.run(['git', 'describe', '--tags', '--dirty=-D'], stdout=subprocess.PIPE).stdout.strip().decode("ascii", "replace")
-    #except:
-    #    version = ""
-
+def setRomInfo(rom, seed, seed_name, settings, player_name, player_id):
     try:
         seednr = int(seed, 16)
     except:
         import hashlib
-        seednr = int(hashlib.md5(seed.encode('ascii', 'replace')).hexdigest(), 16)
+        seednr = int(hashlib.md5(seed).hexdigest(), 16)
 
     if settings.race:
-        seed = "Race"
+        seed_name = "Race"
         if isinstance(settings.race, str):
-            seed += " " + settings.race
+            seed_name += " " + settings.race
         rom.patch(0x00, 0x07, "00", "01")
     else:
         rom.patch(0x00, 0x07, "00", "52")
 
-    line_1_hex = _encode(seed)
+    line_1_hex = _encode(seed_name[:20])
     #line_2_hex = _encode(seed[16:])
     BASE_DRAWING_AREA = 0x98a0
     LINE_WIDTH = 0x20

--- a/worlds/ladx/__init__.py
+++ b/worlds/ladx/__init__.py
@@ -213,6 +213,8 @@ class LinksAwakeningWorld(World):
                         self.multiworld.itempool.append(item)
 
     def pre_fill(self):
+        self.multi_key = self.generate_multi_key()
+
         dungeon_locations = []
         dungeon_locations_by_dungeon = [[], [], [], [], [], [], [], [], []]
         all_state = self.multiworld.get_all_state(use_cache=False)
@@ -390,11 +392,13 @@ class LinksAwakeningWorld(World):
         name_for_rom = self.multiworld.player_name[self.player]
 
         all_names = [self.multiworld.player_name[i + 1] for i in range(len(self.multiworld.player_name))]
+
         rom = generator.generateRom(
             args,
             self.laxdr_options,
             self.player_options,
-            bytes.fromhex(self.multiworld.seed_name[-20:]),
+            self.multi_key,
+            self.multiworld.seed_name,
             self.ladxr_logic,
             rnd=self.multiworld.per_slot_randoms[self.player],
             player_name=name_for_rom,
@@ -411,8 +415,7 @@ class LinksAwakeningWorld(World):
             os.unlink(rompath)
 
     def generate_multi_key(self):
-        return bytes.fromhex(self.multiworld.seed_name[-20:]) + self.player.to_bytes(2, 'big')
+        return self.multiworld.random.randbytes(10) + self.player.to_bytes(2, 'big')
 
     def modify_multidata(self, multidata: dict):
-        multi_key = binascii.hexlify(self.generate_multi_key()).decode()
-        multidata["connect_names"][multi_key] = multidata["connect_names"][self.multiworld.player_name[self.player]]
+        multidata["connect_names"][binascii.hexlify(self.multi_key).decode()] = multidata["connect_names"][self.multiworld.player_name[self.player]]

--- a/worlds/ladx/__init__.py
+++ b/worlds/ladx/__init__.py
@@ -415,7 +415,7 @@ class LinksAwakeningWorld(World):
             os.unlink(rompath)
 
     def generate_multi_key(self):
-        return self.multiworld.random.randbytes(10) + self.player.to_bytes(2, 'big')
+        return bytearray(self.multiworld.random.getrandbits(8) for _ in range(10)) + self.player.to_bytes(2, 'big')
 
     def modify_multidata(self, multidata: dict):
         multidata["connect_names"][binascii.hexlify(self.multi_key).decode()] = multidata["connect_names"][self.multiworld.player_name[self.player]]

--- a/worlds/ladx/__init__.py
+++ b/worlds/ladx/__init__.py
@@ -394,7 +394,7 @@ class LinksAwakeningWorld(World):
             args,
             self.laxdr_options,
             self.player_options,
-            bytes.fromhex(self.multiworld.seed_name),
+            bytes.fromhex(self.multiworld.seed_name[-20:]),
             self.ladxr_logic,
             rnd=self.multiworld.per_slot_randoms[self.player],
             player_name=name_for_rom,
@@ -411,7 +411,7 @@ class LinksAwakeningWorld(World):
             os.unlink(rompath)
 
     def generate_multi_key(self):
-        return bytes.fromhex(self.multiworld.seed_name) + self.player.to_bytes(2, 'big')
+        return bytes.fromhex(self.multiworld.seed_name[-20:]) + self.player.to_bytes(2, 'big')
 
     def modify_multidata(self, multidata: dict):
         multi_key = binascii.hexlify(self.generate_multi_key()).decode()


### PR DESCRIPTION
## What is this fixing or adding?
Auth: we now generate a new random value for the auth value in `pre_fill`
Seed Name: Can now be anything. Truncated to 20 bytes, I can add back in the code to handle two lines and double that if people wanna go nuts.

This has the side effect of eliminating a lot of bytes<->hex conversions 👍

## How was this tested?
Locally - new auth works, the menu displays the custom seed_name. Custom seed_name tested by modifying `Generate.py`

## If this makes graphical changes, please attach screenshots.
![image](https://user-images.githubusercontent.com/8206540/227239229-34bc6fcb-4df5-4ec7-b59c-7ba346536812.png)
