### PR TITLE
Restore "random" option to weighted-settings

### DIFF
--- a/WebHostLib/options.py
+++ b/WebHostLib/options.py
@@ -157,6 +157,11 @@ def create():
             json.dump(player_settings, f, indent=2, separators=(',', ': '))
 
         if not world.hidden and world.web.settings_page is True:
+            # Add the random option to Choice, TextChoice, and Toggle settings
+            for option in game_options.values():
+                if option["type"] == "select":
+                    option["options"].append({"name": "Random", "value": "random"})
+
             weighted_settings["baseOptions"]["game"][game_name] = 0
             weighted_settings["games"][game_name] = {}
             weighted_settings["games"][game_name]["gameSettings"] = game_options

--- a/WebHostLib/options.py
+++ b/WebHostLib/options.py
@@ -106,6 +106,9 @@ def create():
                     if sub_option_id == option.default:
                         this_option["defaultValue"] = sub_option_name
 
+                if not this_option["defaultValue"]:
+                    this_option["defaultValue"] = "random"
+
             elif issubclass(option, Options.Range):
                 game_options[option_name] = {
                     "type": "range",
@@ -161,6 +164,9 @@ def create():
             for option in game_options.values():
                 if option["type"] == "select":
                     option["options"].append({"name": "Random", "value": "random"})
+
+                    if not option["defaultValue"]:
+                        option["defaultValue"] = "random"
 
             weighted_settings["baseOptions"]["game"][game_name] = 0
             weighted_settings["games"][game_name] = {}

--- a/WebHostLib/static/assets/weighted-settings.js
+++ b/WebHostLib/static/assets/weighted-settings.js
@@ -470,7 +470,17 @@ const buildWeightedSettingsDiv = (game, settings, gameItems, gameLocations) => {
           const tr = document.createElement('tr');
             const tdLeft = document.createElement('td');
             tdLeft.classList.add('td-left');
-            tdLeft.innerText = option;
+            switch(option){
+              case 'random':
+                tdLeft.innerText = 'Random';
+                break;
+              case 'random-low':
+                tdLeft.innerText = "Random (Low)";
+                break;
+              case 'random-high':
+                tdLeft.innerText = "Random (High)";
+                break;
+            }
             tr.appendChild(tdLeft);
 
             const tdMiddle = document.createElement('td');


### PR DESCRIPTION
## What is this fixing or adding?
Restore "random" options to weighted-settings (as proposed by @alwaysintreble) and adjust capitalization of hard-coded settings

## How was this tested?
Tested locally on my dev machine.

## If this makes graphical changes, please attach screenshots.
![image](https://user-images.githubusercontent.com/6321333/228968508-1d3407ff-2711-4166-b265-b7ec61bbb617.png)
