### PR TITLE
MMBN3: Adds instructions for using the Legacy Collection ROM for setup

### DIFF
--- a/worlds/mmbn3/docs/setup_en.md
+++ b/worlds/mmbn3/docs/setup_en.md
@@ -12,7 +12,8 @@ As we are using Bizhawk, this guide is only applicable to Windows and Linux syst
   - Windows users must run the prereq installer first, which can also be found at the above link.
 - The built-in Archipelago client, which can be installed [here](https://github.com/ArchipelagoMW/Archipelago/releases)
   (select `MegaMan Battle Network 3 Client` during installation).
-- A US MegaMan Battle Network 3 Blue Rom
+- A US MegaMan Battle Network 3 Blue Rom. If you have the [MegaMan Battle Network Legacy Collection Vol. 1](https://store.steampowered.com/app/1798010/Mega_Man_Battle_Network_Legacy_Collection_Vol_1/)
+on Steam, you can obtain a copy of this ROM from the game's files, see instructions below.
 
 ## Configuring Bizhawk
 
@@ -34,6 +35,14 @@ It is strongly recommended to associate GBA rom extensions (\*.gba) to the Bizha
 To do so, we simply have to search any GBA rom we happened to own, right click and select "Open with...", unfold
 the list that appears and select the bottom option "Look for another application", then browse to the Bizhawk folder
 and select EmuHawk.exe.
+
+## Extracting a ROM from the Legacy Collection
+
+The Steam version of the Legacy Collection contains unmodified GBA ROMs in its files. You can extract these for use with Archipelago.
+
+1. Open the Legacy Collection Vol. 1's Game Files (Right click on the game in your Library, then open Properties -> Installed Files -> Browse)
+2. Open the file `exe/data/exe3b.dat` in a Zip extracting program such as 7Zip or WinRAR.
+3. Extract the file `rom_b_e.srl` somewhere and rename it to `Mega Man Battle Network 3 - Blue Version (USA).gba`
 
 ## Configuring your YAML file
 

--- a/worlds/mmbn3/docs/setup_en.md
+++ b/worlds/mmbn3/docs/setup_en.md
@@ -41,7 +41,7 @@ and select EmuHawk.exe.
 The Steam version of the Legacy Collection contains unmodified GBA ROMs in its files. You can extract these for use with Archipelago.
 
 1. Open the Legacy Collection Vol. 1's Game Files (Right click on the game in your Library, then open Properties -> Installed Files -> Browse)
-2. Open the file `exe/data/exe3b.dat` in a Zip extracting program such as 7Zip or WinRAR.
+2. Open the file `exe/data/exe3b.dat` in a zip-extracting program such as 7-Zip or WinRAR.
 3. Extract the file `rom_b_e.srl` somewhere and rename it to `Mega Man Battle Network 3 - Blue Version (USA).gba`
 
 ## Configuring your YAML file


### PR DESCRIPTION
## What is this fixing or adding?
Adds instructions to MMBN3's Setup Guide for how to extract the ROM from the PC version of the Legacy Collection.

## How was this tested?
Instructions provided and verified by Discord users (Notably tauakiou who provided all the file names in one place, thanks!) who have successfully patched and played the randomizer with files from the Legacy Collection