### PR TITLE
Core: Discourage calls to multiworld random

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -192,14 +192,17 @@ class MultiWorld():
         """Calls to `MultiWorld.random` have been deprecated. Please use `World.random` instead."""
         if __debug__:
             from inspect import stack
-            for frame in stack():
+            stack = stack()
+            for frame in stack:
                 if frame.filename.endswith(("Main.py", "Fill.py")):
                     break
                 if frame.filename.endswith("AutoWorld.py"):
                     # TODO replace with deprecate ~0.5.0
                     if frame.function == "call_single":
+                        calling_frame = stack[1]
                         warnings.warn("Calls to `MultiWorld.random` from a World instance have been deprecated. "
-                                      "Please use `self.random`.")
+                                      "Please use `self.random`. "
+                                      f"Called from {calling_frame.filename}, {calling_frame.function} L{calling_frame.lineno}")
                         break
                     break
             else:

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -189,7 +189,8 @@ class MultiWorld():
     @property
     def random(self) -> random.Random:
         """Calls to `MultiWorld.random` have been deprecated. Please use `World.random` instead."""
-        logging.warning("Calls to `MultiWorld.random` have been deprecated. Please use `World.random` instead.")
+        if __debug__:
+            logging.warning("Calls to `MultiWorld.random` have been deprecated. Please use `World.random` instead.")
         return self._random
 
     def get_all_ids(self) -> Tuple[int, ...]:

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -41,7 +41,7 @@ class ThreadBarrierProxy:
             return getattr(self.obj, name)
         else:
             raise RuntimeError("You are in a threaded context and global random state was removed for your safety. "
-                               "Please use multiworld.per_slot_randoms[player] or randomize ahead of output.")
+                               "Please use World.random or randomize ahead of output.")
 
 
 class MultiWorld():
@@ -81,9 +81,9 @@ class MultiWorld():
 
     game: Dict[int, str]
 
-    random: random.Random
+    _random: random.Random
     per_slot_randoms: Dict[int, random.Random]
-    """Deprecated. Please use `self.random` instead."""
+    """Deprecated. Please use `World.random` instead."""
 
     class AttributeProxy():
         def __init__(self, rule):
@@ -94,7 +94,7 @@ class MultiWorld():
 
     def __init__(self, players: int):
         # world-local random state is saved for multiple generations running concurrently
-        self.random = ThreadBarrierProxy(random.Random())
+        self._random = ThreadBarrierProxy(random.Random())
         self.players = players
         self.player_types = {player: NetUtils.SlotType.player for player in self.player_ids}
         self.glitch_triforce = False
@@ -185,6 +185,12 @@ class MultiWorld():
         self.worlds = {}
         self.per_slot_randoms = {}
         self.plando_options = PlandoOptions.none
+    
+    @property
+    def random(self) -> random.Random:
+        """Calls to `MultiWorld.random` have been deprecated. Please use `World.random` instead."""
+        logging.warning("Calls to `MultiWorld.random` have been deprecated. Please use `World.random` instead.")
+        return self._random
 
     def get_all_ids(self) -> Tuple[int, ...]:
         return self.player_ids + tuple(self.groups)

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -206,8 +206,7 @@ class MultiWorld():
                         break
                     break
             else:
-                if not stack()[1].function.startswith("test_"):
-                    raise ValueError("Unable to properly evaluate stack from multiworld.random call.")
+                raise ValueError(f"Unable to properly evaluate stack from multiworld.random call. {stack}")
         return self._random
 
     def get_all_ids(self) -> Tuple[int, ...]:

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -193,19 +193,18 @@ class MultiWorld():
         if __debug__:
             from inspect import stack
             for frame in stack():
-                if frame.filename.endswith("Main.py"):
+                if frame.filename.endswith(("Main.py", "Fill.py")):
                     break
                 if frame.filename.endswith("AutoWorld.py"):
-                    # TODO remove ~0.5.0
+                    # TODO replace with deprecate ~0.5.0
                     if frame.function == "call_single":
                         warnings.warn("Calls to `MultiWorld.random` from a World instance have been deprecated. "
                                       "Please use `self.random`.")
                         break
-                    assert frame.function != "call_single", ("Calls to `MultiWorld.random` from a World instance have "
-                                                             "been deprecated. Please use `self.random`.")
                     break
             else:
-                raise ValueError("Unable to properly evaluate stack from multiworld.random call.")
+                if not stack()[1].function.startswith("test_"):
+                    raise ValueError("Unable to properly evaluate stack from multiworld.random call.")
         return self._random
 
     def get_all_ids(self) -> Tuple[int, ...]:

--- a/test/general/test_fill.py
+++ b/test/general/test_fill.py
@@ -726,9 +726,9 @@ class TestDistributeItemsRestrictive(unittest.TestCase):
         # copied this code from the beginning of `distribute_items_restrictive`
         # before `distribute_early_items` is called
         fill_locations = sorted(mw.get_unfilled_locations())
-        mw.random.shuffle(fill_locations)
+        mw._random.shuffle(fill_locations)
         itempool = sorted(mw.itempool)
-        mw.random.shuffle(itempool)
+        mw._random.shuffle(itempool)
 
         fill_locations, itempool = distribute_early_items(mw, fill_locations, itempool)
 

--- a/worlds/alttp/Bosses.py
+++ b/worlds/alttp/Bosses.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import logging
-from typing import Optional, Union, List, Tuple, Callable, Dict, TYPE_CHECKING
+from typing import Callable, Dict, List, Optional, TYPE_CHECKING, Tuple, Union
 
 from Fill import FillError
 from .Options import LTTPBosses as Bosses
-from .StateHelpers import can_shoot_arrows, can_extend_magic, can_get_good_bee, has_sword, has_beam_sword, \
-    has_melee_weapon, has_fire_source
+from .StateHelpers import can_extend_magic, can_get_good_bee, can_shoot_arrows, has_beam_sword, has_fire_source, \
+    has_melee_weapon, has_sword
 
 if TYPE_CHECKING:
     from . import ALTTPWorld
