### PR TITLE
Core: `Option.default` typing and definition checking

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -30,6 +30,11 @@ class AssembleOptions(abc.ABCMeta):
         new_options = {name[7:].lower(): option_id for name, option_id in attrs.items() if
                        name.startswith("option_")}
 
+        assert (
+            name in {"Option", "VerifyKeys"} or  # base abstract classes don't need default
+            "default" in attrs or
+            any(hasattr(base, "default") for base in bases)
+        ), f"Option class {name} needs default value"
         assert "random" not in new_options, "Choice option 'random' cannot be manually assigned."
         assert len(new_options) == len(set(new_options.values())), "same ID cannot be used twice. Try alias?"
 
@@ -93,7 +98,8 @@ T = typing.TypeVar('T')
 
 class Option(typing.Generic[T], metaclass=AssembleOptions):
     value: T
-    default = 0
+    default: typing.ClassVar[typing.Union[T, typing.Literal["random"]]]  # type: ignore
+    # https://github.com/python/typing/discussions/1460 the reason for this type: ignore
 
     # convert option_name_long into Name Long as display_name, otherwise name_long is the result.
     # Handled in get_option_name()


### PR DESCRIPTION
## What is this fixing or adding?

The typing of `Option.default` has been making trouble for type-checkers,
and it doesn't make sense to set a default (`0`) that is the wrong type for some subclasses (`FreeText`)

I consulted the python typing discussion board about this
https://github.com/python/typing/discussions/1460
and it seems there is no perfect solution.

This is the best solution offered there.

Also, instead of setting a default in `Option` (where we don't know the type), we check in the metaclass to make sure they have a default.

## How was this tested?

unit tests, and breaking some options to make sure the assertion in the metaclass would fail unit tests if an option doesn't set a default
