### PR TITLE
AdventureDocs: Added example for automatically loading adventure_connector.lua

### DIFF
--- a/host.yaml
+++ b/host.yaml
@@ -180,6 +180,8 @@ adventure_options:
   # Optional, additional args passed into rom_start before the .bin file
   # For example, this can be used to autoload the connector script in BizHawk
   # (see BizHawk --lua= option)
+  # Windows example:
+  # rom_args: "--lua=C:/ProgramData/Archipelago/data/lua/ADVENTURE/adventure_connector.lua"  
   rom_args: " "
   # Set this to true to display item received messages in Emuhawk
   display_msgs: true

--- a/worlds/adventure/docs/setup_en.md
+++ b/worlds/adventure/docs/setup_en.md
@@ -27,6 +27,10 @@ Once Bizhawk has been installed, open Bizhawk and change the following settings:
 BizHawk is running in the background.
 
 - It is recommended that you provide a path to BizHawk in your host.yaml for Adventure so the client can start it automatically
+- At the same time, you can set an option to automatically load the adventure_connector.lua script when launching BizHawk
+from AdventureClient.
+Default Windows install example:
+```rom_args: "--lua=C:/ProgramData/Archipelago/data/lua/ADVENTURE/adventure_connector.lua"```
 
 ## Configuring your YAML file
 
@@ -62,7 +66,8 @@ path as recommended).
 Once both the client and the emulator are started, you must connect them. Within the emulator click on the "Tools"
 menu and select "Lua Console". Click the folder button or press Ctrl+O to open a Lua script.
 
-Navigate to your Archipelago install folder and open `data/lua/ADVENTURE/adventure_connector.lua`.
+Navigate to your Archipelago install folder and open `data/lua/ADVENTURE/adventure_connector.lua`, if it is not
+configured to do this automatically.
 
 To connect the client to the multiserver simply put `<address>:<port>` on the textfield on top and press enter (if the
 server uses password, type in the bottom textfield `/connect <address>:<port> [password]`)


### PR DESCRIPTION
## What is this fixing or adding?
Added an example for automatically loading adventure_connector.lua to setup.md and host.yaml

## How was this tested?
Viewed in PyCharm markdown viewer