### PR TITLE
Allow any valid priority location in yaml even when they are not used in a given game.

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -139,7 +139,13 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
         exclusion_rules(world, player, world.exclude_locations[player].value)
         world.priority_locations[player].value -= world.exclude_locations[player].value
         for location_name in world.priority_locations[player].value:
-            world.get_location(location_name, player).progress_type = LocationProgressType.PRIORITY
+            try:
+                location = world.get_location(location_name, player)
+            except KeyError as e:  # failed to find the given location. Check if it's a legitimate location
+                if location_name not in world.worlds[player].location_name_to_id:
+                    raise Exception(f"Unable to exclude location {location_name} in player {player}'s world.") from e
+            else:
+                location.progress_type = LocationProgressType.PRIORITY
 
     # Set local and non-local item rules.
     if world.players > 1:


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?

Generation errors when someone specifies a location that IS a valid location, but is not actually in use for the current game,  such as "Cantoran" in time spinner, when the Cantoran boss option is off,  or location group name "Everywhere" in certain games, such as Zillion.  (that game has 21 location names defined for each of the 74 rooms in the game, of which, only at most 2 of them are ever used in a given game.)

## How was this tested?

Generated games using a yaml that specifies priority_locations Everywhere, for games that absolutely doesn't use ALL of its named locations no matter what.

## If this makes graphical changes, please attach screenshots.
