### PR TITLE
OriBF: fix py3.8 apworld compatibility

### DIFF
--- a/worlds/oribf/__init__.py
+++ b/worlds/oribf/__init__.py
@@ -1,6 +1,6 @@
 from typing import Set
 
-from ..AutoWorld import World, LogicMixin
+from worlds.AutoWorld import World
 from .Items import item_table, default_pool
 from .Locations import lookup_name_to_id
 from .Rules import set_rules, location_rules


### PR DESCRIPTION
## What is this fixing or adding?
Fixes oribf apworld failing to load on py3.8 and minor import cleanup.

## How was this tested?
`python3.8 setup.py build_exe` on Linux and then generating any game (not oribf). It would show an error loading the world before the commit and not complain after the commit
