### PR TITLE
Pokémon R/B: Fix fishing logic mistake

### DIFF
--- a/worlds/pokemon_rb/regions.py
+++ b/worlds/pokemon_rb/regions.py
@@ -1681,7 +1681,6 @@ def create_regions(self):
     connect(multiworld, player, "Fuchsia City", "Fuchsia Fishing", lambda state: state.has("Super Rod", player), one_way=True)
     connect(multiworld, player, "Pallet Town", "Old Rod Fishing", lambda state: state.has("Old Rod", player), one_way=True)
     connect(multiworld, player, "Pallet Town", "Good Rod Fishing", lambda state: state.has("Good Rod", player), one_way=True)
-    connect(multiworld, player, "Cinnabar Lab Fossil Room", "Good Rod Fishing", one_way=True)
     connect(multiworld, player, "Cinnabar Lab Fossil Room", "Fossil Level", lambda state: logic.fossil_checks(state, 1, player), one_way=True)
     connect(multiworld, player, "Route 5 Gate-N", "Route 5 Gate-S", lambda state: logic.can_pass_guards(state, player))
     connect(multiworld, player, "Route 6 Gate-N", "Route 6 Gate-S", lambda state: logic.can_pass_guards(state, player))


### PR DESCRIPTION
## What is this fixing or adding?
Removes an errant region connection putting Good Rod fishing in logic with access to the Cinnabar Lab Fossil Room. I can only guess this was a copy-paste mistake.

## How was this tested?
Not, but this line definitely shouldn't be here.

## If this makes graphical changes, please attach screenshots.
