### PR TITLE
The Witness: Fix Expert Tutorial Gate Close logic

### DIFF
--- a/worlds/witness/WitnessLogicExpert.txt
+++ b/worlds/witness/WitnessLogicExpert.txt
@@ -14,7 +14,7 @@ Tutorial (Tutorial) - Outside Tutorial - True:
 158005 - 0x0A3B5 (Back Left) - True - Dots & Full Dots
 158006 - 0x0A3B2 (Back Right) - True - Dots & Full Dots
 158007 - 0x03629 (Gate Open) - 0x002C2 - Symmetry & Dots
-158008 - 0x03505 (Gate Close) - 0x2FAF6 & 0x03629 - False
+158008 - 0x03505 (Gate Close) - 0x2FAF6 & 0x03629 - True
 158009 - 0x0C335 (Pillar) - True - Triangles
 158010 - 0x0C373 (Patio Floor) - 0x0C335 - Dots
 159512 - 0x33530 (Cloud EP) - True - True


### PR DESCRIPTION
The Expert logic file says Tutorial Gate Close is impossible to solve.

This is a relic from when that used to be true. Which it isn't anymore.

This probably leads to accessibility checks failing sometimes in Expert + EP shuffle
