### PR TITLE
WebHost: import Markup from markupsafe

### DIFF
--- a/WebHostLib/api/generate.py
+++ b/WebHostLib/api/generate.py
@@ -2,7 +2,8 @@ import json
 import pickle
 from uuid import UUID
 
-from flask import request, session, url_for, Markup
+from flask import request, session, url_for
+from markupsafe import Markup
 from pony.orm import commit
 
 from WebHostLib import app

--- a/WebHostLib/check.py
+++ b/WebHostLib/check.py
@@ -1,7 +1,8 @@
 import zipfile
 from typing import *
 
-from flask import request, flash, redirect, url_for, render_template, Markup
+from flask import request, flash, redirect, url_for, render_template
+from markupsafe import Markup
 
 from WebHostLib import app
 

--- a/WebHostLib/requirements.txt
+++ b/WebHostLib/requirements.txt
@@ -6,3 +6,4 @@ Flask-Caching>=2.0.2
 Flask-Compress>=1.13
 Flask-Limiter>=3.3.0
 bokeh>=3.1.1
+markupsafe>=2.1.3

--- a/WebHostLib/upload.py
+++ b/WebHostLib/upload.py
@@ -7,12 +7,13 @@ import zipfile
 import zlib
 
 from io import BytesIO
-from flask import request, flash, redirect, url_for, session, render_template, Markup
+from flask import request, flash, redirect, url_for, session, render_template
+from markupsafe import Markup
 from pony.orm import commit, flush, select, rollback
 from pony.orm.core import TransactionIntegrityError
 
 import MultiServer
-from NetUtils import NetworkSlot, SlotType
+from NetUtils import SlotType
 from Utils import VersionException, __version__
 from worlds.Files import AutoPatchRegister
 from . import app


### PR DESCRIPTION
## What is this fixing or adding?
DeprecationWarning: 'flask.Markup' is deprecated and will be removed in Flask 2.4. Import 'markupsafe.Markup' instead.

## How was this tested?
I started the webhost.

## If this makes graphical changes, please attach screenshots.
