### PR TITLE
MultiServer: remove remaining forfeit compat from network layer

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -544,7 +544,7 @@ class Context:
             "stored_data": self.stored_data,
             "game_options": {"hint_cost": self.hint_cost, "location_check_points": self.location_check_points,
                              "server_password": self.server_password, "password": self.password,
-                             "forfeit_mode": self.release_mode, "release_mode": self.release_mode,  # TODO remove forfeit_mode around 0.4
+                             "release_mode": self.release_mode,
                              "remaining_mode": self.remaining_mode, "collect_mode": self.collect_mode,
                              "item_cheat": self.item_cheat, "compatibility": self.compatibility}
 
@@ -769,7 +769,6 @@ async def on_client_connected(ctx: Context, client: Client):
 
 def get_permissions(ctx) -> typing.Dict[str, Permission]:
     return {
-        "forfeit": Permission.from_text(ctx.release_mode),  # TODO remove around 0.4
         "release": Permission.from_text(ctx.release_mode),
         "remaining": Permission.from_text(ctx.remaining_mode),
         "collect": Permission.from_text(ctx.collect_mode)


### PR DESCRIPTION
## What is this fixing or adding?
remove remaining forfeit compat from network layer
all the remaining compat is in loaded an old server savegame, which might have to stay forever if we want to still load those.

## How was this tested?
I technically tested that back when we first tried to remove forfeit and had to put this back for compat. Haven't tested this in isolation, let me know if I should.
