### PR TITLE
LADX: use verify() to verify sprites

### DIFF
--- a/worlds/ladx/Options.py
+++ b/worlds/ladx/Options.py
@@ -324,17 +324,22 @@ class GfxMod(FreeText, LADXROption):
                 if extension in self.extensions:
                     GfxMod.__spriteFiles[name].append(file)
                     
+    def verify(self, world, player_name: str, plando_options) -> None:
+        if self.value == "Link" or self.value in GfxMod.__spriteFiles:
+            return
+        raise Exception(f"LADX Sprite '{self.value}' not found. Possible sprites are: {['Link'] + list(GfxMod.__spriteFiles.keys())}")
+            
 
     def to_ladxr_option(self, all_options):
         if self.value == -1 or self.value == "Link":
             return None, None
-        elif self.value in GfxMod.__spriteFiles:
-            if len(GfxMod.__spriteFiles[self.value]) > 1:
-                logger.warning(f"{self.value} does not uniquely identify a file. Possible matches: {GfxMod.__spriteFiles[self.value]}. Using {GfxMod.__spriteFiles[self.value][0]}")
-                return self.ladxr_name, GfxMod.__spriteFiles[self.value][0]
-            return self.ladxr_name, GfxMod.__spriteFiles[self.value][0]
-        logger.error(f"Spritesheet {self.value} not found. Falling back to default sprite.")
-        return None, None
+
+        assert self.value in GfxMod.__spriteFiles
+
+        if len(GfxMod.__spriteFiles[self.value]) > 1:
+            logger.warning(f"{self.value} does not uniquely identify a file. Possible matches: {GfxMod.__spriteFiles[self.value]}. Using {GfxMod.__spriteFiles[self.value][0]}")
+
+        return self.ladxr_name, GfxMod.__spriteFiles[self.value][0]
 
 class Palette(Choice):
     """


### PR DESCRIPTION
## What is this fixing or adding?
It was pointed out to me that I'm not properly verifying sprites. I now properly verify. I'm also changing a missing sprite to be an error to avoid silent failures.

## How was this tested?
Locally, with "Link", "Tarin", and "aaa"
```

Traceback (most recent call last):
  File "D:\dev\Archipelago\Generate.py", line 643, in <module>
    main()
  File "D:\dev\Archipelago\Generate.py", line 197, in main
    raise ValueError(f"File {path} is destroyed. Please fix your yaml.") from e
ValueError: File zigdx.yaml is destroyed. Please fix your yaml.
Traceback (most recent call last):
  File "D:\dev\Archipelago\Generate.py", line 178, in main
    tuple(roll_settings(yaml, args.plando) for yaml in weights_cache[path])
  File "D:\dev\Archipelago\Generate.py", line 178, in <genexpr>
    tuple(roll_settings(yaml, args.plando) for yaml in weights_cache[path])
  File "D:\dev\Archipelago\Generate.py", line 468, in roll_settings
    handle_option(ret, game_weights, option_key, option, plando_options)
  File "D:\dev\Archipelago\Generate.py", line 422, in handle_option
    player_option.verify(AutoWorldRegister.world_types[ret.game], ret.name, plando_options)
  File "D:\dev\Archipelago\worlds\ladx\Options.py", line 330, in verify
    raise Exception(f"LADX Sprite '{self.value}' not found. Possible sprites are: {['Link'] + list(GfxMod.__spriteFiles.keys())}")
Exception: LADX Sprite 'aaa' not found. Possible sprites are: ['Link', 'Bowwow', 'Bunny', 'Luigi', 'Mario', 'Matty_LA', 'Richard', 'Tarin']
```

## If this makes graphical changes, please attach screenshots.
