### PR TITLE
The Witness: Make the path behind Keep Pressure Plates 2 logical in Vanilla and Normal

### DIFF
--- a/worlds/witness/WitnessLogic.txt
+++ b/worlds/witness/WitnessLogic.txt
@@ -377,7 +377,7 @@ Door - 0x0199A (Hedge Maze 4 Shortcut) - 0x019E7
 158196 - 0x01A0F (Hedge Maze 4) - True - True
 Door - 0x01A0E (Hedge Maze 4 Exit) - 0x01A0F
 
-Keep 2nd Pressure Plate (Keep) - Keep 3rd Pressure Plate - 0x01BEA:
+Keep 2nd Pressure Plate (Keep) - Keep 3rd Pressure Plate - True:
 158199 - 0x0A3B9 (Reset Pressure Plates 2) - True - True
 158200 - 0x01BE9 (Pressure Plates 2) - 0x0A3B9 - Stars & Stars + Same Colored Symbol & Black/White Squares
 Door - 0x01BEA (Pressure Plates 2 Exit) - 0x01BE9

--- a/worlds/witness/WitnessLogicVanilla.txt
+++ b/worlds/witness/WitnessLogicVanilla.txt
@@ -377,7 +377,7 @@ Door - 0x0199A (Hedge Maze 4 Shortcut) - 0x019E7
 158196 - 0x01A0F (Hedge Maze 4) - True - True
 Door - 0x01A0E (Hedge Maze 4 Exit) - 0x01A0F
 
-Keep 2nd Pressure Plate (Keep) - Keep 3rd Pressure Plate - 0x01BEA:
+Keep 2nd Pressure Plate (Keep) - Keep 3rd Pressure Plate - True:
 158199 - 0x0A3B9 (Reset Pressure Plates 2) - True - True
 158200 - 0x01BE9 (Pressure Plates 2) - 0x0A3B9 - Black/White Squares
 Door - 0x01BEA (Pressure Plates 2 Exit) - 0x01BE9


### PR DESCRIPTION
There is a path behind the 2nd Pressure Plates puzzle across the wall of the Keep that allows you to completely skip it and advance to Pressure Plate 3.

Knowing that this shortcut exists and that you can skip the Pressure Plates 2 puzzle was deemed unintuitive when the randomizer came out and made a not logically valid path.

This has been the subject of a lot of debate in the #witness channel. With the advent of autotracking and considering many opinions from both veteran players and beginners, I have chosen to make this shortcut logical, meaning it is now possible to e.g. have your Progressive Stars on the third Pressure Plates puzzle or in any of the Shipwreck puzzles.

Note: Expert has always *required* this path (part of the design of Expert is to force you to use lesser known mechanics or paths), which is why only Vanilla and Normal logic are changed.