### PR TITLE
[SM64EX] Fix logic bug with DDD: Collect the Caps...

### DIFF
--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -95,7 +95,7 @@ def set_rules(world, player: int, area_connections):
         add_rule(world.get_location("JRB: Through the Jet Stream", player), lambda state: state.has("Metal Cap", player))
         add_rule(world.get_location("SSL: Free Flying for 8 Red Coins", player), lambda state: state.has("Wing Cap", player))
         add_rule(world.get_location("DDD: Through the Jet Stream", player), lambda state: state.has("Metal Cap", player))
-        add_rule(world.get_location("DDD: Collect the Caps...", player), lambda state: state.has("Metal Cap", player))
+        add_rule(world.get_location("DDD: Collect the Caps...", player), lambda state: state.has("Vanish Cap", player))
         add_rule(world.get_location("Vanish Cap Under the Moat Red Coins", player), lambda state: state.has("Vanish Cap", player))
         add_rule(world.get_location("Cavern of the Metal Cap Red Coins", player), lambda state: state.has("Metal Cap", player))
     if world.StrictCannonRequirements[player]:


### PR DESCRIPTION
## What is this fixing or adding?
Just noticed that the strict cap requirements rule added needing only metal cap for the titled star. This is incorrect, as it's actually Vanish Cap that's needed to phase through the fence and Metal Cap isn't required at all, despite the name of the star.

## How was this tested?
ran the unit tests to make sure i didn't break reachability

## If this makes graphical changes, please attach screenshots.
