### PR TITLE
Launcher: install apworld

### DIFF
--- a/Launcher.py
+++ b/Launcher.py
@@ -11,6 +11,7 @@ Scroll down to components= to add components to the launcher as well as setup.py
 
 import argparse
 import itertools
+import logging
 import shlex
 import subprocess
 import sys
@@ -221,6 +222,15 @@ def run_gui():
     Launcher().run()
 
 
+def run_component(component: Component, *args):
+    if component.func:
+        component.func(*args)
+    elif component.script_name:
+        subprocess.run([*get_exe(component.script_name), *args])
+    else:
+        logging.warning(f"Component {component} does not appear to be executable.")
+
+
 def main(args: Optional[Union[argparse.Namespace, dict]] = None):
     if isinstance(args, argparse.Namespace):
         args = {k: v for k, v in args._get_kwargs()}
@@ -228,16 +238,16 @@ def main(args: Optional[Union[argparse.Namespace, dict]] = None):
         args = {}
 
     if "Patch|Game|Component" in args:
-        file, component, _ = identify(args["Patch|Game|Component"])
+        file, _, component = identify(args["Patch|Game|Component"])
         if file:
             args['file'] = file
         if component:
             args['component'] = component
 
     if 'file' in args:
-        subprocess.run([*get_exe(args['component']), args['file'], *args['args']])
+        run_component(args["component"], args["file"], *args["args"])
     elif 'component' in args:
-        subprocess.run([*get_exe(args['component']), *args['args']])
+        run_component(args["component"], *args["args"])
     else:
         run_gui()
 

--- a/inno_setup.iss
+++ b/inno_setup.iss
@@ -182,6 +182,10 @@ Type: filesandordirs; Name: "{app}\lib\worlds\rogue-legacy*"
 #include "installdelete.iss"
 
 [Registry]
+Root: HKCR; Subkey: ".apworld";                                 ValueData: "{#MyAppName}apworld";        Flags: uninsdeletevalue; ValueType: string;  ValueName: "";
+Root: HKCR; Subkey: "{#MyAppName}apworld";                     ValueData: "Archipelago World Implementation"; Flags: uninsdeletekey;   ValueType: string;  ValueName: "";
+Root: HKCR; Subkey: "{#MyAppName}apworld\DefaultIcon";         ValueData: "{app}\ArchipelagoLauncher.exe,0";                           ValueType: string;  ValueName: "";
+Root: HKCR; Subkey: "{#MyAppName}apworld\shell\open\command";  ValueData: """{app}\ArchipelagoLauncher.exe"" ""%1""";                  ValueType: string;  ValueName: "";
 
 Root: HKCR; Subkey: ".aplttp";                                 ValueData: "{#MyAppName}patch";        Flags: uninsdeletevalue; ValueType: string;  ValueName: ""; Components: client/sni
 Root: HKCR; Subkey: "{#MyAppName}patch";                     ValueData: "Archipelago Binary Patch"; Flags: uninsdeletekey;   ValueType: string;  ValueName: ""; Components: client/sni

--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -1,3 +1,4 @@
+import os.path
 from enum import Enum, auto
 from typing import Optional, Callable, List, Iterable
 
@@ -58,6 +59,25 @@ class SuffixIdentifier:
         return False
 
 
