### PR TITLE
WebHost: Prevent `dict` type options with `valid_keys` from exporting with `[]` on weighted settings.

### DIFF
--- a/WebHostLib/options.py
+++ b/WebHostLib/options.py
@@ -109,7 +109,7 @@ def create():
                     "defaultValue": list(option.default)
                 }
 
-            elif issubclass(option, Options.VerifyKeys):
+            elif issubclass(option, Options.VerifyKeys) and not issubclass(option, Options.OptionDict):
                 if option.valid_keys:
                     game_options[option_name] = {
                         "type": "custom-list",


### PR DESCRIPTION
Thanks HK.

Fix for bug introduced in #1614. Just needed to ensure we ignore `OptionDict`-derived objects/classes since we aren't rendering them anyway.

## What is this fixing or adding?
Fixes this:
![image](https://user-images.githubusercontent.com/11338376/233879773-380bfb00-c351-4706-9743-eaec78d8509c.png)

## How was this tested?
Ran WebHost.py and checked to see if error reappeared. 

It did not, nor did it get outputted in exported yaml.

## If this makes graphical changes, please attach screenshots.
