### PR TITLE
AdventureClient: Change user_path to local_path for locating basepatch file

### DIFF
--- a/AdventureClient.py
+++ b/AdventureClient.py
@@ -436,7 +436,7 @@ async def patch_and_run_game(patch_file, ctx):
         logger.info(msg, extra={'compact_gui': True})
         ctx.gui_error('Error', msg)
 
-    with open(Utils.user_path("data", "adventure_basepatch.bsdiff4"), "rb") as file:
+    with open(Utils.local_path("data", "adventure_basepatch.bsdiff4"), "rb") as file:
         basepatch = bytes(file.read())
 
     base_patched_rom_data = bsdiff4.patch(base_rom, basepatch)


### PR DESCRIPTION
## What is this fixing or adding?
I'm fairly sure this is more correct, and the user_path way may actually have been broken if installed in a location without write access.  

## How was this tested?
Built exe and ran from outside home directory.
