### PR TITLE
Core: log exceptions from generator threadpool

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -14,7 +14,7 @@ from BaseClasses import CollectionState, Item, Location, LocationProgressType, M
 from Fill import balance_multiworld_progression, distribute_items_restrictive, distribute_planned, flood_items
 from Options import StartInventoryPool
 from settings import get_settings
-from Utils import __version__, output_path, version_tuple
+from Utils import NonSilentThreadPoolExecutor, __version__, output_path, version_tuple
 from worlds import AutoWorld
 from worlds.generic.Rules import exclusion_rules, locality_rules
 
@@ -293,7 +293,7 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
 
     output = tempfile.TemporaryDirectory()
     with output as temp_dir:
-        with concurrent.futures.ThreadPoolExecutor(world.players + 2) as pool:
+        with NonSilentThreadPoolExecutor(world.players + 2) as pool:
             check_accessibility_task = pool.submit(world.fulfills_accessibility)
 
             output_file_futures = [pool.submit(AutoWorld.call_stage, world, "generate_output", temp_dir)]


### PR DESCRIPTION
## What is this fixing or adding?

Exceptions from the threadpool that runs, for example, `generate_output` have been silent.
This lets us see exceptions thrown in the threadpool.
https://github.com/ArchipelagoMW/Archipelago/issues/2157

I'm not sure whether it's the best way. But this lets us see exceptions that we couldn't see before.

## How was this tested?

edit a `generate_output` to raise an exception

## If this makes graphical changes, please attach screenshots.
![exception-from-threadpool](https://github.com/ArchipelagoMW/Archipelago/assets/6052147/37ca9335-b322-47d3-afff-c9ec11829980)
