### PR TITLE
Blasphemous: Update docs, item creation

### DIFF
--- a/worlds/blasphemous/Rules.py
+++ b/worlds/blasphemous/Rules.py
@@ -143,7 +143,7 @@ class BlasphemousLogic(LogicMixin):
         return self.has_any({"Debla of the Lights", "Taranto to my Sister", "Cante Jondo of the Three Sisters", \
             "Verdiales of the Forsaken Hamlet", "Cloistered Ruby"}, player) or \
                 (self.has("Tirana of the Celestial Bastion", player) and \
-                    self.has("Fervour Upgrade"), player, 2)
+                    self.has("Fervour Upgrade", player, 2))
     
     def _blasphemous_cherub_22_23_31_32(self, player):
         return self.has_any({"Debla of the Lights", "Taranto to my Sister", "Cloistered Ruby"}, player)

--- a/worlds/blasphemous/__init__.py
+++ b/worlds/blasphemous/__init__.py
@@ -1,4 +1,4 @@
-from typing import Dict, Set, Any
+from typing import Dict, Set, List, Any
 from collections import Counter
 from BaseClasses import Region, Entrance, Location, Item, Tutorial, ItemClassification
 from ..AutoWorld import World, WebWorld
@@ -41,6 +41,8 @@ class BlasphemousWorld(World):
     item_name_groups = group_table
     option_definitions = blasphemous_options
 
+    pre_fill_items = []
+
 
     def set_rules(self):
         rules(self)
@@ -61,7 +63,7 @@ class BlasphemousWorld(World):
         return self.multiworld.random.choice(tears_set)
 
 
-    def generate_basic(self):
+    def create_items(self):
         placed_items = []
 
         placed_items.extend(Vanilla.unrandomized_dict.values())
@@ -258,18 +260,24 @@ class BlasphemousWorld(World):
 
         if self.multiworld.thorn_shuffle[self.player] == 1:
             self.multiworld.local_items[self.player].value.add("Thorn Upgrade")
+
+
+    def get_pre_fill_items(self) -> List["Item"]:
+        return self.pre_fill_items
         
 
     def place_items_from_set(self, location_set: Set[str], name: str):
         for loc in location_set:
             self.multiworld.get_location(loc, self.player)\
                 .place_locked_item(self.create_item(name))
+            self.pre_fill_items.append(self.create_item(name))
 
     
     def place_items_from_dict(self, option_dict: Dict[str, str]):
         for loc, item in option_dict.items():
             self.multiworld.get_location(loc, self.player)\
                 .place_locked_item(self.create_item(item))
+            self.pre_fill_items.append(self.create_item(item))
 
 
     def create_regions(self) -> None:

--- a/worlds/blasphemous/__init__.py
+++ b/worlds/blasphemous/__init__.py
@@ -41,8 +41,6 @@ class BlasphemousWorld(World):
     item_name_groups = group_table
     option_definitions = blasphemous_options
 
-    pre_fill_items = []
-
 
     def set_rules(self):
         rules(self)
@@ -260,24 +258,18 @@ class BlasphemousWorld(World):
 
         if self.multiworld.thorn_shuffle[self.player] == 1:
             self.multiworld.local_items[self.player].value.add("Thorn Upgrade")
-
-
-    def get_pre_fill_items(self) -> List["Item"]:
-        return self.pre_fill_items
         
 
     def place_items_from_set(self, location_set: Set[str], name: str):
         for loc in location_set:
             self.multiworld.get_location(loc, self.player)\
                 .place_locked_item(self.create_item(name))
-            self.pre_fill_items.append(self.create_item(name))
 
     
     def place_items_from_dict(self, option_dict: Dict[str, str]):
         for loc, item in option_dict.items():
             self.multiworld.get_location(loc, self.player)\
                 .place_locked_item(self.create_item(item))
-            self.pre_fill_items.append(self.create_item(item))
 
 
     def create_regions(self) -> None:

--- a/worlds/blasphemous/docs/setup_en.md
+++ b/worlds/blasphemous/docs/setup_en.md
@@ -6,6 +6,7 @@
 - Blasphemous Modding API from: [GitHub](https://github.com/BrandenEK/Blasphemous-Modding-API)
 - Blasphemous Randomizer from: [GitHub](https://github.com/BrandenEK/Blasphemous-Randomizer)
 - Blasphemous Multiworld from: [GitHub](https://github.com/BrandenEK/Blasphemous-Multiworld)
+- (*Optional*) PopTracker Pack from: [GitHub](https://github.com/sassyvania/Blasphemous-Randomizer-Maptracker) 
 
 ## Instructions (Windows)
 
@@ -14,6 +15,8 @@
 2. After the Modding API has been installed, download the [Randomizer](https://github.com/BrandenEK/Blasphemous-Randomizer/releases) and [Multiworld](https://github.com/BrandenEK/Blasphemous-Multiworld/releases) archives, and extract the contents of both into the `Modding` folder.
 
 3. Start Blasphemous. To verfy that the mods are working, look for a version number for both the Randomizer and Multiworld on the title screen.
+
+4. (*Optional*) Add the Blasphemous pack to PopTracker. In game, open the console by pressing backslash `\` and type `randomizer autotracker on` to automatically connect the game to PopTracker.
 
 ## Connecting
 


### PR DESCRIPTION
Updating setup docs to include a link to the poptracker pack for Blasphemous, changing items to be created during `create_items` instead of `generate_basic`, and fixing a typo in the rules.