### PR TITLE
LADX: Fix gen failures with non-ascii player names, fix missing custom

### DIFF
--- a/worlds/ladx/LADXR/locations/shop.py
+++ b/worlds/ladx/LADXR/locations/shop.py
@@ -17,7 +17,7 @@ class ShopItem(ItemInfo):
     def patch(self, rom, option, *, multiworld=None):
         mw_text = ""
         if multiworld:
-            mw_text = f" for player {rom.player_names[multiworld - 1].encode('latin1', 'replace').decode()}"
+            mw_text = f" for player {rom.player_names[multiworld - 1].encode('ascii', 'replace').decode()}"
 
         
         if self.custom_item_name:

--- a/worlds/ladx/LADXR/locations/shop.py
+++ b/worlds/ladx/LADXR/locations/shop.py
@@ -17,18 +17,24 @@ class ShopItem(ItemInfo):
     def patch(self, rom, option, *, multiworld=None):
         mw_text = ""
         if multiworld:
-            mw_text = f" for player {rom.player_names[multiworld - 1]}"
+            mw_text = f" for player {rom.player_names[multiworld - 1].encode('latin1', 'replace').decode()}"
+
+        
+        if self.custom_item_name:
+            name = self.custom_item_name
+        else:
+            name = "{"+option+"}"
 
         if self.__index == 0:
             # Old index, maybe not needed any more
             rom.patch(0x04, 0x37C5, "08", "%02X" % (CHEST_ITEMS[option]))
-            rom.texts[0x030] = formatText(f"Deluxe {{%s}} 200 {{RUPEES}}{mw_text}!" % (option), ask="Buy  No Way")
+            rom.texts[0x030] = formatText(f"Deluxe {name} 200 {{RUPEES}}{mw_text}!", ask="Buy  No Way")
             rom.banks[0x3E][0x3800 + 0x2A1] = CHEST_ITEMS[option]
             if multiworld:
                 rom.banks[0x3E][0x3300 + 0x2A1] = multiworld
         elif self.__index == 1:
             rom.patch(0x04, 0x37C6, "02", "%02X" % (CHEST_ITEMS[option]))
-            rom.texts[0x02C] = formatText(f"{{%s}} Only 980 {{RUPEES}}{mw_text}!" % (option), ask="Buy  No Way")
+            rom.texts[0x02C] = formatText(f"{name} only 980 {{RUPEES}}{mw_text}!", ask="Buy  No Way")
             
             rom.banks[0x3E][0x3800 + 0x2A7] = CHEST_ITEMS[option]
             if multiworld:


### PR DESCRIPTION
## What is this fixing or adding?
* Fixes gen failures due to trying to encode bad characters as ascii or otherwise
* Adds hints for the real item given for non LADX players

## How was this tested?
Locally

## If this makes graphical changes, please attach screenshots.
![image](https://user-images.githubusercontent.com/8206540/228321302-ac212f97-99c7-45ec-940a-2f0105832209.png)
![image](https://user-images.githubusercontent.com/8206540/228321325-d7b29efd-94cc-46d5-bade-fe9e83ec7f66.png)
