### PR TITLE
LttP: use local_early_items for Small Key HC in Standard Keyshuffle

### DIFF
--- a/worlds/alttp/__init__.py
+++ b/worlds/alttp/__init__.py
@@ -247,9 +247,11 @@ class ALTTPWorld(World):
         player = self.player
         world = self.multiworld
 
-        if world.mode[player] == 'standard' and world.smallkey_shuffle[player] \
-                and world.smallkey_shuffle[player] != smallkey_shuffle.option_universal and \
-                world.smallkey_shuffle[player] != smallkey_shuffle.option_own_dungeons:
+        if world.mode[player] == 'standard' \
+                and world.smallkey_shuffle[player] \
+                and world.smallkey_shuffle[player] != smallkey_shuffle.option_universal \
+                and world.smallkey_shuffle[player] != smallkey_shuffle.option_own_dungeons \
+                and world.smallkey_shuffle[player] != smallkey_shuffle.option_start_with:
             self.multiworld.local_early_items[self.player]["Small Key (Hyrule Castle)"] = 1
 
         # system for sharing ER layouts

--- a/worlds/alttp/__init__.py
+++ b/worlds/alttp/__init__.py
@@ -247,6 +247,11 @@ class ALTTPWorld(World):
         player = self.player
         world = self.multiworld
 
+        if world.mode[player] == 'standard' and world.smallkey_shuffle[player] \
+                and world.smallkey_shuffle[player] != smallkey_shuffle.option_universal and \
+                world.smallkey_shuffle[player] != smallkey_shuffle.option_own_dungeons:
+            self.multiworld.local_early_items[self.player]["Small Key (Hyrule Castle)"] = 1
+
         # system for sharing ER layouts
         self.er_seed = str(world.random.randint(0, 2 ** 64))
 
@@ -543,12 +548,8 @@ class ALTTPWorld(World):
     @classmethod
     def stage_fill_hook(cls, world, progitempool, usefulitempool, filleritempool, fill_locations):
         trash_counts = {}
-        standard_keyshuffle_players = set()
+
         for player in world.get_game_players("A Link to the Past"):
-            if world.mode[player] == 'standard' and world.smallkey_shuffle[player] \
-                    and world.smallkey_shuffle[player] != smallkey_shuffle.option_universal and \
-                    world.smallkey_shuffle[player] != smallkey_shuffle.option_own_dungeons:
-                standard_keyshuffle_players.add(player)
             if not world.ganonstower_vanilla[player] or \
                     world.logic[player] in {'owglitches', 'hybridglitches', "nologic"}:
                 pass
@@ -557,27 +558,6 @@ class ALTTPWorld(World):
                                                             world.crystals_needed_for_gt[player] * 4)
             else:
                 trash_counts[player] = world.random.randint(0, world.crystals_needed_for_gt[player] * 2)
-
-        # Make sure the escape small key is placed first in standard with key shuffle to prevent running out of spots
-        # TODO: this might be worthwhile to introduce as generic option for various games and then optimize it
-        if standard_keyshuffle_players:
-            viable = {}
-            for location in world.get_locations():
-                if location.player in standard_keyshuffle_players \
-                        and location.item is None \
-                        and location.can_reach(world.state):
-                    viable.setdefault(location.player, []).append(location)
-
-            for player in standard_keyshuffle_players:
-                loc = world.random.choice(viable[player])
-                key = world.create_item("Small Key (Hyrule Castle)", player)
-                loc.place_locked_item(key)
-                fill_locations.remove(loc)
-            world.random.shuffle(fill_locations)
-            # TODO: investigate not creating the key in the first place
-            progitempool[:] = [item for item in progitempool if
-                               item.player not in standard_keyshuffle_players or
-                               item.name != "Small Key (Hyrule Castle)"]
 
         if trash_counts:
             locations_mapping = {player: [] for player in trash_counts}


### PR DESCRIPTION
## What is this fixing or adding?
use local_early_items for Small Key HC in Standard Keyshuffle
Fixes LttP creating an extra Small Key in that mode combo, correcting the item pool counts.

## How was this tested?
with and without the conditions for this item placement met.

## If this makes graphical changes, please attach screenshots.
