### PR TITLE
kvui: remove fix_heights method

### DIFF
--- a/kvui.py
+++ b/kvui.py
@@ -412,8 +412,6 @@ class GameManager(App):
         return self.container
 
     def update_texts(self, dt):
-        if hasattr(self.tabs.content.children[0], 'fix_heights'):
-            self.tabs.content.children[0].fix_heights()  # TODO: remove this when Kivy fixes this upstream
         if self.ctx.server:
             self.title = self.base_title + " " + Utils.__version__ + \
                          f" | Connected to: {self.ctx.server_address} " \
@@ -534,12 +532,6 @@ class UILog(RecycleView):
     def clean_old(self):
         if len(self.data) > self.messages:
             self.data.pop(0)
-
-    def fix_heights(self):
-        """Workaround fix for divergent texture and layout heights"""
-        for element in self.children[0].children:
-            if element.height != element.texture_size[1]:
-                element.height = element.texture_size[1]
 
 
 class E(ExceptionHandler):


### PR DESCRIPTION
## What is this fixing or adding?
Windows scaling entering an infinite loop starting with kivy 2.2.0

## How was this tested?
https://discord.com/channels/731205301247803413/1138588937007407154

## If this makes graphical changes, please attach screenshots.
