### PR TITLE
LADX: Add options for sword music and nag messages

### DIFF
--- a/worlds/ladx/LADXR/generator.py
+++ b/worlds/ladx/LADXR/generator.py
@@ -56,7 +56,7 @@ from . import hints
 from .locations.keyLocation import KeyLocation
 from .patches import bank34
 
-from ..Options import TrendyGame, Palette
+from ..Options import TrendyGame, Palette, MusicChangeCondition
 
 
 # Function to generate a final rom, this patches the rom with all required patches
@@ -181,7 +181,8 @@ def generateRom(args, settings, ap_settings, auth, seed_name, logic, rnd=None, m
     # patches.reduceRNG.slowdownThreeOfAKind(rom)
     patches.reduceRNG.fixHorseHeads(rom)
     patches.bomb.onlyDropBombsWhenHaveBombs(rom)
-    # patches.aesthetics.noSwordMusic(rom)
+    if ap_settings['music_change_condition'] == MusicChangeCondition.option_always:
+        patches.aesthetics.noSwordMusic(rom)
     patches.aesthetics.reduceMessageLengths(rom, rnd)
     patches.aesthetics.allowColorDungeonSpritesEverywhere(rom)
     if settings.music == 'random':

--- a/worlds/ladx/Options.py
+++ b/worlds/ladx/Options.py
@@ -180,17 +180,22 @@ class InstrumentCount(Range, LADXROption):
     range_end = 8
     default = 8
 
-class ItemPool(Choice):
-    """Effects which items are shuffled.
-[Casual] Places multiple copies of key items.
-[More keys] Adds additional small/nightmare keys so that dungeons are faster.
-[Path of Pain]. Adds negative heart containers to the item pool."""
-    casual = 0
-    more_keys = 1
-    normal = 2
-    painful = 3
-    default = normal
+class NagMessages(DefaultOffToggle, LADXROption):
+    """
+    Controls if nag messages are shown when rocks and crystals are touched. Useful for glitches, annoying for everyone else.
+    """
 
+    ladxr_name = "nagmessages"
+
+class MusicChangeCondition(Choice):
+    """
+    Controls how the music changes.
+    [Sword] When you pick up a sword, the music changes
+    [Always] You always have the post-sword music
+    """
+    option_sword = 0
+    option_always = 1
+    default = option_always
 #             Setting('hpmode', 'Gameplay', 'm', 'Health mode', options=[('default', '', 'Normal'), ('inverted', 'i', 'Inverted'), ('1', '1', 'Start with 1 heart'), ('low', 'l', 'Low max')], default='default',
 #                 description="""
 # [Normal} health works as you would expect.
@@ -388,4 +393,6 @@ links_awakening_options: typing.Dict[str, typing.Type[Option]] = {
     'shuffle_maps': ShuffleMaps,
     'shuffle_compasses': ShuffleCompasses,
     'shuffle_stone_beaks': ShuffleStoneBeaks,
+    'music_change_condition': MusicChangeCondition,
+    'nag_messages': NagMessages
 }

--- a/worlds/ladx/Options.py
+++ b/worlds/ladx/Options.py
@@ -324,17 +324,22 @@ class GfxMod(FreeText, LADXROption):
                 if extension in self.extensions:
                     GfxMod.__spriteFiles[name].append(file)
                     
+    def verify(self, world, player_name: str, plando_options) -> None:
+        if self.value == "Link" or self.value in GfxMod.__spriteFiles:
+            return
+        raise Exception(f"LADX Sprite '{self.value}' not found. Possible sprites are: {['Link'] + list(GfxMod.__spriteFiles.keys())}")
+            
 
     def to_ladxr_option(self, all_options):
         if self.value == -1 or self.value == "Link":
             return None, None
-        elif self.value in GfxMod.__spriteFiles:
-            if len(GfxMod.__spriteFiles[self.value]) > 1:
-                logger.warning(f"{self.value} does not uniquely identify a file. Possible matches: {GfxMod.__spriteFiles[self.value]}. Using {GfxMod.__spriteFiles[self.value][0]}")
-                return self.ladxr_name, GfxMod.__spriteFiles[self.value][0]
-            return self.ladxr_name, GfxMod.__spriteFiles[self.value][0]
-        logger.error(f"Spritesheet {self.value} not found. Falling back to default sprite.")
-        return None, None
+
+        assert self.value in GfxMod.__spriteFiles
+
+        if len(GfxMod.__spriteFiles[self.value]) > 1:
+            logger.warning(f"{self.value} does not uniquely identify a file. Possible matches: {GfxMod.__spriteFiles[self.value]}. Using {GfxMod.__spriteFiles[self.value][0]}")
+
+        return self.ladxr_name, GfxMod.__spriteFiles[self.value][0]
 
 class Palette(Choice):
     """


### PR DESCRIPTION
## What is this fixing or adding?
* Adds option to enable nag messages when touching rocks (default off, as before)
* Adds option to always have the post "you got a sword" music (default on, a change in behavior)

## How was this tested?
Locally, to test the defaults, and then to invert them

## If this makes graphical changes, please attach screenshots.