@@ -188,7 +188,7 @@ boss_location_table: List[Tuple[str, str]] = [
 def place_plando_bosses(world: "ALTTPWorld", bosses: List[str]) -> Tuple[List[str], List[Tuple[str, str]]]:
     # Most to least restrictive order
     boss_locations = boss_location_table.copy()
-    world.world.random.shuffle(boss_locations)
+    world.random.shuffle(boss_locations)
     boss_locations.sort(key=lambda location: -int(restrictive_boss_locations[location]))
     already_placed_bosses: List[str] = []
 

--- a/worlds/alttp/Bosses.py
+++ b/worlds/alttp/Bosses.py
@@ -188,7 +188,7 @@ boss_location_table: List[Tuple[str, str]] = [
 def place_plando_bosses(world: "ALTTPWorld", bosses: List[str]) -> Tuple[List[str], List[Tuple[str, str]]]:
     # Most to least restrictive order
     boss_locations = boss_location_table.copy()
-    world.multiworld.random.shuffle(boss_locations)
+    world.world.random.shuffle(boss_locations)
     boss_locations.sort(key=lambda location: -int(restrictive_boss_locations[location]))
     already_placed_bosses: List[str] = []
 
@@ -275,7 +275,7 @@ def place_bosses(world: "ALTTPWorld") -> None:
     # Most to least restrictive order
     if not remaining_locations and not already_placed_bosses:
         remaining_locations = boss_location_table.copy()
-    multiworld.random.shuffle(remaining_locations)
+    world.random.shuffle(remaining_locations)
     remaining_locations.sort(key=lambda location: -int(restrictive_boss_locations[location]))
 
     all_bosses = sorted(boss_table.keys())  # sorted to be deterministic on older pythons
@@ -285,7 +285,7 @@ def place_bosses(world: "ALTTPWorld") -> None:
         if boss_shuffle == Bosses.option_basic:  # vanilla bosses shuffled
             bosses = placeable_bosses + ['Armos Knights', 'Lanmolas', 'Moldorm']
         else:  # all bosses present, the three duplicates chosen at random
-            bosses = placeable_bosses + multiworld.random.sample(placeable_bosses, 3)
+            bosses = placeable_bosses + world.random.sample(placeable_bosses, 3)
 
         # there is probably a better way to do this
         while already_placed_bosses:
@@ -297,7 +297,7 @@ def place_bosses(world: "ALTTPWorld") -> None:
 
         logging.debug('Bosses chosen %s', bosses)
 
-        multiworld.random.shuffle(bosses)
+        world.random.shuffle(bosses)
         for loc, level in remaining_locations:
             for _ in range(len(bosses)):
                 boss = bosses.pop()
@@ -315,7 +315,7 @@ def place_bosses(world: "ALTTPWorld") -> None:
     elif boss_shuffle == Bosses.option_chaos:  # all bosses chosen at random
         for loc, level in remaining_locations:
             try:
-                boss = multiworld.random.choice(
+                boss = world.random.choice(
                     [b for b in placeable_bosses if can_place_boss(b, loc, level)])
             except IndexError:
                 raise FillError(f'Could not place boss for location {format_boss_location(loc, level)}')
@@ -323,11 +323,11 @@ def place_bosses(world: "ALTTPWorld") -> None:
                 place_boss(world, boss, loc, level)
 
     elif boss_shuffle == Bosses.option_singularity:
-        primary_boss = multiworld.random.choice(placeable_bosses)
+        primary_boss = world.random.choice(placeable_bosses)
         remaining_boss_locations, _ = place_where_possible(world, primary_boss, remaining_locations)
         if remaining_boss_locations:
             # pick a boss to go into the remaining locations
-            remaining_boss = multiworld.random.choice([boss for boss in placeable_bosses if all(
+            remaining_boss = world.random.choice([boss for boss in placeable_bosses if all(
                 can_place_boss(boss, loc, level) for loc, level in remaining_boss_locations)])
             remaining_boss_locations, _ = place_where_possible(world, remaining_boss, remaining_boss_locations)
             if remaining_boss_locations:

--- a/worlds/alttp/Dungeons.py
+++ b/worlds/alttp/Dungeons.py
@@ -222,7 +222,7 @@ def fill_dungeons_restrictive(multiworld: MultiWorld):
                     location.item_rule = lambda item, dungeon=dungeon, orig_rule=orig_rule: \
                         (not (item.player, item.name) in dungeon_specific or item.dungeon is dungeon) and orig_rule(item)
 
-            multiworld.random.shuffle(locations)
+            subworld.random.shuffle(locations)
             # Dungeon-locked items have to be placed first, to not run out of spaces for dungeon-locked items
             # subsort in the order Big Key, Small Key, Other before placing dungeon items
 

--- a/worlds/alttp/Dungeons.py
+++ b/worlds/alttp/Dungeons.py
@@ -222,7 +222,7 @@ def fill_dungeons_restrictive(multiworld: MultiWorld):
                     location.item_rule = lambda item, dungeon=dungeon, orig_rule=orig_rule: \
                         (not (item.player, item.name) in dungeon_specific or item.dungeon is dungeon) and orig_rule(item)
 
-            subworld.random.shuffle(locations)
+            multiworld.random.shuffle(locations)
             # Dungeon-locked items have to be placed first, to not run out of spaces for dungeon-locked items
             # subsort in the order Big Key, Small Key, Other before placing dungeon items
 

--- a/worlds/alttp/EntranceShuffle.py
+++ b/worlds/alttp/EntranceShuffle.py
@@ -1,13 +1,18 @@
 # ToDo: With shuffle_ganon option, prevent gtower from linking to an exit only location through a 2 entrance cave.
+import typing
 from collections import defaultdict
 
+from BaseClasses import MultiWorld
+if typing.TYPE_CHECKING:
+    from . import ALTTPWorld
 from .OverworldGlitchRules import overworld_glitch_connections
 from .UnderworldGlitchRules import underworld_glitch_connections
 
 
-def link_entrances(world, player):
-    connect_two_way(world, 'Links House', 'Links House Exit', player) # unshuffled. For now
-    connect_exit(world, 'Chris Houlihan Room Exit', 'Links House', player) # should always match link's house, except for plandos
+def link_entrances(multiworld: MultiWorld, player: int):
+    world = multiworld.worlds[player]
+    connect_two_way(multiworld, 'Links House', 'Links House Exit', player)  # unshuffled. For now
+    connect_exit(multiworld, 'Chris Houlihan Room Exit', 'Links House', player)  # should always match link's house, except for plandos
 
     Dungeon_Exits = Dungeon_Exits_Base.copy()
     Cave_Exits = Cave_Exits_Base.copy()
@@ -18,55 +23,55 @@ def link_entrances(world, player):
 
     # setup mandatory connections
     for exitname, regionname in mandatory_connections:
-        connect_simple(world, exitname, regionname, player)
+        connect_simple(multiworld, exitname, regionname, player)
 
     # if we do not shuffle, set default connections
-    if world.shuffle[player] == 'vanilla':
+    if multiworld.shuffle[player] == 'vanilla':
         for exitname, regionname in default_connections:
-            connect_simple(world, exitname, regionname, player)
+            connect_simple(multiworld, exitname, regionname, player)
         for exitname, regionname in default_dungeon_connections:
-            connect_simple(world, exitname, regionname, player)
-    elif world.shuffle[player] == 'dungeonssimple':
+            connect_simple(multiworld, exitname, regionname, player)
+    elif multiworld.shuffle[player] == 'dungeonssimple':
         for exitname, regionname in default_connections:
-            connect_simple(world, exitname, regionname, player)
+            connect_simple(multiworld, exitname, regionname, player)
 
-        simple_shuffle_dungeons(world, player)
-    elif world.shuffle[player] == 'dungeonsfull':
+        simple_shuffle_dungeons(multiworld, player)
+    elif multiworld.shuffle[player] == 'dungeonsfull':
         for exitname, regionname in default_connections:
-            connect_simple(world, exitname, regionname, player)
+            connect_simple(multiworld, exitname, regionname, player)
 
-        skull_woods_shuffle(world, player)
+        skull_woods_shuffle(multiworld, player)
 
         dungeon_exits = list(Dungeon_Exits)
         lw_entrances = list(LW_Dungeon_Entrances)
         dw_entrances = list(DW_Dungeon_Entrances)
 
-        if world.mode[player] == 'standard':
+        if multiworld.mode[player] == 'standard':
             # must connect front of hyrule castle to do escape
-            connect_two_way(world, 'Hyrule Castle Entrance (South)', 'Hyrule Castle Exit (South)', player)
+            connect_two_way(multiworld, 'Hyrule Castle Entrance (South)', 'Hyrule Castle Exit (South)', player)
         else:
             dungeon_exits.append(('Hyrule Castle Exit (South)', 'Hyrule Castle Exit (West)', 'Hyrule Castle Exit (East)'))
             lw_entrances.append('Hyrule Castle Entrance (South)')
 
-        if not world.shuffle_ganon:
-            connect_two_way(world, 'Ganons Tower', 'Ganons Tower Exit', player)
+        if not multiworld.shuffle_ganon:
+            connect_two_way(multiworld, 'Ganons Tower', 'Ganons Tower Exit', player)
         else:
             dw_entrances.append('Ganons Tower')
             dungeon_exits.append('Ganons Tower Exit')
 
-        if world.mode[player] == 'standard':
+        if multiworld.mode[player] == 'standard':
             # rest of hyrule castle must be in light world, so it has to be the one connected to east exit of desert
             hyrule_castle_exits = [('Hyrule Castle Exit (West)', 'Hyrule Castle Exit (East)')]
-            connect_mandatory_exits(world, lw_entrances, hyrule_castle_exits, list(LW_Dungeon_Entrances_Must_Exit), player)
-            connect_caves(world, lw_entrances, [], hyrule_castle_exits, player)
+            connect_mandatory_exits(multiworld, lw_entrances, hyrule_castle_exits, list(LW_Dungeon_Entrances_Must_Exit), player)
+            connect_caves(multiworld, lw_entrances, [], hyrule_castle_exits, player)
         else:
-            connect_mandatory_exits(world, lw_entrances, dungeon_exits, list(LW_Dungeon_Entrances_Must_Exit), player)
-        connect_mandatory_exits(world, dw_entrances, dungeon_exits, list(DW_Dungeon_Entrances_Must_Exit), player)
-        connect_caves(world, lw_entrances, dw_entrances, dungeon_exits, player)
-    elif world.shuffle[player] == 'dungeonscrossed':
-        crossed_shuffle_dungeons(world, player)
-    elif world.shuffle[player] == 'simple':
-        simple_shuffle_dungeons(world, player)
+            connect_mandatory_exits(multiworld, lw_entrances, dungeon_exits, list(LW_Dungeon_Entrances_Must_Exit), player)
+        connect_mandatory_exits(multiworld, dw_entrances, dungeon_exits, list(DW_Dungeon_Entrances_Must_Exit), player)
+        connect_caves(multiworld, lw_entrances, dw_entrances, dungeon_exits, player)
+    elif multiworld.shuffle[player] == 'dungeonscrossed':
+        crossed_shuffle_dungeons(multiworld, player)
+    elif multiworld.shuffle[player] == 'simple':
+        simple_shuffle_dungeons(multiworld, player)
 
         old_man_entrances = list(Old_Man_Entrances)
         caves = list(Cave_Exits)
@@ -85,8 +90,8 @@ def link_entrances(world, player):
         while two_door_caves:
             entrance1, entrance2 = two_door_caves.pop()
             exit1, exit2 = caves.pop()
-            connect_two_way(world, entrance1, exit1, player)
-            connect_two_way(world, entrance2, exit2, player)
+            connect_two_way(multiworld, entrance1, exit1, player)
+            connect_two_way(multiworld, entrance2, exit2, player)
 
         # now the remaining pairs
         two_door_caves = list(Two_Door_Caves)
@@ -94,8 +99,8 @@ def link_entrances(world, player):
         while two_door_caves:
             entrance1, entrance2 = two_door_caves.pop()
             exit1, exit2 = caves.pop()
-            connect_two_way(world, entrance1, exit1, player)
-            connect_two_way(world, entrance2, exit2, player)
+            connect_two_way(multiworld, entrance1, exit1, player)
+            connect_two_way(multiworld, entrance2, exit2, player)
 
         # at this point only Light World death mountain entrances remain
         # place old man, has limited options
@@ -106,38 +111,38 @@ def link_entrances(world, player):
         remaining_entrances.extend(old_man_entrances)
         world.random.shuffle(remaining_entrances)
         old_man_entrance = remaining_entrances.pop()
-        connect_two_way(world, old_man_entrance, 'Old Man Cave Exit (West)', player)
-        connect_two_way(world, old_man_exit, 'Old Man Cave Exit (East)', player)
+        connect_two_way(multiworld, old_man_entrance, 'Old Man Cave Exit (West)', player)
+        connect_two_way(multiworld, old_man_exit, 'Old Man Cave Exit (East)', player)
 
         # add old man house to ensure it is always somewhere on light death mountain
         caves.extend(list(Old_Man_House))
         caves.extend(list(three_exit_caves))
 
         # connect rest
-        connect_caves(world, remaining_entrances, [], caves, player)
+        connect_caves(multiworld, remaining_entrances, [], caves, player)
 
         # scramble holes
-        scramble_holes(world, player)
+        scramble_holes(multiworld, player)
 
         # place blacksmith, has limited options
         world.random.shuffle(blacksmith_doors)
         blacksmith_hut = blacksmith_doors.pop()
-        connect_entrance(world, blacksmith_hut, 'Blacksmiths Hut', player)
+        connect_entrance(multiworld, blacksmith_hut, 'Blacksmiths Hut', player)
         bomb_shop_doors.extend(blacksmith_doors)
 
         # place bomb shop, has limited options
         world.random.shuffle(bomb_shop_doors)
         bomb_shop = bomb_shop_doors.pop()
-        connect_entrance(world, bomb_shop, 'Big Bomb Shop', player)
+        connect_entrance(multiworld, bomb_shop, 'Big Bomb Shop', player)
         single_doors.extend(bomb_shop_doors)
 
         # tavern back door cannot be shuffled yet
-        connect_doors(world, ['Tavern North'], ['Tavern'], player)
+        connect_doors(multiworld, ['Tavern North'], ['Tavern'], player)
 
         # place remaining doors
-        connect_doors(world, single_doors, door_targets, player)
-    elif world.shuffle[player] == 'restricted':
-        simple_shuffle_dungeons(world, player)
+        connect_doors(multiworld, single_doors, door_targets, player)
+    elif multiworld.shuffle[player] == 'restricted':
+        simple_shuffle_dungeons(multiworld, player)
 
         lw_entrances = list(LW_Entrances + LW_Single_Cave_Doors + Old_Man_Entrances)
         dw_entrances = list(DW_Entrances + DW_Single_Cave_Doors)
@@ -150,17 +155,17 @@ def link_entrances(world, player):
         door_targets = list(Single_Cave_Targets)
 
         # tavern back door cannot be shuffled yet
-        connect_doors(world, ['Tavern North'], ['Tavern'], player)
+        connect_doors(multiworld, ['Tavern North'], ['Tavern'], player)
 
         # in restricted, the only mandatory exits are in dark world
-        connect_mandatory_exits(world, dw_entrances, caves, dw_must_exits, player)
+        connect_mandatory_exits(multiworld, dw_entrances, caves, dw_must_exits, player)
 
         # place old man, has limited options
         # exit has to come from specific set of doors, the entrance is free to move about
         old_man_entrances = [door for door in old_man_entrances if door in lw_entrances]
         world.random.shuffle(old_man_entrances)
         old_man_exit = old_man_entrances.pop()
-        connect_two_way(world, old_man_exit, 'Old Man Cave Exit (East)', player)
+        connect_two_way(multiworld, old_man_exit, 'Old Man Cave Exit (East)', player)
         lw_entrances.remove(old_man_exit)
 
         # place blacksmith, has limited options
@@ -169,7 +174,7 @@ def link_entrances(world, player):
         blacksmith_doors = [door for door in blacksmith_doors if door in all_entrances]
         world.random.shuffle(blacksmith_doors)
         blacksmith_hut = blacksmith_doors.pop()
-        connect_entrance(world, blacksmith_hut, 'Blacksmiths Hut', player)
+        connect_entrance(multiworld, blacksmith_hut, 'Blacksmiths Hut', player)
         if blacksmith_hut in lw_entrances:
             lw_entrances.remove(blacksmith_hut)
         if blacksmith_hut in dw_entrances:
@@ -182,7 +187,7 @@ def link_entrances(world, player):
         bomb_shop_doors = [door for door in bomb_shop_doors if door in all_entrances]
         world.random.shuffle(bomb_shop_doors)
         bomb_shop = bomb_shop_doors.pop()
-        connect_entrance(world, bomb_shop, 'Big Bomb Shop', player)
+        connect_entrance(multiworld, bomb_shop, 'Big Bomb Shop', player)
         if bomb_shop in lw_entrances:
             lw_entrances.remove(bomb_shop)
         if bomb_shop in dw_entrances:
@@ -191,24 +196,24 @@ def link_entrances(world, player):
         # place the old man cave's entrance somewhere in the light world
         world.random.shuffle(lw_entrances)
         old_man_entrance = lw_entrances.pop()
-        connect_two_way(world, old_man_entrance, 'Old Man Cave Exit (West)', player)
+        connect_two_way(multiworld, old_man_entrance, 'Old Man Cave Exit (West)', player)
 
         # place Old Man House in Light World
-        connect_caves(world, lw_entrances, [], list(Old_Man_House), player) #for multiple seeds
+        connect_caves(multiworld, lw_entrances, [], list(Old_Man_House), player) #for multiple seeds
 
 
         # now scramble the rest
-        connect_caves(world, lw_entrances, dw_entrances, caves, player)
+        connect_caves(multiworld, lw_entrances, dw_entrances, caves, player)
 
         # scramble holes
-        scramble_holes(world, player)
+        scramble_holes(multiworld, player)
 
         doors = lw_entrances + dw_entrances
 
         # place remaining doors
-        connect_doors(world, doors, door_targets, player)
-    elif world.shuffle[player] == 'restricted_legacy':
-        simple_shuffle_dungeons(world, player)
+        connect_doors(multiworld, doors, door_targets, player)
+    elif multiworld.shuffle[player] == 'restricted_legacy':
+        simple_shuffle_dungeons(multiworld, player)
 
         lw_entrances = list(LW_Entrances)
         dw_entrances = list(DW_Entrances)
@@ -222,7 +227,7 @@ def link_entrances(world, player):
         door_targets = list(Single_Cave_Targets)
 
         # only use two exit caves to do mandatory dw connections
-        connect_mandatory_exits(world, dw_entrances, caves, dw_must_exits, player)
+        connect_mandatory_exits(multiworld, dw_entrances, caves, dw_must_exits, player)
         # add three exit doors to pool for remainder
         caves.extend(three_exit_caves)
 
@@ -233,37 +238,37 @@ def link_entrances(world, player):
         lw_entrances.extend(old_man_entrances)
         world.random.shuffle(lw_entrances)
         old_man_entrance = lw_entrances.pop()
-        connect_two_way(world, old_man_entrance, 'Old Man Cave Exit (West)', player)
-        connect_two_way(world, old_man_exit, 'Old Man Cave Exit (East)', player)
+        connect_two_way(multiworld, old_man_entrance, 'Old Man Cave Exit (West)', player)
+        connect_two_way(multiworld, old_man_exit, 'Old Man Cave Exit (East)', player)
 
         # place Old Man House in Light World
-        connect_caves(world, lw_entrances, [], Old_Man_House, player)
+        connect_caves(multiworld, lw_entrances, [], Old_Man_House, player)
 
         # connect rest. There's 2 dw entrances remaining, so we will not run into parity issue placing caves
-        connect_caves(world, lw_entrances, dw_entrances, caves, player)
+        connect_caves(multiworld, lw_entrances, dw_entrances, caves, player)
 
         # scramble holes
-        scramble_holes(world, player)
+        scramble_holes(multiworld, player)
 
         # place blacksmith, has limited options
         world.random.shuffle(blacksmith_doors)
         blacksmith_hut = blacksmith_doors.pop()
-        connect_entrance(world, blacksmith_hut, 'Blacksmiths Hut', player)
+        connect_entrance(multiworld, blacksmith_hut, 'Blacksmiths Hut', player)
         bomb_shop_doors.extend(blacksmith_doors)
 
         # place dam and pyramid fairy, have limited options
         world.random.shuffle(bomb_shop_doors)
         bomb_shop = bomb_shop_doors.pop()
-        connect_entrance(world, bomb_shop, 'Big Bomb Shop', player)
+        connect_entrance(multiworld, bomb_shop, 'Big Bomb Shop', player)
         single_doors.extend(bomb_shop_doors)
 
         # tavern back door cannot be shuffled yet
-        connect_doors(world, ['Tavern North'], ['Tavern'], player)
+        connect_doors(multiworld, ['Tavern North'], ['Tavern'], player)
 
         # place remaining doors
-        connect_doors(world, single_doors, door_targets, player)
-    elif world.shuffle[player] == 'full':
-        skull_woods_shuffle(world, player)
+        connect_doors(multiworld, single_doors, door_targets, player)
+    elif multiworld.shuffle[player] == 'full':
+        skull_woods_shuffle(multiworld, player)
 
         lw_entrances = list(LW_Entrances + LW_Dungeon_Entrances + LW_Single_Cave_Doors + Old_Man_Entrances)
         dw_entrances = list(DW_Entrances + DW_Dungeon_Entrances + DW_Single_Cave_Doors)
@@ -277,18 +282,18 @@ def link_entrances(world, player):
         old_man_house = list(Old_Man_House)
 
         # tavern back door cannot be shuffled yet
-        connect_doors(world, ['Tavern North'], ['Tavern'], player)
+        connect_doors(multiworld, ['Tavern North'], ['Tavern'], player)
 
-        if world.mode[player] == 'standard':
+        if multiworld.mode[player] == 'standard':
             # must connect front of hyrule castle to do escape
-            connect_two_way(world, 'Hyrule Castle Entrance (South)', 'Hyrule Castle Exit (South)', player)
+            connect_two_way(multiworld, 'Hyrule Castle Entrance (South)', 'Hyrule Castle Exit (South)', player)
         else:
             caves.append(tuple(world.random.sample(
                 ['Hyrule Castle Exit (South)', 'Hyrule Castle Exit (West)', 'Hyrule Castle Exit (East)'], 3)))
             lw_entrances.append('Hyrule Castle Entrance (South)')
 
-        if not world.shuffle_ganon:
-            connect_two_way(world, 'Ganons Tower', 'Ganons Tower Exit', player)
+        if not multiworld.shuffle_ganon:
+            connect_two_way(multiworld, 'Ganons Tower', 'Ganons Tower Exit', player)
         else:
             dw_entrances.append('Ganons Tower')
             caves.append('Ganons Tower Exit')
@@ -298,34 +303,34 @@ def link_entrances(world, player):
         #we also places the Old Man House at this time to make sure he can be connected to the desert one way
         if world.random.randint(0, 1) == 0:
             caves += old_man_house
-            connect_mandatory_exits(world, lw_entrances, caves, lw_must_exits, player)
+            connect_mandatory_exits(multiworld, lw_entrances, caves, lw_must_exits, player)
             try:
                 caves.remove(old_man_house[0])
             except ValueError:
                 pass
             else:  # if the cave wasn't placed we get here
-                connect_caves(world, lw_entrances, [], old_man_house, player)
-            connect_mandatory_exits(world, dw_entrances, caves, dw_must_exits, player)
+                connect_caves(multiworld, lw_entrances, [], old_man_house, player)
+            connect_mandatory_exits(multiworld, dw_entrances, caves, dw_must_exits, player)
         else:
-            connect_mandatory_exits(world, dw_entrances, caves, dw_must_exits, player)
+            connect_mandatory_exits(multiworld, dw_entrances, caves, dw_must_exits, player)
             caves += old_man_house
-            connect_mandatory_exits(world, lw_entrances, caves, lw_must_exits, player)
+            connect_mandatory_exits(multiworld, lw_entrances, caves, lw_must_exits, player)
             try:
                 caves.remove(old_man_house[0])
             except ValueError:
                 pass
             else: #if the cave wasn't placed we get here
-                connect_caves(world, lw_entrances, [], old_man_house, player)
-        if world.mode[player] == 'standard':
+                connect_caves(multiworld, lw_entrances, [], old_man_house, player)
+        if multiworld.mode[player] == 'standard':
             # rest of hyrule castle must be in light world
-            connect_caves(world, lw_entrances, [], [('Hyrule Castle Exit (West)', 'Hyrule Castle Exit (East)')], player)
+            connect_caves(multiworld, lw_entrances, [], [('Hyrule Castle Exit (West)', 'Hyrule Castle Exit (East)')], player)
 
         # place old man, has limited options
         # exit has to come from specific set of doors, the entrance is free to move about
         old_man_entrances = [door for door in old_man_entrances if door in lw_entrances]
         world.random.shuffle(old_man_entrances)
         old_man_exit = old_man_entrances.pop()
-        connect_two_way(world, old_man_exit, 'Old Man Cave Exit (East)', player)
+        connect_two_way(multiworld, old_man_exit, 'Old Man Cave Exit (East)', player)
         lw_entrances.remove(old_man_exit)
 
         # place blacksmith, has limited options
@@ -334,7 +339,7 @@ def link_entrances(world, player):
         blacksmith_doors = [door for door in blacksmith_doors if door in all_entrances]
         world.random.shuffle(blacksmith_doors)
         blacksmith_hut = blacksmith_doors.pop()
-        connect_entrance(world, blacksmith_hut, 'Blacksmiths Hut', player)
+        connect_entrance(multiworld, blacksmith_hut, 'Blacksmiths Hut', player)
         if blacksmith_hut in lw_entrances:
             lw_entrances.remove(blacksmith_hut)
         if blacksmith_hut in dw_entrances:
@@ -347,7 +352,7 @@ def link_entrances(world, player):
         bomb_shop_doors = [door for door in bomb_shop_doors if door in all_entrances]
         world.random.shuffle(bomb_shop_doors)
         bomb_shop = bomb_shop_doors.pop()
-        connect_entrance(world, bomb_shop, 'Big Bomb Shop', player)
+        connect_entrance(multiworld, bomb_shop, 'Big Bomb Shop', player)
         if bomb_shop in lw_entrances:
             lw_entrances.remove(bomb_shop)
         if bomb_shop in dw_entrances:
@@ -355,21 +360,21 @@ def link_entrances(world, player):
 
         # place the old man cave's entrance somewhere in the light world
         old_man_entrance = lw_entrances.pop()
-        connect_two_way(world, old_man_entrance, 'Old Man Cave Exit (West)', player)
+        connect_two_way(multiworld, old_man_entrance, 'Old Man Cave Exit (West)', player)
 
 
         # now scramble the rest
-        connect_caves(world, lw_entrances, dw_entrances, caves, player)
+        connect_caves(multiworld, lw_entrances, dw_entrances, caves, player)
 
         # scramble holes
-        scramble_holes(world, player)
+        scramble_holes(multiworld, player)
 
         doors = lw_entrances + dw_entrances
 
         # place remaining doors
-        connect_doors(world, doors, door_targets, player)
-    elif world.shuffle[player] == 'crossed':
-        skull_woods_shuffle(world, player)
+        connect_doors(multiworld, doors, door_targets, player)
+    elif multiworld.shuffle[player] == 'crossed':
+        skull_woods_shuffle(multiworld, player)
 
         entrances = list(LW_Entrances + LW_Dungeon_Entrances + LW_Single_Cave_Doors + Old_Man_Entrances + DW_Entrances + DW_Dungeon_Entrances + DW_Single_Cave_Doors)
         must_exits = list(DW_Entrances_Must_Exit + DW_Dungeon_Entrances_Must_Exit + LW_Dungeon_Entrances_Must_Exit)
@@ -381,35 +386,35 @@ def link_entrances(world, player):
         door_targets = list(Single_Cave_Targets)
 
         # tavern back door cannot be shuffled yet
-        connect_doors(world, ['Tavern North'], ['Tavern'], player)
+        connect_doors(multiworld, ['Tavern North'], ['Tavern'], player)
 
-        if world.mode[player] == 'standard':
+        if multiworld.mode[player] == 'standard':
             # must connect front of hyrule castle to do escape
-            connect_two_way(world, 'Hyrule Castle Entrance (South)', 'Hyrule Castle Exit (South)', player)
+            connect_two_way(multiworld, 'Hyrule Castle Entrance (South)', 'Hyrule Castle Exit (South)', player)
         else:
             caves.append(tuple(world.random.sample(
                 ['Hyrule Castle Exit (South)', 'Hyrule Castle Exit (West)', 'Hyrule Castle Exit (East)'], 3)))
             entrances.append('Hyrule Castle Entrance (South)')
 
-        if not world.shuffle_ganon:
-            connect_two_way(world, 'Ganons Tower', 'Ganons Tower Exit', player)
+        if not multiworld.shuffle_ganon:
+            connect_two_way(multiworld, 'Ganons Tower', 'Ganons Tower Exit', player)
         else:
             entrances.append('Ganons Tower')
             caves.append('Ganons Tower Exit')
 
         #place must-exit caves 
-        connect_mandatory_exits(world, entrances, caves, must_exits, player)
+        connect_mandatory_exits(multiworld, entrances, caves, must_exits, player)
 
-        if world.mode[player] == 'standard':
+        if multiworld.mode[player] == 'standard':
             # rest of hyrule castle must be dealt with
-            connect_caves(world, entrances, [], [('Hyrule Castle Exit (West)', 'Hyrule Castle Exit (East)')], player)
+            connect_caves(multiworld, entrances, [], [('Hyrule Castle Exit (West)', 'Hyrule Castle Exit (East)')], player)
 
         # place old man, has limited options
         # exit has to come from specific set of doors, the entrance is free to move about
         old_man_entrances = [door for door in old_man_entrances if door in entrances]
         world.random.shuffle(old_man_entrances)
         old_man_exit = old_man_entrances.pop()
-        connect_two_way(world, old_man_exit, 'Old Man Cave Exit (East)', player)
+        connect_two_way(multiworld, old_man_exit, 'Old Man Cave Exit (East)', player)
         entrances.remove(old_man_exit)
 
         # place blacksmith, has limited options
@@ -417,7 +422,7 @@ def link_entrances(world, player):
         blacksmith_doors = [door for door in blacksmith_doors if door in entrances]
         world.random.shuffle(blacksmith_doors)
         blacksmith_hut = blacksmith_doors.pop()
-        connect_entrance(world, blacksmith_hut, 'Blacksmiths Hut', player)
+        connect_entrance(multiworld, blacksmith_hut, 'Blacksmiths Hut', player)
         entrances.remove(blacksmith_hut)
         bomb_shop_doors.extend(blacksmith_doors)
 
@@ -427,26 +432,26 @@ def link_entrances(world, player):
         bomb_shop_doors = [door for door in bomb_shop_doors if door in entrances]
         world.random.shuffle(bomb_shop_doors)
         bomb_shop = bomb_shop_doors.pop()
-        connect_entrance(world, bomb_shop, 'Big Bomb Shop', player)
+        connect_entrance(multiworld, bomb_shop, 'Big Bomb Shop', player)
         entrances.remove(bomb_shop)
 
 
         # place the old man cave's entrance somewhere
         world.random.shuffle(entrances)
         old_man_entrance = entrances.pop()
-        connect_two_way(world, old_man_entrance, 'Old Man Cave Exit (West)', player)
+        connect_two_way(multiworld, old_man_entrance, 'Old Man Cave Exit (West)', player)
 
 
         # now scramble the rest
-        connect_caves(world, entrances, [], caves, player)
+        connect_caves(multiworld, entrances, [], caves, player)
 
         # scramble holes
-        scramble_holes(world, player)
+        scramble_holes(multiworld, player)
 
         # place remaining doors
-        connect_doors(world, entrances, door_targets, player)
-    elif world.shuffle[player] == 'full_legacy':
-        skull_woods_shuffle(world, player)
+        connect_doors(multiworld, entrances, door_targets, player)
+    elif multiworld.shuffle[player] == 'full_legacy':
+        skull_woods_shuffle(multiworld, player)
 
         lw_entrances = list(LW_Entrances + LW_Dungeon_Entrances + Old_Man_Entrances)
         dw_entrances = list(DW_Entrances + DW_Dungeon_Entrances)
@@ -459,30 +464,30 @@ def link_entrances(world, player):
         blacksmith_doors = list(Blacksmith_Single_Cave_Doors)
         door_targets = list(Single_Cave_Targets)
 
-        if world.mode[player] == 'standard':
+        if multiworld.mode[player] == 'standard':
             # must connect front of hyrule castle to do escape
-            connect_two_way(world, 'Hyrule Castle Entrance (South)', 'Hyrule Castle Exit (South)', player)
+            connect_two_way(multiworld, 'Hyrule Castle Entrance (South)', 'Hyrule Castle Exit (South)', player)
         else:
             caves.append(tuple(world.random.sample(
                 ['Hyrule Castle Exit (South)', 'Hyrule Castle Exit (West)', 'Hyrule Castle Exit (East)'], 3)))
             lw_entrances.append('Hyrule Castle Entrance (South)')
 
-        if not world.shuffle_ganon:
-            connect_two_way(world, 'Ganons Tower', 'Ganons Tower Exit', player)
+        if not multiworld.shuffle_ganon:
+            connect_two_way(multiworld, 'Ganons Tower', 'Ganons Tower Exit', player)
         else:
             dw_entrances.append('Ganons Tower')
             caves.append('Ganons Tower Exit')
 
         # we randomize which world requirements we fulfill first so we get better dungeon distribution
         if world.random.randint(0, 1) == 0:
-            connect_mandatory_exits(world, lw_entrances, caves, lw_must_exits, player)
-            connect_mandatory_exits(world, dw_entrances, caves, dw_must_exits, player)
+            connect_mandatory_exits(multiworld, lw_entrances, caves, lw_must_exits, player)
+            connect_mandatory_exits(multiworld, dw_entrances, caves, dw_must_exits, player)
         else:
-            connect_mandatory_exits(world, dw_entrances, caves, dw_must_exits, player)
-            connect_mandatory_exits(world, lw_entrances, caves, lw_must_exits, player)
-        if world.mode[player] == 'standard':
+            connect_mandatory_exits(multiworld, dw_entrances, caves, dw_must_exits, player)
+            connect_mandatory_exits(multiworld, lw_entrances, caves, lw_must_exits, player)
+        if multiworld.mode[player] == 'standard':
             # rest of hyrule castle must be in light world
-            connect_caves(world, lw_entrances, [], [('Hyrule Castle Exit (West)', 'Hyrule Castle Exit (East)')], player)
+            connect_caves(multiworld, lw_entrances, [], [('Hyrule Castle Exit (West)', 'Hyrule Castle Exit (East)')], player)
 
         # place old man, has limited options
         # exit has to come from specific set of doors, the entrance is free to move about
@@ -493,36 +498,36 @@ def link_entrances(world, player):
 
         world.random.shuffle(lw_entrances)
         old_man_entrance = lw_entrances.pop()
-        connect_two_way(world, old_man_entrance, 'Old Man Cave Exit (West)', player)
-        connect_two_way(world, old_man_exit, 'Old Man Cave Exit (East)', player)
+        connect_two_way(multiworld, old_man_entrance, 'Old Man Cave Exit (West)', player)
+        connect_two_way(multiworld, old_man_exit, 'Old Man Cave Exit (East)', player)
 
         # place Old Man House in Light World
-        connect_caves(world, lw_entrances, [], list(Old_Man_House), player) #need this to avoid badness with multiple seeds
+        connect_caves(multiworld, lw_entrances, [], list(Old_Man_House), player) #need this to avoid badness with multiple seeds
 
         # now scramble the rest
-        connect_caves(world, lw_entrances, dw_entrances, caves, player)
+        connect_caves(multiworld, lw_entrances, dw_entrances, caves, player)
 
         # scramble holes
-        scramble_holes(world, player)
+        scramble_holes(multiworld, player)
 
         # place blacksmith, has limited options
         world.random.shuffle(blacksmith_doors)
         blacksmith_hut = blacksmith_doors.pop()
-        connect_entrance(world, blacksmith_hut, 'Blacksmiths Hut', player)
+        connect_entrance(multiworld, blacksmith_hut, 'Blacksmiths Hut', player)
         bomb_shop_doors.extend(blacksmith_doors)
 
         # place bomb shop, has limited options
         world.random.shuffle(bomb_shop_doors)
         bomb_shop = bomb_shop_doors.pop()
-        connect_entrance(world, bomb_shop, 'Big Bomb Shop', player)
+        connect_entrance(multiworld, bomb_shop, 'Big Bomb Shop', player)
         single_doors.extend(bomb_shop_doors)
 
         # tavern back door cannot be shuffled yet
-        connect_doors(world, ['Tavern North'], ['Tavern'], player)
+        connect_doors(multiworld, ['Tavern North'], ['Tavern'], player)
 
         # place remaining doors
-        connect_doors(world, single_doors, door_targets, player)
-    elif world.shuffle[player] == 'madness_legacy':
+        connect_doors(multiworld, single_doors, door_targets, player)
+    elif multiworld.shuffle[player] == 'madness_legacy':
         # here lie dragons, connections are no longer two way
         lw_entrances = list(LW_Entrances + LW_Dungeon_Entrances + Old_Man_Entrances)
         dw_entrances = list(DW_Entrances + DW_Dungeon_Entrances)
@@ -571,21 +576,21 @@ def link_entrances(world, player):
                         ('Lumberjack Tree Exit', 'Lumberjack Tree (top)'),
                         (('Skull Woods Second Section Exit (East)', 'Skull Woods Second Section Exit (West)'), 'Skull Woods Second Section (Drop)')]
 
-        if world.mode[player] == 'standard':
+        if multiworld.mode[player] == 'standard':
             # cannot move uncle cave
-            connect_entrance(world, 'Hyrule Castle Secret Entrance Drop', 'Hyrule Castle Secret Entrance', player)
-            connect_exit(world, 'Hyrule Castle Secret Entrance Exit', 'Hyrule Castle Secret Entrance Stairs', player)
-            connect_entrance(world, 'Hyrule Castle Secret Entrance Stairs', 'Hyrule Castle Secret Entrance Exit', player)
+            connect_entrance(multiworld, 'Hyrule Castle Secret Entrance Drop', 'Hyrule Castle Secret Entrance', player)
+            connect_exit(multiworld, 'Hyrule Castle Secret Entrance Exit', 'Hyrule Castle Secret Entrance Stairs', player)
+            connect_entrance(multiworld, 'Hyrule Castle Secret Entrance Stairs', 'Hyrule Castle Secret Entrance Exit', player)
         else:
             lw_hole_entrances.append('Hyrule Castle Secret Entrance Drop')
             hole_targets.append(('Hyrule Castle Secret Entrance Exit', 'Hyrule Castle Secret Entrance'))
             lw_doors.append('Hyrule Castle Secret Entrance Stairs')
             lw_entrances.append('Hyrule Castle Secret Entrance Stairs')
 
-        if not world.shuffle_ganon:
-            connect_two_way(world, 'Ganons Tower', 'Ganons Tower Exit', player)
-            connect_two_way(world, 'Pyramid Entrance', 'Pyramid Exit', player)
-            connect_entrance(world, 'Pyramid Hole', 'Pyramid', player)
+        if not multiworld.shuffle_ganon:
+            connect_two_way(multiworld, 'Ganons Tower', 'Ganons Tower Exit', player)
+            connect_two_way(multiworld, 'Pyramid Entrance', 'Pyramid Exit', player)
+            connect_entrance(multiworld, 'Pyramid Hole', 'Pyramid', player)
         else:
             dw_entrances.append('Ganons Tower')
             caves.append('Ganons Tower Exit')
@@ -608,28 +613,28 @@ def link_entrances(world, player):
             mandatory_dark_world.append('Skull Woods First Section Exit')
         for target in ['Skull Woods First Section (Left)', 'Skull Woods First Section (Right)',
                        'Skull Woods First Section (Top)']:
-            connect_entrance(world, sw_hole_pool.pop(), target, player)
+            connect_entrance(multiworld, sw_hole_pool.pop(), target, player)
 
         # sanctuary has to be in light world
-        connect_entrance(world, lw_hole_entrances.pop(), 'Sewer Drop', player)
+        connect_entrance(multiworld, lw_hole_entrances.pop(), 'Sewer Drop', player)
         mandatory_light_world.append('Sanctuary Exit')
 
         # fill up remaining holes
         for hole in dw_hole_entrances:
             exits, target = hole_targets.pop()
             mandatory_dark_world.append(exits)
-            connect_entrance(world, hole, target, player)
+            connect_entrance(multiworld, hole, target, player)
 
         for hole in lw_hole_entrances:
             exits, target = hole_targets.pop()
             mandatory_light_world.append(exits)
-            connect_entrance(world, hole, target, player)
+            connect_entrance(multiworld, hole, target, player)
 
         # hyrule castle handling
-        if world.mode[player] == 'standard':
+        if multiworld.mode[player] == 'standard':
             # must connect front of hyrule castle to do escape
-            connect_entrance(world, 'Hyrule Castle Entrance (South)', 'Hyrule Castle Exit (South)', player)
-            connect_exit(world, 'Hyrule Castle Exit (South)', 'Hyrule Castle Entrance (South)', player)
+            connect_entrance(multiworld, 'Hyrule Castle Entrance (South)', 'Hyrule Castle Exit (South)', player)
+            connect_exit(multiworld, 'Hyrule Castle Exit (South)', 'Hyrule Castle Entrance (South)', player)
             mandatory_light_world.append(('Hyrule Castle Exit (West)', 'Hyrule Castle Exit (East)'))
         else:
             lw_doors.append('Hyrule Castle Entrance (South)')
@@ -669,8 +674,8 @@ def link_entrances(world, player):
 
             exit = cave[-1]
             cave = cave[:-1]
-            connect_exit(world, exit, entrance, player)
-            connect_entrance(world, worldoors.pop(), exit, player)
+            connect_exit(multiworld, exit, entrance, player)
+            connect_entrance(multiworld, worldoors.pop(), exit, player)
             # rest of cave now is forced to be in this world
             worldspecific.append(cave)
 
@@ -693,8 +698,8 @@ def link_entrances(world, player):
         old_man_exit = old_man_entrances.pop()
         lw_entrances.remove(old_man_exit)
 
-        connect_exit(world, 'Old Man Cave Exit (East)', old_man_exit, player)
-        connect_entrance(world, lw_doors.pop(), 'Old Man Cave Exit (East)', player)
+        connect_exit(multiworld, 'Old Man Cave Exit (East)', old_man_exit, player)
+        connect_entrance(multiworld, lw_doors.pop(), 'Old Man Cave Exit (East)', player)
         mandatory_light_world.append('Old Man Cave Exit (West)')
 
         # we connect up the mandatory associations we have found
@@ -703,18 +708,18 @@ def link_entrances(world, player):
                 mandatory = (mandatory,)
             for exit in mandatory:
                 # point out somewhere
-                connect_exit(world, exit, lw_entrances.pop(), player)
+                connect_exit(multiworld, exit, lw_entrances.pop(), player)
                 # point in from somewhere
-                connect_entrance(world, lw_doors.pop(), exit, player)
+                connect_entrance(multiworld, lw_doors.pop(), exit, player)
 
         for mandatory in mandatory_dark_world:
             if not isinstance(mandatory, tuple):
                 mandatory = (mandatory,)
             for exit in mandatory:
                 # point out somewhere
-                connect_exit(world, exit, dw_entrances.pop(), player)
+                connect_exit(multiworld, exit, dw_entrances.pop(), player)
                 # point in from somewhere
-                connect_entrance(world, dw_doors.pop(), exit, player)
+                connect_entrance(multiworld, dw_doors.pop(), exit, player)
 
         # handle remaining caves
         while caves:
@@ -748,8 +753,8 @@ def link_entrances(world, player):
                     target_entrances = dw_entrances
 
             for exit in cave:
-                connect_exit(world, exit, target_entrances.pop(), player)
-                connect_entrance(world, target_doors.pop(), exit, player)
+                connect_exit(multiworld, exit, target_entrances.pop(), player)
+                connect_entrance(multiworld, target_doors.pop(), exit, player)
 
         # handle simple doors
 
@@ -761,21 +766,21 @@ def link_entrances(world, player):
         # place blacksmith, has limited options
         world.random.shuffle(blacksmith_doors)
         blacksmith_hut = blacksmith_doors.pop()
-        connect_entrance(world, blacksmith_hut, 'Blacksmiths Hut', player)
+        connect_entrance(multiworld, blacksmith_hut, 'Blacksmiths Hut', player)
         bomb_shop_doors.extend(blacksmith_doors)
 
         # place dam and pyramid fairy, have limited options
         world.random.shuffle(bomb_shop_doors)
         bomb_shop = bomb_shop_doors.pop()
-        connect_entrance(world, bomb_shop, 'Big Bomb Shop', player)
+        connect_entrance(multiworld, bomb_shop, 'Big Bomb Shop', player)
         single_doors.extend(bomb_shop_doors)
 
         # tavern back door cannot be shuffled yet
-        connect_doors(world, ['Tavern North'], ['Tavern'], player)
+        connect_doors(multiworld, ['Tavern North'], ['Tavern'], player)
 
         # place remaining doors
-        connect_doors(world, single_doors, door_targets, player)
-    elif world.shuffle[player] == 'insanity':
+        connect_doors(multiworld, single_doors, door_targets, player)
+    elif multiworld.shuffle[player] == 'insanity':
         # beware ye who enter here
 
         entrances = LW_Entrances + LW_Dungeon_Entrances + DW_Entrances + DW_Dungeon_Entrances + Old_Man_Entrances + ['Skull Woods Second Section Door (East)', 'Skull Woods First Section Door', 'Kakariko Well Cave', 'Bat Cave Cave', 'North Fairy Cave', 'Sanctuary', 'Lost Woods Hideout Stump', 'Lumberjack Tree Cave']
@@ -810,13 +815,13 @@ def link_entrances(world, player):
                         'Skull Woods First Section (Left)', 'Skull Woods First Section (Right)', 'Skull Woods First Section (Top)']
 
         # tavern back door cannot be shuffled yet
-        connect_doors(world, ['Tavern North'], ['Tavern'], player)
+        connect_doors(multiworld, ['Tavern North'], ['Tavern'], player)
 
-        if world.mode[player] == 'standard':
+        if multiworld.mode[player] == 'standard':
             # cannot move uncle cave
-            connect_entrance(world, 'Hyrule Castle Secret Entrance Drop', 'Hyrule Castle Secret Entrance', player)
-            connect_exit(world, 'Hyrule Castle Secret Entrance Exit', 'Hyrule Castle Secret Entrance Stairs', player)
-            connect_entrance(world, 'Hyrule Castle Secret Entrance Stairs', 'Hyrule Castle Secret Entrance Exit', player)
+            connect_entrance(multiworld, 'Hyrule Castle Secret Entrance Drop', 'Hyrule Castle Secret Entrance', player)
+            connect_exit(multiworld, 'Hyrule Castle Secret Entrance Exit', 'Hyrule Castle Secret Entrance Stairs', player)
+            connect_entrance(multiworld, 'Hyrule Castle Secret Entrance Stairs', 'Hyrule Castle Secret Entrance Exit', player)
         else:
             hole_entrances.append('Hyrule Castle Secret Entrance Drop')
             hole_targets.append('Hyrule Castle Secret Entrance')
@@ -824,10 +829,10 @@ def link_entrances(world, player):
             entrances.append('Hyrule Castle Secret Entrance Stairs')
             caves.append('Hyrule Castle Secret Entrance Exit')
 
-        if not world.shuffle_ganon:
-            connect_two_way(world, 'Ganons Tower', 'Ganons Tower Exit', player)
-            connect_two_way(world, 'Pyramid Entrance', 'Pyramid Exit', player)
-            connect_entrance(world, 'Pyramid Hole', 'Pyramid', player)
+        if not multiworld.shuffle_ganon:
+            connect_two_way(multiworld, 'Ganons Tower', 'Ganons Tower Exit', player)
+            connect_two_way(multiworld, 'Pyramid Entrance', 'Pyramid Exit', player)
+            connect_entrance(multiworld, 'Pyramid Hole', 'Pyramid', player)
         else:
             entrances.append('Ganons Tower')
             caves.extend(['Ganons Tower Exit', 'Pyramid Exit'])
@@ -842,13 +847,13 @@ def link_entrances(world, player):
 
         # fill up holes
         for hole in hole_entrances:
-            connect_entrance(world, hole, hole_targets.pop(), player)
+            connect_entrance(multiworld, hole, hole_targets.pop(), player)
 
         # hyrule castle handling
-        if world.mode[player] == 'standard':
+        if multiworld.mode[player] == 'standard':
             # must connect front of hyrule castle to do escape
-            connect_entrance(world, 'Hyrule Castle Entrance (South)', 'Hyrule Castle Exit (South)', player)
-            connect_exit(world, 'Hyrule Castle Exit (South)', 'Hyrule Castle Entrance (South)', player)
+            connect_entrance(multiworld, 'Hyrule Castle Entrance (South)', 'Hyrule Castle Exit (South)', player)
+            connect_exit(multiworld, 'Hyrule Castle Exit (South)', 'Hyrule Castle Entrance (South)', player)
             caves.append(('Hyrule Castle Exit (West)', 'Hyrule Castle Exit (East)'))
         else:
             doors.append('Hyrule Castle Entrance (South)')
@@ -877,8 +882,8 @@ def link_entrances(world, player):
 
             exit = cave[-1]
             cave = cave[:-1]
-            connect_exit(world, exit, entrance, player)
-            connect_entrance(world, doors.pop(), exit, player)
+            connect_exit(multiworld, exit, entrance, player)
+            connect_entrance(multiworld, doors.pop(), exit, player)
             # rest of cave now is forced to be in this world
             caves.append(cave)
 
@@ -893,22 +898,22 @@ def link_entrances(world, player):
         old_man_exit = old_man_entrances.pop()
         entrances.remove(old_man_exit)
 
-        connect_exit(world, 'Old Man Cave Exit (East)', old_man_exit, player)
-        connect_entrance(world, doors.pop(), 'Old Man Cave Exit (East)', player)
+        connect_exit(multiworld, 'Old Man Cave Exit (East)', old_man_exit, player)
+        connect_entrance(multiworld, doors.pop(), 'Old Man Cave Exit (East)', player)
         caves.append('Old Man Cave Exit (West)')
 
         # place blacksmith, has limited options
         blacksmith_doors = [door for door in blacksmith_doors if door in doors]
         world.random.shuffle(blacksmith_doors)
         blacksmith_hut = blacksmith_doors.pop()
-        connect_entrance(world, blacksmith_hut, 'Blacksmiths Hut', player)
+        connect_entrance(multiworld, blacksmith_hut, 'Blacksmiths Hut', player)
         doors.remove(blacksmith_hut)
 
         # place dam and pyramid fairy, have limited options
         bomb_shop_doors = [door for door in bomb_shop_doors if door in doors]
         world.random.shuffle(bomb_shop_doors)
         bomb_shop = bomb_shop_doors.pop()
-        connect_entrance(world, bomb_shop, 'Big Bomb Shop', player)
+        connect_entrance(multiworld, bomb_shop, 'Big Bomb Shop', player)
         doors.remove(bomb_shop)
 
         # handle remaining caves
@@ -917,13 +922,13 @@ def link_entrances(world, player):
                 cave = (cave,)
 
             for exit in cave:
-                connect_exit(world, exit, entrances.pop(), player)
-                connect_entrance(world, doors.pop(), exit, player)
+                connect_exit(multiworld, exit, entrances.pop(), player)
+                connect_entrance(multiworld, doors.pop(), exit, player)
 
         # place remaining doors
-        connect_doors(world, doors, door_targets, player)
-    elif world.shuffle[player] == 'insanity_legacy':
-        world.fix_fake_world[player] = False
+        connect_doors(multiworld, doors, door_targets, player)
+    elif multiworld.shuffle[player] == 'insanity_legacy':
+        multiworld.fix_fake_world[player] = False
         # beware ye who enter here
 
         entrances = LW_Entrances + LW_Dungeon_Entrances + DW_Entrances + DW_Dungeon_Entrances + Old_Man_Entrances + ['Skull Woods Second Section Door (East)', 'Skull Woods First Section Door', 'Kakariko Well Cave', 'Bat Cave Cave', 'North Fairy Cave', 'Sanctuary', 'Lost Woods Hideout Stump', 'Lumberjack Tree Cave']
@@ -947,11 +952,11 @@ def link_entrances(world, player):
         hole_targets = ['Kakariko Well (top)', 'Bat Cave (right)', 'North Fairy Cave', 'Lost Woods Hideout (top)', 'Lumberjack Tree (top)', 'Sewer Drop', 'Skull Woods Second Section (Drop)',
                         'Skull Woods First Section (Left)', 'Skull Woods First Section (Right)', 'Skull Woods First Section (Top)']
 
-        if world.mode[player] == 'standard':
+        if multiworld.mode[player] == 'standard':
             # cannot move uncle cave
-            connect_entrance(world, 'Hyrule Castle Secret Entrance Drop', 'Hyrule Castle Secret Entrance', player)
-            connect_exit(world, 'Hyrule Castle Secret Entrance Exit', 'Hyrule Castle Secret Entrance Stairs', player)
-            connect_entrance(world, 'Hyrule Castle Secret Entrance Stairs', 'Hyrule Castle Secret Entrance Exit', player)
+            connect_entrance(multiworld, 'Hyrule Castle Secret Entrance Drop', 'Hyrule Castle Secret Entrance', player)
+            connect_exit(multiworld, 'Hyrule Castle Secret Entrance Exit', 'Hyrule Castle Secret Entrance Stairs', player)
+            connect_entrance(multiworld, 'Hyrule Castle Secret Entrance Stairs', 'Hyrule Castle Secret Entrance Exit', player)
         else:
             hole_entrances.append('Hyrule Castle Secret Entrance Drop')
             hole_targets.append('Hyrule Castle Secret Entrance')
@@ -959,10 +964,10 @@ def link_entrances(world, player):
             entrances.append('Hyrule Castle Secret Entrance Stairs')
             caves.append('Hyrule Castle Secret Entrance Exit')
 
-        if not world.shuffle_ganon:
-            connect_two_way(world, 'Ganons Tower', 'Ganons Tower Exit', player)
-            connect_two_way(world, 'Pyramid Entrance', 'Pyramid Exit', player)
-            connect_entrance(world, 'Pyramid Hole', 'Pyramid', player)
+        if not multiworld.shuffle_ganon:
+            connect_two_way(multiworld, 'Ganons Tower', 'Ganons Tower Exit', player)
+            connect_two_way(multiworld, 'Pyramid Entrance', 'Pyramid Exit', player)
+            connect_entrance(multiworld, 'Pyramid Hole', 'Pyramid', player)
         else:
             entrances.append('Ganons Tower')
             caves.extend(['Ganons Tower Exit', 'Pyramid Exit'])
@@ -977,13 +982,13 @@ def link_entrances(world, player):
 
         # fill up holes
         for hole in hole_entrances:
-            connect_entrance(world, hole, hole_targets.pop(), player)
+            connect_entrance(multiworld, hole, hole_targets.pop(), player)
 
         # hyrule castle handling
-        if world.mode[player] == 'standard':
+        if multiworld.mode[player] == 'standard':
             # must connect front of hyrule castle to do escape
-            connect_entrance(world, 'Hyrule Castle Entrance (South)', 'Hyrule Castle Exit (South)', player)
-            connect_exit(world, 'Hyrule Castle Exit (South)', 'Hyrule Castle Entrance (South)', player)
+            connect_entrance(multiworld, 'Hyrule Castle Entrance (South)', 'Hyrule Castle Exit (South)', player)
+            connect_exit(multiworld, 'Hyrule Castle Exit (South)', 'Hyrule Castle Entrance (South)', player)
             caves.append(('Hyrule Castle Exit (West)', 'Hyrule Castle Exit (East)'))
         else:
             doors.append('Hyrule Castle Entrance (South)')
@@ -1012,8 +1017,8 @@ def link_entrances(world, player):
 
             exit = cave[-1]
             cave = cave[:-1]
-            connect_exit(world, exit, entrance, player)
-            connect_entrance(world, doors.pop(), exit, player)
+            connect_exit(multiworld, exit, entrance, player)
+            connect_entrance(multiworld, doors.pop(), exit, player)
             # rest of cave now is forced to be in this world
             caves.append(cave)
 
@@ -1028,8 +1033,8 @@ def link_entrances(world, player):
         old_man_exit = old_man_entrances.pop()
         entrances.remove(old_man_exit)
 
-        connect_exit(world, 'Old Man Cave Exit (East)', old_man_exit, player)
-        connect_entrance(world, doors.pop(), 'Old Man Cave Exit (East)', player)
+        connect_exit(multiworld, 'Old Man Cave Exit (East)', old_man_exit, player)
+        connect_entrance(multiworld, doors.pop(), 'Old Man Cave Exit (East)', player)
         caves.append('Old Man Cave Exit (West)')
 
         # handle remaining caves
@@ -1038,8 +1043,8 @@ def link_entrances(world, player):
                 cave = (cave,)
 
             for exit in cave:
-                connect_exit(world, exit, entrances.pop(), player)
-                connect_entrance(world, doors.pop(), exit, player)
+                connect_exit(multiworld, exit, entrances.pop(), player)
+                connect_entrance(multiworld, doors.pop(), exit, player)
 
         # handle simple doors
 
@@ -1051,48 +1056,50 @@ def link_entrances(world, player):
         # place blacksmith, has limited options
         world.random.shuffle(blacksmith_doors)
         blacksmith_hut = blacksmith_doors.pop()
-        connect_entrance(world, blacksmith_hut, 'Blacksmiths Hut', player)
+        connect_entrance(multiworld, blacksmith_hut, 'Blacksmiths Hut', player)
         bomb_shop_doors.extend(blacksmith_doors)
 
         # place dam and pyramid fairy, have limited options
         world.random.shuffle(bomb_shop_doors)
         bomb_shop = bomb_shop_doors.pop()
-        connect_entrance(world, bomb_shop, 'Big Bomb Shop', player)
+        connect_entrance(multiworld, bomb_shop, 'Big Bomb Shop', player)
         single_doors.extend(bomb_shop_doors)
 
         # tavern back door cannot be shuffled yet
-        connect_doors(world, ['Tavern North'], ['Tavern'], player)
+        connect_doors(multiworld, ['Tavern North'], ['Tavern'], player)
 
         # place remaining doors
-        connect_doors(world, single_doors, door_targets, player)
+        connect_doors(multiworld, single_doors, door_targets, player)
     else:
         raise NotImplementedError(
-            f'{world.shuffle[player]} Shuffling not supported yet. Player {world.get_player_name(player)}')
+            f'{multiworld.shuffle[player]} Shuffling not supported yet. Player {multiworld.get_player_name(player)}')
 
-    if world.logic[player] in ['owglitches', 'hybridglitches', 'nologic']:
-        overworld_glitch_connections(world, player)
+    if multiworld.logic[player] in ['owglitches', 'hybridglitches', 'nologic']:
+        overworld_glitch_connections(multiworld, player)
         # mandatory hybrid major glitches connections
-        if world.logic[player] in ['hybridglitches', 'nologic']:
-            underworld_glitch_connections(world, player)
+        if multiworld.logic[player] in ['hybridglitches', 'nologic']:
+            underworld_glitch_connections(multiworld, player)
 
     # check for swamp palace fix
-    if world.get_entrance('Dam', player).connected_region.name != 'Dam' or world.get_entrance('Swamp Palace', player).connected_region.name != 'Swamp Palace (Entrance)':
-        world.swamp_patch_required[player] = True
+    if multiworld.get_entrance('Dam', player).connected_region.name != 'Dam' or multiworld.get_entrance('Swamp Palace', player).connected_region.name != 'Swamp Palace (Entrance)':
+        multiworld.swamp_patch_required[player] = True
 
     # check for potion shop location
-    if world.get_entrance('Potion Shop', player).connected_region.name != 'Potion Shop':
-        world.powder_patch_required[player] = True
+    if multiworld.get_entrance('Potion Shop', player).connected_region.name != 'Potion Shop':
+        multiworld.powder_patch_required[player] = True
 
     # check for ganon location
-    if world.get_entrance('Pyramid Hole', player).connected_region.name != 'Pyramid':
-        world.ganon_at_pyramid[player] = False
+    if multiworld.get_entrance('Pyramid Hole', player).connected_region.name != 'Pyramid':
+        multiworld.ganon_at_pyramid[player] = False
 
     # check for Ganon's Tower location
-    if world.get_entrance('Ganons Tower', player).connected_region.name != 'Ganons Tower (Entrance)':
-        world.ganonstower_vanilla[player] = False
+    if multiworld.get_entrance('Ganons Tower', player).connected_region.name != 'Ganons Tower (Entrance)':
+        multiworld.ganonstower_vanilla[player] = False
 
-def link_inverted_entrances(world, player):
-    # Link's house shuffled freely, Houlihan set in mandatory_connections 
+
+def link_inverted_entrances(multiworld: MultiWorld, player: int):
+    world = multiworld.worlds[player]
+    # Link's house shuffled freely, Houlihan set in mandatory_connections
 
     Dungeon_Exits = Inverted_Dungeon_Exits_Base.copy()
     Cave_Exits = Cave_Exits_Base.copy()
@@ -1103,24 +1110,24 @@ def link_inverted_entrances(world, player):
 
     # setup mandatory connections
     for exitname, regionname in inverted_mandatory_connections:
-        connect_simple(world, exitname, regionname, player)
+        connect_simple(multiworld, exitname, regionname, player)
 
     # if we do not shuffle, set default connections
-    if world.shuffle[player] == 'vanilla':
+    if multiworld.shuffle[player] == 'vanilla':
         for exitname, regionname in inverted_default_connections:
-            connect_simple(world, exitname, regionname, player)
+            connect_simple(multiworld, exitname, regionname, player)
         for exitname, regionname in inverted_default_dungeon_connections:
-            connect_simple(world, exitname, regionname, player)
-    elif world.shuffle[player] == 'dungeonssimple':
+            connect_simple(multiworld, exitname, regionname, player)
+    elif multiworld.shuffle[player] == 'dungeonssimple':
         for exitname, regionname in inverted_default_connections:
-            connect_simple(world, exitname, regionname, player)
+            connect_simple(multiworld, exitname, regionname, player)
 
-        simple_shuffle_dungeons(world, player)
-    elif world.shuffle[player] == 'dungeonsfull':
+        simple_shuffle_dungeons(multiworld, player)
+    elif multiworld.shuffle[player] == 'dungeonsfull':
         for exitname, regionname in inverted_default_connections:
-            connect_simple(world, exitname, regionname, player)
+            connect_simple(multiworld, exitname, regionname, player)
 
-        skull_woods_shuffle(world, player)
+        skull_woods_shuffle(multiworld, player)
 
         dungeon_exits = list(Dungeon_Exits)
         lw_entrances = list(Inverted_LW_Dungeon_Entrances)
@@ -1138,8 +1145,8 @@ def link_inverted_entrances(world, player):
         dungeon_exits.append(('Hyrule Castle Exit (South)', 'Hyrule Castle Exit (West)', 'Hyrule Castle Exit (East)'))
         lw_entrances.append('Hyrule Castle Entrance (South)')
         
-        if not world.shuffle_ganon:
-            connect_two_way(world, 'Inverted Ganons Tower', 'Inverted Ganons Tower Exit', player)
+        if not multiworld.shuffle_ganon:
+            connect_two_way(multiworld, 'Inverted Ganons Tower', 'Inverted Ganons Tower Exit', player)
             hc_ledge_entrances = ['Hyrule Castle Entrance (West)', 'Hyrule Castle Entrance (East)']
         else:
             lw_entrances.append('Inverted Ganons Tower')
@@ -1165,16 +1172,16 @@ def link_inverted_entrances(world, player):
         else:
             dw_entrances.remove(aga_door)
 
-        connect_two_way(world, aga_door, 'Inverted Agahnims Tower Exit', player)
+        connect_two_way(multiworld, aga_door, 'Inverted Agahnims Tower Exit', player)
         dungeon_exits.remove('Inverted Agahnims Tower Exit')
 
-        connect_mandatory_exits(world, lw_entrances, dungeon_exits, lw_dungeon_entrances_must_exit, player)
+        connect_mandatory_exits(multiworld, lw_entrances, dungeon_exits, lw_dungeon_entrances_must_exit, player)
 
-        connect_caves(world, lw_entrances, dw_entrances, dungeon_exits, player)
-    elif world.shuffle[player] == 'dungeonscrossed':
-        inverted_crossed_shuffle_dungeons(world, player)
-    elif world.shuffle[player] == 'simple':
-        simple_shuffle_dungeons(world, player)
+        connect_caves(multiworld, lw_entrances, dw_entrances, dungeon_exits, player)
+    elif multiworld.shuffle[player] == 'dungeonscrossed':
+        inverted_crossed_shuffle_dungeons(multiworld, player)
+    elif multiworld.shuffle[player] == 'simple':
+        simple_shuffle_dungeons(multiworld, player)
 
         old_man_entrances = list(Inverted_Old_Man_Entrances)
         caves = list(Cave_Exits)
@@ -1193,8 +1200,8 @@ def link_inverted_entrances(world, player):
         while two_door_caves:
             entrance1, entrance2 = two_door_caves.pop()
             exit1, exit2 = caves.pop()
-            connect_two_way(world, entrance1, exit1, player)
-            connect_two_way(world, entrance2, exit2, player)
+            connect_two_way(multiworld, entrance1, exit1, player)
+            connect_two_way(multiworld, entrance2, exit2, player)
 
         # now the remaining pairs
         two_door_caves = list(Inverted_Two_Door_Caves)
@@ -1202,14 +1209,14 @@ def link_inverted_entrances(world, player):
         while two_door_caves:
             entrance1, entrance2 = two_door_caves.pop()
             exit1, exit2 = caves.pop()
-            connect_two_way(world, entrance1, exit1, player)
-            connect_two_way(world, entrance2, exit2, player)
+            connect_two_way(multiworld, entrance1, exit1, player)
+            connect_two_way(multiworld, entrance2, exit2, player)
         
         # place links house
         links_house_doors = [i for i in bomb_shop_doors + blacksmith_doors if
                              i not in Inverted_Dark_Sanctuary_Doors + Isolated_LH_Doors]
         links_house = world.random.choice(list(links_house_doors))
-        connect_two_way(world, links_house, 'Inverted Links House Exit', player)
+        connect_two_way(multiworld, links_house, 'Inverted Links House Exit', player)
         if links_house in bomb_shop_doors:
             bomb_shop_doors.remove(links_house)
         if links_house in blacksmith_doors:
@@ -1222,8 +1229,8 @@ def link_inverted_entrances(world, player):
         sanc_door = world.random.choice(sanc_doors)
         bomb_shop_doors.remove(sanc_door)
 
-        connect_entrance(world, sanc_door, 'Inverted Dark Sanctuary', player)
-        world.get_entrance('Inverted Dark Sanctuary Exit', player).connect(world.get_entrance(sanc_door, player).parent_region)
+        connect_entrance(multiworld, sanc_door, 'Inverted Dark Sanctuary', player)
+        multiworld.get_entrance('Inverted Dark Sanctuary Exit', player).connect(multiworld.get_entrance(sanc_door, player).parent_region)
         
         lw_dm_entrances = ['Paradox Cave (Bottom)', 'Paradox Cave (Middle)', 'Paradox Cave (Top)', 'Old Man House (Bottom)',
                            'Fairy Ascension Cave (Bottom)', 'Fairy Ascension Cave (Top)', 'Spiral Cave (Bottom)', 'Old Man Cave (East)',
@@ -1234,8 +1241,8 @@ def link_inverted_entrances(world, player):
 
         world.random.shuffle(old_man_entrances)
         old_man_exit = old_man_entrances.pop()
-        connect_two_way(world, 'Bumper Cave (Bottom)', 'Old Man Cave Exit (West)', player)
-        connect_two_way(world, old_man_exit, 'Old Man Cave Exit (East)', player)
+        connect_two_way(multiworld, 'Bumper Cave (Bottom)', 'Old Man Cave Exit (West)', player)
+        connect_two_way(multiworld, old_man_exit, 'Old Man Cave Exit (East)', player)
         if old_man_exit == 'Spike Cave':
             bomb_shop_doors.remove('Spike Cave')
             bomb_shop_doors.extend(old_man_entrances)
@@ -1245,33 +1252,33 @@ def link_inverted_entrances(world, player):
         caves.extend(list(three_exit_caves))
 
         # connect rest
-        connect_caves(world, lw_dm_entrances, [], caves, player)
+        connect_caves(multiworld, lw_dm_entrances, [], caves, player)
         
         # scramble holes
-        scramble_inverted_holes(world, player)
+        scramble_inverted_holes(multiworld, player)
 
         # place blacksmith, has limited options
         blacksmith_doors = [door for door in blacksmith_doors[:]]
         world.random.shuffle(blacksmith_doors)
         blacksmith_hut = blacksmith_doors.pop()
-        connect_entrance(world, blacksmith_hut, 'Blacksmiths Hut', player)
+        connect_entrance(multiworld, blacksmith_hut, 'Blacksmiths Hut', player)
         bomb_shop_doors.extend(blacksmith_doors)
 
         # place bomb shop, has limited options
         bomb_shop_doors = [door for door in bomb_shop_doors[:]]
         world.random.shuffle(bomb_shop_doors)
         bomb_shop = bomb_shop_doors.pop()
-        connect_entrance(world, bomb_shop, 'Inverted Big Bomb Shop', player)
+        connect_entrance(multiworld, bomb_shop, 'Inverted Big Bomb Shop', player)
         single_doors.extend(bomb_shop_doors)
 
         # tavern back door cannot be shuffled yet
-        connect_doors(world, ['Tavern North'], ['Tavern'], player)
+        connect_doors(multiworld, ['Tavern North'], ['Tavern'], player)
 
         # place remaining doors
-        connect_doors(world, single_doors, door_targets, player)
+        connect_doors(multiworld, single_doors, door_targets, player)
     
-    elif world.shuffle[player] == 'restricted':
-        simple_shuffle_dungeons(world, player)
+    elif multiworld.shuffle[player] == 'restricted':
+        simple_shuffle_dungeons(multiworld, player)
 
         lw_entrances = list(Inverted_LW_Entrances + Inverted_LW_Single_Cave_Doors)
         dw_entrances = list(Inverted_DW_Entrances + Inverted_DW_Single_Cave_Doors + Inverted_Old_Man_Entrances)
@@ -1287,7 +1294,7 @@ def link_inverted_entrances(world, player):
         links_house_doors = [i for i in lw_entrances + dw_entrances + lw_must_exits if
                              i not in Inverted_Dark_Sanctuary_Doors + Isolated_LH_Doors]
         links_house = world.random.choice(list(links_house_doors))
-        connect_two_way(world, links_house, 'Inverted Links House Exit', player)
+        connect_two_way(multiworld, links_house, 'Inverted Links House Exit', player)
         if links_house in lw_entrances:
             lw_entrances.remove(links_house)
         elif links_house in dw_entrances:
@@ -1299,21 +1306,21 @@ def link_inverted_entrances(world, player):
         sanc_doors = [door for door in Inverted_Dark_Sanctuary_Doors if door in dw_entrances]
         sanc_door = world.random.choice(sanc_doors)
         dw_entrances.remove(sanc_door)
-        connect_entrance(world, sanc_door, 'Inverted Dark Sanctuary', player)
-        world.get_entrance('Inverted Dark Sanctuary Exit', player).connect(world.get_entrance(sanc_door, player).parent_region)
+        connect_entrance(multiworld, sanc_door, 'Inverted Dark Sanctuary', player)
+        multiworld.get_entrance('Inverted Dark Sanctuary Exit', player).connect(multiworld.get_entrance(sanc_door, player).parent_region)
 
         # tavern back door cannot be shuffled yet
-        connect_doors(world, ['Tavern North'], ['Tavern'], player)
+        connect_doors(multiworld, ['Tavern North'], ['Tavern'], player)
 
         # place must exits
-        connect_mandatory_exits(world, lw_entrances, caves, lw_must_exits, player)
+        connect_mandatory_exits(multiworld, lw_entrances, caves, lw_must_exits, player)
 
         # place old man, has limited options
         # exit has to come from specific set of doors, the entrance is free to move about
         old_man_entrances = [door for door in old_man_entrances if door in dw_entrances]
         world.random.shuffle(old_man_entrances)
         old_man_exit = old_man_entrances.pop()
-        connect_two_way(world, old_man_exit, 'Old Man Cave Exit (East)', player)
+        connect_two_way(multiworld, old_man_exit, 'Old Man Cave Exit (East)', player)
         dw_entrances.remove(old_man_exit)
 
         # place blacksmith, has limited options
@@ -1322,7 +1329,7 @@ def link_inverted_entrances(world, player):
         blacksmith_doors = [door for door in blacksmith_doors if door in all_entrances]
         world.random.shuffle(blacksmith_doors)
         blacksmith_hut = blacksmith_doors.pop()
-        connect_entrance(world, blacksmith_hut, 'Blacksmiths Hut', player)
+        connect_entrance(multiworld, blacksmith_hut, 'Blacksmiths Hut', player)
         if blacksmith_hut in lw_entrances:
             lw_entrances.remove(blacksmith_hut)
         if blacksmith_hut in dw_entrances:
@@ -1335,7 +1342,7 @@ def link_inverted_entrances(world, player):
         bomb_shop_doors = [door for door in bomb_shop_doors if door in all_entrances]
         world.random.shuffle(bomb_shop_doors)
         bomb_shop = bomb_shop_doors.pop()
-        connect_entrance(world, bomb_shop, 'Inverted Big Bomb Shop', player)
+        connect_entrance(multiworld, bomb_shop, 'Inverted Big Bomb Shop', player)
         if bomb_shop in lw_entrances:
             lw_entrances.remove(bomb_shop)
         if bomb_shop in dw_entrances:
@@ -1344,19 +1351,19 @@ def link_inverted_entrances(world, player):
         # place the old man cave's entrance somewhere in the dark world
         world.random.shuffle(dw_entrances)
         old_man_entrance = dw_entrances.pop()
-        connect_two_way(world, old_man_entrance, 'Old Man Cave Exit (West)', player)
+        connect_two_way(multiworld, old_man_entrance, 'Old Man Cave Exit (West)', player)
 
         # now scramble the rest
-        connect_caves(world, lw_entrances, dw_entrances, caves, player)
+        connect_caves(multiworld, lw_entrances, dw_entrances, caves, player)
 
         # scramble holes
-        scramble_inverted_holes(world, player)
+        scramble_inverted_holes(multiworld, player)
 
         doors = lw_entrances + dw_entrances
         # place remaining doors
-        connect_doors(world, doors, door_targets, player)
-    elif world.shuffle[player] == 'full':
-        skull_woods_shuffle(world, player)
+        connect_doors(multiworld, doors, door_targets, player)
+    elif multiworld.shuffle[player] == 'full':
+        skull_woods_shuffle(multiworld, player)
 
         lw_entrances = list(Inverted_LW_Entrances + Inverted_LW_Dungeon_Entrances + Inverted_LW_Single_Cave_Doors)
         dw_entrances = list(Inverted_DW_Entrances + Inverted_DW_Dungeon_Entrances + Inverted_DW_Single_Cave_Doors + Inverted_Old_Man_Entrances)
@@ -1377,12 +1384,12 @@ def link_inverted_entrances(world, player):
             lw_entrances.append('Desert Palace Entrance (North)')
 
         # tavern back door cannot be shuffled yet
-        connect_doors(world, ['Tavern North'], ['Tavern'], player)
+        connect_doors(multiworld, ['Tavern North'], ['Tavern'], player)
 
         lw_entrances.append('Hyrule Castle Entrance (South)')
 
-        if not world.shuffle_ganon:
-            connect_two_way(world, 'Inverted Ganons Tower', 'Inverted Ganons Tower Exit', player)
+        if not multiworld.shuffle_ganon:
+            connect_two_way(multiworld, 'Inverted Ganons Tower', 'Inverted Ganons Tower Exit', player)
             hc_ledge_entrances = ['Hyrule Castle Entrance (West)', 'Hyrule Castle Entrance (East)']
         else:
             lw_entrances.append('Inverted Ganons Tower')
@@ -1408,14 +1415,14 @@ def link_inverted_entrances(world, player):
         else:
             dw_entrances.remove(aga_door)
 
-        connect_two_way(world, aga_door, 'Inverted Agahnims Tower Exit', player)
+        connect_two_way(multiworld, aga_door, 'Inverted Agahnims Tower Exit', player)
         caves.remove('Inverted Agahnims Tower Exit')
 
         # place links house
         links_house_doors = [i for i in lw_entrances + dw_entrances + lw_must_exits if
                              i not in Inverted_Dark_Sanctuary_Doors + Isolated_LH_Doors]
         links_house = world.random.choice(list(links_house_doors))
-        connect_two_way(world, links_house, 'Inverted Links House Exit', player)
+        connect_two_way(multiworld, links_house, 'Inverted Links House Exit', player)
         if links_house in lw_entrances:
             lw_entrances.remove(links_house)
         if links_house in dw_entrances:
@@ -1427,33 +1434,33 @@ def link_inverted_entrances(world, player):
         sanc_doors = [door for door in Inverted_Dark_Sanctuary_Doors if door in dw_entrances]
         sanc_door = world.random.choice(sanc_doors)
         dw_entrances.remove(sanc_door)
-        connect_entrance(world, sanc_door, 'Inverted Dark Sanctuary', player)
-        world.get_entrance('Inverted Dark Sanctuary Exit', player).connect(world.get_entrance(sanc_door, player).parent_region)
+        connect_entrance(multiworld, sanc_door, 'Inverted Dark Sanctuary', player)
+        multiworld.get_entrance('Inverted Dark Sanctuary Exit', player).connect(multiworld.get_entrance(sanc_door, player).parent_region)
         
         # place old man house
         # no dw must exits in inverted, but we randomize whether cave is in light or dark world
         if world.random.randint(0, 1) == 0:
             caves += old_man_house
-            connect_mandatory_exits(world, lw_entrances, caves, lw_must_exits, player)
+            connect_mandatory_exits(multiworld, lw_entrances, caves, lw_must_exits, player)
             try:
                 caves.remove(old_man_house[0])
             except ValueError:
                 pass
             else:  # if the cave wasn't placed we get here
-                connect_caves(world, lw_entrances, [], old_man_house, player)
+                connect_caves(multiworld, lw_entrances, [], old_man_house, player)
         else:
-            connect_caves(world, dw_entrances, [], old_man_house, player)
-            connect_mandatory_exits(world, lw_entrances, caves, lw_must_exits, player)
+            connect_caves(multiworld, dw_entrances, [], old_man_house, player)
+            connect_mandatory_exits(multiworld, lw_entrances, caves, lw_must_exits, player)
 
         # put all HC exits in LW in inverted full shuffle
-        connect_caves(world, lw_entrances, [], [('Hyrule Castle Exit (West)', 'Hyrule Castle Exit (East)', 'Hyrule Castle Exit (South)')], player)
+        connect_caves(multiworld, lw_entrances, [], [('Hyrule Castle Exit (West)', 'Hyrule Castle Exit (East)', 'Hyrule Castle Exit (South)')], player)
 
         # place old man, has limited options
         # exit has to come from specific set of doors, the entrance is free to move about
         old_man_entrances = [door for door in old_man_entrances if door in dw_entrances + lw_entrances]
         world.random.shuffle(old_man_entrances)
         old_man_exit = old_man_entrances.pop()
-        connect_two_way(world, old_man_exit, 'Old Man Cave Exit (East)', player)
+        connect_two_way(multiworld, old_man_exit, 'Old Man Cave Exit (East)', player)
         if old_man_exit in dw_entrances:
             dw_entrances.remove(old_man_exit)
             old_man_world = 'dark'
@@ -1467,7 +1474,7 @@ def link_inverted_entrances(world, player):
         blacksmith_doors = [door for door in blacksmith_doors if door in all_entrances]
         world.random.shuffle(blacksmith_doors)
         blacksmith_hut = blacksmith_doors.pop()
-        connect_entrance(world, blacksmith_hut, 'Blacksmiths Hut', player)
+        connect_entrance(multiworld, blacksmith_hut, 'Blacksmiths Hut', player)
         if blacksmith_hut in lw_entrances:
             lw_entrances.remove(blacksmith_hut)
         if blacksmith_hut in dw_entrances:
@@ -1480,7 +1487,7 @@ def link_inverted_entrances(world, player):
         bomb_shop_doors = [door for door in bomb_shop_doors if door in all_entrances]
         world.random.shuffle(bomb_shop_doors)
         bomb_shop = bomb_shop_doors.pop()
-        connect_entrance(world, bomb_shop, 'Inverted Big Bomb Shop', player)
+        connect_entrance(multiworld, bomb_shop, 'Inverted Big Bomb Shop', player)
         if bomb_shop in lw_entrances:
             lw_entrances.remove(bomb_shop)
         if bomb_shop in dw_entrances:
@@ -1490,24 +1497,24 @@ def link_inverted_entrances(world, player):
         if old_man_world == 'light':
             world.random.shuffle(lw_entrances)
             old_man_entrance = lw_entrances.pop()
-            connect_two_way(world, old_man_entrance, 'Old Man Cave Exit (West)', player)
+            connect_two_way(multiworld, old_man_entrance, 'Old Man Cave Exit (West)', player)
         elif old_man_world == 'dark':
             world.random.shuffle(dw_entrances)
             old_man_entrance = dw_entrances.pop()
-            connect_two_way(world, old_man_entrance, 'Old Man Cave Exit (West)', player)
+            connect_two_way(multiworld, old_man_entrance, 'Old Man Cave Exit (West)', player)
         
         # now scramble the rest
-        connect_caves(world, lw_entrances, dw_entrances, caves, player)
+        connect_caves(multiworld, lw_entrances, dw_entrances, caves, player)
 
         # scramble holes
-        scramble_inverted_holes(world, player)
+        scramble_inverted_holes(multiworld, player)
 
         doors = lw_entrances + dw_entrances
 
         # place remaining doors
-        connect_doors(world, doors, door_targets, player)
-    elif world.shuffle[player] == 'crossed':
-        skull_woods_shuffle(world, player)
+        connect_doors(multiworld, doors, door_targets, player)
+    elif multiworld.shuffle[player] == 'crossed':
+        skull_woods_shuffle(multiworld, player)
 
         entrances = list(Inverted_LW_Entrances + Inverted_LW_Dungeon_Entrances + Inverted_LW_Single_Cave_Doors + Inverted_Old_Man_Entrances + Inverted_DW_Entrances + Inverted_DW_Dungeon_Entrances + Inverted_DW_Single_Cave_Doors)
         must_exits = list(Inverted_LW_Entrances_Must_Exit + Inverted_LW_Dungeon_Entrances_Must_Exit)
@@ -1530,8 +1537,8 @@ def link_inverted_entrances(world, player):
             ['Hyrule Castle Exit (South)', 'Hyrule Castle Exit (West)', 'Hyrule Castle Exit (East)'], 3)))
         entrances.append('Hyrule Castle Entrance (South)')
         
-        if not world.shuffle_ganon:
-            connect_two_way(world, 'Inverted Ganons Tower', 'Inverted Ganons Tower Exit', player)
+        if not multiworld.shuffle_ganon:
+            connect_two_way(multiworld, 'Inverted Ganons Tower', 'Inverted Ganons Tower Exit', player)
             hc_ledge_entrances = ['Hyrule Castle Entrance (West)', 'Hyrule Castle Entrance (East)']
         else:
             entrances.append('Inverted Ganons Tower')
@@ -1550,7 +1557,7 @@ def link_inverted_entrances(world, player):
             must_exits.append(hc_ledge_must_exit)
 
         entrances.remove(aga_door)
-        connect_two_way(world, aga_door, 'Inverted Agahnims Tower Exit', player)
+        connect_two_way(multiworld, aga_door, 'Inverted Agahnims Tower Exit', player)
         caves.remove('Inverted Agahnims Tower Exit')
 
 
@@ -1558,7 +1565,7 @@ def link_inverted_entrances(world, player):
         links_house_doors = [i for i in entrances + must_exits if
                              i not in Inverted_Dark_Sanctuary_Doors + Isolated_LH_Doors]
         links_house = world.random.choice(list(links_house_doors))
-        connect_two_way(world, links_house, 'Inverted Links House Exit', player)
+        connect_two_way(multiworld, links_house, 'Inverted Links House Exit', player)
         if links_house in entrances:
             entrances.remove(links_house)
         elif links_house in must_exits:
@@ -1568,15 +1575,15 @@ def link_inverted_entrances(world, player):
         sanc_doors = [door for door in Inverted_Dark_Sanctuary_Doors if door in entrances]
         sanc_door = world.random.choice(sanc_doors)
         entrances.remove(sanc_door)
-        connect_entrance(world, sanc_door, 'Inverted Dark Sanctuary', player)
-        world.get_entrance('Inverted Dark Sanctuary Exit', player).connect(world.get_entrance(sanc_door, player).parent_region)
+        connect_entrance(multiworld, sanc_door, 'Inverted Dark Sanctuary', player)
+        multiworld.get_entrance('Inverted Dark Sanctuary Exit', player).connect(multiworld.get_entrance(sanc_door, player).parent_region)
 
         # tavern back door cannot be shuffled yet
-        connect_doors(world, ['Tavern North'], ['Tavern'], player)
+        connect_doors(multiworld, ['Tavern North'], ['Tavern'], player)
 
         
         #place must-exit caves 
-        connect_mandatory_exits(world, entrances, caves, must_exits, player)
+        connect_mandatory_exits(multiworld, entrances, caves, must_exits, player)
 
 
         # place old man, has limited options
@@ -1584,7 +1591,7 @@ def link_inverted_entrances(world, player):
         old_man_entrances = [door for door in old_man_entrances if door in entrances]
         world.random.shuffle(old_man_entrances)
         old_man_exit = old_man_entrances.pop()
-        connect_two_way(world, old_man_exit, 'Old Man Cave Exit (East)', player)
+        connect_two_way(multiworld, old_man_exit, 'Old Man Cave Exit (East)', player)
         entrances.remove(old_man_exit)
 
         # place blacksmith, has limited options
@@ -1592,7 +1599,7 @@ def link_inverted_entrances(world, player):
         blacksmith_doors = [door for door in blacksmith_doors if door in entrances]
         world.random.shuffle(blacksmith_doors)
         blacksmith_hut = blacksmith_doors.pop()
-        connect_entrance(world, blacksmith_hut, 'Blacksmiths Hut', player)
+        connect_entrance(multiworld, blacksmith_hut, 'Blacksmiths Hut', player)
         entrances.remove(blacksmith_hut)
 
         # place bomb shop, has limited options
@@ -1601,23 +1608,23 @@ def link_inverted_entrances(world, player):
         bomb_shop_doors = [door for door in bomb_shop_doors if door in entrances]
         world.random.shuffle(bomb_shop_doors)
         bomb_shop = bomb_shop_doors.pop()
-        connect_entrance(world, bomb_shop, 'Inverted Big Bomb Shop', player)
+        connect_entrance(multiworld, bomb_shop, 'Inverted Big Bomb Shop', player)
         entrances.remove(bomb_shop)
         
         # place the old man cave's entrance somewhere
         world.random.shuffle(entrances)
         old_man_entrance = entrances.pop()
-        connect_two_way(world, old_man_entrance, 'Old Man Cave Exit (West)', player)
+        connect_two_way(multiworld, old_man_entrance, 'Old Man Cave Exit (West)', player)
 
         # now scramble the rest
-        connect_caves(world, entrances, [], caves, player)
+        connect_caves(multiworld, entrances, [], caves, player)
 
         # scramble holes
-        scramble_inverted_holes(world, player)
+        scramble_inverted_holes(multiworld, player)
 
         # place remaining doors
-        connect_doors(world, entrances, door_targets, player)
-    elif world.shuffle[player] == 'insanity':
+        connect_doors(multiworld, entrances, door_targets, player)
+    elif multiworld.shuffle[player] == 'insanity':
         # beware ye who enter here
 
         entrances = Inverted_LW_Entrances + Inverted_LW_Dungeon_Entrances + Inverted_DW_Entrances + Inverted_DW_Dungeon_Entrances + Inverted_Old_Man_Entrances + Old_Man_Entrances + ['Skull Woods Second Section Door (East)', 'Skull Woods Second Section Door (West)', 'Skull Woods First Section Door', 'Kakariko Well Cave', 'Bat Cave Cave', 'North Fairy Cave', 'Sanctuary', 'Lost Woods Hideout Stump', 'Lumberjack Tree Cave', 'Hyrule Castle Entrance (South)']
@@ -1659,17 +1666,17 @@ def link_inverted_entrances(world, player):
                         'Skull Woods First Section (Left)', 'Skull Woods First Section (Right)', 'Skull Woods First Section (Top)']
 
         # tavern back door cannot be shuffled yet
