### PR TITLE
FF1: Fix typo in English setup page

### DIFF
--- a/worlds/ff1/docs/multiworld_en.md
+++ b/worlds/ff1/docs/multiworld_en.md
@@ -32,7 +32,7 @@ Generate a game by going to the site and performing the following steps:
    prefer, or it is your first time we suggest starting with the 'Shard Hunt' preset (which requires you to collect a
    number of shards to go to the end dungeon) or the 'Beginner' preset if you prefer to kill the original fiends.
 2. Go to the `Goal` tab and ensure `Archipelago` is enabled. Set your player name to any name that represents you.
-3. Upload you `Final Fantasy(USA).nes` (and click `Remember ROM` for the future!)
+3. Upload your `Final Fantasy(USA).nes` (and click `Remember ROM` for the future!)
 4. Press the `NEW` button beside `Seed` a few times
 5. Click `GENERATE ROM`
 


### PR DESCRIPTION

## What is this fixing or adding?

Fixes a typo in the FF1 setup guide.

## How was this tested?

n/a

## If this makes graphical changes, please attach screenshots.

n/a