### PR TITLE
DS3: Fix health locations setting not enabling

### DIFF
--- a/worlds/dark_souls_3/Locations.py
+++ b/worlds/dark_souls_3/Locations.py
@@ -77,6 +77,7 @@ class DarkSouls3Location(Location):
             "Progressive Items 3",
             "Progressive Items 4",
             "Progressive Items DLC",
+            "Progressive Items Health",
         ]
 
         output = {}
@@ -581,11 +582,7 @@ location_tables = {
         [DS3LocationData(f"Titanite Shard #{i + 1}",       "Titanite Shard",       DS3LocationCategory.PROGRESSIVE_ITEM) for i in range(26)] +
         [DS3LocationData(f"Large Titanite Shard #{i + 1}", "Large Titanite Shard", DS3LocationCategory.PROGRESSIVE_ITEM) for i in range(28)] +
         [DS3LocationData(f"Titanite Slab #{i + 1}",        "Titanite Slab",        DS3LocationCategory.PROGRESSIVE_ITEM) for i in range(3)] +
-        [DS3LocationData(f"Twinkling Titanite #{i + 1}",   "Twinkling Titanite",   DS3LocationCategory.PROGRESSIVE_ITEM) for i in range(15)] +
-
-        # Healing
-        [DS3LocationData(f"Estus Shard #{i + 1}",       "Estus Shard",       DS3LocationCategory.HEALTH) for i in range(11)] +
-        [DS3LocationData(f"Undead Bone Shard #{i + 1}", "Undead Bone Shard", DS3LocationCategory.HEALTH) for i in range(10)],
+        [DS3LocationData(f"Twinkling Titanite #{i + 1}",   "Twinkling Titanite",   DS3LocationCategory.PROGRESSIVE_ITEM) for i in range(15)],
 
     "Progressive Items 2": [] +
         # Items
@@ -683,7 +680,12 @@ location_tables = {
         [DS3LocationData(f"Dark Gem ${i + 1}",                           "Dark Gem",                           DS3LocationCategory.PROGRESSIVE_ITEM) for i in range(2)] +
         [DS3LocationData(f"Blood Gem ${i + 1}",                          "Blood Gem",                          DS3LocationCategory.PROGRESSIVE_ITEM) for i in range(1)] +
         [DS3LocationData(f"Blessed Gem ${i + 1}",                        "Blessed Gem",                        DS3LocationCategory.PROGRESSIVE_ITEM) for i in range(2)] +
-        [DS3LocationData(f"Hollow Gem ${i + 1}",                         "Hollow Gem",                         DS3LocationCategory.PROGRESSIVE_ITEM) for i in range(2)]
+        [DS3LocationData(f"Hollow Gem ${i + 1}",                         "Hollow Gem",                         DS3LocationCategory.PROGRESSIVE_ITEM) for i in range(2)],
+
+    "Progressive Items Health": [] +
+        # Healing
+        [DS3LocationData(f"Estus Shard #{i + 1}",       "Estus Shard",       DS3LocationCategory.HEALTH) for i in range(11)] +
+        [DS3LocationData(f"Undead Bone Shard #{i + 1}", "Undead Bone Shard", DS3LocationCategory.HEALTH) for i in range(10)],
 }
 
 location_dictionary: Dict[str, DS3LocationData] = {}

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -89,7 +89,7 @@ class DarkSouls3World(World):
 
     def create_regions(self):
         progressive_location_table = []
-        if self.multiworld.enable_progressive_locations[self.player].value:
+        if self.multiworld.enable_progressive_locations[self.player] or self.multiworld.enable_health_upgrade_locations[self.player]:
             progressive_location_table = [] + \
                 location_tables["Progressive Items 1"] + \
                 location_tables["Progressive Items 2"] + \
@@ -98,6 +98,10 @@ class DarkSouls3World(World):
 
             if self.multiworld.enable_dlc[self.player].value:
                 progressive_location_table += location_tables["Progressive Items DLC"]
+
+        # Filter to only health items if normal progressive locations aren't randomized
+        if self.multiworld.enable_health_upgrade_locations[self.player] and not self.multiworld.enable_progressive_locations[self.player]:
+            progressive_location_table = [location for location in progressive_location_table if location.category == DS3LocationCategory.HEALTH]
 
         # Create Vanilla Regions
         regions: Dict[str, Region] = {}

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -46,7 +46,7 @@ class DarkSouls3World(World):
     option_definitions = dark_souls_options
     topology_present: bool = True
     web = DarkSouls3Web()
-    data_version = 7
+    data_version = 8
     base_id = 100000
     enabled_location_categories: Set[DS3LocationCategory]
     required_client_version = (0, 4, 2)

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -89,7 +89,7 @@ class DarkSouls3World(World):
 
     def create_regions(self):
         progressive_location_table = []
-        if self.multiworld.enable_progressive_locations[self.player] or self.multiworld.enable_health_upgrade_locations[self.player]:
+        if self.multiworld.enable_progressive_locations[self.player]:
             progressive_location_table = [] + \
                 location_tables["Progressive Items 1"] + \
                 location_tables["Progressive Items 2"] + \
@@ -99,9 +99,8 @@ class DarkSouls3World(World):
             if self.multiworld.enable_dlc[self.player].value:
                 progressive_location_table += location_tables["Progressive Items DLC"]
 
-        # Filter to only health items if normal progressive locations aren't randomized
-        if self.multiworld.enable_health_upgrade_locations[self.player] and not self.multiworld.enable_progressive_locations[self.player]:
-            progressive_location_table = [location for location in progressive_location_table if location.category == DS3LocationCategory.HEALTH]
+        if self.multiworld.enable_health_upgrade_locations[self.player]:
+            progressive_location_table += location_tables["Progressive Items Health"]
 
         # Create Vanilla Regions
         regions: Dict[str, Region] = {}


### PR DESCRIPTION
## What is this fixing or adding?
Health items (estus shards and undead bone shards) are contained within the progressive item tables. So if progressive items aren't enabled, health items can never be added to the multiworld, even if the player has them turned on using `enable_health_upgrade_locations`. The only way to have health locations added is to turn on both `enable_health_upgrade_locations` _and_ `enable_progressive_locations`.

This moves health item locations to their own table so they can be added to the list of progressive items separately from the rest of the consumables. This changes the location ids of just these locations, but nothing we know of checks these location ids. The client will work with any location ids out of the box, and the tracker doesn't monitor progressive locations.

## How was this tested?
Generating a game for each combination of `enable_health_upgrade_locations` and `enable_progressive_locations` to verify that the expected locations are enabled.