-        connect_doors(world, ['Tavern North'], ['Tavern'], player)
+        connect_doors(multiworld, ['Tavern North'], ['Tavern'], player)
 
         hole_entrances.append('Hyrule Castle Secret Entrance Drop')
         hole_targets.append('Hyrule Castle Secret Entrance')
         entrances.append('Hyrule Castle Secret Entrance Stairs')
         caves.append('Hyrule Castle Secret Entrance Exit')
 
-        if not world.shuffle_ganon:
-            connect_two_way(world, 'Inverted Ganons Tower', 'Inverted Ganons Tower Exit', player)
-            connect_two_way(world, 'Inverted Pyramid Entrance', 'Pyramid Exit', player)
-            connect_entrance(world, 'Inverted Pyramid Hole', 'Pyramid', player)
+        if not multiworld.shuffle_ganon:
+            connect_two_way(multiworld, 'Inverted Ganons Tower', 'Inverted Ganons Tower Exit', player)
+            connect_two_way(multiworld, 'Inverted Pyramid Entrance', 'Pyramid Exit', player)
+            connect_entrance(multiworld, 'Inverted Pyramid Hole', 'Pyramid', player)
         else:
             entrances.append('Inverted Ganons Tower')
             caves.extend(['Inverted Ganons Tower Exit', 'Pyramid Exit'])
