### PR TITLE
Docs: add info about maintaining worlds

### DIFF
--- a/docs/adding games.md
+++ b/docs/adding games.md
@@ -341,3 +341,4 @@ The various methods and attributes are documented in `/worlds/AutoWorld.py[World
 [world api.md](https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/world%20api.md),
 though it is also recommended to look at existing implementations to see how all this works first-hand. 
 Once you get all that, all that remains to do is test the game and publish your work.
+Make sure to check out [world maintainer.md](./world%20maintainer.md) before publishing.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -10,5 +10,5 @@ Otherwise, we tend to judge code on a case to case basis.
 For adding a new game to Archipelago and other documentation on how Archipelago functions, please see 
 [the docs folder](/docs/) for the relevant information and feel free to ask any questions in the #archipelago-dev 
 channel in our [Discord](https://archipelago.gg/discord).
-If you want to merge a new game, please make sure to read the responsibilites as
+If you want to merge a new game, please make sure to read the responsibilities as
 [world maintainer](/docs/world%20maintainer.md).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -10,3 +10,5 @@ Otherwise, we tend to judge code on a case to case basis.
 For adding a new game to Archipelago and other documentation on how Archipelago functions, please see 
 [the docs folder](/docs/) for the relevant information and feel free to ask any questions in the #archipelago-dev 
 channel in our [Discord](https://archipelago.gg/discord).
+If you want to merge a new game, please make sure to read the responsibilites as
+[world maintainer](/docs/world%20maintainer.md).

--- a/docs/world maintainer.md
+++ b/docs/world maintainer.md
@@ -31,7 +31,8 @@ nominate someone else (i.e. there are multiple devs).
 ### Getting Voted
 
 When a world is unmaintained, the [core maintainers](https://github.com/orgs/ArchipelagoMW/people)
-can vote for a new maintainer if there is a candidate. The majority of valid, duly votes has to be in favor.
+can vote for a new maintainer if there is a candidate.
+For a vote to pass, the majority of participating core maintainers must vote in the affirmative.
 The time limit is 1 week, but can end early if the majority is reached earlier.
 Voting shall be conducted on Discord in #archipelago-dev.
 
@@ -45,11 +46,12 @@ A world maintainer can resign. If no new maintainer steps up and gets voted, the
 ### Getting Voted out
 
 A world maintainer can be voted out by the [core maintainers](https://github.com/orgs/ArchipelagoMW/people),
-for example when they become unreachable. The majority of valid, duly votes has to be in favor.
+for example when they become unreachable.
+For a vote to pass, the majority of participating core maintainers must vote in the affirmative.
 The time limit is 2 weeks, but can end early if the majority is reached earlier AND the world maintainer was pinged and
 made their case or was pinged and has been unreachable for more than 2 weeks already.
-Voting shall be conducted on Discord in #archipelago-dev.
-Commits that are a direct result of the voting shall include date, voting members and final result in the commit message
+Voting shall be conducted on Discord in #archipelago-dev. Commits that are a direct result of the voting shall include
+date, voting members and final result in the commit message.
 
 
 ## Handling of Unmaintained Worlds

--- a/docs/world maintainer.md
+++ b/docs/world maintainer.md
@@ -15,7 +15,7 @@ Unless these are shared between multiple people, we expect the following from ea
 * Review contents of such pull requests or organize peer reviews or post that you did not review the content.
 * Fix or point out issues when core changes break your code.
 * Use the watch function on GitHub, the #github-updates channel on Discord or check manually from time to time for new
-  pull requests. Core maintainers may also ping you if a pull request concerns your world,
+  pull requests. Core maintainers may also ping you if a pull request concerns your world.
 * Test (or have tested) the world on the main branch from time to time, especially during RC (release candidate) phases
   of development.
 * Let us know of long unavailabilities.
@@ -49,9 +49,10 @@ for example when they become unreachable. The majority of valid, duly votes has 
 The time limit is 2 weeks, but can end early if the majority is reached earlier AND the world maintainer was pinged and
 made their case or was pinged and has been unreachable for more than 2 weeks already.
 Voting shall be conducted on Discord in #archipelago-dev.
+Commits that are a direct result of the voting shall include date, voting members and final result in the commit message
 
 
 ## Handling of Unmaintained Worlds
 
 As long as worlds are known to work for the most part, they can stay included. Once a world becomes broken it shall be
-moved from `worlds/` to `disabled/`.
+moved from `worlds/` to `worlds_disabled/`.

--- a/docs/world maintainer.md
+++ b/docs/world maintainer.md
@@ -54,4 +54,4 @@ Voting shall be conducted on Discord in #archipelago-dev.
 ## Handling of Unmaintained Worlds
 
 As long as worlds are known to work for the most part, they can stay included. Once a world becomes broken it shall be
-moved from `worlds/` to `staging/`.
+moved from `worlds/` to `disabled/`.

--- a/docs/world maintainer.md
+++ b/docs/world maintainer.md
@@ -33,6 +33,7 @@ nominate someone else (i.e. there are multiple devs).
 When a world is unmaintained, the [core maintainers](https://github.com/orgs/ArchipelagoMW/people)
 can vote for a new maintainer if there is a candidate. The majority of valid, duly votes has to be in favor.
 The time limit is 1 week, but can end early if the majority is reached earlier.
+Voting shall be conducted on Discord in #archipelago-dev.
 
 
 ## Dropping out
@@ -47,6 +48,7 @@ A world maintainer can be voted out by the [core maintainers](https://github.com
 for example when they become unreachable. The majority of valid, duly votes has to be in favor.
 The time limit is 2 weeks, but can end early if the majority is reached earlier AND the world maintainer was pinged and
 made their case or was pinged and has been unreachable for more than 2 weeks already.
+Voting shall be conducted on Discord in #archipelago-dev.
 
 
 ## Handling of Unmaintained Worlds

--- a/docs/world maintainer.md
+++ b/docs/world maintainer.md
@@ -3,7 +3,7 @@
 A world maintainer is a person responsible for a world or part of a world in Archipelago.
 
 If a world author does not want to take on the responsibilities of a world maintainer, they can release their world as
-a "private" [APWorld]((/docs/apworld%20specification.md) or maintain their own fork instead.
+a "private" [APWorld](/docs/apworld%20specification.md) or maintain their own fork instead.
 
 
 ## Responsibilites
@@ -14,7 +14,7 @@ Unless those are shared between multiple people, we expect the following from ea
 * Decide if a feature (pull request) should be merged.
 * Review contents of such pull requests or organize peer reviews or post that you did not review the content.
 * Fix or point out issues when core changes break your code.
-* Use the watch function on github, the #github-updates channel in discord or check manually from time to time for new
+* Use the watch function on github, the #github-updates channel on Discord or check manually from time to time for new
   pull requests. Core maintainers may also ping you if a pull request concerns your world,
 * Test (or have tested) the world on the main branch from time to time, especially during RC (release candidate) phases
   of development.

--- a/docs/world maintainer.md
+++ b/docs/world maintainer.md
@@ -30,8 +30,9 @@ nominate someone else (i.e. there are multiple devs).
 
 ### Getting Voted
 
-When a world is unmaintained, the core maintainers can vote for a new maintainer if there is a candidate. The majority
-of valid, duly votes has to be in favor. The time limit is 1 week, but can end early if the majority is reached earlier.
+When a world is unmaintained, the [core maintainers](https://github.com/orgs/ArchipelagoMW/people)
+can vote for a new maintainer if there is a candidate. The majority of valid, duly votes has to be in favor.
+The time limit is 1 week, but can end early if the majority is reached earlier.
 
 
 ## Dropping out
@@ -42,10 +43,10 @@ A world maintainer can resign. If no new maintainer steps up and gets voted, the
 
 ### Getting Voted out
 
-A world maintainer can be voted out by the core maintainers, for example when they become unreachable. The majority of
-valid, duly votes has to be in favor. The time limit is 2 weeks, but can end early if the majority is reached earlier
-AND the world maintainer was pinged and made their case or was pinged and has been unreachable for more than 2 weeks
-already.
+A world maintainer can be voted out by the [core maintainers](https://github.com/orgs/ArchipelagoMW/people),
+for example when they become unreachable. The majority of valid, duly votes has to be in favor.
+The time limit is 2 weeks, but can end early if the majority is reached earlier AND the world maintainer was pinged and
+made their case or was pinged and has been unreachable for more than 2 weeks already.
 
 
 ## Handling of Unmaintained Worlds

--- a/docs/world maintainer.md
+++ b/docs/world maintainer.md
@@ -6,7 +6,7 @@ If a world author does not want to take on the responsibilities of a world maint
 an unofficial [APWorld](/docs/apworld%20specification.md) or maintain their own fork instead.
 
 
-## Responsibilites
+## Responsibilities
 
 Unless these are shared between multiple people, we expect the following from each world maintainer
 
@@ -14,11 +14,11 @@ Unless these are shared between multiple people, we expect the following from ea
 * Decide if a feature (pull request) should be merged.
 * Review contents of such pull requests or organize peer reviews or post that you did not review the content.
 * Fix or point out issues when core changes break your code.
-* Use the watch function on github, the #github-updates channel on Discord or check manually from time to time for new
+* Use the watch function on GitHub, the #github-updates channel on Discord or check manually from time to time for new
   pull requests. Core maintainers may also ping you if a pull request concerns your world,
 * Test (or have tested) the world on the main branch from time to time, especially during RC (release candidate) phases
   of development.
-* Let us know of long unavailabilites.
+* Let us know of long unavailabilities.
 
 
 ## Becoming a World Maintainer

--- a/docs/world maintainer.md
+++ b/docs/world maintainer.md
@@ -1,0 +1,54 @@
+# World Maintainer
+
+A world maintainer is a person responsible for a world or part of a world in Archipelago.
+
+If a world author does not want to take on the responsibilities of a world maintainer, they can release their world as
+a "private" [APWorld]((/docs/apworld%20specification.md) or maintain their own fork instead.
+
+
+## Responsibilites
+
+Unless those are shared between multiple people, we expect the following from each world maintainer
+
+* Be on our Discord to get updates on problems with and suggestions for the world.
+* Decide if a feature (pull request) should be merged.
+* Review contents of such pull requests or organize peer reviews or post that you did not review the content.
+* Fix or point out issues when core changes break your code.
+* Use the watch function on github, the #github-updates channel in discord or check manually from time to time for new
+  pull requests. Core maintainers may also ping you if a pull request concerns your world,
+* Test (or have tested) the world on the main branch from time to time, especially during RC (release candidate) phases
+  of development.
+* Let us know of long unavailabilites.
+
+
+## Becoming a World Maintainer
+
+### Adding a World
+
+When we merge your world into the core Archipelago repository, you automatically become world maintainer unless you
+nominate someone else (i.e. there are multiple devs).
+
+### Getting Voted
+
+When a world is unmaintained, the core maintainers can vote for a new maintainer if there is a candidate. The majority
+of valid, duly votes has to be in favor. The time limit is 1 week, but can end early if the majority is reached earlier.
+
+
+## Dropping out
+
+### Resigning
+
+A world maintainer can resign. If no new maintainer steps up and gets voted, the world becomes unmaintained.
+
+### Getting Voted out
+
+A world maintainer can be voted out by the core maintainers, for example when they become unreachable. The majority of
+valid, duly votes has to be in favor. The time limit is 2 weeks, but can end early if the majority is reached earlier
+AND the world maintainer was pinged and made their case or was pinged and has been unreachable for more than 2 weeks
+already.
+
+
+## Handling of Unmaintained Worlds
+
+As long as worlds are known to work for the most part, they can stay included. Once a world becomes broken it shall be
+moved from `worlds/` to `staging/`.

--- a/docs/world maintainer.md
+++ b/docs/world maintainer.md
@@ -3,12 +3,12 @@
 A world maintainer is a person responsible for a world or part of a world in Archipelago.
 
 If a world author does not want to take on the responsibilities of a world maintainer, they can release their world as
-a "private" [APWorld](/docs/apworld%20specification.md) or maintain their own fork instead.
+an unofficial [APWorld](/docs/apworld%20specification.md) or maintain their own fork instead.
 
 
 ## Responsibilites
 
-Unless those are shared between multiple people, we expect the following from each world maintainer
+Unless these are shared between multiple people, we expect the following from each world maintainer
 
 * Be on our Discord to get updates on problems with and suggestions for the world.
 * Decide if a feature (pull request) should be merged.


### PR DESCRIPTION
Adds responsibilities of world maintainers/authors to the docs and proposes some rules how to fairly vote in and out maintainers.

Who should we ping?