### PR TITLE
settings: add default=None to Group.get

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -118,7 +118,7 @@ class Group:
                 cls._type_cache = typing.get_type_hints(cls, globalns=mod_dict, localns=cls.__dict__)
         return cls._type_cache
 
-    def get(self, key: str, default: Any) -> Any:
+    def get(self, key: str, default: Any = None) -> Any:
         if key in self:
             return self[key]
         return default


### PR DESCRIPTION
## What is this fixing or adding?

`dict.get` has `default=None`, which was missing from `Group.get`'s dict emulation.
This should fix the crash in https://discord.com/channels/731205301247803413/1151196512181833790

## How was this tested?

Running mypy, unittests and 
```python
>>> from settings import get_settings; get_settings()["soe_options"].get("does not exist") is None
True
```
