### PR TITLE
WebHost: Set defaults for lists/sets on Weighted Settings page

### DIFF
--- a/WebHostLib/options.py
+++ b/WebHostLib/options.py
@@ -131,6 +131,7 @@ def create():
                     "type": "items-list",
                     "displayName": option.display_name if hasattr(option, "display_name") else option_name,
                     "description": get_html_doc(option),
+                    "defaultValue": list(option.default)
                 }
 
             elif issubclass(option, Options.LocationSet):
@@ -138,6 +139,7 @@ def create():
                     "type": "locations-list",
                     "displayName": option.display_name if hasattr(option, "display_name") else option_name,
                     "description": get_html_doc(option),
+                    "defaultValue": list(option.default)
                 }
 
             elif issubclass(option, Options.VerifyKeys):
@@ -147,6 +149,7 @@ def create():
                         "displayName": option.display_name if hasattr(option, "display_name") else option_name,
                         "description": get_html_doc(option),
                         "options": list(option.valid_keys),
+                        "defaultValue": list(option.default) if hasattr(option, "default") else []
                     }
 
             else:

--- a/WebHostLib/static/assets/weighted-settings.js
+++ b/WebHostLib/static/assets/weighted-settings.js
@@ -91,7 +91,7 @@ const createDefaultSettings = (settingData) => {
           case 'items-list':
           case 'locations-list':
           case 'custom-list':
-            newSettings[game][gameSetting] = [];
+            newSettings[game][gameSetting] = setting.defaultValue;
             break;
 
           default:


### PR DESCRIPTION
## What is this fixing or adding?
Sets the default values for `OptionSet`/`OptionList` with `valid_keys` and defined defaults.

## How was this tested?
I opened my browser, cleared the localStorage and looked at a couple games with defined defaults, like Rogue Legacy.

## If this makes graphical changes, please attach screenshots.
![image](https://user-images.githubusercontent.com/11338376/231003862-c16da0da-6256-4e50-9705-117c984be3cf.png)
![image](https://user-images.githubusercontent.com/11338376/231003867-93e6d12b-01d6-40a4-8bc6-5f8b775a8b9b.png)
