### PR TITLE
Clients: use certifi

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -23,7 +23,6 @@ from NetUtils import Endpoint, decode, NetworkItem, encode, JSONtoTextParser, \
 from Utils import Version, stream_input, async_start
 from worlds import network_data_package, AutoWorldRegister
 import os
-import certifi
 import ssl
 
 if typing.TYPE_CHECKING:
@@ -34,7 +33,12 @@ logger = logging.getLogger("Client")
 # without terminal, we have to use gui mode
 gui_enabled = not sys.stdout or "--nogui" not in sys.argv
 
-ssl_context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH, cafile=certifi.where())
+
+@Utils.cache_argsless
+def get_ssl_context():
+    import certifi
+    return ssl.create_default_context(ssl.Purpose.SERVER_AUTH, cafile=certifi.where())
+
 
 class ClientCommandProcessor(CommandProcessor):
     def __init__(self, ctx: CommonContext):
@@ -593,7 +597,7 @@ async def server_loop(ctx: CommonContext, address: typing.Optional[str] = None) 
     logger.info(f'Connecting to Archipelago server at {address}')
     try:
         socket = await websockets.connect(address, port=port, ping_timeout=None, ping_interval=None,
-                                          ssl=ssl_context if address.startswith("wss://") else None)
+                                          ssl=get_ssl_context() if address.startswith("wss://") else None)
         if ctx.ui is not None:
             ctx.ui.update_address_bar(server_url.netloc)
         ctx.server = Endpoint(socket)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ schema>=0.7.5
 kivy>=2.2.0
 bsdiff4>=1.2.3
 platformdirs>=3.5.1
+certifi>=2023.5.7


### PR DESCRIPTION
## What is this fixing or adding?

On Windows, the local cert store might be outdated and refuse connection to some servers.

Certifi bundles its own cert store. The only real downside is that outdated AP installations will always have outdated certificates since we bundle the certificates with the installer.

## How was this tested?

Connecting to a ws:// and a wss:// room.