### PR TITLE
MultiServer: Flag for saving on datastore, create_as_hint scout and client state change

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1742,6 +1742,8 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
                     hints.extend(collect_hint_location_id(ctx, client.team, client.slot, location))
                 locs.append(NetworkItem(target_item, location, target_player, flags))
             ctx.notify_hints(client.team, hints, only_new=create_as_hint == 2)
+            if locs and create_as_hint:
+                ctx.save()
             await ctx.send_msgs(client, [{'cmd': 'LocationInfo', 'locations': locs}])
 
         elif cmd == 'StatusUpdate':
@@ -1800,6 +1802,7 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
                 targets.add(client)
             if targets:
                 ctx.broadcast(targets, [args])
+            ctx.save()
 
         elif cmd == "SetNotify":
             if "keys" not in args or type(args["keys"]) != list:
@@ -1817,6 +1820,7 @@ def update_client_status(ctx: Context, client: Client, new_status: ClientStatus)
             ctx.on_goal_achieved(client)
 
         ctx.client_game_state[client.team, client.slot] = new_status
+        ctx.save()
 
 
 class ServerCommandProcessor(CommonCommandProcessor):


### PR DESCRIPTION
## What is this fixing or adding?
Makes server save on more changes than just location checks, as we have more state than that nowadays.

## How was this tested?
Firing up a local webhost, seeing the Disconnected in the Tracker change to Connected by only connecting with TextClient and waiting a moment.

## If this makes graphical changes, please attach screenshots.
![image](https://user-images.githubusercontent.com/3189725/230706980-46b3d78d-52a7-4d1e-a5ad-d835e8df0910.png)
