### PR TITLE
Stardew Valley: Add missing special order logic rules

### DIFF
--- a/worlds/stardew_valley/logic.py
+++ b/worlds/stardew_valley/logic.py
@@ -492,35 +492,39 @@ class StardewLogic:
         })
 
         self.special_order_rules.update({
-            SpecialOrder.island_ingredients: self.has_island_transport() & self.can_farm_perfectly() &
-                                  self.has(Vegetable.taro_root) & self.has(Fruit.pineapple) & self.has(Forageable.ginger),
-            SpecialOrder.cave_patrol: self.can_mine_perfectly() & self.can_mine_to_floor(120),
-            SpecialOrder.aquatic_overpopulation: self.can_fish_perfectly(),
-            SpecialOrder.biome_balance: self.can_fish_perfectly(),
-            SpecialOrder.rock_rejuivenation: self.has(Mineral.ruby) & self.has(Mineral.topaz) & self.has(Mineral.emerald) &
-                                 self.has(Mineral.jade) & self.has(Mineral.amethyst) & self.has_relationship(NPC.emily, 4) &
-                                 self.has(ArtisanGood.cloth) & self.can_reach_region(Region.haley_house),
-            SpecialOrder.gifts_for_george: self.has_season(Season.spring) & self.has(Forageable.leek),
-            SpecialOrder.fragments_of_the_past: self.can_reach_region(Region.dig_site),
-            SpecialOrder.gus_famous_omelet: self.has(AnimalProduct.any_egg),
-            SpecialOrder.crop_order: self.can_farm_perfectly(),
-            SpecialOrder.community_cleanup: self.can_crab_pot(),
-            SpecialOrder.the_strong_stuff: self.can_keg(Vegetable.potato),
-            SpecialOrder.pierres_prime_produce: self.can_farm_perfectly(),
-            SpecialOrder.robins_project: self.can_chop_perfectly() & self.has(Material.hardwood),
-            SpecialOrder.robins_resource_rush: self.can_chop_perfectly() & self.has(Fertilizer.tree) & self.can_mine_perfectly(),
-            SpecialOrder.juicy_bugs_wanted_yum: self.has(Loot.bug_meat),
-            SpecialOrder.tropical_fish: self.has_island_transport() & self.has(Fish.stingray) & self.has(Fish.blue_discus) & self.has(Fish.lionfish),
-            SpecialOrder.a_curious_substance: self.can_mine_perfectly() & self.can_mine_to_floor(80),
-            SpecialOrder.prismatic_jelly: self.can_mine_perfectly() & self.can_mine_to_floor(40),
+            SpecialOrder.island_ingredients: self.can_meet(NPC.caroline) & self.has_island_transport() & self.can_farm_perfectly() &
+                                             self.can_ship(Vegetable.taro_root) & self.can_ship(Fruit.pineapple) & self.can_ship(Forageable.ginger),
+            SpecialOrder.cave_patrol: self.can_meet(NPC.clint) & self.can_mine_perfectly() & self.can_mine_to_floor(120),
+            SpecialOrder.aquatic_overpopulation: self.can_meet(NPC.demetrius) & self.can_fish_perfectly(),
+            SpecialOrder.biome_balance: self.can_meet(NPC.demetrius) & self.can_fish_perfectly(),
+            SpecialOrder.rock_rejuivenation: self.has_relationship(NPC.emily, 4) & self.has(Mineral.ruby) & self.has(Mineral.topaz) &
+                                             self.has(Mineral.emerald) & self.has(Mineral.jade) & self.has(Mineral.amethyst) &
+                                             self.has(ArtisanGood.cloth) & self.can_reach_region(Region.haley_house),
+            SpecialOrder.gifts_for_george: self.can_reach_region(Region.alex_house) & self.has_season(Season.spring) & self.has(Forageable.leek),
+            SpecialOrder.fragments_of_the_past: self.can_reach_region(Region.museum) & self.can_reach_region(Region.dig_site) & self.has_tool(Tool.pickaxe),
+            SpecialOrder.gus_famous_omelet: self.can_reach_region(Region.saloon) & self.has(AnimalProduct.any_egg),
+            SpecialOrder.crop_order: self.can_farm_perfectly() & self.can_ship(),
+            SpecialOrder.community_cleanup: self.can_reach_region(Region.railroad) & self.can_crab_pot(),
+            SpecialOrder.the_strong_stuff: self.can_reach_region(Region.trailer) & self.can_keg(Vegetable.potato),
+            SpecialOrder.pierres_prime_produce: self.can_reach_region(Region.pierre_store) & self.can_farm_perfectly(),
+            SpecialOrder.robins_project: self.can_meet(NPC.robin) & self.can_reach_region(Region.carpenter) & self.can_chop_perfectly() &
+                                         self.has(Material.hardwood),
+            SpecialOrder.robins_resource_rush: self.can_meet(NPC.robin) & self.can_reach_region(Region.carpenter) & self.can_chop_perfectly() &
+                                               self.has(Fertilizer.tree) & self.can_mine_perfectly(),
+            SpecialOrder.juicy_bugs_wanted_yum: self.can_reach_region(Region.beach) & self.has(Loot.bug_meat),
+            SpecialOrder.tropical_fish: self.can_meet(NPC.willy) & self.received("Island Resort") & self.has_island_transport() &
+                                        self.has(Fish.stingray) & self.has(Fish.blue_discus) & self.has(Fish.lionfish),
+            SpecialOrder.a_curious_substance: self.can_reach_region(Region.wizard_tower) & self.can_mine_perfectly() & self.can_mine_to_floor(80),
+            SpecialOrder.prismatic_jelly: self.can_reach_region(Region.wizard_tower) & self.can_mine_perfectly() & self.can_mine_to_floor(40),
             SpecialOrder.qis_crop: self.can_farm_perfectly() & self.can_reach_region(Region.greenhouse) &
                          self.can_reach_region(Region.island_west) & self.has_total_skill_level(50) &
-                         self.has(Machine.seed_maker),
+                         self.has(Machine.seed_maker) & self.has_building(Building.shipping_bin),
             SpecialOrder.lets_play_a_game: self.has_junimo_kart_max_level(),
             SpecialOrder.four_precious_stones: self.has_lived_months(MAX_MONTHS) & self.has("Prismatic Shard") &
                                     self.can_mine_perfectly_in_the_skull_cavern(),
             SpecialOrder.qis_hungry_challenge: self.can_mine_perfectly_in_the_skull_cavern() & self.has_max_buffs(),
-            SpecialOrder.qis_cuisine: self.can_cook() & (self.can_spend_money_at(Region.saloon, 205000) | self.can_spend_money_at(Region.pierre_store, 170000)),
+            SpecialOrder.qis_cuisine: self.can_cook() & (self.can_spend_money_at(Region.saloon, 205000) | self.can_spend_money_at(Region.pierre_store, 170000)) &
+                                      self.can_ship(),
             SpecialOrder.qis_kindness: self.can_give_loved_gifts_to_everyone(),
             SpecialOrder.extended_family: self.can_fish_perfectly() & self.has(Fish.angler) & self.has(Fish.glacierfish) &
                                self.has(Fish.crimsonfish) & self.has(Fish.mutant_carp) & self.has(Fish.legend),
@@ -1604,4 +1608,10 @@ class StardewLogic:
         for rarecrow_number in range(1, 9):
             rules.append(self.received(f"Rarecrow #{rarecrow_number}"))
         return And(rules)
+
+    def can_ship(self, item: str = "") -> StardewRule:
+        shipping_bin_rule = self.has_building(Building.shipping_bin)
+        if item == "":
+            return shipping_bin_rule
+        return shipping_bin_rule & self.has(item)
 

--- a/worlds/stardew_valley/logic.py
+++ b/worlds/stardew_valley/logic.py
@@ -1161,7 +1161,7 @@ class StardewLogic:
                 item_rules.append(bundle_item.item.name)
                 if bundle_item.quality > highest_quality_yet:
                     highest_quality_yet = bundle_item.quality
-        return self.has(item_rules, number_required) & self.can_grow_gold_quality(highest_quality_yet)
+        return self.can_reach_region(Region.wizard_tower) & self.has(item_rules, number_required) & self.can_grow_gold_quality(highest_quality_yet)
 
     def can_grow_gold_quality(self, quality: int) -> StardewRule:
         if quality <= 0:


### PR DESCRIPTION
## What is this fixing or adding?

It was brought to my attention that about half the special orders have, as a completion condition once the items are collected, to drop them off somewhere or talk to someone. These drop-off locations are always available in vanilla, but with entrance randomization, they might not be.

So I went over the whole list and added missing logic rules for either regions or NPCs, so that the quests are garanteed to be completable with entrance randomization.

## How was this tested?
Ran the unit tests to make sure I didn't break anything, other than that it's just making logic a bit more strict so it can't really introduce new softlocks, just remove some

The changes were made based on the requirements listed here: https://stardewvalleywiki.com/Quests#List_of_Special_Orders