### PR TITLE
DLCQuest: Fix Documentation Broken Link 

### DIFF
--- a/worlds/dlcquest/docs/setup_en.md
+++ b/worlds/dlcquest/docs/setup_en.md
@@ -19,7 +19,7 @@ guide: [Basic Multiworld Setup Guide](/tutorial/Archipelago/setup/en)
 
 ### Where do I get a YAML file?
 
-You can customize your settings by visiting the [DLC Quest Player Settings Page](../player-settings)
+You can customize your settings by visiting the [DLC Quest Player Settings Page](/games/DLCQuest/player-settings)
 
 ## Joining a MultiWorld Game
 


### PR DESCRIPTION
## What is this fixing or adding?
The link to the setting page was incorrect, it has been fix.

## How was this tested?
It is markdown.
