### PR TITLE
Subnautica: add extra Laser Cutter Fragment to priority filler

### DIFF
--- a/worlds/subnautica/__init__.py
+++ b/worlds/subnautica/__init__.py
@@ -116,15 +116,16 @@ class SubnauticaWorld(World):
             # list of high-count important fragments as priority filler
                 [
                     "Cyclops Engine Fragment",
-                    "Modification Station Fragment",
-                    "Mobile Vehicle Bay Fragment",
-                    "Seamoth Fragment",
                     "Cyclops Hull Fragment",
                     "Cyclops Bridge Fragment",
+                    "Seamoth Fragment",
                     "Prawn Suit Fragment",
+                    "Mobile Vehicle Bay Fragment",
+                    "Modification Station Fragment",
                     "Moonpool Fragment",
+                    "Laser Cutter Fragment",
                  ],
-                k=min(extras, 8)):
+                k=min(extras, 9)):
             item = self.create_item(item_name)
             pool.append(item)
             extras -= 1


### PR DESCRIPTION
## What is this fixing or adding?
Adds a fourth Laser Cutter Fragment to the pool, if there is space for one.
This was supposed to be there, I just forgot to list it.

## How was this tested?
Running Generate and counting Fragments

## If this makes graphical changes, please attach screenshots.
