### PR TITLE
Rogue Legacy: The 1.0 Version Update

### DIFF
--- a/worlds/rogue_legacy/Items.py
+++ b/worlds/rogue_legacy/Items.py
@@ -260,8 +260,6 @@ item_groups: Dict[str, Set[str]] = {
 
 item_table: Dict[str, RLItemData] = {
     # Vendors
-    "Blacksmith":               RLItemData(ItemClassification.progression,    0, get_none),
-    "Enchantress":              RLItemData(ItemClassification.progression,    1, get_none),
     "Architect":                RLItemData(ItemClassification.useful,         2, get_architect_quantity),
 
     # Classes

--- a/worlds/rogue_legacy/Items.py
+++ b/worlds/rogue_legacy/Items.py
@@ -350,7 +350,7 @@ item_table: Dict[str, RLItemData] = {
     "Piece of the Fountain":    RLItemData(ItemClassification.progression_skip_balancing, 180, get_fountain_pieces),
 
     # Wallets
-    "Progressive Wallet":       RLItemData(ItemClassification.progression,  190, get_wallet_quantity),
+    "Progressive Spending":     RLItemData(ItemClassification.progression,  190, get_wallet_quantity),
 
     # Filler and Traps - These will be generated automatically when filler items are needed.
     "Triple Stat Increase":     RLItemData(ItemClassification.filler,        30, get_none, 5),

--- a/worlds/rogue_legacy/Items.py
+++ b/worlds/rogue_legacy/Items.py
@@ -225,13 +225,11 @@ class RLItemData:
 
 item_groups: Dict[str, Set[str]] = {
     "Vendor": {
-        "Enchantress",
         "Enchantress - Sword",
         "Enchantress - Helm",
         "Enchantress - Chest",
         "Enchantress - Limbs",
         "Enchantress - Cape",
-        "Blacksmith",
         "Blacksmith - Sword",
         "Blacksmith - Helm",
         "Blacksmith - Chest",

--- a/worlds/rogue_legacy/Locations.py
+++ b/worlds/rogue_legacy/Locations.py
@@ -1,94 +1,322 @@
-from typing import Dict, NamedTuple, Optional
+from dataclasses import dataclass
+from typing import Callable, Dict, Optional, Set, Union
 
-from BaseClasses import Location
+from BaseClasses import Location, MultiWorld
+from .Items import RLItem, item_table
+
+__all__ = ["RLLocation", "RLLocationData", "location_groups", "location_table"]
+
+LOCATION_ID_OFFSET = 91_000
+
+
+def always_create(multiworld: MultiWorld, player: int) -> bool:
+    return True
+
+
+def get_chest_region(chests_per_zone: int, current_index: int) -> str:
+    """Returns the correct region name for this chest, assuming universal chests are enabled."""
+    if current_index < chests_per_zone:
+        return "Castle Hamson"
+    elif current_index < chests_per_zone * 2:
+        return "Forest Abkhazia"
+    elif current_index < chests_per_zone * 3:
+        return "The Maya"
+    else:
+        return "The Land of Darkness"
+
+
+def can_create_normal_chest(multiworld: MultiWorld, player: int, index: int):
+    """Returns if it's possible to create this normal chest location during generation."""
+    if getattr(multiworld, "universal_chests")[player]:
+        return False
+
+    return getattr(multiworld, "chests_per_zone")[player] > index
+
+
+def can_create_universal_chest(multiworld: MultiWorld, player: int, index: int):
+    """Returns if it's possible to create this universal chest location during generation."""
+    if not getattr(multiworld, "universal_chests")[player]:
+        return False
+
+    return getattr(multiworld, "chests_per_zone")[player] * 4 > index
+
+
+def can_create_normal_fairy_chest(multiworld: MultiWorld, player: int, index: int):
+    """Returns if it's possible to create this normal fairy chest location during generation."""
+    if getattr(multiworld, "universal_fairy_chests")[player]:
+        return False
+
+    return getattr(multiworld, "fairy_chests_per_zone")[player] > index
+
+
+def can_create_universal_fairy_chest(multiworld: MultiWorld, player: int, index: int):
+    """Returns if it's possible to create this universal fairy chest location during generation."""
+    if not getattr(multiworld, "universal_fairy_chests")[player]:
+        return False
+
+    return getattr(multiworld, "fairy_chests_per_zone")[player] * 4 > index
+
+
+def get_castle_boss(multiworld: MultiWorld, player: int) -> str:
+    if getattr(multiworld, "khidr")[player] == "challenge":
+        return "Defeat Neo Khidr"
+
+    return "Defeat Khidr"
+
+
+def get_forest_boss(multiworld: MultiWorld, player: int) -> str:
+    if getattr(multiworld, "alexander")[player] == "challenge":
+        return "Defeat Alexander IV"
+
+    return "Defeat Alexander"
+
+
+def get_tower_boss(multiworld: MultiWorld, player: int) -> str:
+    if getattr(multiworld, "leon")[player] == "challenge":
+        return "Defeat Ponce de Freon"
+
+    return "Defeat Ponce de Leon"
+
+
+def get_dungeon_boss(multiworld: MultiWorld, player: int) -> str:
+    if getattr(multiworld, "herodotus")[player] == "challenge":
+        return "Defeat Astrodotus"
+
+    return "Defeat Herodotus"
+
+
+def get_final_boss(multiworld: MultiWorld, player: int) -> str:
+    return "Defeat The Fountain"
+
+
+def get_open_door(multiworld: MultiWorld, player: int) -> str:
+    return "Open Fountain Room Door"
 
 
 class RLLocation(Location):
     game: str = "Rogue Legacy"
 
 
-class RLLocationData(NamedTuple):
-    category: str
-    code: Optional[int] = None
+@dataclass
+class RLLocationData:
+    """A collection of metadata for each location prior to creation into an RLLocation."""
+    name: str
+    region: Union[str, Callable[[MultiWorld, int], str]]
+    address: Optional[int]
+    can_create: Callable[[MultiWorld, int], bool]
+    locked_item: Optional[Callable[[MultiWorld, int], str]]
+
+    def __init__(
+            self,
+            region: Union[str, Callable[[MultiWorld, int], str]],
+            address: Optional[int] = None,
+            can_create: Callable[[MultiWorld, int], bool] = always_create,
+            locked_item: Optional[Callable[[MultiWorld, int], str]] = None):
+        self.region = region
+        self.address = address + LOCATION_ID_OFFSET if address else None
+        self.can_create = can_create
+        self.locked_item = locked_item
+
+    @property
+    def event(self) -> bool:
+        """Returns True if this is an event location."""
+        return not self.address
+
+    def create_location(self, multiworld: MultiWorld, player: int):
+        """Creates the location from its location metadata and place in its appropriate region."""
+        # Get region name.
+        if isinstance(self.region, str):
+            region = multiworld.get_region(self.region, player)
+        else:
+            region = multiworld.get_region(self.region(multiworld, player), player)
+
+        # Create location and place.
+        location = RLLocation(player, self.name, self.address, region)
+        region.locations.append(location)
+
+        # If a location must contain a locked item, create and place that item.
+        if self.locked_item:
+            item_name = self.locked_item(multiworld, player)
+            item_data = item_table[item_name]
+            location.place_locked_item(RLItem(item_name, item_data.classification, item_data.code, player))
 
 
-def get_locations_by_category(category: str) -> Dict[str, RLLocationData]:
-    location_dict: Dict[str, RLLocationData] = {}
-    for name, data in location_table.items():
-        if data.category == category:
-            location_dict.setdefault(name, data)
-
-    return location_dict
-
+location_groups: Dict[str, Set[str]] = {
+    "Boss Rewards": {
+        "Castle Hamson - Boss Reward",
+        "Forest Abkhazia - Boss Reward",
+        "The Maya - Boss Reward",
+        "Land of Darkness - Boss Reward",
+    },
+    "Mini Boss Rewards": {
+        "Barbatos & Amon's Reward",   
+        "Botis' Reward",              
+        "Stolas & Focalor's Reward",  
+        "Sallos' Reward",             
+        "Berith & Halphas' Reward",   
+    },
+    "Manor Renovations": {
+        "Manor - Ground Road",          
+        "Manor - Main Base",            
+        "Manor - Main Bottom Window",   
+        "Manor - Main Top Window",      
+        "Manor - Main Rooftop",         
+        "Manor - Left Wing Base",       
+        "Manor - Left Wing Window",     
+        "Manor - Left Wing Rooftop",    
+        "Manor - Left Big Base",        
+        "Manor - Left Big Upper 1",     
+        "Manor - Left Big Upper 2",     
+        "Manor - Left Big Windows",     
+        "Manor - Left Big Rooftop",     
+        "Manor - Left Far Base",        
+        "Manor - Left Far Roof",        
+        "Manor - Left Extension",       
+        "Manor - Left Tree 1",          
+        "Manor - Left Tree 2",          
+        "Manor - Right Wing Base",      
+        "Manor - Right Wing Window",    
+        "Manor - Right Wing Rooftop",   
+        "Manor - Right Big Base",       
+        "Manor - Right Big Upper",      
+        "Manor - Right Big Rooftop",    
+        "Manor - Right High Base",      
+        "Manor - Right High Upper",     
+        "Manor - Right High Tower",     
+        "Manor - Right Extension",      
+        "Manor - Right Tree",           
+        "Manor - Observatory Base",     
+        "Manor - Observatory Telescope",
+    },
+    "Secret Room": {
+        "Secret Room Left Chest",
+        "Secret Room Right Chest",
+    },
+}
 
 location_table: Dict[str, RLLocationData] = {
     # Manor Renovation
-    "Manor - Ground Road":                      RLLocationData("Manor",   91_000),
-    "Manor - Main Base":                        RLLocationData("Manor",   91_001),
-    "Manor - Main Bottom Window":               RLLocationData("Manor",   91_002),
-    "Manor - Main Top Window":                  RLLocationData("Manor",   91_003),
-    "Manor - Main Rooftop":                     RLLocationData("Manor",   91_004),
-    "Manor - Left Wing Base":                   RLLocationData("Manor",   91_005),
-    "Manor - Left Wing Window":                 RLLocationData("Manor",   91_006),
-    "Manor - Left Wing Rooftop":                RLLocationData("Manor",   91_007),
-    "Manor - Left Big Base":                    RLLocationData("Manor",   91_008),
-    "Manor - Left Big Upper 1":                 RLLocationData("Manor",   91_009),
-    "Manor - Left Big Upper 2":                 RLLocationData("Manor",   91_010),
-    "Manor - Left Big Windows":                 RLLocationData("Manor",   91_011),
-    "Manor - Left Big Rooftop":                 RLLocationData("Manor",   91_012),
-    "Manor - Left Far Base":                    RLLocationData("Manor",   91_013),
-    "Manor - Left Far Roof":                    RLLocationData("Manor",   91_014),
-    "Manor - Left Extension":                   RLLocationData("Manor",   91_015),
-    "Manor - Left Tree 1":                      RLLocationData("Manor",   91_016),
-    "Manor - Left Tree 2":                      RLLocationData("Manor",   91_017),
-    "Manor - Right Wing Base":                  RLLocationData("Manor",   91_018),
-    "Manor - Right Wing Window":                RLLocationData("Manor",   91_019),
-    "Manor - Right Wing Rooftop":               RLLocationData("Manor",   91_020),
-    "Manor - Right Big Base":                   RLLocationData("Manor",   91_021),
-    "Manor - Right Big Upper":                  RLLocationData("Manor",   91_022),
-    "Manor - Right Big Rooftop":                RLLocationData("Manor",   91_023),
-    "Manor - Right High Base":                  RLLocationData("Manor",   91_024),
-    "Manor - Right High Upper":                 RLLocationData("Manor",   91_025),
-    "Manor - Right High Tower":                 RLLocationData("Manor",   91_026),
-    "Manor - Right Extension":                  RLLocationData("Manor",   91_027),
-    "Manor - Right Tree":                       RLLocationData("Manor",   91_028),
-    "Manor - Observatory Base":                 RLLocationData("Manor",   91_029),
-    "Manor - Observatory Telescope":            RLLocationData("Manor",   91_030),
+    "Manor - Ground Road":                      RLLocationData("Manor - Tier 1",         0),
+    "Manor - Main Base":                        RLLocationData("Manor - Tier 1",         1),
+    "Manor - Main Bottom Window":               RLLocationData("Manor - Tier 1",         2),
+    "Manor - Main Top Window":                  RLLocationData("Manor - Tier 1",         3),
+    "Manor - Main Rooftop":                     RLLocationData("Manor - Tier 1",         4),
+    "Manor - Left Wing Base":                   RLLocationData("Manor - Tier 1",         5),
+    "Manor - Left Wing Window":                 RLLocationData("Manor - Tier 2",         6),
+    "Manor - Left Wing Rooftop":                RLLocationData("Manor - Tier 2",         7),
+    "Manor - Left Big Base":                    RLLocationData("Manor - Tier 2",         8),
+    "Manor - Left Big Upper 1":                 RLLocationData("Manor - Tier 3",         9),
+    "Manor - Left Big Upper 2":                 RLLocationData("Manor - Tier 3",        10),
+    "Manor - Left Big Windows":                 RLLocationData("Manor - Tier 3",        11),
+    "Manor - Left Big Rooftop":                 RLLocationData("Manor - Tier 3",        12),
+    "Manor - Left Far Base":                    RLLocationData("Manor - Tier 3",        13),
+    "Manor - Left Far Roof":                    RLLocationData("Manor - Tier 3",        14),
+    "Manor - Left Extension":                   RLLocationData("Manor - Tier 3",        15),
+    "Manor - Left Tree 1":                      RLLocationData("Manor - Tier 2",        16),
+    "Manor - Left Tree 2":                      RLLocationData("Manor - Tier 2",        17),
+    "Manor - Right Wing Base":                  RLLocationData("Manor - Tier 1",        18),
+    "Manor - Right Wing Window":                RLLocationData("Manor - Tier 2",        19),
+    "Manor - Right Wing Rooftop":               RLLocationData("Manor - Tier 2",        20),
+    "Manor - Right Big Base":                   RLLocationData("Manor - Tier 2",        21),
+    "Manor - Right Big Upper":                  RLLocationData("Manor - Tier 3",        22),
+    "Manor - Right Big Rooftop":                RLLocationData("Manor - Tier 3",        23),
+    "Manor - Right High Base":                  RLLocationData("Manor - Tier 4",        24),
+    "Manor - Right High Upper":                 RLLocationData("Manor - Tier 4",        25),
+    "Manor - Right High Tower":                 RLLocationData("Manor - Tier 4",        26),
+    "Manor - Right Extension":                  RLLocationData("Manor - Tier 3",        27),
+    "Manor - Right Tree":                       RLLocationData("Manor - Tier 2",        28),
+    "Manor - Observatory Base":                 RLLocationData("Manor - Tier 4",        29),
+    "Manor - Observatory Telescope":            RLLocationData("Manor - Tier 4",        30),
 
     # Boss Rewards
-    "Castle Hamson Boss Reward":                RLLocationData("Boss",    91_100),
-    "Forest Abkhazia Boss Reward":              RLLocationData("Boss",    91_102),
-    "The Maya Boss Reward":                     RLLocationData("Boss",    91_104),
-    "Land of Darkness Boss Reward":             RLLocationData("Boss",    91_106),
+    "Castle Hamson - Boss Reward":              RLLocationData("Castle Hamson",        100),
+    "Forest Abkhazia - Boss Reward":            RLLocationData("Forest Abkhazia",      102),
+    "The Maya - Boss Reward":                   RLLocationData("The Maya",             104),
+    "Land of Darkness - Boss Reward":           RLLocationData("The Land of Darkness", 106),
 
-    # Special Locations
-    "Jukebox":                                  RLLocationData("Special", 91_200),
-    "Painting":                                 RLLocationData("Special", 91_201),
-    "Cheapskate Elf's Game":                    RLLocationData("Special", 91_202),
-    "Carnival":                                 RLLocationData("Special", 91_203),
+    # One-off Locations
+    "The Jukebox":                              RLLocationData("Castle Hamson",        200),
+    "CDG Portrait":                             RLLocationData("Castle Hamson",        201),
+    "Cheapskate Elf's Reward":                  RLLocationData("Cheapskate Elf",       202),
+    "Carnival Reward":                          RLLocationData("Castle Hamson",        203),
+    "Secret Room Left Chest":                   RLLocationData("The Secret Room",      204),
+    "Secret Room Right Chest":                  RLLocationData("The Secret Room",      205),
+    "Barbatos & Amon's Reward":                 RLLocationData("Castle Hamson",        206),
+    "Botis' Reward":                            RLLocationData("Castle Hamson",        207),
+    "Stolas & Focalor's Reward":                RLLocationData("Castle Hamson",        208),
+    "Sallos' Reward":                           RLLocationData("Castle Hamson",        209),
+    "Berith & Halphas' Reward":                 RLLocationData("Castle Hamson",        210),
 
     # Diaries
-    **{f"Diary {i+1}":                          RLLocationData("Diary",   91_300 + i) for i in range(0,  25)},
+    **{f"Diary Entry {i+1}":                    RLLocationData("Castle Hamson",        300+i) for i in range(0,   6)},
+    **{f"Diary Entry {i+1}":                    RLLocationData("Forest Abkhazia",      300+i) for i in range(6,  12)},
+    **{f"Diary Entry {i+1}":                    RLLocationData("The Maya",             300+i) for i in range(12, 18)},
+    **{f"Diary Entry {i+1}":                    RLLocationData("The Land of Darkness", 300+i) for i in range(18, 24)},
+    "The Final Diary Entry":                    RLLocationData("The Fountain Room",    324),
 
     # Chests
-    **{f"Castle Hamson - Chest {i+1}":          RLLocationData("Chests",  91_600 + i) for i in range(0,  50)},
-    **{f"Forest Abkhazia - Chest {i+1}":        RLLocationData("Chests",  91_700 + i) for i in range(0,  50)},
-    **{f"The Maya - Chest {i+1}":               RLLocationData("Chests",  91_800 + i) for i in range(0,  50)},
-    **{f"Land of Darkness - Chest {i+1}":       RLLocationData("Chests",  91_900 + i) for i in range(0,  50)},
-    **{f"Chest {i+1}":                          RLLocationData("Chests",  92_000 + i) for i in range(0, 200)},
+    **{f"Castle Hamson - Chest {i+1}":          RLLocationData(
+        "Castle Hamson",
+        600+i,
+        lambda multiworld, player, i=i: can_create_normal_chest(multiworld, player, i),
+    ) for i in range(50)},
+    **{f"Forest Abkhazia - Chest {i+1}":        RLLocationData(
+        "Forest Abkhazia",
+        700+i,
+        lambda multiworld, player, i=i: can_create_normal_chest(multiworld, player, i),
+    ) for i in range(50)},
+    **{f"The Maya - Chest {i+1}":               RLLocationData(
+        "The Maya",
+        800+i,
+        lambda multiworld, player, i=i: can_create_normal_chest(multiworld, player, i),
+    ) for i in range(50)},
+    **{f"Land of Darkness - Chest {i+1}":       RLLocationData(
+        "The Land of Darkness",
+        900+i,
+        lambda multiworld, player, i=i: can_create_normal_chest(multiworld, player, i),
+    ) for i in range(50)},
+    **{f"Universal Chest {i+1}":                RLLocationData(
+        lambda multiworld, player, i=i: get_chest_region(getattr(multiworld, "chests_per_zone")[player], i),
+        1000+i,
+        lambda multiworld, player, i=i: can_create_universal_chest(multiworld, player, i),
+    ) for i in range(200)},
 
     # Fairy Chests
-    **{f"Castle Hamson - Fairy Chest {i+1}":    RLLocationData("Fairies", 91_400 + i) for i in range(0,  15)},
-    **{f"Forest Abkhazia - Fairy Chest {i+1}":  RLLocationData("Fairies", 91_450 + i) for i in range(0,  15)},
-    **{f"The Maya - Fairy Chest {i+1}":         RLLocationData("Fairies", 91_500 + i) for i in range(0,  15)},
-    **{f"Land of Darkness - Fairy Chest {i+1}": RLLocationData("Fairies", 91_550 + i) for i in range(0,  15)},
-    **{f"Fairy Chest {i+1}":                    RLLocationData("Fairies", 92_200 + i) for i in range(0,  60)},
+    **{f"Castle Hamson - Fairy Chest {i+1}":    RLLocationData(
+        "Castle Fairy Chests",
+        400+i,
+        lambda multiworld, player, i=i: can_create_normal_fairy_chest(multiworld, player, i),
+    ) for i in range(15)},
+    **{f"Forest Abkhazia - Fairy Chest {i+1}":  RLLocationData(
+        "Forest Fairy Chests",
+        450+i,
+        lambda multiworld, player, i=i: can_create_normal_fairy_chest(multiworld, player, i),
+    ) for i in range(15)},
+    **{f"The Maya - Fairy Chest {i+1}":         RLLocationData(
+        "Tower Fairy Chests",
+        500+i,
+        lambda multiworld, player, i=i: can_create_normal_fairy_chest(multiworld, player, i),
+    ) for i in range(15)},
+    **{f"Land of Darkness - Fairy Chest {i+1}": RLLocationData(
+        "Dungeon Fairy Chests",
+        550+i,
+        lambda multiworld, player, i=i: can_create_normal_fairy_chest(multiworld, player, i),
+    ) for i in range(15)},
+    **{f"Universal Fairy Chest {i+1}":          RLLocationData(
+        lambda multiworld, player, i=i: get_chest_region(getattr(multiworld, "fairy_chests_per_zone")[player], i),
+        1200+i,
+        lambda multiworld, player, i=i: can_create_universal_fairy_chest(multiworld, player, i),
+    ) for i in range(60)},
+
+    # Events
+    "Castle Hamson Boss":                       RLLocationData("Castle Hamson",        locked_item=get_castle_boss),
+    "Forest Abkhazia Boss":                     RLLocationData("Forest Abkhazia",      locked_item=get_forest_boss),
+    "The Maya Boss":                            RLLocationData("The Maya",             locked_item=get_tower_boss),
+    "Land of Darkness Boss":                    RLLocationData("The Land of Darkness", locked_item=get_dungeon_boss),
+    "The Fountain Room Boss":                   RLLocationData("The Fountain Room",    locked_item=get_final_boss),
+    "The Fountain Room Door":                   RLLocationData("Castle Hamson",        locked_item=get_open_door)
 }
 
-event_location_table: Dict[str, RLLocationData] = {
-    "Castle Hamson Boss Room":                  RLLocationData("Event"),
-    "Forest Abkhazia Boss Room":                RLLocationData("Event"),
-    "The Maya Boss Room":                       RLLocationData("Event"),
-    "Land of Darkness Boss Room":               RLLocationData("Event"),
-    "Fountain Room":                            RLLocationData("Event"),
-}
+# Set the location name for each location based on key.
+for location_name, location_data in location_table.items():
+    location_data.name = location_name

--- a/worlds/rogue_legacy/Options.py
+++ b/worlds/rogue_legacy/Options.py
@@ -1,6 +1,6 @@
 from typing import Dict
 
-from Options import Choice, Range, Option, Toggle, DeathLink, DefaultOnToggle, OptionSet
+from Options import Choice, DeathLink, DefaultOnToggle, Option, OptionSet, Range, StartInventoryPool, Toggle
 
 
 class StartingGender(Choice):
@@ -28,33 +28,17 @@ class StartingClass(Choice):
     option_miner = 5
     option_spellthief = 6
     option_lich = 7
+    option_dragon = 8
+    option_traitor = 9
     default = 0
 
 
-class NewGamePlus(Choice):
+class NewGamePlus(Toggle):
     """
     Puts the castle in new game plus mode which vastly increases enemy level, but increases gold gain by 50%. Not
     recommended for those inexperienced to Rogue Legacy!
     """
-    display_name = "New Game Plus"
-    option_normal = 0
-    option_new_game_plus = 1
-    option_new_game_plus_2 = 2
-    alias_hard = 1
-    alias_brutal = 2
-    default = 0
-
-
-class LevelScaling(Range):
-    """
-    A percentage modifier for scaling enemy level as you continue throughout the castle. 100 means enemies will have
-    100% level scaling (normal). Setting this too high will result in enemies with absurdly high levels, you have been
-    warned.
-    """
-    display_name = "Enemy Level Scaling Percentage"
-    range_start = 1
-    range_end = 300
-    default = 100
+    display_name = "New Game+ Mode"
 
 
 class FairyChestsPerZone(Range):
@@ -65,7 +49,7 @@ class FairyChestsPerZone(Range):
     display_name = "Fairy Chests Per Zone"
     range_start = 0
     range_end = 15
-    default = 1
+    default = 0
 
 
 class ChestsPerZone(Range):
@@ -74,35 +58,23 @@ class ChestsPerZone(Range):
     gold or stat bonuses can be found in Chests.
     """
     display_name = "Chests Per Zone"
-    range_start = 20
+    range_start = 25
     range_end = 50
-    default = 20
+    default = 25
 
 
 class UniversalFairyChests(Toggle):
     """
-    Determines if fairy chests should be combined into one pool instead of per zone, similar to Risk of Rain 2.
+    Determines if fairy chests should be combined into one pool instead of per zone.
     """
     display_name = "Universal Fairy Chests"
 
 
 class UniversalChests(Toggle):
     """
-    Determines if non-fairy chests should be combined into one pool instead of per zone, similar to Risk of Rain 2.
+    Determines if non-fairy chests should be combined into one pool instead of per zone.
     """
     display_name = "Universal Non-Fairy Chests"
-
-
-class Vendors(Choice):
-    """
-    Determines where to place the Blacksmith and Enchantress unlocks in logic (or start with them unlocked).
-    """
-    display_name = "Vendors"
-    option_start_unlocked = 0
-    option_early = 1
-    option_normal = 2
-    option_anywhere = 3
-    default = 1
 
 
 class Architect(Choice):
@@ -114,8 +86,7 @@ class Architect(Choice):
     option_early = 1
     option_anywhere = 2
     option_disabled = 3
-    alias_normal = 2
-    default = 2
+    default = 1
 
 
 class ArchitectFee(Range):
@@ -131,17 +102,46 @@ class ArchitectFee(Range):
 
 class DisableCharon(Toggle):
     """
-    Prevents Charon from taking your money when you re-enter the castle. Also removes Haggling from the Item Pool.
+    Prevents Charon from taking your money when you re-enter the castle.
+
+    This also removes the Haggling skill and Charon's Obol Shrine from the item pool.
     """
-    display_name = "Disable Charon"
+    display_name = "Remove Charon"
 
 
-class RequirePurchasing(DefaultOnToggle):
+class ShuffleBlacksmith(DefaultOnToggle):
+    """
+    Shuffles the types of items you can purchase from the Blacksmith into the item pool.
+
+    For example, to purchase Limbs-type equipment, you need to find the Blacksmith - Limbs item.
+    """
+    display_name = "Shuffle Blacksmith Specialties"
+
+
+class ShuffleEnchantress(DefaultOnToggle):
+    """
+    Shuffles the types of items you can purchase from the Enchantress into the item pool.
+
+    For example, to purchase Limbs-type runes, you need to find the Enchantress - Limbs item.
+    """
+    display_name = "Shuffle Enchantress Specialties"
+
+
+class RequireVendorPurchasing(DefaultOnToggle):
     """
     Determines where you will be required to purchase equipment and runes from the Blacksmith and Enchantress before
-    equipping them. If you disable require purchasing, Manor Renovations are scaled to take this into account.
+    equipping them.
     """
-    display_name = "Require Purchasing"
+    display_name = "Require Purchasing from Vendors"
+
+
+class RequireSkillPurchasing(DefaultOnToggle):
+    """
+    Determines if you will be required to purchase your skill upgrades in the manor when received.
+
+    If disabled, you will automatically obtain the skill levels.
+    """
+    display_name = "Require Purchasing from Skills"
 
 
 class ProgressiveBlueprints(Toggle):
@@ -165,42 +165,56 @@ class GoldGainMultiplier(Choice):
     default = 0
 
 
-class NumberOfChildren(Range):
+class SpendingRestrictions(DefaultOnToggle):
+    """
+    Prevents the player from spending more than a certain amount of gold per life without certain upgrades.
+
+    Tier 0: Can only spend up to 2,500 gold per life.
+    Tier 1: Can only spend up to 10,000 gold per life.
+    Tier 2: Can only spend up to 25,000 gold per life.
+    Tier 3: Can only spend up to 50,000 gold per life.
+    Tier 4: Can spend an unlimited amount of gold.
+    """
+    display_name = "Gold Spending Limits"
+
+
+class NumberOfChildren(Choice):
     """
     Determines the number of offspring you can choose from on the lineage screen after a death.
+
+    "Variable" means the number of children you can choose from will between randomly picked from 1 and 5 every
+    generation.
     """
     display_name = "Number of Children"
-    range_start = 1
-    range_end = 5
+    option_one = 1
+    option_two = 2
+    option_three = 3
+    option_four = 4
+    option_five = 5
+    option_variable = 6
+    alias_1 = 1
+    alias_2 = 2
+    alias_3 = 3
+    alias_4 = 4
+    alias_5 = 5
     default = 3
 
 
-class AdditionalNames(OptionSet):
+class CastleSize(Choice):
     """
-    Set of additional names your potential offspring can have. If Allow Default Names is disabled, this is the only list
-    of names your children can have. The first value will also be your initial character's name depending on Starting
-    Gender.
-    """
-    display_name = "Additional Names"
+    Adjusts the scaling factor for how big a castle can be. Larger castles scale enemy levels quicker, but will take
+    longer to generate.
 
-
-class AllowDefaultNames(DefaultOnToggle):
+    Standard: Castle Hamson is the same size as in vanilla Rogue Legacy.
+    Large: Castle Hamson is 4x larger than vanilla Rogue Legacy.
+    Very Large: Castle Hamson is 8x larger than vanilla Rogue Legacy.
+    Labyrinth: Castle Hamson is 12x larger than vanilla Rogue Legacy.
     """
-    Determines if the default names defined in the vanilla game are allowed to be used. Warning: Your world will not
-    generate if the number of Additional Names defined is less than the Number of Children value.
-    """
-    display_name = "Allow Default Names"
-
-
-class CastleScaling(Range):
-    """
-    Adjusts the scaling factor for how big a castle can be. Larger castles scale enemies quicker and also take longer
-    to generate. 100 means normal castle size.
-    """
-    display_name = "Castle Size Scaling Percentage"
-    range_start = 50
-    range_end = 300
-    default = 100
+    display_name = "Castle Hamson Size"
+    option_standard = 0
+    option_large = 1
+    option_very_large = 2
+    option_labyrinth = 3
 
 
 class ChallengeBossKhidr(Choice):
@@ -323,41 +337,90 @@ class CritDamageUpPool(Range):
     default = 5
 
 
-class FreeDiaryOnGeneration(DefaultOnToggle):
+class FountainDoorRequirement(Choice):
     """
-    Allows the player to get a free diary check every time they regenerate the castle in the starting room.
+    Determines the requirements to open the door to the Fountain Room.
+
+    Adds Pieces of the Fountain to the pool if one of the chosen requirements requires them.
     """
-    display_name = "Free Diary On Generation"
+    display_name = "Fountain Door Requirement"
+    option_bosses = 0
+    option_fountain_pieces = 1
+    option_both = 2
+    default = 0
+
+
+class FountainPiecesAvailable(Range):
+    """
+    If Fountain Door Requirement requires Pieces of the Fountain, how many should exist to be found?
+    """
+    display_name = "Fountain Pieces Available"
+    range_start = 1
+    range_end = 50
+    default = 20
+
+
+class FountainPiecesRequired(Range):
+    """
+    If Fountain Door Requirement requires Pieces of the Fountain, what percentage of fountain pieces (minimum 1), should
+    be required to fulfil the Fountain Door Requirement?
+    """
+    display_name = "Required Fountain Pieces Percentage"
+    range_start = 25
+    range_end = 100
+    default = 75
 
 
 class AvailableClasses(OptionSet):
     """
     List of classes that will be in the item pool to find. The upgraded form of the class will be added with it.
-    The upgraded form of your starting class will be available regardless.
+
+    The upgraded form of your starting class will always be available.
     """
     display_name = "Available Classes"
-    default = {"Knight", "Mage", "Barbarian", "Knave", "Shinobi", "Miner", "Spellthief", "Lich", "Dragon", "Traitor"}
-    valid_keys = {"Knight", "Mage", "Barbarian", "Knave", "Shinobi", "Miner", "Spellthief", "Lich", "Dragon", "Traitor"}
+    default = {
+        "Knights",
+        "Mages",
+        "Barbarians",
+        "Knaves",
+        "Shinobis",
+        "Miners",
+        "Spellthieves",
+        "Liches",
+        "Dragons",
+        "Traitors",
+    }
+    valid_keys = default.copy()
+
+
+class IncludeTraps(Toggle):
+    """
+    Includes some items that only exist to make your life worse.
+    """
+    display_name = "Include Traps"
 
 
 rl_options: Dict[str, type(Option)] = {
+    "start_inventory": StartInventoryPool,
     "starting_gender": StartingGender,
     "starting_class": StartingClass,
-    "available_classes": AvailableClasses,
     "new_game_plus": NewGamePlus,
-    "fairy_chests_per_zone": FairyChestsPerZone,
+    "universal_chests": UniversalChests,
     "chests_per_zone": ChestsPerZone,
     "universal_fairy_chests": UniversalFairyChests,
-    "universal_chests": UniversalChests,
-    "vendors": Vendors,
+    "fairy_chests_per_zone": FairyChestsPerZone,
     "architect": Architect,
     "architect_fee": ArchitectFee,
     "disable_charon": DisableCharon,
-    "require_purchasing": RequirePurchasing,
+    "shuffle_blacksmith": ShuffleBlacksmith,
+    "shuffle_enchantress": ShuffleEnchantress,
+    "require_vendor_purchasing": RequireVendorPurchasing,
+    "require_skill_purchasing": RequireSkillPurchasing,
     "progressive_blueprints": ProgressiveBlueprints,
     "gold_gain_multiplier": GoldGainMultiplier,
+    "spending_restrictions": SpendingRestrictions,
     "number_of_children": NumberOfChildren,
-    "free_diary_on_generation": FreeDiaryOnGeneration,
+    "castle_size": CastleSize,
     "khidr": ChallengeBossKhidr,
     "alexander": ChallengeBossAlexander,
     "leon": ChallengeBossLeon,
@@ -370,8 +433,10 @@ rl_options: Dict[str, type(Option)] = {
     "equip_pool": EquipUpPool,
     "crit_chance_pool": CritChanceUpPool,
     "crit_damage_pool": CritDamageUpPool,
-    "allow_default_names": AllowDefaultNames,
-    "additional_lady_names": AdditionalNames,
-    "additional_sir_names": AdditionalNames,
+    "fountain_door_requirement": FountainDoorRequirement,
+    "fountain_pieces_available": FountainPiecesAvailable,
+    "fountain_pieces_percentage": FountainPiecesRequired,
+    "include_traps": IncludeTraps,
+    "available_classes": AvailableClasses,
     "death_link": DeathLink,
 }

--- a/worlds/rogue_legacy/Options.py
+++ b/worlds/rogue_legacy/Options.py
@@ -170,9 +170,9 @@ class SpendingRestrictions(DefaultOnToggle):
     Prevents the player from spending more than a certain amount of gold per life without certain upgrades.
 
     Tier 0: Can only spend up to 2,500 gold per life.
-    Tier 1: Can only spend up to 10,000 gold per life.
-    Tier 2: Can only spend up to 25,000 gold per life.
-    Tier 3: Can only spend up to 50,000 gold per life.
+    Tier 1: Can only spend up to 5,000 gold per life.
+    Tier 2: Can only spend up to 10,000 gold per life.
+    Tier 3: Can only spend up to 20,000 gold per life.
     Tier 4: Can spend an unlimited amount of gold.
     """
     display_name = "Gold Spending Limits"
@@ -356,8 +356,8 @@ class FountainPiecesAvailable(Range):
     """
     display_name = "Fountain Pieces Available"
     range_start = 1
-    range_end = 50
-    default = 20
+    range_end = 25
+    default = 15
 
 
 class FountainPiecesRequired(Range):

--- a/worlds/rogue_legacy/Regions.py
+++ b/worlds/rogue_legacy/Regions.py
@@ -1,111 +1,86 @@
-from typing import Dict, List, NamedTuple, Optional
+from typing import Callable, Dict, List, NamedTuple
 
-from BaseClasses import MultiWorld, Region, Entrance
-from .Locations import RLLocation, location_table, get_locations_by_category
+from BaseClasses import CollectionState
+from .Rules import can_open_door, has_defeated_castle, has_defeated_forest, has_defeated_tower, \
+    has_fairy_progression, has_upgrades_percentage
+
+__all__ = ["RLRegionData", "region_table"]
 
 
 class RLRegionData(NamedTuple):
-    locations: Optional[List[str]]
-    region_exits: Optional[List[str]]
+    exits: List[str] = []
+    rules: Callable[[CollectionState, int], bool] = lambda state, player: True
 
 
-def create_regions(multiworld: MultiWorld, player: int):
-    regions: Dict[str, RLRegionData] = {
-        "Menu":              RLRegionData(None, ["Castle Hamson"]),
-        "The Manor":         RLRegionData([],   []),
-        "Castle Hamson":     RLRegionData([],   ["Forest Abkhazia", "The Maya", "Land of Darkness",
-                                                 "The Fountain Room", "The Manor"]),
-        "Forest Abkhazia":   RLRegionData([],   []),
-        "The Maya":          RLRegionData([],   []),
-        "Land of Darkness":  RLRegionData([],   []),
-        "The Fountain Room": RLRegionData([],   None),
-    }
+region_table: Dict[str, RLRegionData] = {
+    # Start
+    "Menu":                 RLRegionData(
+        exits=["Manor - Tier 1", "Castle Hamson"],
+    ),
 
-    # Artificially stagger diary spheres for progression.
-    for diary in range(0, 25):
-        region: str
-        if 0 <= diary < 6:
-            region = "Castle Hamson"
-        elif 6 <= diary < 12:
-            region = "Forest Abkhazia"
-        elif 12 <= diary < 18:
-            region = "The Maya"
-        elif 18 <= diary < 24:
-            region = "Land of Darkness"
-        else:
-            region = "The Fountain Room"
-        regions[region].locations.append(f"Diary {diary + 1}")
+    # Manor Renovation
+    "Manor - Tier 1":       RLRegionData(
+        exits=["Manor - Tier 2"],
+    ),
+    "Manor - Tier 2":       RLRegionData(
+        exits=["Manor - Tier 3"],
+        rules=lambda state, player: state.can_reach("Forest Abkhazia", "Region", player),
+    ),
+    "Manor - Tier 3":       RLRegionData(
+        exits=["Manor - Tier 4"],
+        rules=lambda state, player: state.can_reach("The Maya", "Region", player),
+    ),
+    "Manor - Tier 4":       RLRegionData(
+        rules=lambda state, player: state.can_reach("The Land of Darkness", "Region", player),
+    ),
 
-    # Manor & Special
-    for manor in get_locations_by_category("Manor").keys():
-        regions["The Manor"].locations.append(manor)
-    for special in get_locations_by_category("Special").keys():
-        regions["Castle Hamson"].locations.append(special)
-
-    # Boss Rewards
-    regions["Castle Hamson"].locations.append("Castle Hamson Boss Reward")
-    regions["Forest Abkhazia"].locations.append("Forest Abkhazia Boss Reward")
-    regions["The Maya"].locations.append("The Maya Boss Reward")
-    regions["Land of Darkness"].locations.append("Land of Darkness Boss Reward")
-
-    # Events
-    regions["Castle Hamson"].locations.append("Castle Hamson Boss Room")
-    regions["Forest Abkhazia"].locations.append("Forest Abkhazia Boss Room")
-    regions["The Maya"].locations.append("The Maya Boss Room")
-    regions["Land of Darkness"].locations.append("Land of Darkness Boss Room")
-    regions["The Fountain Room"].locations.append("Fountain Room")
-
-    # Chests
-    chests = int(multiworld.chests_per_zone[player])
-    for i in range(0, chests):
-        if multiworld.universal_chests[player]:
-            regions["Castle Hamson"].locations.append(f"Chest {i + 1}")
-            regions["Forest Abkhazia"].locations.append(f"Chest {i + 1 + chests}")
-            regions["The Maya"].locations.append(f"Chest {i + 1 + (chests * 2)}")
-            regions["Land of Darkness"].locations.append(f"Chest {i + 1 + (chests * 3)}")
-        else:
-            regions["Castle Hamson"].locations.append(f"Castle Hamson - Chest {i + 1}")
-            regions["Forest Abkhazia"].locations.append(f"Forest Abkhazia - Chest {i + 1}")
-            regions["The Maya"].locations.append(f"The Maya - Chest {i + 1}")
-            regions["Land of Darkness"].locations.append(f"Land of Darkness - Chest {i + 1}")
+    # Castle Hamson Zones
+    "Castle Hamson":        RLRegionData(
+        exits=[
+            "Forest Abkhazia",
+            "The Maya",
+            "The Land of Darkness",
+            "The Fountain Room",
+            "Castle Fairy Chests",
+            "Cheapskate Elf",
+            "The Secret Room",
+        ],
+    ),
+    "Forest Abkhazia":      RLRegionData(
+        exits=["Forest Fairy Chests"],
+        rules=lambda state, player: has_upgrades_percentage(state, player, 15) and has_defeated_castle(state, player),
+    ),
+    "The Maya":             RLRegionData(
+        exits=["Tower Fairy Chests"],
+        rules=lambda state, player: has_upgrades_percentage(state, player, 30) and has_defeated_forest(state, player),
+    ),
+    "The Land of Darkness": RLRegionData(
+        exits=["Dungeon Fairy Chests"],
+        rules=lambda state, player: has_upgrades_percentage(state, player, 45) and has_defeated_tower(state, player),
+    ),
+    "The Fountain Room":    RLRegionData(
+        rules=lambda state, player: has_upgrades_percentage(state, player, 60) and can_open_door(state, player),
+    ),
 
     # Fairy Chests
-    chests = int(multiworld.fairy_chests_per_zone[player])
-    for i in range(0, chests):
-        if multiworld.universal_fairy_chests[player]:
-            regions["Castle Hamson"].locations.append(f"Fairy Chest {i + 1}")
-            regions["Forest Abkhazia"].locations.append(f"Fairy Chest {i + 1 + chests}")
-            regions["The Maya"].locations.append(f"Fairy Chest {i + 1 + (chests * 2)}")
-            regions["Land of Darkness"].locations.append(f"Fairy Chest {i + 1 + (chests * 3)}")
-        else:
-            regions["Castle Hamson"].locations.append(f"Castle Hamson - Fairy Chest {i + 1}")
-            regions["Forest Abkhazia"].locations.append(f"Forest Abkhazia - Fairy Chest {i + 1}")
-            regions["The Maya"].locations.append(f"The Maya - Fairy Chest {i + 1}")
-            regions["Land of Darkness"].locations.append(f"Land of Darkness - Fairy Chest {i + 1}")
+    "Castle Fairy Chests":  RLRegionData(
+        rules=lambda state, player: has_fairy_progression(state, player),
+    ),
+    "Forest Fairy Chests":  RLRegionData(
+        rules=lambda state, player: has_fairy_progression(state, player),
+    ),
+    "Tower Fairy Chests":   RLRegionData(
+        rules=lambda state, player: has_fairy_progression(state, player),
+    ),
+    "Dungeon Fairy Chests": RLRegionData(
+        rules=lambda state, player: has_fairy_progression(state, player),
+    ),
 
-    # Set up the regions correctly.
-    for name, data in regions.items():
-        multiworld.regions.append(create_region(multiworld, player, name, data))
-
-    multiworld.get_entrance("Castle Hamson", player).connect(multiworld.get_region("Castle Hamson", player))
-    multiworld.get_entrance("The Manor", player).connect(multiworld.get_region("The Manor", player))
-    multiworld.get_entrance("Forest Abkhazia", player).connect(multiworld.get_region("Forest Abkhazia", player))
-    multiworld.get_entrance("The Maya", player).connect(multiworld.get_region("The Maya", player))
-    multiworld.get_entrance("Land of Darkness", player).connect(multiworld.get_region("Land of Darkness", player))
-    multiworld.get_entrance("The Fountain Room", player).connect(multiworld.get_region("The Fountain Room", player))
-
-
-def create_region(multiworld: MultiWorld, player: int, name: str, data: RLRegionData):
-    region = Region(name, player, multiworld)
-    if data.locations:
-        for loc_name in data.locations:
-            loc_data = location_table.get(loc_name)
-            location = RLLocation(player, loc_name, loc_data.code if loc_data else None, region)
-            region.locations.append(location)
-
-    if data.region_exits:
-        for exit in data.region_exits:
-            entrance = Entrance(player, exit, region)
-            region.exits.append(entrance)
-
-    return region
+    # Special Areas
+    "Cheapskate Elf":       RLRegionData(
+        rules=lambda state, player: state.has("Nerdy Glasses Shrine", player),
+    ),
+    "The Secret Room":      RLRegionData(
+        rules=lambda state, player: state.has("Calypso's Compass Shrine", player),
+    ),
+}

--- a/worlds/rogue_legacy/Regions.py
+++ b/worlds/rogue_legacy/Regions.py
@@ -1,8 +1,9 @@
 from typing import Callable, Dict, List, NamedTuple
 
 from BaseClasses import CollectionState
-from .Rules import can_access_secret_room, can_cheat_cheapskate_elf, can_open_door, has_defeated_castle, \
-    has_defeated_forest, has_defeated_tower, has_fairy_progression
+from .Rules import can_access_secret_room, can_afford_tier2, can_afford_tier3, can_afford_tier4, \
+    can_cheat_cheapskate_elf, can_open_door, has_defeated_castle, has_defeated_forest, has_defeated_tower, \
+    has_fairy_progression
 
 __all__ = ["RegionExit", "region_table"]
 
@@ -17,9 +18,9 @@ region_table: Dict[str, List[RegionExit]] = {
     "Menu": [RegionExit("Manor - Tier 1"), RegionExit("Castle Hamson")],
 
     # Manor Renovation
-    "Manor - Tier 1": [RegionExit("Manor - Tier 2", has_defeated_castle)],
-    "Manor - Tier 2": [RegionExit("Manor - Tier 3", has_defeated_forest)],
-    "Manor - Tier 3": [RegionExit("Manor - Tier 4", has_defeated_tower)],
+    "Manor - Tier 1": [RegionExit("Manor - Tier 2", can_afford_tier2)],
+    "Manor - Tier 2": [RegionExit("Manor - Tier 3", can_afford_tier3)],
+    "Manor - Tier 3": [RegionExit("Manor - Tier 4", can_afford_tier4)],
     "Manor - Tier 4": [],
 
     # Main Zones

--- a/worlds/rogue_legacy/Regions.py
+++ b/worlds/rogue_legacy/Regions.py
@@ -1,86 +1,49 @@
 from typing import Callable, Dict, List, NamedTuple
 
 from BaseClasses import CollectionState
-from .Rules import can_open_door, has_defeated_castle, has_defeated_forest, has_defeated_tower, \
-    has_fairy_progression, has_upgrades_percentage
+from .Rules import can_access_secret_room, can_cheat_cheapskate_elf, can_open_door, has_defeated_castle, \
+    has_defeated_forest, has_defeated_tower, has_fairy_progression
 
-__all__ = ["RLRegionData", "region_table"]
-
-
-class RLRegionData(NamedTuple):
-    exits: List[str] = []
-    rules: Callable[[CollectionState, int], bool] = lambda state, player: True
+__all__ = ["RegionExit", "region_table"]
 
 
-region_table: Dict[str, RLRegionData] = {
+class RegionExit(NamedTuple):
+    region: str
+    access_rule: Callable[[CollectionState, int], bool] = lambda state, player: True
+
+
+region_table: Dict[str, List[RegionExit]] = {
     # Start
-    "Menu":                 RLRegionData(
-        exits=["Manor - Tier 1", "Castle Hamson"],
-    ),
+    "Menu": [RegionExit("Manor - Tier 1"), RegionExit("Castle Hamson")],
 
     # Manor Renovation
-    "Manor - Tier 1":       RLRegionData(
-        exits=["Manor - Tier 2"],
-    ),
-    "Manor - Tier 2":       RLRegionData(
-        exits=["Manor - Tier 3"],
-        rules=lambda state, player: state.can_reach("Forest Abkhazia", "Region", player),
-    ),
-    "Manor - Tier 3":       RLRegionData(
-        exits=["Manor - Tier 4"],
-        rules=lambda state, player: state.can_reach("The Maya", "Region", player),
-    ),
-    "Manor - Tier 4":       RLRegionData(
-        rules=lambda state, player: state.can_reach("The Land of Darkness", "Region", player),
-    ),
+    "Manor - Tier 1": [RegionExit("Manor - Tier 2", has_defeated_castle)],
+    "Manor - Tier 2": [RegionExit("Manor - Tier 3", has_defeated_forest)],
+    "Manor - Tier 3": [RegionExit("Manor - Tier 4", has_defeated_tower)],
+    "Manor - Tier 4": [],
 
-    # Castle Hamson Zones
-    "Castle Hamson":        RLRegionData(
-        exits=[
-            "Forest Abkhazia",
-            "The Maya",
-            "The Land of Darkness",
-            "The Fountain Room",
-            "Castle Fairy Chests",
-            "Cheapskate Elf",
-            "The Secret Room",
-        ],
-    ),
-    "Forest Abkhazia":      RLRegionData(
-        exits=["Forest Fairy Chests"],
-        rules=lambda state, player: has_upgrades_percentage(state, player, 15) and has_defeated_castle(state, player),
-    ),
-    "The Maya":             RLRegionData(
-        exits=["Tower Fairy Chests"],
-        rules=lambda state, player: has_upgrades_percentage(state, player, 30) and has_defeated_forest(state, player),
-    ),
-    "The Land of Darkness": RLRegionData(
-        exits=["Dungeon Fairy Chests"],
-        rules=lambda state, player: has_upgrades_percentage(state, player, 45) and has_defeated_tower(state, player),
-    ),
-    "The Fountain Room":    RLRegionData(
-        rules=lambda state, player: has_upgrades_percentage(state, player, 60) and can_open_door(state, player),
-    ),
+    # Main Zones
+    "Castle Hamson": [
+        RegionExit("Forest Abkhazia", has_defeated_castle),
+        RegionExit("The Maya", has_defeated_forest),
+        RegionExit("The Land of Darkness", has_defeated_tower),
+        RegionExit("The Fountain Room", can_open_door),
+        RegionExit("Castle Fairy Chests", has_fairy_progression),
+        RegionExit("Cheapskate Elf", can_cheat_cheapskate_elf),
+        RegionExit("The Secret Room", can_access_secret_room),
+    ],
+    "Forest Abkhazia": [RegionExit("Forest Fairy Chests", has_fairy_progression)],
+    "The Maya": [RegionExit("Tower Fairy Chests", has_fairy_progression)],
+    "The Land of Darkness": [RegionExit("Dungeon Fairy Chests", has_fairy_progression)],
+    "The Fountain Room": [],
 
     # Fairy Chests
-    "Castle Fairy Chests":  RLRegionData(
-        rules=lambda state, player: has_fairy_progression(state, player),
-    ),
-    "Forest Fairy Chests":  RLRegionData(
-        rules=lambda state, player: has_fairy_progression(state, player),
-    ),
-    "Tower Fairy Chests":   RLRegionData(
-        rules=lambda state, player: has_fairy_progression(state, player),
-    ),
-    "Dungeon Fairy Chests": RLRegionData(
-        rules=lambda state, player: has_fairy_progression(state, player),
-    ),
+    "Castle Fairy Chests": [],
+    "Forest Fairy Chests": [],
+    "Tower Fairy Chests": [],
+    "Dungeon Fairy Chests": [],
 
     # Special Areas
-    "Cheapskate Elf":       RLRegionData(
-        rules=lambda state, player: state.has("Nerdy Glasses Shrine", player),
-    ),
-    "The Secret Room":      RLRegionData(
-        rules=lambda state, player: state.has("Calypso's Compass Shrine", player),
-    ),
+    "Cheapskate Elf": [],
+    "The Secret Room": [],
 }

--- a/worlds/rogue_legacy/Rules.py
+++ b/worlds/rogue_legacy/Rules.py
@@ -1,9 +1,12 @@
 from BaseClasses import CollectionState, MultiWorld
+from worlds.rogue_legacy.Options import FountainDoorRequirement, FountainPiecesAvailable, FountainPiecesRequired
 
 
-def get_upgrade_total(multiworld: MultiWorld, player: int) -> int:
-    return int(multiworld.health_pool[player]) + int(multiworld.mana_pool[player]) + \
-           int(multiworld.attack_pool[player]) + int(multiworld.magic_damage_pool[player])
+def get_total_upgrades(multiworld: MultiWorld, player: int) -> int:
+    return getattr(multiworld, "health_pool")[player].value + \
+           getattr(multiworld, "mana_pool")[player].value + \
+           getattr(multiworld, "attack_pool")[player].value + \
+           getattr(multiworld, "magic_damage_pool")[player].value
 
 
 def get_upgrade_count(state: CollectionState, player: int) -> int:
@@ -11,24 +14,30 @@ def get_upgrade_count(state: CollectionState, player: int) -> int:
            state.item_count("Attack Up", player) + state.item_count("Magic Damage Up", player)
 
 
-def has_vendors(state: CollectionState, player: int) -> bool:
-    return state.has_all({"Blacksmith", "Enchantress"}, player)
-
-
 def has_upgrade_amount(state: CollectionState, player: int, amount: int) -> bool:
     return get_upgrade_count(state, player) >= amount
 
 
 def has_upgrades_percentage(state: CollectionState, player: int, percentage: float) -> bool:
-    return has_upgrade_amount(state, player, round(get_upgrade_total(state.multiworld, player) * (percentage / 100)))
+    return has_upgrade_amount(state, player, round(get_total_upgrades(state.multiworld, player) * (percentage / 100)))
 
 
 def has_movement_rune(state: CollectionState, player: int) -> bool:
     return state.has("Vault Runes", player) or state.has("Sprint Runes", player) or state.has("Sky Runes", player)
 
 
+def has_enchantress_pieces(state: CollectionState, player: int) -> bool:
+    return any([
+        state.has("Enchantress - Sword", player),
+        state.has("Enchantress - Helm", player),
+        state.has("Enchantress - Chest", player),
+        state.has("Enchantress - Limbs", player),
+        state.has("Enchantress - Cape", player),
+    ])
+
+
 def has_fairy_progression(state: CollectionState, player: int) -> bool:
-    return state.has("Dragons", player) or (state.has("Enchantress", player) and has_movement_rune(state, player))
+    return state.has("Dragons", player) or (has_enchantress_pieces(state, player) and has_movement_rune(state, player))
 
 
 def has_defeated_castle(state: CollectionState, player: int) -> bool:
@@ -47,67 +56,27 @@ def has_defeated_dungeon(state: CollectionState, player: int) -> bool:
     return state.has("Defeat Herodotus", player) or state.has("Defeat Astrodotus", player)
 
 
-def set_rules(multiworld: MultiWorld, player: int):
-    # If 'vendors' are 'normal', then expect it to show up in the first half(ish) of the spheres.
-    if multiworld.vendors[player] == "normal":
-        multiworld.get_location("Forest Abkhazia Boss Reward", player).access_rule = \
-            lambda state: has_vendors(state, player)
+def has_defeated_all_bosses(state: CollectionState, player: int) -> bool:
+    return all([
+        has_defeated_castle(state, player),
+        has_defeated_forest(state, player),
+        has_defeated_tower(state, player),
+        has_defeated_dungeon(state, player),
+    ])
 
-    # Gate each manor location so everything isn't dumped into sphere 1.
-    manor_rules = {
-        "Defeat Khidr" if multiworld.khidr[player] == "vanilla" else "Defeat Neo Khidr": [
-            "Manor - Left Wing Window",
-            "Manor - Left Wing Rooftop",
-            "Manor - Right Wing Window",
-            "Manor - Right Wing Rooftop",
-            "Manor - Left Big Base",
-            "Manor - Right Big Base",
-            "Manor - Left Tree 1",
-            "Manor - Left Tree 2",
-            "Manor - Right Tree",
-        ],
-        "Defeat Alexander" if multiworld.alexander[player] == "vanilla" else "Defeat Alexander IV": [
-            "Manor - Left Big Upper 1",
-            "Manor - Left Big Upper 2",
-            "Manor - Left Big Windows",
-            "Manor - Left Big Rooftop",
-            "Manor - Left Far Base",
-            "Manor - Left Far Roof",
-            "Manor - Left Extension",
-            "Manor - Right Big Upper",
-            "Manor - Right Big Rooftop",
-            "Manor - Right Extension",
-        ],
-        "Defeat Ponce de Leon" if multiworld.leon[player] == "vanilla" else "Defeat Ponce de Freon": [
-            "Manor - Right High Base",
-            "Manor - Right High Upper",
-            "Manor - Right High Tower",
-            "Manor - Observatory Base",
-            "Manor - Observatory Telescope",
-        ]
-    }
 
-    # Set rules for manor locations.
-    for event, locations in manor_rules.items():
-        for location in locations:
-            multiworld.get_location(location, player).access_rule = lambda state: state.has(event, player)
+def can_open_door(state: CollectionState, player: int) -> bool:
+    objective: FountainDoorRequirement = getattr(state.multiworld, "fountain_door_requirement")[player]
+    available: FountainPiecesAvailable = getattr(state.multiworld, "fountain_pieces_available")[player].value
+    percentage: FountainPiecesRequired = getattr(state.multiworld, "fountain_pieces_percentage")[player].value
+    fountain_pieces_requirement = round(max(available * (percentage / 100), 1))
 
-    # Set rules for fairy chests to decrease headache of expectation to find non-movement fairy chests.
-    for fairy_location in [location for location in multiworld.get_locations(player) if "Fairy" in location.name]:
-        fairy_location.access_rule = lambda state: has_fairy_progression(state, player)
-
-    # Region rules.
-    multiworld.get_entrance("Forest Abkhazia", player).access_rule = \
-        lambda state: has_upgrades_percentage(state, player, 12.5) and has_defeated_castle(state, player)
-
-    multiworld.get_entrance("The Maya", player).access_rule = \
-        lambda state: has_upgrades_percentage(state, player, 25) and has_defeated_forest(state, player)
-
-    multiworld.get_entrance("Land of Darkness", player).access_rule = \
-        lambda state: has_upgrades_percentage(state, player, 37.5) and has_defeated_tower(state, player)
-
-    multiworld.get_entrance("The Fountain Room", player).access_rule = \
-        lambda state: has_upgrades_percentage(state, player, 50) and has_defeated_dungeon(state, player)
-
-    # Win condition.
-    multiworld.completion_condition[player] = lambda state: state.has("Defeat The Fountain", player)
+    if objective == "bosses":
+        return has_defeated_all_bosses(state, player)
+    elif objective == "fountain_pieces":
+        return state.has("Piece of the Fountain", player, fountain_pieces_requirement)
+    else:
+        return all([
+            has_defeated_all_bosses(state, player),
+            state.has("Piece of the Fountain", player, fountain_pieces_requirement),
+        ])

--- a/worlds/rogue_legacy/Rules.py
+++ b/worlds/rogue_legacy/Rules.py
@@ -1,5 +1,5 @@
 from BaseClasses import CollectionState, MultiWorld
-from .Options import FountainDoorRequirement, FountainPiecesAvailable, FountainPiecesRequired
+from .Options import FountainDoorRequirement, FountainPiecesAvailable, FountainPiecesRequired, SpendingRestrictions
 
 
 def get_total_upgrades(multiworld: MultiWorld, player: int) -> int:
@@ -43,28 +43,28 @@ def has_fairy_progression(state: CollectionState, player: int) -> bool:
 def has_defeated_castle(state: CollectionState, player: int) -> bool:
     return all([
         state.has("Defeat Khidr", player) or state.has("Defeat Neo Khidr", player),
-        has_upgrades_percentage(state, player, 8),
+        has_upgrades_percentage(state, player, 30),
     ])
 
 
 def has_defeated_forest(state: CollectionState, player: int) -> bool:
     return all([
         state.has("Defeat Alexander", player) or state.has("Defeat Alexander IV", player),
-        has_upgrades_percentage(state, player, 8),
+        has_upgrades_percentage(state, player, 45),
     ])
 
 
 def has_defeated_tower(state: CollectionState, player: int) -> bool:
     return all([
         state.has("Defeat Ponce de Leon", player) or state.has("Defeat Ponce de Freon", player),
-        has_upgrades_percentage(state, player, 8),
+        has_upgrades_percentage(state, player, 60),
     ])
 
 
 def has_defeated_dungeon(state: CollectionState, player: int) -> bool:
     return all([
         state.has("Defeat Herodotus", player) or state.has("Defeat Astrodotus", player),
-        has_upgrades_percentage(state, player, 8),
+        has_upgrades_percentage(state, player, 75),
     ])
 
 
@@ -103,3 +103,36 @@ def can_access_secret_room(state: CollectionState, player: int) -> bool:
 
 def can_cheat_cheapskate_elf(state: CollectionState, player: int) -> bool:
     return state.has("Nerdy Glasses Shrine", player)
+
+
+def can_afford_tier2(state: CollectionState, player: int) -> bool:
+    restrictions: SpendingRestrictions = getattr(state.multiworld, "spending_restrictions")[player]
+    if not has_defeated_castle(state, player):
+        return False
+
+    if restrictions:
+        return state.has("Progressive Spending", player)
+
+    return True
+
+
+def can_afford_tier3(state: CollectionState, player: int) -> bool:
+    restrictions: SpendingRestrictions = getattr(state.multiworld, "spending_restrictions")[player]
+    if not has_defeated_forest(state, player):
+        return False
+
+    if restrictions:
+        return state.has("Progressive Spending", player, 2)
+
+    return True
+
+
+def can_afford_tier4(state: CollectionState, player: int) -> bool:
+    restrictions: SpendingRestrictions = getattr(state.multiworld, "spending_restrictions")[player]
+    if not has_defeated_tower(state, player):
+        return False
+
+    if restrictions:
+        return state.has("Progressive Spending", player, 3)
+
+    return True

--- a/worlds/rogue_legacy/Rules.py
+++ b/worlds/rogue_legacy/Rules.py
@@ -1,5 +1,5 @@
 from BaseClasses import CollectionState, MultiWorld
-from worlds.rogue_legacy.Options import FountainDoorRequirement, FountainPiecesAvailable, FountainPiecesRequired
+from .Options import FountainDoorRequirement, FountainPiecesAvailable, FountainPiecesRequired
 
 
 def get_total_upgrades(multiworld: MultiWorld, player: int) -> int:
@@ -41,19 +41,31 @@ def has_fairy_progression(state: CollectionState, player: int) -> bool:
 
 
 def has_defeated_castle(state: CollectionState, player: int) -> bool:
-    return state.has("Defeat Khidr", player) or state.has("Defeat Neo Khidr", player)
+    return all([
+        state.has("Defeat Khidr", player) or state.has("Defeat Neo Khidr", player),
+        has_upgrades_percentage(state, player, 8),
+    ])
 
 
 def has_defeated_forest(state: CollectionState, player: int) -> bool:
-    return state.has("Defeat Alexander", player) or state.has("Defeat Alexander IV", player)
+    return all([
+        state.has("Defeat Alexander", player) or state.has("Defeat Alexander IV", player),
+        has_upgrades_percentage(state, player, 8),
+    ])
 
 
 def has_defeated_tower(state: CollectionState, player: int) -> bool:
-    return state.has("Defeat Ponce de Leon", player) or state.has("Defeat Ponce de Freon", player)
+    return all([
+        state.has("Defeat Ponce de Leon", player) or state.has("Defeat Ponce de Freon", player),
+        has_upgrades_percentage(state, player, 8),
+    ])
 
 
 def has_defeated_dungeon(state: CollectionState, player: int) -> bool:
-    return state.has("Defeat Herodotus", player) or state.has("Defeat Astrodotus", player)
+    return all([
+        state.has("Defeat Herodotus", player) or state.has("Defeat Astrodotus", player),
+        has_upgrades_percentage(state, player, 8),
+    ])
 
 
 def has_defeated_all_bosses(state: CollectionState, player: int) -> bool:
@@ -80,3 +92,14 @@ def can_open_door(state: CollectionState, player: int) -> bool:
             has_defeated_all_bosses(state, player),
             state.has("Piece of the Fountain", player, fountain_pieces_requirement),
         ])
+
+
+def can_access_secret_room(state: CollectionState, player: int) -> bool:
+    return all([
+        state.has("Calypso's Compass Shrine", player),
+        has_defeated_tower(state, player),
+    ])
+
+
+def can_cheat_cheapskate_elf(state: CollectionState, player: int) -> bool:
+    return state.has("Nerdy Glasses Shrine", player)

--- a/worlds/rogue_legacy/__init__.py
+++ b/worlds/rogue_legacy/__init__.py
@@ -2,6 +2,7 @@ from typing import List
 
 from BaseClasses import Region, Tutorial
 from worlds.AutoWorld import WebWorld, World
+from worlds.generic.Rules import allow_self_locking_items
 from .Items import RLItem, RLItemData, filler_items, item_groups, item_table
 from .Locations import RLLocation, location_groups, location_table
 from .Options import rl_options
@@ -69,6 +70,10 @@ class RLWorld(World):
 
     def set_rules(self):
         self.multiworld.completion_condition[self.player] = lambda state: state.has("Defeat The Fountain", self.player)
+
+        # Special rules to allow self-locking for some regions... because why not.
+        allow_self_locking_items(self.multiworld.get_region("Cheapskate Elf", self.player), "Nerdy Glasses Shrine")
+        allow_self_locking_items(self.multiworld.get_region("The Secret Room", self.player), "Calypso's Compass Shrine")
 
     def create_regions(self):
         # Instantiate Regions

--- a/worlds/rogue_legacy/__init__.py
+++ b/worlds/rogue_legacy/__init__.py
@@ -1,18 +1,17 @@
 from typing import List
 
-from BaseClasses import Tutorial
+from BaseClasses import Region, Tutorial
 from worlds.AutoWorld import WebWorld, World
-from .Items import RLItem, RLItemData, event_item_table, get_items_by_category, item_table
-from .Locations import RLLocation, location_table
+from .Items import RLItem, RLItemData, filler_items, item_groups, item_table
+from .Locations import RLLocation, location_groups, location_table
 from .Options import rl_options
-from .Regions import create_regions
-from .Rules import set_rules
+from .Regions import region_table
 
 
 class RLWeb(WebWorld):
     theme = "stone"
     tutorials = [Tutorial(
-        "Multiworld Setup Guide",
+        "Rogue Legacy Randomizer - Setup Guide",
         "A guide to setting up the Rogue Legacy Randomizer software on your computer. This guide covers single-player, "
         "multiworld, and related software.",
         "English",
@@ -32,214 +31,79 @@ class RLWorld(World):
     """
     game = "Rogue Legacy"
     option_definitions = rl_options
-    topology_present = True
-    data_version = 4
-    required_client_version = (0, 3, 5)
+    data_version = 5
+    required_client_version = (0, 4, 2)
     web = RLWeb()
 
-    item_name_to_id = {name: data.code for name, data in item_table.items()}
-    location_name_to_id = {name: data.code for name, data in location_table.items()}
-
-    # TODO: Replace calls to this function with "options-dict", once that PR is completed and merged.
-    def get_setting(self, name: str):
-        return getattr(self.multiworld, name)[self.player]
-
-    def fill_slot_data(self) -> dict:
-        return {option_name: self.get_setting(option_name).value for option_name in rl_options}
+    item_name_to_id = {name: data.code for name, data in item_table.items() if not data.event}
+    location_name_to_id = {name: data.address for name, data in location_table.items() if not data.event}
+    item_name_groups = item_groups
+    location_name_groups = location_groups
 
     def generate_early(self):
-        # Check validation of names.
-        additional_lady_names = len(self.get_setting("additional_lady_names").value)
-        additional_sir_names = len(self.get_setting("additional_sir_names").value)
-        if not self.get_setting("allow_default_names"):
-            if additional_lady_names < int(self.get_setting("number_of_children")):
-                raise Exception(
-                    f"allow_default_names is off, but not enough names are defined in additional_lady_names. "
-                    f"Expected {int(self.get_setting('number_of_children'))}, Got {additional_lady_names}")
+        # Set starting items.
+        self.multiworld.push_precollected(self.create_item("Blacksmith"))
+        self.multiworld.push_precollected(self.create_item("Enchantress"))
+        if self.get_setting("architect") == "start_unlocked":
+            self.multiworld.push_precollected(self.create_item("Architect"))
 
-            if additional_sir_names < int(self.get_setting("number_of_children")):
-                raise Exception(
-                    f"allow_default_names is off, but not enough names are defined in additional_sir_names. "
-                    f"Expected {int(self.get_setting('number_of_children'))}, Got {additional_sir_names}")
+    def create_item(self, name: str) -> RLItem:
+        item_data = item_table[name]
+        return RLItem(name, item_data.classification, item_data.code, self.player)
 
     def create_items(self):
         item_pool: List[RLItem] = []
-        total_locations = len(self.multiworld.get_unfilled_locations(self.player))
-        for name, data in item_table.items():
-            quantity = data.max_quantity
+        location_count = len(self.multiworld.get_unfilled_locations(self.player))
 
-            # Architect
-            if name == "Architect":
-                if self.get_setting("architect") == "disabled":
-                    continue
-                if self.get_setting("architect") == "start_unlocked":
-                    self.multiworld.push_precollected(self.create_item(name))
-                    continue
-                if self.get_setting("architect") == "early":
-                    self.multiworld.local_early_items[self.player]["Architect"] = 1
+        # Create each item we can create.
+        for item_data in item_table.values():
+            item_pool += [
+                self.create_item(item_data.name)
+                for _ in range(item_data.creation_quantity(self.multiworld, self.player))
+            ]
 
-            # Blacksmith and Enchantress
-            if name == "Blacksmith" or name == "Enchantress":
-                if self.get_setting("vendors") == "start_unlocked":
-                    self.multiworld.push_precollected(self.create_item(name))
-                    continue
-                if self.get_setting("vendors") == "early":
-                    self.multiworld.local_early_items[self.player]["Blacksmith"] = 1
-                    self.multiworld.local_early_items[self.player]["Enchantress"] = 1
-
-            # Haggling
-            if name == "Haggling" and self.get_setting("disable_charon"):
-                continue
-
-            # Blueprints
-            if data.category == "Blueprints":
-                # No progressive blueprints if progressive_blueprints are disabled.
-                if name == "Progressive Blueprints" and not self.get_setting("progressive_blueprints"):
-                    continue
-                # No distinct blueprints if progressive_blueprints are enabled.
-                elif name != "Progressive Blueprints" and self.get_setting("progressive_blueprints"):
-                    continue
-
-            # Classes
-            if data.category == "Classes":
-                if name == "Progressive Knights":
-                    if "Knight" not in self.get_setting("available_classes"):
-                        continue
-
-                    if self.get_setting("starting_class") == "knight":
-                        quantity = 1
-                if name == "Progressive Mages":
-                    if "Mage" not in self.get_setting("available_classes"):
-                        continue
-
-                    if self.get_setting("starting_class") == "mage":
-                        quantity = 1
-                if name == "Progressive Barbarians":
-                    if "Barbarian" not in self.get_setting("available_classes"):
-                        continue
-
-                    if self.get_setting("starting_class") == "barbarian":
-                        quantity = 1
-                if name == "Progressive Knaves":
-                    if "Knave" not in self.get_setting("available_classes"):
-                        continue
-
-                    if self.get_setting("starting_class") == "knave":
-                        quantity = 1
-                if name == "Progressive Miners":
-                    if "Miner" not in self.get_setting("available_classes"):
-                        continue
-
-                    if self.get_setting("starting_class") == "miner":
-                        quantity = 1
-                if name == "Progressive Shinobis":
-                    if "Shinobi" not in self.get_setting("available_classes"):
-                        continue
-
-                    if self.get_setting("starting_class") == "shinobi":
-                        quantity = 1
-                if name == "Progressive Liches":
-                    if "Lich" not in self.get_setting("available_classes"):
-                        continue
-
-                    if self.get_setting("starting_class") == "lich":
-                        quantity = 1
-                if name == "Progressive Spellthieves":
-                    if "Spellthief" not in self.get_setting("available_classes"):
-                        continue
-
-                    if self.get_setting("starting_class") == "spellthief":
-                        quantity = 1
-                if name == "Dragons":
-                    if "Dragon" not in self.get_setting("available_classes"):
-                        continue
-                if name == "Traitors":
-                    if "Traitor" not in self.get_setting("available_classes"):
-                        continue
-
-            # Skills
-            if name == "Health Up":
-                quantity = self.get_setting("health_pool")
-            elif name == "Mana Up":
-                quantity = self.get_setting("mana_pool")
-            elif name == "Attack Up":
-                quantity = self.get_setting("attack_pool")
-            elif name == "Magic Damage Up":
-                quantity = self.get_setting("magic_damage_pool")
-            elif name == "Armor Up":
-                quantity = self.get_setting("armor_pool")
-            elif name == "Equip Up":
-                quantity = self.get_setting("equip_pool")
-            elif name == "Crit Chance Up":
-                quantity = self.get_setting("crit_chance_pool")
-            elif name == "Crit Damage Up":
-                quantity = self.get_setting("crit_damage_pool")
-
-            # Ignore filler, it will be added in a later stage.
-            if data.category == "Filler":
-                continue
-
-            item_pool += [self.create_item(name) for _ in range(0, quantity)]
-
-        # Fill any empty locations with filler items.
-        while len(item_pool) < total_locations:
+        # If we didn't generate enough items to fill our locations, generate some filler!
+        while len(item_pool) < location_count:
             item_pool.append(self.create_item(self.get_filler_item_name()))
 
         self.multiworld.itempool += item_pool
 
-    def get_filler_item_name(self) -> str:
-        fillers = get_items_by_category("Filler")
-        weights = [data.weight for data in fillers.values()]
-        return self.multiworld.random.choices([filler for filler in fillers.keys()], weights, k=1)[0]
-
-    def create_item(self, name: str) -> RLItem:
-        data = item_table[name]
-        return RLItem(name, data.classification, data.code, self.player)
-
-    def create_event(self, name: str) -> RLItem:
-        data = event_item_table[name]
-        return RLItem(name, data.classification, data.code, self.player)
-
     def set_rules(self):
-        set_rules(self.multiworld, self.player)
+        self.multiworld.completion_condition[self.player] = lambda state: state.has("Defeat The Fountain", self.player)
 
     def create_regions(self):
-        create_regions(self.multiworld, self.player)
-        self._place_events()
+        # Instantiate Regions
+        for region_name in region_table.keys():
+            self.multiworld.regions.append(Region(region_name, self.player, self.multiworld))
 
-    def _place_events(self):
-        # Fountain
-        self.multiworld.get_location("Fountain Room", self.player).place_locked_item(
-            self.create_event("Defeat The Fountain"))
+        # Create locations.
+        for location_data in location_table.values():
+            # Ignore locations that cannot be created as the appropriate settings are not valid.
+            if not location_data.can_create(self.multiworld, self.player):
+                continue
 
-        # Khidr / Neo Khidr
-        if self.get_setting("khidr") == "vanilla":
-            self.multiworld.get_location("Castle Hamson Boss Room", self.player).place_locked_item(
-                self.create_event("Defeat Khidr"))
-        else:
-            self.multiworld.get_location("Castle Hamson Boss Room", self.player).place_locked_item(
-                self.create_event("Defeat Neo Khidr"))
+            location_data.create_location(self.multiworld, self.player)
 
-        # Alexander / Alexander IV
-        if self.get_setting("alexander") == "vanilla":
-            self.multiworld.get_location("Forest Abkhazia Boss Room", self.player).place_locked_item(
-                self.create_event("Defeat Alexander"))
-        else:
-            self.multiworld.get_location("Forest Abkhazia Boss Room", self.player).place_locked_item(
-                self.create_event("Defeat Alexander IV"))
+        # Connect regions and set access rules.
+        for region_name, region_data in region_table.items():
+            region = self.multiworld.get_region(region_name, self.player)
+            region.add_exits(region_data.exits, {
+                exiting_region: lambda state: region_table[exiting_region].rules(state, self.player)
+                for exiting_region in region_data.exits
+            })
 
-        # Ponce de Leon / Ponce de Freon
-        if self.get_setting("leon") == "vanilla":
-            self.multiworld.get_location("The Maya Boss Room", self.player).place_locked_item(
-                self.create_event("Defeat Ponce de Leon"))
-        else:
-            self.multiworld.get_location("The Maya Boss Room", self.player).place_locked_item(
-                self.create_event("Defeat Ponce de Freon"))
+    # TODO: Replace calls to this function with #933's solution, once that PR is merged.
+    def get_setting(self, name: str):
+        return getattr(self.multiworld, name)[self.player]
 
-        # Herodotus / Astrodotus
-        if self.get_setting("herodotus") == "vanilla":
-            self.multiworld.get_location("Land of Darkness Boss Room", self.player).place_locked_item(
-                self.create_event("Defeat Herodotus"))
-        else:
-            self.multiworld.get_location("Land of Darkness Boss Room", self.player).place_locked_item(
-                self.create_event("Defeat Astrodotus"))
+    def get_filler_item_name(self) -> str:
+        if self.get_setting("include_traps"):
+            filler_names = filler_items["names"] + filler_items["trap_names"]
+            filler_weights = filler_items["weights"] + filler_items["trap_weights"]
+            return self.random.choices(filler_names, filler_weights, k=1)[0]
+
+        return self.random.choices(filler_items["names"], filler_items["weights"], k=1)[0]
+
+    # TODO: Only set required slot data.
+    def fill_slot_data(self) -> dict:
+        return {option_name: self.get_setting(option_name).value for option_name in rl_options}

--- a/worlds/rogue_legacy/__init__.py
+++ b/worlds/rogue_legacy/__init__.py
@@ -44,9 +44,13 @@ class RLWorld(World):
     def generate_early(self):
         # Set starting items.
         self.multiworld.push_precollected(self.create_item("Blacksmith"))
-        # self.multiworld.push_precollected(self.create_item("Enchantress"))
+        self.multiworld.push_precollected(self.create_item("Enchantress"))
         if self.get_setting("architect") == "start_unlocked":
             self.multiworld.push_precollected(self.create_item("Architect"))
+
+    # def generate_basic(self) -> None:
+    #     from Utils import visualize_regions
+    #     visualize_regions(self.multiworld.get_region("Menu", self.player), "rogue_legacy.puml")
 
     def create_item(self, name: str) -> RLItem:
         item_data = item_table[name]

--- a/worlds/rogue_legacy/__init__.py
+++ b/worlds/rogue_legacy/__init__.py
@@ -41,9 +41,6 @@ class RLWorld(World):
     location_name_groups = location_groups
 
     def generate_early(self):
-        # Set starting items.
-        self.multiworld.push_precollected(self.create_item("Blacksmith"))
-        self.multiworld.push_precollected(self.create_item("Enchantress"))
         if self.get_setting("architect") == "start_unlocked":
             self.multiworld.push_precollected(self.create_item("Architect"))
         elif self.get_setting("architect") == "early":

--- a/worlds/rogue_legacy/__init__.py
+++ b/worlds/rogue_legacy/__init__.py
@@ -34,7 +34,6 @@ class RLWorld(World):
     data_version = 5
     required_client_version = (0, 4, 2)
     web = RLWeb()
-    topology_present = True
 
     item_name_to_id = {name: data.code for name, data in item_table.items() if not data.event}
     location_name_to_id = {name: data.address for name, data in location_table.items() if not data.event}
@@ -47,10 +46,8 @@ class RLWorld(World):
         self.multiworld.push_precollected(self.create_item("Enchantress"))
         if self.get_setting("architect") == "start_unlocked":
             self.multiworld.push_precollected(self.create_item("Architect"))
-
-    # def generate_basic(self) -> None:
-    #     from Utils import visualize_regions
-    #     visualize_regions(self.multiworld.get_region("Menu", self.player), "rogue_legacy.puml")
+        elif self.get_setting("architect") == "early":
+            self.multiworld.early_items[self.player] = {"Architect": 1}
 
     def create_item(self, name: str) -> RLItem:
         item_data = item_table[name]
@@ -95,7 +92,7 @@ class RLWorld(World):
             region.add_exits({
                 region_exit.region: f"{region_exit.region} Entrance" for region_exit in region_exits
             }, {
-                region_exit.region: lambda state: region_exit.access_rule(state, self.player)
+                region_exit.region: lambda state, region_exit=region_exit: region_exit.access_rule(state, self.player)
                 for region_exit in region_exits
             })
 

--- a/worlds/rogue_legacy/docs/en_Rogue Legacy.md
+++ b/worlds/rogue_legacy/docs/en_Rogue Legacy.md
@@ -1,34 +1,58 @@
-# Rogue Legacy (PC)
+# Rogue Legacy Randomizer
 
 ## Where is the settings page?
 
-The [player settings page for this game](../player-settings) contains most of the options you need to 
-configure and export a config file. Some settings can only be made in YAML, but an explanation can be found in the
-[template yaml here](../../../static/generated/configs/Rogue%20Legacy.yaml).
+The [player settings page for Rogue Legacy Randomizer](../player-settings) contains most of the options you need to 
+configure and export a config file. You can also visit the [weighted settings page](/weighted-settings) for the 
+remaining advanced options for Rogue Legacy, or download a 
+[template config file here](/static/generated/configs/Rogue%20Legacy.yaml).
 
-## What does randomization do to this game?
+## What does randomization mean for Rogue Legacy?
 
-Rogue Legacy Randomizer takes all the classes, skills, runes, and blueprints and spreads them out into chests, the manor
-upgrade screen, bosses, and some special individual locations. The goal is to become powerful enough to defeat the four
-zone bosses and then defeat The Fountain.
+Rogue Legacy Randomizer takes all the classes, skills, runes, blueprints, and other miscellaneous items and places them
+in random chests, the manor, and other special locations. The goal is to become powerful enough to defeat The Fountain.
 
-## What items and locations get shuffled?
-All the skill upgrades, class upgrades, runes packs, and equipment packs are shuffled in the manor upgrade screen, diary
-checks, chests and fairy chests, and boss rewards. Skill upgrades are also grouped in packs of 5 to make the finding of
-stats less of a chore. Runes and Equipment are also grouped together.
+## What items and locations can I find?
 
-Some additional locations that can contain items are the Jukebox, the Portraits, and the mini-game rewards.
+The following "things" are potential items you could find:
 
-## Which items can be in another player's world?
+* Every class upgrade.
+* Every skill upgrade (in groups of 5).
+* Every blueprint.
+* Every rune.
+* Free shrines that give a specific relic.
+* Various stat-increases and gold.
+* The slots for the Blacksmith and Enchantress (if shuffled).
+* The Architect (if shuffled).
+* Per life spending increases (if enabled).
+* Pieces of the Fountain to unlock the final boss room (if enabled).
+* Various unhelpful traps (if enabled).
 
-Any of the items which can be shuffled may also be placed into another player's world. It is possible to choose to limit
-certain items to your own world.
+You'll potentially find all of these (and other world items) in the following locations:
+
+* The Manor upgrades screen.
+* In chests in each zone (or any chest if **Universal Chests** are enabled).
+* In fairy chests in each zone (or any fairy chest if **Universal Fairy Chests** are enabled).
+* Inside the chests for each boss.
+* Inside the chests for each mini-boss.
+* As a reward from the Carnival mini-game and Cheapskate Elf mini-game.
+* Inside the chests in the secret room.
+* Beside the Jukebox.
+* Underneath the portrait of a previous Cellar Door Games project.
+* By reading one of the 25 diary entries.
+
 ## When the player receives an item, what happens?
 
-When the player receives an item, your character will hold the item above their head and display it to the world. It's
-good for business!
+You'll get an alert on the sidebar showing all the recent items that you have received. You can also pause and option
+your character card to see all items received.
+
+## What are Fountain pieces?
+
+As an alternative objective to beating the 4 main bosses, you can turn Rogue Legacy into a collect-a-thon where you need
+to find enough "fountain pieces" to open the door. You can also combine it with the normal goal if you still want to be
+required to defeat each boss.
 
 ## What do I do if I encounter a bug with the game?
 
-Please reach out to Phar#4444 on Discord or you can drop a bug report on the 
-[GitHub page for Rogue Legacy Randomizer](https://github.com/ThePhar/RogueLegacyRandomizer/issues/new?assignees=&labels=bug&template=report-an-issue---.md&title=%5BIssue%5D).
+Drop a bug report in the Archipelago Discord server and ping ***@thephar*** in the created thread. Be sure to include
+what actions you were taking and your crash log if applicable.

--- a/worlds/rogue_legacy/docs/en_Rogue Legacy.md
+++ b/worlds/rogue_legacy/docs/en_Rogue Legacy.md
@@ -54,5 +54,5 @@ required to defeat each boss.
 
 ## What do I do if I encounter a bug with the game?
 
-Drop a bug report in the Archipelago Discord server and ping ***@thephar*** in the created thread. Be sure to include
+Drop a bug report in the Archipelago Discord server and ping **@thephar** in the created thread. Be sure to include
 what actions you were taking and your crash log if applicable.

--- a/worlds/rogue_legacy/docs/en_Rogue Legacy.md
+++ b/worlds/rogue_legacy/docs/en_Rogue Legacy.md
@@ -52,6 +52,10 @@ As an alternative objective to beating the 4 main bosses, you can turn Rogue Leg
 to find enough "fountain pieces" to open the door. You can also combine it with the normal goal if you still want to be
 required to defeat each boss.
 
+## How do I set this up?
+
+Check out the [setup guides here](/tutorial/#Rogue%20Legacy) for more information.
+
 ## What do I do if I encounter a bug with the game?
 
 Drop a bug report in the Archipelago Discord server and ping **@thephar** in the created thread. Be sure to include

--- a/worlds/rogue_legacy/docs/rogue-legacy_en.md
+++ b/worlds/rogue_legacy/docs/rogue-legacy_en.md
@@ -41,4 +41,4 @@ game.
 ## So... what about `<insert inquiry here>`?
 
 If you have any questions, concerns, ~~or death threats~~, join the [Archipelago Discord](https://discord.gg/8Z65BR2) 
-server and post your comments in the **#rogue-legacy** channel. You can also directly ping ***@thephar*** in Discord. 
+server and post your comments in the **#rogue-legacy** channel. You can also directly ping **@thephar** in Discord. 

--- a/worlds/rogue_legacy/docs/rogue-legacy_en.md
+++ b/worlds/rogue_legacy/docs/rogue-legacy_en.md
@@ -1,35 +1,44 @@
 # Rogue Legacy Randomizer Setup Guide
 
-## Required Software
+## So... what do I need?
+
+To play Rogue Legacy Randomizer, you'll need the following software:
 
 - Rogue Legacy Randomizer from the
-  [Rogue Legacy Randomizer Releases Page](https://github.com/ThePhar/RogueLegacyRandomizer/releases)
+  [Rogue Legacy Randomizer Releases Page](https://github.com/ThePhar/RogueLegacyRandomizer/releases).
 
-## Recommended Installation Instructions
+## So... how do I install this?
 
 Please read the README file on the 
 [Rogue Legacy Randomizer GitHub](https://github.com/ThePhar/RogueLegacyRandomizer/blob/master/README.md) page for 
 up-to-date installation instructions.
 
-## Configuring your YAML file
+## So... what is Rogue Legacy Randomizer?
 
-### What is a YAML file and why do I need one?
+Check out the [Game Info page](/games/Rogue%20Legacy/info/en) for more information about Rogue Legacy Randomizer.
 
-Your YAML file contains a set of configuration options which provide the generator with information about how it should
-generate your game. Each player of a multiworld will provide their own YAML file. This setup allows each player to enjoy
-an experience customized for their taste, and different players in the same multiworld can all have different options.
+## So... how do I create settings?
 
-### Where do I get a YAML file?
+You will need to generate a player config file that provides the generator with the necessary information about how it 
+should generate the game. Each player in the multiworld should provide their own settings file. This setup allows each 
+player to enjoy an experience customized for their taste, and different players in the same multiworld can all have 
+different options.
 
-you can customize your settings by visiting the [Rogue Legacy Settings Page](/games/Rogue%20Legacy/player-settings).
+For additional information on "Archipelago" check out the [Archipelago setup guides](/tutorial/#Archipelago).
 
-### Connect to the MultiServer
+### Where do I get a player settings file?
 
-Once in game, press the start button and the AP connection screen should appear. You will fill out the hostname, port,
-slot name, and password (if applicable). You should only need to fill out hostname, port, and password if the server
-provides an alternative one to the default values.
+You can create your settings files by visiting the [Rogue Legacy Settings Page](/games/Rogue%20Legacy/player-settings).
+From there, you can either create a single player game by clicking "Generate Game" or you can output a settings file for
+multiplayer games by clicking "Export Settings" and providing it to the game host to generate.
 
-### Play the game
+### How do I connect to the Archipelago server?
 
-Once you have entered the required values, you go to Connect and then select Confirm on the "Ready to Start" screen. Now
-you're off to start your legacy!
+Once in-game, press the start button and enter the hostname, port, your slot name, and room password (if applicable).
+Then select "Connect" and confirm on the "Ready to Start" prompt. You should then connect to the server and start the
+game.
+
+## So... what about `<insert inquiry here>`?
+
+If you have any questions, concerns, ~~or death threats~~, join the [Archipelago Discord](https://discord.gg/8Z65BR2) 
+server and post your comments in the **#rogue-legacy** channel. You can also directly ping ***@thephar*** in Discord. 

--- a/worlds/rogue_legacy/test/TestUnique.py
+++ b/worlds/rogue_legacy/test/TestUnique.py
@@ -1,8 +1,8 @@
 from typing import Dict
 
 from . import RLTestBase
-from worlds.rogue_legacy.Items import RLItemData, item_table
-from worlds.rogue_legacy.Locations import RLLocationData, location_table
+from ..Items import item_table
+from ..Locations import location_table
 
 
 class UniqueTest(RLTestBase):
@@ -10,6 +10,10 @@ class UniqueTest(RLTestBase):
     def test_item_ids_are_all_unique():
         item_ids: Dict[int, str] = {}
         for name, data in item_table.items():
+            # Ignore events.
+            if data.event:
+                continue
+
             assert data.code not in item_ids.keys(), f"'{name}': {data.code}, is not unique. " \
                                                      f"'{item_ids[data.code]}' also has this identifier."
             item_ids[data.code] = name
@@ -18,6 +22,10 @@ class UniqueTest(RLTestBase):
     def test_location_ids_are_all_unique():
         location_ids: Dict[int, str] = {}
         for name, data in location_table.items():
-            assert data.code not in location_ids.keys(), f"'{name}': {data.code}, is not unique. " \
-                                                         f"'{location_ids[data.code]}' also has this identifier."
-            location_ids[data.code] = name
+            # Ignore events.
+            if data.event:
+                continue
+
+            assert data.address not in location_ids.keys(), f"'{name}': {data.address}, is not unique. " \
+                                                            f"'{location_ids[data.address]}' also has this identifier."
+            location_ids[data.address] = name


### PR DESCRIPTION
## What is this fixing or adding?
This wraps up the AP-side updates for the Rogue Legacy Randomizer 1.0. Here are the following updates:

* Removes Blacksmith and Enchantress from item pool, replacing them with per-slot unlocks for each vendor.
* Increases minimum chests to 25.
* Sets default fairy chest count to 0.
* Removes additional names options. Can be set on the client instead of on the server.
* Complete re-write of the setup guides and game info documents.
* Adds a new optional objective to opening the Fountain Room door: Fountain Pieces
	* In lieu of or in addition to defeating the normal bosses, players can turn RLR into a collect-a-thon to open the door, similar to Ganon Triforce Hunt mode in ALTTP.
* Adds new locations for each mini-boss and the secret room.
* Adds new relics and shrines players can find to choose to start each new life with a relic instead of relying on luck.
* Removes free check for Cheapskate Elf's game, now logically locked behind "Nerdy Glasses Shrine".
* The Secret Room is logically locked behind "Calypso's Compass Shrine".
* Adds a spending restriction option to prevent players from spending more than a certain amount per life.
	* To increase this limit, there are new items in the pool to find.
* Rename the keys in `available_classes` option.
* Adds new castle size option. Castle can be between vanilla Rogue Legacy sizes up to 12 times larger.
* Adds a new variable children option to have a random amount of children between 1 and 5 each generation.
* Adds an option to force players to purchase skills found in the manor instead of receiving them automatically.
* Renamed "Disable Charon" to "Remove Charon". ~~He's like actually gone now. No more good mood.~~
* Removed NG+ 2. It was a bad idea anyway.
* Scaling manor prices so further manor renovation purchases require more gold to "collect".
* Allow players to start with Dragons or Traitors.
* Adds a bunch of traps that will probably ruin players' days if they enable them.
	* Random Teleport - Teleports the player to a random room in the castle.
	* Hedgehog's Curse - Replaces the player's current relic with Hedgehog's Curse.
	* Vertigo - Gives the player Vertigo.
	* Genetic Lottery - Completely randomizes the player's current gender, class, spell, and relic.
* Adds a new relic that allows players to find the nearest boss room easily.
* Adds some item groups and location groups.
* Other QoL changes on the client to be released soon.

This will most likely mark the final feature version of Rogue Legacy Randomizer until Cellar Door Games releases the source code for Rogue Legacy, as a lot of work will need to be re-done once moving over.

## How was this tested?
It's been locally tested quite a few times during development, but I'm awaiting running a large test in the Archipelago Server before marking this PR for review.

## If this makes graphical changes, please attach screenshots.
N/A