### PR TITLE
Terraria: Fix Soul of Sight requiring Post-The Twins flag instead of access to The Twins

### DIFF
--- a/worlds/terraria/Rules.dsv
+++ b/worlds/terraria/Rules.dsv
@@ -295,7 +295,7 @@ Nuclear Rod;                        Calamity | Minions(1);                      
 Acid Rain Tier 2;                   Calamity | Location | Item;                 #Acid Rain Tier 1 & Aquatic Scourge;
 
 // The Twins
-Soul of Sight;                      ;                                           The Twins;
+Soul of Sight;                      ;                                           #The Twins;
 Steampunker;                        Npc;                                        @mech_boss(1);
 Hammush;                            ;                                           Truffle & @mech_boss(1);
 Rainbow Rod;                        ;                                           Hardmode Anvil & Crystal Shard & Unicorn Horn & Pixie Dust & Soul of Light & Soul of Sight;


### PR DESCRIPTION
## What is this fixing or adding?
Fixes [Soul of Sight](https://terraria.wiki.gg/wiki/Soul_of_Sight) requiring Post-The Twins flag instead of access to The Twins. It's a Terraria item that drops from The Twins.

## How was this tested?
I generated 2 games and they were fine
