### PR TITLE
Core: prevent loading duplicate worlds

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -772,3 +772,7 @@ def async_start(co: Coroutine[typing.Any, typing.Any, bool], name: Optional[str]
     task = asyncio.create_task(co, name=name)
     _faf_tasks.add(task)
     task.add_done_callback(_faf_tasks.discard)
+
+
+class DuplicateWorldDefinition(Exception):
+    pass

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -9,6 +9,7 @@ from typing import Any, Callable, ClassVar, Dict, FrozenSet, List, Optional, Set
 
 from BaseClasses import CollectionState
 from Options import AssembleOptions
+from Utils import DuplicateWorldDefinition
 
 if TYPE_CHECKING:
     from BaseClasses import MultiWorld, Item, Location, Tutorial
@@ -55,7 +56,7 @@ class AutoWorldRegister(type):
         new_class = super().__new__(mcs, name, bases, dct)
         if "game" in dct:
             if dct["game"] in AutoWorldRegister.world_types:
-                raise RuntimeError(f"""Game {dct["game"]} already registered.""")
+                raise DuplicateWorldDefinition(f"""Game {dct["game"]} already registered.""")
             AutoWorldRegister.world_types[dct["game"]] = new_class
         new_class.__file__ = sys.modules[new_class.__module__].__file__
         if ".apworld" in new_class.__file__:

--- a/worlds/__init__.py
+++ b/worlds/__init__.py
@@ -5,6 +5,8 @@ import typing
 import warnings
 import zipimport
 
+from Utils import DuplicateWorldDefinition
+
 folder = os.path.dirname(__file__)
 
 __all__ = {
@@ -77,6 +79,9 @@ for world_source in world_sources:
                     importer.exec_module(mod)
         else:
             importlib.import_module(f".{world_source.path}", "worlds")
+    except DuplicateWorldDefinition as e:
+        # we want to stop here, instead of loading a "random" world
+        raise e
     except Exception as e:
         # A single world failing can still mean enough is working for the user, log and carry on
         import traceback


### PR DESCRIPTION
## What is this fixing or adding?
prevent loading duplicate worlds

## How was this tested?
minimally
