### PR TITLE
SMW & DKC3: Add `get_filler_item_name` override

### DIFF
--- a/worlds/dkc3/__init__.py
+++ b/worlds/dkc3/__init__.py
@@ -216,5 +216,8 @@ class DKC3World(World):
 
         return created_item
 
+    def get_filler_item_name(self) -> str:
+        return self.multiworld.random.choice(list(junk_table.keys()))
+
     def set_rules(self):
         set_rules(self.multiworld, self.player)

--- a/worlds/smw/__init__.py
+++ b/worlds/smw/__init__.py
@@ -270,5 +270,8 @@ class SMWWorld(World):
 
         return created_item
 
+    def get_filler_item_name(self) -> str:
+        return ItemName.one_up_mushroom
+
     def set_rules(self):
         set_rules(self.multiworld, self.player)


### PR DESCRIPTION
## What is this fixing or adding?
Adds an explicit custom filler item pool for SMW and DKC3.

## How was this tested?
Generated with item links with `null` replacement items.

## If this makes graphical changes, please attach screenshots.
