### PR TITLE
WebHost: Fix docs generation from a .apworld

### DIFF
--- a/WebHost.py
+++ b/WebHost.py
@@ -72,6 +72,7 @@ def create_ordered_tutorials_file() -> typing.List[typing.Dict[str, typing.Any]]
             with zipfile.ZipFile(zipfile_path) as zf:
                 for zfile in zf.infolist():
                     if not zfile.is_dir() and "/docs/" in zfile.filename:
+                        zfile.filename = os.path.basename(zfile.filename)
                         zf.extract(zfile, target_path)
         else:
             source_path = Utils.local_path(os.path.dirname(world.__file__), "docs")


### PR DESCRIPTION
## What is this fixing or adding?

`zfile.filename` is the full path within the archive, so by default `zf.extract` will maintain that directory structure when extracting.

This causes the docs to be placed in the wrong place, as the Javascript code expects them to be placed directly in the game folder.

## How was this tested?

Added `mmbn3.apworld` to my `worlds/` folder and ran `WebHost.py`. Prior to my change, this created `WebHostLib/static/generated/docs/MegaMan\ Battle\ Network\ 3/mmbn3/docs/` and copied `en_MegaMan Battle Network 3.md` and `setup_en.md` there, which is incorrect (note the extra `/mmbn3/docs` in that path). Trying to open either of these pages from the link in `/games` leads to a 404.

After my change, `mmb3/docs/` folders are not created. Instead the two .md files are copied into `WebHostLib/static/generated/docs/MegaMan\ Battle\ Network\ 3` and the links from `/games` work as expected.

## If this makes graphical changes, please attach screenshots.
