### PR TITLE
Setup: delete outdated Enemizer and SNI files

### DIFF
--- a/inno_setup.iss
+++ b/inno_setup.iss
@@ -179,6 +179,8 @@ Type: dirifempty; Name: "{app}"
 [InstallDelete]
 Type: files; Name: "{app}\ArchipelagoLttPClient.exe"
 Type: filesandordirs; Name: "{app}\lib\worlds\rogue-legacy*"
+Type: filesandordirs; Name: "{app}\SNI\lua*"
+Type: filesandordirs; Name: "{app}\EnemizerCLI*"
 #include "installdelete.iss"
 
 [Registry]

--- a/worlds/alttp/__init__.py
+++ b/worlds/alttp/__init__.py
@@ -36,7 +36,7 @@ class ALTTPWeb(WebWorld):
         "English",
         "multiworld_en.md",
         "multiworld/en",
-        ["Farrak Kilhn"]
+        ["Farrak Kilhn", "Berserker"]
     )
 
     setup_de = Tutorial(

--- a/worlds/alttp/docs/multiworld_en.md
+++ b/worlds/alttp/docs/multiworld_en.md
@@ -82,8 +82,7 @@ first time launching, you may be prompted to allow it to communicate through the
 3. Click on **New Lua Script Window...**
 4. In the new window, click **Browse...**
 5. Select the connector lua file included with your client
-    - Look in the Archipelago folder for `/SNI/lua/x64` or `/SNI/lua/x86` depending on if the
-      emulator is 64-bit or 32-bit.
+    - Look in the Archipelago folder for `/SNI/lua/`.
 6. If you see an error while loading the script that states `socket.dll missing` or similar, navigate to the folder of 
 the lua you are using in your file explorer and copy the `socket.dll` to the base folder of your snes9x install.
 
@@ -97,8 +96,7 @@ the lua you are using in your file explorer and copy the `socket.dll` to the bas
 3. Click on the Tools menu and click on **Lua Console**
 4. Click Script -> Open Script...
 5. Select the `Connector.lua` file you downloaded above
-    - Look in the Archipelago folder for `/SNI/lua/x64` or `/SNI/lua/x86` depending on if the
-      emulator is 64-bit or 32-bit. Please note the most recent versions of BizHawk are 64-bit only.
+    - Look in the Archipelago folder for `/SNI/lua/`.
 
 
 ##### RetroArch 1.10.1 or newer


### PR DESCRIPTION
## What is this fixing or adding?
Cleans out /SNI/lua and /EnemizerCLI/ on install/update

## How was this tested?
watched outdated lua files in SNI poof during setup.
As I was using current cx-Freeze, AP itself didn't work, but that should not be related.

## If this makes graphical changes, please attach screenshots.
