### PR TITLE
[TLOZ] MD5 validation update

### DIFF
--- a/worlds/tloz/Rom.py
+++ b/worlds/tloz/Rom.py
@@ -1,10 +1,11 @@
+import hashlib
 import zlib
 import os
 
 import Utils
 from worlds.Files import APDeltaPatch
 
-NA10CHECKSUM = 'D7AE93DF'
+NA10CHECKSUM = '337bd6f1a1163df31bf2633665589ab0'
 ROM_PLAYER_LIMIT = 65535
 ROM_NAME = 0x10
 bit_positions = [0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80]
@@ -44,7 +45,6 @@ rupees_to_add = 0x067D
 
 
 class TLoZDeltaPatch(APDeltaPatch):
-    checksum = NA10CHECKSUM
     hash = NA10CHECKSUM
     game = "The Legend of Zelda"
     patch_file_ending = ".aptloz"
@@ -61,8 +61,9 @@ def get_base_rom_bytes(file_name: str = "") -> bytes:
         file_name = get_base_rom_path(file_name)
         base_rom_bytes = bytes(Utils.read_snes_rom(open(file_name, "rb")))
 
-        basechecksum = str(hex(zlib.crc32(base_rom_bytes))).upper()[2:]
-        if NA10CHECKSUM != basechecksum:
+        basemd5 = hashlib.md5()
+        basemd5.update(base_rom_bytes)
+        if NA10CHECKSUM != basemd5.hexdigest():
             raise Exception('Supplied Base Rom does not match known CRC-32 for NA (1.0) release. '
                             'Get the correct game and version, then dump it')
         get_base_rom_bytes.base_rom_bytes = base_rom_bytes

--- a/worlds/tloz/Rom.py
+++ b/worlds/tloz/Rom.py
@@ -64,7 +64,7 @@ def get_base_rom_bytes(file_name: str = "") -> bytes:
         basemd5 = hashlib.md5()
         basemd5.update(base_rom_bytes)
         if NA10CHECKSUM != basemd5.hexdigest():
-            raise Exception('Supplied Base Rom does not match known CRC-32 for NA (1.0) release. '
+            raise Exception('Supplied Base Rom does not match known MD5 for NA (1.0) release. '
                             'Get the correct game and version, then dump it')
         get_base_rom_bytes.base_rom_bytes = base_rom_bytes
     return base_rom_bytes


### PR DESCRIPTION
## What is this fixing or adding?
The method TLoZ was trying to validate it's baserom with was different from basically every other ROM game. Almost all the other ROM games use the same method as each other (except for the external patchers like FF1 and SoE, and OoT has its own special handling that's vastly different), so updating TLoZ to match. Otherwise, attempting to generate without having the base rom present will attempt to ask for the base rom but fail to validate, as reported here: https://discord.com/channels/731205301247803413/1136846040998346842

Also got rid of the checksum attribute for the TLoZDeltaPatch as it didn't seem to be used anywhere, so felt it was unnecessary and partially confusing to have it right next to the hash attribute that is actually used.

## How was this tested?
did a test gen with the ROM file not present. generator asked for me to supply the baserom and genned successfuly. @Zunawe also tested as shown in the linked discord post.

## If this makes graphical changes, please attach screenshots.
