### PR TITLE
CI: remove cython3 beta testing

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -43,8 +43,6 @@ jobs:
             os: windows-latest
           - python: {version: '3.10'}  # current
             os: macos-latest
-          - python: {version: '3.10'}  # current
-            os: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -26,14 +26,12 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    name: Test Python ${{ matrix.python.version }} ${{ matrix.os }} ${{ matrix.cython }}
+    name: Test Python ${{ matrix.python.version }} ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        cython:
-          - ''  # default
         python:
           - {version: '3.8'}
           - {version: '3.9'}
@@ -47,7 +45,6 @@ jobs:
             os: macos-latest
           - python: {version: '3.10'}  # current
             os: ubuntu-latest
-            cython: beta
 
     steps:
     - uses: actions/checkout@v3
@@ -55,11 +52,6 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python.version }}
-    - name: Install cython beta
-      if: ${{ matrix.cython == 'beta' }}
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install --pre --upgrade cython
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Cython 3.0.0 was released: https://cython.readthedocs.io/en/latest/src/changes.html

If we want to keep it for when Cython makes a pre-release of 3.1, just close the PR.