### PR TITLE
SNIClient: Fixed root cause of crashes of hardware for ALttP Collect.

### DIFF
--- a/SNIClient.py
+++ b/SNIClient.py
@@ -565,14 +565,16 @@ async def snes_write(ctx: SNIContext, write_list: typing.List[typing.Tuple[int, 
         PutAddress_Request: SNESRequest = {"Opcode": "PutAddress", "Operands": [], 'Space': 'SNES'}
         try:
             for address, data in write_list:
-                PutAddress_Request['Operands'] = [hex(address)[2:], hex(len(data))[2:]]
-                # REVIEW: above: `if snes_socket is None: return False`
-                # Does it need to be checked again?
-                if ctx.snes_socket is not None:
-                    await ctx.snes_socket.send(dumps(PutAddress_Request))
-                    await ctx.snes_socket.send(data)
-                else:
-                    snes_logger.warning(f"Could not send data to SNES: {data}")
+                while data:
+                    # Divide the write into packets of 256 bytes.
+                    PutAddress_Request['Operands'] = [hex(address)[2:], hex(min(len(data), 256))[2:]]
+                    if ctx.snes_socket is not None:
+                        await ctx.snes_socket.send(dumps(PutAddress_Request))
+                        await ctx.snes_socket.send(data[:256])
+                        address += 256
+                        data = data[256:]
+                    else:
+                        snes_logger.warning(f"Could not send data to SNES: {data}")
         except ConnectionClosed:
             return False
 


### PR DESCRIPTION

Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?

As it turns out, SD2SNES / FXPAK Pro has a limit as to how many bytes can be written in a single command packet.  Exceed this limit, and the hardware will crash.  That limit is 512 bytes.  This limit not only includes that data to be written, but ALSO the 65816 assembler code required to write that data to ram.  As a result, a full release of all locations in the game exceeds this buffer, and on older versions of the Super Nintendo Interface,  caused crashes on real hardware.   Even 512 bytes of data to write is too much as that leaves no room for the data writing code. (which super nintendo interface deals with itself.)

The fix is to split large writes into 256 byte buffers.

## How was this tested?

Do a release on a Link to the Past slot that has item non-local.  Tested both with and without this code in place.  The tests without the fix crashed or closed the snes connection as expected.  The fix resulted in everything showing as collected in the tracker,  other than the forbidden things.

## If this makes graphical changes, please attach screenshots.
