### PR TITLE
Hollow Knight: Update outdated setup documentation

### DIFF
--- a/worlds/hk/docs/setup_en.md
+++ b/worlds/hk/docs/setup_en.md
@@ -4,7 +4,7 @@
 * Download and unzip the Scarab+ Mod Manager from the [Scarab+ website](https://themulhima.github.io/Scarab/).
 * A legal copy of Hollow Knight.
 
-## Installing the Archipelago Mod using Scarab
+## Installing the Archipelago Mod using Scarab+
 1. Launch Scarab+ and ensure it locates your Hollow Knight installation directory.
 2. Click the "Install" button near the "Archipelago" mod entry.
    * If desired, also install "Archipelago Map Mod" to use as an in-game tracker.

--- a/worlds/hk/docs/setup_en.md
+++ b/worlds/hk/docs/setup_en.md
@@ -8,7 +8,7 @@
 1. Launch Scarab+ and ensure it locates your Hollow Knight installation directory.
 2. Click the "Install" button near the "Archipelago" mod entry.
    * If desired, also install "Archipelago Map Mod" to use as an in-game tracker.
-4. Launch the game, you're all set!
+3. Launch the game, you're all set!
 
 ### What to do if Scarab+ fails to find your XBox Game Pass installation directory
 1. Enter the XBox app and move your mouse over "Hollow Knight" on the left sidebar. 

--- a/worlds/hk/docs/setup_en.md
+++ b/worlds/hk/docs/setup_en.md
@@ -4,14 +4,11 @@
 * Download and unzip the Scarab+ Mod Manager from the [Scarab+ website](https://themulhima.github.io/Scarab/).
 * A legal copy of Hollow Knight.
 
-## Optional Software
-* Archipelago Map Mod from Scarab+
-  * Ensure that both RandoMapMod and MapChanger are uninstalled or disabled as they are incompatible with Archipelago Map Mod.
-
 ## Installing the Archipelago Mod using Scarab
 1. Launch Scarab+ and ensure it locates your Hollow Knight installation directory.
 2. Click the "Install" button near the "Archipelago" mod entry.
-3. Launch the game, you're all set!
+   * If desired, also install "Archipelago Map Mod" to use as an in-game tracker.
+4. Launch the game, you're all set!
 
 ### What to do if Scarab+ fails to find your XBox Game Pass installation directory
 1. Enter the XBox app and move your mouse over "Hollow Knight" on the left sidebar. 


### PR DESCRIPTION
## What is this fixing or adding?

The documentation for installing the map mod are outdated as of the most recent version of the mod. The instructions currently instruct users to uninstall a required dependency. I also moved the instructions for installing optional mods after the instructions for installing the mod installer and required mods.

## How was this tested?
I read it
