### PR TITLE
The Legend of Zelda Conntector: Make items obtained counter in save data 16 bits.

### DIFF
--- a/data/lua/connector_tloz.lua
+++ b/data/lua/connector_tloz.lua
@@ -174,11 +174,18 @@ for key, value in pairs(itemAPids) do
     itemIDNames[value] = key
 end
 
+local function getItemsObtained()
+    return bit.lshift(u8(itemsObtainedHigh), 8) + u8(itemsObtained)
+end
 
+local function setItemsObtained(value)
+    wU8(itemsObtainedHigh, bit.rshift(value, 8))
+    wU8(itemsObtained, bit.band(value, 0xFF))
+end
 
 local function determineItem(array)
     memdomain.ram()
-    currentItemsObtained = u8(itemsObtained)
+    currentItemsObtained = getItemsObtained()
     
 end
 
@@ -354,15 +361,6 @@ end
 
 local function gotSmallKey()
     wU8(keys, math.min(u8(keys) + 1, 9))
-end
-
-local function getItemsObtained()
-    return bit.bor(bit.lshift(u8(itemsObtainedHigh), 8), u8(itemsObtained))
-end
-
-local function setItemsObtained(value)
-    wU8(itemsObtainedHigh, bit.rshift(value, 8))
-    wU8(itemsObtained, bit.band(value, 0xFF))
 end
 
 local function gotItem(item)
@@ -571,7 +569,7 @@ function receive()
 end
 
 function main()
-    if not checkBizhawkVersion() then
+    if not checkBizHawkVersion() then
         return
     end
     server, error = socket.bind('localhost', 52980)

--- a/data/lua/connector_tloz.lua
+++ b/data/lua/connector_tloz.lua
@@ -176,11 +176,11 @@ end
 
 
 
---[[local function determineItem(array)
+local function determineItem(array)
     memdomain.ram()
     currentItemsObtained = u8(itemsObtained)
     
-end]]
+end
 
 local function gotSword()
     local currentSword = u8(sword)
@@ -357,7 +357,7 @@ local function gotSmallKey()
 end
 
 local function getItemsObtained()
-    return bit.lshift(u8(itemsObtainedHigh), 8) + u8(itemsObtained)
+    return bit.bor(bit.lshift(u8(itemsObtainedHigh), 8), u8(itemsObtained))
 end
 
 local function setItemsObtained(value)

--- a/data/lua/connector_tloz.lua
+++ b/data/lua/connector_tloz.lua
@@ -175,7 +175,7 @@ for key, value in pairs(itemAPids) do
 end
 
 local function getItemsObtained()
-    return bit.lshift(u8(itemsObtainedHigh), 8) + u8(itemsObtained)
+    return bit.bor(bit.lshift(u8(itemsObtainedHigh), 8), u8(itemsObtained))
 end
 
 local function setItemsObtained(value)

--- a/data/lua/connector_tloz.lua
+++ b/data/lua/connector_tloz.lua
@@ -67,6 +67,7 @@ local itemsObtained         = 0x0677
 local takeAnyCavesChecked   = 0x0678
 local localTriforce         = 0x0679
 local bonusItemsObtained    = 0x067A
+local itemsObtainedHigh     = 0x067B
 
 itemAPids = {
     ["Boomerang"] = 7100,
@@ -175,11 +176,11 @@ end
 
 
 
-local function determineItem(array)
+--[[local function determineItem(array)
     memdomain.ram()
     currentItemsObtained = u8(itemsObtained)
     
-end
+end]]
 
 local function gotSword()
     local currentSword = u8(sword)
@@ -355,6 +356,15 @@ local function gotSmallKey()
     wU8(keys, math.min(u8(keys) + 1, 9))
 end
 
+local function getItemsObtained()
+    return bit.lshift(u8(itemsObtainedHigh), 8) + u8(itemsObtained)
+end
+
+local function setItemsObtained(value)
+    wU8(itemsObtainedHigh, bit.rshift(value, 8))
+    wU8(itemsObtained, bit.band(value, 0xFF))
+end
+
 local function gotItem(item)
     --Write itemCode to itemToLift
     --Write 128 to itemLiftTimer
@@ -364,8 +374,8 @@ local function gotItem(item)
     wU8(0x505, itemCode)
     wU8(0x506, 128)
     wU8(0x602, 4)
-    numberObtained = u8(itemsObtained) + 1
-    wU8(itemsObtained, numberObtained)
+    numberObtained = getItemsObtained() + 1
+    setItemsObtained(numberObtained)
     if itemName == "Boomerang" then gotBoomerang() end
     if itemName == "Bow" then gotBow() end
     if itemName == "Magical Boomerang" then gotMagicalBoomerang() end
@@ -476,7 +486,7 @@ function processBlock(block)
                 if i > u8(bonusItemsObtained) then
                     if u8(0x505) == 0 then
                         gotItem(item)
-                        wU8(itemsObtained, u8(itemsObtained) - 1)
+                        setItemsObtained(getItemsObtained() - 1)
                         wU8(bonusItemsObtained, u8(bonusItemsObtained) + 1)
                     end
                 end
@@ -494,7 +504,7 @@ function processBlock(block)
             for i, item in ipairs(itemsBlock) do
                 memDomain.ram()
                 if u8(0x505) == 0 then
-                    if i > u8(itemsObtained) then
+                    if i > getItemsObtained() then
                         gotItem(item)
                     end
                 end
@@ -546,7 +556,7 @@ function receive()
     retTable["gameMode"] = gameMode
     retTable["overworldHC"] = getHCLocation()
     retTable["overworldPB"] = getPBLocation()
-    retTable["itemsObtained"] = u8(itemsObtained)
+    retTable["itemsObtained"] = getItemsObtained()
     msg = json.encode(retTable).."\n"
     local ret, error = zeldaSocket:send(msg)
     if ret == nil then
@@ -561,7 +571,7 @@ function receive()
 end
 
 function main()
-    if not checkBizHawkVersion() then
+    if not checkBizhawkVersion() then
         return
     end
     server, error = socket.bind('localhost', 52980)


### PR DESCRIPTION
## What is this fixing or adding?
Certain multiworld settings (bug observed with item link settings) can cause the total item count in TLoZ world to exceed 255. This causes an overflow in the loop to receive all pending items. This adds an additional byte to be used as a high byte for the items obtained counter.

This approach was taken due to the surrounding bytes being occupied, preventing a direct 16-bit number from being used without moving to a different location and leaving more empty bytes in the memory block for save data.

## How was this tested?
When I encountered this problem in my own game, I made this as my fix for the problem. It worked without any noticeable side effects. Save persistence was checked with a reboot after ensuring data had been saved. Additionally, the [variables table](https://github.com/Rosalie-A/zelda1-disassembly/blob/Z1AP/src/Variables.inc) and connector script were checked for conflicts.

## If this makes graphical changes, please attach screenshots.
N/A.