@@ -1683,7 +1690,7 @@ def link_inverted_entrances(world, player):
 
         # fill up holes
         for hole in hole_entrances:
-            connect_entrance(world, hole, hole_targets.pop(), player)
+            connect_entrance(multiworld, hole, hole_targets.pop(), player)
 
         doors.append('Hyrule Castle Entrance (South)')
         caves.append(('Hyrule Castle Exit (South)', 'Hyrule Castle Exit (West)', 'Hyrule Castle Exit (East)'))
@@ -1692,7 +1699,7 @@ def link_inverted_entrances(world, player):
         links_house_doors = [i for i in entrances + entrances_must_exits if
                              i not in Inverted_Dark_Sanctuary_Doors + Isolated_LH_Doors]
         links_house = world.random.choice(list(links_house_doors))
-        connect_two_way(world, links_house, 'Inverted Links House Exit', player)
+        connect_two_way(multiworld, links_house, 'Inverted Links House Exit', player)
         if links_house in entrances:
             entrances.remove(links_house)
         elif links_house in entrances_must_exits:
@@ -1703,8 +1710,8 @@ def link_inverted_entrances(world, player):
         sanc_door = world.random.choice(sanc_doors)
         entrances.remove(sanc_door)
         doors.remove(sanc_door)
-        connect_entrance(world, sanc_door, 'Inverted Dark Sanctuary', player)
-        world.get_entrance('Inverted Dark Sanctuary Exit', player).connect(world.get_entrance(sanc_door, player).parent_region)
+        connect_entrance(multiworld, sanc_door, 'Inverted Dark Sanctuary', player)
+        multiworld.get_entrance('Inverted Dark Sanctuary Exit', player).connect(multiworld.get_entrance(sanc_door, player).parent_region)
 
         # now let's deal with mandatory reachable stuff
         def extract_reachable_exit(cavelist):
