### PR TITLE
Core: default data_version to 0

### DIFF
--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -159,7 +159,7 @@ class World(metaclass=AutoWorldRegister):
     location_name_groups: ClassVar[Dict[str, Set[str]]] = {}
     """maps location group names to sets of locations. Example: {"Sewer": {"Sewer Key Drop 1", "Sewer Key Drop 2"}}"""
 
-    data_version: ClassVar[int] = 1
+    data_version: ClassVar[int] = 0
     """
     Increment this every time something in your world's names/id mappings changes.
 

--- a/worlds/blasphemous/__init__.py
+++ b/worlds/blasphemous/__init__.py
@@ -32,7 +32,7 @@ class BlasphemousWorld(World):
 
     game: str = "Blasphemous"
     web = BlasphemousWeb()
-    data_version: 1
+    data_version = 1
 
     item_name_to_id = {item["name"]: (base_id + index) for index, item in enumerate(item_table)}
     location_name_to_id = {loc["name"]: (base_id + index) for index, loc in enumerate(location_table)}


### PR DESCRIPTION
This allows new (ap-)worlds to function with old clients without having to define a version.