### PR TITLE
Factorio: allow for team number in EnergyLink key

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -785,7 +785,7 @@ async def process_server_cmd(ctx: CommonContext, args: dict):
         if "DeathLink" in tags and ctx.last_death_link != args["data"]["time"]:
             ctx.on_deathlink(args["data"])
     elif cmd == "SetReply":
-        if args["key"] == "EnergyLink":
+        if args["key"].startswith("EnergyLink"):
             ctx.current_energy_link_value = args["value"]
             if ctx.ui:
                 ctx.ui.set_new_energy_link_value()


### PR DESCRIPTION
## What is this fixing or adding?
allow for team number in EnergyLink key

## How was this tested?
teams aren't re-implemented yet, so can't test the full thing. But admittedly didn't test that nothing is broken yet either.

## If this makes graphical changes, please attach screenshots.
