### PR TITLE
Tests: Add a test that worlds can create filler without generation steps

### DIFF
--- a/test/general/TestItems.py
+++ b/test/general/TestItems.py
@@ -1,4 +1,6 @@
 import unittest
+
+from BaseClasses import Item
 from worlds.AutoWorld import AutoWorldRegister
 from . import setup_solo_multiworld
 
@@ -11,6 +13,12 @@ class TestBase(unittest.TestCase):
                 with self.subTest("Create Item", item_name=item_name, game_name=game_name):
                     item = proxy_world.create_item(item_name)
                     self.assertEqual(item.name, item_name)
+    
+    def testCreateFiller(self):
+        for game_name, world_type in AutoWorldRegister.world_types.items():
+            world = setup_solo_multiworld(world_type, ()).worlds[1]
+            with self.subTest("Create Filler", game_name=game_name):
+                self.assertIsInstance(world.create_filler(), Item)
 
     def testItemNameGroupHasValidItem(self):
         """Test that all item name groups contain valid items. """

--- a/test/general/TestItems.py
+++ b/test/general/TestItems.py
@@ -16,9 +16,10 @@ class TestBase(unittest.TestCase):
     
     def testCreateFiller(self):
         for game_name, world_type in AutoWorldRegister.world_types.items():
-            world = setup_solo_multiworld(world_type, ()).worlds[1]
-            with self.subTest("Create Filler", game_name=game_name):
-                self.assertIsInstance(world.create_filler(), Item)
+            if world_type.item_name_to_id:
+                world = setup_solo_multiworld(world_type, ()).worlds[1]
+                with self.subTest("Create Filler", game_name=game_name):
+                    self.assertIsInstance(world.create_filler(), Item)
 
     def testItemNameGroupHasValidItem(self):
         """Test that all item name groups contain valid items. """


### PR DESCRIPTION
## What is this fixing or adding?
Item Link filler replacement creates a new world and then creates filler with that world, if that new world can't actually create filler, generation will crash so this is a test for that.

## How was this tested?
📄 ✍️ 
