### PR TITLE
WebHost, Factorio: Fix item IDs for science packs in multiFactorioTracker.html

### DIFF
--- a/WebHostLib/templates/multiFactorioTracker.html
+++ b/WebHostLib/templates/multiFactorioTracker.html
@@ -27,12 +27,12 @@
 {% endblock %}
 {% block custom_table_row scoped  %}
 {% if games[player] == "Factorio" %}
-<td class="center-column">{% if inventory[team][player][131161] or inventory[team][player][131281] %}✔{% endif %}</td>
-<td class="center-column">{% if inventory[team][player][131172] or inventory[team][player][131281] > 1%}✔{% endif %}</td>
-<td class="center-column">{% if inventory[team][player][131195] or inventory[team][player][131281] > 2%}✔{% endif %}</td>
-<td class="center-column">{% if inventory[team][player][131240] or inventory[team][player][131281] > 3%}✔{% endif %}</td>
-<td class="center-column">{% if inventory[team][player][131240] or inventory[team][player][131281] > 4%}✔{% endif %}</td>
-<td class="center-column">{% if inventory[team][player][131220] or inventory[team][player][131281] > 5%}✔{% endif %}</td>
+<td class="center-column">{% if inventory[team][player][131161] or inventory[team][player][131283] %}✔{% endif %}</td>
+<td class="center-column">{% if inventory[team][player][131172] or inventory[team][player][131283] > 1%}✔{% endif %}</td>
+<td class="center-column">{% if inventory[team][player][131195] or inventory[team][player][131283] > 2%}✔{% endif %}</td>
+<td class="center-column">{% if inventory[team][player][131240] or inventory[team][player][131283] > 3%}✔{% endif %}</td>
+<td class="center-column">{% if inventory[team][player][131240] or inventory[team][player][131283] > 4%}✔{% endif %}</td>
+<td class="center-column">{% if inventory[team][player][131220] or inventory[team][player][131283] > 5%}✔{% endif %}</td>
 {% else %}
 <td class="center-column">❌</td>
 <td class="center-column">❌</td>

--- a/WebHostLib/templates/multiFactorioTracker.html
+++ b/WebHostLib/templates/multiFactorioTracker.html
@@ -29,8 +29,8 @@
 {% if games[player] == "Factorio" %}
 <td class="center-column">{% if inventory[team][player][131161] or inventory[team][player][131283] %}✔{% endif %}</td>
 <td class="center-column">{% if inventory[team][player][131172] or inventory[team][player][131283] > 1%}✔{% endif %}</td>
-<td class="center-column">{% if inventory[team][player][131195] or inventory[team][player][131283] > 2%}✔{% endif %}</td>
-<td class="center-column">{% if inventory[team][player][131240] or inventory[team][player][131283] > 3%}✔{% endif %}</td>
+<td class="center-column">{% if inventory[team][player][131095] or inventory[team][player][131283] > 2%}✔{% endif %}</td>
+<td class="center-column">{% if inventory[team][player][131195] or inventory[team][player][131283] > 3%}✔{% endif %}</td>
 <td class="center-column">{% if inventory[team][player][131240] or inventory[team][player][131283] > 4%}✔{% endif %}</td>
 <td class="center-column">{% if inventory[team][player][131220] or inventory[team][player][131283] > 5%}✔{% endif %}</td>
 {% else %}


### PR DESCRIPTION
## What is this fixing or adding?

The Factorio WebTracker had the wrong item ID and was reporting how many progressive-research-speeds the user had instead of how many progressive-science-packs.
The chemical and production science IDs for non-progressive science packs were also wrong and have been corrected.

Fixes https://discord.com/channels/731205301247803413/1131705681997729964

## How was this tested?

I ran WebHost.py from latest main to look at /datapackage and saw the item IDs didn't match this template file, so I changed it to match.

## If this makes graphical changes, please attach screenshots.