@@ -1728,8 +1735,8 @@ def link_inverted_entrances(world, player):
 
             exit = cave[-1]
             cave = cave[:-1]
-            connect_exit(world, exit, entrance, player)
-            connect_entrance(world, doors.pop(), exit, player)
+            connect_exit(multiworld, exit, entrance, player)
+            connect_entrance(multiworld, doors.pop(), exit, player)
             # rest of cave now is forced to be in this world
             caves.append(cave)
 
@@ -1744,22 +1751,22 @@ def link_inverted_entrances(world, player):
         old_man_exit = old_man_entrances.pop()
         entrances.remove(old_man_exit)
 
-        connect_exit(world, 'Old Man Cave Exit (East)', old_man_exit, player)
-        connect_entrance(world, doors.pop(), 'Old Man Cave Exit (East)', player)
+        connect_exit(multiworld, 'Old Man Cave Exit (East)', old_man_exit, player)
+        connect_entrance(multiworld, doors.pop(), 'Old Man Cave Exit (East)', player)
         caves.append('Old Man Cave Exit (West)')
 
         # place blacksmith, has limited options
         blacksmith_doors = [door for door in blacksmith_doors if door in doors]
         world.random.shuffle(blacksmith_doors)
         blacksmith_hut = blacksmith_doors.pop()
