### PR TITLE
KH2-AntipointReset

### DIFF
--- a/KH2Client.py
+++ b/KH2Client.py
@@ -433,7 +433,8 @@ class KH2Context(CommonContext):
                 if len(self.kh2seedsave["AmountInvo"][ItemType]["Ability"][itemname]) < \
                         self.AbilityQuantityDict[itemname]:
                     if itemname in self.sora_ability_set:
-                        self.kh2seedsave["AmountInvo"][ItemType]["Ability"][itemname].append(self.kh2seedsave["SoraInvo"][abilityInvoType])
+                        self.kh2seedsave["AmountInvo"][ItemType]["Ability"][itemname].append(
+                                self.kh2seedsave["SoraInvo"][abilityInvoType])
                         self.kh2seedsave["SoraInvo"][abilityInvoType] -= TwilightZone
                     elif itemname in self.donald_ability_set:
                         self.kh2seedsave["AmountInvo"][ItemType]["Ability"][itemname].append(
@@ -686,6 +687,10 @@ class KH2Context(CommonContext):
                         self.kh2.read_bytes(self.kh2.base_address + self.Save + itemData.memaddr, 1), "big")
                 if (int.from_bytes(self.kh2.read_bytes(self.kh2.base_address + self.Save + itemData.memaddr, 1),
                                    "big") & 0x1 << itemData.bitmask) == 0:
+                    # when getting a form anti points should be reset to 0 but bit-shift doesn't trigger the game.
+                    if itemName in {"Valor Form", "Wisdom Form", "Limit Form", "Master Form", "Final Form"}:
+                        self.kh2.write_bytes(self.kh2.base_address + self.Save + 0x3410,
+                                             (0).to_bytes(1, 'big'), 1)
                     self.kh2.write_bytes(self.kh2.base_address + self.Save + itemData.memaddr,
                                          (itemMemory | 0x01 << itemData.bitmask).to_bytes(1, 'big'), 1)
 


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?
When getting a drive form normally sora's anti points reset to 0. However, when writing the form into sora's inventory doesn't trigger the game to do this so I do it manually. 

## How was this tested?
I had 1 anti point and gave sora a drive form then it reset to 0.

## If this makes graphical changes, please attach screenshots.
