### PR TITLE
Subnautica: add free samples option

### DIFF
--- a/worlds/subnautica/Options.py
+++ b/worlds/subnautica/Options.py
@@ -1,6 +1,6 @@
 import typing
 
-from Options import Choice, Range, DeathLink, DefaultOnToggle, StartInventoryPool
+from Options import Choice, Range, DeathLink, Toggle, DefaultOnToggle, StartInventoryPool
 from .Creatures import all_creatures, Definitions
 
 
@@ -33,6 +33,12 @@ class SwimRule(Choice):
 class EarlySeaglide(DefaultOnToggle):
     """Make sure 2 of the Seaglide Fragments are available in or near the Safe Shallows (Sphere 1 Locations)."""
     display_name = "Early Seaglide"
+
+
+class FreeSamples(Toggle):
+    """Get free items with your blueprints.
+    Items that can go into your inventory are awarded when you unlock their blueprint through Archipelago."""
+    display_name = "Free Samples"
 
 
 class Goal(Choice):
@@ -100,6 +106,7 @@ class SubnauticaDeathLink(DeathLink):
 options = {
     "swim_rule": SwimRule,
     "early_seaglide": EarlySeaglide,
+    "free_samples": FreeSamples,
     "goal": Goal,
     "creature_scans": CreatureScans,
     "creature_scan_logic": AggressiveScanLogic,

--- a/worlds/subnautica/__init__.py
+++ b/worlds/subnautica/__init__.py
@@ -45,7 +45,7 @@ class SubnauticaWorld(World):
     option_definitions = Options.options
 
     data_version = 9
-    required_client_version = (0, 3, 9)
+    required_client_version = (0, 4, 0)
 
     creatures_to_scan: List[str]
 
@@ -129,6 +129,7 @@ class SubnauticaWorld(World):
             "vanilla_tech": vanilla_tech,
             "creatures_to_scan": self.creatures_to_scan,
             "death_link": self.multiworld.death_link[self.player].value,
+            "free_samples": self.multiworld.free_samples[self.player].value,
         }
 
         return slot_data


### PR DESCRIPTION
## What is this fixing or adding?
adds free_samples to Subnautica, very similar to Factorio

## How was this tested?
With various item types at least once (vehicles, compound items, regular items, fragments etc.)
Did not test the whole range of items, but in testing I noticed that the game just creates dummy items for BS, so should be easy enough to fix if it comes up and not be fatal.

## If this makes graphical changes, please attach screenshots.
![image](https://user-images.githubusercontent.com/3189725/234016853-f549524a-726f-4409-aada-1f51c50a8847.png)
