### PR TITLE
Muse Dash: Fix Rare Test Failure

### DIFF
--- a/worlds/musedash/test/TestPlandoSettings.py
+++ b/worlds/musedash/test/TestPlandoSettings.py
@@ -19,7 +19,9 @@ class TestIncludedSongSizeDoesntGrow(MuseDashTestBase):
 
     def test_included_songs_plando(self) -> None:
         muse_dash_world = self.multiworld.worlds[1]
+        songs = muse_dash_world.included_songs.copy()
+        songs.append(muse_dash_world.victory_song_name)
 
-        assert "Operation Blade" in muse_dash_world.included_songs, f"Logical songs is missing a plando song"
-        assert "Autumn Moods" in muse_dash_world.included_songs, f"Logical songs is missing a plando song"
-        assert "Fireflies" in muse_dash_world.included_songs, f"Logical songs is missing a plando song"
+        assert "Operation Blade" in songs, "Logical songs is missing a plando song: Operation Blade"
+        assert "Autumn Moods" in songs, "Logical songs is missing a plando song: Autumn Moods"
+        assert "Fireflies" in songs, "Logical songs is missing a plando song: Fireflies"


### PR DESCRIPTION
## What is this fixing or adding?
This fixes a rare test failure where the one of the included songs actually ended up chosen as the goal song.

## How was this tested?
Confirmed that the test pass when one song was a goal song.

## If this makes graphical changes, please attach screenshots.
