### PR TITLE
Webhost: add a download link to the header

### DIFF
--- a/WebHostLib/templates/header/baseHeader.html
+++ b/WebHostLib/templates/header/baseHeader.html
@@ -24,7 +24,7 @@
             </div>
             <a href="/faq/en">f.a.q</a>
             <a href="https://discord.gg/8Z65BR2" target="_blank">discord</a>
-            <a href="/tutorial/Archipelago/setup/en">download</a>
+            <a href="{{url_for('tutorial', game='Archipelago', file='setup', lang='en')}}">download</a>
         </div>
         <div id="base-header-right-mobile">
             <a id="base-header-mobile-menu-button" href="#">

--- a/WebHostLib/templates/header/baseHeader.html
+++ b/WebHostLib/templates/header/baseHeader.html
@@ -24,6 +24,7 @@
             </div>
             <a href="/faq/en">f.a.q</a>
             <a href="https://discord.gg/8Z65BR2" target="_blank">discord</a>
+            <a href="/tutorial/Archipelago/setup/en">download</a>
         </div>
         <div id="base-header-right-mobile">
             <a id="base-header-mobile-menu-button" href="#">


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

Discussion happened here https://discord.com/channels/731205301247803413/1149270316774858793
I can also see the link being "Quick Start" but I put it as "Download" as that seems more straight forward for new people in my opinion.

## What is this fixing or adding?

This adds a download link to quickly go to the setup guide to install Archipelago.

## How was this tested?

Ran webhost.py

## If this makes graphical changes, please attach screenshots.
<img width="1626" alt="Screenshot 2023-09-07 at 11 34 47 AM" src="https://github.com/ArchipelagoMW/Archipelago/assets/19377912/8c7c09a9-ab3f-4736-bdd4-0e99ec7c23d2">
