### PR TITLE
Stardew Valley: Fix typo with woods obelisk item

### DIFF
--- a/worlds/stardew_valley/data/items.csv
+++ b/worlds/stardew_valley/data/items.csv
@@ -595,5 +595,5 @@ id,name,classification,groups,mod_name
 10109,Delores <3,progression,FRIENDSANITY,Delores - Custom NPC
 10110,Ayeisha <3,progression,FRIENDSANITY,Ayeisha - The Postal Worker (Custom NPC)
 10111,Riley <3,progression,FRIENDSANITY,Custom NPC - Riley
-10301,Progressive Wood Obelisk Sigils,progression,,DeepWoods
+10301,Progressive Woods Obelisk Sigils,progression,,DeepWoods
 10302,Progressive Skull Cavern Elevator,progression,,Skull Cavern Elevator

--- a/worlds/stardew_valley/items.py
+++ b/worlds/stardew_valley/items.py
@@ -226,7 +226,7 @@ def create_elevators(item_factory: StardewItemFactory, world_options: StardewOpt
 
     items.extend([item_factory(item) for item in ["Progressive Mine Elevator"] * 24])
     if ModNames.deepwoods in world_options[options.Mods]:
-        items.extend([item_factory(item) for item in ["Progressive Wood Obelisk Sigils"] * 10])
+        items.extend([item_factory(item) for item in ["Progressive Woods Obelisk Sigils"] * 10])
     if ModNames.skull_cavern_elevator in world_options[options.Mods]:
         items.extend([item_factory(item) for item in ["Progressive Skull Cavern Elevator"] * 8])
 

--- a/worlds/stardew_valley/mods/logic/deepwoods.py
+++ b/worlds/stardew_valley/mods/logic/deepwoods.py
@@ -26,7 +26,7 @@ def can_reach_woods_depth(vanilla_logic, depth: int) -> StardewRule:
 def has_woods_rune_to_depth(vanilla_logic, floor: int) -> StardewRule:
     if vanilla_logic.options[options.ElevatorProgression] == options.ElevatorProgression.option_vanilla:
         return True_()
-    return vanilla_logic.received("Progressive Wood Obelisk Sigils", count=int(floor / 10))
+    return vanilla_logic.received("Progressive Woods Obelisk Sigils", count=int(floor / 10))
 
 
 def can_chop_to_depth(vanilla_logic, floor: int) -> StardewRule:


### PR DESCRIPTION
## What is this fixing or adding?
This adds the feature of
- Allowing player to actually receive Woods Obelisk floors by naming the item correctly.

## How was this tested?
What I did was stare at the fact that I typed the letter "s" for perhaps five minutes, and then spent twenty minutes remembering for the billionth time how to push a branch to a different remote.

## If this makes graphical changes, please attach screenshots.
No.