### PR TITLE
Core: remove outdated assert on push_item

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -445,7 +445,6 @@ class MultiWorld():
         self.state.collect(item, True)
 
     def push_item(self, location: Location, item: Item, collect: bool = True):
-        assert location.can_fill(self.state, item, False), f"Cannot place {item} into {location}."
         location.item = item
         item.location = location
         if collect:


### PR DESCRIPTION
## What is this fixing or adding?
removes and assert that checks against self.state, which can be the wrong state in custom fill stages, such as LttP dungeon fill.

## How was this tested?
https://discord.com/channels/731205301247803413/1096220217409015848/1096225892059054130

## If this makes graphical changes, please attach screenshots.
