### PR TITLE
LADX: Added credits for included sprite sheets

### DIFF
--- a/worlds/ladx/docs/en_Links Awakening DX.md
+++ b/worlds/ladx/docs/en_Links Awakening DX.md
@@ -42,6 +42,20 @@ This randomizer is based on (forked from) the wonderful work daid did on LADXR -
 
 The autotracker code for communication with magpie tracker is directly copied from kbranch's repo - https://github.com/kbranch/Magpie/tree/master/autotracking
 
+### Sprites
+
+The following sprite sheets have been included with permission of their respective authors:
+
+* by Madam Materia (https://www.twitch.tv/isabelle_zephyr)
+  * Matty_LA
+* by Linker (https://twitter.com/BenjaminMaksym)
+  * Bowwow
+  * Bunny
+  * Luigi
+  * Mario
+  * Richard
+  * Tarin
+
 ## Some tips from LADXR...
 
 <h3>Locations</h3>


### PR DESCRIPTION
## What is this fixing or adding?
Adding proper credits for the creators of the sprite sheets included in the LADX implementation, with links as requested by the creators.