### PR TITLE
MultiServer: if there is a hint cost, don't make it 0

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -597,7 +597,7 @@ class Context:
 
     def get_hint_cost(self, slot):
         if self.hint_cost:
-            return max(0, int(self.hint_cost * 0.01 * len(self.locations[slot])))
+            return max(1, int(self.hint_cost * 0.01 * len(self.locations[slot])))
         return 0
 
     def recheck_hints(self, team: typing.Optional[int] = None, slot: typing.Optional[int] = None):

--- a/kvui.py
+++ b/kvui.py
@@ -148,9 +148,11 @@ class ServerLabel(HovererableLabel):
                     for permission_name, permission_data in ctx.permissions.items():
                         text += f"\n    {permission_name}: {permission_data}"
                 if ctx.hint_cost is not None and ctx.total_locations:
+                    min_cost = int(ctx.server_version >= (0, 3, 9))
                     text += f"\nA new !hint <itemname> costs {ctx.hint_cost}% of checks made. " \
-                            f"For you this means every {max(1, int(ctx.hint_cost * 0.01 * ctx.total_locations))} " \
-                            "location checks."
+                            f"For you this means every " \
+                            f"{max(min_cost, int(ctx.hint_cost * 0.01 * ctx.total_locations))}" \
+                            f" location checks."
                 elif ctx.hint_cost == 0:
                     text += "\n!hint is free to use."
 

--- a/kvui.py
+++ b/kvui.py
@@ -149,7 +149,7 @@ class ServerLabel(HovererableLabel):
                         text += f"\n    {permission_name}: {permission_data}"
                 if ctx.hint_cost is not None and ctx.total_locations:
                     text += f"\nA new !hint <itemname> costs {ctx.hint_cost}% of checks made. " \
-                            f"For you this means every {max(0, int(ctx.hint_cost * 0.01 * ctx.total_locations))} " \
+                            f"For you this means every {max(1, int(ctx.hint_cost * 0.01 * ctx.total_locations))} " \
                             "location checks."
                 elif ctx.hint_cost == 0:
                     text += "\n!hint is free to use."


### PR DESCRIPTION
## What is this fixing or adding?
if there is a hint cost, don't make it 0
This fixes Clique being able to hint for all its items and locations if hint cost is lower than 50%

## How was this tested?
I didn't, sorry.

