### PR TITLE
Fixing shallow copy during item reclassification.

### DIFF
--- a/worlds/witness/items.py
+++ b/worlds/witness/items.py
@@ -99,7 +99,7 @@ class WitnessPlayerItems:
         self._locations: WitnessPlayerLocations = locat
 
         # Duplicate the static item data, then make any player-specific adjustments to classification.
-        self.item_data: Dict[str, ItemData] = copy.copy(StaticWitnessItems.item_data)
+        self.item_data: Dict[str, ItemData] = copy.deepcopy(StaticWitnessItems.item_data)
 
         # Remove all progression items that aren't actually in the game.
         self.item_data = {name: data for (name, data) in self.item_data.items()


### PR DESCRIPTION
This fixes an error where item reclassification due to player-specific settings was being applied not to a copy of the item data, but the original data itself, causing strange behavior in multiworlds with different settings.