### PR TITLE
[Blasphemous] Various logic fixes

### DIFF
--- a/worlds/blasphemous/Rules.py
+++ b/worlds/blasphemous/Rules.py
@@ -488,8 +488,7 @@ def rules(blasphemousworld):
                 state._blasphemous_fall_relic(player))) or \
                     (state._blasphemous_root_relic(player) and \
                         state._blasphemous_cherub_6(player)) or \
-                            (state._blasphemous_debla(player) or \
-                                state._blasphemous_taranto(player)))
+                            state._blasphemous_taranto(player))
     set_rule(world.get_location("BotSS: Starting room ledge", player),
         lambda state: state._blasphemous_blood_relic(player) and \
             state._blasphemous_fall_relic(player))

--- a/worlds/blasphemous/Rules.py
+++ b/worlds/blasphemous/Rules.py
@@ -134,7 +134,7 @@ class BlasphemousLogic(LogicMixin):
                         self.has("Fervour Upgrade", player, 2))
     
     def _blasphemous_cherub_20(self, player):
-        return self.has_any({"Debla of the Lights", "Lorqiana", "Zarabanda of the Safe Haven", "Taranto to my Sister", \
+        return self.has_any({"Debla of the Lights", "Lorquiana", "Zarabanda of the Safe Haven", "Taranto to my Sister", \
             "Cante Jondo of the Three Sisters", "Cloistered Ruby"}, player) or \
                     (self.has_any({"Aubade of the Nameless Guardian", "Tirana of the Celestial Bastion"}, player) and \
                         self.has("Fervour Upgrade", player, 2))
@@ -484,9 +484,9 @@ def rules(blasphemousworld):
     # Brotherhood of the Silent Sorrow
     set_rule(world.get_location("BotSS: Starting room Child of Moonlight", player),
         lambda state: (state._blasphemous_blood_relic(player) and \
-            (state._blasphemous_root_relic(player)) or \
-                (state._blasphemous_fall_relic(player))) or \
-                    (state._blasphemous_blood_relic(player) and \
+            (state._blasphemous_root_relic(player) or \
+                state._blasphemous_fall_relic(player))) or \
+                    (state._blasphemous_root_relic(player) and \
                         state._blasphemous_cherub_6(player)) or \
                             (state._blasphemous_debla(player) or \
                                 state._blasphemous_taranto(player)))
@@ -555,9 +555,11 @@ def rules(blasphemousworld):
             state._blasphemous_bridge_access(player) and \
                 state._blasphemous_1_mask(player) and \
                     state._blasphemous_bronze_key(player) and \
-                        state._blasphemous_miasma_relic(player) and \
+                        (state._blasphemous_miasma_relic(player) and \
                             state._blasphemous_water_relic(player) and \
-                                state._blasphemous_root_relic(player))
+                                state._blasphemous_root_relic(player) or \
+                                    state._blasphemous_fall_relic(player) and \
+                                        state._blasphemous_root_relic(player)))
     set_rule(world.get_location("DC: Child of Moonlight, behind pillar", player),
         lambda state: state._blasphemous_miasma_relic(player) and \
             state._blasphemous_water_relic(player))
@@ -700,21 +702,19 @@ def rules(blasphemousworld):
             state._blasphemous_root_relic(player))
     set_rule(world.get_location("MaH: Sierpes' eye", player),
         lambda state: state._blasphemous_bridge_access(player) and \
-            (state._blasphemous_root_relic(player)) or \
+            (state._blasphemous_root_relic(player) or \
                 state._blasphemous_water_relic(player) or \
-                    state._blasphemous_dawn_heart(player))
+                    state._blasphemous_dawn_heart(player)))
     set_rule(world.get_location("MaH: Sierpes", player),
         lambda state: state._blasphemous_bridge_access(player) and \
-            (state._blasphemous_root_relic(player)) or \
+            (state._blasphemous_root_relic(player) or \
                 state._blasphemous_water_relic(player) or \
-                    state._blasphemous_dawn_heart(player))
+                    state._blasphemous_dawn_heart(player)))
 
     # Patio of the Silent Steps
     set_rule(world.get_location("PotSS: Second area ledge", player),
         lambda state: state._blasphemous_root_relic(player) or \
-            state._blasphemous_dawn_heart(player) or \
-                (state._blasphemous_wheel(player) and \
-                    state._blasphemous_ranged(player)))
+            state._blasphemous_dawn_heart(player))
     set_rule(world.get_location("PotSS: Third area upper ledge", player),
         lambda state: state._blasphemous_root_relic(player) or \
             state._blasphemous_dawn_heart(player))
