### PR TITLE
Stardew valley: Supported Mods documentation and changes required for legal reasons

### DIFF
--- a/worlds/stardew_valley/__init__.py
+++ b/worlds/stardew_valley/__init__.py
@@ -12,7 +12,6 @@ from .options import stardew_valley_options, StardewOptions, fetch_options
 from .regions import create_regions
 from .rules import set_rules
 from worlds.generic.Rules import set_rule
-from .mods.mod_data import mod_versions
 from .strings.goal_names import Goal
 
 client_version = 0
@@ -276,13 +275,8 @@ class StardewValleyWorld(World):
             key, value = self.modified_bundles[bundle_key].to_pair()
             modified_bundles[key] = value
 
-        instance_mod_versions = {}
-        for mod in mod_versions:
-            if mod in self.options[options.Mods]:
-                instance_mod_versions[mod] = mod_versions[mod]
-
         excluded_options = [options.BundleRandomization, options.BundlePrice,
-                            options.NumberOfMovementBuffs, options.NumberOfLuckBuffs, options.Mods]
+                            options.NumberOfMovementBuffs, options.NumberOfLuckBuffs]
         slot_data = dict(self.options.options)
         for option in excluded_options:
             slot_data.pop(option.internal_name)
@@ -291,7 +285,6 @@ class StardewValleyWorld(World):
             "randomized_entrances": self.randomized_entrances,
             "modified_bundles": modified_bundles,
             "client_version": "4.0.0",
-            "mod_versions": instance_mod_versions,
         })
 
         return slot_data

--- a/worlds/stardew_valley/__init__.py
+++ b/worlds/stardew_valley/__init__.py
@@ -33,14 +33,15 @@ class StardewWebWorld(WebWorld):
     theme = "dirt"
     bug_report_page = "https://github.com/agilbert1412/StardewArchipelago/issues/new?labels=bug&title=%5BBug%5D%3A+Brief+Description+of+bug+here"
 
-    tutorials = [Tutorial(
-        "Multiworld Setup Guide",
-        "A guide to playing Stardew Valley with Archipelago.",
-        "English",
-        "setup_en.md",
-        "setup/en",
-        ["KaitoKid", "Jouramie", "Witchybun (Mod Support)", "Exempt-Medic (Proofreading)"]
-    )]
+    tutorials = [
+        Tutorial(
+            "Multiworld Setup Guide",
+            "A guide to playing Stardew Valley with Archipelago.",
+            "English",
+            "setup_en.md",
+            "setup/en",
+            ["KaitoKid", "Jouramie", "Witchybun (Mod Support)", "Exempt-Medic (Proofreading)"]
+        )]
 
 
 class StardewValleyWorld(World):

--- a/worlds/stardew_valley/docs/en_Stardew Valley.md
+++ b/worlds/stardew_valley/docs/en_Stardew Valley.md
@@ -93,8 +93,15 @@ Starting in version 4.x.x, some Stardew Valley mods unrelated to Archipelago are
 This means that, for these specific mods, if you decide to include them in your yaml settings, the multiworld will be generated with the assumption that you will install and play with these mods.
 The multiworld will contain related items and locations for these mods, the specifics will vary from mod to mod
 
