### PR TITLE
Terraria: Fix Necromantic Scroll requiring Post-Mourning Wood instead of access to Mourning Wood

### DIFF
--- a/worlds/terraria/Rules.dsv
+++ b/worlds/terraria/Rules.dsv
@@ -428,7 +428,7 @@ Duke Fishron;                       Location | Item;                            
 Pumpkin Moon;                       ;                                           Hardmode Anvil & Pumpkin & Ectoplasm & (@calamity | Hallowed Bar);
 Spooky Armor;                       ArmorMinions(4);                            Pumpkin Moon;
 Mourning Wood;                      Location | Item;                            Pumpkin Moon;
-Necromantic Scroll;                 Minions(1);                                 Mourning Wood;
+Necromantic Scroll;                 Minions(1);                                 #Mourning Wood;
 Papyrus Scarab;                     Minions(1);                                 Tinkerer's Workshop & Hercules Beetle & Necromantic Scroll;
 Pumpking;                           Location | Item;                            Pumpkin Moon;
 The Horseman's Blade;               ;                                           #Pumpking;


### PR DESCRIPTION
## What is this fixing or adding?
Fixes a simple logic bug where [Necromantic Scroll](https://terraria.wiki.gg/wiki/Necromantic_Scroll) required the Post-Mourning Wood check item instead of inheriting the requirements for Mourning Wood (it's a Terraria item that drops by killing Mourning Wood)

## How was this tested?
Generated games, printed internal debug info verifying the problem was fixed. The bug likely hasn't ever manifested, so there were no seeds to test on.
