### PR TITLE
Fill: fix cleanup-after-swapping performance

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -152,8 +152,8 @@ def fill_restrictive(world: MultiWorld, base_state: CollectionState, locations: 
 
     if cleanup_required:
         # validate all placements and remove invalid ones
+        state = sweep_from_pool(base_state, [])
         for placement in placements:
-            state = sweep_from_pool(base_state, [])
             if world.accessibility[placement.item.player] != "minimal" and not placement.can_reach(state):
                 placement.item.location = None
                 unplaced_items.append(placement.item)


### PR DESCRIPTION
#1800 introduced a cleanup pass to "eject" unreachable items to hopefully get better error reporting of what could not be placed. The code to do so has an unnecessary amount of sweeps from pool.