-        connect_entrance(world, blacksmith_hut, 'Blacksmiths Hut', player)
+        connect_entrance(multiworld, blacksmith_hut, 'Blacksmiths Hut', player)
         doors.remove(blacksmith_hut)
 
         # place dam and pyramid fairy, have limited options
         bomb_shop_doors = [door for door in bomb_shop_doors if door in doors]
         world.random.shuffle(bomb_shop_doors)
         bomb_shop = bomb_shop_doors.pop()
-        connect_entrance(world, bomb_shop, 'Inverted Big Bomb Shop', player)
+        connect_entrance(multiworld, bomb_shop, 'Inverted Big Bomb Shop', player)
         doors.remove(bomb_shop)
 
         # handle remaining caves
@@ -1768,35 +1775,35 @@ def link_inverted_entrances(world, player):
                 cave = (cave,)
 
             for exit in cave:
-                connect_exit(world, exit, entrances.pop(), player)
-                connect_entrance(world, doors.pop(), exit, player)
+                connect_exit(multiworld, exit, entrances.pop(), player)
+                connect_entrance(multiworld, doors.pop(), exit, player)
 
         # place remaining doors
-        connect_doors(world, doors, door_targets, player)
+        connect_doors(multiworld, doors, door_targets, player)
     else:
         raise NotImplementedError('Shuffling not supported yet')
 
