### PR TITLE
ChecksFinder: Move create item logic to `create_items`.

### DIFF
--- a/worlds/checksfinder/__init__.py
+++ b/worlds/checksfinder/__init__.py
@@ -45,7 +45,7 @@ class ChecksFinderWorld(World):
             'race': self.multiworld.is_race,
         }
 
-    def generate_basic(self):
+    def create_items(self):
 
         # Generate item pool
         itempool = []


### PR DESCRIPTION
## What is this fixing or adding?

ChecksFinder was adding items to the itempool in `generate_basic`, which is not allowed.

## How was this tested?

Ran unittests including the one from #1460.
Generated a game and played it.
