### PR TITLE
Core: Add dict functionality to OptionDict

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -771,7 +771,7 @@ class VerifyKeys(metaclass=FreezeValidKeys):
                                     f"Did you mean '{picks[0][0]}' ({picks[0][1]}% sure)")
 
 
-class OptionDict(Option[typing.Dict[str, typing.Any]], VerifyKeys):
+class OptionDict(Option[typing.Dict[str, typing.Any]], VerifyKeys, typing.Mapping[str, typing.Any]):
     default: typing.Dict[str, typing.Any] = {}
     supports_weighting = False
 
@@ -788,15 +788,15 @@ class OptionDict(Option[typing.Dict[str, typing.Any]], VerifyKeys):
 
     def get_option_name(self, value):
         return ", ".join(f"{key}: {v}" for key, v in value.items())
-    
-    def items(self):
-        return self.value.items()
-    
-    def __getitem__(self, item):
-        return self.value[item]
 
-    def __contains__(self, item):
-        return item in self.value
+    def __getitem__(self, item: str):
+        return self.value.__getitem__(item)
+
+    def __iter__(self) -> typing.Iterator[str]:
+        return self.value.__iter__()
+
+    def __len__(self) -> int:
+        return self.value.__len__()
 
 
 class ItemDict(OptionDict):

--- a/Options.py
+++ b/Options.py
@@ -788,6 +788,12 @@ class OptionDict(Option[typing.Dict[str, typing.Any]], VerifyKeys):
 
     def get_option_name(self, value):
         return ", ".join(f"{key}: {v}" for key, v in value.items())
+    
+    def items(self):
+        return self.value.items()
+    
+    def __getitem__(self, item):
+        return self.value[item]
 
     def __contains__(self, item):
         return item in self.value

--- a/Options.py
+++ b/Options.py
@@ -789,7 +789,7 @@ class OptionDict(Option[typing.Dict[str, typing.Any]], VerifyKeys, typing.Mappin
     def get_option_name(self, value):
         return ", ".join(f"{key}: {v}" for key, v in value.items())
 
-    def __getitem__(self, item: str):
+    def __getitem__(self, item: str) -> typing.Any:
         return self.value.__getitem__(item)
 
     def __iter__(self) -> typing.Iterator[str]:


### PR DESCRIPTION
## What is this fixing or adding?
Title. It seemed weird to me that these aren't really supported by the "OptionDict". I think if you make something that isn't actually a dict, you probably know to override or not use these.

## How was this tested?
Put it in The Messenger and generated a few seeds/debugged.

## If this makes graphical changes, please attach screenshots.
