### PR TITLE
[TLOZ] Pols Voice Logic Fix

### DIFF
--- a/worlds/tloz/Rules.py
+++ b/worlds/tloz/Rules.py
@@ -34,7 +34,7 @@ def set_rules(tloz_world: "TLoZWorld"):
                                         state.has("Heart Container", player, int(hearts / 2))) or
                                        (state.has("Red Ring", player) and
                                         state.has("Heart Container", player, int(hearts / 4))))
-            if "Pols Voice" in location:  # This enemy needs specific weapons
+            if "Pols Voice" in location.name:  # This enemy needs specific weapons
                 add_rule(world.get_location(location.name, player),
                          lambda state: state.has_group("swords", player) or state.has("Bow", player))
 

--- a/worlds/tloz/Rules.py
+++ b/worlds/tloz/Rules.py
@@ -33,9 +33,11 @@ def set_rules(tloz_world: "TLoZWorld"):
                                        (state.has("Blue Ring", player) and
                                         state.has("Heart Container", player, int(hearts / 2))) or
                                        (state.has("Red Ring", player) and
-                                        state.has("Heart Container", player, int(hearts / 4)))
+                                        state.has("Heart Container", player, int(hearts / 4))))
+            if "Pols Voice" in location:  # This enemy needs specific weapons
+                add_rule(world.get_location(location.name, player),
+                         lambda state: state.has_group("swords", player) or state.has("Bow", player))
 
-                         )
     # No requiring anything in a shop until we can farm for money
     for location in shop_locations:
         add_rule(world.get_location(location, player),


### PR DESCRIPTION
## What is this fixing or adding?
Was informed that Pols Voice require certain weapons to kill that might not be guaranteed by the starting weapon. This is the only regular enemy in the game that cannot be killed by either any of the starting weapons or bombs which can be bought, so adding this rule should prevent any issues.

## How was this tested?
passed unit tests and ran about a dozen test generations

## If this makes graphical changes, please attach screenshots.
