### PR TITLE
SA2B: Fix `generate_filler_item_name`

### DIFF
--- a/worlds/sa2b/__init__.py
+++ b/worlds/sa2b/__init__.py
@@ -422,7 +422,7 @@ class SA2BWorld(World):
         return created_item
 
     def get_filler_item_name(self) -> str:
-        self.multiworld.random.choice(junk_table.keys())
+        return self.multiworld.random.choice(list(junk_table.keys()))
 
     def set_rules(self):
         set_rules(self.multiworld, self.player, self.gate_bosses, self.boss_rush_map, self.mission_map, self.mission_count_map)


### PR DESCRIPTION
## What is this fixing or adding?
`generate_filler_item_name` in SA2 has been broken on main since December. I fixed it.

## How was this tested?
Generated with some sketchy item links settings.

## If this makes graphical changes, please attach screenshots.
