### PR TITLE
Stardew Valley: Turned the Treehouse into an unlockable item

### DIFF
--- a/worlds/stardew_valley/__init__.py
+++ b/worlds/stardew_valley/__init__.py
@@ -56,7 +56,7 @@ class StardewValleyWorld(World):
     item_name_to_id = {name: data.code for name, data in item_table.items()}
     location_name_to_id = {name: data.code for name, data in location_table.items()}
 
-    data_version = 2
+    data_version = 3
     required_client_version = (0, 4, 0)
 
     options: StardewOptions

--- a/worlds/stardew_valley/data/items.csv
+++ b/worlds/stardew_valley/data/items.csv
@@ -271,6 +271,7 @@ id,name,classification,groups,mod_name
 284,Cute Baby,progression,"BABY",
 285,Ugly Baby,progression,"BABY",
 286,Deluxe Scarecrow Recipe,progression,"FESTIVAL,RARECROW",
+287,Treehouse,progression,"GINGER_ISLAND",
 4001,Burnt,trap,TRAP,
 4002,Darkness,trap,TRAP,
 4003,Frozen,trap,TRAP,

--- a/worlds/stardew_valley/items.py
+++ b/worlds/stardew_valley/items.py
@@ -415,6 +415,7 @@ def create_walnut_purchase_rewards(item_factory: StardewItemFactory, world_optio
     items.extend([item_factory("Boat Repair"),
                   item_factory("Open Professor Snail Cave"),
                   item_factory("Ostrich Incubator Recipe"),
+                  item_factory("Treehouse"),
                   *[item_factory(item) for item in items_by_group[Group.WALNUT_PURCHASE]]])
 
 

--- a/worlds/stardew_valley/rules.py
+++ b/worlds/stardew_valley/rules.py
@@ -211,8 +211,7 @@ def set_entrance_rules(logic, multi_world, player, world_options: StardewOptions
     MultiWorldRules.set_rule(multi_world.get_entrance(Entrance.enter_wizard_basement, player),
                              logic.has_relationship(NPC.wizard, 4))
     MultiWorldRules.set_rule(multi_world.get_entrance(Entrance.mountain_to_leo_treehouse, player),
-                             logic.has_relationship(NPC.leo, 6) & logic.can_reach_region(Region.island_south) &
-                             logic.can_reach_region(Region.island_east) & logic.can_reach_region(Region.leo_hut))
+                             logic.received("Treehouse"))
     if ModNames.alec in world_options[options.Mods]:
         MultiWorldRules.set_rule(multi_world.get_entrance(AlecEntrance.petshop_to_bedroom, player),
                                  (logic.has_relationship(ModNPC.alec, 2) | magic.can_blink(logic)).simplify())

--- a/worlds/stardew_valley/test/TestOptions.py
+++ b/worlds/stardew_valley/test/TestOptions.py
@@ -67,8 +67,8 @@ class TestGenerateDynamicOptions(SVTestBase):
                 continue
             for value in option.options:
                 with self.subTest(f"{option.internal_name}: {value} [Seed: {seed}]"):
-                    choices = {option.internal_name: option.options[value]}
-                    multiworld = setup_solo_multiworld(choices, seed)
+                    world_options = {option.internal_name: option.options[value]}
+                    multiworld = setup_solo_multiworld(world_options, seed)
                     basic_checks(self, multiworld)
 
 


### PR DESCRIPTION
## What is this fixing or adding?
Leo's Treehouse construction is now an Archipelago Item. This allows it to be used in logic and simplify unlock conditions.
With Entrance Randomizer, this allows the fill algorithm to give access to this door regardless of Leo's status, removing some rare softlocks

## How was this tested?
Ran tests, generated some games and played with them to check the new item
Also reproduced the softlock originally found by @ThePhar and confirmed it no longer happens
