### PR TITLE
Launcher: deprecate FUNC Component type

### DIFF
--- a/Launcher.py
+++ b/Launcher.py
@@ -155,10 +155,10 @@ def run_gui():
         container: ContainerLayout
         grid: GridLayout
 
-        _tools = {c.display_name: c for c in components if c.type == Type.TOOL and isfile(get_exe(c)[-1])}
-        _clients = {c.display_name: c for c in components if c.type == Type.CLIENT and isfile(get_exe(c)[-1])}
-        _adjusters = {c.display_name: c for c in components if c.type == Type.ADJUSTER and isfile(get_exe(c)[-1])}
-        _funcs = {c.display_name: c for c in components if c.type == Type.FUNC}
+        _tools = {c.display_name: c for c in components if c.type == Type.TOOL}
+        _clients = {c.display_name: c for c in components if c.type == Type.CLIENT}
+        _adjusters = {c.display_name: c for c in components if c.type == Type.ADJUSTER}
+        _miscs = {c.display_name: c for c in components if c.type == Type.MISC}
 
         def __init__(self, ctx=None):
             self.title = self.base_title
@@ -199,7 +199,7 @@ def run_gui():
                     button_layout.add_widget(button)
 
             for (tool, client) in itertools.zip_longest(itertools.chain(
-                    self._tools.items(), self._funcs.items(), self._adjusters.items()), self._clients.items()):
+                    self._tools.items(), self._miscs.items(), self._adjusters.items()), self._clients.items()):
                 # column 1
                 if tool:
                     build_button(tool[1])
@@ -215,7 +215,7 @@ def run_gui():
 
         @staticmethod
         def component_action(button):
-            if button.component.type == Type.FUNC:
+            if button.component.func:
                 button.component.func()
             else:
                 launch(get_exe(button.component), button.component.cli)

--- a/Utils.py
+++ b/Utils.py
@@ -785,3 +785,10 @@ def async_start(co: Coroutine[typing.Any, typing.Any, bool], name: Optional[str]
     task = asyncio.create_task(co, name=name)
     _faf_tasks.add(task)
     task.add_done_callback(_faf_tasks.discard)
+
+
+def deprecate(message: str):
+    if __debug__:
+        raise Exception(message)
+    import warnings
+    warnings.warn(message)

--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -14,7 +14,7 @@ class Type(Enum):
 
 class Component:
     display_name: str
-    type: Optional[Type]
+    type: Type
     script_name: Optional[str]
     frozen_name: Optional[str]
     icon: str  # just the name, no suffix
@@ -23,8 +23,8 @@ class Component:
     file_identifier: Optional[Callable[[str], bool]]
 
     def __init__(self, display_name: str, script_name: Optional[str] = None, frozen_name: Optional[str] = None,
-                 cli: bool = False, icon: str = 'icon', component_type: Type = None, func: Optional[Callable] = None,
-                 file_identifier: Optional[Callable[[str], bool]] = None):
+                 cli: bool = False, icon: str = 'icon', component_type: Optional[Type] = None,
+                 func: Optional[Callable] = None, file_identifier: Optional[Callable[[str], bool]] = None):
         self.display_name = display_name
         self.script_name = script_name
         self.frozen_name = frozen_name or f'Archipelago{script_name}' if script_name else None

--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -10,6 +10,7 @@ class Type(Enum):
     CLIENT = auto()
     ADJUSTER = auto()
     FUNC = auto()  # do not use anymore
+    HIDDEN = auto()
 
 
 class Component:
@@ -35,9 +36,9 @@ class Component:
             deprecate(f"Launcher Component {self.display_name} is using Type.FUNC Type, which is pending removal.")
             component_type = Type.MISC
 
-        self.type = component_type or \
-            Type.CLIENT if 'Client' in display_name else \
-            Type.ADJUSTER if 'Adjuster' in display_name else Type.MISC
+        self.type = component_type or (
+            Type.CLIENT if "Client" in display_name else
+            Type.ADJUSTER if "Adjuster" in display_name else Type.MISC)
         self.func = func
         self.file_identifier = file_identifier
 
@@ -64,7 +65,7 @@ class SuffixIdentifier:
 
 components: List[Component] = [
     # Launcher
-    Component('', 'Launcher'),
+    Component('Launcher', 'Launcher', component_type=Type.HIDDEN),
     # Core
     Component('Host', 'MultiServer', 'ArchipelagoServer', cli=True,
               file_identifier=SuffixIdentifier('.archipelago', '.zip')),

--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -33,6 +33,7 @@ class Component:
         if component_type == Type.FUNC:
             from Utils import deprecate
             deprecate(f"Launcher Component {self.display_name} is using Type.FUNC Type, which is pending removal.")
+            component_type = Type.MISC
 
         self.type = component_type or \
             Type.CLIENT if 'Client' in display_name else \

--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -6,10 +6,10 @@ from Utils import local_path
 
 class Type(Enum):
     TOOL = auto()
-    FUNC = auto()  # not a real component, do not use anymore
+    MISC = auto()
     CLIENT = auto()
     ADJUSTER = auto()
-    MISC = FUNC
+    FUNC = auto()  # do not use anymore
 
 
 class Component:
@@ -30,8 +30,11 @@ class Component:
         self.frozen_name = frozen_name or f'Archipelago{script_name}' if script_name else None
         self.icon = icon
         self.cli = cli
+        if component_type == Type.FUNC:
+            from Utils import deprecate
+            deprecate(f"Launcher Component {self.display_name} is using Type.FUNC Type, which is pending removal.")
+
         self.type = component_type or \
-            None if not display_name else \
             Type.CLIENT if 'Client' in display_name else \
             Type.ADJUSTER if 'Adjuster' in display_name else Type.MISC
         self.func = func

--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -1,14 +1,15 @@
 from enum import Enum, auto
 from typing import Optional, Callable, List, Iterable
 
-from Utils import local_path, is_windows
+from Utils import local_path
 
 
 class Type(Enum):
     TOOL = auto()
-    FUNC = auto()  # not a real component
+    FUNC = auto()  # not a real component, do not use anymore
     CLIENT = auto()
     ADJUSTER = auto()
+    MISC = FUNC
 
 
 class Component:
@@ -31,9 +32,8 @@ class Component:
         self.cli = cli
         self.type = component_type or \
             None if not display_name else \
-            Type.FUNC if func else \
             Type.CLIENT if 'Client' in display_name else \
-            Type.ADJUSTER if 'Adjuster' in display_name else Type.TOOL
+            Type.ADJUSTER if 'Adjuster' in display_name else Type.MISC
         self.func = func
         self.file_identifier = file_identifier
 


### PR DESCRIPTION
## What is this fixing or adding?
removes that any callable is always FUNC, instead of say CLIENT

## How was this tested?
running Launcher.py

## If this makes graphical changes, please attach screenshots.
