### PR TITLE
ALttP: fix minimal + dungeon item fill interaction

### DIFF
--- a/worlds/alttp/Dungeons.py
+++ b/worlds/alttp/Dungeons.py
@@ -164,6 +164,12 @@ def fill_dungeons_restrictive(world):
                                  (5 if (item.player, item.name) in dungeon_specific else 0))
             for item in in_dungeon_items:
                 all_state_base.remove(item)
+
+            # Remove completion condition so that minimal-accessibility worlds place keys properly
+            for player in {item.player for item in in_dungeon_items}:
+                if all_state_base.has("Triforce", player):
+                    all_state_base.remove(world.worlds[player].create_item("Triforce"))
+
             fill_restrictive(world, all_state_base, locations, in_dungeon_items, True, True, allow_excluded=True)
 
 


### PR DESCRIPTION
## What is this fixing or adding?
If dungeon items from minimal worlds were to be filled during `fill_dungeons_restrictive`, the completion condition would not be cleared from `all_state_base` before filling, which caused the accessibility checks to never trigger. This removes the condition to ensure that the fill proceeds correctly.

## How was this tested?
https://discord.com/channels/731205301247803413/731214280439103580/1104724505806524457 yamls no longer fail to roll.