### PR TITLE
Pokémon R/B: Fix broken options

### DIFF
--- a/worlds/pokemon_rb/__init__.py
+++ b/worlds/pokemon_rb/__init__.py
@@ -138,7 +138,7 @@ class PokemonRedBlueWorld(World):
 
         if self.multiworld.key_items_only[self.player]:
             self.multiworld.trainersanity[self.player] = self.multiworld.trainersanity[self.player].from_text("off")
-            self.multiworld.dexsanity[self.player] = self.multiworld.dexsanity[self.player].from_text("false")
+            self.multiworld.dexsanity[self.player].value = 0
             self.multiworld.randomize_hidden_items[self.player] = \
                 self.multiworld.randomize_hidden_items[self.player].from_text("off")
 

--- a/worlds/pokemon_rb/logic.py
+++ b/worlds/pokemon_rb/logic.py
@@ -53,7 +53,7 @@ def has_key_items(state, count, player):
                                         "Hideout Key", "Card Key 2F", "Card Key 3F", "Card Key 4F", "Card Key 5F",
                                         "Card Key 6F", "Card Key 7F", "Card Key 8F", "Card Key 9F", "Card Key 10F",
                                         "Card Key 11F", "Exp. All", "Fire Stone", "Thunder Stone", "Water Stone",
-                                        "Leaf Stone"] if state.has(item, player)])
+                                        "Leaf Stone", "Moon Stone"] if state.has(item, player)])
                  + min(state.count("Progressive Card Key", player), 10))
     return key_items >= count
 

--- a/worlds/pokemon_rb/rom.py
+++ b/worlds/pokemon_rb/rom.py
@@ -238,18 +238,19 @@ def generate_output(self, output_directory: str):
                     data[address] = 0 if "Elevator" in connected_map_name else warp_to_ids[i]
                     data[address + 1] = map_ids[connected_map_name]
 
-    for i, gym_leader in enumerate(("Pewter Gym - Brock TM", "Cerulean Gym - Misty TM",
-                                    "Vermilion Gym - Lt. Surge TM", "Celadon Gym - Erika TM",
-                                    "Fuchsia Gym - Koga TM", "Saffron Gym - Sabrina TM",
-                                    "Cinnabar Gym - Blaine TM", "Viridian Gym - Giovanni TM")):
-        item_name = self.multiworld.get_location(gym_leader, self.player).item.name
-        if item_name.startswith("TM"):
-            try:
-                tm = int(item_name[2:4])
-                move = poke_data.moves[self.local_tms[tm - 1]]["id"]
-                data[rom_addresses["Gym_Leader_Moves"] + (2 * i)] = move
-            except KeyError:
-                pass
+    if not self.multiworld.key_items_only[self.player]:
+        for i, gym_leader in enumerate(("Pewter Gym - Brock TM", "Cerulean Gym - Misty TM",
+                                        "Vermilion Gym - Lt. Surge TM", "Celadon Gym - Erika TM",
+                                        "Fuchsia Gym - Koga TM", "Saffron Gym - Sabrina TM",
+                                        "Cinnabar Gym - Blaine TM", "Viridian Gym - Giovanni TM")):
+            item_name = self.multiworld.get_location(gym_leader, self.player).item.name
+            if item_name.startswith("TM"):
+                try:
+                    tm = int(item_name[2:4])
+                    move = poke_data.moves[self.local_tms[tm - 1]]["id"]
+                    data[rom_addresses["Gym_Leader_Moves"] + (2 * i)] = move
+                except KeyError:
+                    pass
 
     def set_trade_mon(address, loc):
         mon = self.multiworld.get_location(loc, self.player).item.name


### PR DESCRIPTION
## What is this fixing or adding?
1) Fixes `key_items_only` which was attempting to set `dexsanity` to an invalid value due to a last-minute renaming of the choices, and fixes a crash due to an attempt to check gym leader TM locations to set TM moves.
2) Fixes a missing check for Moon Stone on Key Items checks, which caused setting the Key Items conditions to 100 to lead to generation failure.

## How was this tested?
Generating a `key_items_only` game with 100% key items required
