### PR TITLE
Zillion: ensure 1st sphere not empty

### DIFF
--- a/worlds/zillion/requirements.txt
+++ b/worlds/zillion/requirements.txt
@@ -1,1 +1,1 @@
-zilliandomizer @ git+https://github.com/beauxq/zilliandomizer@cd6a940ad7b585c75a560b91468d6b9eee030559#0.5.2
+zilliandomizer @ git+https://github.com/beauxq/zilliandomizer@4b27d115269db25fe73b0471b73495f41df1323c#0.5.3


### PR DESCRIPTION
## What is this fixing or adding?

Zillion could rarely have no locations in 1st sphere

https://github.com/ArchipelagoMW/Archipelago/actions/runs/6191949342/job/16811145959

## How was this tested?

unit tests (in both zilliandomizer package and AP)

and playing through an AP game
