### PR TITLE
Docs: Mention Git in the "Optional" section of "Running from Source"

### DIFF
--- a/docs/running from source.md
+++ b/docs/running from source.md
@@ -69,6 +69,19 @@ It should be dropped as "SNI" into the root folder of the project. Alternatively
 host.yaml at your SNI folder.
 
 
+## Optional: Git
+
+[Git](https://git-scm.com) is required to install the Zilliandomizer package. This will be required to generate seeds that include a Zillion world.
+
+It is also generally recommended to have Git installed and understand how to use it, especially if you're thinking about contributing.
+Git will allow you to keep your copy of the repository updated without having to redownload the .zip manually.
+It lets you manage branches or forks of the repository with ease, and it will be all but required to submit your changes via a pull request.
+
+You can download the latest release of Git at [The downloads page on the Git website]https://git-scm.com/downloads).
+
+Beyond that, there are also graphical interfaces for Git that make it more accessible.
+For repositories on Github (such as this one), [Github Desktop](https://desktop.github.com) is one such option.
+
 ## Running tests
 
 Run `pip install pytest pytest-subtests`, then use your IDE to run tests or run `pytest` from the source folder.

--- a/docs/running from source.md
+++ b/docs/running from source.md
@@ -78,7 +78,7 @@ It is also generally recommended to have Git installed and understand how to use
 Git will allow you to keep your copy of the repository updated without having to redownload the .zip manually.
 It lets you manage branches or forks of the repository with ease, and it will be all but required to submit your changes via a pull request.
 
-You can download the latest release of Git at [The downloads page on the Git website]https://git-scm.com/downloads).
+You can download the latest release of Git at [The downloads page on the Git website](https://git-scm.com/downloads).
 
 Beyond that, there are also graphical interfaces for Git that make it more accessible.
 For repositories on Github (such as this one), [Github Desktop](https://desktop.github.com) is one such option.

--- a/docs/running from source.md
+++ b/docs/running from source.md
@@ -75,8 +75,6 @@ host.yaml at your SNI folder.
 It may be possible to run Archipelago from source without it, at your own risk.
 
 It is also generally recommended to have Git installed and understand how to use it, especially if you're thinking about contributing.
-Git will allow you to keep your copy of the repository updated without having to redownload the .zip manually.
-It lets you manage branches or forks of the repository with ease, and it will be all but required to submit your changes via a pull request.
 
 You can download the latest release of Git at [The downloads page on the Git website](https://git-scm.com/downloads).
 

--- a/docs/running from source.md
+++ b/docs/running from source.md
@@ -80,6 +80,7 @@ You can download the latest release of Git at [The downloads page on the Git web
 
 Beyond that, there are also graphical interfaces for Git that make it more accessible.
 For repositories on Github (such as this one), [Github Desktop](https://desktop.github.com) is one such option.
+PyCharm has a built-in version control integration that supports Git.
 
 ## Running tests
 

--- a/docs/running from source.md
+++ b/docs/running from source.md
@@ -71,7 +71,8 @@ host.yaml at your SNI folder.
 
 ## Optional: Git
 
-[Git](https://git-scm.com) is required to install the Zilliandomizer package. This will be required to generate seeds that include a Zillion world.
+[Git](https://git-scm.com) is required to install some of the packages that Archipelago depends on.
+It may be possible to run Archipelago from source without it, at your own risk.
 
 It is also generally recommended to have Git installed and understand how to use it, especially if you're thinking about contributing.
 Git will allow you to keep your copy of the repository updated without having to redownload the .zip manually.


### PR DESCRIPTION
GIt is required to install the Zilliandomizer package.

Also, this is probably just nice to have.