### PR TITLE
FF1: Added URange fix for Bizhawk 2.9 support

### DIFF
--- a/data/lua/common.lua
+++ b/data/lua/common.lua
@@ -31,6 +31,7 @@ local untestedBizhawkMessage = "Warning: this version of bizhawk is newer than w
 u8 = memory.read_u8
 wU8 = memory.write_u8
 u16 = memory.read_u16_le
+uRange = memory.readbyterange
 
 function getMaxMessageLength()
   local denominator = 12


### PR DESCRIPTION
URange wasn't moved to common.lua (and no longer exists in connector_ff1.lua) when the lua files were changed for Bizhawk 2.9 socket change.

(This could also be added to the connector_ff1.lua instead if preferred since I believe it's the only one that leverages it but this is where those functions were centralized)

## What is this fixing or adding?

The socket change/lua changes broke functionality for FF1Client when they were restructured since the URange function was removed.

## How was this tested?

Tested vs Bizhawk 2.8 and 2.9, works for both. (Otherwise they failed to connect since they couldn't read the slot name/location/item names in the rom)
The original lua fix corrected the main socket issue this function just got forgotten in the move.

## If this makes graphical changes, please attach screenshots.
