### PR TITLE
Allow specifying an additional folder for loading apworlds from for generation

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -11,6 +11,7 @@ from collections import Counter, ChainMap
 from typing import Dict, Tuple, Callable, Any, Union
 
 import ModuleUpdate
+from worlds import WorldLoader
 
 ModuleUpdate.update()
 
@@ -56,6 +57,8 @@ def mystery_argparse():
                         help='Output rolled mystery results to yaml up to specified number (made for async multiworld)')
     parser.add_argument('--plando', default=defaults["plando_options"],
                         help='List of options that can be set manually. Can be combined, for example "bosses, items"')
+    parser.add_argument('--additional_apworld_path', default=defaults["additional_apworld_path"],
+                        help='Input directory for discovery of additional .apworld files.')
     args = parser.parse_args()
     if not os.path.isabs(args.weights_file_path):
         args.weights_file_path = os.path.join(args.player_files_path, args.weights_file_path)
@@ -72,6 +75,10 @@ def get_seed_name(random_source) -> str:
 def main(args=None, callback=ERmain):
     if not args:
         args, options = mystery_argparse()
+
+    args.additional_apworld_path = "T:\ApWorlds"
+    if args.additional_apworld_path:
+        WorldLoader.add_apworlds_source_folder(args.additional_apworld_path)
 
     seed = get_seed(args.seed)
     random.seed(seed)

--- a/Launcher.py
+++ b/Launcher.py
@@ -11,6 +11,7 @@ Scroll down to components= to add components to the launcher as well as setup.py
 
 import argparse
 import itertools
+import logging
 import shlex
 import subprocess
 import sys
@@ -221,6 +222,15 @@ def run_gui():
     Launcher().run()
 
 
+def run_component(component: Component, *args):
+    if component.func:
+        component.func(*args)
+    elif component.script_name:
+        subprocess.run([*get_exe(component.script_name), *args])
+    else:
+        logging.warning(f"Component {component} does not appear to be executable.")
+
+
 def main(args: Optional[Union[argparse.Namespace, dict]] = None):
     if isinstance(args, argparse.Namespace):
         args = {k: v for k, v in args._get_kwargs()}
@@ -228,16 +238,16 @@ def main(args: Optional[Union[argparse.Namespace, dict]] = None):
         args = {}
 
     if "Patch|Game|Component" in args:
-        file, component, _ = identify(args["Patch|Game|Component"])
+        file, _, component = identify(args["Patch|Game|Component"])
         if file:
             args['file'] = file
         if component:
             args['component'] = component
 
     if 'file' in args:
-        subprocess.run([*get_exe(args['component']), args['file'], *args['args']])
+        run_component(args["component"], args["file"], *args["args"])
     elif 'component' in args:
-        subprocess.run([*get_exe(args['component']), *args['args']])
+        run_component(args["component"], *args["args"])
     else:
         run_gui()
 

--- a/WebHostLib/tracker.py
+++ b/WebHostLib/tracker.py
@@ -11,10 +11,12 @@ from werkzeug.exceptions import abort
 from MultiServer import Context, get_saving_second
 from NetUtils import SlotType
 from Utils import restricted_loads
-from worlds import lookup_any_item_id_to_name, lookup_any_location_id_to_name, network_data_package
+from worlds import WorldLoader, lookup_any_item_id_to_name, lookup_any_location_id_to_name, network_data_package
 from worlds.alttp import Items
 from . import app, cache
 from .models import GameDataPackage, Room
