### PR TITLE
Raft: Fix item prefilling

### DIFF
--- a/worlds/raft/__init__.py
+++ b/worlds/raft/__init__.py
@@ -43,8 +43,6 @@ class RaftWorld(World):
     data_version = 2
     required_client_version = (0, 3, 4)
 
-    raft_frequencyItemsPerPlayer = {}
-
     def create_items(self):
         minRPSpecified = self.multiworld.minimum_resource_pack_amount[self.player].value
         maxRPSpecified = self.multiworld.maximum_resource_pack_amount[self.player].value
@@ -59,7 +57,9 @@ class RaftWorld(World):
                 frequencyItems.append(raft_item)
             pool.append(raft_item)
         if self.multiworld.island_frequency_locations[self.player].value <= 3:
-            self.raft_frequencyItemsPerPlayer[self.player] = frequencyItems
+            if not hasattr(self.multiworld, "raft_frequencyItemsPerPlayer"):
+                self.multiworld.raft_frequencyItemsPerPlayer = {}
+            self.multiworld.raft_frequencyItemsPerPlayer[self.player] = frequencyItems
 
         extraItemNamePool = []
         extras = len(location_table) - len(item_table) - 1 # Victory takes up 1 unaccounted-for slot
@@ -201,14 +201,14 @@ class RaftWorld(World):
             RaftItem("Victory", ItemClassification.progression, None, player=self.player))
     
     def setLocationItem(self, location: str, itemName: str):
-        itemToUse = next(filter(lambda itm: itm.name == itemName, self.raft_frequencyItemsPerPlayer[self.player]))
-        self.raft_frequencyItemsPerPlayer[self.player].remove(itemToUse)
+        itemToUse = next(filter(lambda itm: itm.name == itemName, self.multiworld.raft_frequencyItemsPerPlayer[self.player]))
+        self.multiworld.raft_frequencyItemsPerPlayer[self.player].remove(itemToUse)
         self.multiworld.itempool.remove(itemToUse)
         self.multiworld.get_location(location, self.player).place_locked_item(itemToUse)
     
     def setLocationItemFromRegion(self, region: str, itemName: str):
-        itemToUse = next(filter(lambda itm: itm.name == itemName, self.raft_frequencyItemsPerPlayer[self.player]))
-        self.raft_frequencyItemsPerPlayer[self.player].remove(itemToUse)
+        itemToUse = next(filter(lambda itm: itm.name == itemName, self.multiworld.raft_frequencyItemsPerPlayer[self.player]))
+        self.multiworld.raft_frequencyItemsPerPlayer[self.player].remove(itemToUse)
         self.multiworld.itempool.remove(itemToUse)
         location = random.choice(list(loc for loc in location_table if loc["region"] == region))
         self.multiworld.get_location(location["name"], self.player).place_locked_item(itemToUse)

--- a/worlds/raft/__init__.py
+++ b/worlds/raft/__init__.py
@@ -78,10 +78,10 @@ class RaftWorld(World):
                     # instead add progressive-frequency as its own item a smaller amount of times to prevent
                     # flooding the duplicate item pool with them.
                     if self.multiworld.island_frequency_locations[self.player].value == 4:
-                        # Progressives are not in item_pool, need to create faux item for duplicate item pool
-                        # This can still be filtered out later by duplicate_items setting
-                        dupeItemPool.append({ "name": "progressive-frequency", "progression": True }) # Progressive frequencies need to be included
-                        dupeItemPool.append({ "name": "progressive-frequency", "progression": True }) # Double up for volume increase
+                        for _ in range(2):
+                            # Progressives are not in item_pool, need to create faux item for duplicate item pool
+                            # This can still be filtered out later by duplicate_items setting
+                            dupeItemPool.append({ "name": "progressive-frequency", "progression": True }) # Progressive frequencies need to be included
                     # Always remove non-progressive Frequency items
                     dupeItemPool = (itm for itm in dupeItemPool if "Frequency" not in itm["name"])
                 

--- a/worlds/raft/__init__.py
+++ b/worlds/raft/__init__.py
@@ -43,6 +43,8 @@ class RaftWorld(World):
     data_version = 2
     required_client_version = (0, 3, 4)
 
+    raft_frequencyItems = []
+
     def create_items(self):
         minRPSpecified = self.multiworld.minimum_resource_pack_amount[self.player].value
         maxRPSpecified = self.multiworld.maximum_resource_pack_amount[self.player].value
@@ -52,6 +54,8 @@ class RaftWorld(World):
         pool = []
         for item in item_table:
             raft_item = self.create_item_replaceAsNecessary(item["name"])
+            if "Frequency" in item["name"]:
+                self.raft_frequencyItems.append(raft_item)
             pool.append(raft_item)
 
         extraItemNamePool = []
@@ -129,7 +133,7 @@ class RaftWorld(World):
         return super(RaftWorld, self).collect_item(state, item, remove)
 
     def pre_fill(self):
-        if self.multiworld.island_frequency_locations[self.player] == 0:
+        if self.multiworld.island_frequency_locations[self.player] == 0: # Vanilla
             self.setLocationItem("Radio Tower Frequency to Vasagatan", "Vasagatan Frequency")
             self.setLocationItem("Vasagatan Frequency to Balboa", "Balboa Island Frequency")
             self.setLocationItem("Relay Station quest", "Caravan Island Frequency")
