### PR TITLE
Pokemon RB: Fix typo on the game info page

### DIFF
--- a/worlds/pokemon_rb/docs/en_Pokemon Red and Blue.md
+++ b/worlds/pokemon_rb/docs/en_Pokemon Red and Blue.md
@@ -20,7 +20,7 @@ Many baseline changes are made to the game, including:
 * PC item storage increased to 64 slots (up from 50).
 * You can hold B to run (or bike extra fast!).
 * You can hold select while talking to a trainer to re-battle them.
-* You can select "Pallet Warp" below the "Continue" option to warp to Pallet Towna s you load your save.
+* You can select "Pallet Warp" below the "Continue" option to warp to Pallet Town as you load your save.
 * Mew can be encountered at the S.S. Anne dock truck. This can be randomized depending on your settings.
 * The S.S. Anne will never depart.
 * Seafoam Islands entrances are swapped. This means you need Strength to travel through from Cinnabar Island to Fuchsia


### PR DESCRIPTION
## What is this fixing or adding?

Fixes a typo on the Pokemon RB game info page

Thanks Shiny for pointing it out https://discord.com/channels/731205301247803413/1043592720603693167/1147300361883893790

## How was this tested?

It wasn't, just a doc change