### PR TITLE
LttP: Check for item_link group on get_filler_item_name

### DIFF
--- a/worlds/alttp/__init__.py
+++ b/worlds/alttp/__init__.py
@@ -767,7 +767,7 @@ class ALTTPWorld(World):
                 item)))
 
     def get_filler_item_name(self) -> str:
-        if self.multiworld.goal[self.player] == "icerodhunt":
+        if self.multiworld.player_types[self.player] == 1 and self.multiworld.goal[self.player] == "icerodhunt":
             item = "Nothing"
         else:
             item = self.multiworld.random.choice(extras_list)


### PR DESCRIPTION
## What is this fixing or adding?
Fixes crashing when trying to item link several ALttP worlds together using replacement_item: null and link_replacement: true. ALttP doesn't check for whether the current player is an itemlink group while checking for Ice Rod Hunt, so we add an additional check there.
There may be additional things I did not consider when making this however; my familiarity with ALttP is not great.
## How was this tested?
Generating a game with 2 ALttP meta'd into an itemlink with Everything itemlinked, and replacement_item set to null.

## If this makes graphical changes, please attach screenshots.
