### PR TITLE
Muse Dash: Add mentions to Muse Plus to Docs and Options.

### DIFF
--- a/worlds/musedash/Options.py
+++ b/worlds/musedash/Options.py
@@ -3,8 +3,8 @@ from Options import Toggle, Option, Range, Choice, DeathLink, ItemSet
 
 
 class AllowJustAsPlannedDLCSongs(Toggle):
-    """Whether [Just As Planned]/[Muse Plus] DLC Songs, and all the DLCs along with it, will be included in the randomizer."""
-    display_name = "Allow [Just As Planned]/[Muse Plus] DLC Songs"
+    """Whether [Just as Planned]/[Muse Plus] DLC Songs, and all the DLCs along with it, will be included in the randomizer."""
+    display_name = "Allow [Just as Planned]/[Muse Plus] DLC Songs"
 
 
 class StreamerModeEnabled(Toggle):
@@ -125,7 +125,7 @@ class TrapTypes(Choice):
     - VFX Traps consist of visual effects that play over the song. (i.e. Grayscale.)
     - SFX Traps consist of changing your sfx setting to one possibly more annoying sfx.
     Traps last the length of a song, or until you die.
-    Note: SFX traps are only available with Just As Planned dlc songs.
+    Note: SFX traps are only available if [Just as Planned] DLC songs are enabled.
     """
     display_name = "Available Trap Types"
     option_None = 0

--- a/worlds/musedash/Options.py
+++ b/worlds/musedash/Options.py
@@ -3,8 +3,8 @@ from Options import Toggle, Option, Range, Choice, DeathLink, ItemSet
 
 
 class AllowJustAsPlannedDLCSongs(Toggle):
-    """Whether 'Just as Planned DLC' songs, and all the DLCs along with it, will be included in the randomizer."""
-    display_name = "Allow Just As Planned DLC Songs"
+    """Whether [Just As Planned]/[Muse Plus] DLC Songs, and all the DLCs along with it, will be included in the randomizer."""
+    display_name = "Allow [Just As Planned]/[Muse Plus] DLC Songs"
 
 
 class StreamerModeEnabled(Toggle):

--- a/worlds/musedash/docs/en_Muse Dash.md
+++ b/worlds/musedash/docs/en_Muse Dash.md
@@ -17,7 +17,7 @@ The goal of Muse Dash is to collect a number of **Music Sheets**. Once you've co
 
 Only the base Muse Dash game is required in order to play this game.
 
-However, the **Just as Planned DLC** is recommended as the number of possible songs increases from 60+ to 400+ songs, which adds to the variety and increases replayability.
+However, the **[Just as Planned]**/**[Muse Plus]** DLC are recommended, as they increase the number of possible songs from 60+ to 400+ songs, which adds to the variety and increases replayability.
 
 ## What Other Adjustments have been made to the Base Game?
 - Several song select filters have been added to make finding songs to play easy.

--- a/worlds/musedash/docs/en_Muse Dash.md
+++ b/worlds/musedash/docs/en_Muse Dash.md
@@ -17,7 +17,7 @@ The goal of Muse Dash is to collect a number of **Music Sheets**. Once you've co
 
 Only the base Muse Dash game is required in order to play this game.
 
-However, the **[Just as Planned]**/**[Muse Plus]** DLC are recommended, as they increase the number of possible songs from 60+ to 400+ songs, which adds to the variety and increases replayability.
+However, the **[Just as Planned]**/**[Muse Plus]** DLC is recommended, as they increase the number of possible songs from 60+ to 400+ songs, which adds to the variety and increases replayability.
 
 ## What Other Adjustments have been made to the Base Game?
 - Several song select filters have been added to make finding songs to play easy.

--- a/worlds/musedash/docs/setup_en.md
+++ b/worlds/musedash/docs/setup_en.md
@@ -8,7 +8,7 @@
 
 - Windows 8 or Newer.
 - Muse Dash: [Available on Steam](https://store.steampowered.com/app/774171/Muse_Dash/)
-  - \[Optional\] Just As Planned DLC: [Also Available on Steam](https://store.steampowered.com/app/1055810/Muse_Dash__Just_as_planned/)
+  - \[Optional\] [Just as Planned] DLC: [Also Available on Steam](https://store.steampowered.com/app/1055810/Muse_Dash__Just_as_planned/)
 - Melon Loader: [GitHub](https://github.com/LavaGang/MelonLoader/releases/latest)
   - .Net Framework 4.8 may be needed for the installer: [Download](https://dotnet.microsoft.com/en-us/download/dotnet-framework/net48)
 - .Net 6.0 (If not already installed): [Download](https://dotnet.microsoft.com/en-us/download/dotnet/6.0#runtime-6.0.15)


### PR DESCRIPTION
## What is this fixing or adding?
Adds mentions of [Muse Plus] (The upcoming replacement to [Just as Planned])

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/7556376/a345eae9-20ed-4fe5-90cf-8f566247ca08)
![image](https://github.com/ArchipelagoMW/Archipelago/assets/7556376/66da0f84-49c9-4d0f-9613-5bafd9fbff90)
