### PR TITLE
Muse Dash: Add 2023 Anniversary songs and remove a hidden song

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Currently, the following games are supported:
 * Undertale
 * Bumper Stickers
 * Mega Man Battle Network 3: Blue Version
+* Muse Dash
 
 For setup and instructions check out our [tutorials page](https://archipelago.gg/tutorial/).
 Downloads can be found at [Releases](https://github.com/ArchipelagoMW/Archipelago/releases), including compiled

--- a/worlds/musedash/MuseDashCollection.py
+++ b/worlds/musedash/MuseDashCollection.py
@@ -22,8 +22,7 @@ class MuseDashCollections:
         "MuseDash ka nanika hi",
         "Rush-Hour",
         "Find this Month's Featured Playlist",
-        "PeroPero in the Universe",
-        "CHAOS Glitch"
+        "PeroPero in the Universe"
     ]
 
     album_items: Dict[str, AlbumData] = {}

--- a/worlds/musedash/MuseDashCollection.py
+++ b/worlds/musedash/MuseDashCollection.py
@@ -128,6 +128,10 @@ class MuseDashCollections:
         if len(difficulty) <= 0 or difficulty == "?" or difficulty == "¿":
             return None
 
+        # 0 is used as a filler and no songs actually have a 0 difficulty song.
+        if difficulty == "0":
+            return None
+
         # Curse the 2023 april fools update. Used on 3rd Avenue.
         if difficulty == "〇":
             return 10

--- a/worlds/musedash/MuseDashData.txt
+++ b/worlds/musedash/MuseDashData.txt
@@ -74,7 +74,7 @@ snooze|43-19|Just as Planned  Plus|False|5|7|10|
 Kuishinbo Hacker feat.Kuishinbo Akachan|43-20|Just as Planned  Plus|True|5|7|9|
 Inu no outa|43-21|Just as Planned  Plus|True|3|5|7|
 Prism Fountain|43-22|Just as Planned  Plus|True|7|9|11|
-Gospel|43-23|Just as Planned  Plus|False|4|6|10|
+Gospel|43-23|Just as Planned  Plus|False|4|6|9|
 East Ai Li Lovely|62-0|Happy Otaku Pack Vol.17|False|2|4|7|
 Mori Umi no Fune|62-1|Happy Otaku Pack Vol.17|True|5|7|9|
 Ooi|62-2|Happy Otaku Pack Vol.17|True|5|7|10|
@@ -450,3 +450,9 @@ Love Patrol|63-2|MUSE RADIO FM104|True|3|5|7|
 Mahorova|63-3|MUSE RADIO FM104|True|3|5|8|
 Yoru no machi|63-4|MUSE RADIO FM104|True|1|4|7|
 INTERNET YAMERO|63-5|MUSE RADIO FM104|True|6|8|10|
+Abracadabra|43-24|Just as Planned  Plus|False|6|8|10|
+Squalldecimator feat. EZ-Ven|43-25|Just as Planned  Plus|True|5|7|9|
+Amateras Rhythm|43-26|Just as Planned  Plus|True|6|8|11|
+Record one's Dream|43-27|Just as Planned  Plus|False|4|7|10|
+Lunatic|43-28|Just as Planned  Plus|True|5|8|10|
+Jiumeng|43-29|Just as Planned  Plus|True|3|6|8|

--- a/worlds/musedash/__init__.py
+++ b/worlds/musedash/__init__.py
@@ -40,7 +40,7 @@ class MuseDashWorld(World):
     game = "Muse Dash"
     option_definitions = musedash_options
     topology_present = False
-    data_version = 6
+    data_version = 7
     web = MuseDashWebWorld()
 
     music_sheet_name: str = "Music Sheet"

--- a/worlds/musedash/test/TestRemovedSongs.py
+++ b/worlds/musedash/test/TestRemovedSongs.py
@@ -1,0 +1,28 @@
+from . import MuseDashTestBase
+
+# The worst case settings are DLC songs off, and enabling streamer mode.
+# This ends up with only 25 valid songs that can be chosen.
+# These tests ensure that this won't fail generation
+
+class TestWorstCaseHighDifficulty(MuseDashTestBase):
+    options = {
+        "starting_song_count": 10,
+        "allow_just_as_planned_dlc_songs": True,
+        "additional_song_count": 500,
+    }
+
+    removed_songs = [
+        "CHAOS Glitch",
+        "FM 17314 SUGAR RADIO"
+    ]
+
+    def test_songs_have_difficulty(self) -> None:
+        # This test is done on a world where every song should be added.
+        muse_dash_world = self.multiworld.worlds[1]
+
+        for song_name in self.removed_songs:
+            assert song_name not in muse_dash_world.starting_songs, \
+                f"Song '{song_name}' was included into the starting songs when it shouldn't."
+
+            assert song_name not in muse_dash_world.included_songs, \
+                f"Song '{song_name}' was included into the included songs when it shouldn't."

--- a/worlds/musedash/test/TestRemovedSongs.py
+++ b/worlds/musedash/test/TestRemovedSongs.py
@@ -4,7 +4,7 @@ from . import MuseDashTestBase
 # This ends up with only 25 valid songs that can be chosen.
 # These tests ensure that this won't fail generation
 
-class TestWorstCaseHighDifficulty(MuseDashTestBase):
+class TestRemovedSongs(MuseDashTestBase):
     options = {
         "starting_song_count": 10,
         "allow_just_as_planned_dlc_songs": True,
@@ -16,7 +16,7 @@ class TestWorstCaseHighDifficulty(MuseDashTestBase):
         "FM 17314 SUGAR RADIO"
     ]
 
-    def test_songs_have_difficulty(self) -> None:
+    def test_remove_songs_are_not_generated(self) -> None:
         # This test is done on a world where every song should be added.
         muse_dash_world = self.multiworld.worlds[1]
 

--- a/worlds/musedash/test/TestRemovedSongs.py
+++ b/worlds/musedash/test/TestRemovedSongs.py
@@ -1,8 +1,5 @@
 from . import MuseDashTestBase
 
-# The worst case settings are DLC songs off, and enabling streamer mode.
-# This ends up with only 25 valid songs that can be chosen.
-# These tests ensure that this won't fail generation
 
 class TestRemovedSongs(MuseDashTestBase):
     options = {


### PR DESCRIPTION
## What is this fixing or adding?
- Adds the 2023 anniversary songs. (Why did this come out soon after merge and not before. ;_;)
  - Also includes update to a song's difficulty. 
- Removed Chaos Glitch as that is a hidden song. (Requiring knowledge of how to even get it to show.)
  - Includes fixing an oversight where 0 diff songs could be included. (0 is used as null for these songs)
- Add Muse Dash to the github list.

## How was this tested?
Generated local files. New test added to ensure the removed songs are actually removed.

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/7556376/b7389dbe-047a-4b3b-a267-626f12105ba1)
