### PR TITLE
Multiserver cleaner exit

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1865,7 +1865,7 @@ class ServerCommandProcessor(CommonCommandProcessor):
 
     def _cmd_exit(self) -> bool:
         """Shutdown the server"""
-        async_start(self.ctx.server.ws_server._close())
+        self.ctx.server.ws_server.close()
         if self.ctx.shutdown_task:
             self.ctx.shutdown_task.cancel()
         self.ctx.exit_event.set()

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2206,7 +2206,7 @@ async def auto_shutdown(ctx, to_cancel=None):
     await asyncio.sleep(ctx.auto_shutdown)
     while not ctx.exit_event.is_set():
         if not ctx.client_activity_timers.values():
-            async_start(ctx.server.ws_server._close())
+            ctx.server.ws_server.close()
             ctx.exit_event.set()
             if to_cancel:
                 for task in to_cancel:
@@ -2217,7 +2217,7 @@ async def auto_shutdown(ctx, to_cancel=None):
             delta = datetime.datetime.now(datetime.timezone.utc) - newest_activity
             seconds = ctx.auto_shutdown - delta.total_seconds()
             if seconds < 0:
-                async_start(ctx.server.ws_server._close())
+                ctx.server.ws_server.close()
                 ctx.exit_event.set()
                 if to_cancel:
                     for task in to_cancel:


### PR DESCRIPTION
## What is this fixing or adding?
A few days ago we upgraded WebSockets, what I didn't notice then is that there is now a proper close method, so we can use that instead.


## How was this tested?
Ran /exit and it did indeed exit.

## If this makes graphical changes, please attach screenshots.
