### PR TITLE
[Factorio] Fine control on revealed tech tree information

### DIFF
--- a/worlds/factorio/Options.py
+++ b/worlds/factorio/Options.py
@@ -147,13 +147,17 @@ class TechTreeInformation(Choice):
     """How much information should be displayed in the tech tree.
     None: No indication what a research unlocks
     Advancement: Indicators which researches unlock items that are considered logical advancements
+    Recipient: Labels with recipients of unlocked items; researches are not prefilled into the !hint command.
+    Recipient Advancement: Labels witch recipients of unlocked items, indicates which are considered logical advancements
     Full: Labels with exact names and recipients of unlocked items; all researches are prefilled into the !hint command.
     """
     display_name = "Technology Tree Information"
     option_none = 0
     option_advancement = 1
-    option_full = 2
-    default = 2
+    option_recipient = 2
+    option_recipient_advancement = 3
+    option_full = 4
+    default = 4
 
 
 class RecipeTime(Choice):

--- a/worlds/factorio/data/mod_template/data-final-fixes.lua
+++ b/worlds/factorio/data/mod_template/data-final-fixes.lua
@@ -179,7 +179,7 @@ table.insert(new_tree_copy.effects, {type = "nothing", effect_description = "Ing
 copy_factorio_icon(new_tree_copy, "{{ progressive_technology_table[item.name][0] }}")
 {%- else -%}
 {#- use default AP icon if no Factorio graphics exist -#}
-{% if item.advancement or not tech_tree_information %}set_ap_icon(new_tree_copy){% else %}set_ap_unimportant_icon(new_tree_copy){% endif %}
+{% if tech_tree_information in [0, 2] or tech_tree_information in [1, 3] and item.advancement %}set_ap_icon(new_tree_copy){% else %}set_ap_unimportant_icon(new_tree_copy){% endif %}
 {%- endif -%}
 {#- connect Technology  #}
 {%- if location in tech_tree_layout_prerequisites %}

--- a/worlds/factorio/data/mod_template/locale/en/locale.cfg
+++ b/worlds/factorio/data/mod_template/locale/en/locale.cfg
@@ -17,10 +17,8 @@ ap-{{ location.address }}-= {{location.name}}
 {% for location, item in locations %}
 {%- if location.revealed %}
 ap-{{ location.address }}-=Researching this technology sends {{ item.name }} to {{ player_names[item.player] }}{% if item.advancement %}, which is considered a logical advancement{% elif item.useful %}, which is considered useful{% elif item.trap %}, which is considered fun{% endif %}.
-{%- elif tech_tree_information == 1 and item.advancement %}
-ap-{{ location.address }}-=Researching this technology sends something to someone, which is considered a logical advancement.
 {%- else %}
-ap-{{ location.address }}-=Researching this technology sends something to someone.
+ap-{{ location.address }}-=Researching this technology sends something to {% if tech_tree_information in [2, 3] %}{{ player_names[item.player] }}{% else %}someone{% endif %}{% if tech_tree_information in [1, 3] and item.advancement %}, which is considered a logical advancement{% endif %}.
 {%- endif -%}
 {% endfor %}
 


### PR DESCRIPTION
## What is this fixing or adding?
Added two new TechTreeInformation settings, that
- only show the recipient
- only show the recipient, and if it is an advancement

This allows prioritizing locations of another player without spoiling every location or cluttering the !hints.

## How was this tested?
Generated and loaded a mod for every setting.
