### PR TITLE
The Messenger: strip generated filler items for a sufficiently small pool

### DIFF
--- a/worlds/messenger/__init__.py
+++ b/worlds/messenger/__init__.py
@@ -49,17 +49,14 @@ class MessengerWorld(World):
     base_offset = 0xADD_000
     item_name_to_id = {item: item_id
                        for item_id, item in enumerate(ALL_ITEMS, base_offset)}
-    seal_locs = [seal for seals in SEALS.values() for seal in seals]
-    mega_shard_locs = [shard for shards in MEGA_SHARDS.values() for shard in shards]
-    shop_locs = [f"The Shop - {shop_loc}" for shop_loc in SHOP_ITEMS]
     location_name_to_id = {location: location_id
                            for location_id, location in
                            enumerate([
                                *ALWAYS_LOCATIONS,
-                               *seal_locs,
-                               *mega_shard_locs,
+                               *[seal for seals in SEALS.values() for seal in seals],
+                               *[shard for shards in MEGA_SHARDS.values() for shard in shards],
                                *BOSS_LOCATIONS,
-                               *shop_locs,
+                               *[f"The Shop - {shop_loc}" for shop_loc in SHOP_ITEMS],
                                *FIGURINES,
                                "Money Wrench",
                            ], base_offset)}
@@ -127,13 +124,15 @@ class MessengerWorld(World):
             for i in range(self.required_seals):
                 seals[i].classification = ItemClassification.progression_skip_balancing
             itempool += seals
-
+        
+        remaining_fill = len(self.multiworld.get_unfilled_locations(self.player)) - len(itempool)
+        filler_pool = dict(list(FILLER.items())[2:]) if remaining_fill < 10 else FILLER
         itempool += [self.create_item(filler_item)
                      for filler_item in
                      self.multiworld.random.choices(
-                         list(FILLER),
-                         weights=list(FILLER.values()),
-                         k=len(self.multiworld.get_unfilled_locations(self.player)) - len(itempool)
+                         list(filler_pool),
+                         weights=list(filler_pool.values()),
+                         k=remaining_fill
                      )]
 
         self.multiworld.itempool += itempool

--- a/worlds/messenger/test/TestShop.py
+++ b/worlds/messenger/test/TestShop.py
@@ -16,6 +16,7 @@ class ShopCostTest(MessengerTestBase):
             with self.subTest("has cost", loc=loc):
                 self.assertFalse(self.can_reach_location(loc))
 
+    def testShopPrices(self) -> None:
         prices: Dict[str, int] = self.multiworld.worlds[self.player].shop_prices
         for loc, price in prices.items():
             with self.subTest("prices", loc=loc):
@@ -48,6 +49,15 @@ class ShopCostMinTest(ShopCostTest):
         "shop_price": "random",
         "shuffle_seals": "false",
     }
+    
+    def testShopRules(self) -> None:
+        if self.multiworld.worlds[self.player].total_shards:
+            super().testShopRules()
+        else:
+            for loc in SHOP_ITEMS:
+                loc = f"The Shop - {loc}"
+                with self.subTest("has cost", loc=loc):
+                    self.assertTrue(self.can_reach_location(loc))
 
     def testDBoost(self) -> None:
         pass


### PR DESCRIPTION
## What is this fixing or adding?
I added a unit test that tests the shop costs with the minimum amount of generated locations. With the settings in that test only 6 items can possibly be currency and if none of those have a value over 100, then all of the shop locations are immediately accessible. There's still settings where a player can have even 0 possible currency items but that's their own fault, which is fine. This change is primarily so the unit test doesn't fail by slicing the filler dictionary before filler is created if the amount of items that still need to be generated is sufficiently small.

## How was this tested?
Ran the unit test about 100 times. There's still a very slim chance it can fail if the random object generates 6 "Time Shard (50)". Only way to fully prevent that is to slice the dictionary an additional value. Will do if requested, but would prefer not to.

## If this makes graphical changes, please attach screenshots.
