### PR TITLE
Witness: Fix unsolvable EPs not being precompleted (Impossible seeds)

### DIFF
--- a/worlds/witness/__init__.py
+++ b/worlds/witness/__init__.py
@@ -66,7 +66,8 @@ class WitnessWorld(World):
             'log_ids_to_hints': self.log_ids_to_hints,
             'progressive_item_lists': self.items.MULTI_LISTS_BY_CODE,
             'obelisk_side_id_to_EPs': self.static_logic.OBELISK_SIDE_ID_TO_EP_HEXES,
-            'precompleted_puzzles': [int(h, 16) for h in self.player_logic.EXCLUDED_LOCATIONS],
+            'precompleted_puzzles': [int(h, 16) for h in
+                                     self.player_logic.EXCLUDED_LOCATIONS | self.player_logic.PRECOMPLETED_LOCATIONS],
             'entity_to_name': self.static_logic.ENTITY_ID_TO_NAME,
         }
 


### PR DESCRIPTION
One of the recent PRs accidentally removed all ability for the client to see which EPs are precompleted due to settings.

This is pretty bad, as the client now thinks these EPs need to be completed for "Obelisk Side" locations, when the generator does not. This would lead to **impossible seeds.**