### PR TITLE
[TLOZ] Fix filepath error for base patch

### DIFF
--- a/worlds/tloz/__init__.py
+++ b/worlds/tloz/__init__.py
@@ -192,7 +192,7 @@ class TLoZWorld(World):
         # Remove map/compass check so they're always on
         # Removing a bit from the boss roars flags, so we can have more dungeon items. This allows us to
         # go past 0x1F items for dungeon items.
-        base_patch = get_data(__name__, os.path.join(os.path.dirname(__file__), "z1_base_patch.bsdiff4"))
+        base_patch = get_data(__name__, "z1_base_patch.bsdiff4")
         rom_data = bsdiff4.patch(rom.read(), base_patch)
         rom_data = bytearray(rom_data)
         # Set every item to the new nothing value, but keep room flags. Type 2 boss roars should


### PR DESCRIPTION
## What is this fixing or adding?
using os.path.join was causing duplicate parts of the filepath in certain environments. turns out it's not needed when loading the basepatch in our current world structure. this should hopefully fix genning issues on the RC beta site (and presumably the main site once the RC turns into the release)

## How was this tested?
genned a seed successfully. made sure base patch took by checking a shop and seeing that a checked shop location moved upwards as is intended.

i request @Berserker66 to test this with his environment on a webhost to make sure a TLOZ properly gens and does not have the same error that birthed this PR (bug report with error here: https://discord.com/channels/731205301247803413/1139279406343393301) before merging.

## If this makes graphical changes, please attach screenshots.
N/A