-    if world.logic[player] in ['owglitches', 'hybridglitches', 'nologic']:
-        overworld_glitch_connections(world, player)
+    if multiworld.logic[player] in ['owglitches', 'hybridglitches', 'nologic']:
+        overworld_glitch_connections(multiworld, player)
         # mandatory hybrid major glitches connections
-        if world.logic[player] in ['hybridglitches', 'nologic']:
-            underworld_glitch_connections(world, player)
+        if multiworld.logic[player] in ['hybridglitches', 'nologic']:
+            underworld_glitch_connections(multiworld, player)
 
     # patch swamp drain
-    if world.get_entrance('Dam', player).connected_region.name != 'Dam' or world.get_entrance('Swamp Palace', player).connected_region.name != 'Swamp Palace (Entrance)':
-        world.swamp_patch_required[player] = True
+    if multiworld.get_entrance('Dam', player).connected_region.name != 'Dam' or multiworld.get_entrance('Swamp Palace', player).connected_region.name != 'Swamp Palace (Entrance)':
+        multiworld.swamp_patch_required[player] = True
 
     # check for potion shop location
-    if world.get_entrance('Potion Shop', player).connected_region.name != 'Potion Shop':
-        world.powder_patch_required[player] = True
+    if multiworld.get_entrance('Potion Shop', player).connected_region.name != 'Potion Shop':
+        multiworld.powder_patch_required[player] = True
 
     # check for ganon location
-    if world.get_entrance('Inverted Pyramid Hole', player).connected_region.name != 'Pyramid':
-        world.ganon_at_pyramid[player] = False
+    if multiworld.get_entrance('Inverted Pyramid Hole', player).connected_region.name != 'Pyramid':
+        multiworld.ganon_at_pyramid[player] = False
    
     # check for Ganon's Tower location
-    if world.get_entrance('Inverted Ganons Tower', player).connected_region.name != 'Ganons Tower (Entrance)':
-        world.ganonstower_vanilla[player] = False
+    if multiworld.get_entrance('Inverted Ganons Tower', player).connected_region.name != 'Ganons Tower (Entrance)':
+        multiworld.ganonstower_vanilla[player] = False
 
 
 def connect_simple(world, exitname, regionname, player):
@@ -2297,7 +2304,8 @@ def inverted_crossed_shuffle_dungeons(world, player: int):
     connect_caves(world, dungeon_entrances, [], dungeon_exits, player)
     assert not dungeon_exits, "make sure all exits are accounted for"
 
-def unbias_some_entrances(world, Dungeon_Exits, Cave_Exits, Old_Man_House, Cave_Three_Exits):
+
+def unbias_some_entrances(world: "ALTTPWorld", Dungeon_Exits, Cave_Exits, Old_Man_House, Cave_Three_Exits):
     def shuffle_lists_in_list(ls):
         for i, item in enumerate(ls):
             if isinstance(item, list):

--- a/worlds/alttp/EntranceShuffle.py
+++ b/worlds/alttp/EntranceShuffle.py
@@ -1906,7 +1906,7 @@ def scramble_holes(world, player):
         connect_entrance(world, drop, target, player)
 
 
-def scramble_inverted_holes(world, player):
+def scramble_inverted_holes(multiworld: MultiWorld, player: int):
     hole_entrances = [('Kakariko Well Cave', 'Kakariko Well Drop'),
                       ('Bat Cave Cave', 'Bat Cave Drop'),
                       ('North Fairy Cave', 'North Fairy Cave Drop'),
@@ -1920,9 +1920,9 @@ def scramble_inverted_holes(world, player):
                     ('Lost Woods Hideout Exit', 'Lost Woods Hideout (top)'),
                     ('Lumberjack Tree Exit', 'Lumberjack Tree (top)')]
 
-    if not world.shuffle_ganon:
-        connect_two_way(world, 'Inverted Pyramid Entrance', 'Pyramid Exit', player)
-        connect_entrance(world, 'Inverted Pyramid Hole', 'Pyramid', player)
+    if not multiworld.shuffle_ganon:
+        connect_two_way(multiworld, 'Inverted Pyramid Entrance', 'Pyramid Exit', player)
+        connect_entrance(multiworld, 'Inverted Pyramid Hole', 'Pyramid', player)
     else:
         hole_targets.append(('Pyramid Exit', 'Pyramid'))
 
@@ -1931,24 +1931,24 @@ def scramble_inverted_holes(world, player):
     hole_targets.append(('Hyrule Castle Secret Entrance Exit', 'Hyrule Castle Secret Entrance'))
 
     # do not shuffle sanctuary into pyramid hole unless shuffle is crossed
-    if world.shuffle[player] == 'crossed':
+    if multiworld.shuffle[player] == 'crossed':
         hole_targets.append(('Sanctuary Exit', 'Sewer Drop'))
-    if world.shuffle_ganon:
-        world.random.shuffle(hole_targets)
+    if multiworld.shuffle_ganon:
+        multiworld.worlds[player].random.shuffle(hole_targets)
         exit, target = hole_targets.pop()
-        connect_two_way(world, 'Inverted Pyramid Entrance', exit, player)
-        connect_entrance(world, 'Inverted Pyramid Hole', target, player)
-    if world.shuffle[player] != 'crossed':
+        connect_two_way(multiworld, 'Inverted Pyramid Entrance', exit, player)
+        connect_entrance(multiworld, 'Inverted Pyramid Hole', target, player)
+    if multiworld.shuffle[player] != 'crossed':
         hole_targets.append(('Sanctuary Exit', 'Sewer Drop'))
 
-    world.random.shuffle(hole_targets)
+    multiworld.worlds[player].random.shuffle(hole_targets)
     for entrance, drop in hole_entrances:
         exit, target = hole_targets.pop()
-        connect_two_way(world, entrance, exit, player)
-        connect_entrance(world, drop, target, player)
+        connect_two_way(multiworld, entrance, exit, player)
+        connect_entrance(multiworld, drop, target, player)
 
 
-def connect_random(multiworld: MultiWorld, exitlist: typing.List[str], targetlist: typing.List[str], player, two_way=False):
+def connect_random(multiworld: MultiWorld, exitlist: typing.List[str], targetlist: typing.List[str], player: int, two_way=False):
     targetlist = list(targetlist)
     multiworld.worlds[player].random.shuffle(targetlist)
 

--- a/worlds/alttp/EntranceShuffle.py
+++ b/worlds/alttp/EntranceShuffle.py
@@ -1860,7 +1860,8 @@ def connect_two_way(world, entrancename, exitname, player):
     world.spoiler.set_entrance(entrance.name, exit.name, 'both', player)
 
 
-def scramble_holes(world, player):
+def scramble_holes(multiworld: MultiWorld, player: int):
+    world = multiworld.worlds[player]
     hole_entrances = [('Kakariko Well Cave', 'Kakariko Well Drop'),
                       ('Bat Cave Cave', 'Bat Cave Drop'),
                       ('North Fairy Cave', 'North Fairy Cave Drop'),
@@ -1874,36 +1875,36 @@ def scramble_holes(world, player):
                     ('Lost Woods Hideout Exit', 'Lost Woods Hideout (top)'),
                     ('Lumberjack Tree Exit', 'Lumberjack Tree (top)')]
 
-    if not world.shuffle_ganon:
-        connect_two_way(world, 'Pyramid Entrance', 'Pyramid Exit', player)
-        connect_entrance(world, 'Pyramid Hole', 'Pyramid', player)
+    if not multiworld.shuffle_ganon:
+        connect_two_way(multiworld, 'Pyramid Entrance', 'Pyramid Exit', player)
+        connect_entrance(multiworld, 'Pyramid Hole', 'Pyramid', player)
     else:
         hole_targets.append(('Pyramid Exit', 'Pyramid'))
 
-    if world.mode[player] == 'standard':
+    if multiworld.mode[player] == 'standard':
         # cannot move uncle cave
-        connect_two_way(world, 'Hyrule Castle Secret Entrance Stairs', 'Hyrule Castle Secret Entrance Exit', player)
-        connect_entrance(world, 'Hyrule Castle Secret Entrance Drop', 'Hyrule Castle Secret Entrance', player)
+        connect_two_way(multiworld, 'Hyrule Castle Secret Entrance Stairs', 'Hyrule Castle Secret Entrance Exit', player)
+        connect_entrance(multiworld, 'Hyrule Castle Secret Entrance Drop', 'Hyrule Castle Secret Entrance', player)
     else:
         hole_entrances.append(('Hyrule Castle Secret Entrance Stairs', 'Hyrule Castle Secret Entrance Drop'))
         hole_targets.append(('Hyrule Castle Secret Entrance Exit', 'Hyrule Castle Secret Entrance'))
 
     # do not shuffle sanctuary into pyramid hole unless shuffle is crossed
-    if world.shuffle[player] == 'crossed':
+    if multiworld.shuffle[player] == 'crossed':
         hole_targets.append(('Sanctuary Exit', 'Sewer Drop'))
-    if world.shuffle_ganon:
+    if multiworld.shuffle_ganon:
         world.random.shuffle(hole_targets)
         exit, target = hole_targets.pop()
-        connect_two_way(world, 'Pyramid Entrance', exit, player)
-        connect_entrance(world, 'Pyramid Hole', target, player)
-    if world.shuffle[player] != 'crossed':
+        connect_two_way(multiworld, 'Pyramid Entrance', exit, player)
+        connect_entrance(multiworld, 'Pyramid Hole', target, player)
+    if multiworld.shuffle[player] != 'crossed':
         hole_targets.append(('Sanctuary Exit', 'Sewer Drop'))
 
     world.random.shuffle(hole_targets)
     for entrance, drop in hole_entrances:
         exit, target = hole_targets.pop()
-        connect_two_way(world, entrance, exit, player)
-        connect_entrance(world, drop, target, player)
+        connect_two_way(multiworld, entrance, exit, player)
+        connect_entrance(multiworld, drop, target, player)
 
 
 def scramble_inverted_holes(multiworld: MultiWorld, player: int):

--- a/worlds/alttp/EntranceShuffle.py
+++ b/worlds/alttp/EntranceShuffle.py
@@ -9,7 +9,7 @@ if typing.TYPE_CHECKING:
 from .OverworldGlitchRules import overworld_glitch_connections
 from .UnderworldGlitchRules import underworld_glitch_connections
 
-Caves = list[list[str] | tuple[str, str, str] | tuple[str, ...] | str | tuple[str, str]]
+Caves = typing.List[typing.Union[typing.List[str], typing.Tuple[str, str, str], typing.Tuple[str, ...], str, typing.Tuple[str, str]]]
 
 def link_entrances(multiworld: MultiWorld, player: int):
     world = multiworld.worlds[player]

--- a/worlds/alttp/ItemPool.py
+++ b/worlds/alttp/ItemPool.py
@@ -493,9 +493,10 @@ take_any_locations_inverted.sort()
 take_any_locations.sort()
 
 
-def set_up_take_anys(world, player):
+def set_up_take_anys(multiworld: MultiWorld, player: int):
+    world = multiworld.worlds[player]
     # these are references, do not modify these lists in-place
-    if world.mode[player] == 'inverted':
+    if multiworld.mode[player] == 'inverted':
         take_any_locs = take_any_locations_inverted
     else:
         take_any_locs = take_any_locations
@@ -503,20 +504,20 @@ def set_up_take_anys(world, player):
     regions = world.random.sample(take_any_locs, 5)
 
     old_man_take_any = LTTPRegion("Old Man Sword Cave", LTTPRegionType.Cave, 'the sword cave', player, world)
-    world.regions.append(old_man_take_any)
+    multiworld.regions.append(old_man_take_any)
 
     reg = regions.pop()
