### PR TITLE
Undertale: /savepath fix

### DIFF
--- a/UndertaleClient.py
+++ b/UndertaleClient.py
@@ -36,7 +36,7 @@ class UndertaleCommandProcessor(ClientCommandProcessor):
     def _cmd_savepath(self, directory: str):
         """Redirect to proper save data folder. (Use before connecting!)"""
         if isinstance(self.ctx, UndertaleContext):
-            UndertaleContext.save_game_folder = directory
+            self.ctx.save_game_folder = directory
             self.output("Changed to the following directory: " + directory)
 
     @mark_raw


### PR DESCRIPTION
## What is this fixing or adding?
Updates the /savepath command to edit the instantiated self.ctx instead of the static UndertaleContext

## How was this tested?
Platform: Linux Mint
Ran from AppImage, precompiled executables, and from source, player inventory did not update upon connecting to server.
Sourced .item files from a Windows user testing the same seed, player inventory was updated.
Ran from modified source on a new save file, player inventory updates as expected.

## If this makes graphical changes, please attach screenshots.
No graphical changes.