### PR TITLE
MultiServer: fix wrong missing for empty state w/o speedups and add/fix tests

### DIFF
--- a/NetUtils.py
+++ b/NetUtils.py
@@ -390,7 +390,7 @@ class _LocationStore(dict, typing.MutableMapping[int, typing.Dict[int, typing.Tu
         checked = state[team, slot]
         if not checked:
             # This optimizes the case where everyone connects to a fresh game at the same time.
-            return list(self)
+            return list(self[slot])
         return [location_id for
                 location_id in self[slot] if
                 location_id not in checked]

--- a/test/netutils/TestLocationStore.py
+++ b/test/netutils/TestLocationStore.py
@@ -115,6 +115,11 @@ class Base:
             self.assertEqual(self.store.get_remaining(empty_state, 0, 1), [13, 21, 22])
             self.assertEqual(self.store.get_remaining(empty_state, 0, 3), [99])
 
+        def test_location_set_intersection(self) -> None:
+            locations = {10, 11, 12}
+            locations.intersection_update(self.store[1])
+            self.assertEqual(locations, {11, 12})
+
     class TestLocationStoreConstructor(unittest.TestCase):
         """Test constructors for a given store type."""
         type: type

--- a/test/netutils/TestLocationStore.py
+++ b/test/netutils/TestLocationStore.py
@@ -97,19 +97,19 @@ class Base:
             self.assertEqual(self.store.get_for_player(3), {4: {9}})
             self.assertEqual(self.store.get_for_player(1), {1: {13}, 2: {22, 23}})
 
-        def get_checked(self) -> None:
+        def test_get_checked(self) -> None:
             self.assertEqual(self.store.get_checked(full_state, 0, 1), [11, 12, 13])
             self.assertEqual(self.store.get_checked(one_state, 0, 1), [12])
             self.assertEqual(self.store.get_checked(empty_state, 0, 1), [])
             self.assertEqual(self.store.get_checked(full_state, 0, 3), [9])
 
-        def get_missing(self) -> None:
+        def test_get_missing(self) -> None:
             self.assertEqual(self.store.get_missing(full_state, 0, 1), [])
             self.assertEqual(self.store.get_missing(one_state, 0, 1), [11, 13])
             self.assertEqual(self.store.get_missing(empty_state, 0, 1), [11, 12, 13])
             self.assertEqual(self.store.get_missing(empty_state, 0, 3), [9])
 
-        def get_remaining(self) -> None:
+        def test_get_remaining(self) -> None:
             self.assertEqual(self.store.get_remaining(full_state, 0, 1), [])
             self.assertEqual(self.store.get_remaining(one_state, 0, 1), [13, 21])
             self.assertEqual(self.store.get_remaining(empty_state, 0, 1), [13, 21, 22])


### PR DESCRIPTION
## What is this fixing or adding?

* The pure python implementation had a bug in get_missing for empty state optimization, which is an optimization for the case where everyone is connecting to a fresh game for the first time. This was missed because 3 of the tests got disabled during a refactor.
* Re-enable the 3 tests
* New test to verify set intersection behave correctly.

## How was this tested?

By running the tests
