### PR TITLE
WebHost: Fix as_dict attribute error

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -24,6 +24,7 @@ __all__ = ["main"]
 def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = None):
     if not baked_server_options:
         baked_server_options = get_settings().server_options.as_dict()
+    assert isinstance(baked_server_options, dict)
     if args.outputpath:
         os.makedirs(args.outputpath, exist_ok=True)
         output_path.cached_path = args.outputpath

--- a/Main.py
+++ b/Main.py
@@ -23,7 +23,7 @@ __all__ = ["main"]
 
 def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = None):
     if not baked_server_options:
-        baked_server_options = get_settings().server_options
+        baked_server_options = get_settings().server_options.as_dict()
     if args.outputpath:
         os.makedirs(args.outputpath, exist_ok=True)
         output_path.cached_path = args.outputpath
@@ -372,7 +372,7 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
                     "connect_names": {name: (0, player) for player, name in world.player_name.items()},
                     "locations": locations_data,
                     "checks_in_area": checks_in_area,
-                    "server_options": baked_server_options.as_dict(),
+                    "server_options": baked_server_options,
                     "er_hint_data": er_hint_data,
                     "precollected_items": precollected_items,
                     "precollected_hints": precollected_hints,


### PR DESCRIPTION
## What is this fixing or adding?
Moves conversion of server options to dict to avoid causing an AttributeError when `baked_server_options` is not `None`. Introduced in 827444f5a4e065bc310c889892580eb1f97c73cb

## How was this tested?
Running the webhost locally and generating a couple seeds.