### PR TITLE
Stardew Valley: Fixed Help wanted rules, added missing coffee bean to cropsanity

### DIFF
--- a/worlds/stardew_valley/data/crops.csv
+++ b/worlds/stardew_valley/data/crops.csv
@@ -7,6 +7,7 @@ Blueberry,Summer,Blueberry Seeds,Summer,"Pierre's General Store,JojaMart"
 Bok Choy,Fall,Bok Choy Seeds,Fall,"Pierre's General Store,JojaMart"
 Cactus Fruit,,Cactus Seeds,,Oasis
 Cauliflower,Spring,Cauliflower Seeds,Spring,"Pierre's General Store,JojaMart"
+Coffee Bean,"Spring,Summer",Coffee Bean,"Summer,Fall","Traveling Cart"
 Corn,"Summer,Fall",Corn Seeds,"Summer,Fall","Pierre's General Store,JojaMart"
 Cranberries,Fall,Cranberry Seeds,Fall,"Pierre's General Store,JojaMart"
 Eggplant,Fall,Eggplant Seeds,Fall,"Pierre's General Store,JojaMart"

--- a/worlds/stardew_valley/data/items.csv
+++ b/worlds/stardew_valley/data/items.csv
@@ -272,6 +272,7 @@ id,name,classification,groups,mod_name
 285,Ugly Baby,progression,"BABY",
 286,Deluxe Scarecrow Recipe,progression,"FESTIVAL,RARECROW",
 287,Treehouse,progression,"GINGER_ISLAND",
+288,Coffee Bean,progression,CROPSANITY,
 4001,Burnt,trap,TRAP,
 4002,Darkness,trap,TRAP,
 4003,Frozen,trap,TRAP,

--- a/worlds/stardew_valley/data/locations.csv
+++ b/worlds/stardew_valley/data/locations.csv
@@ -1036,6 +1036,7 @@ id,region,name,tags,mod_name
 2344,Farm,Harvest Peach,"CROPSANITY",
 2345,Farm,Harvest Banana,"CROPSANITY,GINGER_ISLAND",
 2346,Farm,Harvest Mango,"CROPSANITY,GINGER_ISLAND",
+2347,Farm,Harvest Coffee Bean,"CROPSANITY",
 5001,Stardew Valley,Level 1 Luck,"LUCK_LEVEL,SKILL_LEVEL",Luck Skill
 5002,Stardew Valley,Level 2 Luck,"LUCK_LEVEL,SKILL_LEVEL",Luck Skill
 5003,Stardew Valley,Level 3 Luck,"LUCK_LEVEL,SKILL_LEVEL",Luck Skill

--- a/worlds/stardew_valley/logic.py
+++ b/worlds/stardew_valley/logic.py
@@ -7,6 +7,7 @@ from typing import Dict, Union, Optional, Iterable, Sized, List, Set
 from . import options
 from .data import all_fish, FishItem, all_purchasable_seeds, SeedItem, all_crops, CropItem
 from .data.bundle_data import BundleItem
+from .data.crops_data import crops_by_name
 from .data.fish_data import island_fish
 from .data.museum_data import all_museum_items, MuseumItem, all_artifact_items, dwarf_scrolls
 from .data.recipe_data import all_cooking_recipes, CookingRecipe, RecipeSource, FriendshipSource, QueenOfSauceSource, \
@@ -139,7 +140,7 @@ class StardewLogic:
         self.crop_rules.update({crop.name: self.can_grow_crop(crop) for crop in all_crops})
         self.crop_rules.update({
             Seed.coffee: (self.has_season(Season.spring) | self.has_season(
-                Season.summer)) & self.has_traveling_merchant(),
+                Season.summer)) & self.can_buy_seed(crops_by_name[Seed.coffee].seed),
             Fruit.ancient_fruit: (self.received("Ancient Seeds") | self.received("Ancient Seeds Recipe")) &
                              self.can_reach_region(Region.greenhouse) & self.has(Machine.seed_maker),
         })

