### PR TITLE
Raft: Fix collecting progressive filler items

### DIFF
--- a/worlds/raft/__init__.py
+++ b/worlds/raft/__init__.py
@@ -138,6 +138,8 @@ class RaftWorld(World):
         return RaftItem(rpName, ItemClassification.filler, self.item_name_to_id[rpName], player=self.player)
     
     def collect_item(self, state, item, remove=False):
+        if item.advancement is False:
+            return None
         if item.name in progressive_item_list:
             prog_table = progressive_item_list[item.name]
             if remove:


### PR DESCRIPTION
## What is this fixing or adding?
According to #2062, filler items should not be collected (IIRC due to performance reasons). Raft was collecting progressive non-progression (...yea) items, which is unnecessary since they don't contribute to progression. This makes Raft's `collect_item` return `None` with non-progression progressive items.

## How was this tested?
Ran the unit test in #2062 for Raft only.