### PR TITLE
The Messenger: Fix a typo preventing a location from being created

### DIFF
--- a/worlds/messenger/Regions.py
+++ b/worlds/messenger/Regions.py
@@ -74,7 +74,7 @@ MEGA_SHARDS: Dict[str, List[str]] = {
     "Underworld": ["Under Entrance Mega Shard", "Hot Tub Mega Shard", "Projectile Pit Mega Shard"],
     "Forlorn Temple": ["Sunny Day Mega Shard", "Down Under Mega Shard"],
     "Sunken Shrine": ["Mega Shard of the Moon", "Beginner's Mega Shard", "Mega Shard of the Stars", "Mega Shard of the Sun"],
-    "RIviere Turquoise Entrance": ["Waterfall Mega Shard"],
+    "Riviere Turquoise Entrance": ["Waterfall Mega Shard"],
     "Riviere Turquoise": ["Quick Restock Mega Shard 1", "Quick Restock Mega Shard 2"],
     "Elemental Skylands": ["Earth Mega Shard", "Water Mega Shard"],
 }

--- a/worlds/messenger/test/TestLocations.py
+++ b/worlds/messenger/test/TestLocations.py
@@ -1,0 +1,16 @@
+from . import MessengerTestBase
+from ..SubClasses import MessengerLocation
+
+
+class LocationsTest(MessengerTestBase):
+    options = {
+        "shuffle_shards": "true",
+    }
+
+    @property
+    def run_default_tests(self) -> bool:
+        return False
+    
+    def testLocationsExist(self):
+        for location in self.multiworld.worlds[1].location_name_to_id:
+            self.assertIsInstance(self.multiworld.get_location(location, self.player), MessengerLocation)


### PR DESCRIPTION
## What is this fixing or adding?
`I` =/= `i`

## How was this tested?
wrote a unit test for it.

## If this makes graphical changes, please attach screenshots.
