### PR TITLE
Zillion: webhost config fix

### DIFF
--- a/worlds/zillion/__init__.py
+++ b/worlds/zillion/__init__.py
@@ -10,6 +10,7 @@ import logging
 
 from BaseClasses import ItemClassification, LocationProgressType, \
     MultiWorld, Item, CollectionState, Entrance, Tutorial
+from .config import detect_test
 from .logic import cs_to_zz_locs
 from .region import ZillionLocation, ZillionRegion
 from .options import ZillionStartChar, zillion_options, validate
@@ -145,8 +146,7 @@ class ZillionWorld(World):
 
         self._item_counts = item_counts
 
-        import __main__
-        rom_dir_name = "" if "test" in __main__.__file__ else os.path.dirname(get_base_rom_path())
+        rom_dir_name = "" if detect_test() else os.path.dirname(get_base_rom_path())
         with redirect_stdout(self.lsi):  # type: ignore
             self.zz_system.make_patcher(rom_dir_name)
             self.zz_system.make_randomizer(zz_op)

--- a/worlds/zillion/config.py
+++ b/worlds/zillion/config.py
@@ -2,3 +2,20 @@ import os
 
 base_id = 8675309
 zillion_map = os.path.join(os.path.dirname(__file__), "empty-zillion-map-row-col-labels-281.png")
+
+
+def detect_test() -> bool:
+    """
+    Parts of generation that are in unit tests need the rom.
+    This is to detect whether we are running unit tests
+    so we can work around the need for the rom.
+    """
+    import __main__
+    try:
+        if "test" in __main__.__file__:
+            return True
+    except AttributeError:
+        # In some environments, __main__ doesn't have __file__
+        # We'll assume that's not unit tests.
+        pass
+    return False


### PR DESCRIPTION
## What is this fixing or adding?

Zillion generation on archipelago.gg is failing.

https://discord.com/channels/731205301247803413/1147772247562534996

## How was this tested?

I can't reproduce this with my own webhost. Generation works when I run `WebHost.py` I don't know how the archipelago.gg webhost is configured to make this happen.

This seems like it should fix it based on the error message I see, but without being able to reproduce the webhost configuration, I don't see a way to test whether this fixes the problem.

I made sure it didn't cause any new generation problems with my configuration.