### PR TITLE
WebHost: flask caching doesn't do lazy init anymore

### DIFF
--- a/WebHost.py
+++ b/WebHost.py
@@ -14,7 +14,7 @@ import settings
 
 Utils.local_path.cached_path = os.path.dirname(__file__) or "."  # py3.8 is not abs. remove "." when dropping 3.8
 
-from WebHostLib import register, app as raw_app
+from WebHostLib import register, cache, app as raw_app
 from waitress import serve
 
 from WebHostLib.models import db
@@ -40,6 +40,7 @@ def get_app():
         app.config["HOST_ADDRESS"] = Utils.get_public_ipv4()
         logging.info(f"HOST_ADDRESS was set to {app.config['HOST_ADDRESS']}")
 
+    cache.init_app(app)
     db.bind(**app.config["PONY"])
     db.generate_mapping(create_tables=True)
     return app

--- a/WebHostLib/__init__.py
+++ b/WebHostLib/__init__.py
@@ -49,11 +49,11 @@ app.config["PONY"] = {
     'create_db': True
 }
 app.config["MAX_ROLL"] = 20
-app.config["CACHE_TYPE"] = "flask_caching.backends.SimpleCache"
+app.config["CACHE_TYPE"] = "SimpleCache"
 app.config["JSON_AS_ASCII"] = False
 app.config["HOST_ADDRESS"] = ""
 
-cache = Cache(app)
+cache = Cache()
 Compress(app)
 
 


### PR DESCRIPTION
## What is this fixing or adding?
cache config was not taking, as the config was not updated when the cache actually initializes.
I know for sure this used to work, but I didn't check on it for months :(

## How was this tested?
on prod, of course.

## If this makes graphical changes, please attach screenshots.
