### PR TITLE
LTTP: Fix bad parens in new check logging

### DIFF
--- a/worlds/alttp/Client.py
+++ b/worlds/alttp/Client.py
@@ -332,7 +332,7 @@ async def track_locations(ctx, roomid, roomdata) -> bool:
         location = ctx.location_names[location_id]
         snes_logger.info(
             f'New Check: {location} ' +
-            f'({len(ctx.checked_locations + 1 if ctx.checked_locations else ctx.locations_checked)}/' +
+            f'({len(ctx.checked_locations) + 1 if ctx.checked_locations else len(ctx.locations_checked)}/' +
             f'{len(ctx.missing_locations) + len(ctx.checked_locations)})')
 
     try:


### PR DESCRIPTION
## What is this fixing or adding?

had the parens around the sets incorrect.

## How was this tested?

Rolled a seed and did two checks. First one without connecting and second after connecting.

## If this makes graphical changes, please attach screenshots.
![Screenshot_11](https://user-images.githubusercontent.com/13184667/232950991-21ca40bd-2b85-4b04-ba38-99ce1e6338d6.png)
