### PR TITLE
CI: Update workflows to use Python 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,10 +66,10 @@ jobs:
       - name: Get a recent python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - name: Install build-time dependencies
         run: |
-          echo "PYTHON=python3.9" >> $GITHUB_ENV
+          echo "PYTHON=python3.11" >> $GITHUB_ENV
           wget -nv https://github.com/AppImage/AppImageKit/releases/download/$APPIMAGETOOL_VERSION/appimagetool-x86_64.AppImage
           chmod a+rx appimagetool-x86_64.AppImage
           ./appimagetool-x86_64.AppImage --appimage-extract

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,10 +44,10 @@ jobs:
       - name: Get a recent python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - name: Install build-time dependencies
         run: |
-          echo "PYTHON=python3.9" >> $GITHUB_ENV
+          echo "PYTHON=python3.11" >> $GITHUB_ENV
           wget -nv https://github.com/AppImage/AppImageKit/releases/download/$APPIMAGETOOL_VERSION/appimagetool-x86_64.AppImage
           chmod a+rx appimagetool-x86_64.AppImage
           ./appimagetool-x86_64.AppImage --appimage-extract

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -38,14 +38,15 @@ jobs:
           - {version: '3.8'}
           - {version: '3.9'}
           - {version: '3.10'}
+          - {version: '3.11'}
         include:
           - python: {version: '3.8'}  # win7 compat
             os: windows-latest
-          - python: {version: '3.10'}  # current
+          - python: {version: '3.11'}  # current
             os: windows-latest
-          - python: {version: '3.10'}  # current
+          - python: {version: '3.11'}  # current
             os: macos-latest
-          - python: {version: '3.10'}  # current
+          - python: {version: '3.11'}  # current
             os: ubuntu-latest
             cython: beta
 


### PR DESCRIPTION
## What is this fixing or adding?
Title. Confirmed it built using Ubuntu action, but will need @black-sliver to verify for Linux test/build actions. This will be needed as it's expected for AP 0.4.2 to be built on 3.11.

This should be the next stage since AP works on 3.11 as of #1821, so after this workflow update, wait for #1948 and #1933 merged, release one final Windows 7 supported release, then drop 3.8 and 3.9 workflows (and Windows 7 support).

## How was this tested?
Ran build action on repo fork and it built successfully. Ran 3.11 unit tests locally and passed.

## If this makes graphical changes, please attach screenshots.
N/A