### PR TITLE
SM: failing generation fixes

### DIFF
--- a/worlds/sm/__init__.py
+++ b/worlds/sm/__init__.py
@@ -105,7 +105,6 @@ class SMWorld(World):
     def __init__(self, world: MultiWorld, player: int):
         self.rom_name_available_event = threading.Event()
         self.locations = {}
-        self.is_prog_balancing = False
         super().__init__(world, player)
 
     @classmethod
@@ -145,10 +144,6 @@ class SMWorld(World):
         missingPool = 109 - len(itemPool)
         for i in range(missingPool):
             itemPool.append(ItemManager.Items['Nothing'])
-
-        doorOpenerItems = ['Missile', 'Super', 'PowerBomb', 'Spazer', 'Ice', 'Wave' ,'Plasma']
-        hasAreaOrDoorRando = self.multiworld.area_randomization[self.player].value != 0 or \
-                             self.multiworld.doors_colors_rando[self.player].value != 0
         
         # Generate item pool
         pool = []
@@ -176,10 +171,6 @@ class SMWorld(World):
                 isAdvancement = False
 
             classification = ItemClassification.progression if isAdvancement else ItemClassification.filler
-            if hasAreaOrDoorRando and self.multiworld.progression_balancing[self.player].value != 0:
-                if isAdvancement and item.Type in doorOpenerItems:
-                    classification = ItemClassification.progression_skip_balancing
-
             itemClass = ItemManager.Items[item.Type].Class
             smitem = SMItem(item.Name, 
                             classification, 
@@ -747,7 +738,6 @@ class SMWorld(World):
                                     self.variaRando.args.escapeRando)
         
         self.variaRando.randoExec.postProcessItemLocs(self.itemLocs, self.variaRando.args.hideItems)
-        self.is_prog_balancing = True
 
     @classmethod
     def stage_post_fill(cls, world):
@@ -814,8 +804,7 @@ class SMLocation(Location):
         assert self.parent_region, "Can't reach location without region"
         return self.access_rule(state) and \
                 self.parent_region.can_reach(state) and \
-                (state.multiworld.worlds[self.player].is_prog_balancing or \
-                self.can_comeback(state, self.item))
+                self.can_comeback(state, self.item)
     
     def can_comeback(self, state: CollectionState, item):
         randoExec = state.multiworld.worlds[self.player].variaRando.randoExec

--- a/worlds/sm/variaRandomizer/graph/graph.py
+++ b/worlds/sm/variaRandomizer/graph/graph.py
@@ -362,7 +362,8 @@ class AccessGraph(object):
 
     # test access from an access point to another, given an optional item
     def canAccess(self, smbm, srcAccessPointName, destAccessPointName, maxDiff, item=None):
-        if item is not None:
+        addAndRemoveItem = item is not None and (smbm.isCountItem(item) or not smbm.haveItem(item))
+        if addAndRemoveItem:
             smbm.addItem(item)
         #print("canAccess: item: {}, src: {}, dest: {}".format(item, srcAccessPointName, destAccessPointName))
         destAccessPoint = self.accessPoints[destAccessPointName]
@@ -371,7 +372,7 @@ class AccessGraph(object):
         can = destAccessPoint in availAccessPoints
         # if not can:
         #     self.log.debug("canAccess KO: avail = {}".format([ap.Name for ap in availAccessPoints.keys()]))
-        if item is not None:
+        if addAndRemoveItem:
             smbm.removeItem(item)
         #print("canAccess: {}".format(can))
         return can

--- a/worlds/sm/variaRandomizer/graph/location.py
+++ b/worlds/sm/variaRandomizer/graph/location.py
@@ -59,9 +59,12 @@ class Location:
 
     def evalPostAvailable(self, smbm):
         if self.difficulty.bool == True and self.PostAvailable is not None:
-            smbm.addItem(self.itemName)
+            addAndRemoveItem = smbm.isCountItem(self.itemName) or not smbm.haveItem(self.itemName)
+            if addAndRemoveItem:
+                smbm.addItem(self.itemName)
             postAvailable = self.PostAvailable(smbm)
-            smbm.removeItem(self.itemName)
+            if addAndRemoveItem:
+                smbm.removeItem(self.itemName)
 
             self.difficulty = self.difficulty & postAvailable
             if self.locDifficulty is not None:

--- a/worlds/sm/variaRandomizer/logic/smboolmanager.py
+++ b/worlds/sm/variaRandomizer/logic/smboolmanager.py
@@ -91,9 +91,12 @@ class SMBoolManager(object):
         return itemsDict
 
     def withItem(self, item, func):
-        self.addItem(item)
+        addAndRemoveItem = self.isCountItem(item) or not self.haveItem(item)
+        if addAndRemoveItem:
+            self.addItem(item)
         ret = func(self)
-        self.removeItem(item)
+        if addAndRemoveItem:
+            self.removeItem(item)
         return ret
 
     def resetItems(self):

--- a/worlds/sm/variaRandomizer/rom/rompatcher.py
+++ b/worlds/sm/variaRandomizer/rom/rompatcher.py
@@ -279,11 +279,12 @@ class RomPatcher:
 
             # apply area patches
             if self.settings["area"] == True:
+                areaPatches = list(RomPatcher.IPSPatches['Area'])
                 if not self.settings["areaLayout"]:
                     for p in ['area_rando_layout.ips', 'Sponge_Bath_Blinking_Door', 'east_ocean.ips', 'aqueduct_bomb_blocks.ips']:
-                       RomPatcher.IPSPatches['Area'].remove(p)
-                    RomPatcher.IPSPatches['Area'].append('area_rando_layout_base.ips')
-                for patchName in RomPatcher.IPSPatches['Area']:
+                       areaPatches.remove(p)
+                    areaPatches.append('area_rando_layout_base.ips')
+                for patchName in areaPatches:
                     self.applyIPSPatch(patchName)
             else:
                 self.applyIPSPatch('area_ids_alt.ips')

--- a/worlds/sm/variaRandomizer/utils/objectives.py
+++ b/worlds/sm/variaRandomizer/utils/objectives.py
@@ -740,7 +740,7 @@ class Objectives(object):
                 if c not in char2tile:
                     continue
                 romFile.writeWord(0x3800 + char2tile[c])
-
+        Synonyms.alreadyUsed = []
         # write goal completed positions y in sprites OAM
         baseY = 0x40
         addr = Addresses.getOne('objectivesSpritesOAM')


### PR DESCRIPTION
## What is this fixing or adding?

fixed bad comeback check logic:
- fixed wrong condition in Collect to assign lastAP
- ~~limited comeback check to filling stage~~
- ~~now excludes items that can open doors from progression balancing if Area or Door Rando is used~~

- fixed possible infinite loop in generating output when many SM worlds are present
- fixed new VARIA code that changed a list used for every SM worlds and would throw if many SM worlds uses Aea rando and not AreaLayout

edit: 
fixed failing unit test that put to light a destructive collection state that could happen in can_comeback, allowing for a unified comeback check solution that doesnt limit it to filling stage and doesnt need to exclude items that can open doors from progression balancing.

## How was this tested?
I generated a lot of multiwords with 20 SM worlds having random start locations, area and door rando. They were often failing before the fixes and now passes.
