### PR TITLE
LADX: Fix hints generation for longer location names

### DIFF
--- a/worlds/ladx/LADXR/generator.py
+++ b/worlds/ladx/LADXR/generator.py
@@ -249,6 +249,7 @@ def generateRom(args, settings, ap_settings, auth, seed_name, logic, rnd=None, m
     all_items = multiworld.get_items()
     our_items = [item for item in all_items if item.player == player_id and item.location and item.code is not None and item.location.show_in_spoiler]
     our_useful_items = [item for item in our_items if ItemClassification.progression in item.classification]
+
     def gen_hint():
         chance = rnd.uniform(0, 1)
         if chance < JUNK_HINT:
@@ -267,9 +268,14 @@ def generateRom(args, settings, ap_settings, auth, seed_name, logic, rnd=None, m
             location_name = location.ladxr_item.metadata.name
         else:
             location_name = location.name
+
         hint = f"{name} {location.item} is at {location_name}"
         if location.player != player_id:
             hint += f" in {multiworld.player_name[location.player]}'s world"
+
+        # Cap hint size at 85
+        # Realistically we could go bigger but let's be safe instead
+        hint = hint[:85]
 
         return hint
 

--- a/worlds/ladx/LADXR/pointerTable.py
+++ b/worlds/ladx/LADXR/pointerTable.py
@@ -59,12 +59,14 @@ class PointerTable:
             self.__storage = [{"bank": self.__storage[0]["bank"], "start": self.__storage[0]["start"], "end": self.__storage[-1]["end"]}]
         if "expand_to_end_of_bank" in info and info["expand_to_end_of_bank"]:
             for st in self.__storage:
-                expand = True
-                for st2 in self.__storage:
-                    if st["bank"] == st2["bank"] and st["end"] < st2["end"]:
-                        expand = False
-                if expand:
-                    st["end"] = 0x4000
+                if info["expand_to_end_of_bank"] == True or st["bank"] in info["expand_to_end_of_bank"]:
+                    expand = True
+                    for st2 in self.__storage:
+                        if st["bank"] == st2["bank"] and st["end"] < st2["end"]:
+                            expand = False
+                    if expand:
+                        st["end"] = 0x4000
+        self.storage = self.__storage
 
         # for s in sorted(self.__storage, key=lambda s: (s["bank"], s["start"])):
         #     print(self.__class__.__name__, s)

--- a/worlds/ladx/LADXR/romTables.py
+++ b/worlds/ladx/LADXR/romTables.py
@@ -13,6 +13,7 @@ class Texts(PointerTable):
             "pointers_bank": 0x1C,
             "banks_addr": 0x741,
             "banks_bank": 0x1C,
+            "expand_to_end_of_bank": {0x09}
         })
 
 
@@ -185,6 +186,7 @@ class ROMWithTables(ROM):
 
         # Ability to patch any text in the game with different text
         self.texts = Texts(self)
+
         # Ability to modify rooms
         self.entities = Entities(self)
         self.rooms_overworld_top = RoomsOverworldTop(self)
@@ -202,6 +204,9 @@ class ROMWithTables(ROM):
         self.itemNames = {}
 
     def save(self, filename, *, name=None):
+        # Assert special handling of bank 9 expansion is fine
+        for i in range(0x3d42, 0x4000):
+            assert self.banks[9][i] == 0, self.banks[9][i]
         self.texts.store(self)
         self.entities.store(self)
         self.rooms_overworld_top.store(self)


### PR DESCRIPTION
## What is this fixing or adding?
Fixes text pointer storer running out of space when location name is long by:
 1. Giving some more space in bank 9 for hints
 2. Capping hint length at 85
...this would be better solved by redoing how owl hint text boxes are done but this is far easier to fix for now.

## How was this tested?
Generation with forced long unique hint names. I haven't technically run a ROM using this, but the space is unused, unless something specifically goes looking in bank 9 for zeroes (why?!).

## If this makes graphical changes, please attach screenshots.