+[Supported Mods Documentation](https://github.com/agilbert1412/StardewArchipelago/blob/4.x.x/Documentation/Supported%20Mods.md)
+
 List of supported mods:
 
+- General
+  - [DeepWoods](https://www.nexusmods.com/stardewvalley/mods/2571)
+  - [Tractor Mod](https://www.nexusmods.com/stardewvalley/mods/1401)
+  - [Bigger Backpack](https://www.nexusmods.com/stardewvalley/mods/1845)
+  - [Skull Cavern Elevator](https://www.nexusmods.com/stardewvalley/mods/963)
 - Skills
   - [Luck Skill](https://www.nexusmods.com/stardewvalley/mods/521)
   - [Magic](https://www.nexusmods.com/stardewvalley/mods/2007)
@@ -114,11 +121,6 @@ List of supported mods:
   - [Shiko - New Custom NPC](https://www.nexusmods.com/stardewvalley/mods/3732)
   - [Delores - Custom NPC](https://www.nexusmods.com/stardewvalley/mods/5510)
   - [Custom NPC - Riley](https://www.nexusmods.com/stardewvalley/mods/5811)
-- Other
-  - [DeepWoods](https://www.nexusmods.com/stardewvalley/mods/2571)
-  - [Tractor Mod](https://www.nexusmods.com/stardewvalley/mods/1401)
-  - [Bigger Backpack](https://www.nexusmods.com/stardewvalley/mods/1845)
-  - [Skull Cavern Elevator](https://www.nexusmods.com/stardewvalley/mods/963)
 
 ## Multiplayer
 

--- a/worlds/stardew_valley/docs/setup_en.md
+++ b/worlds/stardew_valley/docs/setup_en.md
@@ -11,7 +11,7 @@
 - Archipelago from the [Archipelago Releases Page](https://github.com/ArchipelagoMW/Archipelago/releases)
     - (Only for the TextClient)
 - Other Stardew Valley Mods [Nexus Mods](https://www.nexusmods.com/stardewvalley)
-    - There are supported mods (see related section in this page), that you can add to your yaml and include them in the archipelago randomization
+    - There are [supported mods](https://github.com/agilbert1412/StardewArchipelago/blob/4.x.x/Documentation/Supported%20Mods.md), that you can add to your yaml and include them in the archipelago randomization
     - It is **not** recommended to further mod Stardew Valley with unsupported mods, although it is possible to do so. Mod interactions can be unpredictable, and no support will be offered for related bugs.
     - The more unsupported mods you have, and the bigger they are, the more likely things are to break.
 
@@ -79,44 +79,7 @@ For a better chat experience, you can also use the official Archipelago Text Cli
 
 ### Playing with supported mods
 
-To include supported mods in your multiworld slot, you need to include a section in your yaml settings called "mods".
-This section must be an array with the **exact** names of every mod you wish to include. Any improperly typed mod name will be ignored.
-![image](https://i.imgur.com/uOHtXmU.png)
-
-These mods will then be included in the multiworld generation, and considered in logic. For example, the Magic mod includes a spell that allow a player to teleport, and, if included, teleporting can be required to reach checks.
-
-Furthermore, as mod development can be unpredictable, the generator and the StardewArchipelago client are designed and tested for a very specific version of any supported mod. When installing them, you must choose the correct version, or you will not be able to play.
-The StardewArchipelago mod will inform you if some of your supported mods have the wrong version, and tell you what version you need.
-
-Some supported mods have config files that can be customized, but sometimes, some settings are mandatory for compatibility with Archipelago. When that is the case, StardewArchipelago will override these settings.
-
-Most mosts also have dependencies to some library/utility mods. You will need to install these as well, but dependency versions are less strict.
-
-If you can load the supported mod on the correct version, the exact version of a dependency is not important.
-
-#### All supported mod exact names and required versions:
-  - "DeepWoods"
-  - "Tractor Mod"
-  - "Bigger Backpack"
-  - "Skull Cavern Elevator"
-  - "Luck Skill"
-  - "Magic"
-  - "Socializing Skill"
-  - "Archaeology"
-  - "Cooking Skill"
-  - "Binning Skill"
-  - "Ayeisha - The Postal Worker (Custom NPC)"
-  - "Mister Ginger (cat npc)"
-  - "Juna - Roommate NPC"
-  - "Professor Jasper Thomas"
-  - "Alec Revisited"
-  - "Custom NPC - Yoba"
-  - "Custom NPC Eugene"
-  - "'Prophet' Wellwick"
-  - "Shiko - New Custom NPC"
-  - "Delores - Custom NPC"
-  - "Custom NPC - Riley"
-
+See the [Supported mods documentation](https://github.com/agilbert1412/StardewArchipelago/blob/4.x.x/Documentation/Supported%20Mods.md)
 
 ### Multiplayer
 

--- a/worlds/stardew_valley/docs/setup_en.md
+++ b/worlds/stardew_valley/docs/setup_en.md
@@ -11,8 +11,8 @@
 - Archipelago from the [Archipelago Releases Page](https://github.com/ArchipelagoMW/Archipelago/releases)
     - (Only for the TextClient)
 - Other Stardew Valley Mods [Nexus Mods](https://www.nexusmods.com/stardewvalley)
-    - For Supported mods (see related section in this page), it is recommend to install them from the mods archive available with the StardewArchipelago mod release
-    - It is **not** recommended to further mod Stardew Valley with unsupported mods, altough it is possible to do so. Mod interactions can be unpredictable, and no support will be offered for related bugs.
+    - There are supported mods (see related section in this page), that you can add to your yaml and include them in the archipelago randomization
+    - It is **not** recommended to further mod Stardew Valley with unsupported mods, although it is possible to do so. Mod interactions can be unpredictable, and no support will be offered for related bugs.
     - The more unsupported mods you have, and the bigger they are, the more likely things are to break.
 
 ## Configuring your YAML file
@@ -86,35 +86,36 @@ This section must be an array with the **exact** names of every mod you wish to 
 These mods will then be included in the multiworld generation, and considered in logic. For example, the Magic mod includes a spell that allow a player to teleport, and, if included, teleporting can be required to reach checks.
 
 Furthermore, as mod development can be unpredictable, the generator and the StardewArchipelago client are designed and tested for a very specific version of any supported mod. When installing them, you must choose the correct version, or you will not be able to play.
+The StardewArchipelago mod will inform you if some of your supported mods have the wrong version, and tell you what version you need.
 
-A Zip archive of **every supported mod** is included in the [StardewArchipelago Mod Releases](https://github.com/agilbert1412/StardewArchipelago/releases) alongside the main mod, which should all have the correct versions available. The archive also contains recommended configs for customizable mods.
+Some supported mods have config files that can be customized, but sometimes, some settings are mandatory for compatibility with Archipelago. When that is the case, StardewArchipelago will override these settings.
 
-The archive also contains every dependency for these mods, but dependency versions are less strict.
+Most mosts also have dependencies to some library/utility mods. You will need to install these as well, but dependency versions are less strict.
 
 If you can load the supported mod on the correct version, the exact version of a dependency is not important.
 
 #### All supported mod exact names and required versions:
-  - "DeepWoods" -> 3.0.0-beta
-  - "Tractor Mod" -> 4.16.4
-  - "Bigger Backpack" -> 6.0.0
-  - "Skull Cavern Elevator" -> 1.5.0
-  - "Luck Skill" -> 1.2.4
-  - "Magic" -> 0.8.2
-  - "Socializing Skill" -> 1.1.5
-  - "Archaeology" -> 1.5.0
-  - "Cooking Skill" -> 1.4.5
-  - "Binning Skill" -> 1.2.7
-  - "Ayeisha - The Postal Worker (Custom NPC)" -> 0.5.0-alpha
-  - "Mister Ginger (cat npc)" -> 1.5.9
-  - "Juna - Roommate NPC" -> 2.1.3
-  - "Professor Jasper Thomas" -> 1.7.6
-  - "Alec Revisited" -> 2.1.0
-  - "Custom NPC - Yoba" -> 1.0.0
-  - "Custom NPC Eugene" -> 1.3.1
-  - "'Prophet' Wellwick" -> 1.0.0
-  - "Shiko - New Custom NPC" -> 1.1.0
-  - "Delores - Custom NPC" -> 1.1.2
-  - "Custom NPC - Riley" -> 1.2.2
+  - "DeepWoods"
+  - "Tractor Mod"
+  - "Bigger Backpack"
+  - "Skull Cavern Elevator"
+  - "Luck Skill"
+  - "Magic"
+  - "Socializing Skill"
+  - "Archaeology"
+  - "Cooking Skill"
+  - "Binning Skill"
+  - "Ayeisha - The Postal Worker (Custom NPC)"
+  - "Mister Ginger (cat npc)"
+  - "Juna - Roommate NPC"
+  - "Professor Jasper Thomas"
+  - "Alec Revisited"
+  - "Custom NPC - Yoba"
+  - "Custom NPC Eugene"
+  - "'Prophet' Wellwick"
+  - "Shiko - New Custom NPC"
+  - "Delores - Custom NPC"
+  - "Custom NPC - Riley"
 
 
 ### Multiplayer

--- a/worlds/stardew_valley/docs/setup_en.md
+++ b/worlds/stardew_valley/docs/setup_en.md
@@ -11,7 +11,8 @@
 - Archipelago from the [Archipelago Releases Page](https://github.com/ArchipelagoMW/Archipelago/releases)
     - (Only for the TextClient)
 - Other Stardew Valley Mods [Nexus Mods](https://www.nexusmods.com/stardewvalley)
-    - There are [supported mods](https://github.com/agilbert1412/StardewArchipelago/blob/4.x.x/Documentation/Supported%20Mods.md), that you can add to your yaml and include them in the archipelago randomization
+    - There are [supported mods](https://github.com/agilbert1412/StardewArchipelago/blob/4.x.x/Documentation/Supported%20Mods.md) that you can add to your yaml to include them with the Archipelago randomization
+
     - It is **not** recommended to further mod Stardew Valley with unsupported mods, although it is possible to do so. Mod interactions can be unpredictable, and no support will be offered for related bugs.
     - The more unsupported mods you have, and the bigger they are, the more likely things are to break.
 

--- a/worlds/stardew_valley/mods/mod_data.py
+++ b/worlds/stardew_valley/mods/mod_data.py
@@ -21,28 +21,3 @@ class ModNames:
     ayeisha = "Ayeisha - The Postal Worker (Custom NPC)"
     riley = "Custom NPC - Riley"
     skull_cavern_elevator = "Skull Cavern Elevator"
-
-
-mod_versions = {
-    ModNames.deepwoods: "3.0.0-beta",
-    ModNames.tractor: "4.16.4",
-    ModNames.big_backpack: "6.0.0",
-    ModNames.luck_skill: "1.2.4",
-    ModNames.magic: "0.8.2",
-    ModNames.socializing_skill: "1.1.5",
-    ModNames.archaeology: "1.5.0",
-    ModNames.cooking_skill: "1.4.5",
-    ModNames.binning_skill: "1.2.7",
-    ModNames.juna: "2.1.3",
-    ModNames.jasper: "1.7.6",
-    ModNames.alec: "2.1.0",
-    ModNames.yoba: "1.0.0",
-    ModNames.eugene: "1.3.1",
-    ModNames.wellwick: "1.0.0",
-    ModNames.ginger: "1.5.9",
-    ModNames.shiko: "1.1.0",
-    ModNames.delores: "1.1.2",
-    ModNames.ayeisha: "0.5.0-alpha",
-    ModNames.riley: "1.2.2",
-    ModNames.skull_cavern_elevator: "1.5.0",
-}


### PR DESCRIPTION
## What is this fixing or adding?
It was pointed out that distributing an archive with copies of all the supported mods could lead to legal problems down the line. So we are moving away from this approach.
This also means that, in the event that a mod gets updated and the previous version is no longer available, we need the ability to update the mod's supported version at any point in time, and cannot rely on AP's release schedule for such updates that will, in most cases, be only changing the string for the required version.

Changes:
- Scrub all references to the support mods zip file from documentation
- Create dedicated "Supported Mods" documentation page, external to AP so we can keep it updated with mod versions regardless of their release schedule
- Remove mod version validation from the AP backend, and manage that in the mod itself, for the same reason.

## How was this tested?
Generated, connected, and played a bit on worlds with mods on this new version
