### PR TITLE
Setup: flip apworld list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,6 @@ non_apworlds: set = {
     "Overcooked! 2",
     "Pokemon Red and Blue",
     "Raft",
-    "Risk of Rain 2",
     "Secret of Evermore",
     "Slay the Spire",
     "Starcraft 2 Wings of Liberty",

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ non_apworlds: set = {
     "Starcraft 2 Wings of Liberty",
     "Sudoku",
     "Super Mario 64",
+    "The Witness",
     "VVVVVV",
     "Wargroove",
     "Zillion",

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,6 @@ non_apworlds: set = {
     "Kingdom Hearts 2",
     "Lufia II Ancient Cave",
     "Meritous",
-    "Noita",
     "Ocarina of Time",
     "Overcooked! 2",
     "Pokemon Red and Blue",

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,6 @@ non_apworlds: set = {
     "Starcraft 2 Wings of Liberty",
     "Sudoku",
     "Super Mario 64",
-    "The Legend of Zelda",
     "The Witness",
     "VVVVVV",
     "Wargroove",

--- a/setup.py
+++ b/setup.py
@@ -60,20 +60,38 @@ from Utils import version_tuple, is_windows, is_linux
 
 
 # On  Python < 3.10 LogicMixin is not currently supported.
-apworlds: set = {
-    "Subnautica",
-    "Factorio",
-    "Rogue Legacy",
-    "Sonic Adventure 2 Battle",
-    "Donkey Kong Country 3",
-    "Super Mario World",
-    "Stardew Valley",
-    "Timespinner",
-    "Minecraft",
-    "The Messenger",
-    "Links Awakening DX",
-    "Super Metroid",
-    "SMZ3",
+non_apworlds: set = {
+    "A Link to the Past",
+    "Adventure",
+    "ArchipIDLE",
+    "Archipelago",
+    "Blasphemous",
+    "ChecksFinder",
+    "Clique",
+    "DLCQuest",
+    "Dark Souls III",
+    "Final Fantasy",
+    "Hollow Knight",
+    "Hylics 2",
+    "Kingdom Hearts 2",
+    "Lufia II Ancient Cave",
+    "Meritous",
+    "Noita",
+    "Ocarina of Time",
+    "Overcooked! 2",
+    "Pokemon Red and Blue",
+    "Raft",
+    "Risk of Rain 2",
+    "Secret of Evermore",
+    "Slay the Spire",
+    "Starcraft 2 Wings of Liberty",
+    "Sudoku",
+    "Super Mario 64",
+    "The Legend of Zelda",
+    "The Witness",
+    "VVVVVV",
+    "Wargroove",
+    "Zillion",
 }
 
 
@@ -322,11 +340,12 @@ class BuildExeCommand(cx_Freeze.command.build_exe.BuildEXE):
         os.makedirs(self.buildfolder / "Players" / "Templates", exist_ok=True)
         from Options import generate_yaml_templates
         from worlds.AutoWorld import AutoWorldRegister
-        assert not apworlds - set(AutoWorldRegister.world_types), "Unknown world designated for .apworld"
+        assert not non_apworlds - set(AutoWorldRegister.world_types), \
+            f"Unknown world {non_apworlds - set(AutoWorldRegister.world_types)} designated for .apworld"
         folders_to_remove: typing.List[str] = []
         generate_yaml_templates(self.buildfolder / "Players" / "Templates", False)
         for worldname, worldtype in AutoWorldRegister.world_types.items():
-            if worldname in apworlds:
+            if worldname not in non_apworlds:
                 file_name = os.path.split(os.path.dirname(worldtype.__file__))[1]
                 world_directory = self.libfolder / "worlds" / file_name
                 # this method creates an apworld that cannot be moved to a different OS or minor python version,

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,6 @@ non_apworlds: set = {
     "Starcraft 2 Wings of Liberty",
     "Sudoku",
     "Super Mario 64",
-    "The Witness",
     "VVVVVV",
     "Wargroove",
     "Zillion",

--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -17,8 +17,8 @@ from .ExtractedData import locations, starts, multi_locations, location_to_regio
     event_names, item_effects, connectors, one_ways, vanilla_shop_costs, vanilla_location_costs
 from .Charms import names as charm_names
 
-from BaseClasses import Region, Entrance, Location, MultiWorld, Item, LocationProgressType, Tutorial, ItemClassification
-from ..AutoWorld import World, LogicMixin, WebWorld
+from BaseClasses import Region, Location, MultiWorld, Item, LocationProgressType, Tutorial, ItemClassification
+from worlds.AutoWorld import World, LogicMixin, WebWorld
 
 path_of_pain_locations = {
     "Soul_Totem-Path_of_Pain_Below_Thornskip",

--- a/worlds/oribf/Rules.py
+++ b/worlds/oribf/Rules.py
@@ -1,9 +1,15 @@
+from typing import Set
+
 from .RulesData import location_rules
-from ..generic.Rules import set_rule
-from BaseClasses import Location
+from worlds.generic.Rules import set_rule
+from BaseClasses import Location, CollectionState
 
 
 # TODO: implement Mapstone counting, Open, OpenWorld, connection rules
+
+def oribf_has_all(state: CollectionState, items: Set[str], player:int) -> bool:
+    return all(state.prog_items[item, player] if type(item) == str
+               else state.prog_items[item[0], player] >= item[1] for item in items)
 
 def set_rules(world):
     temp_base_rule(world.multiworld, world.player)
@@ -22,7 +28,7 @@ def add_or_rule_check_first(world, location: str, player: int, conditionsets):
             location.access_rule = tautology
             return
     rule = lambda state, conditionsets=conditionsets: any(
-        state._oribf_has_all(conditionset, player) for conditionset in conditionsets)
+        oribf_has_all(state, conditionset, player) for conditionset in conditionsets)
     if location.access_rule is Location.access_rule:
         location.access_rule = rule
     else:
@@ -31,7 +37,7 @@ def add_or_rule_check_first(world, location: str, player: int, conditionsets):
 
 
 def temp_base_rule(world, player):
-    world.completion_condition[player] = lambda state: state._oribf_has_all(
+    world.completion_condition[player] = lambda state: oribf_has_all(state,
         {"Bash", "ChargeFlame", "ChargeJump", "Climb", "Dash", "DoubleJump", "Glide", "Grenade", "Stomp", "WallJump"},
         player)
 

--- a/worlds/oribf/__init__.py
+++ b/worlds/oribf/__init__.py
@@ -69,9 +69,3 @@ class OriBlindForest(World):
         return Item(name,
                     ItemClassification.progression if not name.startswith("EX") else ItemClassification.filler,
                     item_table[name], self.player)
-
-
-class OriBlindForestLogic(LogicMixin):
-    def _oribf_has_all(self, items: Set[str], player:int):
-        return all(self.prog_items[item, player] if type(item) == str
-                   else self.prog_items[item[0], player] >= item[1] for item in items)


### PR DESCRIPTION
## What is this fixing or adding?
technically, makes Ori BF an apworld.

The goal however is to have a list of worlds that have yet to convert to apworld compatible and I'd also like to mandate going forward that no worlds are ever added to this list.

## How was this tested?
Running Launcher and TextClient and looking into the log for exceptions.

## If this makes graphical changes, please attach screenshots.
