### PR TITLE
[OC2] Only Calculate Priority Locations Once

### DIFF
--- a/worlds/overcooked2/__init__.py
+++ b/worlds/overcooked2/__init__.py
@@ -249,8 +249,9 @@ class Overcooked2World(World):
             self.level_mapping = None
 
     def set_location_priority(self) -> None:
+        priority_locations = self.get_priority_locations()
         for level in Overcooked2Level():
-            if level.level_id in self.get_priority_locations():
+            if level.level_id in priority_locations:
                 location: Location = self.multiworld.get_location(level.location_name_item, self.player)
                 location.progress_type = LocationProgressType.PRIORITY
 


### PR DESCRIPTION
## What is this fixing or adding?
- The location balancing option for overcooked was accidentally generating 44 sets of priority locations instead just one set

## How was this tested?
pytest
