### PR TITLE
The Messenger: override start_inventory description

### DIFF
--- a/worlds/messenger/Options.py
+++ b/worlds/messenger/Options.py
@@ -1,10 +1,15 @@
-from Options import DefaultOnToggle, DeathLink, Range, Accessibility, Choice, Toggle
+from Options import DefaultOnToggle, DeathLink, Range, Accessibility, Choice, Toggle, StartInventory
 
 
 class MessengerAccessibility(Accessibility):
     default = Accessibility.option_locations
     # defaulting to locations accessibility since items makes certain items self-locking
     __doc__ = Accessibility.__doc__.replace(f"default {Accessibility.default}", f"default {default}")
+
+
+class MessengerInventory(StartInventory):
+    __doc__ = f"{StartInventory.__doc__} These items will be removed from the generated item pool."
+    display_name = "Start Inventory from Pool"
 
 
 class Logic(Choice):
@@ -70,6 +75,7 @@ class RequiredSeals(Range):
 
 messenger_options = {
     "accessibility": MessengerAccessibility,
+    "start_inventory": MessengerInventory,
     "logic_level": Logic,
     "shuffle_seals": PowerSeals,
     "shuffle_shards": MegaShards,

--- a/worlds/messenger/Options.py
+++ b/worlds/messenger/Options.py
@@ -1,15 +1,10 @@
-from Options import DefaultOnToggle, DeathLink, Range, Accessibility, Choice, Toggle, StartInventory
+from Options import DefaultOnToggle, DeathLink, Range, Accessibility, Choice, Toggle, StartInventoryPool
 
 
 class MessengerAccessibility(Accessibility):
     default = Accessibility.option_locations
     # defaulting to locations accessibility since items makes certain items self-locking
     __doc__ = Accessibility.__doc__.replace(f"default {Accessibility.default}", f"default {default}")
-
-
-class MessengerInventory(StartInventory):
-    __doc__ = f"{StartInventory.__doc__} These items will be removed from the generated item pool."
-    display_name = "Start Inventory from Pool"
 
 
 class Logic(Choice):
@@ -75,7 +70,7 @@ class RequiredSeals(Range):
 
 messenger_options = {
     "accessibility": MessengerAccessibility,
-    "start_inventory": MessengerInventory,
+    "start_inventory": StartInventoryPool,
     "logic_level": Logic,
     "shuffle_seals": PowerSeals,
     "shuffle_shards": MegaShards,


### PR DESCRIPTION
## What is this fixing or adding?
Updates the description and display name to properly represent how start_inventory works in my game.

## How was this tested?
Looked at the generated yaml template. Does not get properly represented on the website and changes nothing there.

## If this makes graphical changes, please attach screenshots.
