### PR TITLE
[Zillion] 3.11 compatibility fix

### DIFF
--- a/ZillionClient.py
+++ b/ZillionClient.py
@@ -447,9 +447,9 @@ async def zillion_sync_task(ctx: ZillionContext) -> None:
                     ctx.known_name = name
                     async_start(ctx.connect())
                     await asyncio.wait((
-                        ctx.got_room_info.wait(),
-                        ctx.exit_event.wait(),
-                        asyncio.sleep(6)
+                        asyncio.create_task(ctx.got_room_info.wait()),
+                        asyncio.create_task(ctx.exit_event.wait()),
+                        asyncio.create_task(asyncio.sleep(6))
                     ), return_when=asyncio.FIRST_COMPLETED)
             else:  # no name found in game
                 if not help_message_shown:


### PR DESCRIPTION
## What is this fixing or adding?

https://docs.python.org/3/library/asyncio-task.html

> Changed in version 3.11: Passing coroutine objects to wait() directly is forbidden.

## How was this tested?

in Python 3.11
connected to MultiServer with a game and checked a location
(what didn't work before this change)
