### PR TITLE
TLoZ: Setup doc update

### DIFF
--- a/worlds/tloz/docs/multiworld_en.md
+++ b/worlds/tloz/docs/multiworld_en.md
@@ -23,6 +23,11 @@
         2. Check the box next to **Always use this app to open .nes files**.
         3. Scroll to the bottom of the list and click the grey text **Look for another App on this PC**.
         4. Browse for `EmuHawk.exe` located inside your BizHawk folder (from step 1) and click **Open**.
+3. (EmuHawk version ≤ 2.8) Go to Config > Customize. Switch to the Advanced tab, then switch the Lua Core from "NLua+KopiLua" to
+  "Lua+LuaInterface". Then restart EmuHawk. This is required for the Lua script to function correctly.
+  **NOTE: Even if "Lua+LuaInterface" is already selected, toggle between the two options and reselect it. Fresh installs** 
+  **of newer versions of EmuHawk have a tendency to show "Lua+LuaInterface" as the default selected option but still load** 
+  **"NLua+KopiLua" until this step is done.**
 
 ## Create a Config (.yaml) File
 
@@ -78,10 +83,10 @@ Once the Archipelago server has been hosted:
 
 1. Open EmuHawk 2.3.1 or higher and load your ROM OR click your ROM file if it is already associated with the
    extension `*.nes`.
-2. Navigate to where you installed Archipelago, then to `data/lua`, and drag+drop the `connector_ff1.lua` script onto
+2. Navigate to where you installed Archipelago, then to `data/lua`, and drag+drop the `connector_tloz.lua` script onto
    the main EmuHawk window.
     1. You could instead open the Lua Console manually, click `Script` 〉 `Open Script`, and navigate to
-       `connector_ff1.lua` with the file picker.
+       `connector_tloz.lua` with the file picker.
     2. If it gives a `NLua.Exceptions.LuaScriptException: .\socket.lua:13: module 'socket.core' not found:` exception
        close your emulator entirely, restart it and re-run these steps.
     3. If it says `Must use a version of BizHawk 2.3.1 or higher`, double-check your BizHawk version by clicking **

--- a/worlds/tloz/docs/multiworld_en.md
+++ b/worlds/tloz/docs/multiworld_en.md
@@ -4,7 +4,7 @@
 
 - The Zelda1Client
     - Bundled with Archipelago: [Archipelago Releases Page](https://github.com/ArchipelagoMW/Archipelago/releases)
-- The BizHawk emulator. Versions 2.3.1 and higher are supported. Version 2.7 is recommended
+- The BizHawk emulator. Versions 2.3.1 and higher are supported.
     - [BizHawk at TASVideos](https://tasvideos.org/BizHawk)
 
 ## Optional Software


### PR DESCRIPTION
## What is this fixing or adding?
- add section about configuring lua core (shamelessly taken from the OoT setup guide) on bizhawk version 2.8 and below
- fix wrong reference to the ff1 connector lua to correctly reference the tloz connector lua
- remove reference to recommended bizhawk version. it's unnecessary

## How was this tested?
ran the webhost to verify changes

## If this makes graphical changes, please attach screenshots.
