### PR TITLE
The Messenger: Throw error for invalid names and replace `_` with ` `

### DIFF
--- a/worlds/messenger/__init__.py
+++ b/worlds/messenger/__init__.py
@@ -71,10 +71,8 @@ class MessengerWorld(World):
     def stage_assert_generate(cls, multiworld: MultiWorld) -> None:
         for player in multiworld.get_game_players(cls.game):
             player_name = multiworld.player_name[player] = multiworld.get_player_name(player).replace("_", " ")
-            if not player_name.isalnum():
-                for char in player_name:
-                    if not (char.isalnum() or char in {' ', '-'}):
-                        raise NameError(f"Player name {player_name} is not alpha-numeric.")
+            if not all(c.isalnum() or c in "- " for c in player_name):
+                raise ValueError(f"Player name {player_name} is not alpha-numeric.")
 
     def generate_early(self) -> None:
         if self.multiworld.goal[self.player] == Goal.option_power_seal_hunt:

--- a/worlds/messenger/__init__.py
+++ b/worlds/messenger/__init__.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Dict, Any, Optional, List
 
-from BaseClasses import Tutorial, ItemClassification
+from BaseClasses import Tutorial, ItemClassification, MultiWorld
 from worlds.AutoWorld import World, WebWorld
 from .Constants import NOTES, PHOBEKINS, ALL_ITEMS, ALWAYS_LOCATIONS, SEALS, BOSS_LOCATIONS
 from .Options import messenger_options, NotesNeeded, Goal, PowerSeals, Logic
@@ -66,6 +66,15 @@ class MessengerWorld(World):
 
     total_seals: int = 0
     required_seals: int = 0
+    
+    @classmethod
+    def stage_assert_generate(cls, multiworld: MultiWorld) -> None:
+        for player in multiworld.get_game_players(cls.game):
+            player_name = multiworld.player_name[player] = multiworld.get_player_name(player).replace("_", " ")
+            if not player_name.isalnum():
+                for char in player_name:
+                    if not (char.isalnum() or char in {' ', '-'}):
+                        raise NameError(f"Player name {player_name} is not alpha-numeric.")
 
     def generate_early(self) -> None:
         if self.multiworld.goal[self.player] == Goal.option_power_seal_hunt:


### PR DESCRIPTION
## What is this fixing or adding?
Players are unable to connect to the multiworld if their names are invalid so going to straight up prevent it from generating.

## How was this tested?
Did a few test generations with `_` ` ` and some invalid characters

## If this makes graphical changes, please attach screenshots.
