### PR TITLE
MMBN3: Press program now has proper color index when received remotely

### DIFF
--- a/data/lua/connector_mmbn3.lua
+++ b/data/lua/connector_mmbn3.lua
@@ -354,7 +354,7 @@ end
 
 local getProgramColorIndex = function(program_id, program_color)
     -- The general case, most programs use white pink or yellow. This is the values the enums already have
-    if program_id >= 23 and program_id <= 47 then
+    if program_id >= 20 and program_id <= 47 then
         return program_color-1
     end
     --The final three programs only have a color index 0, so just return those


### PR DESCRIPTION
## What is this fixing or adding?
Fixes the Lua code for determining which index a program should use for color to properly set Press Program (and the starting programs of BlkMind, EnrgyChng, and Alpha, in case they are ever randomized in the future).

## How was this tested?
Manually toggled bits to find the proper index for these programs, rewrote the lua script to include them properly in their group, and ran a local seed to test if `!getitem` gave the program with the right index. Memory viewing confirmed proper bit was set, and item was properly accessible in inventory.