### PR TITLE
Core: skip ModuleUpdate in subprocess

### DIFF
--- a/ModuleUpdate.py
+++ b/ModuleUpdate.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import subprocess
+import multiprocessing
 import warnings
 
 local_dir = os.path.dirname(__file__)
@@ -9,7 +10,8 @@ requirements_files = {os.path.join(local_dir, 'requirements.txt')}
 if sys.version_info < (3, 8, 6):
     raise RuntimeError("Incompatible Python Version. 3.8.7+ is supported.")
 
-update_ran = getattr(sys, "frozen", False)  # don't run update if environment is frozen/compiled
+# don't run update if environment is frozen/compiled or if not the parent process (skip in subprocess)
+update_ran = getattr(sys, "frozen", False) or multiprocessing.parent_process()
 
 if not update_ran:
     for entry in os.scandir(os.path.join(local_dir, "worlds")):


### PR DESCRIPTION
## What is this fixing or adding?
skip ModuleUpdate in subprocess

ModuleUpdate can be skipped for speed in multiprocessing cases.
Also, when not getting everything installed, like apsc2 for 3.11 currently, a subprocess may ask for installation attempts again.

## How was this tested?
locally on 3.11

## If this makes graphical changes, please attach screenshots.
