### PR TITLE
WebHost: Fix broken styling of multitracker navigation

### DIFF
--- a/WebHostLib/templates/multiTrackerNavigation.html
+++ b/WebHostLib/templates/multiTrackerNavigation.html
@@ -2,7 +2,7 @@
     <div id="tracker-navigation">
         {% for enabled_tracker in enabled_multiworld_trackers %}
             {% set tracker_url = url_for(enabled_tracker.endpoint, tracker=room.tracker) %}
-            <a class="tracker-navigation-button{%- if enabled_tracker.current -%} selected{% endif %}"
+            <a class="tracker-navigation-button{% if enabled_tracker.current %} selected{% endif %}"
                href="{{ tracker_url }}">{{ enabled_tracker.name }}</a>
         {% endfor %}
     </div>


### PR DESCRIPTION
## What is this fixing or adding?
Fixes the styling of the multitracker navigation element.

Specifically, this ~~reverts~~ *fixes* a refactoring of the code that resulted in the class of the selected button becoming `tracker-navigation-buttonselected`.

## How was this tested?
Accessing the multitracker

## If this makes graphical changes, please attach screenshots.

Broken:
![image](https://user-images.githubusercontent.com/2582617/229257788-888a556b-c69f-4438-821b-c75001fb0049.png)

Fixed: (different game)
![image](https://user-images.githubusercontent.com/2582617/229257801-e0fd703a-a72a-49d8-811e-1f49c0c09464.png)
