### PR TITLE
WebHost: Adjustments to player-settings.css for better UI on small view-port widths.

### DIFF
--- a/WebHostLib/static/styles/player-settings.css
+++ b/WebHostLib/static/styles/player-settings.css
@@ -5,7 +5,8 @@ html{
 }
 
 #player-settings{
-    max-width: 1000px;
+    box-sizing: border-box;
+    max-width: 1024px;
     margin-left: auto;
     margin-right: auto;
     background-color: rgba(0, 0, 0, 0.15);
@@ -163,6 +164,11 @@ html{
     background-color: #ffef00; /* Same as .interactive in globalStyles.css */
 }
 
+#player-settings table .randomize-button[data-tooltip]::after {
+    left: unset;
+    right: 0;
+}
+
 #player-settings table label{
     display: block;
     min-width: 200px;
@@ -177,18 +183,31 @@ html{
     vertical-align: top;
 }
 
-@media all and (max-width: 1000px), all and (orientation: portrait){
+@media all and (max-width: 1024px) {
+    #player-settings {
+        border-radius: 0;
+    }
+
     #player-settings #game-options{
         justify-content: flex-start;
         flex-wrap: wrap;
     }
 
-    #player-settings .left, #player-settings .right{
-        flex-grow: unset;
+    #player-settings .left,
+    #player-settings .right {
+        margin: 0;
+    }
+
+    #game-options table {
+        margin-bottom: 0;
     }
 
     #game-options table label{
         display: block;
         min-width: 200px;
+    }
+
+    #game-options table tr td {
+        width: 50%;
     }
 }


### PR DESCRIPTION
## What is this fixing or adding?
Fixes a layout bug when displaying player settings if view-port width is too small which causes settings to become misaligned and waste a lot of screen real-estate to the right.

Also removes portrait orientation media rule as it forces the aforementioned "small view-port width" display mode, which is (to me at least) annoying on larger displays that have long portrait windows if my width was still large enough to render the normal display anyway.

## How was this tested?
Checked output on Firefox and Chrome for PC and Safari on iOS to verify changes against [archipelago.gg](https://archipelago.gg). 

Was not able to verify on Android mobile browsers. ~~Think I can afford two phones? I can barely afford the one!~~

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/11338376/5e66610b-bd14-4b70-bea2-32a5a2c3e808)
![image](https://github.com/ArchipelagoMW/Archipelago/assets/11338376/157ae412-65d3-42ae-805d-982fe26aadfa)
![image](https://github.com/ArchipelagoMW/Archipelago/assets/11338376/8d30cc93-5ef7-4398-b421-ae7a7a02befe)
