### PR TITLE
MMBN3: Fixes hint spam when receiving a hint

### DIFF
--- a/MMBN3Client.py
+++ b/MMBN3Client.py
@@ -71,7 +71,7 @@ class MMBN3Context(CommonContext):
         self.auth_name = None
         self.slot_data = dict()
         self.patching_error = False
-        self.scouted_locs = []
+        self.sent_hints = []
 
     async def server_auth(self, password_requested: bool = False):
         if password_requested and not self.password:
@@ -178,11 +178,12 @@ async def parse_payload(payload: dict, ctx: MMBN3Context, force: bool):
     if ctx.slot_data.get("trade_quest_hinting", 0) == 2:
         trade_bits = [loc.id for loc in scoutable_locations
                         if check_location_scouted(loc, payload["locations"])]
-        if ctx.scouted_locs != trade_bits:
-            ctx.scouted_locs = trade_bits
+        scouted_locs = [loc for loc in trade_bits if loc not in ctx.sent_hints]
+        if len(scouted_locs) > 0:
+            ctx.sent_hints.extend(scouted_locs)
             await ctx.send_msgs([{
                 "cmd": "LocationScouts",
-                "locations": ctx.scouted_locs,
+                "locations": scouted_locs,
                 "create_as_hint": 2
             }])
 

--- a/MMBN3Client.py
+++ b/MMBN3Client.py
@@ -71,6 +71,7 @@ class MMBN3Context(CommonContext):
         self.auth_name = None
         self.slot_data = dict()
         self.patching_error = False
+        self.scouted_locs = []
 
     async def server_auth(self, password_requested: bool = False):
         if password_requested and not self.password:
@@ -175,13 +176,15 @@ async def parse_payload(payload: dict, ctx: MMBN3Context, force: bool):
 
     # If trade hinting is enabled, send scout checks
     if ctx.slot_data.get("trade_quest_hinting", 0) == 2:
-        scouted_locs = [loc.id for loc in scoutable_locations
+        trade_bits = [loc.id for loc in scoutable_locations
                         if check_location_scouted(loc, payload["locations"])]
-        await ctx.send_msgs([{
-            "cmd": "LocationScouts",
-            "locations": scouted_locs,
-            "create_as_hint": 2
-        }])
+        if ctx.scouted_locs != trade_bits:
+            ctx.scouted_locs = trade_bits
+            await ctx.send_msgs([{
+                "cmd": "LocationScouts",
+                "locations": ctx.scouted_locs,
+                "create_as_hint": 2
+            }])
 
 
 def check_location_packet(location, memory):


### PR DESCRIPTION
## What is this fixing or adding?
MMBN3 was sending the list of all hinted objects every server tick, which was spamming the server with hints after one is collected. Now, it'll keep a running list of sent hints and only send new hints.

## How was this tested?
Generated a game, checked each hint location, and received only one message. Checked both internal and external item hints.