### PR TITLE
alttp: fix Armosknight defeatrule (removed Red Boomerang)

### DIFF
--- a/worlds/alttp/Bosses.py
+++ b/worlds/alttp/Bosses.py
@@ -42,8 +42,7 @@ def ArmosKnightsDefeatRule(state, player: int) -> bool:
             (state.has('Cane of Byrna', player) and can_extend_magic(state, player, 16)) or
             (state.has('Ice Rod', player) and can_extend_magic(state, player, 32)) or
             (state.has('Fire Rod', player) and can_extend_magic(state, player, 32)) or
-            state.has('Blue Boomerang', player) or
-            state.has('Red Boomerang', player))
+            state.has('Blue Boomerang', player))
 
 
 def LanmolasDefeatRule(state, player: int) -> bool:


### PR DESCRIPTION
## What is this fixing or adding?

Removed .has('Red Boomerang') call because Armosknight can't be defeated with the Red Boomerang. Only the Blue can hurt Armosknight (ref: http://alttp.mymm1.com/dmgtable.php)

## How was this tested?


## If this makes graphical changes, please attach screenshots.
