### PR TITLE
WebHost: Fix special-range value setting to `custom` when randomization is toggled off

### DIFF
--- a/WebHostLib/static/assets/player-settings.js
+++ b/WebHostLib/static/assets/player-settings.js
@@ -148,7 +148,7 @@ const buildOptionsTable = (settings, romOpts = false) => {
         randomButton.classList.add('randomize-button');
         randomButton.setAttribute('data-key', setting);
         randomButton.setAttribute('data-tooltip', 'Toggle randomization for this option!');
-        randomButton.addEventListener('click', (event) => toggleRandomize(event, [select]));
+        randomButton.addEventListener('click', (event) => toggleRandomize(event, select));
         if (currentSettings[gameName][setting] === 'random') {
           randomButton.classList.add('active');
           select.disabled = true;
@@ -185,7 +185,7 @@ const buildOptionsTable = (settings, romOpts = false) => {
         randomButton.classList.add('randomize-button');
         randomButton.setAttribute('data-key', setting);
         randomButton.setAttribute('data-tooltip', 'Toggle randomization for this option!');
-        randomButton.addEventListener('click', (event) => toggleRandomize(event, [range]));
+        randomButton.addEventListener('click', (event) => toggleRandomize(event, range));
         if (currentSettings[gameName][setting] === 'random') {
           randomButton.classList.add('active');
           range.disabled = true;
@@ -269,7 +269,7 @@ const buildOptionsTable = (settings, romOpts = false) => {
         randomButton.setAttribute('data-key', setting);
         randomButton.setAttribute('data-tooltip', 'Toggle randomization for this option!');
         randomButton.addEventListener('click', (event) => toggleRandomize(
-            event, [specialRange, specialRangeSelect])
+            event, specialRange, specialRangeSelect)
         );
         if (currentSettings[gameName][setting] === 'random') {
           randomButton.classList.add('active');
@@ -294,22 +294,26 @@ const buildOptionsTable = (settings, romOpts = false) => {
   return table;
 };
 
-const toggleRandomize = (event, inputElements) => {
+const toggleRandomize = (event, inputElement, optionalSelectElement) => {
   const active = event.target.classList.contains('active');
   const randomButton = event.target;
 
   if (active) {
     randomButton.classList.remove('active');
-    for (const element of inputElements) {
-      element.disabled = undefined;
-      updateGameSetting(element);
+    inputElement.disabled = undefined;
+    if (optionalSelectElement) {
+      optionalSelectElement.disabled = undefined;
     }
+
+    updateGameSetting(inputElement);
   } else {
     randomButton.classList.add('active');
-    for (const element of inputElements) {
-      element.disabled = true;
-      updateGameSetting(randomButton);
+    inputElement.disabled = true;
+    if (optionalSelectElement) {
+      optionalSelectElement.disabled = true;
     }
+
+    updateGameSetting(randomButton);
   }
 };
 

--- a/WebHostLib/static/assets/player-settings.js
+++ b/WebHostLib/static/assets/player-settings.js
@@ -294,7 +294,7 @@ const buildOptionsTable = (settings, romOpts = false) => {
   return table;
 };
 
-const toggleRandomize = (event, inputElement, optionalSelectElement) => {
+const toggleRandomize = (event, inputElement, optionalSelectElement = null) => {
   const active = event.target.classList.contains('active');
   const randomButton = event.target;
 

--- a/WebHostLib/static/assets/player-settings.js
+++ b/WebHostLib/static/assets/player-settings.js
@@ -304,17 +304,15 @@ const toggleRandomize = (event, inputElement, optionalSelectElement) => {
     if (optionalSelectElement) {
       optionalSelectElement.disabled = undefined;
     }
-
-    updateGameSetting(inputElement);
   } else {
     randomButton.classList.add('active');
     inputElement.disabled = true;
     if (optionalSelectElement) {
       optionalSelectElement.disabled = true;
     }
-
-    updateGameSetting(randomButton);
   }
+
+  updateGameSetting(randomButton);
 };
 
 const updateBaseSetting = (event) => {


### PR DESCRIPTION
## What is this fixing or adding?
Discord Bug Report: https://discord.com/channels/731205301247803413/1113657616397246544

> **Exempt-Medic**: If you go to any game's settings page and set progression balancing to Custom and then click the die to randomize it and then click the die again to unrandomize it, the progression balancing gets given a value of "custom" and attempting to generate gives the error:
> > Something went wrong and your game could not be generated. {'player': 'Failed to generate mystery in player: Error generating option progression_balancing in The Witness'}

---

When toggling randomization off on any "Special Range" type option on a player settings page, it would update the "value" of the option to: `custom`, causing a generation issue as its not a valid option.

This fixes that issue by preventing an unneeded update to game settings when toggled.

## How was this tested?
Ran WebHost and tested value set in localStorage is valid.

Before:
![image](https://github.com/ArchipelagoMW/Archipelago/assets/11338376/ebff02ae-2e0d-4a77-bf58-297cb355b176)
![image](https://github.com/ArchipelagoMW/Archipelago/assets/11338376/397b20b6-9b75-4cd5-ab3d-1c01f7606421)

After:
![image](https://github.com/ArchipelagoMW/Archipelago/assets/11338376/d309aefc-6c79-4ed5-9557-fcdf98dc18c4)
![image](https://github.com/ArchipelagoMW/Archipelago/assets/11338376/73d8ead3-4be2-42e8-9526-17a09f01e97d)

## If this makes graphical changes, please attach screenshots.
See above.