### PR TITLE
Fix broken link in Stardew Setup Guide

### DIFF
--- a/worlds/stardew_valley/docs/setup_en.md
+++ b/worlds/stardew_valley/docs/setup_en.md
@@ -23,7 +23,7 @@ guide: [Basic Multiworld Setup Guide](/tutorial/Archipelago/setup/en)
 
 ### Where do I get a YAML file?
 
-You can customize your settings by visiting the [Stardew Valley Player Settings Page](../player-settings)
+You can customize your settings by visiting the [Stardew Valley Player Settings Page](/games/Stardew%20Valley/player-settings)
 
 ## Joining a MultiWorld Game
 


### PR DESCRIPTION
## What is this fixing or adding?
The link from the Stardew Setup Guide to the Stardew Settings page was broken and was leading to an error 404
Now it works properly