### PR TITLE
Stardew Valley - Add missing Rare seed when using Seed Shuffle Option [3.x.x]

### DIFF
--- a/worlds/stardew_valley/data/items.csv
+++ b/worlds/stardew_valley/data/items.csv
@@ -187,6 +187,7 @@ id,name,classification,groups
 199,Willy: 1 <3,progression,FRIENDSANITY
 200,Wizard: 1 <3,progression,FRIENDSANITY
 201,Pet: 1 <3,progression,FRIENDSANITY
+251,Rare Seed,progression,"SEED_SHUFFLE"
 5000,Resource Pack: 500 Money,filler,"BASE_RESOURCE,RESOURCE_PACK"
 5001,Resource Pack: 1000 Money,filler,"BASE_RESOURCE,RESOURCE_PACK"
 5002,Resource Pack: 1500 Money,filler,"BASE_RESOURCE,RESOURCE_PACK"

--- a/worlds/stardew_valley/items.py
+++ b/worlds/stardew_valley/items.py
@@ -208,6 +208,8 @@ def create_items(item_factory: StardewItemFactory, locations_count: int, items_t
         if item in items:
             items.remove(item)
 
+    remove_buffs_if_necessary(items, locations_count)
+
     assert len(items) <= locations_count, \
         "There should be at least as many locations as there are mandatory items"
     logger.debug(f"Created {len(items)} unique items")
@@ -431,3 +433,21 @@ def fill_with_resource_packs(item_factory: StardewItemFactory, world_options: op
         items.append(item_factory(resource_pack.create_name_from_multiplier(resource_pack_multiplier)))
 
     return items
+
+
+def remove_buffs_if_necessary(items, locations_count):
+    num_items = len(items)
+    if num_items <= locations_count:
+        return
+    while num_items > locations_count:
+        for item in items:
+            if item.name == "Movement Speed Bonus":
+                items.remove(item)
+                break
+        for item in items:
+            if item.name == "Luck Bonus":
+                items.remove(item)
+                break
+        if num_items == len(items):
+            return
+        num_items = len(items)

--- a/worlds/stardew_valley/logic.py
+++ b/worlds/stardew_valley/logic.py
@@ -649,7 +649,7 @@ class StardewLogic:
         return self.has_max_fishing_rod() & skill_rule
 
     def can_buy_seed(self, seed: SeedItem):
-        if self.options[options.SeedShuffle] == options.SeedShuffle.option_disabled or seed.name == "Rare Seed":
+        if self.options[options.SeedShuffle] == options.SeedShuffle.option_disabled:
             item_rule = True_()
         else:
             item_rule = self.received(seed.name)

--- a/worlds/stardew_valley/test/TestRules.py
+++ b/worlds/stardew_valley/test/TestRules.py
@@ -60,6 +60,10 @@ class TestProgressiveToolsLogic(SVTestBase):
 
         tuesday = self.world.create_item("Traveling Merchant: Tuesday")
         self.multiworld.state.collect(tuesday, event=True)
+        assert not self.world.logic.can_reach_location("Old Master Cannoli")(self.multiworld.state)
+
+        rare_seed = self.world.create_item("Rare Seed")
+        self.multiworld.state.collect(rare_seed, event=True)
         assert self.world.logic.can_reach_location("Old Master Cannoli")(self.multiworld.state)
 
         self.remove(fall)


### PR DESCRIPTION
## What is this fixing or adding?
One seed was missing from Seed shuffle. Since the client waits until you receive it to show it in shops, it needs to get generated

## How was this tested?
Ran the automated tests, plus the changes are all cherry picked from a further ahead branch that is functional
