### PR TITLE
Test: fix setting seed from the hash of the seed method, rather than …

### DIFF
--- a/test/general/TestHelpers.py
+++ b/test/general/TestHelpers.py
@@ -1,5 +1,4 @@
-from random import seed
-from typing import Dict, Optional, Callable, Tuple, List
+from typing import Dict, Optional, Callable
 
 from BaseClasses import MultiWorld, CollectionState, Region
 import unittest
@@ -13,7 +12,7 @@ class TestHelpers(unittest.TestCase):
         self.multiworld = MultiWorld(self.player)
         self.multiworld.game[self.player] = "helper_test_game"
         self.multiworld.player_name = {1: "Tester"}
-        self.multiworld.set_seed(seed)
+        self.multiworld.set_seed()
         self.multiworld.set_default_common_options()
 
     def testRegionHelpers(self) -> None:


### PR DESCRIPTION
## What is this fixing or adding?
I'm guessing seed was meant to be called, rather than passed in as "bound method or function".

## How was this tested?
it is a test

## If this makes graphical changes, please attach screenshots.
