### PR TITLE
DOOM 1993: Fix crash when generating games with "allow_death_logic" enabled

### DIFF
--- a/worlds/doom_1993/__init__.py
+++ b/worlds/doom_1993/__init__.py
@@ -127,8 +127,8 @@ class DOOM1993World(World):
         # Forbid progression items to locations that can be missed and can't be picked up. (e.g. One-time timed
         # platform) Unless the user allows for it.
         if getattr(self.multiworld, "allow_death_logic")[self.player]:
-            self.multiworld.exclude_locations[self.player] += set(Locations.death_logic_locations)
-    
+            self.multiworld.exclude_locations[self.player].value.update(Locations.death_logic_locations)
+
     def create_item(self, name: str) -> DOOM1993Item:
         item_id: int = self.item_name_to_id[name]
         return DOOM1993Item(name, Items.item_table[item_id]["classification"], item_id, self.player)
@@ -170,7 +170,7 @@ class DOOM1993World(World):
 
             self.multiworld.get_location(event, self.player).place_locked_item(self.create_event(event))
             self.location_count -= 1
-    
+
         # Special case for E2M6 and E3M8, where you enter a normal door then get stuck behind with a key door.
         # We need to put the key in the locations available behind this door.
         if self.included_episodes[1]:


### PR DESCRIPTION
## What is this fixing or adding?
This fixes an issue where generating a multiworld with a DOOM 1993 game would fail if the game had the `allow_death_logic` option enabled. The stack trace/error output from `ArchipelagoGenerate.exe` would look something like below:

```
...
Creating World.
Creating Items.
Calculating Access Rules.
Uncaught exception
Traceback (most recent call last):
  File "__startup__.py", line 130, in run
  File "console.py", line 16, in run
  File "Generate.py", line 646, in <module>
  File "Generate.py", line 227, in main
  File "Main.py", line 141, in main
  File "worlds\AutoWorld.py", line 109, in call_all
  File "worlds\AutoWorld.py", line 101, in call_single
  File "worlds\doom_1993\__init__.py", line 130, in set_rules
TypeError: unsupported operand type(s) for +=: 'ExcludeLocations' and 'set'
Traceback (most recent call last):
  File "__startup__.py", line 130, in run
  File "console.py", line 16, in run
  File "Generate.py", line 646, in <module>
  File "Generate.py", line 227, in main
  File "Main.py", line 141, in main
  File "worlds\AutoWorld.py", line 109, in call_all
  File "worlds\AutoWorld.py", line 101, in call_single
  File "worlds\doom_1993\__init__.py", line 130, in set_rules
TypeError: unsupported operand type(s) for +=: 'ExcludeLocations' and 'set'
```

The fix is to change how the excluded locations are updated in `worlds/doom_1993/__init__.py:set_rules` to update `ExcludeLocations.value` instead of `ExcludeLocations` directly.

## How was this tested?

Created a multiworld with two DOOM games, one with `allow_death_logic` enabled and one disabled. The spoiler log shows that the 7 locations that should be excluded were only excluded for the game with the option disabled.