### PR TITLE
Core: add correct flags to precollected items

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -326,7 +326,7 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
                     games[slot] = world.game[slot]
                     slot_info[slot] = NetUtils.NetworkSlot(group["name"], world.game[slot], world.player_types[slot],
                                                            group_members=sorted(group["players"]))
-                precollected_items = {player: [item.code for item in world_precollected if type(item.code) == int]
+                precollected_items = {player: [{'code': item.code, 'flags': item.flags} for item in world_precollected if type(item.code) == int]
                                       for player, world_precollected in world.precollected_items.items()}
                 precollected_hints = {player: set() for player in range(1, world.players + 1 + len(world.groups))}
 

--- a/Main.py
+++ b/Main.py
@@ -326,7 +326,7 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
                     games[slot] = world.game[slot]
                     slot_info[slot] = NetUtils.NetworkSlot(group["name"], world.game[slot], world.player_types[slot],
                                                            group_members=sorted(group["players"]))
-                precollected_items = {player: [{'code': item.code, 'flags': item.flags} for item in world_precollected if type(item.code) == int]
+                precollected_items = {player: [(item.code, item.flags) for item in world_precollected if type(item.code) == int]
                                       for player, world_precollected in world.precollected_items.items()}
                 precollected_hints = {player: set() for player in range(1, world.players + 1 + len(world.groups))}
 

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -424,8 +424,8 @@ class Context:
                              for player, loc_data in decoded_obj["er_hint_data"].items()}
 
         # load start inventory:
-        for slot, item_codes in decoded_obj["precollected_items"].items():
-            self.start_inventory[slot] = [NetworkItem(item_code, -2, 0) for item_code in item_codes]
+        for slot, items in decoded_obj["precollected_items"].items():
+            self.start_inventory[slot] = [NetworkItem(item['code'], -2, 0, item['flags']) for item in items]
 
         for slot, hints in decoded_obj["precollected_hints"].items():
             self.hints[0, slot].update(hints)

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -425,7 +425,7 @@ class Context:
 
         # load start inventory:
         for slot, items in decoded_obj["precollected_items"].items():
-            self.start_inventory[slot] = [NetworkItem(item['code'], -2, 0, item['flags']) for item in items]
+            self.start_inventory[slot] = [NetworkItem(item[0], -2, 0, item[1]) for item in items]
 
         for slot, hints in decoded_obj["precollected_hints"].items():
             self.hints[0, slot].update(hints)


### PR DESCRIPTION

## What is this fixing or adding?
precollected items just had a default flag 


## How was this tested?
ran generate and multiserver to test the changes


## Why I added this
While the flags aren't being used anywhere at the moment I am working on a web based text client that I would like to use the flags to correctly color the precollected items. I think the Archipelago tracker could eventually use this information as well.
