### PR TITLE
Launcher: Allow opening patches for clients without an exe

### DIFF
--- a/Launcher.py
+++ b/Launcher.py
@@ -50,17 +50,20 @@ def open_host_yaml():
 def open_patch():
     suffixes = []
     for c in components:
-        if isfile(get_exe(c)[-1]):
-            suffixes += c.file_identifier.suffixes if c.type == Type.CLIENT and \
-                                                      isinstance(c.file_identifier, SuffixIdentifier) else []
+        suffixes += c.file_identifier.suffixes if c.type == Type.CLIENT and \
+                                                  isinstance(c.file_identifier, SuffixIdentifier) else []
     try:
-        filename = open_filename('Select patch', (('Patches', suffixes),))
+        filename = open_filename("Select patch", (("Patches", suffixes),))
     except Exception as e:
-        messagebox('Error', str(e), error=True)
+        messagebox("Error", str(e), error=True)
     else:
         file, component = identify(filename)
         if file and component:
-            launch([*get_exe(component), file], component.cli)
+            exe = get_exe(component)
+            if exe is None or not isfile(exe[-1]):
+                exe = get_exe("Launcher")
+
+            launch([*exe, file], component.cli)
 
 
 def generate_yamls():
@@ -107,7 +110,7 @@ def identify(path: Union[None, str]):
         return None, None
     for component in components:
         if component.handles_file(path):
-            return path,  component
+            return path, component
         elif path == component.display_name or path == component.script_name:
             return None, component
     return None, None
@@ -117,25 +120,25 @@ def get_exe(component: Union[str, Component]) -> Optional[Sequence[str]]:
     if isinstance(component, str):
         name = component
         component = None
-        if name.startswith('Archipelago'):
+        if name.startswith("Archipelago"):
             name = name[11:]
-        if name.endswith('.exe'):
+        if name.endswith(".exe"):
             name = name[:-4]
-        if name.endswith('.py'):
+        if name.endswith(".py"):
             name = name[:-3]
         if not name:
             return None
         for c in components:
-            if c.script_name == name or c.frozen_name == f'Archipelago{name}':
+            if c.script_name == name or c.frozen_name == f"Archipelago{name}":
                 component = c
                 break
         if not component:
             return None
     if is_frozen():
-        suffix = '.exe' if is_windows else ''
-        return [local_path(f'{component.frozen_name}{suffix}')]
+        suffix = ".exe" if is_windows else ""
+        return [local_path(f"{component.frozen_name}{suffix}")] if component.frozen_name else None
     else:
-        return [sys.executable, local_path(f'{component.script_name}.py')]
+        return [sys.executable, local_path(f"{component.script_name}.py")] if component.script_name else None
 
 
 def launch(exe, in_terminal=False):

--- a/Launcher.py
+++ b/Launcher.py
@@ -50,8 +50,10 @@ def open_host_yaml():
 def open_patch():
     suffixes = []
     for c in components:
-        suffixes += c.file_identifier.suffixes if c.type == Type.CLIENT and \
-                                                  isinstance(c.file_identifier, SuffixIdentifier) else []
+        if c.type == Type.CLIENT and \
+                isinstance(c.file_identifier, SuffixIdentifier) and \
+                (c.script_name is None or isfile(get_exe(c)[-1])):
+            suffixes += c.file_identifier.suffixes
     try:
         filename = open_filename("Select patch", (("Patches", suffixes),))
     except Exception as e:


### PR DESCRIPTION
## What is this fixing or adding?

Right now the "Open Patch" button in the launcher is restricted to only recognize file extensions associated with root-level clients. So the only way for an apworld with a bespoke internal client to open a patch file is to open it directly with the launcher.

This removes the exe requirement, and if no exe is found after the file is identified, the file is given directly to the launcher, which should identify the patch file and run `component.func` in `run_component`.

## How was this tested?

Dropped a Pokemon Emerald apworld into `worlds/` and was able to open an `apemerald` patch file to launch the Emerald client that's inside the apworld. Also verified that an `apz5` file still opened and patched correctly. All tested on source only.
