### PR TITLE
Witness: "Fix" one of the hints not being a Haiku (seriously)

### DIFF
--- a/worlds/witness/hints.py
+++ b/worlds/witness/hints.py
@@ -10,7 +10,7 @@ joke_hints = [
     "You can do it!",
     "I believe in you!",
     "The person playing is cute. <3",
-    "dash dot, dash dash dash, dash, dot dot dot dot, dot dot, dash dot, dash dash dot",
+    "dash dot, dash dash dash,\ndash, dot dot dot dot, dot dot,\ndash dot, dash dash dot",
     "When you think about it, there are actually a lot of bubbles in a stream.",
     "Never gonna give you up\nNever gonna let you down\nNever gonna run around and desert you",
     "Thanks to the Archipelago developers for making this possible.",


### PR DESCRIPTION
I hope this gets a prize for "Most irrelevant PR in AP history"

**Explanation:**

Witness has joke hints that were submitted by community members.

When changing the hint system on the client side to be able to auto-wrap, decisions were made about which line breaks in joke hints were still explicitly important, with most of them being removed.

The hint that is subject of this PR was somewhat devalued in the process.

-. --- - .... .. -. --. translates to "Nothing", which I thought was the entirety of the joke.

However, the line breaks were actually also important, because:

dash dot, dash dash dash,
dash, dot dot dot dot, dot dot,
dash dot, dash dash dot

is a Haiku! And the hint's creator (oddGarrett I believe) said this was specifically part of the creative vision for this joke hint. They said it's fine, I don't need to change it, but I couldn't let that stand.

So, the explicit line breaks for this joke hint are back.