### PR TITLE
SMZ3: Fixed Ganon sign text on AllDungeonsDefeatMotherBrain goal

### DIFF
--- a/worlds/smz3/TotalSMZ3/Patch.py
+++ b/worlds/smz3/TotalSMZ3/Patch.py
@@ -122,7 +122,7 @@ class Patch:
 
         self.WriteGanonInvicible(config.Goal)
         self.WritePreOpenPyramid(config.Goal)
-        self.WriteCrystalsNeeded(self.myWorld.TowerCrystals, self.myWorld.GanonCrystals)
+        self.WriteCrystalsNeeded(self.myWorld.TowerCrystals, self.myWorld.GanonCrystals, config.Goal)
         self.WriteBossesNeeded(self.myWorld.TourianBossTokens)
         self.WriteRngBlock()
 
@@ -753,12 +753,15 @@ class Patch:
     def WriteBossesNeeded(self, tourianBossTokens):
         self.patches.append((Snes(0xF47200), getWordArray(tourianBossTokens)))
 
-    def WriteCrystalsNeeded(self, towerCrystals, ganonCrystals):
+    def WriteCrystalsNeeded(self, towerCrystals, ganonCrystals, goal: Goal):
         self.patches.append((Snes(0x30805E), [towerCrystals]))
         self.patches.append((Snes(0x30805F), [ganonCrystals]))
 
         self.stringTable.SetTowerRequirementText(f"You need {towerCrystals} crystals to enter Ganon's Tower.")
-        self.stringTable.SetGanonRequirementText(f"You need {ganonCrystals} crystals to defeat Ganon.")
+        if (goal == Goal.AllDungeonsDefeatMotherBrain):
+            self.stringTable.SetGanonRequirementText(f"You need to complete all the dungeons to defeat Ganon.")
+        else:
+            self.stringTable.SetGanonRequirementText(f"You need {ganonCrystals} crystals to defeat Ganon.")
 
     def WriteRngBlock(self):
         #/* Repoint RNG Block */

--- a/worlds/smz3/TotalSMZ3/Patch.py
+++ b/worlds/smz3/TotalSMZ3/Patch.py
@@ -759,7 +759,7 @@ class Patch:
 
         self.stringTable.SetTowerRequirementText(f"You need {towerCrystals} crystals to enter Ganon's Tower.")
         if (goal == Goal.AllDungeonsDefeatMotherBrain):
-            self.stringTable.SetGanonRequirementText(f"You need to complete all the dungeons to defeat Ganon.")
+            self.stringTable.SetGanonRequirementText(f"You need to complete all the dungeons and bosses to defeat Ganon.")
         else:
             self.stringTable.SetGanonRequirementText(f"You need {ganonCrystals} crystals to defeat Ganon.")
 


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?
SMZ3's Ganon Sign previously erroneously told the user how many crystals the "ganon_vulnerable" config option rolled, regardless of if it chose the AllDungeonsDefeatMotherBrain goal.

## How was this tested?
A game was generated with the problematic settings and the sign was read to confirm the text change. A second game was generated with normal settings to confirm the text does not change on other goals.

## If this makes graphical changes, please attach screenshots.
![image](https://user-images.githubusercontent.com/28274052/228132693-fcfdadd9-7772-4feb-8322-ff461e928e43.png)
![image](https://user-images.githubusercontent.com/28274052/228132718-15c05dc1-063c-4e33-a87f-368b7653217b.png)

Last note: I would appreciate if anyone would like to suggest alternate wording for the all dungeons goal sign text. The current text is 4 lines long in game, and i'm not sure what total's smz3 uses for all dungeons goal text.