### PR TITLE
The Messenger: Fix location access for Figurine Shop Locations

### DIFF
--- a/worlds/messenger/SubClasses.py
+++ b/worlds/messenger/SubClasses.py
@@ -67,7 +67,8 @@ class MessengerShopLocation(MessengerLocation):
             cost *= 2
         can_afford = state.has("Shards", self.player, min(cost, world.total_shards))
         if "Figurine" in self.name:
-            return state.has("Money Wrench", self.player) and can_afford
+            return state.has("Money Wrench", self.player) and can_afford\
+                and state.can_reach("Money Wrench", "Location", self.player)
         return can_afford
 
 


### PR DESCRIPTION
## What is this fixing or adding?
The Money Wrench location needs to actually be interacted with in order to access the area of the shop that has the figurine. The client is smart enough to not allow the player into the area until they have the actual item but I had the oversight that they still require to interact with the location first and the logic wasn't accounting for that.

## How was this tested?
Was looking through generated playthroughs and noticed this 😬 

## If this makes graphical changes, please attach screenshots.