-    entrance = world.get_region(reg, player).entrances[0]
-    connect_entrance(world, entrance.name, old_man_take_any.name, player)
+    entrance = multiworld.get_region(reg, player).entrances[0]
+    connect_entrance(multiworld, entrance.name, old_man_take_any.name, player)
     entrance.target = 0x58
     old_man_take_any.shop = TakeAny(old_man_take_any, 0x0112, 0xE2, True, True, total_shop_slots)
-    world.shops.append(old_man_take_any.shop)
+    multiworld.shops.append(old_man_take_any.shop)
 
-    swords = [item for item in world.itempool if item.player == player and item.type == 'Sword']
+    swords = [item for item in multiworld.itempool if item.player == player and item.type == 'Sword']
     if swords:
         sword = world.random.choice(swords)
-        world.itempool.remove(sword)
-        world.itempool.append(ItemFactory('Rupees (20)', player))
+        multiworld.itempool.remove(sword)
+        multiworld.itempool.append(ItemFactory('Rupees (20)', player))
         old_man_take_any.shop.add_inventory(0, sword.name, 0, 0, create_location=True)
     else:
         old_man_take_any.shop.add_inventory(0, 'Rupees (300)', 0, 0, create_location=True)
@@ -525,17 +526,17 @@ def set_up_take_anys(world, player):
         take_any = LTTPRegion("Take-Any #{}".format(num+1), LTTPRegionType.Cave, 'a cave of choice', player, world)
         world.regions.append(take_any)
 
-        target, room_id = world.random.choice([(0x58, 0x0112), (0x60, 0x010F), (0x46, 0x011F)])
+        target, room_id = multiworld.random.choice([(0x58, 0x0112), (0x60, 0x010F), (0x46, 0x011F)])
         reg = regions.pop()
-        entrance = world.get_region(reg, player).entrances[0]
-        connect_entrance(world, entrance.name, take_any.name, player)
+        entrance = multiworld.get_region(reg, player).entrances[0]
+        connect_entrance(multiworld, entrance.name, take_any.name, player)
         entrance.target = target
         take_any.shop = TakeAny(take_any, room_id, 0xE3, True, True, total_shop_slots + num + 1)
-        world.shops.append(take_any.shop)
+        multiworld.shops.append(take_any.shop)
         take_any.shop.add_inventory(0, 'Blue Potion', 0, 0)
         take_any.shop.add_inventory(1, 'Boss Heart Container', 0, 0, create_location=True)
 
-    world.initialize_regions()
+    multiworld.initialize_regions()
 
 
 def get_pool_core(multiworld: MultiWorld, player: int):
@@ -693,13 +694,14 @@ def get_pool_core(multiworld: MultiWorld, player: int):
             additional_pieces_to_place)
 
 
-def make_custom_item_pool(world, player):
-    shuffle = world.shuffle[player]
-    difficulty = world.difficulty[player]
-    timer = world.timer[player]
-    goal = world.goal[player]
-    mode = world.mode[player]
-    customitemarray = world.customitemarray
+def make_custom_item_pool(multiworld: MultiWorld, player):
+    world = multiworld.worlds[player]
+    shuffle = multiworld.shuffle[player]
+    difficulty = multiworld.difficulty[player]
+    timer = multiworld.timer[player]
+    goal = multiworld.goal[player]
+    mode = multiworld.mode[player]
+    customitemarray = multiworld.customitemarray
 
     pool = []
     placed_items = {}
@@ -798,10 +800,10 @@ def make_custom_item_pool(world, player):
             thisbottle = world.random.choice(diff.bottles)
         pool.append(thisbottle)
 
-    if "triforce" in world.goal[player]:
-        pool.extend(["Triforce Piece"] * world.triforce_pieces_available[player])
-        itemtotal += world.triforce_pieces_available[player]
-        treasure_hunt_count = world.triforce_pieces_required[player]
+    if "triforce" in multiworld.goal[player]:
+        pool.extend(["Triforce Piece"] * multiworld.triforce_pieces_available[player])
+        itemtotal += multiworld.triforce_pieces_available[player]
+        treasure_hunt_count = multiworld.triforce_pieces_required[player]
         treasure_hunt_icon = 'Triforce Piece'
 
     if timer in ['display', 'timed', 'timed-countdown']:
@@ -816,7 +818,7 @@ def make_custom_item_pool(world, player):
         itemtotal = itemtotal + 1
 
     if mode == 'standard':
-        if world.smallkey_shuffle[player] == smallkey_shuffle.option_universal:
+        if multiworld.smallkey_shuffle[player] == smallkey_shuffle.option_universal:
             key_location = world.random.choice(
                 ['Secret Passage', 'Hyrule Castle - Boomerang Chest', 'Hyrule Castle - Map Chest',
                  'Hyrule Castle - Zelda\'s Chest', 'Sewers - Dark Cross'])
@@ -839,9 +841,9 @@ def make_custom_item_pool(world, player):
         pool.extend(['Magic Mirror'] * customitemarray[22])
         pool.extend(['Moon Pearl'] * customitemarray[28])
 
-    if world.smallkey_shuffle[player] == smallkey_shuffle.option_universal:
+    if multiworld.smallkey_shuffle[player] == smallkey_shuffle.option_universal:
         itemtotal = itemtotal - 28  # Corrects for small keys not being in item pool in universal Mode
-        if world.key_drop_shuffle[player]:
+        if multiworld.key_drop_shuffle[player]:
             itemtotal = itemtotal - (len(key_drop_data) - 1)
     if itemtotal < total_items_to_place:
         pool.extend(['Nothing'] * (total_items_to_place - itemtotal))

--- a/worlds/alttp/ItemPool.py
+++ b/worlds/alttp/ItemPool.py
@@ -400,11 +400,11 @@ def generate_itempool(world):
             loc.address = None
         elif multiworld.goal[player] == 'icerodhunt':
             # key drop item removed because of icerodhunt
-            multiworld.itempool.append(ItemFactory(GetBeemizerItem(world, player, 'Nothing'), player))
+            multiworld.itempool.append(ItemFactory(GetBeemizerItem(multiworld, player, 'Nothing'), player))
             multiworld.push_precollected(drop_item)
         elif "Small" in key_data[3] and multiworld.smallkey_shuffle[player] == smallkey_shuffle.option_universal:
             # key drop shuffle and universal keys are on. Add universal keys in place of key drop keys.
-            multiworld.itempool.append(ItemFactory(GetBeemizerItem(world, player, 'Small Key (Universal)'), player))
+            multiworld.itempool.append(ItemFactory(GetBeemizerItem(multiworld, player, 'Small Key (Universal)'), player))
     dungeon_item_replacements = sum(difficulties[multiworld.difficulty[player]].extras, []) * 2
     world.random.shuffle(dungeon_item_replacements)
     if multiworld.goal[player] == 'icerodhunt':
@@ -523,10 +523,10 @@ def set_up_take_anys(multiworld: MultiWorld, player: int):
         old_man_take_any.shop.add_inventory(0, 'Rupees (300)', 0, 0, create_location=True)
 
     for num in range(4):
-        take_any = LTTPRegion("Take-Any #{}".format(num+1), LTTPRegionType.Cave, 'a cave of choice', player, world)
-        world.regions.append(take_any)
+        take_any = LTTPRegion("Take-Any #{}".format(num+1), LTTPRegionType.Cave, 'a cave of choice', player, multiworld)
+        multiworld.regions.append(take_any)
 
-        target, room_id = multiworld.random.choice([(0x58, 0x0112), (0x60, 0x010F), (0x46, 0x011F)])
+        target, room_id = world.random.choice([(0x58, 0x0112), (0x60, 0x010F), (0x46, 0x011F)])
         reg = regions.pop()
         entrance = multiworld.get_region(reg, player).entrances[0]
         connect_entrance(multiworld, entrance.name, take_any.name, player)
@@ -669,7 +669,7 @@ def get_pool_core(multiworld: MultiWorld, player: int):
     if multiworld.smallkey_shuffle[player] == smallkey_shuffle.option_universal:
         pool.extend(diff.universal_keys)
         if mode == 'standard':
-            if world.key_drop_shuffle[player] and world.goal[player] != 'icerodhunt':
+            if multiworld.key_drop_shuffle[player] and multiworld.goal[player] != 'icerodhunt':
                 key_locations = ['Secret Passage', 'Hyrule Castle - Map Guard Key Drop']
                 key_location = world.random.choice(key_locations)
                 key_locations.remove(key_location)
@@ -687,7 +687,7 @@ def get_pool_core(multiworld: MultiWorld, player: int):
                 key_location = world.random.choice(key_locations)
                 place_item(key_location, "Small Key (Universal)")
                 pool = pool[:-3]
-        if world.key_drop_shuffle[player]:
+        if multiworld.key_drop_shuffle[player]:
             pass # pool.extend([item_to_place] * (len(key_drop_data) - 1))
 
     return (pool, placed_items, precollected_items, clock_mode, treasure_hunt_count, treasure_hunt_icon,

--- a/worlds/alttp/Items.py
+++ b/worlds/alttp/Items.py
@@ -10,14 +10,16 @@ def GetBeemizerItem(world, player: int, item):
         return item
 
     # first roll - replaceable item should be replaced, within beemizer_total_chance
-    if not world.beemizer_total_chance[player] or world.random.random() > (world.beemizer_total_chance[player] / 100):
+    if (not world.beemizer_total_chance[player]
+            or world.worlds[player].random.random() > (world.beemizer_total_chance[player] / 100)):
         return item
 
     # second roll - bee replacement should be trap, within beemizer_trap_chance
-    if not world.beemizer_trap_chance[player] or world.random.random() > (world.beemizer_trap_chance[player] / 100):
+    if (not world.beemizer_trap_chance[player]
+            or world.worlds[player].random.random() > (world.beemizer_trap_chance[player] / 100)):
         return "Bee" if isinstance(item, str) else world.create_item("Bee", player)
     else:
-        return "Bee Trap" if isinstance(item, str) else world.create_item("Bee Trap", player)        
+        return "Bee Trap" if isinstance(item, str) else world.create_item("Bee Trap", player)
 
 
 # should be replaced with direct world.create_item(item) call in the future

--- a/worlds/alttp/Shops.py
+++ b/worlds/alttp/Shops.py
@@ -428,7 +428,7 @@ def set_up_shops(multiworld: MultiWorld, player: int):
     if multiworld.smallkey_shuffle[player] == smallkey_shuffle.option_universal or multiworld.retro_bow[player]:
         for shop in world.random.sample([s for s in multiworld.shops if
                                          s.custom and not s.locked and s.type == ShopType.Shop and s.region.player == player],
-                                             5):
+                                        5):
             shop.locked = True
             slots = [0, 1, 2]
             world.random.shuffle(slots)

--- a/worlds/alttp/__init__.py
+++ b/worlds/alttp/__init__.py
@@ -492,7 +492,7 @@ class ALTTPWorld(World):
 
     @classmethod
     def stage_post_fill(cls, multiworld: MultiWorld):
-        ShopSlotFill(multiworld, multiworld.worlds[multiworld.get_game_players(cls.game)[0]].random)
+        ShopSlotFill(multiworld, multiworld.random)
 
     @property
     def use_enemizer(self) -> bool:
@@ -557,11 +557,11 @@ class ALTTPWorld(World):
             self.rom_name_available_event.set() # make sure threading continues and errors are collected
 
     @classmethod
-    def stage_extend_hint_information(cls, world, hint_data: typing.Dict[int, typing.Dict[int, str]]):
-        er_hint_data = {player: {} for player in world.get_game_players("A Link to the Past") if
-                        world.shuffle[player] != "vanilla" or world.retro_caves[player]}
+    def stage_extend_hint_information(cls, multiworld: MultiWorld, hint_data: typing.Dict[int, typing.Dict[int, str]]):
+        er_hint_data = {player: {} for player in multiworld.get_game_players("A Link to the Past") if
+                        multiworld.shuffle[player] != "vanilla" or multiworld.retro_caves[player]}
 
-        for region in world.regions:
+        for region in multiworld.regions:
             if region.player in er_hint_data and region.locations:
                 main_entrance = region.get_connecting_entrance(is_main_entrance)
                 for location in region.locations:
@@ -571,7 +571,7 @@ class ALTTPWorld(World):
         hint_data.update(er_hint_data)
 
     @classmethod
-    def stage_modify_multidata(cls, multiworld, multidata: dict):
+    def stage_modify_multidata(cls, multiworld: MultiWorld, multidata: dict):
 
         ordered_areas = (
             'Light World', 'Dark World', 'Hyrule Castle', 'Agahnims Tower', 'Eastern Palace', 'Desert Palace',
@@ -629,10 +629,10 @@ class ALTTPWorld(World):
                     world.logic[player] in {'owglitches', 'hybridglitches', "nologic"}:
                 pass
             elif 'triforcehunt' in world.goal[player] and ('local' in world.goal[player] or world.players == 1):
-                trash_counts[player] = world.worlds[player].random.randint(world.crystals_needed_for_gt[player] * 2,
+                trash_counts[player] = world.random.randint(world.crystals_needed_for_gt[player] * 2,
                                                                            world.crystals_needed_for_gt[player] * 4)
             else:
-                trash_counts[player] = world.worlds[player].random.randint(0, world.crystals_needed_for_gt[player] * 2)
+                trash_counts[player] = world.random.randint(0, world.crystals_needed_for_gt[player] * 2)
 
         if trash_counts:
             locations_mapping = {player: [] for player in trash_counts}
@@ -642,7 +642,7 @@ class ALTTPWorld(World):
 
             for player, trash_count in trash_counts.items():
                 gtower_locations = locations_mapping[player]
-                world.worlds[player].random.shuffle(gtower_locations)
+                world.random.shuffle(gtower_locations)
 
                 while gtower_locations and filleritempool and trash_count > 0:
                     spot_to_fill = gtower_locations.pop()

--- a/worlds/alttp/__init__.py
+++ b/worlds/alttp/__init__.py
@@ -264,7 +264,7 @@ class ALTTPWorld(World):
         if not os.path.exists(rom_file):
             raise FileNotFoundError(rom_file)
         if multiworld.is_race:
-            pass
+            import xxtea
         for player in multiworld.get_game_players(cls.game):
             if multiworld.worlds[player].use_enemizer:
                 check_enemizer(multiworld.worlds[player].enemizer_path)

--- a/worlds/alttp/__init__.py
+++ b/worlds/alttp/__init__.py
@@ -630,7 +630,7 @@ class ALTTPWorld(World):
                 pass
             elif 'triforcehunt' in world.goal[player] and ('local' in world.goal[player] or world.players == 1):
                 trash_counts[player] = world.worlds[player].random.randint(world.crystals_needed_for_gt[player] * 2,
-                                                            world.crystals_needed_for_gt[player] * 4)
+                                                                           world.crystals_needed_for_gt[player] * 4)
             else:
                 trash_counts[player] = world.worlds[player].random.randint(0, world.crystals_needed_for_gt[player] * 2)
 

--- a/worlds/zillion/requirements.txt
+++ b/worlds/zillion/requirements.txt
@@ -1,1 +1,2 @@
-zilliandomizer @ git+https://github.com/beauxq/zilliandomizer@cd6a940ad7b585c75a560b91468d6b9eee030559#0.5.2
+zilliandomizer @ git+https://github.com/beauxq/zilliandomizer@ae00a4b186be897c7cfaf429a0e0ff83c4ecf28c#0.6.0
+typing-extensions>=4.7, <5

--- a/worlds/zillion/requirements.txt
+++ b/worlds/zillion/requirements.txt
@@ -1,2 +1,1 @@
-zilliandomizer @ git+https://github.com/beauxq/zilliandomizer@ae00a4b186be897c7cfaf429a0e0ff83c4ecf28c#0.6.0
-typing-extensions>=4.7, <5
+zilliandomizer @ git+https://github.com/beauxq/zilliandomizer@cd6a940ad7b585c75a560b91468d6b9eee030559#0.5.2


### PR DESCRIPTION
## What is this fixing or adding?
Marks calls to `MultiWorld.random` as "deprecated" with a property getter. Uses private attr for the actual object. Removes references to the public random from core and LTTP. Not happy with how I did it with core, but not sure there's a better way to do it, and not really planning to remove the private attr. Next step is to just remove the property.

## How was this tested?
Unit tests. Needs a bunch of practical testing with LTTP as I had to touch a ton of code.

## If this makes graphical changes, please attach screenshots.
