### PR TITLE
Core: fix start_inventory_from_pool 

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -165,19 +165,24 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
             for count in items.values():
                 new_items.append(player_world.create_filler())
         target: int = sum(sum(items.values()) for items in depletion_pool.values())
-        for item in world.itempool:
+        for i, item in enumerate(world.itempool):
             if depletion_pool[item.player].get(item.name, 0):
                 target -= 1
                 depletion_pool[item.player][item.name] -= 1
                 # quick abort if we have found all items
                 if not target:
+                    new_items.extend(world.itempool[i+1:])
                     break
             else:
                 new_items.append(item)
-        for player, remaining_items in depletion_pool.items():
-            if remaining_items:
-                raise Exception(f"{world.get_player_name(player)}"
-                                f" is trying to remove items from their pool that don't exist: {remaining_items}")
+
+        # leftovers?
+        if target:
+            for player, remaining_items in depletion_pool.items():
+                remaining_items = {name: count for name, count in remaining_items.items() if count}
+                if remaining_items:
+                    raise Exception(f"{world.get_player_name(player)}"
+                                    f" is trying to remove items from their pool that don't exist: {remaining_items}")
         world.itempool[:] = new_items
 
     # temporary home for item links, should be moved out of Main


### PR DESCRIPTION
## What is this fixing or adding?
Core: fix start_inventory_from_pool breaking if it's removing the last instance of an item from pool.
Core: fix start_inventory_from_pool removing arbitrary items from pool if quick abort branch is entered.

## How was this tested?
https://discord.com/channels/731205301247803413/1103404853654470706

## If this makes graphical changes, please attach screenshots.
