### PR TITLE
sm64ex,v6: Use create_items for itempool modification

### DIFF
--- a/worlds/sm64ex/__init__.py
+++ b/worlds/sm64ex/__init__.py
@@ -71,7 +71,7 @@ class SM64World(World):
 
         return item
 
-    def generate_basic(self):
+    def create_items(self):
         starcount = self.multiworld.AmountOfStars[self.player].value
         if (not self.multiworld.EnableCoinStars[self.player].value):
             starcount = max(35,self.multiworld.AmountOfStars[self.player].value-15)

--- a/worlds/v6/__init__.py
+++ b/worlds/v6/__init__.py
@@ -54,10 +54,11 @@ class V6World(World):
     def create_item(self, name: str) -> Item:
         return V6Item(name, ItemClassification.progression, item_table[name], self.player)
 
-    def generate_basic(self):
+    def create_items(self):
         trinkets = [self.create_item("Trinket " + str(i+1).zfill(2)) for i in range(0,20)]
         self.multiworld.itempool += trinkets
 
+    def generate_basic(self):
         musiclist_o = [1,2,3,4,9,12]
         musiclist_s = musiclist_o.copy()
         if self.multiworld.MusicRandomizer[self.player].value:


### PR DESCRIPTION
For #1460 

## What is this fixing or adding?
Only modify itempool in `create_items` for V6, sm64ex.

sm64ex was only doing item creation in `generate_basic` anyway, so it was just renamed.

v6 also did music randomization. This was kept in `generate_basic`, while itempool mods were moved to their own `create_items` function.

## How was this tested?
Tested normal generation.
