### PR TITLE
WebHost Config: Config option for custom port ranges

### DIFF
--- a/WebHostLib/__init__.py
+++ b/WebHostLib/__init__.py
@@ -29,6 +29,7 @@ app.config["SELFLAUNCHKEY"] = None  # can point to a SSL Certificate Key to encr
 app.config["SELFGEN"] = True  # application process is in charge of scheduling Generations.
 app.config["DEBUG"] = False
 app.config["PORT"] = 80
+app.config["GAME_PORTS"] = "49152-65535"
 app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
 app.config['MAX_CONTENT_LENGTH'] = 64 * 1024 * 1024  # 64 megabyte limit
 # if you want to deploy, make sure you have a non-guessable secret key

--- a/WebHostLib/autolauncher.py
+++ b/WebHostLib/autolauncher.py
@@ -180,6 +180,7 @@ class MultiworldInstance():
         self.cert = config["SELFLAUNCHCERT"]
         self.key = config["SELFLAUNCHKEY"]
         self.host = config["HOST_ADDRESS"]
+        self.game_ports = config["GAME_PORTS"]
 
     def start(self):
         if self.process and self.process.is_alive():
@@ -188,7 +189,7 @@ class MultiworldInstance():
         logging.info(f"Spinning up {self.room_id}")
         process = multiprocessing.Process(group=None, target=run_server_process,
                                           args=(self.room_id, self.ponyconfig, get_static_server_data(),
-                                                self.cert, self.key, self.host),
+                                                self.cert, self.key, self.host, self.game_ports),
                                           name="MultiHost")
         process.start()
         # bind after start to prevent thread sync issues with guardian.

--- a/WebHostLib/customserver.py
+++ b/WebHostLib/customserver.py
@@ -19,6 +19,8 @@ import Utils
 
 from MultiServer import Context, server, auto_shutdown, ServerCommandProcessor, ClientMessageProcessor, load_server_cert
 from Utils import restricted_loads, cache_argsless
+
+from . import app
 from .models import Command, GameDataPackage, Room, db
 
 
@@ -84,13 +86,13 @@ class WebHostContext(Context):
             time.sleep(5)
 
     @db_session
-    def load(self, room_id: int):
+    def load(self, room_id: int, game_ports: str):
         self.room_id = room_id
         room = Room.get(id=room_id)
         if room.last_port:
             self.port = room.last_port
         else:
-            self.port = get_random_port()
+            self.port = get_random_port(game_ports)
 
         multidata = self.decompress(room.seed.multidata)
         game_data_packages = {}
@@ -133,8 +135,36 @@ class WebHostContext(Context):
         return d
 
 
-def get_random_port():
-    return random.randint(49152, 65535)
+def get_random_port(game_ports):
+    config_range_list = game_ports.split(",")
+    available_ports = []
+    for item in config_range_list:
+        if '-' in item:
+            start, end = map(int, item.split('-'))
+            available_ports.extend(range(start, end+1))
+        else:
+            available_ports.append(int(item))
+
+    port = get_port_from_list(available_ports)
+
+    return port
+
+
+def get_port_from_list(available_ports: list) -> int:
+    while available_ports:
+        port = random.choice(available_ports)
+        available_ports.remove(port)
+
+        if not is_port_in_use(port):
+            break
+    else:
+        port = 0
+    return port
+
+
+def is_port_in_use(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        return s.connect_ex(('localhost', port)) == 0
 
 
 @cache_argsless
@@ -157,7 +187,7 @@ def get_static_server_data() -> dict:
 
 def run_server_process(room_id, ponyconfig: dict, static_server_data: dict,
                        cert_file: typing.Optional[str], cert_key_file: typing.Optional[str],
-                       host: str):
+                       host: str, game_ports: str):
     # establish DB connection for multidata and multisave
     db.bind(**ponyconfig)
     db.generate_mapping(check_tables=False)
@@ -165,7 +195,7 @@ def run_server_process(room_id, ponyconfig: dict, static_server_data: dict,
     async def main():
         Utils.init_logging(str(room_id), write_mode="a")
         ctx = WebHostContext(static_server_data)
-        ctx.load(room_id)
+        ctx.load(room_id, game_ports)
         ctx.init_save()
         ssl_context = load_server_cert(cert_file, cert_key_file) if cert_file else None
         try:

--- a/docs/webhost configuration sample.yaml
+++ b/docs/webhost configuration sample.yaml
@@ -17,6 +17,10 @@
 # Web hosting port
 #PORT: 80
 
+# Ports used for game hosting. Values can be specific ports, port ranges or both. Default is: "49152-65535"
+# Examples of valid values: "40000-41000,49152-65535"
+#GAME_PORTS: "49152-65535"
+
 # Place where uploads go.
 #UPLOAD_FOLDER: uploads
 


### PR DESCRIPTION
## What is this fixing or adding?
Added a new option to the example config that will allow you to define ports that can be used for the WebHost. By default it will operate with the already existing port ranges.

## How was this tested?
Running WebHost and loading up a lot of different servers.

## If this makes graphical changes, please attach screenshots.
N/A