### PR TITLE
Core: set convert_name_groups to true for LocationSet

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -904,6 +904,7 @@ class StartHints(ItemSet):
 
 class LocationSet(OptionSet):
     verify_location_name = True
+    convert_name_groups = True
 
 
 class StartLocationHints(LocationSet):


### PR DESCRIPTION
## What is this fixing or adding?
Allows location name groups to be used for LocationSet options like ItemSet

## How was this tested?
rolled a seed with 'Everywhere' before and after the change

## If this makes graphical changes, please attach screenshots.
