### PR TITLE
Core, Options: make option resolution a class method

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -490,16 +490,6 @@ def roll_settings(weights: dict, plando_options: PlandoOptions = PlandoOptions.b
                     ))
     elif ret.game == "A Link to the Past":
         roll_alttp_settings(ret, game_weights, plando_options)
-    elif PlandoOptions.connections in plando_options:
-        ret.plando_connections = []
-        options = game_weights.get("plando_connections", [])
-        for placement in options:
-            if roll_percentage(get_choice("percentage", placement, 100)):
-                ret.plando_connections.append(PlandoConnection(
-                    get_choice("entrance", placement),
-                    get_choice("exit", placement),
-                    get_choice("direction", placement)
-                ))
 
     return ret
 

--- a/Generate.py
+++ b/Generate.py
@@ -410,19 +410,13 @@ def roll_triggers(weights: dict, triggers: list) -> dict:
 
 
 def handle_option(ret: argparse.Namespace, game_weights: dict, option_key: str, option: type(Options.Option), plando_options: PlandoOptions):
-    if option_key in game_weights:
-        try:
-            if not option.supports_weighting:
-                player_option = option.from_any(game_weights[option_key])
-            else:
-                player_option = option.from_any(get_choice(option_key, game_weights))
-            setattr(ret, option_key, player_option)
-        except Exception as e:
-            raise Exception(f"Error generating option {option_key} in {ret.game}") from e
-        else:
-            player_option.verify(AutoWorldRegister.world_types[ret.game], ret.name, plando_options)
+    try:
+        player_option = option.get_choice(option_key, game_weights)
+        setattr(ret, option_key, player_option)
+    except Exception as e:
+        raise Exception(f"Error generating option {option_key} in {ret.game}") from e
     else:
-        setattr(ret, option_key, option.from_any(option.default))  # call the from_any here to support default "random"
+        player_option.verify(AutoWorldRegister.world_types[ret.game], ret.name, plando_options)
 
 
 def roll_settings(weights: dict, plando_options: PlandoOptions = PlandoOptions.bosses):
