### PR TITLE
Minecraft: avoid duplicate prefix in output file name

### DIFF
--- a/worlds/minecraft/__init__.py
+++ b/worlds/minecraft/__init__.py
@@ -173,7 +173,7 @@ class MinecraftWorld(World):
 
     def generate_output(self, output_directory: str) -> None:
         data = self._get_mc_data()
-        filename = f"AP_{self.multiworld.get_out_file_name_base(self.player)}.apmc"
+        filename = f"{self.multiworld.get_out_file_name_base(self.player)}.apmc"
         with open(os.path.join(output_directory, filename), 'wb') as f:
             f.write(b64encode(bytes(json.dumps(data), 'utf-8')))
 


### PR DESCRIPTION
## What is this fixing or adding?

Minecraft's \*.apmc files came with an additional prefix, resulting in the name "AP_AP_\<seedname\>_\<player\>.apmc", unlike most other game patches.

![AP_AP_before](https://github.com/ArchipelagoMW/Archipelago/assets/109771707/07ade7aa-55d6-44d3-9382-026587ba9de2)


## How was this tested?

Generated a game and looked at the generated patch file.

## If this makes graphical changes, please attach screenshots.

![AP_after](https://github.com/ArchipelagoMW/Archipelago/assets/109771707/2cb3e6f1-c831-473c-a8fd-59d11717e843)
