### PR TITLE
Core: Update ThreadBarrierProxy error message

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -40,7 +40,8 @@ class ThreadBarrierProxy:
             return getattr(self.obj, name)
         else:
             raise RuntimeError("You are in a threaded context and global random state was removed for your safety. "
-                               "Please use multiworld.per_slot_randoms[player] or randomize ahead of output.")
+                               "Please use self.random or randomize ahead of output."
+                               "Check your slot data for other errors as well, such as outputting Location objects.")
 
 
 class MultiWorld():


### PR DESCRIPTION
## What is this fixing or adding?
Updating the error message since it sent us on a wild goose chase looking to figure out why randoms were causing an error, where the actual error was from accidentally putting a Location into slot_data instead of its name.

Also changing the recommendation from per_slot_randoms to self.random to mirror the change in PR #2098 that got done last week.

## How was this tested?
N/A

## If this makes graphical changes, please attach screenshots.
N/A