### PR TITLE
worlds,clients,kvui: use user_path

### DIFF
--- a/OoTClient.py
+++ b/OoTClient.py
@@ -289,7 +289,10 @@ async def patch_and_run_game(apz5_file):
     decomp_path = base_name + '-decomp.z64'
     comp_path = base_name + '.z64'
     # Load vanilla ROM, patch file, compress ROM
-    rom = Rom(Utils.local_path(Utils.get_options()["oot_options"]["rom_file"]))
+    rom_file_name = Utils.get_options()["oot_options"]["rom_file"]
+    if not os.path.exists(rom_file_name):
+        rom_file_name = Utils.user_path(rom_file_name)
+    rom = Rom(rom_file_name)
     apply_patch_file(rom, apz5_file,
         sub_file=(os.path.basename(base_name) + '.zpf'
             if zipfile.is_zipfile(apz5_file)

--- a/Utils.py
+++ b/Utils.py
@@ -88,7 +88,10 @@ def is_frozen() -> bool:
 
 
 def local_path(*path: str) -> str:
-    """Returns path to a file in the local Archipelago installation or source."""
+    """
+    Returns path to a file in the local Archipelago installation or source.
+    This might be read-only and user_path should be used instead for ROMs, configuration, etc.
+    """
     if hasattr(local_path, 'cached_path'):
         pass
     elif is_frozen():

--- a/kvui.py
+++ b/kvui.py
@@ -608,7 +608,7 @@ class KivyJSONtoTextParser(JSONtoTextParser):
 ExceptionManager.add_handler(E())
 
 Builder.load_file(Utils.local_path("data", "client.kv"))
-user_file = Utils.local_path("data", "user.kv")
+user_file = Utils.user_path("data", "user.kv")
 if os.path.exists(user_file):
     logging.info("Loading user.kv into builder.")
     Builder.load_file(user_file)

--- a/worlds/pokemon_rb/rom.py
+++ b/worlds/pokemon_rb/rom.py
@@ -955,7 +955,7 @@ def get_base_rom_path(game_version: str) -> str:
     options = Utils.get_options()
     file_name = options["pokemon_rb_options"][f"{game_version}_rom_file"]
     if not os.path.exists(file_name):
-        file_name = Utils.local_path(file_name)
+        file_name = Utils.user_path(file_name)
     return file_name
 
 

--- a/worlds/tloz/Rom.py
+++ b/worlds/tloz/Rom.py
@@ -74,5 +74,5 @@ def get_base_rom_path(file_name: str = "") -> str:
     if not file_name:
         file_name = options["tloz_options"]["rom_file"]
     if not os.path.exists(file_name):
-        file_name = Utils.local_path(file_name)
+        file_name = Utils.user_path(file_name)
     return file_name


### PR DESCRIPTION
## What is this fixing or adding?
* OoTClient did not allow absolute paths in host.yaml
* OoTClient used local_path instead of user_path for the ROM
* TLoZ used local_path instead of user_path for the ROM
* Pokemon R/B used local_path instead of user_path for the ROM
* kvui used local_path instead of user_path for user overrides

What is user_path? On a regular windows install user_path and local_path is the same. When running from a read-only directory, such as an AppImage (i.e. the user can't install ROMs into local_path), user_path points to the user's home folder instead.

## How was this tested?
It wasn't for the most part. I don't have the required ROMs. Would be good if people could verify i did not add typos.
