### PR TITLE
Spoiler: Prevent locations from outputting to playthrough if `Location.show_in_spoiler` is `False`.

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1280,7 +1280,7 @@ class Spoiler:
             AutoWorld.call_all(self.multiworld, "write_spoiler", outfile)
 
             locations = [(str(location), str(location.item) if location.item is not None else "Nothing")
-                         for location in self.multiworld.get_locations()]
+                         for location in self.multiworld.get_locations() if location.show_in_spoiler]
             outfile.write('\n\nLocations:\n\n')
             outfile.write('\n'.join(
                 ['%s: %s' % (location, item) for location, item in locations]))

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1224,7 +1224,7 @@ class Spoiler:
             self.paths.update(
                 {str(location): get_path(state, location.parent_region)
                  for sphere in collection_spheres for location in sphere
-                 if location.player == player})
+                 if location.player == player and location.show_in_spoiler})
             if player in multiworld.get_game_players("A Link to the Past"):
                 # If Pyramid Fairy Entrance needs to be reached, also path to Big Bomb Shop
                 # Maybe move the big bomb over to the Event system instead?

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1188,9 +1188,15 @@ class Spoiler:
                                          chain.from_iterable(multiworld.precollected_items.values())
                                          if item.advancement])}
 
-        for i, sphere in enumerate(collection_spheres):
-            self.playthrough[str(i + 1)] = {
-                str(location): str(location.item) for location in sorted(sphere)}
+        sphere_index = 1
+        for sphere in collection_spheres:
+            sphere_data = {str(location): str(location.item) for location in sorted(sphere) if location.show_in_spoiler}
+            if len(sphere_data) == 0:  # No 'visible' locations in sphere to show.
+                continue
+
+            self.playthrough[sphere_index] = sphere_data
+            sphere_index += 1
+
         if create_paths:
             self.create_paths(state, collection_spheres)
 
@@ -1224,7 +1230,7 @@ class Spoiler:
             self.paths.update(
                 {str(location): get_path(state, location.parent_region)
                  for sphere in collection_spheres for location in sphere
-                 if location.player == player and location.show_in_spoiler})
+                 if location.player == player})
             if player in multiworld.get_game_players("A Link to the Past"):
                 # If Pyramid Fairy Entrance needs to be reached, also path to Big Bomb Shop
                 # Maybe move the big bomb over to the Event system instead?
@@ -1274,7 +1280,7 @@ class Spoiler:
             AutoWorld.call_all(self.multiworld, "write_spoiler", outfile)
 
             locations = [(str(location), str(location.item) if location.item is not None else "Nothing")
-                         for location in self.multiworld.get_locations() if location.show_in_spoiler]
+                         for location in self.multiworld.get_locations()]
             outfile.write('\n\nLocations:\n\n')
             outfile.write('\n'.join(
                 ['%s: %s' % (location, item) for location, item in locations]))

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1194,7 +1194,7 @@ class Spoiler:
             if len(sphere_data) == 0:  # No 'visible' locations in sphere to show.
                 continue
 
-            self.playthrough[sphere_index] = sphere_data
+            self.playthrough[str(sphere_index)] = sphere_data
             sphere_index += 1
 
         if create_paths:

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1191,7 +1191,7 @@ class Spoiler:
         sphere_index = 1
         for sphere in collection_spheres:
             sphere_data = {str(location): str(location.item) for location in sorted(sphere) if location.show_in_spoiler}
-            if len(sphere_data) == 0:  # No 'visible' locations in sphere to show.
+            if not sphere_data:  # No 'visible' locations in sphere to show.
                 continue
 
             self.playthrough[str(sphere_index)] = sphere_data


### PR DESCRIPTION
## What is this fixing or adding?
If `Location.show_in_spoiler` is `False`, the location does not output to the Location list in spoiler, but still outputs to the Playthrough section. This also removes the location from appearing in the Playthrough section.

## How was this tested?
Generated 2 same seed games on #1883 with `main` and these commits merged on top. Got the following outputs:

Before:
[Before-AP_14089154938208861744_Spoiler.txt](https://github.com/ArchipelagoMW/Archipelago/files/11929210/Before-AP_14089154938208861744_Spoiler.txt)

After:
[After-AP_14089154938208861744_Spoiler.txt](https://github.com/ArchipelagoMW/Archipelago/files/11929209/After-AP_14089154938208861744_Spoiler.txt)

## If this makes graphical changes, please attach screenshots.
If you're too lazy \:P to check out the spoiler text files:
![image](https://github.com/ArchipelagoMW/Archipelago/assets/11338376/7826bc15-ac8d-41cc-b485-d078116fa612)
