### PR TITLE
Witness: APworld compatibility, but for real this time

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,6 @@ non_apworlds: set = {
     "Starcraft 2 Wings of Liberty",
     "Sudoku",
     "Super Mario 64",
-    "The Witness",
     "VVVVVV",
     "Wargroove",
     "Zillion",

--- a/worlds/witness/__init__.py
+++ b/worlds/witness/__init__.py
@@ -6,7 +6,7 @@ import typing
 from BaseClasses import Region, Location, MultiWorld, Item, Entrance, Tutorial, ItemClassification
 from .hints import get_always_hint_locations, get_always_hint_items, get_priority_hint_locations, \
     get_priority_hint_items, make_hints, generate_joke_hints
-from ..AutoWorld import World, WebWorld
+from worlds.AutoWorld import World, WebWorld
 from .player_logic import WitnessPlayerLogic
 from .static_logic import StaticWitnessLogic
 from .locations import WitnessPlayerLocations, StaticWitnessLocations

--- a/worlds/witness/rules.py
+++ b/worlds/witness/rules.py
@@ -10,8 +10,8 @@ from .player_logic import WitnessPlayerLogic
 from .Options import is_option_enabled, get_option_value
 from .locations import WitnessPlayerLocations
 from . import StaticWitnessLogic
-from ..AutoWorld import LogicMixin
-from ..generic.Rules import set_rule
+from worlds.AutoWorld import LogicMixin
+from worlds.generic.Rules import set_rule
 
 
 class WitnessLogic(LogicMixin):


### PR DESCRIPTION
Removed relative imports from outside the Witness package. Then, removed Witness from the apworld exclusion list in setup.py

Tested: python setup.py build_exe, go to the build, confirm that a witness .apworld was created, generate a seed with a Witness world. It worked, although I got some errors from oribf and stardew valley which I thought I'd mention

(Python 3.9)