### PR TITLE
Stardew Valley: Fixed Leo's Treehouse being randomized too aggressively

### DIFF
--- a/worlds/stardew_valley/logic.py
+++ b/worlds/stardew_valley/logic.py
@@ -350,7 +350,7 @@ class StardewLogic:
             Ingredient.vinegar: self.can_spend_money_at(Region.pierre_store, 200),
             AnimalProduct.void_egg: self.can_spend_money_at(Region.sewer, 5000) | (self.has_building(Building.fish_pond) & self.has(Fish.void_salmon)),
             Loot.void_essence: self.can_mine_in_the_mines_floor_81_120() | self.can_mine_in_the_skull_cavern(),
-            ArtisanGood.void_mayonnaise: self.has(Machine.mayonnaise_machine) & self.has(AnimalProduct.void_egg),
+            ArtisanGood.void_mayonnaise: (self.can_reach_region(Region.witch_swamp) & self.can_fish()) | (self.has(Machine.mayonnaise_machine) & self.has(AnimalProduct.void_egg)),
             Ingredient.wheat_flour: self.can_spend_money_at(Region.pierre_store, 100) |
                                     (self.has_building(Building.mill) & self.has(Vegetable.wheat)),
             WaterItem.white_algae: self.can_fish() & self.can_reach_region(Region.mines_floor_20),

--- a/worlds/stardew_valley/regions.py
+++ b/worlds/stardew_valley/regions.py
@@ -239,7 +239,7 @@ vanilla_connections = [
     ConnectionData(Entrance.mountain_to_tent, Region.tent,
                    flag=RandomizationFlag.NON_PROGRESSION | RandomizationFlag.LEAD_TO_OPEN_AREA),
     ConnectionData(Entrance.mountain_to_leo_treehouse, Region.leo_treehouse,
-                   flag=RandomizationFlag.NON_PROGRESSION | RandomizationFlag.LEAD_TO_OPEN_AREA | RandomizationFlag.GINGER_ISLAND),
+                   flag=RandomizationFlag.BUILDINGS | RandomizationFlag.LEAD_TO_OPEN_AREA | RandomizationFlag.GINGER_ISLAND),
     ConnectionData(Entrance.mountain_to_carpenter_shop, Region.carpenter,
                    flag=RandomizationFlag.NON_PROGRESSION | RandomizationFlag.LEAD_TO_OPEN_AREA),
     ConnectionData(Entrance.mountain_to_maru_room, Region.maru_room,

--- a/worlds/stardew_valley/rules.py
+++ b/worlds/stardew_valley/rules.py
@@ -211,7 +211,8 @@ def set_entrance_rules(logic, multi_world, player, world_options: StardewOptions
     MultiWorldRules.set_rule(multi_world.get_entrance(Entrance.enter_wizard_basement, player),
                              logic.has_relationship(NPC.wizard, 4))
     MultiWorldRules.set_rule(multi_world.get_entrance(Entrance.mountain_to_leo_treehouse, player),
-                             logic.has_relationship(NPC.leo, 6) & logic.can_reach_region(Region.island_south))
+                             logic.has_relationship(NPC.leo, 6) & logic.can_reach_region(Region.island_south) &
+                             logic.can_reach_region(Region.island_east) & logic.can_reach_region(Region.leo_hut))
     if ModNames.alec in world_options[options.Mods]:
         MultiWorldRules.set_rule(multi_world.get_entrance(AlecEntrance.petshop_to_bedroom, player),
                                  (logic.has_relationship(ModNPC.alec, 2) | magic.can_blink(logic)).simplify())

--- a/worlds/stardew_valley/test/TestRegions.py
+++ b/worlds/stardew_valley/test/TestRegions.py
@@ -3,7 +3,7 @@ import sys
 import unittest
 
 from . import SVTestBase, setup_solo_multiworld
-from .. import StardewOptions, options, StardewValleyWorld, True_
+from .. import StardewOptions, options, StardewValleyWorld
 from ..regions import vanilla_regions, vanilla_connections, randomize_connections, RandomizationFlag
 
 connections_by_name = {connection.name for connection in vanilla_connections}


### PR DESCRIPTION
## What is this fixing or adding?
Leo's TreeHouse is an entrance that only opens after unlocking Ginger Island, meeting Leo, and earning 6 hearts with him. Therefore, in the randomizer, this entrance requires progression items.

This change fixes a bug where the entrance was randomized under the "Non-progression" setting. It is now correctly under the "Buildings" setting

Additional fix for a very unlikely entrance randomizer softlock: Void Mayonnaise can be fished from the witch's swamp, and this has been added in logic to avoid problems with obtaining void eggs making an infinite loop there

## How was this tested?
Ran the automated tests and checked the result of randomization. Generate a few manual multiworlds
