### PR TITLE
Core: store multidata/multisave enums by value on py3.11

### DIFF
--- a/NetUtils.py
+++ b/NetUtils.py
@@ -6,7 +6,7 @@ from json import JSONEncoder, JSONDecoder
 
 import websockets
 
-from Utils import Version
+from Utils import ByValue, Version
 
 
 class JSONMessagePart(typing.TypedDict, total=False):
@@ -20,7 +20,7 @@ class JSONMessagePart(typing.TypedDict, total=False):
     flags: int
 
 
-class ClientStatus(enum.IntEnum):
+class ClientStatus(ByValue, enum.IntEnum):
     CLIENT_UNKNOWN = 0
     CLIENT_CONNECTED = 5
     CLIENT_READY = 10
@@ -28,7 +28,7 @@ class ClientStatus(enum.IntEnum):
     CLIENT_GOAL = 30
 
 
-class SlotType(enum.IntFlag):
+class SlotType(ByValue, enum.IntFlag):
     spectator = 0b00
     player = 0b01
     group = 0b10
@@ -39,7 +39,7 @@ class SlotType(enum.IntFlag):
         return self.value != 0b01
 
 
-class Permission(enum.IntFlag):
+class Permission(ByValue, enum.IntFlag):
     disabled = 0b000  # 0, completely disables access
     enabled = 0b001  # 1, allows manual use
     goal = 0b010  # 2, allows manual use after goal completion

--- a/Utils.py
+++ b/Utils.py
@@ -508,6 +508,15 @@ def restricted_loads(s):
     return RestrictedUnpickler(io.BytesIO(s)).load()
 
 
+class ByValue:
+    """
+    Mixin for enums to pickle value instead of name (restores pre-3.11 behavior). Use as left-most parent.
+    See https://github.com/python/cpython/pull/26658 for why this exists.
+    """
+    def __reduce_ex__(self, prot):
+        return self.__class__, (self._value_, )
+
+
 class KeyedDefaultDict(collections.defaultdict):
     """defaultdict variant that uses the missing key as argument to default_factory"""
     default_factory: typing.Callable[[typing.Any], typing.Any]


### PR DESCRIPTION
## What is this fixing or adding?

Python 3.11 changed to pickle/store enums by name rather than by value. This breaks our safe unpickle, it produces bigger pickles and it makes it impossible to rename keys in enums after the fact.
Changing it back to ByValue produces the same output as py<=3.10.

Change in python is here: https://github.com/python/cpython/pull/26658

## How was this tested?

```
$ python --version
Python 3.11.3
$ Generate.py
$ MultiServer.py ...
/send Player1 A Shrubbery
/save
$ MultiServer.py ...
Loaded save file with 1 received items for 1 players
```