@@ -855,15 +855,15 @@ def rules(blasphemousworld):
     set_rule(world.get_location("Confessor Dungeon 6 extra", player),
         lambda state: state._blasphemous_bead(player) and \
             state._blasphemous_bridge_access(player) and \
-                (state._blasphemous_1_mask(player) or \
-                    state._blasphemous_blood_relic(player) and \
+                (state._blasphemous_blood_relic(player) or \
+                    state._blasphemous_1_mask(player) and \
                         state._blasphemous_silver_key(player) and \
                             state._blasphemous_bronze_key(player)))
     set_rule(world.get_location("Confessor Dungeon 6 main", player),
         lambda state: state._blasphemous_bead(player) and \
             state._blasphemous_bridge_access(player) and \
-                (state._blasphemous_1_mask(player) or \
-                    state._blasphemous_blood_relic(player) and \
+                (state._blasphemous_blood_relic(player) or \
+                    state._blasphemous_1_mask(player) and \
                         state._blasphemous_silver_key(player) and \
                             state._blasphemous_bronze_key(player)))
     set_rule(world.get_location("Confessor Dungeon 7 extra", player),
@@ -887,15 +887,15 @@ def rules(blasphemousworld):
     set_rule(world.get_location("Defeat 2 Amanecidas", player),
         lambda state: state._blasphemous_bell(player) and \
             state._blasphemous_open_holes(player) and \
-                state._blasphemous_blood_relic(player) and \
-                    (state._blasphemous_root_relic(player) or \
+                (state._blasphemous_blood_relic(player) and \
+                    state._blasphemous_root_relic(player) or \
                         state._blasphemous_bridge_access(player)))
     set_rule(world.get_location("Defeat 3 Amanecidas", player),
         lambda state: state._blasphemous_bell(player) and \
             state._blasphemous_open_holes(player) and \
                 state._blasphemous_bridge_access(player) and \
-                    state._blasphemous_blood_relic(player) and \
-                        (state._blasphemous_root_relic(player) or \
+                    (state._blasphemous_blood_relic(player) and \
+                        state._blasphemous_root_relic(player) or \
                             (state._blasphemous_1_mask(player) and \
                                 state._blasphemous_bronze_key(player) and \
                                     state._blasphemous_silver_key(player))))
@@ -1030,6 +1030,11 @@ def rules(blasphemousworld):
                         state._blasphemous_water_relic(player) or \
                             (state._blasphemous_wheel(player) and \
                                 state._blasphemous_ranged(player)))
+        set_rule(world.get_location("PotSS: Second area ledge", player),
+            lambda state: state._blasphemous_root_relic(player) or \
+                state._blasphemous_dawn_heart(player) or \
+                    (state._blasphemous_wheel(player) and \
+                        state._blasphemous_ranged(player)))
         set_rule(world.get_location("PotSS: Third area upper ledge", player),
             lambda state: state._blasphemous_root_relic(player) or \
                 state._blasphemous_dawn_heart(player) or \
@@ -1049,15 +1054,15 @@ def rules(blasphemousworld):
         set_rule(world.get_location("Confessor Dungeon 6 extra", player),
             lambda state: state._blasphemous_bead(player) and \
                 state._blasphemous_ex_bridge_access(player) and \
-                    (state._blasphemous_1_mask(player) or \
-                        state._blasphemous_blood_relic(player) and \
+                    (state._blasphemous_blood_relic(player) or \
+                        state._blasphemous_1_mask(player) and \
                             state._blasphemous_silver_key(player) and \
                                 state._blasphemous_bronze_key(player)))
         set_rule(world.get_location("Confessor Dungeon 6 main", player),
             lambda state: state._blasphemous_bead(player) and \
                 state._blasphemous_ex_bridge_access(player) and \
-                    (state._blasphemous_1_mask(player) or \
-                        state._blasphemous_blood_relic(player) and \
+                    (state._blasphemous_blood_relic(player) or \
+                        state._blasphemous_1_mask(player) and \
                             state._blasphemous_silver_key(player) and \
                                 state._blasphemous_bronze_key(player)))
         set_rule(world.get_location("Confessor Dungeon 7 extra", player),
@@ -1077,15 +1082,15 @@ def rules(blasphemousworld):
         set_rule(world.get_location("Defeat 2 Amanecidas", player),
             lambda state: state._blasphemous_bell(player) and \
                 state._blasphemous_open_holes(player) and \
-                    state._blasphemous_blood_relic(player) and \
-                        (state._blasphemous_root_relic(player) or \
+                    (state._blasphemous_blood_relic(player) and \
+                        state._blasphemous_root_relic(player) or \
                             state._blasphemous_ex_bridge_access(player)))
         set_rule(world.get_location("Defeat 3 Amanecidas", player),
             lambda state: state._blasphemous_bell(player) and \
                 state._blasphemous_open_holes(player) and \
                     state._blasphemous_ex_bridge_access(player) and \
-                        state._blasphemous_blood_relic(player) and \
-                            (state._blasphemous_root_relic(player) or \
+                        (state._blasphemous_blood_relic(player) and \
+                            state._blasphemous_root_relic(player) or \
                                 (state._blasphemous_1_mask(player) and \
                                     state._blasphemous_bronze_key(player) and \
                                         state._blasphemous_silver_key(player))))


### PR DESCRIPTION
## What is this fixing or adding?

This makes a few changes to logic to better match the 1.3 rando's logic. This fixes instances where the wrong items were expected, fixes a typo of "Lorqiana", moves the expert logic on "PotSS: Second area ledge" to only apply if on expert, and adds a new route to "DC: Mea Culpa altar" via Linen of Golden Thread + Three Gnarled Tongues

## How was this tested?

By comparing the AP logic to the rando 1.3 logic. The Mea Culpa route was tested manually, in-game.