### PR TITLE
[TLOZ] Fix start weapon locations

### DIFF
--- a/worlds/tloz/ItemPool.py
+++ b/worlds/tloz/ItemPool.py
@@ -92,16 +92,17 @@ def get_pool_core(world):
         placed_items[location] = item
 
     # Starting Weapon
+    start_weapon_locations = starting_weapon_locations.copy()
     starting_weapon = random.choice(starting_weapons)
     if world.multiworld.StartingPosition[world.player] == StartingPosition.option_safe:
-        placed_items[starting_weapon_locations[0]] = starting_weapon
+        placed_items[start_weapon_locations[0]] = starting_weapon
     elif world.multiworld.StartingPosition[world.player] in \
             [StartingPosition.option_unsafe, StartingPosition.option_dangerous]:
         if world.multiworld.StartingPosition[world.player] == StartingPosition.option_dangerous:
             for location in dangerous_weapon_locations:
                 if world.multiworld.ExpandedPool[world.player] or "Drop" not in location:
-                    starting_weapon_locations.append(location)
-        placed_items[random.choice(starting_weapon_locations)] = starting_weapon
+                    start_weapon_locations.append(location)
+        placed_items[random.choice(start_weapon_locations)] = starting_weapon
     else:
         pool.append(starting_weapon)
     for other_weapons in starting_weapons:

--- a/worlds/tloz/ItemPool.py
+++ b/worlds/tloz/ItemPool.py
@@ -92,17 +92,16 @@ def get_pool_core(world):
         placed_items[location] = item
 
     # Starting Weapon
-    start_weapon_locations = starting_weapon_locations.copy()
     starting_weapon = random.choice(starting_weapons)
     if world.multiworld.StartingPosition[world.player] == StartingPosition.option_safe:
-        placed_items[start_weapon_locations[0]] = starting_weapon
+        placed_items[starting_weapon_locations[0]] = starting_weapon
     elif world.multiworld.StartingPosition[world.player] in \
             [StartingPosition.option_unsafe, StartingPosition.option_dangerous]:
         if world.multiworld.StartingPosition[world.player] == StartingPosition.option_dangerous:
             for location in dangerous_weapon_locations:
                 if world.multiworld.ExpandedPool[world.player] or "Drop" not in location:
-                    start_weapon_locations.append(location)
-        placed_items[random.choice(start_weapon_locations)] = starting_weapon
+                    starting_weapon_locations.append(location)
+        placed_items[random.choice(starting_weapon_locations)] = starting_weapon
     else:
         pool.append(starting_weapon)
     for other_weapons in starting_weapons:


### PR DESCRIPTION
## What is this fixing or adding?
Makes a fresh copy of starting weapon locations when get_pool_core is ran
Should fix the issue of dangerous_weapon_locations getting appended to the list for other worlds past the first world that has dangerous StartingPosition, as well as running into the error if ExpandedPool was different between players
Credit for fix goes to @Silvris in the AP Discord

(also apologies for stupid commit history. sleepy Figment accidentally committed to my main at first instead of making a new branch)

## How was this tested?
Ran a few gens with a weights yaml for 100 TLOZ worlds

## If this makes graphical changes, please attach screenshots.
