### PR TITLE
LADX: use custom collect/remove to keep track of logical rupee counts instead of LogixMixin

### DIFF
--- a/worlds/ladx/Items.py
+++ b/worlds/ladx/Items.py
@@ -32,12 +32,16 @@ class DungeonItemData(ItemData):
         s = self.ladxr_id[:-1]
         return DungeonItemType.__dict__[s]
 
+
 class TradeItemData(ItemData):
     vanilla_location = None
+
     def __new__(cls, item_name, ladxr_id, classification, vanilla_location):
         self = super(ItemData, cls).__new__(cls, (item_name, ladxr_id, classification))
         self.vanilla_location = vanilla_location
         return self
+
+
 class LinksAwakeningItem(Item):
     game: str = Common.LINKS_AWAKENING
 
@@ -48,6 +52,7 @@ class LinksAwakeningItem(Item):
 
         super().__init__(item_data.item_name, classification, Common.BASE_ID + item_data.item_id, player)
         self.item_data = item_data
+
 
 # TODO: use _NAMES instead?
 class ItemName:

--- a/worlds/ladx/Locations.py
+++ b/worlds/ladx/Locations.py
@@ -1,12 +1,11 @@
-from BaseClasses import Region, Entrance, Location
-from worlds.AutoWorld import LogicMixin
+from BaseClasses import Region, Entrance, Location, CollectionState
 
 
 from .LADXR.checkMetadata import checkMetadataTable
 from .Common import *
 from worlds.generic.Rules import add_item_rule
-from .Items import ladxr_item_to_la_item_name, ItemName, LinksAwakeningItem
-from .LADXR.locations.tradeSequence import TradeRequirements, TradeSequenceItem
+from .Items import ladxr_item_to_la_item_name
+
 
 prefilled_events = ["ANGLER_KEYHOLE", "RAFT", "MEDICINE2", "CASTLE_BUTTON"]
 
@@ -80,27 +79,19 @@ class LinksAwakeningLocation(Location):
         add_item_rule(self, filter_item)
 
 
-def has_free_weapon(state: "CollectionState", player: int) -> bool:
+def has_free_weapon(state: CollectionState, player: int) -> bool:
     return state.has("Progressive Sword", player) or state.has("Magic Rod", player) or state.has("Boomerang", player) or state.has("Hookshot", player)
 
+
 # If the player has access to farm enough rupees to afford a game, we assume that they can keep beating the game
-def can_farm_rupees(state: "CollectionState", player: int) -> bool:
+def can_farm_rupees(state: CollectionState, player: int) -> bool:
     return has_free_weapon(state, player) and (state.has("Can Play Trendy Game", player=player) or state.has("RAFT", player=player))
 
 
-class LinksAwakeningLogic(LogicMixin):
-    rupees = {
-        ItemName.RUPEES_20: 0,
-        ItemName.RUPEES_50: 0,
-        ItemName.RUPEES_100: 100,
-        ItemName.RUPEES_200: 200,
-        ItemName.RUPEES_500: 500,
-    }
-
-    def get_credits(self, player: int):
-        if can_farm_rupees(self, player):
-            return 999999999
-        return sum(self.count(item_name, player) * amount for item_name, amount in self.rupees.items())
+def get_credits(state: CollectionState, player: int):
+    if can_farm_rupees(state, player):
+        return 999999999
+    return state.prog_items["RUPEES", player]
 
 
 class LinksAwakeningRegion(Region):
@@ -137,7 +128,7 @@ class GameStateAdapater:
 
     def get(self, item, default):
         if item == "RUPEES":
-            return self.state.get_credits(self.player)
+            return get_credits(self.state, self.player)
         elif item.endswith("_USED"):
             return 0
         else:


### PR DESCRIPTION
## What is this fixing or adding?
https://github.com/ArchipelagoMW/Archipelago/issues/1840
use custom collect/remove to keep track of logical rupee counts instead of LogixMixin
Didn't test, but it should be marginally faster
May contain some pep8, sorry

## How was this tested?
only once so far

@zig-for 
