### PR TITLE
Generate: Add skip progression balancing argument.

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -7,8 +7,8 @@ import random
 import string
 import urllib.parse
 import urllib.request
-from collections import Counter, ChainMap
-from typing import Dict, Tuple, Callable, Any, Union
+from collections import ChainMap, Counter
+from typing import Any, Callable, Dict, Tuple, Union
 
 import ModuleUpdate
 
@@ -53,6 +53,8 @@ def mystery_argparse():
                         help='Output rolled mystery results to yaml up to specified number (made for async multiworld)')
     parser.add_argument('--plando', default=defaults["plando_options"],
                         help='List of options that can be set manually. Can be combined, for example "bosses, items"')
+    parser.add_argument("--skip_prog_balancing", action="store_true",
+                        help="Skip progression balancing step during generation.")
     args = parser.parse_args()
     if not os.path.isabs(args.weights_file_path):
         args.weights_file_path = os.path.join(args.player_files_path, args.weights_file_path)
@@ -140,6 +142,7 @@ def main(args=None, callback=ERmain):
     erargs.race = args.race
     erargs.outputname = seed_name
     erargs.outputpath = args.outputpath
+    erargs.skip_prog_balancing = args.skip_prog_balancing
 
     settings_cache: Dict[str, Tuple[argparse.Namespace, ...]] = \
         {fname: (tuple(roll_settings(yaml, args.plando) for yaml in yamls) if args.samesettings else None)

--- a/Main.py
+++ b/Main.py
@@ -285,8 +285,10 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
 
     AutoWorld.call_all(world, 'post_fill')
 
-    if world.players > 1:
+    if world.players > 1 and not args.skip_prog_balancing:
         balance_multiworld_progression(world)
+    else:
+        logger.info("Progression balancing skipped.")
 
     logger.info(f'Beginning output...')
 


### PR DESCRIPTION
## What is this fixing or adding?
Adds a command line argument for `Generate.py` to skip progression balancing step, regardless of individual player `progression_balancing` settings. Argument is called `--skip_prog_balancing`.

Run with command line: `python Generate.py` (No changes)
```
Archipelago (0.4.1) logging initialized on Windows-10-10.0.22621-SP0 running Python 3.10.8
P1 Weights: Test1.yaml >> Generated by https://archipelago.gg/
P2 Weights: Test2.yaml >> Generated by https://archipelago.gg/
Generating for 2 players, 48891933062538200934 Seed 99530657785344493820 with plando: bosses
Archipelago Version 0.4.1  -  Seed: 99530657785344493820

[...Worlds Info...]

Creating World.
Creating Items.
Calculating Access Rules.
Running Item Plando
Running Pre Main Fill.
Filling the world with 145 items.
Balancing multiworld progression for 2 Players.
Beginning output...
Generating output files (2/2).
Calculating playthrough.
Creating final archive at C:\Users\Phar\PycharmProjects\archipelago\output\AP_48891933062538200934.zip
Done. Enjoy. Total Time: 0.2825881000026129
```

Run with command line: `python Generate.py --skip_prog_balancing` (Note: skipped message and faster generation time)
```
Archipelago (0.4.1) logging initialized on Windows-10-10.0.22621-SP0 running Python 3.10.8
P1 Weights: Test1.yaml >> Generated by https://archipelago.gg/
P2 Weights: Test2.yaml >> Generated by https://archipelago.gg/
Generating for 2 players, 42643419601722786858 Seed 50354090084942403599 with plando: bosses
Archipelago Version 0.4.1  -  Seed: 50354090084942403599

[...Worlds Info...]

Creating World.
Creating Items.
Calculating Access Rules.
Running Item Plando
Running Pre Main Fill.
Filling the world with 145 items.
Progression balancing skipped.
Beginning output...
Generating output files (2/2).
Calculating playthrough.
Creating final archive at C:\Users\Phar\PycharmProjects\archipelago\output\AP_42643419601722786858.zip
Done. Enjoy. Total Time: 0.10602330000256188
```

Changes to help: `python Generate.py --help`
```
usage: Generate.py [-h] [--weights_file_path WEIGHTS_FILE_PATH] [--samesettings] [--player_files_path PLAYER_FILES_PATH] [--seed SEED] [--multi MULTI] [--spoiler SPOILER] [--outputpath OUTPUTPATH] [--race] [--meta_file_path META_FILE_PATH] [--log_level LOG_LEVEL] [--yaml_output YAML_OUTPUT] [--plando PLANDO] [--skip_prog_balancing]

CMD Generation Interface, defaults come from host.yaml.

options:
  -h, --help            show this help message and exit
  --weights_file_path WEIGHTS_FILE_PATH
                        Path to the weights file to use for rolling game settings, urls are also valid
  --samesettings        Rolls settings per weights file rather than per player
  --player_files_path PLAYER_FILES_PATH
                        Input directory for player files.
  --seed SEED           Define seed number to generate.
  --multi MULTI
  --spoiler SPOILER
  --outputpath OUTPUTPATH
                        Path to output folder. Absolute or relative to cwd.
  --race
  --meta_file_path META_FILE_PATH
  --log_level LOG_LEVEL
                        Sets log level
  --yaml_output YAML_OUTPUT
                        Output rolled mystery results to yaml up to specified number (made for async multiworld)
  --plando PLANDO       List of options that can be set manually. Can be combined, for example "bosses, items"
  --skip_prog_balancing
                        Skip progression balancing step during generation.
```

## How was this tested?
Ran multiple generations to confirm progression balancing was skipped with argument and not skipped without.

## If this makes graphical changes, please attach screenshots.
N/A