### PR TITLE
The Messenger: actually implement `get_filler_item_name`

### DIFF
--- a/worlds/messenger/__init__.py
+++ b/worlds/messenger/__init__.py
@@ -132,10 +132,9 @@ class MessengerWorld(World):
 
         remaining_fill = len(self.multiworld.get_unfilled_locations(self.player)) - len(itempool)
         if remaining_fill < 10:
-            filler_pool = dict(list(FILLER.items())[2:])
             self._filler_items = self.random.choices(
-                                      list(filler_pool),
-                                      weights=list(filler_pool.values()),
+                                      list(FILLER)[2:],
+                                      weights=list(FILLER.values())[2:],
                                       k=remaining_fill
             )
         itempool += [self.create_filler() for _ in range(remaining_fill)]

--- a/worlds/messenger/__init__.py
+++ b/worlds/messenger/__init__.py
@@ -133,13 +133,11 @@ class MessengerWorld(World):
         remaining_fill = len(self.multiworld.get_unfilled_locations(self.player)) - len(itempool)
         if remaining_fill < 10:
             filler_pool = dict(list(FILLER.items())[2:])
-            self._filler_items = [name
-                                  for name in
-                                  self.random.choices(
+            self._filler_items = self.random.choices(
                                       list(filler_pool),
                                       weights=list(filler_pool.values()),
                                       k=remaining_fill
-                                  )]
+            )
         itempool += [self.create_filler() for _ in range(remaining_fill)]
 
         self.multiworld.itempool += itempool
@@ -171,9 +169,11 @@ class MessengerWorld(World):
 
     def get_filler_item_name(self) -> str:
         if not getattr(self, "_filler_items", None):
-            self._filler_items = [name for name in self.random.choices(list(FILLER),
-                                                                       weights=list(FILLER.values()),
-                                                                       k=100)]
+            self._filler_items = [name for name in self.random.choices(
+                list(FILLER),
+                weights=list(FILLER.values()),
+                k=20
+            )]
         return self._filler_items.pop(0)
 
     def create_item(self, name: str) -> MessengerItem:

--- a/worlds/messenger/__init__.py
+++ b/worlds/messenger/__init__.py
@@ -173,7 +173,7 @@ class MessengerWorld(World):
         if not getattr(self, "_filler_items", None):
             self._filler_items = [name for name in self.random.choices(list(FILLER),
                                                                        weights=list(FILLER.values()),
-                                                                       k=50)]
+                                                                       k=100)]
         return self._filler_items.pop(0)
 
     def create_item(self, name: str) -> MessengerItem:


### PR DESCRIPTION
## What is this fixing or adding?
Returns more proper filler for item links instead of hardcoded "Time Shard" which is basically worthless. The 100 is a completely arbitrary number, could be any number really, but that should be enough to satisfy most multiworlds, as maximum filler generated without starting_inventory is 98. This isn't high priority, as it really only has an effect on item links.

## How was this tested?
Generated a few multiworlds to satisfy all the different combinations and tests.

## If this makes graphical changes, please attach screenshots.
