### PR TITLE
- Added a missing logic rule for talking to Leo

### DIFF
--- a/worlds/stardew_valley/logic.py
+++ b/worlds/stardew_valley/logic.py
@@ -1095,6 +1095,8 @@ class StardewLogic:
         rules = [self.can_reach_any_region(villager.locations)]
         if npc == NPC.kent:
             rules.append(self.has_year_two())
+        if npc == NPC.leo:
+            rules.append(self.received("Island West Turtle"))
 
         return And(rules)
 

--- a/worlds/stardew_valley/logic.py
+++ b/worlds/stardew_valley/logic.py
@@ -1095,7 +1095,7 @@ class StardewLogic:
         rules = [self.can_reach_any_region(villager.locations)]
         if npc == NPC.kent:
             rules.append(self.has_year_two())
-        if npc == NPC.leo:
+        elif npc == NPC.leo:
             rules.append(self.received("Island West Turtle"))
 
         return And(rules)


### PR DESCRIPTION
## What is this fixing or adding?
Talking to Leo requires the Island West turtle to have moved, so he comes down from his perch and talks to the player. That rule was not there, which means it can softlock a world if the turtle was in his friendship hearts.

## How was this tested?
Unit tests