@@ -137,7 +141,7 @@ class RaftWorld(World):
             self.setLocationItem("Tangaroa Frequency to Varuna Point", "Varuna Point Frequency")
             self.setLocationItem("Varuna Point Frequency to Temperance", "Temperance Frequency")
             self.setLocationItem("Temperance Frequency to Utopia", "Utopia Frequency")
-        elif self.multiworld.island_frequency_locations[self.player] == 1:
+        elif self.multiworld.island_frequency_locations[self.player] == 1: # Random on island
             self.setLocationItemFromRegion("RadioTower", "Vasagatan Frequency")
             self.setLocationItemFromRegion("Vasagatan", "Balboa Island Frequency")
             self.setLocationItemFromRegion("BalboaIsland", "Caravan Island Frequency")
@@ -173,9 +177,9 @@ class RaftWorld(World):
                 else:
                     currentLocation = availableLocationList[0] # Utopia (only one left in list)
                 availableLocationList.remove(currentLocation)
-                if self.multiworld.island_frequency_locations[self.player] == 2:
+                if self.multiworld.island_frequency_locations[self.player] == 2: # Random island order
                     self.setLocationItem(locationToVanillaFrequencyLocationMap[previousLocation], locationToFrequencyItemMap[currentLocation])
-                elif self.multiworld.island_frequency_locations[self.player] == 3:
+                elif self.multiworld.island_frequency_locations[self.player] == 3: # Random on island random order
                     self.setLocationItemFromRegion(previousLocation, locationToFrequencyItemMap[currentLocation])
                 previousLocation = currentLocation
 
@@ -184,12 +188,14 @@ class RaftWorld(World):
             RaftItem("Victory", ItemClassification.progression, None, player=self.player))
     
     def setLocationItem(self, location: str, itemName: str):
-        itemToUse = next(filter(lambda itm: itm.name == itemName, self.multiworld.itempool))
+        itemToUse = next(filter(lambda itm: itm.name == itemName, self.raft_frequencyItems))
+        self.raft_frequencyItems.remove(itemToUse)
         self.multiworld.itempool.remove(itemToUse)
         self.multiworld.get_location(location, self.player).place_locked_item(itemToUse)
     
     def setLocationItemFromRegion(self, region: str, itemName: str):
-        itemToUse = next(filter(lambda itm: itm.name == itemName, self.multiworld.itempool))
+        itemToUse = next(filter(lambda itm: itm.name == itemName, self.raft_frequencyItems))
+        self.raft_frequencyItems.remove(itemToUse)
         self.multiworld.itempool.remove(itemToUse)
         location = random.choice(list(loc for loc in location_table if loc["region"] == region))
         self.multiworld.get_location(location["name"], self.player).place_locked_item(itemToUse)

--- a/worlds/raft/__init__.py
+++ b/worlds/raft/__init__.py
@@ -73,10 +73,15 @@ class RaftWorld(World):
                 dupeItemPool = item_table.copy()
                 # Remove frequencies if necessary
                 if self.multiworld.island_frequency_locations[self.player].value != 5: # Not completely random locations
+                    # If we let frequencies stay in with progressive-frequencies, the progressive-frequency item
+                    # will be included 7 times. This is a massive flood of progressive-frequency items, so we
+                    # instead add progressive-frequency as its own item a smaller amount of times to prevent
+                    # flooding the duplicate item pool with them.
                     if self.multiworld.island_frequency_locations[self.player].value == 4:
                         # Progressives are not in item_pool, need to create faux item for duplicate item pool
                         # This can still be filtered out later by duplicate_items setting
-                        dupeItemPool.append({ "name": "progressive-frequency", "progression": True }) # Progressive frequencies need to be duped
+                        dupeItemPool.append({ "name": "progressive-frequency", "progression": True }) # Progressive frequencies need to be included
+                        dupeItemPool.append({ "name": "progressive-frequency", "progression": True }) # Double up for volume increase
                     # Always remove non-progressive Frequency items
                     dupeItemPool = (itm for itm in dupeItemPool if "Frequency" not in itm["name"])
                 


### PR DESCRIPTION
## What is this fixing or adding?
Raft is prefilling frequencies incorrectly when multiple Raft worlds with different frequencies are used in the same multiworld. This makes Raft worlds use their own items instead of any Raft world's items.

Currently, what Raft's prefilling is doing is it's looking for the first item with a given name in the item pool. When every Raft player in a multiworld has similar settings (in this case, everyone either has prefilled items or does not have prefilled items), this is not a problem -- players' items are inserted into the item pool and removed from the item pool in (hopefully) the same order, so their generations are correct. However, when there are different settings in different Raft worlds, problems arise. Now, the Raft worlds that prefill items are at risk of using _other_ Raft worlds' items, since they're pulling the first item with a given name, rather than guaranteeing their own item.

**This does three things:**
1. Correctly prefills frequencies on all Raft worlds, even with different settings
2. Puts progressive-frequencies into the duplicate item pool. It reduces the odds of getting a progressive-frequency when filling the items (compared to any frequency in a non-progressive frequency mode) to avoid spamming a ton of progressive-frequency items.
3. Tracks the items that will be prefilled per-world, meaning that we don't need to look through the entire multiworld's item pool to pull out the items we care about. This is likely a performance win, especially on larger multiworlds.

## How was this tested?
Manually tested multiple different Raft configurations with multiple different settings for frequency placement in multiple multiworld generations, and verified that each Raft world's locations were in an expected spot.
I also mixed up the order of the frequency placements to verify that it wasn't just a "lucky order" in which players' items were prefilled.