### PR TITLE
Setup: fix broken cx_freeze import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,8 @@ if install_cx_freeze:
         input(f'Requirement {requirement} is not satisfied, press enter to install it')
     subprocess.call([sys.executable, '-m', 'pip', 'install', requirement, '--upgrade'])
     import pkg_resources
-    import cx_Freeze
+
+import cx_Freeze
 
 # .build only exists if cx-Freeze is the right version, so we have to update/install that first before this line
 import setuptools.command.build


### PR DESCRIPTION
## What is this fixing or adding?
A wrong indentation in setup.py made it stop working if cx_freeze was already installed.

## How was this tested?
https://discord.com/channels/731205301247803413/731214280439103580/1089325393330311199