### PR TITLE
Hollow Knight:  fix split cloak for reverse fill

### DIFF
--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -519,13 +519,15 @@ class HKWorld(World):
                 prog_items[effect_name, self.player] += effect_value
 
             # a directional overflow in dash grants an upgrade for the other side
-            if item.name in {"Left_Mothwing_Cloak", "Right_Mothwing_Cloak"}:
-                if prog_items["RIGHTDASH", self.player] > 2 > prog_items["LEFTDASH", self.player]:
-                    prog_items["OVERFLOWLEFTDASH", self.player] += 1
-                    prog_items["LEFTDASH", self.player] += 1
-                elif prog_items["LEFTDASH", self.player] > 2 > prog_items["RIGHTDASH", self.player]:
-                    prog_items["OVERFLOWRIGHTDASH", self.player] += 1
-                    prog_items["RIGHTDASH", self.player] += 1
+            if item.name == "Right_Mothwing_Cloak" and \
+                    prog_items["RIGHTDASH", self.player] > 2 > prog_items["LEFTDASH", self.player]:
+                prog_items["OVERFLOWLEFTDASH", self.player] += 1
+                prog_items["LEFTDASH", self.player] += 1
+            elif item.name == "Left_Mothwing_Cloak" and \
+                    prog_items["LEFTDASH", self.player] > 2 > prog_items["RIGHTDASH", self.player]:
+                prog_items["OVERFLOWRIGHTDASH", self.player] += 1
+                prog_items["RIGHTDASH", self.player] += 1
+
         return change
 
     def remove(self, state, item: HKItem) -> bool:


### PR DESCRIPTION
## What is this fixing or adding?
I have no idea

## How was this tested?
running generate once

## Actual

I found this bit of suspicious code, that I don't really know what it does. But whatever it does do, would need replication in reverse in remove to work correctly. So whatever it is doing it is doing wrong.
