### PR TITLE
DLCQuest: Add missing gun law

### DIFF
--- a/worlds/dlcquest/Rules.py
+++ b/worlds/dlcquest/Rules.py
@@ -105,6 +105,8 @@ def set_basic_shuffled_items_rules(World_Options, player, world):
              lambda state: state.has("Sword", player) or state.has("Gun", player))
     set_rule(world.get_location("West Cave Sheep", player),
              lambda state: state.has("Sword", player) or state.has("Gun", player))
+    set_rule(world.get_location("Gun", player),
+             lambda state: state.has("Gun Pack", player))
 
     if World_Options[Options.TimeIsMoney] == Options.TimeIsMoney.option_required:
         set_rule(world.get_location("Sword", player),


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?
a missing rule in the logic was implemented where the gun pack was not needed for the gun location item, but only the ability to get to the npc.

## How was this tested?
run test

## If this makes graphical changes, please attach screenshots.