+def install_apworld(path: str):
+    import shutil
+    import worlds
+    basename = os.path.basename(path)
+    target = os.path.join(worlds.folder, basename)
+
+    if basename in os.listdir(worlds.folder):
+        # overwrite existing apworld
+        os.unlink(target)
+        shutil.copy(path, target)
+
+    else:
+        # we can at least import for now to minimally test it.
+        source = worlds.WorldSource(path, is_zip=True, relative=False)
+        success = source.load()
+        if success:
+            shutil.copy(path, target)
+
+
 components: List[Component] = [
     # Launcher
     Component('', 'Launcher'),
@@ -66,6 +86,7 @@ components: List[Component] = [
               file_identifier=SuffixIdentifier('.archipelago', '.zip')),
     Component('Generate', 'Generate', cli=True),
     Component('Text Client', 'CommonClient', 'ArchipelagoTextClient'),
+    Component("APWorld Installer", file_identifier=SuffixIdentifier('.apworld'), func=install_apworld),
     # SNI
     Component('SNI Client', 'SNIClient',
               file_identifier=SuffixIdentifier('.apz3', '.apm3', '.apsoe', '.aplttp', '.apsm', '.apsmz3', '.apdkc3',

--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -95,7 +95,7 @@ components: List[Component] = [
     # Zillion
     Component('Zillion Client', 'ZillionClient',
               file_identifier=SuffixIdentifier('.apzl')),
-    #Kingdom Hearts 2
+    # Kingdom Hearts 2
     Component('KH2 Client', "KH2Client"),
 ]
 

--- a/worlds/__init__.py
+++ b/worlds/__init__.py
@@ -39,9 +39,50 @@ class DataPackage(typing.TypedDict):
 class WorldSource(typing.NamedTuple):
     path: str  # typically relative path from this module
     is_zip: bool = False
+    relative: bool = True  # relative to regular world import folder
 
     def __repr__(self):
         return f"{self.__class__.__name__}({self.path}, is_zip={self.is_zip})"
+
+    @property
+    def resolved_path(self) -> str:
+        if self.relative:
+            return os.path.join(folder, self.path)
+        return self.path
+
+    def load(self) -> bool:
+        try:
+            if self.is_zip:
+                importer = zipimport.zipimporter(self.resolved_path)
+                if hasattr(importer, "find_spec"):  # new in Python 3.10
+                    spec = importer.find_spec(self.path.split(".", 1)[0])
+                    mod = importlib.util.module_from_spec(spec)
+                else:  # TODO: remove with 3.8 support
+                    mod = importer.load_module(self.path.split(".", 1)[0])
+
+                mod.__package__ = f"worlds.{mod.__package__}"
+                mod.__name__ = f"worlds.{mod.__name__}"
+                sys.modules[mod.__name__] = mod
+                with warnings.catch_warnings():
+                    warnings.filterwarnings("ignore", message="__package__ != __spec__.parent")
+                    # Found no equivalent for < 3.10
+                    if hasattr(importer, "exec_module"):
+                        importer.exec_module(mod)
+            else:
+                importlib.import_module(f".{self.path}", "worlds")
+            return True
+
+        except Exception as e:
+            # A single world failing can still mean enough is working for the user, log and carry on
+            import traceback
+            import io
+            file_like = io.StringIO()
+            print(f"Could not load world {self}:", file=file_like)
+            traceback.print_exc(file=file_like)
+            file_like.seek(0)
+            import logging
+            logging.exception(file_like.read())
+            return False
 
 
 # find potential world containers, currently folders and zip-importable .apworld's
@@ -58,35 +99,7 @@ for file in os.scandir(folder):
 # import all submodules to trigger AutoWorldRegister
 world_sources.sort()
 for world_source in world_sources:
-    try:
-        if world_source.is_zip:
-            importer = zipimport.zipimporter(os.path.join(folder, world_source.path))
-            if hasattr(importer, "find_spec"):  # new in Python 3.10
-                spec = importer.find_spec(world_source.path.split(".", 1)[0])
-                mod = importlib.util.module_from_spec(spec)
-            else:  # TODO: remove with 3.8 support
-                mod = importer.load_module(world_source.path.split(".", 1)[0])
-
-            mod.__package__ = f"worlds.{mod.__package__}"
-            mod.__name__ = f"worlds.{mod.__name__}"
-            sys.modules[mod.__name__] = mod
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore", message="__package__ != __spec__.parent")
-                # Found no equivalent for < 3.10
-                if hasattr(importer, "exec_module"):
-                    importer.exec_module(mod)
-        else:
-            importlib.import_module(f".{world_source.path}", "worlds")
-    except Exception as e:
-        # A single world failing can still mean enough is working for the user, log and carry on
-        import traceback
-        import io
-        file_like = io.StringIO()
-        print(f"Could not load world {world_source}:", file=file_like)
-        traceback.print_exc(file=file_like)
-        file_like.seek(0)
-        import logging
-        logging.exception(file_like.read())
+    world_source.load()
 
 lookup_any_item_id_to_name = {}
 lookup_any_location_id_to_name = {}


### PR DESCRIPTION
## What is this fixing or adding?
allows installation of apworlds via Launcher

## How was this tested?
by turning subnautica into an apworld and running the new Launcher commands

This is a draft as plenty of things need addressing first:
 * worlds.folder might not be writable on linux(?)
 * tests should be run, however currently importing an already loaded world will quickly fail, so a new Process might need to be started to import just that world and run tests (new executable in frozen state?)
 * user confirmation should be gathered and a warning about executable code contained should be displayed