### PR TITLE
Muse Dash: Make item_name_to_id and location_name_to_id ordering deterministic

### DIFF
--- a/worlds/musedash/MuseDashCollection.py
+++ b/worlds/musedash/MuseDashCollection.py
@@ -10,6 +10,7 @@ def load_text_file(name: str) -> str:
 class MuseDashCollections:
     """Contains all the data of Muse Dash, loaded from MuseDashData.txt."""
 
+    MUSIC_SHEET_NAME: str = "Music Sheet"
     MUSIC_SHEET_CODE: int
 
     FREE_ALBUMS = [
@@ -25,6 +26,8 @@ class MuseDashCollections:
         "PeroPero in the Universe"
     ]
 
+    item_names_to_id: Dict[str, int] = {}
+    location_names_to_id: Dict[str, int] = {}
     album_items: Dict[str, AlbumData] = {}
     album_locations: Dict[str, int] = {}
     song_items: Dict[str, SongData] = {}
@@ -47,9 +50,13 @@ class MuseDashCollections:
 
     def __init__(self, start_item_id: int, items_per_location: int):
         self.MUSIC_SHEET_CODE = start_item_id
+        self.item_names_to_id[self.MUSIC_SHEET_NAME] = start_item_id
 
         self.vfx_trap_items = {k: (v + start_item_id) for (k, v) in self.vfx_trap_items.items()}
+        self.item_names_to_id.update(self.vfx_trap_items)
+
         self.sfx_trap_items = {k: (v + start_item_id) for (k, v) in self.sfx_trap_items.items()}
+        self.item_names_to_id.update(self.sfx_trap_items)
 
         item_id_index = start_item_id + 50
         location_id_index = start_item_id
@@ -62,6 +69,7 @@ class MuseDashCollections:
 
             if sections[2] not in self.album_items:
                 self.album_items[sections[2]] = AlbumData(item_id_index)
+                self.item_names_to_id[sections[2]] = item_id_index
                 item_id_index += 1
 
             # Data is in the format 'Song|UID|Album|StreamerMode|EasyDiff|HardDiff|MasterDiff|SecretDiff'
@@ -83,18 +91,21 @@ class MuseDashCollections:
 
             self.song_items[song_name] = SongData(item_id_index, song_is_free, steamer_mode,
                                                   diff_of_easy, diff_of_hard, diff_of_master)
+            self.item_names_to_id[song_name] = item_id_index
             item_id_index += 1
 
         for name in self.album_items.keys():
             for i in range(0, items_per_location):
                 new_name = f"{name}-{i}"
                 self.album_locations[new_name] = location_id_index
+                self.location_names_to_id[new_name] = location_id_index
                 location_id_index += 1
 
         for name in self.song_items.keys():
             for i in range(0, items_per_location):
                 new_name = f"{name}-{i}"
                 self.song_locations[new_name] = location_id_index
+                self.location_names_to_id[new_name] = location_id_index
                 location_id_index += 1
 
     def get_songs_with_settings(self, dlc_songs: bool, streamer_mode_active: bool,

--- a/worlds/musedash/MuseDashCollection.py
+++ b/worlds/musedash/MuseDashCollection.py
@@ -52,6 +52,8 @@ class MuseDashCollections:
 
     def __init__(self, start_item_id: int, items_per_location: int):
         self.MUSIC_SHEET_CODE = start_item_id
+        self.item_names_to_id[self.MUSIC_SHEET_NAME] = self.MUSIC_SHEET_CODE
+
         self.vfx_trap_items.update({k: (v + start_item_id) for (k, v) in self.vfx_trap_items.items()})
         self.sfx_trap_items.update({k: (v + start_item_id) for (k, v) in self.sfx_trap_items.items()})
 

--- a/worlds/musedash/__init__.py
+++ b/worlds/musedash/__init__.py
@@ -40,24 +40,14 @@ class MuseDashWorld(World):
     game = "Muse Dash"
     option_definitions = musedash_options
     topology_present = False
-    data_version = 7
+    data_version = 8
     web = MuseDashWebWorld()
-
-    music_sheet_name: str = "Music Sheet"
 
     # Necessary Data
     md_collection = MuseDashCollections(2900000, 2)
 
-    item_name_to_id = {
-        name: data.code for name, data in md_collection.album_items.items() | md_collection.song_items.items()
-    }
-    item_name_to_id[music_sheet_name] = md_collection.MUSIC_SHEET_CODE
-    for item in md_collection.sfx_trap_items.items() | md_collection.vfx_trap_items.items():
-        item_name_to_id[item[0]] = item[1]
-
-    location_name_to_id = {
-        name: id for name, id in md_collection.album_locations.items() | md_collection.song_locations.items()
-    }
+    item_name_to_id = md_collection.item_names_to_id
+    location_name_to_id = md_collection.location_names_to_id
 
     # Working Data
     victory_song_name: str = ""
@@ -164,8 +154,10 @@ class MuseDashWorld(World):
         if self.location_count < minimum_location_count:
             self.location_count = minimum_location_count
 
+        assert self.victory_song_name not in self.included_songs
+
     def create_item(self, name: str) -> Item:
-        if name == self.music_sheet_name:
+        if name == self.md_collection.MUSIC_SHEET_NAME:
             return MuseDashFixedItem(name, ItemClassification.progression_skip_balancing,
                                      self.md_collection.MUSIC_SHEET_CODE, self.player)
 
@@ -191,7 +183,7 @@ class MuseDashWorld(World):
 
         # First add all goal song tokens
         for _ in range(0, item_count):
-            self.multiworld.itempool.append(self.create_item(self.music_sheet_name))
+            self.multiworld.itempool.append(self.create_item(self.md_collection.MUSIC_SHEET_NAME))
 
         # Then add all traps
         trap_count = self.get_trap_count()
@@ -255,7 +247,7 @@ class MuseDashWorld(World):
 
     def set_rules(self) -> None:
         self.multiworld.completion_condition[self.player] = lambda state: \
-            state.has(self.music_sheet_name, self.player, self.get_music_sheet_win_count())
+            state.has(self.md_collection.MUSIC_SHEET_NAME, self.player, self.get_music_sheet_win_count())
 
     def get_available_traps(self) -> List[str]:
         dlc_songs = self.multiworld.allow_just_as_planned_dlc_songs[self.player]

--- a/worlds/musedash/__init__.py
+++ b/worlds/musedash/__init__.py
@@ -154,8 +154,6 @@ class MuseDashWorld(World):
         if self.location_count < minimum_location_count:
             self.location_count = minimum_location_count
 
-        assert self.victory_song_name not in self.included_songs
-
     def create_item(self, name: str) -> Item:
         if name == self.md_collection.MUSIC_SHEET_NAME:
             return MuseDashFixedItem(name, ItemClassification.progression_skip_balancing,


### PR DESCRIPTION
## What is this fixing or adding?
Changes how the Muse Dash world creates the `item_name_to_id` and `location_name_to_id` dictionaries to ensure that they have the same ordering each time. Without this, the datapackage for Muse Dash seemed to change each time generation was run. 

Also included is a `data_version` update that I missed in https://github.com/ArchipelagoMW/Archipelago/pull/2047

## How was this tested?
- Multiple generations to check ordering and checksum stayed consistent. 
- Ran tests and generations to ensure no logic changed.

## If this makes graphical changes, please attach screenshots.
N/A