### PR TITLE
Raft: Only modify itempool during create_items

### DIFF
--- a/worlds/raft/__init__.py
+++ b/worlds/raft/__init__.py
@@ -48,15 +48,17 @@ class RaftWorld(World):
         maxRPSpecified = self.multiworld.maximum_resource_pack_amount[self.player].value
         minimumResourcePackAmount = min(minRPSpecified, maxRPSpecified)
         maximumResourcePackAmount = max(minRPSpecified, maxRPSpecified)
+        isFillingFrequencies = self.multiworld.island_frequency_locations[self.player].value <= 3
         # Generate item pool
         pool = []
         frequencyItems = []
         for item in item_table:
             raft_item = self.create_item_replaceAsNecessary(item["name"])
-            if "Frequency" in item["name"]:
+            if isFillingFrequencies and "Frequency" in item["name"]:
                 frequencyItems.append(raft_item)
-            pool.append(raft_item)
-        if self.multiworld.island_frequency_locations[self.player].value <= 3:
+            else:
+                pool.append(raft_item)
+        if isFillingFrequencies:
             if not hasattr(self.multiworld, "raft_frequencyItemsPerPlayer"):
                 self.multiworld.raft_frequencyItemsPerPlayer = {}
             self.multiworld.raft_frequencyItemsPerPlayer[self.player] = frequencyItems
@@ -103,6 +105,10 @@ class RaftWorld(World):
                     pool.append(raft_item)
 
         self.multiworld.itempool += pool
+
+        # Victory item
+        self.multiworld.get_location("Utopia Complete", self.player).place_locked_item(
+            RaftItem("Victory", ItemClassification.progression, None, player=self.player))
 
     def set_rules(self):
         set_rules(self.multiworld, self.player)
@@ -195,21 +201,15 @@ class RaftWorld(World):
                 elif self.multiworld.island_frequency_locations[self.player] == 3: # Random on island random order
                     self.setLocationItemFromRegion(previousLocation, locationToFrequencyItemMap[currentLocation])
                 previousLocation = currentLocation
-
-        # Victory item
-        self.multiworld.get_location("Utopia Complete", self.player).place_locked_item(
-            RaftItem("Victory", ItemClassification.progression, None, player=self.player))
     
     def setLocationItem(self, location: str, itemName: str):
         itemToUse = next(filter(lambda itm: itm.name == itemName, self.multiworld.raft_frequencyItemsPerPlayer[self.player]))
         self.multiworld.raft_frequencyItemsPerPlayer[self.player].remove(itemToUse)
-        self.multiworld.itempool.remove(itemToUse)
         self.multiworld.get_location(location, self.player).place_locked_item(itemToUse)
     
     def setLocationItemFromRegion(self, region: str, itemName: str):
         itemToUse = next(filter(lambda itm: itm.name == itemName, self.multiworld.raft_frequencyItemsPerPlayer[self.player]))
         self.multiworld.raft_frequencyItemsPerPlayer[self.player].remove(itemToUse)
-        self.multiworld.itempool.remove(itemToUse)
         location = random.choice(list(loc for loc in location_table if loc["region"] == region))
         self.multiworld.get_location(location["name"], self.player).place_locked_item(itemToUse)
     


### PR DESCRIPTION
## What is this fixing or adding?

Making itempool only modified during create_items, rather than in prefill.

## How was this tested?

Generated Raft worlds with different configurations that generated different items/prefills to make sure they still worked. Ran unit tests, including the one in [PR 1460](https://github.com/ArchipelagoMW/Archipelago/pull/1460/files) (modified so it only ran for Raft). Everything passed and worked as expected.