### PR TITLE
WebHost: add spoiler level field to generate form

### DIFF
--- a/WebHostLib/api/generate.py
+++ b/WebHostLib/api/generate.py
@@ -48,9 +48,8 @@ def generate_api():
         if len(options) > app.config["MAX_ROLL"]:
             return {"text": "Max size of multiworld exceeded",
                     "detail": app.config["MAX_ROLL"]}, 409
-        meta = get_meta(meta_options_source)
-        meta["race"] = race
-        results, gen_options = roll_options(options, meta["plando_options"])
+        meta = get_meta(meta_options_source, race)
+        results, gen_options = roll_options(options, set(meta["plando_options"]))
         if any(type(result) == str for result in results.values()):
             return {"text": str(results),
                     "detail": results}, 400

--- a/WebHostLib/check.py
+++ b/WebHostLib/check.py
@@ -52,11 +52,12 @@ def get_yaml_data(file) -> Union[Dict[str, str], str, Markup]:
 
                 if any(file.filename.endswith(".archipelago") for file in infolist):
                     return Markup("Error: Your .zip file contains an .archipelago file. "
-                                 'Did you mean to <a href="/uploads">host a game</a>?')
+                                  'Did you mean to <a href="/uploads">host a game</a>?')
 
                 for file in infolist:
                     if file.filename.endswith(banned_zip_contents):
-                        return "Uploaded data contained a rom file, which is likely to contain copyrighted material. Your file was deleted."
+                        return "Uploaded data contained a rom file, which is likely to contain copyrighted material. " \
+                               "Your file was deleted."
                     elif file.filename.endswith((".yaml", ".json", ".yml", ".txt")):
                         options[file.filename] = zfile.open(file, "r").read()
         else:

--- a/WebHostLib/generate.py
+++ b/WebHostLib/generate.py
@@ -6,7 +6,7 @@ import tempfile
 import zipfile
 import concurrent.futures
 from collections import Counter
-from typing import Dict, Optional, Any
+from typing import Dict, Optional, Any, Union, List
 
 from flask import request, flash, redirect, url_for, session, render_template
 from pony.orm import commit, db_session
@@ -22,7 +22,7 @@ from .models import Generation, STATE_ERROR, STATE_QUEUED, Seed, UUID
 from .upload import upload_zip_to_db
 
 
-def get_meta(options_source: dict) -> dict:
+def get_meta(options_source: dict, race: bool = False) -> Dict[str, Union[List[str], Dict[str, Any]]]:
     plando_options = {
         options_source.get("plando_bosses", ""),
         options_source.get("plando_items", ""),
@@ -39,7 +39,21 @@ def get_meta(options_source: dict) -> dict:
         "item_cheat": bool(int(options_source.get("item_cheat", 1))),
         "server_password": options_source.get("server_password", None),
     }
-    return {"server_options": server_options, "plando_options": list(plando_options)}
+    generator_options = {
+        "spoiler": int(options_source.get("spoiler", 0)),
+        "race": race
+    }
+
+    if race:
+        server_options["item_cheat"] = False
+        server_options["remaining_mode"] = "disabled"
+        generator_options["spoiler"] = 0
+
+    return {
+        "server_options": server_options,
+        "plando_options": list(plando_options),
+        "generator_options": generator_options,
+    }
 
 
 @app.route('/generate', methods=['GET', 'POST'])
@@ -55,13 +69,8 @@ def generate(race=False):
             if isinstance(options, str):
                 flash(options)
             else:
-                meta = get_meta(request.form)
-                meta["race"] = race
-                results, gen_options = roll_options(options, meta["plando_options"])
-
-                if race:
-                    meta["server_options"]["item_cheat"] = False
-                    meta["server_options"]["remaining_mode"] = "disabled"
+                meta = get_meta(request.form, race)
+                results, gen_options = roll_options(options, set(meta["plando_options"]))
 
                 if any(type(result) == str for result in results.values()):
                     return render_template("checkResult.html", results=results)
@@ -97,7 +106,7 @@ def gen_game(gen_options: dict, meta: Optional[Dict[str, Any]] = None, owner=Non
         meta: Dict[str, Any] = {}
 
     meta.setdefault("server_options", {}).setdefault("hint_cost", 10)
-    race = meta.setdefault("race", False)
+    race = meta["generator_options"].setdefault("race", False)
 
     def task():
         target = tempfile.TemporaryDirectory()
@@ -114,13 +123,13 @@ def gen_game(gen_options: dict, meta: Optional[Dict[str, Any]] = None, owner=Non
         erargs = parse_arguments(['--multi', str(playercount)])
         erargs.seed = seed
         erargs.name = {x: "" for x in range(1, playercount + 1)}  # only so it can be overwritten in mystery
-        erargs.spoiler = 0 if race else 3
+        erargs.spoiler = meta["generator_options"]["spoiler"]
         erargs.race = race
         erargs.outputname = seedname
         erargs.outputpath = target.name
         erargs.teams = 1
         erargs.plando_options = PlandoOptions.from_set(meta.setdefault("plando_options",
-                                                                        {"bosses", "items", "connections", "texts"}))
+                                                                       {"bosses", "items", "connections", "texts"}))
 
         name_counter = Counter()
         for player, (playerfile, settings) in enumerate(gen_options.items(), 1):

--- a/WebHostLib/templates/generate.html
+++ b/WebHostLib/templates/generate.html
@@ -119,6 +119,28 @@
                                         </select>
                                     </td>
                                 </tr>
+                                <tr>
+                                    <td>
+                                        <label for="spoiler">Spoiler Log:
+                                            <span class="interactive" data-tooltip="Generates a text listing all randomized elements.
+Warning: playthrough can take a significant amount of time for larger multiworlds.">
+                                                (?)
+                                            </span>
+                                        </label>
+                                    </td>
+                                    <td>
+                                        <select name="spoiler" id="spoiler">
+                                            {% if race -%}
+                                                <option value="0">Disabled in Race mode</option>
+                                            {%- else -%}
+                                                <option value="3">Enabled with playthrough and traversal</option>
+                                                <option value="2">Enabled with playthrough</option>
+                                                <option value="1">Enabled</option>
+                                                <option value="0">Disabled</option>
+                                            {%- endif -%}
+                                        </select>
+                                    </td>
+                                </tr>
                             </tbody>
                         </table>
                         </div>


### PR DESCRIPTION
## What is this fixing or adding?
add spoiler level field to generate form
and to /api/ endpoint

## How was this tested?
using the form for a few generations
hoping api is tested by @LegendaryLinux , beyond what TestAPIGenerate.py already does

I know there's more AP related bots floating around that use our API, but I don't know who to contact for those or where to find them.