### PR TITLE
KH2: Ability Sync Fix

### DIFF
--- a/KH2Client.py
+++ b/KH2Client.py
@@ -272,6 +272,10 @@ class KH2Context(CommonContext):
         if cmd in {"ReceivedItems"}:
             start_index = args["index"]
             if start_index == 0:
+                # resetting everything that were sent from the server
+                self.kh2seedsave["SoraInvo"][0] = 0x25D8
+                self.kh2seedsave["DonaldInvo"][0] = 0x26F4
+                self.kh2seedsave["GoofyInvo"][0] = 0x280A
                 self.kh2seedsave["itemIndex"] = - 1
                 self.kh2seedsave["AmountInvo"]["ServerItems"] = {
                     "Ability":      {},
@@ -429,8 +433,7 @@ class KH2Context(CommonContext):
                 if len(self.kh2seedsave["AmountInvo"][ItemType]["Ability"][itemname]) < \
                         self.AbilityQuantityDict[itemname]:
                     if itemname in self.sora_ability_set:
-                        self.kh2seedsave["AmountInvo"][ItemType]["Ability"][itemname].append(
-                                self.kh2seedsave["SoraInvo"][abilityInvoType])
+                        self.kh2seedsave["AmountInvo"][ItemType]["Ability"][itemname].append(self.kh2seedsave["SoraInvo"][abilityInvoType])
                         self.kh2seedsave["SoraInvo"][abilityInvoType] -= TwilightZone
                     elif itemname in self.donald_ability_set:
                         self.kh2seedsave["AmountInvo"][ItemType]["Ability"][itemname].append(
@@ -641,7 +644,10 @@ class KH2Context(CommonContext):
                     current = self.kh2.read_short(self.kh2.base_address + self.Save + slot)
                     ability = current & 0x0FFF
                     if ability | 0x8000 != (0x8000 + itemData.memaddr):
-                        self.kh2.write_short(self.kh2.base_address + self.Save + slot, itemData.memaddr)
+                        if current - 0x8000 > 0:
+                            self.kh2.write_short(self.kh2.base_address + self.Save + slot, (0x8000 + itemData.memaddr))
+                        else:
+                            self.kh2.write_short(self.kh2.base_address + self.Save + slot, itemData.memaddr)
             # removes the duped ability if client gave faster than the game.
             for charInvo in {"SoraInvo", "DonaldInvo", "GoofyInvo"}:
                 if self.kh2.read_short(self.kh2.base_address + self.Save + self.kh2seedsave[charInvo][1]) != 0 and \
@@ -730,7 +736,9 @@ class KH2Context(CommonContext):
                 if int.from_bytes(self.kh2.read_bytes(self.kh2.base_address + self.Save + itemData.memaddr, 1),
                                   "big") != amountOfItems \
                         and int.from_bytes(self.kh2.read_bytes(self.kh2.base_address + self.Slot1 + 0x1B2, 1),
-                                           "big") >= 5 and 0x130293 in self.locations_checked:
+                                           "big") >= 5 and int.from_bytes(
+                        self.kh2.read_bytes(self.kh2.base_address + self.Save + 0x23DF, 1),
+                        "big") > 0:
                     self.kh2.write_bytes(self.kh2.base_address + self.Save + itemData.memaddr,
                                          amountOfItems.to_bytes(1, 'big'), 1)
 


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?
When reconnecting and getting a 0 packet it doesnt reset the inventory slot so it starts from where it left off instead of at the beginning.

## How was this tested?
I connected to the server, got a ability from the server then disconnected then reconnected and it didnt overwrite/duplicate the ability

## If this makes graphical changes, please attach screenshots.
