### PR TITLE
Launcher: close it when launching Clients

### DIFF
--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -58,7 +58,7 @@ def launch_subprocess(func: Callable, name: str = None, close_launcher: bool = T
         if app:
             app = cast(App, app)
             # ran into what appears to be https://groups.google.com/g/kivy-users/c/saWDLoYCSZ4 with PyCharm.
-            # Closing the window explicitly cleanes it up.
+            # Closing the window explicitly cleans it up.
             app.root_window.close()
             app.stop()
             process.daemon = False

--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -48,7 +48,7 @@ class Component:
     def __repr__(self):
         return f"{self.__class__.__name__}({self.display_name})"
 
-def launch_subprocess(func: Callable, name: str = None, close_launcher = True):
+def launch_subprocess(func: Callable, name: str = None, close_launcher: bool = True):
     import multiprocessing
     process = multiprocessing.Process(target=func, name=name, daemon=True)
 

--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -1,5 +1,5 @@
 from enum import Enum, auto
-from typing import Optional, Callable, List, Iterable
+from typing import Optional, Callable, List, Iterable, cast
 
 from Utils import local_path
 
@@ -48,9 +48,20 @@ class Component:
     def __repr__(self):
         return f"{self.__class__.__name__}({self.display_name})"
 
-def launch_subprocess(func: Callable, name: str = None):
+def launch_subprocess(func: Callable, name: str = None, close_launcher = True):
     import multiprocessing
     process = multiprocessing.Process(target=func, name=name, daemon=True)
+
+    if close_launcher:
+        from kivy.app import App
+        app = App.get_running_app()
+        if app:
+            app = cast(App, app)
+            # ran into what appears to be https://groups.google.com/g/kivy-users/c/saWDLoYCSZ4 with PyCharm.
+            # Closing the window explicitly cleanes it up.
+            app.root_window.close()
+            app.stop()
+            process.daemon = False
     process.start()
 
 class SuffixIdentifier:


### PR DESCRIPTION
## What is this fixing or adding?
Makes it so the Launcher closes when launching FactorioClient and TextClient, but allows the Component control over that behaviour.

## How was this tested?
With FactorioClient and TextClient on Windows and Py3.11

## If this makes graphical changes, please attach screenshots.
