### PR TITLE
Pokemon R/B: locations accessibility fixes, etc

### DIFF
--- a/worlds/pokemon_rb/__init__.py
+++ b/worlds/pokemon_rb/__init__.py
@@ -69,7 +69,7 @@ class PokemonRedBlueWorld(World):
     settings: typing.ClassVar[PokemonSettings]
 
     data_version = 9
-    required_client_version = (0, 3, 9)
+    required_client_version = (0, 4, 2)
 
     topology_present = True
 
@@ -520,10 +520,12 @@ class PokemonRedBlueWorld(World):
             for location in locations:
                 if not location.can_reach(all_state):
                     pokedex.locations.remove(location)
+                    if location in self.local_locs:
+                        self.local_locs.remove(location)
                     self.dexsanity_table[poke_data.pokemon_dex[location.name.split(" - ")[1]] - 1] = False
                     remove_items += 1
 
-            for _ in range(remove_items - 5):
+            for _ in range(remove_items):
                 balls.append(balls.pop(0))
                 for ball in balls:
                     try:

--- a/worlds/pokemon_rb/__init__.py
+++ b/worlds/pokemon_rb/__init__.py
@@ -263,6 +263,8 @@ class PokemonRedBlueWorld(World):
                         break
                     else:
                         unplaced_items.append(item)
+            else:
+                raise FillError(f"Pokemon Red and Blue local item fill failed for player {loc.player}: could not place {item.name}")
             progitempool += [item for item in unplaced_items if item.advancement]
             usefulitempool += [item for item in unplaced_items if item.useful]
             filleritempool += [item for item in unplaced_items if (not item.advancement) and (not item.useful)]


### PR DESCRIPTION
## What is this fixing or adding?
When accessibility is `locations`, Dexsanity locations not reachable in an all state are deleted. However some locations may already have been added to a list of locations to fill with local items. This fixes a `ValueError` that would occur in this case.

Also fixes the corresponding item removal which was reducing the number of items it was deleting by 5. I haven't the slightest recollection or idea why this was done in the first place.

Adds an error when local location fills fail. I've only observed this happening on a branch with lots of crazy other changes for my own games but probably a good thing to have.

Updates required client version because why are you playing on 0.3.9? Time to update.

## How was this tested?
Generating yaml provided by @ScorelessPine with their seed number, seeing no errors.