### PR TITLE
Core: fix start_inventory_from_pool only adding one filler per item name

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -159,7 +159,8 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
         for player, items in depletion_pool.items():
             player_world: AutoWorld.World = world.worlds[player]
             for count in items.values():
-                new_items.append(player_world.create_filler())
+                for _ in range(count):
+                    new_items.append(player_world.create_filler())
         target: int = sum(sum(items.values()) for items in depletion_pool.values())
         for i, item in enumerate(world.itempool):
             if depletion_pool[item.player].get(item.name, 0):
@@ -179,6 +180,7 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
                 if remaining_items:
                     raise Exception(f"{world.get_player_name(player)}"
                                     f" is trying to remove items from their pool that don't exist: {remaining_items}")
+        assert len(world.itempool) == len(new_items), "Item Pool amounts should not change."
         world.itempool[:] = new_items
 
     # temporary home for item links, should be moved out of Main


### PR DESCRIPTION
## What is this fixing or adding?
https://discord.com/channels/731205301247803413/1152413200067854407

## How was this tested?
I joinked the Subnautica yaml, wrote the assert, saw it trigger. Then wrote the fix and tested that the assert doesn't trigger anymore.

## If this makes graphical changes, please attach screenshots.
