### PR TITLE
Terraria: Fix Python 3.8 compat

### DIFF
--- a/worlds/terraria/Checks.py
+++ b/worlds/terraria/Checks.py
@@ -191,7 +191,7 @@ def validate_conditions(
 def mark_progression(
     conditions: List[
         Tuple[
-            bool, int, Union[str, tuple[Union[bool, None], list]], Union[str, int, None]
+            bool, int, Union[str, Tuple[Union[bool, None], list]], Union[str, int, None]
         ]
     ],
     progression: Set[str],

--- a/worlds/terraria/Rules.dsv
+++ b/worlds/terraria/Rules.dsv
@@ -455,8 +455,8 @@ Empress of Light;                   Location | Item | Goal;                     
 # empress_of_light
 
 // Lunatic Cultist
-Lunatic Cultist;                    Location | Item;                            (@calamity | (Dungeon & Golem)) & Wall of Flesh;
-Astrum Deus;                        Calamity | Location | Item;                 Titan Heart;
+Lunatic Cultist;                    Location | Item | Goal;                     (@calamity | (Dungeon & Golem)) & Wall of Flesh;
+Astrum Deus;                        Calamity | Location | Item | Goal;          Titan Heart;
 # lunatic_cultist
 # astrum_deus
 Ancient Manipulator;                ;                                           #Lunatic Cultist;

--- a/worlds/terraria/Rules.dsv
+++ b/worlds/terraria/Rules.dsv
@@ -455,8 +455,8 @@ Empress of Light;                   Location | Item | Goal;                     
 # empress_of_light
 
 // Lunatic Cultist
-Lunatic Cultist;                    Location | Item | Goal;                     (@calamity | (Dungeon & Golem)) & Wall of Flesh;
-Astrum Deus;                        Calamity | Location | Item | Goal;          Titan Heart;
+Lunatic Cultist;                    Location | Item;                            (@calamity | (Dungeon & Golem)) & Wall of Flesh;
+Astrum Deus;                        Calamity | Location | Item;                 Titan Heart;
 # lunatic_cultist
 # astrum_deus
 Ancient Manipulator;                ;                                           #Lunatic Cultist;


### PR DESCRIPTION
## What is this fixing or adding?
Fixes Python 3.8 compatibility in the Terraria world

## How was this tested?
I ran `Generate.py` and with Python 3.8 and it crashed. Then I made this change and ran it again, and it didn't crash.
