### PR TITLE
LADX: fix egg sprite in non-patched gfx mode

### DIFF
--- a/worlds/ladx/LADXR/generator.py
+++ b/worlds/ladx/LADXR/generator.py
@@ -64,9 +64,6 @@ from ..Options import TrendyGame, Palette, MusicChangeCondition
 def generateRom(args, settings, ap_settings, auth, seed_name, logic, rnd=None, multiworld=None, player_name=None, player_names=[], player_id = 0):
     rom_patches = []
 
-    if ap_settings["ap_title_screen"]:
-        rom_patches.append(pkgutil.get_data(__name__, "patches/title_screen.bdiff4"))
-
     rom = ROMWithTables(args.input_filename, rom_patches)
     rom.player_names = player_names
     pymods = []
@@ -416,9 +413,7 @@ def generateRom(args, settings, ap_settings, auth, seed_name, logic, rnd=None, m
     assert(len(auth) == 12)
     rom.patch(0x00, SEED_LOCATION, None, binascii.hexlify(auth))
 
-
     for pymod in pymods:
         pymod.postPatch(rom)
-
 
     return rom


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?
Gfxmods that used a full graphics file (ported from LADX, all our included sprites are bsdiff4 only) would overwrite the egg tiles. Instead of applying the patch first, I now apply it last

## How was this tested?
Locally. Used `Rosa.bin` from LADXR, noted large pink egg, even with title screen patch on. After this fix, the egg looks correct.

## If this makes graphical changes, please attach screenshots.
