### PR TITLE
[WebHost] Fix weighted-settings UI incorrectly populating range values

### DIFF
--- a/WebHostLib/static/assets/weighted-settings.js
+++ b/WebHostLib/static/assets/weighted-settings.js
@@ -78,8 +78,6 @@ const createDefaultSettings = (settingData) => {
             break;
           case 'range':
           case 'special_range':
-            newSettings[game][gameSetting][setting.min] = 0;
-            newSettings[game][gameSetting][setting.max] = 0;
             newSettings[game][gameSetting]['random'] = 0;
             newSettings[game][gameSetting]['random-low'] = 0;
             newSettings[game][gameSetting]['random-high'] = 0;

--- a/WebHostLib/static/assets/weighted-settings.js
+++ b/WebHostLib/static/assets/weighted-settings.js
@@ -296,33 +296,33 @@ const buildWeightedSettingsDiv = (game, settings) => {
         if (((setting.max - setting.min) + 1) < 11) {
           for (let i=setting.min; i <= setting.max; ++i) {
             const tr = document.createElement('tr');
-              const tdLeft = document.createElement('td');
-              tdLeft.classList.add('td-left');
-              tdLeft.innerText = i;
-              tr.appendChild(tdLeft);
+            const tdLeft = document.createElement('td');
+            tdLeft.classList.add('td-left');
+            tdLeft.innerText = i;
+            tr.appendChild(tdLeft);
 
-              const tdMiddle = document.createElement('td');
-              tdMiddle.classList.add('td-middle');
-              const range = document.createElement('input');
-              range.setAttribute('type', 'range');
-              range.setAttribute('id', `${game}-${settingName}-${i}-range`);
-              range.setAttribute('data-game', game);
-              range.setAttribute('data-setting', settingName);
-              range.setAttribute('data-option', i);
-              range.setAttribute('min', 0);
-              range.setAttribute('max', 50);
-              range.addEventListener('change', updateGameSetting);
-              range.value = currentSettings[game][settingName][i];
-              tdMiddle.appendChild(range);
-              tr.appendChild(tdMiddle);
+            const tdMiddle = document.createElement('td');
+            tdMiddle.classList.add('td-middle');
+            const range = document.createElement('input');
+            range.setAttribute('type', 'range');
+            range.setAttribute('id', `${game}-${settingName}-${i}-range`);
+            range.setAttribute('data-game', game);
+            range.setAttribute('data-setting', settingName);
+            range.setAttribute('data-option', i);
+            range.setAttribute('min', 0);
+            range.setAttribute('max', 50);
+            range.addEventListener('change', updateGameSetting);
+            range.value = currentSettings[game][settingName][i] || 0;
+            tdMiddle.appendChild(range);
+            tr.appendChild(tdMiddle);
 
-              const tdRight = document.createElement('td');
-              tdRight.setAttribute('id', `${game}-${settingName}-${i}`)
-              tdRight.classList.add('td-right');
-              tdRight.innerText = range.value;
-              tr.appendChild(tdRight);
+            const tdRight = document.createElement('td');
+            tdRight.setAttribute('id', `${game}-${settingName}-${i}`)
+            tdRight.classList.add('td-right');
+            tdRight.innerText = range.value;
+            tr.appendChild(tdRight);
 
-              rangeTbody.appendChild(tr);
+            rangeTbody.appendChild(tr);
           }
         } else {
           const hintText = document.createElement('p');


### PR DESCRIPTION
## What is this fixing or adding?
Fix a bug causing weighted-settings UI to incorrectly display range values with no default as having a value of 25.

## How was this tested?
Tested locally on my development machine.

## If this makes graphical changes, please attach screenshots.
Using OoT as an example, the weighted-settings option `ganon_bosskey_rewards` configuration is:
```json
"ganon_bosskey_rewards": {
  "type": "range",
  "displayName": "Dungeon Rewards Required for Ganon's BK",
  "description": "Set how many dungeon rewards are required to receive Ganon BK.",
  "defaultValue": 9,
  "min": 1,
  "max": 9
},
```

This causes weigeted-settings to create a localStorage setting of:
![image](https://user-images.githubusercontent.com/6321333/227798094-8b642849-6681-4beb-b3c4-83b67c0e308e.png)

And because options with a value of `0` are skipped during `.yaml` generation, the resulting file would contain:
![image](https://user-images.githubusercontent.com/6321333/227798743-f31419d7-e442-4b7d-85a4-4b7dfe9c25fd.png)


localStorage settings are generated and saved before the UI for weighted-settings is generated. localStorage is used to populate the values of range options in the UI. Due to a bug in the generation of the UI, the above settings would be displayed as below, when in fact only the option `9` would have a value of 25. The others should be zero.
![image](https://user-images.githubusercontent.com/6321333/227797773-a715a901-5c83-432d-b153-5b6a6a89ec9d.png)

As this has been fixed, the UI for range options now generates correctly:
![image](https://user-images.githubusercontent.com/6321333/227797865-d9b51dd8-66df-459c-8456-e6ca455204f5.png)

The output for the YAML file was never incorrect, but the previously broken UI could have caused users to unknowingly set every value of a setting to zero.
