### PR TITLE
MultiServer: exit console task when console thread dies

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2118,13 +2118,15 @@ class ServerCommandProcessor(CommonCommandProcessor):
 async def console(ctx: Context):
     import sys
     queue = asyncio.Queue()
-    Utils.stream_input(sys.stdin, queue)
+    worker = Utils.stream_input(sys.stdin, queue)
     while not ctx.exit_event.is_set():
         try:
             # I don't get why this while loop is needed. Works fine without it on clients,
             # but the queue.get() for server never fulfills if the queue is empty when entering the await.
             while queue.qsize() == 0:
                 await asyncio.sleep(0.05)
+                if not worker.is_alive():
+                    return
             input_text = await queue.get()
             queue.task_done()
             ctx.commandprocessor(input_text)


### PR DESCRIPTION
## What is this fixing or adding?

When running MultiServer without stdin or with broken stdin, the console task will spin in
```python
            while queue.qsize() == 0:
                await asyncio.sleep(0.05)
```
Returning from the task when the thread dies frees up resources.