### PR TITLE
SC2: Typo fix in option display name

### DIFF
--- a/worlds/sc2wol/Options.py
+++ b/worlds/sc2wol/Options.py
@@ -320,7 +320,7 @@ class OptionalBossLocations(LocationInclusion):
     Warning: The generation may fail if too many locations are excluded by this way.
     See also: Excluded Locations, Item Plando (https://archipelago.gg/tutorial/Archipelago/plando/en#item-plando)
     """
-    display_name = "Challenge Locations"
+    display_name = "Optional Boss Locations"
 
 
 # noinspection PyTypeChecker


### PR DESCRIPTION
## What is this fixing or adding?
Fixes wrong option display name
Broken:
![Snímek obrazovky pořízený 2023-09-16 21-52-32](https://github.com/ArchipelagoMW/Archipelago/assets/3447808/3f23ca8c-ad49-4d1c-b5d1-c77bde6fd057)

## How was this tested?
Fixed:
![Snímek obrazovky pořízený 2023-09-16 21-53-40](https://github.com/ArchipelagoMW/Archipelago/assets/3447808/29d2b457-115e-4991-8272-63daaa8e5a7e)
