### PR TITLE
Core: Add display name for `item_links` Option.

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
+
 import abc
 import logging
-from copy import deepcopy
 import math
 import numbers
-import typing
 import random
+import typing
+from copy import deepcopy
 
-from schema import Schema, And, Or, Optional
+from schema import And, Optional, Or, Schema
+
 from Utils import get_fuzzy_results
 
 if typing.TYPE_CHECKING:
@@ -949,6 +951,7 @@ class DeathLink(Toggle):
 
 class ItemLinks(OptionList):
     """Share part of your item pool with other players."""
+    display_name = "Item Links"
     default = []
     schema = Schema([
         {


### PR DESCRIPTION
## What is this fixing or adding?
Just adds a display name. Mostly so spoiler prints `Item Links` instead of `item_links`.

Also re-sorts the imports in `Option.py` since my IDE does that. \:P

## How was this tested?
Looked at spoiler log after generating game.

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/11338376/d176de52-87fd-4481-9555-6929a50cceab)
wow