### PR TITLE
The Messenger, Docs: Change links for the release

### DIFF
--- a/worlds/messenger/__init__.py
+++ b/worlds/messenger/__init__.py
@@ -12,7 +12,7 @@ from . import Rules
 class MessengerWeb(WebWorld):
     theme = "ocean"
 
-    bug_report_page = "https://github.com/minous27/TheMessengerRandomizerMod/issues"
+    bug_report_page = "https://github.com/alwaysintreble/TheMessengerRandomizerModAP/issues"
 
     tut_en = Tutorial(
         "Multiworld Setup Tutorial",

--- a/worlds/messenger/docs/en_The Messenger.md
+++ b/worlds/messenger/docs/en_The Messenger.md
@@ -5,6 +5,7 @@
 - [Settings Page](../../../../games/The%20Messenger/player-settings)
 - [Courier Github](https://github.com/Brokemia/Courier)
 - [The Messenger Randomizer Github](https://github.com/minous27/TheMessengerRandomizerMod)
+- [The Messenger Randomizer AP Github](https://github.com/alwaysintreble/TheMessengerRandomizerModAP)
 - [Jacksonbird8237's Item Tracker](https://github.com/Jacksonbird8237/TheMessengerItemTracker)
 - [PopTracker Pack](https://github.com/alwaysintreble/TheMessengerTrackPack)
 

--- a/worlds/messenger/docs/setup_en.md
+++ b/worlds/messenger/docs/setup_en.md
@@ -4,7 +4,7 @@
 - [Game Info](../../../../games/The%20Messenger/info/en)
 - [Settings Page](../../../../games/The%20Messenger/player-settings)
 - [Courier Github](https://github.com/Brokemia/Courier)
-- [The Messenger Randomizer Github](https://github.com/minous27/TheMessengerRandomizerMod)
+- [The Messenger Randomizer AP Github](https://github.com/alwaysintreble/TheMessengerRandomizerModAP)
 - [Jacksonbird8237's Item Tracker](https://github.com/Jacksonbird8237/TheMessengerItemTracker)
 - [PopTracker Pack](https://github.com/alwaysintreble/TheMessengerTrackPack)
 
@@ -13,17 +13,20 @@
 1. Download and install Courier Mod Loader using the instructions on the release page
    * [Latest release is currently 0.7.1](https://github.com/Brokemia/Courier/releases)
 2. Download and install the randomizer mod
-   1. Download the latest TheMessengerRandomizer.zip from the [The Messenger Randomizer Mod releases page](https://github.com/minous27/TheMessengerRandomizerMod/releases)
+   1. Download the latest TheMessengerRandomizer.zip from the
+      [The Messenger Randomizer Mod AP releases page](https://github.com/alwaysintreble/TheMessengerRandomizerModAP/releases)
    2. Extract the zip file to `TheMessenger/Mods/` of your game's install location
+      * You can have both the non AP randomizer and the AP randomizer installed, but the AP randomizer is backwards
+        compatible, so it can be safely removed.
    3. Optionally, Backup your save game
-     * On Windows
-       1. Press `Windows Key + R` to open run
-       2. Type `%appdata%` to access AppData
-       3. Navigate to `AppData/locallow/SabotageStudios/The Messenger`
-       4. Rename `SaveGame.txt` to any name of your choice
-     * On Linux
-       1. Navigate to `steamapps/compatdata/764790/pfx/drive_c/users/steamuser/AppData/LocalLow/Sabotage Studio/The Messenger`
-       2. Rename `SaveGame.txt` to any name of your choice
+      * On Windows
+        1. Press `Windows Key + R` to open run
+        2. Type `%appdata%` to access AppData
+        3. Navigate to `AppData/locallow/SabotageStudios/The Messenger`
+        4. Rename `SaveGame.txt` to any name of your choice
+      * On Linux
+        1. Navigate to `steamapps/compatdata/764790/pfx/drive_c/users/steamuser/AppData/LocalLow/Sabotage Studio/The Messenger`
+        2. Rename `SaveGame.txt` to any name of your choice
 
 ## Joining a MultiWorld Game
 
@@ -44,7 +47,7 @@
 ## Troubleshooting
 
 If you launch the game, and it hangs on the splash screen for more than 30 seconds try these steps:
-1. Close the game and remove `TheMessengerRandomizer` from the `Mods` folder.
+1. Close the game and remove `TheMessengerRandomizerAP` from the `Mods` folder.
 2. Launch The Messenger
 3. Delete any save slot
 4. Reinstall the randomizer mod following step 2 of the installation.

--- a/worlds/messenger/docs/setup_en.md
+++ b/worlds/messenger/docs/setup_en.md
@@ -13,7 +13,7 @@
 1. Download and install Courier Mod Loader using the instructions on the release page
    * [Latest release is currently 0.7.1](https://github.com/Brokemia/Courier/releases)
 2. Download and install the randomizer mod
-   1. Download the latest TheMessengerRandomizer.zip from the
+   1. Download the latest TheMessengerRandomizerAP.zip from the
       [The Messenger Randomizer Mod AP releases page](https://github.com/alwaysintreble/TheMessengerRandomizerModAP/releases)
    2. Extract the zip file to `TheMessenger/Mods/` of your game's install location
       * You can have both the non AP randomizer and the AP randomizer installed, but the AP randomizer is backwards
@@ -43,6 +43,16 @@
 5. Select the `Connect to Archipelago` button
 6. Navigate to save file selection
 7. Select a new valid randomizer save
+
+## Continuing a MultiWorld Game
+
+At any point while playing, it is completely safe to quit. Returning to the title screen or closing the game will
+disconnect you from the server. To reconnect to an in progress MultiWorld, simply load the correct save file for that
+MultiWorld.
+
+If the reconnection fails, the message on screen will state you are disconnected. If this happens, you can return to the
+main menu and connect to the server as in [Joining a Multiworld Game](#joining-a-multiworld-game), then load the correct
+save file.
 
 ## Troubleshooting
 

--- a/worlds/messenger/docs/setup_en.md
+++ b/worlds/messenger/docs/setup_en.md
@@ -16,8 +16,8 @@
    1. Download the latest TheMessengerRandomizerAP.zip from the
       [The Messenger Randomizer Mod AP releases page](https://github.com/alwaysintreble/TheMessengerRandomizerModAP/releases)
    2. Extract the zip file to `TheMessenger/Mods/` of your game's install location
-      * You can have both the non AP randomizer and the AP randomizer installed, but the AP randomizer is backwards
-        compatible, so it can be safely removed.
+      * You can have both the non-AP randomizer and the AP randomizer installed at the same time, but the AP randomizer
+        is backwards compatible, so the non-AP one can be safely removed.
    3. Optionally, Backup your save game
       * On Windows
         1. Press `Windows Key + R` to open run


### PR DESCRIPTION
## What is this fixing or adding?
While I wanted the release to be managed completely on a singular fork, Minous doesn't have the time to devote to this, so changing all the links to point to my fork to manage it. The mod is still completely backwards compatible and noted as such.