### PR TITLE
Core: Band-aid fixes `start_inventory_from_pool` causing generation failures if any world doesn't utilize it.

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -7,9 +7,9 @@ import random
 import secrets
 import typing  # this can go away when Python 3.8 support is dropped
 from argparse import Namespace
-from collections import OrderedDict, Counter, deque, ChainMap
+from collections import ChainMap, Counter, OrderedDict, deque
 from enum import IntEnum, IntFlag
-from typing import List, Dict, Optional, Set, Iterable, Union, Any, Tuple, TypedDict, Callable, NamedTuple
+from typing import Any, Callable, Dict, Iterable, List, NamedTuple, Optional, Set, Tuple, TypedDict, Union
 
 import NetUtils
 import Options
@@ -73,6 +73,7 @@ class MultiWorld():
     exclude_locations: Dict[int, Options.ExcludeLocations]
     priority_locations: Dict[int, Options.PriorityLocations]
     start_inventory: Dict[int, Options.StartInventory]
+    start_inventory_from_pool: Dict[int, Options.StartInventoryPool]
     start_hints: Dict[int, Options.StartHints]
     start_location_hints: Dict[int, Options.StartLocationHints]
     item_links: Dict[int, Options.ItemLinks]
@@ -121,7 +122,6 @@ class MultiWorld():
         self.early_items = {player: {} for player in self.player_ids}
         self.local_early_items = {player: {} for player in self.player_ids}
         self.indirect_connections = {}
-        self.start_inventory_from_pool = {player: Options.StartInventoryPool({}) for player in range(1, players + 1)}
         self.fix_trock_doors = self.AttributeProxy(
             lambda player: self.shuffle[player] != 'vanilla' or self.mode[player] == 'inverted')
         self.fix_skullwoods_exit = self.AttributeProxy(

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -73,7 +73,6 @@ class MultiWorld():
     exclude_locations: Dict[int, Options.ExcludeLocations]
     priority_locations: Dict[int, Options.PriorityLocations]
     start_inventory: Dict[int, Options.StartInventory]
-    start_inventory_from_pool: Dict[int, Options.StartInventoryPool]
     start_hints: Dict[int, Options.StartHints]
     start_location_hints: Dict[int, Options.StartLocationHints]
     item_links: Dict[int, Options.ItemLinks]
@@ -122,6 +121,7 @@ class MultiWorld():
         self.early_items = {player: {} for player in self.player_ids}
         self.local_early_items = {player: {} for player in self.player_ids}
         self.indirect_connections = {}
+        self.start_inventory_from_pool: Dict[int, Options.StartInventoryPool] = {}
         self.fix_trock_doors = self.AttributeProxy(
             lambda player: self.shuffle[player] != 'vanilla' or self.mode[player] == 'inverted')
         self.fix_skullwoods_exit = self.AttributeProxy(

--- a/Main.py
+++ b/Main.py
@@ -1,23 +1,23 @@
 import collections
+import concurrent.futures
 import logging
 import os
-import time
-import zlib
-import concurrent.futures
 import pickle
 import tempfile
+import time
 import zipfile
-from typing import Dict, List, Tuple, Optional, Set
+import zlib
+from typing import Dict, List, Optional, Set, Tuple
 
-from BaseClasses import Item, MultiWorld, CollectionState, Region, LocationProgressType, Location
 import worlds
-from worlds.alttp.SubClasses import LTTPRegionType
-from worlds.alttp.Regions import is_main_entrance
-from Fill import distribute_items_restrictive, flood_items, balance_multiworld_progression, distribute_planned
-from worlds.alttp.Shops import FillDisabledShopSlots
-from Utils import output_path, get_options, __version__, version_tuple
-from worlds.generic.Rules import locality_rules, exclusion_rules
+from BaseClasses import CollectionState, Item, Location, LocationProgressType, MultiWorld, Region
+from Fill import balance_multiworld_progression, distribute_items_restrictive, distribute_planned, flood_items
+from Utils import __version__, get_options, output_path, version_tuple
 from worlds import AutoWorld
+from worlds.alttp.Regions import is_main_entrance
+from worlds.alttp.Shops import FillDisabledShopSlots
+from worlds.alttp.SubClasses import LTTPRegionType
+from worlds.generic.Rules import exclusion_rules, locality_rules
 
 ordered_areas = (
     'Light World', 'Dark World', 'Hyrule Castle', 'Agahnims Tower', 'Eastern Palace', 'Desert Palace',
@@ -115,9 +115,11 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
         for item_name, count in world.start_inventory[player].value.items():
             for _ in range(count):
                 world.push_precollected(world.create_item(item_name, player))
-        for item_name, count in world.start_inventory_from_pool[player].value.items():
-            for _ in range(count):
-                world.push_precollected(world.create_item(item_name, player))
+
+        if player in world.start_inventory_from_pool:
+            for item_name, count in world.start_inventory_from_pool[player].value.items():
+                for _ in range(count):
+                    world.push_precollected(world.create_item(item_name, player))
 
     logger.info('Creating World.')
     AutoWorld.call_all(world, "create_regions")
@@ -154,7 +156,8 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
 
     # remove starting inventory from pool items.
     # Because some worlds don't actually create items during create_items this has to be as late as possible.
-    if any(world.start_inventory_from_pool[player].value for player in world.player_ids):
+    if player in world.start_inventory_from_pool and any(
+            world.start_inventory_from_pool[player].value for player in world.player_ids):
         new_items: List[Item] = []
         depletion_pool: Dict[int, Dict[str, int]] = {
             player: world.start_inventory_from_pool[player].value.copy() for player in world.player_ids}


### PR DESCRIPTION
## What is this fixing or adding?
See title.

![image](https://user-images.githubusercontent.com/11338376/231026120-99fb0c93-bf70-4497-9164-e1f2fa5122a9.png)

## How was this tested?
Ran a generation with an ALTTP (which uses it) and StS (which does not) and it successfully generated.

## If this makes graphical changes, please attach screenshots.
N/A