### PR TITLE
Tests: sort custom loaded tests

### DIFF
--- a/test/worlds/__init__.py
+++ b/test/worlds/__init__.py
@@ -8,13 +8,13 @@ def load_tests(loader, standard_tests, pattern):
     suite.addTests(standard_tests)
     folders = [os.path.join(os.path.split(world.__file__)[0], "test")
                for world in AutoWorldRegister.world_types.values()]
-    all_tests = []
-    for folder in folders:
-        if os.path.exists(folder):
-            for test_collection in loader.discover(folder, top_level_dir=file_path):
-                for test_suite in test_collection:
-                    for test_case in test_suite:
-                        all_tests.append(test_case)
+
+    all_tests = [
+        test_case for folder in folders if os.path.exists(folder)
+        for test_collection in loader.discover(folder, top_level_dir=file_path)
+        for test_suite in test_collection
+        for test_case in test_suite
+    ]
 
     suite.addTests(sorted(all_tests, key=lambda test: test.__module__))
     return suite

--- a/test/worlds/__init__.py
+++ b/test/worlds/__init__.py
@@ -8,7 +8,13 @@ def load_tests(loader, standard_tests, pattern):
     suite.addTests(standard_tests)
     folders = [os.path.join(os.path.split(world.__file__)[0], "test")
                for world in AutoWorldRegister.world_types.values()]
+    all_tests = []
     for folder in folders:
         if os.path.exists(folder):
-            suite.addTests(loader.discover(folder, top_level_dir=file_path))
+            for test_collection in loader.discover(folder, top_level_dir=file_path):
+                for test_suite in test_collection:
+                    for test_case in test_suite:
+                        all_tests.append(test_case)
+
+    suite.addTests(sorted(all_tests, key=lambda test: test.__module__))
     return suite


### PR DESCRIPTION
## What is this fixing or adding?
Sorts tests by folder, resulting in less categories created from our custom loader. Possibly only visible in PyCharm?

## How was this tested?


## If this makes graphical changes, please attach screenshots.
turns
![image](https://github.com/ArchipelagoMW/Archipelago/assets/3189725/186e4f9b-26eb-4ae5-b8c6-bc79bfc7c38e)
into
![image](https://github.com/ArchipelagoMW/Archipelago/assets/3189725/f1b6d8a2-590e-4fec-9399-59080eac44d1)
