### PR TITLE
Terraria: Fix Lunatic Cultist goal immediately awarded

### DIFF
--- a/worlds/terraria/Rules.dsv
+++ b/worlds/terraria/Rules.dsv
@@ -455,8 +455,8 @@ Empress of Light;                   Location | Item | Goal;                     
 # empress_of_light
 
 // Lunatic Cultist
-Lunatic Cultist;                    Location | Item;                            (@calamity | (Dungeon & Golem)) & Wall of Flesh;
-Astrum Deus;                        Calamity | Location | Item;                 Titan Heart;
+Lunatic Cultist;                    Location | Item | Goal;                     (@calamity | (Dungeon & Golem)) & Wall of Flesh;
+Astrum Deus;                        Calamity | Location | Item | Goal;          Titan Heart;
 # lunatic_cultist
 # astrum_deus
 Ancient Manipulator;                ;                                           #Lunatic Cultist;


### PR DESCRIPTION
## What is this fixing or adding?

Having the Lunatic Cultist goal would cause victory upon joining with the Terraria client. This fixes that.

## How was this tested?

Before/after testing. The bug is a pretty obvious one.
