### PR TITLE
WebHost: Clean up the exported yaml in weighted settings

### DIFF
--- a/WebHostLib/static/assets/weighted-settings.js
+++ b/WebHostLib/static/assets/weighted-settings.js
@@ -1154,7 +1154,7 @@ const validateSettings = () => {
       if (
         Object.keys(settings[game][setting]).length === 1 &&
         !Array.isArray(settings[game][setting]) &&
-        setting !== "start_inventory"
+        setting !== 'start_inventory'
       ) {
         settings[game][setting] = Object.keys(settings[game][setting])[0];
       }
@@ -1170,10 +1170,10 @@ const validateSettings = () => {
 
       // Remove empty start inventory
       else if (
-        setting === "start_inventory" &&
-        Object.keys(settings[game]["start_inventory"]).length === 0
+        setting === 'start_inventory' &&
+        Object.keys(settings[game]['start_inventory']).length === 0
       ) {
-        delete settings[game]["start_inventory"];
+        delete settings[game]['start_inventory'];
       }
     });
   });

--- a/WebHostLib/static/assets/weighted-settings.js
+++ b/WebHostLib/static/assets/weighted-settings.js
@@ -1134,8 +1134,8 @@ const validateSettings = () => {
       return;
     }
 
-    // Remove any disabled options
     Object.keys(settings[game]).forEach((setting) => {
+      // Remove any disabled options
       Object.keys(settings[game][setting]).forEach((option) => {
         if (settings[game][setting][option] === 0) {
           delete settings[game][setting][option];
@@ -1149,11 +1149,42 @@ const validateSettings = () => {
       ) {
         errorMessage = `${game} // ${setting} has no values above zero!`;
       }
+
+      // Remove weights from options with only one possibility
+      if (
+        Object.keys(settings[game][setting]).length === 1 &&
+        !Array.isArray(settings[game][setting]) &&
+        setting !== "start_inventory"
+      ) {
+        settings[game][setting] = Object.keys(settings[game][setting])[0];
+      }
+
+      // Remove empty arrays
+      else if (
+        ['exclude_locations', 'priority_locations', 'local_items', 
+        'non_local_items', 'start_hints', 'start_location_hints'].includes(setting) &&
+        settings[game][setting].length === 0
+      ) {
+        delete settings[game][setting];
+      }
+
+      // Remove empty start inventory
+      else if (
+        setting === "start_inventory" &&
+        Object.keys(settings[game]["start_inventory"]).length === 0
+      ) {
+        delete settings[game]["start_inventory"];
+      }
     });
   });
 
   if (Object.keys(settings.game).length === 0) {
     errorMessage = 'You have not chosen a game to play!';
+  }
+
+  // Remove weights if there is only one game
+  else if (Object.keys(settings.game).length === 1) {
+    settings.game = Object.keys(settings.game)[0];
   }
 
   // If an error occurred, alert the user and do not export the file


### PR DESCRIPTION
## What is this fixing or adding?
Clean up exported yaml in weighted settings by removing weighted options in instances where there is only one possible option, in addition removes some empty arrays and empty 'starting_inventory'

## How was this tested?
exported a few dozen yamls with variable settings and verified

## If this makes graphical changes, please attach screenshots.
