### PR TITLE
Tests: load custom tests from apworld

### DIFF
--- a/test/worlds/__init__.py
+++ b/test/worlds/__init__.py
@@ -1,20 +1,42 @@
 def load_tests(loader, standard_tests, pattern):
     import os
     import unittest
-    from ..TestBase import file_path
+    import Utils
+    import typing
+    import zipfile
+    import importlib
+    import inspect
+
     from worlds.AutoWorld import AutoWorldRegister
 
     suite = unittest.TestSuite()
     suite.addTests(standard_tests)
-    folders = [os.path.join(os.path.split(world.__file__)[0], "test")
+    folders = [(os.path.join(os.path.split(world.__file__)[0], "test"), world.zip_path)
                for world in AutoWorldRegister.world_types.values()]
 
-    all_tests = [
-        test_case for folder in folders if os.path.exists(folder)
-        for test_collection in loader.discover(folder, top_level_dir=file_path)
-        for test_suite in test_collection
-        for test_case in test_suite
+    all_tests: typing.List[unittest.TestCase] = [
     ]
 
+    for folder, zip_path in folders:
+        if os.path.exists(folder) and not zip_path:
+            all_tests.extend(
+                test_case
+                for test_collection in loader.discover(folder, top_level_dir=Utils.local_path("."))
+                for test_suite in test_collection
+                for test_case in test_suite
+            )
+        elif zip_path and os.path.exists(zip_path):
+            with zipfile.ZipFile(zip_path) as zf:
+                for zip_info in zf.infolist():
+                    if "__pycache__" in zip_info.filename:
+                        continue
+                    if "test" in zip_info.filename and zip_info.filename.endswith((".py", ".pyc", ".pyo")):
+                        import_path = "worlds." + os.path.splitext(zip_info.filename)[0].replace("/", ".")
+                        module = importlib.import_module(import_path)
+                        for name, obj in inspect.getmembers(module, inspect.isclass):
+                            if issubclass(obj, unittest.TestCase):
+                                all_tests.extend(obj(method_name) for method_name in loader.getTestCaseNames(obj))
+
+    assert all_tests, "No custom tests found, when it was expected to find them."
     suite.addTests(sorted(all_tests, key=lambda test: test.__module__))
     return suite


### PR DESCRIPTION
## What is this fixing or adding?
allows tests to be loaded from .apworld
nugget from wip_launcher_tests branch

## How was this tested?
https://discord.com/channels/731205301247803413/731214280439103580/1124492884670951585

## If this makes graphical changes, please attach screenshots.
