### PR TITLE
Undertale: Change Save Data Folder Location

### DIFF
--- a/UndertaleClient.py
+++ b/UndertaleClient.py
@@ -32,6 +32,11 @@ class UndertaleCommandProcessor(ClientCommandProcessor):
             self.ctx.patch_game()
             self.output("Patched.")
 
+    def _cmd_savepath(self, directory: str):
+        """Redirect to proper save data folder. (Only use if needed!)"""
+        if isinstance(self.ctx, UndertaleContext):
+            UndertaleContext.save_game_folder = directory
+
     @mark_raw
     def _cmd_auto_patch(self, steaminstall: typing.Optional[str] = None):
         """Patch the game automatically."""

--- a/UndertaleClient.py
+++ b/UndertaleClient.py
@@ -33,7 +33,7 @@ class UndertaleCommandProcessor(ClientCommandProcessor):
             self.output("Patched.")
 
     def _cmd_savepath(self, directory: str):
-        """Redirect to proper save data folder. (Only use if needed!)"""
+        """Redirect to proper save data folder. (Use before connecting!)"""
         if isinstance(self.ctx, UndertaleContext):
             UndertaleContext.save_game_folder = directory
 

--- a/UndertaleClient.py
+++ b/UndertaleClient.py
@@ -36,6 +36,7 @@ class UndertaleCommandProcessor(ClientCommandProcessor):
         """Redirect to proper save data folder. (Use before connecting!)"""
         if isinstance(self.ctx, UndertaleContext):
             UndertaleContext.save_game_folder = directory
+            self.output("Changed to the following directory: " + directory)
 
     @mark_raw
     def _cmd_auto_patch(self, steaminstall: typing.Optional[str] = None):

--- a/worlds/undertale/docs/undertale_en.md
+++ b/worlds/undertale/docs/undertale_en.md
@@ -13,6 +13,12 @@ by opening the Undertale directory through Steam), it will then make an Undertal
 Archipelago install location. That contains the version of Undertale you will use for Archipelago. (You will need to
 redo this step when updating Archipelago.)
 
+**Linux Users**: This guide is mostly similar; however, when Undertale is installed on Steam, it defaults to a Linux
+supported variant; this randomizer only supports the Windows version.  To fix this, right-click the game in Steam, go to
+Properties -> Compatibility, and check "Force the use of a specific Steam Play compatibility tool".  This
+downloads the Windows version instead.  If the play button is greyed out in Steam, be sure to go to
+Settings -> Compatibility and toggle "Enable Steam Play for all other titles".
+
 ### Connect to the MultiServer
 
 Make sure both Undertale and its client are running. (Undertale will ask for a saveslot, it can be 1 through 99, none 
@@ -22,6 +28,20 @@ In the top text box of the client, type the
 `Ip Address` (or `Hostname`) and `Port` separated with a `:` symbol. (Ex. `archipelago.gg:38281`)
 
 The client will then ask for the slot name, input that in the text box at the bottom of the client.
+
+**Linux Users**: When you start the client, it is likely that the save data path is incorrect, and how the game
+is played depends on where the save data folder is located.
+
+*On Steam (via Proton)*: This assumes the game is in a Steam Library folder.  Right-click Undertale, go to Manage -> 
+Browse Local Files.  Move back to the steamapps folder, open compatdata/391540 (391540 is the "magic number" for
+Undertale in Steam and can be confirmed by visiting its store page and looking at the URL).  Save data from here is at
+/pfx/drive_c/users/steamuser/AppData/Local/UNDERTALE.
+
+*Through WINE directly*: This depends on the prefix used.  If it is default, then the save data is located at
+/home/USERNAME/.wine/drive_c/users/USERNAME/AppData/Local/UNDERTALE.
+
+Once the save data folder is located, run the /savepath command to redirect the client to the correct save data folder
+before connecting.
 
 ### Play the game
 


### PR DESCRIPTION
## What is this fixing or adding?
Adds a new command to the client, named /savepath.  This lets you target the path where your save data is stored.  Normally the client automatically finds the correct place, due to the Windows platform; however Linux platforms for example would have to utilize Wine in order to play what is currently implement and would thus utilize a wine prefix.  Doing this allows the user to redirect the client to the correct folder on launch.  Its a rough solution but should make the game playable for Linux until something more sophisticated is made.

## How was this tested?

- Ran the client, connected, used the command, did !getitem Spider Donut, received it.
- Ran the client, used the command, connected, did !getitem Spider Donut, received it.
