### PR TITLE
Adventure: Fix error in connector lua that was fairly harmless in BizHawk 2.8 but throws in 2.9

### DIFF
--- a/data/lua/connector_adventure.lua
+++ b/data/lua/connector_adventure.lua
@@ -598,7 +598,7 @@ function main()
                 if ( localItemLocations ~= nil and localItemLocations[tostring(carry_item)] ~= nil ) then
                     pending_local_items_collected[localItemLocations[tostring(carry_item)]] =
                         localItemLocations[tostring(carry_item)]
-                    table.remove(localItemLocations, tostring(carry_item))
+                    localItemLocations[tostring(carry_item)] = nil
                     skip_inventory_items[carry_item] = carry_item
                 end
             end


### PR DESCRIPTION
## What is this fixing or adding?
Fixes a connector_adventure.lua script bug that throws in BizHawk 2.9, breaking the connection, when a local item is touched by the player.  This is the fix I mentioned I'd need to make when discussing PR#1685

## How was this tested?
Added logging to verify local item location state.  Collected a local item using 2.8 to create a save that allowed for quick access.  Checked that this broke in 2.9.  Applied fix and verified that it works properly in 2.8 and 2.9.  Removed logging that was used to verify the local item location state.
