### PR TITLE
Docs: Making steps for BizHawk setup clearer.

### DIFF
--- a/worlds/dkc3/docs/setup_en.md
+++ b/worlds/dkc3/docs/setup_en.md
@@ -100,7 +100,7 @@ the lua you are using in your file explorer and copy the `socket.dll` to the bas
    Once you have changed the loaded core, you must restart BizHawk.
 2. Load your ROM file if it hasn't already been loaded.
 3. Click on the Tools menu and click on **Lua Console**
-4. Click the button to open a new Lua script.
+4. Click the Open Folder icon that says `Open Script` via the tooltip on mouse hover, or click the Script Menu then `Open Script...`, or press `Ctrl-O`.
 5. Select the `Connector.lua` file included with your client
     - Look in the Archipelago folder for `/SNI/lua/x64` or `/SNI/lua/x86` depending on if the
       emulator is 64-bit or 32-bit. Please note the most recent versions of BizHawk are 64-bit only.

--- a/worlds/sm/docs/multiworld_en.md
+++ b/worlds/sm/docs/multiworld_en.md
@@ -100,7 +100,7 @@ the lua you are using in your file explorer and copy the `socket.dll` to the bas
    Once you have changed the loaded core, you must restart BizHawk.
 2. Load your ROM file if it hasn't already been loaded.
 3. Click on the Tools menu and click on **Lua Console**
-4. Click the button to open a new Lua script.
+4. Click the Open Folder icon that says `Open Script` via the tooltip on mouse hover, or click the Script Menu then `Open Script...`, or press `Ctrl-O`.
 5. Select the `Connector.lua` file included with your client
     - Look in the Archipelago folder for `/SNI/lua/x64` or `/SNI/lua/x86` depending on if the
       emulator is 64-bit or 32-bit. Please note the most recent versions of BizHawk are 64-bit only.

--- a/worlds/smw/docs/setup_en.md
+++ b/worlds/smw/docs/setup_en.md
@@ -90,7 +90,7 @@ the lua you are using in your file explorer and copy the `socket.dll` to the bas
    Once you have changed the loaded core, you must restart BizHawk.
 2. Load your ROM file if it hasn't already been loaded.
 3. Click on the Tools menu and click on **Lua Console**
-4. Click the button to open a new Lua script.
+4. Click the Open Folder icon that says `Open Script` via the tooltip on mouse hover, or click the Script Menu then `Open Script...`, or press `Ctrl-O`.
 5. Select the `Connector.lua` file included with your client
     - Look in the Archipelago folder for `/SNI/lua/x64` or `/SNI/lua/x86` depending on if the
       emulator is 64-bit or 32-bit. Please note the most recent versions of BizHawk are 64-bit only.

--- a/worlds/smz3/docs/multiworld_en.md
+++ b/worlds/smz3/docs/multiworld_en.md
@@ -98,7 +98,7 @@ the lua you are using in your file explorer and copy the `socket.dll` to the bas
    Once you have changed the loaded core, you must restart BizHawk.
 2. Load your ROM file if it hasn't already been loaded.
 3. Click on the Tools menu and click on **Lua Console**
-4. Click the button to open a new Lua script.
+4. Click the Open Folder icon that says `Open Script` via the tooltip on mouse hover, or click the Script Menu then `Open Script...`, or press `Ctrl-O`.
 5. Select the `Connector.lua` file included with your client
     - Look in the Archipelago folder for `/SNI/lua/x64` or `/SNI/lua/x86` depending on if the
       emulator is 64-bit or 32-bit. Please note the most recent versions of BizHawk are 64-bit only.

--- a/worlds/soe/docs/multiworld_en.md
+++ b/worlds/soe/docs/multiworld_en.md
@@ -85,7 +85,7 @@ you may be prompted to allow it to communicate through the Windows Firewall.
    Once you have changed the loaded core, you must restart BizHawk.
 2. Load your ROM file if it hasn't already been loaded.
 3. Click on the Tools menu and click on **Lua Console**
-4. Click the button to open a new Lua script.
+4. Click the Open Folder icon that says `Open Script` via the tooltip on mouse hover, or click the Script Menu then `Open Script...`, or press `Ctrl-O`.
 5. Select any `Connector.lua` file from your SNI installation
 
 ##### bsnes-plus-nwa


### PR DESCRIPTION
## What is this fixing or adding?

The wording on the BizHawk steps to setup was unclear here:
https://archipelago.gg/tutorial/Super%20Mario%20World/setup/en#bizhawk

> 4. Click the button to open a new Lua script.

This is unclear because opening a "new Lua script" overwrites whichever one you choose.

## How was this tested?

It's a content change.