### PR TITLE
WebHost: recycle generator processes

### DIFF
--- a/WebHostLib/__init__.py
+++ b/WebHostLib/__init__.py
@@ -34,7 +34,7 @@ app.config['MAX_CONTENT_LENGTH'] = 64 * 1024 * 1024  # 64 megabyte limit
 # if you want to deploy, make sure you have a non-guessable secret key
 app.config["SECRET_KEY"] = bytes(socket.gethostname(), encoding="utf-8")
 # at what amount of worlds should scheduling be used, instead of rolling in the web-thread
-app.config["JOB_THRESHOLD"] = 2
+app.config["JOB_THRESHOLD"] = 1
 # after what time in seconds should generation be aborted, freeing the queue slot. Can be set to None to disable.
 app.config["JOB_TIME"] = 600
 app.config['SESSION_PERMANENT'] = True

--- a/WebHostLib/autolauncher.py
+++ b/WebHostLib/autolauncher.py
@@ -135,7 +135,7 @@ def autogen(config: dict):
             with Locker("autogen"):
 
                 with multiprocessing.Pool(config["GENERATORS"], initializer=init_db,
-                                          initargs=(config["PONY"],)) as generator_pool:
+                                          initargs=(config["PONY"],), maxtasksperchild=10) as generator_pool:
                     with db_session:
                         to_start = select(generation for generation in Generation if generation.state == STATE_STARTED)
 


### PR DESCRIPTION
## What is this fixing or adding?
A few days ago we noticed slowly increasing memory use on processes that generate worlds. This change should reclaim that memory again and by default no longer use the webthreads to gen, leaving them out of the problem.

Finding the root cause would still be nice, but this at least treats the symptom.

## How was this tested?
by setting maxtasksperchild to 1 and seeing python.exe processes appear and disappear.

## If this makes graphical changes, please attach screenshots.
