### PR TITLE
WebHost: Support multi-select during check/generate file upload

### DIFF
--- a/WebHostLib/generate.py
+++ b/WebHostLib/generate.py
@@ -64,8 +64,8 @@ def generate(race=False):
         if 'file' not in request.files:
             flash('No file part')
         else:
-            file = request.files['file']
-            options = get_yaml_data(file)
+            files = request.files.getlist('file')
+            options = get_yaml_data(files)
             if isinstance(options, str):
                 flash(options)
             else:

--- a/WebHostLib/templates/check.html
+++ b/WebHostLib/templates/check.html
@@ -17,7 +17,7 @@
             </p>
             <div id="check-form-wrapper">
                 <form id="check-form" method="post" enctype="multipart/form-data">
-                    <input id="file-input" type="file" name="file">
+                    <input id="file-input" type="file" name="file" multiple>
                 </form>
                 <button id="check-button">Upload</button>
             </div>

--- a/WebHostLib/templates/check.html
+++ b/WebHostLib/templates/check.html
@@ -19,7 +19,7 @@
                 <form id="check-form" method="post" enctype="multipart/form-data">
                     <input id="file-input" type="file" name="file" multiple>
                 </form>
-                <button id="check-button">Upload</button>
+                <button id="check-button">Upload File(s)</button>
             </div>
         </div>
     </div>

--- a/WebHostLib/templates/generate.html
+++ b/WebHostLib/templates/generate.html
@@ -203,7 +203,7 @@ Warning: playthrough can take a significant amount of time for larger multiworld
                         </div>
                     </div>
                     <div id="generate-form-button-row">
-                        <input id="file-input" type="file" name="file">
+                        <input id="file-input" type="file" name="file" multiple>
                     </div>
                 </form>
                 <button id="generate-game-button">Upload File</button>

--- a/WebHostLib/templates/generate.html
+++ b/WebHostLib/templates/generate.html
@@ -206,7 +206,7 @@ Warning: playthrough can take a significant amount of time for larger multiworld
                         <input id="file-input" type="file" name="file" multiple>
                     </div>
                 </form>
-                <button id="generate-game-button">Upload File</button>
+                <button id="generate-game-button">Upload File(s)</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## What is this fixing or adding?

This will allow the user to select multiple YAML files via Shift-Click or Control-Click in their browser when generating a game via the site instead of having to zip them locally first.

Implements this suggestion from #general-suggestions: https://discord.com/channels/731205301247803413/1139359972401102940

There were some suggestions in that thread to make this even better that aren't implemented here, but I agree with " just allowing multi-select in the prompt would go a long, long ways to make it easier" and chose to implement that for now.

## How was this tested?

Locally by running WebHost.py. Validated that single-YAML and single-zip uploads still work as expected, then also tried multiple YAMLs. For fun I also tried multiple zips, then a zip+yaml upload and those worked too. I don't think multiple zips or zip+yamls is a particularly common use case but I see no reason to block it either.

## If this makes graphical changes, please attach screenshots.
