### PR TITLE
Docs: Update `generate_output` docstring

### DIFF
--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -309,8 +309,8 @@ class World(metaclass=AutoWorldRegister):
         This happens before progression balancing, so the items may not be in their final locations yet."""
 
     def generate_output(self, output_directory: str) -> None:
-        """This method gets called from a threadpool, do not use world.random here.
-        If you need any last-second randomization, use MultiWorld.per_slot_randoms[slot] instead."""
+        """This method gets called from a threadpool, do not use multiworld.random here.
+        If you need any last-second randomization, use self.random instead."""
         pass
 
     def fill_slot_data(self) -> Dict[str, Any]:  # json of WebHostLib.models.Slot


### PR DESCRIPTION
## What is this fixing or adding?

The `generate_output` docstring has become particularly confusing now that MultiWorld objects are being encouraged to be named `multiworld` and `per_slot_randoms` is deprecated in favor of `AutoWorld.random`, which might now be confused with the term `world.random`.

Did a search for `world.random` in the whole codebase outside world implementations and didn't find any other documentation that looks like this.