### PR TITLE
OoT: Fix generating on 3.11 due to deprecated seeding from hash

### DIFF
--- a/worlds/oot/Cosmetics.py
+++ b/worlds/oot/Cosmetics.py
@@ -769,7 +769,7 @@ patch_sets[0x1F073FD9] = {
 
 def patch_cosmetics(ootworld, rom):
     # Use the world's slot seed for cosmetics
-    random.seed(ootworld.multiworld.per_slot_randoms[ootworld.player])
+    random.seed(ootworld.random.getrandbits(16))
 
     # try to detect the cosmetic patch data format
     versioned_patch_set = None


### PR DESCRIPTION
## What is this fixing or adding?
3.11 support

## How was this tested?
Generated before and after and error went away
@espeon65536 
## If this makes graphical changes, please attach screenshots.
