### PR TITLE
Factorio: flatten science pack curve

### DIFF
--- a/worlds/factorio/Locations.py
+++ b/worlds/factorio/Locations.py
@@ -14,7 +14,7 @@ def make_pools() -> Dict[str, List[str]]:
     for i, pack in enumerate(MaxSciencePack.get_ordered_science_packs(), start=1):
         max_needed: int = 0xff
         prefix: str = f"AP-{i}-"
-        pools[pack] = [prefix + hex(int(x))[2:].upper().zfill(2) for x in range(1, max_needed + 1)]
+        pools[pack] = [prefix + hex(x)[2:].upper().zfill(2) for x in range(1, max_needed + 1)]
     return pools
 
 

--- a/worlds/factorio/Locations.py
+++ b/worlds/factorio/Locations.py
@@ -1,32 +1,30 @@
 from typing import Dict, List
 
-from .Technologies import factorio_base_id, factorio_id
+from .Technologies import factorio_base_id
 from .Options import MaxSciencePack
 
 boundary: int = 0xff
 total_locations: int = 0xff
 
 assert total_locations <= boundary
-assert factorio_base_id != factorio_id
 
 
 def make_pools() -> Dict[str, List[str]]:
     pools: Dict[str, List[str]] = {}
     for i, pack in enumerate(MaxSciencePack.get_ordered_science_packs(), start=1):
-        max_needed: int = sum(divmod(boundary, i))
-        scale: float = boundary / max_needed
+        max_needed: int = 0xff
         prefix: str = f"AP-{i}-"
-        pools[pack] = [prefix + hex(int(x * scale))[2:].upper().zfill(2) for x in range(1, max_needed + 1)]
+        pools[pack] = [prefix + hex(int(x))[2:].upper().zfill(2) for x in range(1, max_needed + 1)]
     return pools
 
 
 location_pools: Dict[str, List[str]] = make_pools()
 
 location_table: Dict[str, int] = {}
-end_id: int = factorio_id
+end_id: int = factorio_base_id
 for pool in location_pools.values():
     location_table.update({name: ap_id for ap_id, name in enumerate(pool, start=end_id)})
     end_id += len(pool)
 
-assert end_id - len(location_table) == factorio_id
+assert end_id - len(location_table) == factorio_base_id
 del pool

--- a/worlds/factorio/Mod.py
+++ b/worlds/factorio/Mod.py
@@ -96,7 +96,7 @@ def generate_mod(world: "Factorio", output_directory: str):
             settings_template = template_env.get_template("settings.lua")
     # get data for templates
     locations = [(location, location.item)
-                 for location in world.locations]
+                 for location in world.science_locations]
     mod_name = f"AP-{multiworld.seed_name}-P{player}-{multiworld.get_file_safe_player_name(player)}"
 
     random = multiworld.per_slot_randoms[player]

