### PR TITLE
[TLOZ] Add FileNotFoundError handling for base rom

### DIFF
--- a/worlds/tloz/__init__.py
+++ b/worlds/tloz/__init__.py
@@ -77,6 +77,12 @@ class TLoZWorld(World):
         self.levels = None
         self.filler_items = None
 
+    @classmethod
+    def stage_assert_generate(cls, multiworld: MultiWorld):
+        rom_file = get_base_rom_path()
+        if not os.path.exists(rom_file):
+            raise FileNotFoundError(rom_file)
+
     def create_item(self, name: str):
         return TLoZItem(name, item_table[name].classification, self.item_name_to_id[name], self.player)
 


### PR DESCRIPTION
## What is this fixing or adding?
Adds proper handling of FileNotFoundError for if the program cant find the TLOZ base rom (i.e. someone forgot to put their base rom into the folder)

## How was this tested?
Ran a local generation and a webhost generation and got the proper error message.

## If this makes graphical changes, please attach screenshots.
![image](https://user-images.githubusercontent.com/59876300/232175690-e321205f-e624-41c9-b65f-cf18f31d0514.png)
