### PR TITLE
Settings: change/fix tests behavior

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,3 +1,7 @@
 import warnings
-warnings.simplefilter("always")
 
+import settings
+
+warnings.simplefilter("always")
+settings.no_gui = True
+settings.skip_autosave = True

--- a/test/general/TestHostYAML.py
+++ b/test/general/TestHostYAML.py
@@ -1,22 +1,27 @@
+import os
 import unittest
+from tempfile import TemporaryFile
 
+from settings import Settings
 import Utils
 
 
 class TestIDs(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
-        with open(Utils.local_path("host.yaml")) as f:
+        with TemporaryFile("w+", encoding="utf-8") as f:
+            Settings(None).dump(f)
+            f.seek(0, os.SEEK_SET)
             cls.yaml_options = Utils.parse_yaml(f.read())
 
-    def testUtilsHasHost(self):
+    def test_utils_in_yaml(self) -> None:
         for option_key, option_set in Utils.get_default_options().items():
             with self.subTest(option_key):
                 self.assertIn(option_key, self.yaml_options)
                 for sub_option_key in option_set:
                     self.assertIn(sub_option_key, self.yaml_options[option_key])
 
-    def testHostHasUtils(self):
+    def test_yaml_in_utils(self) -> None:
         utils_options = Utils.get_default_options()
         for option_key, option_set in self.yaml_options.items():
             with self.subTest(option_key):


### PR DESCRIPTION
## What is this fixing or adding?

* avoid saving and gui stuff when running tests
* change TestHostYAML to use a fresh yaml rather than the local/user copy
  * host.yaml is .gitignored, so it makes no sense to validate it
  * the test changed from "validate consistency" (between host.yaml and defaults) to "validate output" (of settings)

## How was this tested?

By running the tests