### PR TITLE
Settings: implement saving of dict and sequence, add graceful crashing

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -735,9 +735,17 @@ class Settings(Group):
     def save(self, location: Optional[str] = None) -> None:  # as above
         location = location or self._filename
         assert location, "No file specified"
+        temp_location = location + ".tmp"  # not using tempfile to test expected file access
+        # remove old temps
+        if os.path.exists(temp_location):
+            os.unlink(temp_location)
         # can't use utf-8-sig because it breaks backward compat: pyyaml on Windows with bytes does not strip the BOM
-        with open(location, "w", encoding="utf-8") as f:
+        with open(temp_location, "w", encoding="utf-8") as f:
             self.dump(f)
+        # replace old with new
+        if os.path.exists(location):
+            os.unlink(location)
+        os.rename(temp_location, location)
         self._filename = location
 
     def dump(self, f: TextIO, level: int = 0) -> None:

--- a/settings.py
+++ b/settings.py
@@ -206,10 +206,10 @@ class Group:
     @classmethod
     def _dump_item(cls, name: Optional[str], attr: object, f: TextIO, level: int) -> None:
         """Write a group, dict or sequence item to f, where attr can be a scalar or a collection"""
-        from Utils import Dumper as BaseDumper
-        from yaml import ScalarNode, MappingNode
 
         # lazy construction of yaml Dumper to avoid loading Utils early
+        from Utils import Dumper as BaseDumper
+        from yaml import ScalarNode, MappingNode
         if not hasattr(cls, "_dumper"):
             if cls is Group or not hasattr(Group, "_dumper"):
                 class Dumper(BaseDumper):
@@ -255,7 +255,7 @@ class Group:
 
     def dump(self, f: TextIO, level: int = 0) -> None:
         """Dump Group to stream f at given indentation level"""
-        # There is no easy way to generate extra lines into default,
+        # There is no easy way to generate extra lines into default yaml output,
         # so we format part of it by hand using an odd recursion here and in _dump_*.
 
         self._dumping = True

--- a/settings.py
+++ b/settings.py
@@ -239,10 +239,7 @@ class Group:
             f.write(f"{indent}{name}:\n")
             for dict_key, value in attr.items():
                 # not dumping doc string here, since there is no way to upcast it after dumping
-                if isinstance(value, (Group, dict, list, tuple, set)):
-                    cls._dump_item(dict_key, value, f, level=level + 1)
-                else:
-                    cls._dump_value({dict_key: _to_builtin(value)}, f, level=level+1)
+                cls._dump_item(dict_key, value, f, level=level + 1)
         else:
             cls._dump_value({name: _to_builtin(attr)}, f, level=level)
 

--- a/settings.py
+++ b/settings.py
@@ -142,13 +142,21 @@ class Group:
                 if k not in self.__dict__:
                     attr = attr.__class__()  # make a copy of default
                     setattr(self, k, attr)
-                attr.update(v)
+                if isinstance(v, dict):
+                    attr.update(v)
+                else:
+                    warnings.warn(f"{self.__class__.__name__}.{k} "
+                                  f"tried to update Group from {type(v)}")
             elif isinstance(attr, dict):
                 # update dict
                 if k not in self.__dict__:
                     attr = attr.copy()  # make a copy of default
                     setattr(self, k, attr)
-                attr.update(v)
+                if isinstance(v, dict):
+                    attr.update(v)
+                else:
+                    warnings.warn(f"{self.__class__.__name__}.{k} "
+                                  f"tried to update dict from {type(v)}")
             else:
                 # assign value, try to upcast to type hint
                 annotation = self.get_type_hints().get(k, None)


### PR DESCRIPTION
## What is this fixing or adding?

* implements dict support for Group.dump allowing to add/remove APWorlds (it would crash for unknown Groups otherwise)
* implements sequence support for Group.dump allowing to save/load scalar sequences (no upcasting)
  * this is future proofing to not break when downgrading from something like \
    `plando_options: Set[PlandoEnum] = {PlandoEnum.Bosses}`
* skip invalid values when loading a dict/Group from host.yaml. This might still crash later, but the error might be more appropriate
* keep the old file when crashing during save

## How was this tested?

* adding dicts of dicts to SoE
* adding sets, tuples and list of lists as well as lists of dicts to SoE
* generating a fresh host.yaml
* loading a "destroyed" host.yaml