### PR TITLE
Core: create random object for item link worlds

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -208,6 +208,9 @@ class MultiWorld():
             getattr(self, option_key)[new_id] = option(option.default)
         for option_key, option in Options.per_game_common_options.items():
             getattr(self, option_key)[new_id] = option(option.default)
+        
+        world_type.random = random.Random(self.random.getrandbits(64))
+        self.per_slot_randoms[new_id] = world_type.random
 
         self.worlds[new_id] = world_type(self, new_id)
         self.worlds[new_id].collect_item = classmethod(AutoWorld.World.collect_item).__get__(self.worlds[new_id])


### PR DESCRIPTION
## What is this fixing or adding?
Item link worlds don't have their own random object, so this creates that to help prevent ignorant crashes.

## How was this tested?
found this when writing #2081

## If this makes graphical changes, please attach screenshots.
