### PR TITLE
Stardew Valley - Add alias for renamed Fishsanity option

### DIFF
--- a/worlds/stardew_valley/options.py
+++ b/worlds/stardew_valley/options.py
@@ -292,6 +292,7 @@ class Fishsanity(Choice):
     option_legendaries = 1
     option_special = 2
     option_randomized = 3
+    alias_random_selection = option_randomized
     option_all = 4
 
 


### PR DESCRIPTION
## What is this fixing or adding?
During the development of 3.x.x, we renamed an option in fishsanity from random_selection to randomized
This adds an alias so that older yamls don't break on it

## How was this tested?
Ran the automated tests