### PR TITLE
kvui: block settings menu

### DIFF
--- a/kvui.py
+++ b/kvui.py
@@ -488,6 +488,10 @@ class GameManager(App):
         if hasattr(self, "energy_link_label"):
             self.energy_link_label.text = f"EL: {Utils.format_SI_prefix(self.ctx.current_energy_link_value)}J"
 
+    # default F1 keybind, opens a settings menu, that seems to break the layout engine once closed
+    def open_settings(self, *largs):
+        pass
+
 
 class LogtoUI(logging.Handler):
     def __init__(self, on_log):


### PR DESCRIPTION
## What is this fixing or adding?
On kivy UI the default F1 keybind opens a settings menu, that seems to break the layout engine once closed

## How was this tested?
pressed F1 and nothing happened
