### PR TITLE
Terraria: Add the rest of the settings to slot data

### DIFF
--- a/worlds/terraria/__init__.py
+++ b/worlds/terraria/__init__.py
@@ -338,5 +338,9 @@ class TerrariaWorld(World):
     def fill_slot_data(self) -> Dict[str, object]:
         return {
             "goal": list(self.goal_locations),
+            "achievements": self.multiworld.achievements[self.player].value,
+            "fill_extra_checks_with": self.multiworld.fill_extra_checks_with[
+                self.player
+            ].value,
             "deathlink": bool(self.multiworld.death_link[self.player]),
         }

--- a/worlds/terraria/__init__.py
+++ b/worlds/terraria/__init__.py
@@ -339,8 +339,6 @@ class TerrariaWorld(World):
         return {
             "goal": list(self.goal_locations),
             "achievements": self.multiworld.achievements[self.player].value,
-            "fill_extra_checks_with": self.multiworld.fill_extra_checks_with[
-                self.player
-            ].value,
+            "fill_extra_checks_with": self.multiworld.fill_extra_checks_with[self.player].value,
             "deathlink": bool(self.multiworld.death_link[self.player]),
         }


### PR DESCRIPTION
## What is this fixing or adding?
Added some Terraria settings to slot data that were missing, but not necessary. @SerpentAI wanted them for their tracker.

## How was this tested?
I generated a game and printed the slot data and it looks good