### PR TITLE
[Core] Allow ordered data types for `valid_keys` field

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -726,12 +726,13 @@ class VerifyKeys:
     @classmethod
     def verify_keys(cls, data: typing.List[str]):
         if cls.valid_keys:
+            valid_keys = set(cls.valid_keys)
             data = set(data)
             dataset = set(word.casefold() for word in data) if cls.valid_keys_casefold else set(data)
-            extra = dataset - cls.valid_keys
+            extra = dataset - valid_keys
             if extra:
                 raise Exception(f"Found unexpected key {', '.join(extra)} in {cls}. "
-                                f"Allowed keys: {cls.valid_keys}.")
+                                f"Allowed keys: {valid_keys}.")
 
     def verify(self, world: typing.Type[World], player_name: str, plando_options: "PlandoOptions") -> None:
         if self.convert_name_groups and self.verify_item_name:


### PR DESCRIPTION
## What is this fixing or adding?
- Modify `verify_keys()` to allow for ordered `valid_keys` so that they can be displayed to the user in a deterministic order
- This means `OptionSet` and `OptionList` can now specify the order in which the option values appear to the user

## How was this tested?
- #1688