--- a/worlds/stardew_valley/rules.py
+++ b/worlds/stardew_valley/rules.py
@@ -357,25 +357,51 @@ def set_special_order_rules(all_location_names: List[str], logic: StardewLogic, 
             MultiWorldRules.set_rule(multi_world.get_location(qi_order.name, player), order_rule.simplify())
 
 
-def set_help_wanted_quests_rules(logic: StardewLogic, multi_world, player, world_options):
-    desired_number_help_wanted: int = world_options[options.HelpWantedLocations] // 7
-    for i in range(0, desired_number_help_wanted):
-        prefix = "Help Wanted:"
-        delivery = "Item Delivery"
-        rule = logic.has_lived_months(i).simplify()
-        fishing_rule = rule & logic.can_fish()
-        slay_rule = rule & logic.can_do_combat_at_level("Basic")
-        item_delivery_index = (i * 4) + 1
-        for j in range(item_delivery_index, item_delivery_index + 4):
-            location_name = f"{prefix} {delivery} {j}"
-            MultiWorldRules.set_rule(multi_world.get_location(location_name, player), rule)
+help_wanted_prefix = "Help Wanted:"
+item_delivery = "Item Delivery"
+gathering = "Gathering"
+fishing = "Fishing"
+slay_monsters = "Slay Monsters"
 
-        MultiWorldRules.set_rule(multi_world.get_location(f"{prefix} Gathering {i + 1}", player),
-                                 rule)
-        MultiWorldRules.set_rule(multi_world.get_location(f"{prefix} Fishing {i + 1}", player),
-                                 fishing_rule.simplify())
-        MultiWorldRules.set_rule(multi_world.get_location(f"{prefix} Slay Monsters {i + 1}", player),
-                                 slay_rule.simplify())
+
+def set_help_wanted_quests_rules(logic: StardewLogic, multi_world, player, world_options):
+    help_wanted_number = world_options[options.HelpWantedLocations]
+    for i in range(0, help_wanted_number):
+        set_number = i // 7
+        month_rule = logic.has_lived_months(set_number).simplify()
+        quest_number = set_number + 1
+        quest_number_in_set = i % 7
+        if quest_number_in_set < 4:
+            quest_number = set_number * 4 + quest_number_in_set + 1
+            set_help_wanted_delivery_rule(multi_world, player, month_rule, quest_number)
+        elif quest_number_in_set == 4:
+            set_help_wanted_fishing_rule(logic, multi_world, player, month_rule, quest_number)
+        elif quest_number_in_set == 5:
+            set_help_wanted_slay_monsters_rule(logic, multi_world, player, month_rule, quest_number)
+        elif quest_number_in_set == 6:
+            set_help_wanted_gathering_rule(multi_world, player, month_rule, quest_number)
+
+
+def set_help_wanted_delivery_rule(multi_world, player, month_rule, quest_number):
+    location_name = f"{help_wanted_prefix} {item_delivery} {quest_number}"
+    MultiWorldRules.set_rule(multi_world.get_location(location_name, player), month_rule)
+
+
+def set_help_wanted_gathering_rule(multi_world, player, month_rule, quest_number):
+    location_name = f"{help_wanted_prefix} {gathering} {quest_number}"
+    MultiWorldRules.set_rule(multi_world.get_location(location_name, player), month_rule)
+
+
+def set_help_wanted_fishing_rule(logic: StardewLogic, multi_world, player, month_rule, quest_number):
+    location_name = f"{help_wanted_prefix} {fishing} {quest_number}"
+    fishing_rule = month_rule & logic.can_fish()
+    MultiWorldRules.set_rule(multi_world.get_location(location_name, player), fishing_rule.simplify())
+
+
+def set_help_wanted_slay_monsters_rule(logic: StardewLogic, multi_world, player, month_rule, quest_number):
+    location_name = f"{help_wanted_prefix} {slay_monsters} {quest_number}"
+    slay_rule = month_rule & logic.can_do_combat_at_level("Basic")
+    MultiWorldRules.set_rule(multi_world.get_location(location_name, player), slay_rule.simplify())
 
 
 def set_fishsanity_rules(all_location_names: List[str], logic: StardewLogic, multi_world: MultiWorld, player: int):


### PR DESCRIPTION
## What is this fixing or adding?
The Help Wanted setting, when using a number not divisible by 7, was missing some logic rules for the remainder. Now the rules should be set properly
The cropsanity setting was missing one crop, the coffee bean. This adds it

## How was this tested?
Ran unit tests, generated a couple of worlds.