### PR TITLE
Core: ordered valid keys

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -57,9 +57,6 @@ class AssembleOptions(abc.ABCMeta):
             else:
                 assert verifiers, "class Option is supposed to implement def verify"
 
-        if "valid_keys" in attrs:
-            attrs["_valid_keys"] = frozenset(attrs["valid_keys"])
-
         # auto-validate schema on __init__
         if "schema" in attrs.keys():
 
@@ -718,7 +715,14 @@ class SpecialRange(Range):
                             f"random-range-high-<min>-<max>, or random-range-<min>-<max>.")
 
 
-class VerifyKeys:
+class FreezeValidKeys(AssembleOptions):
+    def __new__(mcs, name, bases, attrs):
+        if "valid_keys" in attrs:
+            attrs["_valid_keys"] = frozenset(attrs["valid_keys"])
+        return super(FreezeValidKeys, mcs).__new__(mcs, name, bases, attrs)
+
+
+class VerifyKeys(metaclass=FreezeValidKeys):
     valid_keys: typing.Iterable = []
     _valid_keys: frozenset  # gets created by AssembleOptions from valid_keys
     valid_keys_casefold: bool = False

--- a/Options.py
+++ b/Options.py
@@ -57,6 +57,9 @@ class AssembleOptions(abc.ABCMeta):
             else:
                 assert verifiers, "class Option is supposed to implement def verify"
 
+        if "valid_keys" in attrs:
+            attrs["_valid_keys"] = frozenset(attrs["valid_keys"])
+
         # auto-validate schema on __init__
         if "schema" in attrs.keys():
 
@@ -715,16 +718,9 @@ class SpecialRange(Range):
                             f"random-range-high-<min>-<max>, or random-range-<min>-<max>.")
 
 
-class FreezeValidKeys(abc.ABCMeta):
-    def __new__(mcs, name, bases, attrs):
-        if "valid_keys" in attrs:
-            attrs["_valid_keys"] = frozenset(attrs["valid_keys"])
-        return super(FreezeValidKeys, mcs).__new__(mcs, name, bases, attrs)
-
-
 class VerifyKeys:
     valid_keys: typing.Iterable = []
-    _valid_keys: frozenset
+    _valid_keys: frozenset  # gets created by AssembleOptions from valid_keys
     valid_keys_casefold: bool = False
     convert_name_groups: bool = False
     verify_item_name: bool = False
@@ -800,6 +796,10 @@ class ItemDict(OptionDict):
 
 
 class OptionList(Option[typing.List[typing.Any]], VerifyKeys):
+    # Supports duplicate entries and ordering.
+    # If only unique entries are needed and input order of elements does not matter, OptionSet should be used instead.
+    # Not a docstring so it doesn't get grabbed by the options system.
+
     default: typing.List[typing.Any] = []
     supports_weighting = False
 

--- a/Options.py
+++ b/Options.py
@@ -739,7 +739,7 @@ class VerifyKeys(metaclass=FreezeValidKeys):
             extra = dataset - cls._valid_keys
             if extra:
                 raise Exception(f"Found unexpected key {', '.join(extra)} in {cls}. "
-                                f"Allowed keys: {cls.valid_keys}.")
+                                f"Allowed keys: {cls._valid_keys}.")
 
     def verify(self, world: typing.Type[World], player_name: str, plando_options: "PlandoOptions") -> None:
         if self.convert_name_groups and self.verify_item_name:

--- a/Options.py
+++ b/Options.py
@@ -715,8 +715,16 @@ class SpecialRange(Range):
                             f"random-range-high-<min>-<max>, or random-range-<min>-<max>.")
 
 
+class FreezeValidKeys(abc.ABCMeta):
+    def __new__(mcs, name, bases, attrs):
+        if "valid_keys" in attrs:
+            attrs["_valid_keys"] = frozenset(attrs["valid_keys"])
+        return super(FreezeValidKeys, mcs).__new__(mcs, name, bases, attrs)
+
+
 class VerifyKeys:
-    valid_keys = frozenset()
+    valid_keys: typing.Iterable = []
+    _valid_keys: frozenset
     valid_keys_casefold: bool = False
     convert_name_groups: bool = False
     verify_item_name: bool = False
@@ -728,7 +736,7 @@ class VerifyKeys:
         if cls.valid_keys:
             data = set(data)
             dataset = set(word.casefold() for word in data) if cls.valid_keys_casefold else set(data)
-            extra = dataset - cls.valid_keys
+            extra = dataset - cls._valid_keys
             if extra:
                 raise Exception(f"Found unexpected key {', '.join(extra)} in {cls}. "
                                 f"Allowed keys: {cls.valid_keys}.")


### PR DESCRIPTION
## What is this fixing or adding?
allows using a list or tuple or such to provide allowed keys for Options in an ordered way, so that UI can use that ordering.

## How was this tested?
By posting this to discord and having others do it.
