### PR TITLE
sm64ex: Fix possible inaccessible region

### DIFF
--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -30,6 +30,8 @@ def set_rules(world, player: int, area_connections):
         fix_reg(entrance_ids, 20, 5, swaplist, world)
         # Guarantee BITFS is not mapped to DDD
         fix_reg(entrance_ids, 22, 8, swaplist, world)
+        if entrance_ids.index(22) == 5: # If BITFS is mapped to HMC...
+            fix_reg(entrance_ids, 20, 8, swaplist, world) # ... then dont allow COTMC to be mapped to DDD
     temp_assign = dict(zip(entrance_ids,destination_regions)) # Used for Rules only
 
     # Destination Format: LVL | AREA with LVL = LEVEL_x, AREA = Area as used in sm64 code


### PR DESCRIPTION
## What is this fixing or adding?
If BitFS leads to HMC, then COTMC entrance (which is in HMC) should not be allowed to point to DDD, which is required to enter BitFS in the first place.

## How was this tested?
Still generates fine, and uses the same fix method as other regions

## If this makes graphical changes, please attach screenshots.