--- a/worlds/factorio/Shapes.py
+++ b/worlds/factorio/Shapes.py
@@ -24,7 +24,7 @@ def get_shapes(factorio_world: "Factorio") -> Dict["FactorioScienceLocation", Se
     player = factorio_world.player
     prerequisites: Dict["FactorioScienceLocation", Set["FactorioScienceLocation"]] = {}
     layout = world.tech_tree_layout[player].value
-    locations: List["FactorioScienceLocation"] = sorted(factorio_world.locations, key=lambda loc: loc.name)
+    locations: List["FactorioScienceLocation"] = sorted(factorio_world.science_locations, key=lambda loc: loc.name)
     world.random.shuffle(locations)
 
     if layout == TechTreeLayout.option_single:

--- a/worlds/factorio/Technologies.py
+++ b/worlds/factorio/Technologies.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import string
+import pkgutil
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor
 from typing import Dict, Set, FrozenSet, Tuple, Union, List, Any
@@ -11,7 +12,7 @@ from typing import Dict, Set, FrozenSet, Tuple, Union, List, Any
 import Utils
 from . import Options
 
-factorio_id = factorio_base_id = 2 ** 17
+factorio_tech_id = factorio_base_id = 2 ** 17
 # Factorio technologies are imported from a .json document in /data
 source_folder = os.path.join(os.path.dirname(__file__), "data")
 
@@ -19,7 +20,6 @@ pool = ThreadPoolExecutor(1)
 
 
 def load_json_data(data_name: str) -> Union[List[str], Dict[str, Any]]:
-    import pkgutil
     return json.loads(pkgutil.get_data(__name__, "data/" + data_name + ".json").decode())
 
 
@@ -33,7 +33,9 @@ items_future = pool.submit(load_json_data, "items")
 tech_table: Dict[str, int] = {}
 technology_table: Dict[str, Technology] = {}
 
-always = lambda state: True
+
+def always(state):
+    return True
 
 
 class FactorioElement:
@@ -49,7 +51,6 @@ class FactorioElement:
 class Technology(FactorioElement):  # maybe make subclass of Location?
     has_modifier: bool
     factorio_id: int
-    name: str
     ingredients: Set[str]
     progressive: Tuple[str]
     unlocks: Union[Set[str], bool]  # bool case is for progressive technologies
@@ -192,9 +193,9 @@ recipe_sources: Dict[str, Set[str]] = {}  # recipe_name -> technology source
 # recipes and technologies can share names in Factorio
 for technology_name, data in sorted(techs_future.result().items()):
     current_ingredients = set(data["ingredients"])
-    technology = Technology(technology_name, current_ingredients, factorio_id,
+    technology = Technology(technology_name, current_ingredients, factorio_tech_id,
                             has_modifier=data["has_modifier"], unlocks=set(data["unlocks"]))
-    factorio_id += 1
+    factorio_tech_id += 1
     tech_table[technology_name] = technology.factorio_id
     technology_table[technology_name] = technology
     for recipe_name in technology.unlocks:
@@ -417,8 +418,8 @@ progressive_technology_table: Dict[str, Technology] = {}
 for root in sorted_rows:
     progressive = progressive_rows[root]
     assert all(tech in tech_table for tech in progressive), "declared a progressive technology without base technology"
-    factorio_id += 1
-    progressive_technology = Technology(root, technology_table[progressive[0]].ingredients, factorio_id,
+    factorio_tech_id += 1
+    progressive_technology = Technology(root, technology_table[progressive[0]].ingredients, factorio_tech_id,
                                         progressive,
                                         has_modifier=any(technology_table[tech].has_modifier for tech in progressive),
                                         unlocks=any(technology_table[tech].unlocks for tech in progressive))
@@ -500,3 +501,4 @@ valid_ingredients: Set[str] = stacking_items | fluids
 # cleanup async helpers
 pool.shutdown()
 del pool
+del factorio_tech_id

--- a/worlds/factorio/Technologies.py
+++ b/worlds/factorio/Technologies.py
@@ -391,17 +391,13 @@ progressive_rows["progressive-energy-shield"] = ("energy-shield-equipment", "ene
 progressive_rows["progressive-wall"] = ("stone-wall", "gate")
 progressive_rows["progressive-follower"] = ("defender", "distractor", "destroyer")
 progressive_rows["progressive-inserter"] = ("fast-inserter", "stack-inserter")
-
-sorted_rows = sorted(progressive_rows)
-# to keep ID mappings the same.
-# If there's a breaking change at some point, then this should be moved in with the sorted ordering
 progressive_rows["progressive-turret"] = ("gun-turret", "laser-turret")
-sorted_rows.append("progressive-turret")
 progressive_rows["progressive-flamethrower"] = ("flamethrower",)  # leaving out flammables, as they do nothing
-sorted_rows.append("progressive-flamethrower")
 progressive_rows["progressive-personal-roboport-equipment"] = ("personal-roboport-equipment",
                                                                "personal-roboport-mk2-equipment")
-sorted_rows.append("progressive-personal-roboport-equipment")
+
+sorted_rows = sorted(progressive_rows)
+
 # integrate into
 source_target_mapping: Dict[str, str] = {
     "progressive-braking-force": "progressive-train-network",

--- a/worlds/factorio/__init__.py
+++ b/worlds/factorio/__init__.py
@@ -64,8 +64,8 @@ class Factorio(World):
     item_name_groups = {
         "Progressive": set(progressive_tech_table.keys()),
     }
-    data_version = 7
-    required_client_version = (0, 3, 6)
+    data_version = 8
+    required_client_version = (0, 4, 0)
 
     ordered_science_packs: typing.List[str] = MaxSciencePack.get_ordered_science_packs()
     tech_mix: int = 0


### PR DESCRIPTION
## What is this fixing or adding?
instead of 255, 127, 85 etc. Locations for the respective science packs, the pools are now a clean 255, 255, 255 etc. 
When selecting Locations for the generation, this means a roughly equal amount of Locations per highest pack.

Raising min Client version to 0.4.0, while technically not required, it does prevent a confused client if:
0.3.8 Client connects to 0.4.1 Multiworld, then connects to a 0.4.0 or 0.3.8 Multiworld where IDs are changed but checksum is not yet in place.

## How was this tested?
I looked at a spoiler log.
