### PR TITLE
Plando: fix automatic locations only working for the first world

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -487,8 +487,10 @@ class MultiWorld():
     def get_unfilled_locations_for_players(self, location_names: List[str], players: Iterable[int]):
         for player in players:
             if not location_names:
-                location_names = [location.name for location in self.get_unfilled_locations(player)]
-            for location_name in location_names:
+                valid_locations = [location.name for location in self.get_unfilled_locations(player)]
+            else:
+                valid_locations = location_names.copy()
+            for location_name in valid_locations:
                 location = self._location_cache.get((location_name, player), None)
                 if location is not None and location.item is None:
                     yield location

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -489,7 +489,7 @@ class MultiWorld():
             if not location_names:
                 valid_locations = [location.name for location in self.get_unfilled_locations(player)]
             else:
-                valid_locations = location_names.copy()
+                valid_locations = location_names
             for location_name in valid_locations:
                 location = self._location_cache.get((location_name, player), None)
                 if location is not None and location.item is None:


### PR DESCRIPTION
## What is this fixing or adding?
An issue would occur when attempting to plando items to multiple worlds of varying games. "location_names" would be populated by the locations of the first game, and then not cleaned afterwards. Thus, later iterations of the loop would fail as it would be looking for locations from the first game in subsequent games. This fixes the issue by setting "valid_locations" to a copy of "location_names" if it is non-empty or the list of locations per game if it is.

## How was this tested?
https://cdn.discordapp.com/attachments/1135349606176260258/1135350398727766116/Plando_Dumping_All_Items_to_Single_Game.zip
Test sample given from bug report, "A Link to the Past" and "Ocarina of Time" have Triforce Pieces plando'd into 5 different worlds. Without this change, Triforce Pieces would only be placed into Radz Awakening and Radz 5 (both LADX), while with this change Triforce Pieces are placed into all 5 worlds.

## If this makes graphical changes, please attach screenshots.