@@ -467,7 +461,7 @@ def roll_settings(weights: dict, plando_options: PlandoOptions = PlandoOptions.b
 
     ret.name = get_choice('name', weights)
     for option_key, option in Options.common_options.items():
-        setattr(ret, option_key, option.from_any(get_choice(option_key, weights, option.default)))
+        setattr(ret, option_key, option.get_choice(option_key, weights))
 
     for option_key, option in world_type.option_definitions.items():
         handle_option(ret, game_weights, option_key, option, plando_options)

--- a/Options.py
+++ b/Options.py
@@ -135,10 +135,7 @@ class Option(typing.Generic[T], metaclass=AssembleOptions):
             return cls.name_lookup[value]
 
     @classmethod
-    def get_choice(cls, key: str, weights: typing.Dict[typing.Any]) -> Option[T]:
-        if key not in weights or not weights[key]:
-            return cls.from_any(cls.default)
-        option_weights = weights[key]
+    def get_choice(cls, option_weights: typing.Dict[typing.Any]) -> Option[T]:
         if not cls.supports_weighting:  # TODO remove this attribute ~0.4.5
             return cls.from_any(option_weights)
         if type(option_weights) is list:
@@ -147,7 +144,7 @@ class Option(typing.Generic[T], metaclass=AssembleOptions):
             return cls.from_any(option_weights)
         if any(option_weights.values()):
             return cls.from_any(random.choices(list(option_weights), weights=list(map(int, option_weights.values())))[0])
-        raise RuntimeError(f"All options specified in \"{key}\" are weighted as zero.")
+        raise RuntimeError(f"All options specified for \"{cls}\" are weighted as zero.")
 
     def __int__(self) -> T:
         return self.value
@@ -805,10 +802,8 @@ class OptionDict(Option[typing.Dict[str, typing.Any]], VerifyKeys, typing.Mappin
         return ", ".join(f"{key}: {v}" for key, v in value.items())
 
     @classmethod
-    def get_choice(cls, key: str, weights: typing.Dict[typing.Any]) -> Option[T]:
-        if key in weights:
-            return cls.from_any(weights[key])
-        return cls.from_any(cls.default)
+    def get_choice(cls, option_weights: typing.Dict[typing.Any]) -> Option[T]:
+        return cls.from_any(option_weights)
 
     def __getitem__(self, item: str) -> typing.Any:
         return self.value.__getitem__(item)
@@ -856,10 +851,8 @@ class OptionList(Option[typing.List[typing.Any]], VerifyKeys):
         return ", ".join(map(str, value))
 
     @classmethod
-    def get_choice(cls, key: str, weights: typing.Dict[typing.Any]) -> Option[T]:
-        if key in weights:
-            return cls.from_any(weights[key])
-        return cls.from_any(cls.default)
+    def get_choice(cls, option_weights: typing.Dict[typing.Any]) -> Option[T]:
+        return cls.from_any(option_weights)
 
     def __contains__(self, item):
         return item in self.value
@@ -888,10 +881,8 @@ class OptionSet(Option[typing.Set[str]], VerifyKeys):
         return ", ".join(sorted(value))
 
     @classmethod
-    def get_choice(cls, key: str, weights: typing.Dict[typing.Any]) -> Option[T]:
-        if key in weights:
-            return cls.from_any(weights[key])
-        return cls.from_any(cls.default)
+    def get_choice(cls, option_weights: typing.Dict[typing.Any]) -> Option[T]:
+        return cls.from_any(option_weights)
 
     def __contains__(self, item):
         return item in self.value

--- a/test/general/TestOptions.py
+++ b/test/general/TestOptions.py
@@ -1,11 +1,40 @@
 import unittest
+from collections import ChainMap
+
+import Options
 from worlds.AutoWorld import AutoWorldRegister
 
 
 class TestOptions(unittest.TestCase):
+
     def testOptionsHaveDocString(self):
         for gamename, world_type in AutoWorldRegister.world_types.items():
             if not world_type.hidden:
                 for option_key, option in world_type.option_definitions.items():
                     with self.subTest(game=gamename, option=option_key):
                         self.assertTrue(option.__doc__)
+
+    def testOptionsGetChoice(self):
+        weights = {
+            "progression_balancing":
+                {
+                    "0": 50,
+                    "50":  50,
+                    "99": 50,
+                },
+            "accessibility": 1,  # items
+            "start_inventory":
+                {
+                    "Progressive Sword": 2,
+                },
+        }
+
+        world_type = AutoWorldRegister.world_types["A Link to the Past"]
+        for option_key, option in ChainMap(Options.common_options, Options.per_game_common_options,
+                                           world_type.option_definitions).items():
+            result = option.get_choice(option_key, weights)
+            if option_key == "progression_balancing":
+                self.assertIn(result.value, {0, 50, 99})
+            else:
+                expected_result = option.default if option_key not in weights else weights[option_key]
+                self.assertEqual(result.value, expected_result)

--- a/test/general/TestOptions.py
+++ b/test/general/TestOptions.py
@@ -29,10 +29,10 @@ class TestOptions(unittest.TestCase):
                 },
         }
 
-        world_type = AutoWorldRegister.world_types["A Link to the Past"]
+        world_type = AutoWorldRegister.world_types["A Link to the Past"]  # what else
         for option_key, option in ChainMap(Options.common_options, Options.per_game_common_options,
                                            world_type.option_definitions).items():
-            result = option.get_choice(option_key, weights)
+            result = option.get_choice(weights[option_key]) if option_key in weights else option.from_any(option.default)
             if option_key == "progression_balancing":
                 self.assertIn(result.value, {0, 50, 99})
             else:

--- a/test/general/TestOptions.py
+++ b/test/general/TestOptions.py
@@ -32,7 +32,8 @@ class TestOptions(unittest.TestCase):
         world_type = AutoWorldRegister.world_types["A Link to the Past"]  # what else
         for option_key, option in ChainMap(Options.common_options, Options.per_game_common_options,
                                            world_type.option_definitions).items():
-            result = option.get_choice(weights[option_key]) if option_key in weights else option.from_any(option.default)
+            result = option.get_choice(weights[option_key]) \
+                if option_key in weights else option.from_any(option.default)
             if option_key == "progression_balancing":
                 self.assertIn(result.value, {0, 50, 99})
             else:


### PR DESCRIPTION
## What is this fixing or adding?
changes calls to `get_choice` a class method so that it can be easily modified by worlds. This also deprecates the `supports_weighting` attribute. Mixed on whether the option_key in game_weights check should be done before calling option.get_choice, so did a version with the resolution in the method, and a version without.

## How was this tested?
Generated about 20 or so games with various random options, and added a unit test.

## If this makes graphical changes, please attach screenshots.
