### PR TITLE
Core: Region connection helpers

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -878,7 +878,7 @@ class Region:
         for connecting_region, name in exits.items():
             self.connect(self.multiworld.get_region(connecting_region, self.player),
                          name if name else f"{self.name} -> {connecting_region}",
-                         rules[connecting_region] if connecting_region in rules else None)
+                         rules[connecting_region] if rules and connecting_region in rules else None)
 
     def __repr__(self):
         return self.__str__()

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -841,18 +841,18 @@ class Region:
         for location, address in locations.items():
             self.locations.append(location_type(self.player, location, address, self))
     
-    def connect(self, exiting_region: Region, name: Optional[str] = None,
+    def connect(self, connecting_region: Region, name: Optional[str] = None,
                 rule: Optional[Callable[[CollectionState], bool]] = None) -> None:
         """
         Connects this Region to another Region, placing the provided rule on the connection.
         
-        :param exiting_region: Region object to connect to path is `self -> exiting_region`
+        :param connecting_region: Region object to connect to path is `self -> exiting_region`
         :param name: name of the connection being created
         :param rule: callable to determine access of this connection to go from self to the exiting_region"""
-        _exit = self.create_exit(name) if name else self.create_exit(f"{self.name} -> {exiting_region}")
+        _exit = self.create_exit(name) if name else self.create_exit(f"{self.name} -> {connecting_region}")
         if rule:
             _exit.access_rule = rule
-        _exit.connect(exiting_region)
+        _exit.connect(connecting_region)
     
     def create_exit(self, name: str) -> Entrance:
         """
@@ -876,10 +876,9 @@ class Region:
         if not isinstance(exits, Dict):
             exits = dict.fromkeys(exits)
         for connecting_region, name in exits.items():
-            entrance = self.create_exit(name) if name else self.create_exit(f"{self.name} -> {connecting_region}")
-            if rules and connecting_region in rules:
-                entrance.access_rule = rules[connecting_region]
-            entrance.connect(self.multiworld.get_region(connecting_region, self.player))
+            self.connect(self.multiworld.get_region(connecting_region, self.player),
+                         name if name else f"{self.name} -> {connecting_region}",
+                         rules[connecting_region] if connecting_region in rules else None)
 
     def __repr__(self):
         return self.__str__()

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -897,7 +897,7 @@ class Region:
             _exit.access_rule = rule
         _exit.connect(connecting_region)
     
-    def create_exit(self, name: str) -> entrance_type:
+    def create_exit(self, name: str) -> Entrance:
         """
         Creates and returns an Entrance object as an exit of this region.
         
@@ -928,11 +928,6 @@ class Region:
 
     def __str__(self):
         return self.multiworld.get_name_string_for_object(self) if self.multiworld else f'{self.name} (Player {self.player})'
-    
-    def __class_getitem__(cls, item: Any) -> typing.Type[Region]:
-        if issubclass(item, Entrance):
-            cls.entrance_type = item
-            return cls
 
 
     def __init__(self, player: int, name: str = '', parent: Region = None):

--- a/docs/world api.md
+++ b/docs/world api.md
@@ -496,30 +496,28 @@ def create_items(self) -> None:
 def create_regions(self) -> None:
     # Add regions to the multiworld. "Menu" is the required starting point.
     # Arguments to Region() are name, player, world, and optionally hint_text
-    r = Region("Menu", self.player, self.multiworld)
-    # Set Region.exits to a list of entrances that are reachable from region
-    r.exits = [Entrance(self.player, "New game", r)]  # or use r.exits.append
-    # Append region to MultiWorld's regions
-    self.multiworld.regions.append(r)  # or use += [r...]
+    menu_region = Region("Menu", self.player, self.multiworld)
+    self.multiworld.regions.append(menu_region)  # or use += [menu_region...]
     
-    r = Region("Main Area", self.player, self.multiworld)
+    main_region = Region("Main Area", self.player, self.multiworld)
     # Add main area's locations to main area (all but final boss)
-    r.locations = [MyGameLocation(self.player, location.name,
-                   self.location_name_to_id[location.name], r)]
-    r.exits = [Entrance(self.player, "Boss Door", r)]
-    self.multiworld.regions.append(r)
+    main_region.add_locations(main_region_locations, MyGameLocation)
+    # or 
+    # main_region.locations = \
+    #   [MyGameLocation(self.player, location_name, self.location_name_to_id[location_name], main_region]
+    self.multiworld.regions.append(main_region)
     
-    r = Region("Boss Room", self.player, self.multiworld)
-    # add event to Boss Room
-    r.locations = [MyGameLocation(self.player, "Final Boss", None, r)]
-    self.multiworld.regions.append(r)
-    
-    # If entrances are not randomized, they should be connected here, otherwise
-    # they can also be connected at a later stage.
-    self.multiworld.get_entrance("New Game", self.player)
-        .connect(self.multiworld.get_region("Main Area", self.player))
-    self.multiworld.get_entrance("Boss Door", self.player)
-        .connect(self.multiworld.get_region("Boss Room", self.player))
+    boss_region = Region("Boss Room", self.player, self.multiworld)
+    # Add event to Boss Room
+    boss_region.locations.append(MyGameLocation(self.player, "Final Boss", None, boss_region))
+
+    # If entrances are not randomized, they should be connected here,
+    # otherwise they can also be connected at a later stage.
+    # Create Entrances and connect the Regions
+    menu_region.connect(main_region)  # connects the "Menu" and "Main Area", can also pass a rule
+    # or
+    main_region.add_exits({"Boss Room": "Boss Door"}, {"Boss Room": lambda state: state.has("Sword", self.player)})
+    # Connects the "Main Area" and "Boss Room" regions, and places a rule requiring the "Sword" item to traverse
     
     # If setting location access rules from data is easier here, set_rules can
     # possibly omitted.


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?
`Region.connect` and `Region.create_exit`. latter returns an entrance that can be used for other things (?) and former allows easy connection between two regions without needing the full structure of `add_exits`. Also added deprecation warning to creating Entrance elsewhere, since there's a ton of duplicated code from people doing so. Made it a separate commit so it can be easily dropped if desired.

## How was this tested?
unit tests and checking that the logs print the warning correctly

## If this makes graphical changes, please attach screenshots.
