### PR TITLE
Setup: pin cx-Freeze to latest working version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 # This is a bit jank. We need cx-Freeze to be able to run anything from this script, so install it
 try:
-    requirement = 'cx-Freeze>=6.14.7'
+    requirement = 'cx-Freeze==6.14.9'
     import pkg_resources
     try:
         pkg_resources.require(requirement)


### PR DESCRIPTION
## What is this fixing or adding?
worlds being just their init and nothing else.
Upstream bug: https://github.com/marcelotduarte/cx_Freeze/issues/1907


## If this makes graphical changes, please attach screenshots.
