### PR TITLE
WebHost: give active rooms a chance to reclaim their port

### DIFF
--- a/WebHostLib/customserver.py
+++ b/WebHostLib/customserver.py
@@ -203,6 +203,11 @@ def run_server_process(room_id, ponyconfig: dict, static_server_data: dict,
     with Locker(room_id):
         try:
             asyncio.run(main())
+        except KeyboardInterrupt:
+            with db_session:
+                room = Room.get(id=room_id)
+                # ensure the Room does not spin up again on its own, minute of safety buffer
+                room.last_activity = datetime.datetime.utcnow() - datetime.timedelta(minutes=1, seconds=room.timeout)
         except:
             with db_session:
                 room = Room.get(id=room_id)


### PR DESCRIPTION
## What is this fixing or adding?
give active rooms a chance to reclaim their port

## How was this tested?
on my local copy of a webhost so far, but I have little reason to suspect it shouldn't work on the main one.
