### PR TITLE
lufia2ac: use an appropriate dungeon sprite and battle theme for each boss

### DIFF
--- a/worlds/lufia2ac/Options.py
+++ b/worlds/lufia2ac/Options.py
@@ -174,6 +174,39 @@ class Boss(RandomGroupsChoice):
     option_master = 0x26
     default = option_master
 
+    _sprite: Dict[int, int] = {
+        option_lizard_man: 0x9E,
+        option_big_catfish: 0xC5,
+        option_regal_goblin: 0x9D,
+        option_follower_x2: 0x76,
+        option_camu: 0x75,
+        option_tarantula: 0xC6,
+        option_pierre: 0x77,
+        option_daniele: 0x78,
+        option_gades_a: 0x7A,
+        option_mummy_x4: 0xA8,
+        option_troll_x3: 0xA9,
+        option_gades_b: 0x7A,
+        option_idura_a: 0x74,
+        option_lion_x2: 0xB7,
+        option_idura_b: 0x74,
+        option_idura_c: 0x74,
+        option_rogue_flower: 0x96,
+        option_soldier_x4: 0x18,
+        option_gargoyle_x4: 0xC4,
+        option_venge_ghost: 0xD0,
+        option_white_dragon_x3: 0xC3,
+        option_fire_dragon: 0xC0,
+        option_ghost_ship: 0xC8,
+        option_tank: 0xC7,
+        option_gades_c: 0x7A,
+        option_amon: 0x79,
+        option_erim: 0x38,
+        option_daos: 0x7B,
+        option_egg_dragon: 0xC0,
+        option_master: 0x94,
+    }
+
     random_groups = {
         "random-low": ["lizard_man", "big_catfish", "regal_goblin", "follower_x2", "camu", "tarantula", "pierre",
                        "daniele", "mummy_x4", "troll_x3"],
@@ -186,6 +219,15 @@ class Boss(RandomGroupsChoice):
     @property
     def flag(self) -> int:
         return 0xFE if self.value == Boss.option_master else 0xFF
+
+    @property
+    def music(self) -> int:
+        return 0x1B if self.value in {Boss.option_master, Boss.option_gades_a, Boss.option_gades_b, Boss.option_gades_c,
+                                      Boss.option_amon, Boss.option_erim, Boss.option_daos} else 0x19
+
+    @property
+    def sprite(self) -> int:
+        return Boss._sprite[self.value]
 
 
 class CapsuleCravingsJPStyle(Toggle):

--- a/worlds/lufia2ac/__init__.py
+++ b/worlds/lufia2ac/__init__.py
@@ -201,8 +201,10 @@ class L2ACWorld(World):
                 rom_bytearray[offset:offset + 1] = self.o.party_starting_level.value.to_bytes(1, "little")
             for offset in range(0x02B39A, 0x02B457, 0x1B):
                 rom_bytearray[offset:offset + 3] = self.o.party_starting_level.xp.to_bytes(3, "little")
+            rom_bytearray[0x03AE49:0x03AE49 + 1] = self.o.boss.sprite.to_bytes(1, "little")
             rom_bytearray[0x05699E:0x05699E + 147] = self.get_goal_text_bytes()
             rom_bytearray[0x056AA3:0x056AA3 + 24] = self.o.default_party.event_script
+            rom_bytearray[0x072740:0x072740 + 1] = self.o.boss.music.to_bytes(1, "little")
             rom_bytearray[0x072742:0x072742 + 1] = self.o.boss.value.to_bytes(1, "little")
             rom_bytearray[0x072748:0x072748 + 1] = self.o.boss.flag.to_bytes(1, "little")
             rom_bytearray[0x09D59B:0x09D59B + 256] = self.get_node_connection_table()


### PR DESCRIPTION
## What is this fixing or adding?

When the `boss` option is used to change the encounter on the final floor, a matching dungeon sprite will now be loaded instead of the Master's sprite. The music during the fight will also match the battle theme used for that boss during the main game.

Aside from being visually consistent, this has the additional advantage that players who selected mystery bosses can now see which kind of foe they are about to encounter, and can thus change their equipment accordingly before starting to fight. 

## How was this tested?

See screenshots.

## If this makes graphical changes, please attach screenshots.

![AP_07758176404715800194_P1_Player1_026](https://github.com/ArchipelagoMW/Archipelago/assets/109771707/f982b688-20a6-4463-bde1-d73a28a14e68) ![AP_07758176404715800194_P1_Player1_021](https://github.com/ArchipelagoMW/Archipelago/assets/109771707/3be166a6-7317-4b28-b51a-9e7600b31b96) ![AP_07758176404715800194_P1_Player1_024](https://github.com/ArchipelagoMW/Archipelago/assets/109771707/0790015f-edaa-44d4-a196-20c90220ece6) ![AP_07758176404715800194_P1_Player1_025](https://github.com/ArchipelagoMW/Archipelago/assets/109771707/93c65659-3ff8-439a-a597-2a79c2d27910)
