### PR TITLE
WebHost: index columns used by landing page.

### DIFF
--- a/WebHostLib/models.py
+++ b/WebHostLib/models.py
@@ -21,7 +21,7 @@ class Slot(db.Entity):
 class Room(db.Entity):
     id = PrimaryKey(UUID, default=uuid4)
     last_activity = Required(datetime, default=lambda: datetime.utcnow(), index=True)
-    creation_time = Required(datetime, default=lambda: datetime.utcnow())
+    creation_time = Required(datetime, default=lambda: datetime.utcnow(), index=True)  # index used by landing page
     owner = Required(UUID, index=True)
     commands = Set('Command')
     seed = Required('Seed', index=True)
@@ -38,7 +38,7 @@ class Seed(db.Entity):
     rooms = Set(Room)
     multidata = Required(bytes, lazy=True)
     owner = Required(UUID, index=True)
-    creation_time = Required(datetime, default=lambda: datetime.utcnow())
+    creation_time = Required(datetime, default=lambda: datetime.utcnow(), index=True)  # index used by landing page
     slots = Set(Slot)
     spoiler = Optional(LongStr, lazy=True)
     meta = Required(LongStr, default=lambda: "{\"race\": false}")  # additional meta information/tags


### PR DESCRIPTION
## What is this fixing or adding?
```
[2023-05-19 19:11:01,203] GET NEW CONNECTION
[2023-05-19 19:11:01,205] SELECT COUNT(*)
FROM `room` `room`
WHERE `room`.`creation_time` >= %s
[datetime.datetime(2023, 5, 12, 19, 11, 1, 203309)]
[2023-05-19 19:11:11,214] SELECT COUNT(*)
FROM `seed` `seed`
WHERE `seed`.`creation_time` >= %s
[datetime.datetime(2023, 5, 12, 19, 11, 11, 214101)]
[2023-05-19 19:11:27,055] COMMIT
[2023-05-19 19:11:27,056] RELEASE CONNECTION
```

Gets turned into:
```
[2023-05-19 19:16:47,013] GET NEW CONNECTION
[2023-05-19 19:16:47,014] SELECT COUNT(*)
FROM `room` `room`
WHERE `room`.`creation_time` >= %s
[datetime.datetime(2023, 5, 12, 19, 16, 47, 12650)]
[2023-05-19 19:16:47,015] SELECT COUNT(*)
FROM `seed` `seed`
WHERE `seed`.`creation_time` >= %s
[datetime.datetime(2023, 5, 12, 19, 16, 47, 15504)]
[2023-05-19 19:16:47,027] COMMIT
[2023-05-19 19:16:47,027] RELEASE CONNECTION
```

## How was this tested?
on prod

## If this makes graphical changes, please attach screenshots.
