### PR TITLE
MultiServer: fix broken ping

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2272,8 +2272,7 @@ async def main(args: argparse.Namespace):
 
     ssl_context = load_server_cert(args.cert, args.cert_key) if args.cert else None
 
-    ctx.server = websockets.serve(functools.partial(server, ctx=ctx), host=ctx.host, port=ctx.port, ping_timeout=None,
-                                  ping_interval=None, ssl=ssl_context)
+    ctx.server = websockets.serve(functools.partial(server, ctx=ctx), host=ctx.host, port=ctx.port, ssl=ssl_context)
     ip = args.host if args.host else Utils.get_public_ipv4()
     logging.info('Hosting game at %s:%d (%s)' % (ip, ctx.port,
                                                  'No password' if not ctx.password else 'Password: %s' % ctx.password))


### PR DESCRIPTION
Ping argument seems to have changed in an update of websockets. This uses the lib's default of 20s now.

## How was this tested?
Wasn't