### PR TITLE
Webhost: Fix failing gen for players > 1

### DIFF
--- a/WebHostLib/generate.py
+++ b/WebHostLib/generate.py
@@ -130,6 +130,7 @@ def gen_game(gen_options: dict, meta: Optional[Dict[str, Any]] = None, owner=Non
         erargs.teams = 1
         erargs.plando_options = PlandoOptions.from_set(meta.setdefault("plando_options",
                                                                        {"bosses", "items", "connections", "texts"}))
+        erargs.skip_prog_balancing = False
 
         name_counter = Counter()
         for player, (playerfile, settings) in enumerate(gen_options.items(), 1):


### PR DESCRIPTION
## What is this fixing or adding?
Title. a new CL arg was added but since it doesn't exist from webhost caused gen to crash when it was hit. Alternative fix is to use getattr but this allows it to be more easily exposed if that becomes desired in the future.

## How was this tested?
Generated with multiple players before and after the change.

## If this makes graphical changes, please attach screenshots.
