### PR TITLE
Core: deprecate direct Entrance creation

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -878,6 +878,10 @@ class Entrance:
         self.name = name
         self.parent_region = parent
         self.player = player
+        from inspect import stack
+        if not stack()[1].function == "create_exit":
+            logging.warning(f"Direct Entrance creation is deprecated.\n{stack()[1][1::1]}\n"
+                            "Please use `Region.create_exit`, `Region.connect` or `Region.add_exits` to create Entrances")
 
     def can_reach(self, state: CollectionState) -> bool:
         if self.parent_region.can_reach(state) and self.access_rule(state):

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -10,6 +10,7 @@ from argparse import Namespace
 from collections import ChainMap, Counter, deque
 from enum import IntEnum, IntFlag
 from typing import Any, Callable, Dict, Iterable, Iterator, List, NamedTuple, Optional, Set, Tuple, TypedDict, Union
+from inspect import stack
 
 import NetUtils
 import Options
@@ -878,7 +879,6 @@ class Entrance:
         self.name = name
         self.parent_region = parent
         self.player = player
-        from inspect import stack
         frame_info = stack()[1]
         if frame_info.function != "create_exit":
             logging.warning("Direct Entrance creation is deprecated. Please use `Region.create_exit`, "

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -879,9 +879,12 @@ class Entrance:
         self.parent_region = parent
         self.player = player
         from inspect import stack
-        if not stack()[1].function == "create_exit":
-            logging.warning(f"Direct Entrance creation is deprecated.\n{stack()[1][1::1]}\n"
-                            "Please use `Region.create_exit`, `Region.connect` or `Region.add_exits` to create Entrances")
+        frame_info = stack()[1]
+        if frame_info.function != "create_exit":
+            logging.warning("Direct Entrance creation is deprecated. Please use `Region.create_exit`, "
+                            "`Region.connect` or `Region.add_exits` to create Entrances.\n"
+                            f"  File \"{frame_info.filename}\", line {frame_info.lineno}, in {frame_info.function}\n"
+                            f"    {frame_info.code_context[0].lstrip()}")
 
     def can_reach(self, state: CollectionState) -> bool:
         if self.parent_region.can_reach(state) and self.access_rule(state):


### PR DESCRIPTION
## What is this fixing or adding?
Title. Logs a warning if a function not named "create_exit" is used to create an Entrance object. Incredibly dirty solution, but haven't been able to come up with a better one.

## How was this tested?
Ran some tests creating entrances directly and with the helpers.

## If this makes graphical changes, please attach screenshots.
