### PR TITLE
Secret of Evermore: auto launch SNI before browser when SNIClient patched

### DIFF
--- a/SNIClient.py
+++ b/SNIClient.py
@@ -684,6 +684,7 @@ async def main() -> None:
         logging.info(f"Wrote rom file to {romfile}")
         if args.diff_file.endswith(".apsoe"):
             import webbrowser
+            async_start(run_game(romfile))
             await _snes_connect(SNIContext(args.snes, args.connect, args.password), args.snes)
             webbrowser.open(f"http://www.evermizer.com/apclient/#server={meta['server']}")
             logging.info("Starting Evermizer Client in your Browser...")

--- a/SNIClient.py
+++ b/SNIClient.py
@@ -684,6 +684,7 @@ async def main() -> None:
         logging.info(f"Wrote rom file to {romfile}")
         if args.diff_file.endswith(".apsoe"):
             import webbrowser
+            await _snes_connect(SNIContext(args.snes, args.connect, args.password), args.snes)
             webbrowser.open(f"http://www.evermizer.com/apclient/#server={meta['server']}")
             logging.info("Starting Evermizer Client in your Browser...")
             import time

--- a/SNIClient.py
+++ b/SNIClient.py
@@ -315,7 +315,7 @@ def launch_sni() -> None:
             f"please start it yourself if it is not running")
 
 
-async def _snes_connect(ctx: SNIContext, address: str) -> WebSocketClientProtocol:
+async def _snes_connect(ctx: SNIContext, address: str, retry: bool = True) -> WebSocketClientProtocol:
     address = f"ws://{address}" if "://" not in address else address
     snes_logger.info("Connecting to SNI at %s ..." % address)
     seen_problems: typing.Set[str] = set()
@@ -336,6 +336,8 @@ async def _snes_connect(ctx: SNIContext, address: str) -> WebSocketClientProtoco
             await asyncio.sleep(1)
         else:
             return snes_socket
+        if not retry:
+            break
 
 
 class SNESRequest(typing.TypedDict):
@@ -685,7 +687,7 @@ async def main() -> None:
         if args.diff_file.endswith(".apsoe"):
             import webbrowser
             async_start(run_game(romfile))
-            await _snes_connect(SNIContext(args.snes, args.connect, args.password), args.snes)
+            await _snes_connect(SNIContext(args.snes, args.connect, args.password), args.snes, False)
             webbrowser.open(f"http://www.evermizer.com/apclient/#server={meta['server']}")
             logging.info("Starting Evermizer Client in your Browser...")
             import time


### PR DESCRIPTION
## What is this fixing or adding?
Auto launches SNI if it isn't already running, before opening the browser, if the `.apsoe` is patched through SNIClient.

## How was this tested?

![Screenshot_26](https://github.com/ArchipelagoMW/Archipelago/assets/13184667/8c2163dd-ddff-4c0b-97a7-e0f588a202ee)

## If this makes graphical changes, please attach screenshots.
