### PR TITLE
Core: Import `random` for type hint on World.random

### DIFF
--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -11,6 +11,7 @@ from BaseClasses import CollectionState
 from Options import AssembleOptions
 
 if TYPE_CHECKING:
+    import random
     from BaseClasses import MultiWorld, Item, Location, Tutorial
     from . import GamesPackage
 


### PR DESCRIPTION
## What is this fixing or adding?
#1649 added self.random with a correct type hint, but didn't import random, which caused the hint to be interpreted as `Any` (at least in VS Code for me)

## How was this tested?
Seeing VS Code pick up the type hint in other files and running `Generate.py`

## If this makes graphical changes, please attach screenshots.
N/A