### PR TITLE
MultiServer: fix unclosed parenthesis in connection message

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -795,7 +795,7 @@ async def on_client_joined(ctx: Context, client: Client):
     ctx.broadcast_text_all(
         f"{ctx.get_aliased_name(client.team, client.slot)} (Team #{client.team + 1}) "
         f"{verb} {ctx.games[client.slot]} has joined. "
-        f"Client({version_str}), {client.tags}).",
+        f"Client({version_str}), {client.tags}.",
         {"type": "Join", "team": client.team, "slot": client.slot, "tags": client.tags})
     ctx.notify_client(client, "Now that you are connected, "
                               "you can use !help to list commands to run via the server. "


### PR DESCRIPTION
## What is this fixing or adding?
Removes an unclosed parenthesis within the MultiServer connection message.

## How was this tested?
Hosted using MultiServer.py and then joined with a TextClient, confirmed that the resulting message did not contain the additional parenthesis.

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/58583688/87575a9e-7c53-422b-9f3c-ed2f0fabb8c1)
