### PR TITLE
LADX: Fix crash in item pick up with > 100 players

### DIFF
--- a/worlds/ladx/LADXR/generator.py
+++ b/worlds/ladx/LADXR/generator.py
@@ -259,9 +259,9 @@ def generateRom(args, settings, ap_settings, auth, seed_name, logic, rnd=None, m
         mw = None
         if spot.item_owner != spot.location_owner:
             mw = spot.item_owner
-            if mw > 255:
-                # Don't torture the game with higher slot numbers
-                mw = 255
+            if mw > 100:
+                # There are only 101 player name slots (99 + "The Server" + "another world"), so don't use more than that
+                mw = 100
         spot.patch(rom, spot.item, multiworld=mw)
     patches.enemies.changeBosses(rom, world_setup.boss_mapping)
     patches.enemies.changeMiniBosses(rom, world_setup.miniboss_mapping)

--- a/worlds/ladx/LADXR/patches/bank3e.asm/itemnames.asm
+++ b/worlds/ladx/LADXR/patches/bank3e.asm/itemnames.asm
@@ -73,8 +73,6 @@ MessageAddPlayerName:
     jr  C, .continue
     ld  a, 100
 .continue:
-
-db "XXXXXSTART"
     ld  h, 0 ; bc = a, hl = a
     ld  l, a
     ld  b, 0
@@ -89,7 +87,7 @@ db "XXXXXSTART"
     
     call MessageCopyString
     ret
-db "XXXXXEND"
+
 ItemNamePointers:
     dw ItemNamePowerBracelet
     dw ItemNameShield

--- a/worlds/ladx/LADXR/patches/bank3e.asm/itemnames.asm
+++ b/worlds/ladx/LADXR/patches/bank3e.asm/itemnames.asm
@@ -67,7 +67,14 @@ MessageAddFromPlayerOld:
 
 ; hahaha none of this follows calling conventions
 MessageAddPlayerName:
-    ; call MessagePad    
+    ; call MessagePad
+
+    cp  101
+    jr  C, .continue
+    ld  a, 100
+.continue:
+
+db "XXXXXSTART"
     ld  h, 0 ; bc = a, hl = a
     ld  l, a
     ld  b, 0
@@ -79,9 +86,10 @@ MessageAddPlayerName:
     add hl, bc ; 17
     ld  bc, MultiNamePointers
     add hl, bc ; hl = MultiNamePointers + wLinkGiveItemFrom * 17
+    
     call MessageCopyString
     ret
-
+db "XXXXXEND"
 ItemNamePointers:
     dw ItemNamePowerBracelet
     dw ItemNameShield


### PR DESCRIPTION
## What is this fixing or adding?
We only store 100 players in the ROM due to running out of space. However, the item pickup code assumed 255. This patch does two things:
* Fixes the patchers not to put player numbers > 100 in the ROM
* Patches the player name copier ingame to ignore numbers > 100, in case one sneaks in anyhow.

## How was this tested?


## If this makes graphical changes, please attach screenshots.
