### PR TITLE
Core: Set locality rules after `set_rules` stage.

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -141,13 +141,14 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
         for location_name in world.priority_locations[player].value:
             world.get_location(location_name, player).progress_type = LocationProgressType.PRIORITY
 
-    AutoWorld.call_all(world, "generate_basic")
-
+    # Set local and non-local item rules.
     if world.players > 1:
         locality_rules(world)
     else:
         world.non_local_items[1].value = set()
         world.local_items[1].value = set()
+    
+    AutoWorld.call_all(world, "generate_basic")
 
     # remove starting inventory from pool items.
     # Because some worlds don't actually create items during create_items this has to be as late as possible.

--- a/Main.py
+++ b/Main.py
@@ -133,12 +133,6 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
         world.non_local_items[player].value -= world.local_items[player].value
         world.non_local_items[player].value -= set(world.local_early_items[player])
 
-    if world.players > 1:
-        locality_rules(world)
-    else:
-        world.non_local_items[1].value = set()
-        world.local_items[1].value = set()
-
     AutoWorld.call_all(world, "set_rules")
 
     for player in world.player_ids:
@@ -148,6 +142,12 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
             world.get_location(location_name, player).progress_type = LocationProgressType.PRIORITY
 
     AutoWorld.call_all(world, "generate_basic")
+
+    if world.players > 1:
+        locality_rules(world)
+    else:
+        world.non_local_items[1].value = set()
+        world.local_items[1].value = set()
 
     # remove starting inventory from pool items.
     # Because some worlds don't actually create items during create_items this has to be as late as possible.


### PR DESCRIPTION
## What is this fixing or adding?
If games reassign `Location.item_rule`s in `set_rules` ~~or `generate_basic`~~, then `local` and `non_local` item rules will be "overwritten". 

For example, Clique sets an item_rule in `set_rules` (made sense to me), but another player set an item as "local_only". In the seed generated, it may still ended up on the Clique location.

Since there's doesn't appear to be consensus that `item_rule`s should not be set after `create_items`, this should prevent weird behavior if that were to occur up until `item plando` and `fill` stages, where I argue this chance should be less likely.

Since

## How was this tested?
Ran unit tests and seed with known placement error, and misplacement disappeared.

## If this makes graphical changes, please attach screenshots.
Spoiler:
![image](https://github.com/ArchipelagoMW/Archipelago/assets/11338376/e686312a-7cd4-435e-9a84-15865050bb63)
![image](https://github.com/ArchipelagoMW/Archipelago/assets/11338376/e20eb3c0-58bc-49d6-ad9f-fa919dd96caf)

Before fix w/ same seed:
![image](https://github.com/ArchipelagoMW/Archipelago/assets/11338376/1a3be644-bb46-4d5e-9b2b-cff6cf7c435c)

After fix w/ same seed:
![image](https://github.com/ArchipelagoMW/Archipelago/assets/11338376/e40ad8c6-f6da-49e1-a025-3ea6e01fd599)
