### PR TITLE
SMW: Move item creation earlier

### DIFF
--- a/worlds/smw/__init__.py
+++ b/worlds/smw/__init__.py
@@ -78,7 +78,12 @@ class SMWWorld(World):
         if self.multiworld.early_climb[self.player]:
             self.multiworld.local_early_items[self.player][ItemName.mario_climb] = 1
 
-    def generate_basic(self):
+
+    def create_regions(self):
+        location_table = setup_locations(self.multiworld, self.player)
+        create_regions(self.multiworld, self.player, location_table)
+
+        # Not generate basic
         itempool: typing.List[SMWItem] = []
 
         self.active_level_dict = dict(zip(generate_level_list(self.multiworld, self.player), full_level_list))
@@ -234,10 +239,6 @@ class SMWWorld(World):
                     break
 
             hint_data[self.player] = er_hint_data
-
-    def create_regions(self):
-        location_table = setup_locations(self.multiworld, self.player)
-        create_regions(self.multiworld, self.player, location_table)
 
     def create_item(self, name: str, force_non_progression=False) -> Item:
         data = item_table[name]


### PR DESCRIPTION
## What is this fixing or adding?
Move Generate Basic earlier to pass tests

## How was this tested?
A few generations

## If this makes graphical changes, please attach screenshots.