+
+WorldLoader.load_worlds()
 
 alttp_icons = {
     "Blue Shield": r"https://www.zeldadungeon.net/wiki/images/8/85/Fighters-Shield.png",

--- a/Zelda1Client.py
+++ b/Zelda1Client.py
@@ -13,9 +13,11 @@ from typing import List
 
 import Utils
 from Utils import async_start
-from worlds import lookup_any_location_id_to_name
+from worlds import WorldLoader, lookup_any_location_id_to_name
 from CommonClient import CommonContext, server_loop, gui_enabled, console_loop, ClientCommandProcessor, logger, \
     get_base_parser
+
+WorldLoader.load_worlds()
 
 from worlds.tloz.Items import item_game_ids
 from worlds.tloz.Locations import location_ids

--- a/host.yaml
+++ b/host.yaml
@@ -83,6 +83,9 @@ generator:
   # List of options that can be plando'd. Can be combined, for example "bosses, items"
   # Available options: bosses, items, texts, connections
   plando_options: "bosses"
+  # Additional folder to scan for .apworld files in addition to the "worlds" folder
+  # can be left empty if no additional folders should be scanned
+  additional_apworld_path: null
 sni_options:
   # Set this to your SNI folder location if you want the MultiClient to attempt an auto start, does nothing if not found
   sni_path: "SNI"

--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -95,7 +95,7 @@ components: List[Component] = [
     # Zillion
     Component('Zillion Client', 'ZillionClient',
               file_identifier=SuffixIdentifier('.apzl')),
-    #Kingdom Hearts 2
+    # Kingdom Hearts 2
     Component('KH2 Client', "KH2Client"),
 ]
 

--- a/worlds/__init__.py
+++ b/worlds/__init__.py
@@ -42,7 +42,7 @@ class WorldSource(typing.NamedTuple):
     relative: bool = True  # relative to regular world import folder
 
     def __repr__(self):
-        return f"{self.__class__.__name__}({self.path}, is_zip={self.is_zip})"
+        return f"{self.__class__.__name__}({self.path}, is_zip={self.is_zip}, relative={self.relative})"
 
     @property
     def resolved_path(self) -> str:
@@ -55,10 +55,10 @@ class WorldSource(typing.NamedTuple):
             if self.is_zip:
                 importer = zipimport.zipimporter(self.resolved_path)
                 if hasattr(importer, "find_spec"):  # new in Python 3.10
-                    spec = importer.find_spec(self.path.split(".", 1)[0])
+                    spec = importer.find_spec(os.path.basename(self.path).rsplit(".", 1)[0])
                     mod = importlib.util.module_from_spec(spec)
                 else:  # TODO: remove with 3.8 support
-                    mod = importer.load_module(self.path.split(".", 1)[0])
+                    mod = importer.load_module(os.path.basename(self.path).rsplit(".", 1)[0])
 
                 mod.__package__ = f"worlds.{mod.__package__}"
                 mod.__name__ = f"worlds.{mod.__name__}"

--- a/worlds/__init__.py
+++ b/worlds/__init__.py
@@ -39,9 +39,50 @@ class DataPackage(typing.TypedDict):
 class WorldSource(typing.NamedTuple):
     path: str  # typically relative path from this module
     is_zip: bool = False
+    relative: bool = True  # relative to regular world import folder
 
     def __repr__(self):
         return f"{self.__class__.__name__}({self.path}, is_zip={self.is_zip})"
+
+    @property
+    def resolved_path(self) -> str:
+        if self.relative:
+            return os.path.join(folder, self.path)
+        return self.path
+
+    def load(self) -> bool:
+        try:
+            if self.is_zip:
+                importer = zipimport.zipimporter(self.resolved_path)
+                if hasattr(importer, "find_spec"):  # new in Python 3.10
+                    spec = importer.find_spec(self.path.split(".", 1)[0])
+                    mod = importlib.util.module_from_spec(spec)
+                else:  # TODO: remove with 3.8 support
+                    mod = importer.load_module(self.path.split(".", 1)[0])
+
+                mod.__package__ = f"worlds.{mod.__package__}"
+                mod.__name__ = f"worlds.{mod.__name__}"
+                sys.modules[mod.__name__] = mod
+                with warnings.catch_warnings():
+                    warnings.filterwarnings("ignore", message="__package__ != __spec__.parent")
+                    # Found no equivalent for < 3.10
+                    if hasattr(importer, "exec_module"):
+                        importer.exec_module(mod)
+            else:
+                importlib.import_module(f".{self.path}", "worlds")
+            return True
+
+        except Exception as e:
+            # A single world failing can still mean enough is working for the user, log and carry on
+            import traceback
+            import io
+            file_like = io.StringIO()
+            print(f"Could not load world {self}:", file=file_like)
+            traceback.print_exc(file=file_like)
+            file_like.seek(0)
+            import logging
+            logging.exception(file_like.read())
+            return False
 
 
 # find potential world containers, currently folders and zip-importable .apworld's
@@ -58,35 +99,7 @@ for file in os.scandir(folder):
 # import all submodules to trigger AutoWorldRegister
 world_sources.sort()
 for world_source in world_sources:
-    try:
-        if world_source.is_zip:
-            importer = zipimport.zipimporter(os.path.join(folder, world_source.path))
-            if hasattr(importer, "find_spec"):  # new in Python 3.10
-                spec = importer.find_spec(world_source.path.split(".", 1)[0])
-                mod = importlib.util.module_from_spec(spec)
-            else:  # TODO: remove with 3.8 support
-                mod = importer.load_module(world_source.path.split(".", 1)[0])
-
-            mod.__package__ = f"worlds.{mod.__package__}"
-            mod.__name__ = f"worlds.{mod.__name__}"
-            sys.modules[mod.__name__] = mod
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore", message="__package__ != __spec__.parent")
-                # Found no equivalent for < 3.10
-                if hasattr(importer, "exec_module"):
-                    importer.exec_module(mod)
-        else:
-            importlib.import_module(f".{world_source.path}", "worlds")
-    except Exception as e:
-        # A single world failing can still mean enough is working for the user, log and carry on
-        import traceback
-        import io
-        file_like = io.StringIO()
-        print(f"Could not load world {world_source}:", file=file_like)
-        traceback.print_exc(file=file_like)
-        file_like.seek(0)
-        import logging
-        logging.exception(file_like.read())
+    world_source.load()
 
 lookup_any_item_id_to_name = {}
 lookup_any_location_id_to_name = {}


### PR DESCRIPTION
## What is this fixing or adding?
Includes #1753

Delayed loading of worlds so the sources to load from can still be altered before the load is triggered
Allow specifying an additional folder for loading apworlds from for generation

this is usefull when you want to dynamically download additional apworlds for generation but your archipelago is installed on a read-only filesystem thus disallowing write access on the worlds folder

## How was this tested?
Still in progress, PR put up for feedback tho
