### PR TITLE
core: remove the correct item from the item_pool in fill_restrictive

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -51,7 +51,10 @@ def fill_restrictive(world: MultiWorld, base_state: CollectionState, locations: 
         items_to_place = [items.pop()
                           for items in reachable_items.values() if items]
         for item in items_to_place:
-            item_pool.remove(item)
+            for p, pool_item in enumerate(item_pool):
+                if pool_item is item:
+                    item_pool.pop(p)
+                    break
         maximum_exploration_state = sweep_from_pool(
             base_state, item_pool + unplaced_items)
 

--- a/test/general/TestFill.py
+++ b/test/general/TestFill.py
@@ -433,6 +433,20 @@ class TestFillRestrictive(unittest.TestCase):
         self.assertTrue(multi_world.state.prog_items[item.name, item.player], "Sweep did not collect - Test flawed")
         self.assertEqual(multi_world.state.prog_items[item.name, item.player], 1, "Sweep collected multiple times")
 
+    def test_correct_item_instance_removed_from_pool(self):
+        multi_world = generate_multi_world()
+        player1 = generate_player_data(multi_world, 1, 2, 2)
+
+        player1.prog_items[0].name = "Different_item_instance_but_same_item_name"
+        player1.prog_items[1].name = "Different_item_instance_but_same_item_name"
+        loc0 = player1.locations[0]
+
+        fill_restrictive(multi_world, multi_world.state,
+                         [loc0], player1.prog_items)
+
+        self.assertEqual(1, len(player1.prog_items))
+        self.assertIsNot(loc0.item, player1.prog_items[0], "Filled item was still present in item pool")
+
 
 class TestDistributeItemsRestrictive(unittest.TestCase):
     def test_basic_distribute(self):


### PR DESCRIPTION
## What is this fixing or adding?

In `fill_restrictive` it is possible that the item which is placed is *not* the same item as the one that is removed from the pool of items to be filled.
(This can happen because `list.remove` operates on equality (not identity) and items compare equal as soon as their name and player are the same.
The bug thus occurs when there are two item instances in the pool that belong to the same player and have the same item name.)

This can lead to strange behavior such as locations where `loc.item.location is not loc` or items where `itm.location is None` after fill (*without* triggering any warning about unplaced items), which also lead to https://discord.com/channels/731205301247803413/1134521806099853352.


## How was this tested?

The PR includes a new unittest that failed when ran without the corresponding fix.
