### PR TITLE
TLoZ: fix LauncherComponents entry

### DIFF
--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -104,7 +104,7 @@ components: List[Component] = [
     # Pokémon
     Component('Pokemon Client', 'PokemonClient', file_identifier=SuffixIdentifier('.apred', '.apblue')),
     # TLoZ
-    Component('Zelda 1 Client', 'Zelda1Client'),
+    Component('Zelda 1 Client', 'Zelda1Client', file_identifier=SuffixIdentifier('.aptloz')),
     # ChecksFinder
     Component('ChecksFinder Client', 'ChecksFinderClient'),
     # Starcraft 2


### PR DESCRIPTION
## What is this fixing or adding?
The LauncherComponents entry for TLoZ didn't include a file suffix identifier, which forbade the file picker from selecting `.aptloz` files in some platforms.

## How was this tested?
This was not tested, since it could only be reproduced in a Linux machine and none of the devs have one ready. This is a very simple change, and just double checking the spelling is correct should suffice.