### PR TITLE
alttp: Add fill_slot_data function

### DIFF
--- a/worlds/alttp/__init__.py
+++ b/worlds/alttp/__init__.py
@@ -724,6 +724,23 @@ class ALTTPWorld(World):
                         res.append(item)
         return res
 
+    def fill_slot_data(self):
+        slot_data = {}
+        for option_name in alttp_options:
+            option = getattr(self.multiworld, option_name)[self.player]
+            slot_data[option_name] = option.value
+
+        slot_data.update({
+            'mode': self.multiworld.mode[self.player],
+            'goal': self.multiworld.goal[self.player],
+            'dark_room_logic': self.multiworld.dark_room_logic[self.player],
+            'mm_medalion': self.multiworld.required_medallions[self.player][0],
+            'tr_medalion': self.multiworld.required_medallions[self.player][1],
+            'shop_shuffle': self.multiworld.shop_shuffle[self.player]}
+        )
+
+        return slot_data
+
 
 def get_same_seed(world, seed_def: tuple) -> str:
     seeds: typing.Dict[tuple, str] = getattr(world, "__named_seeds", {})

--- a/worlds/alttp/__init__.py
+++ b/worlds/alttp/__init__.py
@@ -727,17 +727,22 @@ class ALTTPWorld(World):
     def fill_slot_data(self):
         slot_data = {}
         if not self.multiworld.is_race:
-            for option_name in alttp_options:
-                option = getattr(self.multiworld, option_name)[self.player]
-                slot_data[option_name] = option.value
-    
+            slot_options = ["crystals_needed_for_gt", "crystals_needed_for_ganon", "open_pyramid",
+                            "bigkey_shuffle", "smallkey_shuffle", "compass_shuffle", "map_shuffle",
+                            "progressive", "swordless", "retro_bow", "retro_caves", "shop_item_slots",
+                            "boss_shuffle", "pot_shuffle", "enemy_shuffle"]
+
+            slot_data = {option_name: getattr(self.multiworld, option_name)[self.player].value for option_name in slot_options}
+
             slot_data.update({
                 'mode': self.multiworld.mode[self.player],
                 'goal': self.multiworld.goal[self.player],
                 'dark_room_logic': self.multiworld.dark_room_logic[self.player],
                 'mm_medalion': self.multiworld.required_medallions[self.player][0],
                 'tr_medalion': self.multiworld.required_medallions[self.player][1],
-                'shop_shuffle': self.multiworld.shop_shuffle[self.player]}
+                'shop_shuffle': self.multiworld.shop_shuffle[self.player],
+                'entrance_shuffle': self.multiworld.shuffle[self.player]
+                }
             )
         return slot_data
         

--- a/worlds/alttp/__init__.py
+++ b/worlds/alttp/__init__.py
@@ -726,21 +726,21 @@ class ALTTPWorld(World):
 
     def fill_slot_data(self):
         slot_data = {}
-        for option_name in alttp_options:
-            option = getattr(self.multiworld, option_name)[self.player]
-            slot_data[option_name] = option.value
-
-        slot_data.update({
-            'mode': self.multiworld.mode[self.player],
-            'goal': self.multiworld.goal[self.player],
-            'dark_room_logic': self.multiworld.dark_room_logic[self.player],
-            'mm_medalion': self.multiworld.required_medallions[self.player][0],
-            'tr_medalion': self.multiworld.required_medallions[self.player][1],
-            'shop_shuffle': self.multiworld.shop_shuffle[self.player]}
-        )
-
+        if not multiworld.is_race:
+            for option_name in alttp_options:
+                option = getattr(self.multiworld, option_name)[self.player]
+                slot_data[option_name] = option.value
+    
+            slot_data.update({
+                'mode': self.multiworld.mode[self.player],
+                'goal': self.multiworld.goal[self.player],
+                'dark_room_logic': self.multiworld.dark_room_logic[self.player],
+                'mm_medalion': self.multiworld.required_medallions[self.player][0],
+                'tr_medalion': self.multiworld.required_medallions[self.player][1],
+                'shop_shuffle': self.multiworld.shop_shuffle[self.player]}
+            )
         return slot_data
-
+        
 
 def get_same_seed(world, seed_def: tuple) -> str:
     seeds: typing.Dict[tuple, str] = getattr(world, "__named_seeds", {})

--- a/worlds/alttp/__init__.py
+++ b/worlds/alttp/__init__.py
@@ -727,6 +727,10 @@ class ALTTPWorld(World):
     def fill_slot_data(self):
         slot_data = {}
         if not self.multiworld.is_race:
+            # all of these option are NOT used by the SNI- or Text-Client.
+            # they are used by the alttp-poptracker pack (https://github.com/StripesOO7/alttp-ap-poptracker-pack)
+            # for convenient auto-tracking of the generated settings and adjusting the tracker accordingly
+
             slot_options = ["crystals_needed_for_gt", "crystals_needed_for_ganon", "open_pyramid",
                             "bigkey_shuffle", "smallkey_shuffle", "compass_shuffle", "map_shuffle",
                             "progressive", "swordless", "retro_bow", "retro_caves", "shop_item_slots",

--- a/worlds/alttp/__init__.py
+++ b/worlds/alttp/__init__.py
@@ -726,7 +726,7 @@ class ALTTPWorld(World):
 
     def fill_slot_data(self):
         slot_data = {}
-        if not multiworld.is_race:
+        if not self.multiworld.is_race:
             for option_name in alttp_options:
                 option = getattr(self.multiworld, option_name)[self.player]
                 slot_data[option_name] = option.value

--- a/worlds/zillion/logic.py
+++ b/worlds/zillion/logic.py
@@ -28,7 +28,7 @@ def set_randomizer_locs(cs: CollectionState, p: int, zz_r: Randomizer) -> int:
             if isinstance(z_loc.item, ZillionItem) and z_loc.item.player == p \
             else zz_empty
         zz_r.locations[zz_name].item = zz_item
-        _hash += hash(zz_name) ^ hash(zz_item)
+        _hash += (hash(zz_name) * (z_loc.zz_loc.req.gun + 2)) ^ hash(zz_item)
     return _hash
 
 


### PR DESCRIPTION
## What is this fixing or adding?
Add fill_slot_data function. 
Used by StripesOO7's pop-tracker pack to auto populate settings as convenience for the user

## How was this tested?
Generated a bunch of seeds and played most of them with a smaller private group.

## If this makes graphical changes, please attach screenshots.
N/A