### PR TITLE
Stardew Valley: Fix two logic bugs with the wizard on Entrance Randomizer

### DIFF
--- a/worlds/stardew_valley/data/villagers_data.py
+++ b/worlds/stardew_valley/data/villagers_data.py
@@ -39,6 +39,7 @@ oasis = (Region.oasis,)
 sewers = (Region.sewer,)
 island = (Region.island_east,)
 secret_woods = (Region.secret_woods,)
+wizard_tower = (Region.wizard_tower,)
 
 golden_pumpkin = ("Golden Pumpkin",)
 # magic_rock_candy = ("Magic Rock Candy",)
@@ -314,7 +315,7 @@ milf = villager(NPC.robin, False, carpenter, Season.fall, universal_loves + robi
 sandy = villager(NPC.sandy, False, oasis, Season.fall, universal_loves + sandy_loves, False)
 vincent = villager(NPC.vincent, False, town, Season.spring, universal_loves + vincent_loves, True)
 willy = villager(NPC.willy, False, beach, Season.summer, universal_loves + willy_loves, True)
-wizard = villager(NPC.wizard, False, forest, Season.winter, universal_loves + wizard_loves, True)
+wizard = villager(NPC.wizard, False, wizard_tower, Season.winter, universal_loves + wizard_loves, True)
 
 # Custom NPCs
 alec = villager(ModNPC.alec, True, forest, Season.winter, universal_loves + trilobite, True, ModNames.alec)

--- a/worlds/stardew_valley/logic.py
+++ b/worlds/stardew_valley/logic.py
@@ -1166,14 +1166,15 @@ class StardewLogic:
     def can_complete_bundle(self, bundle_requirements: List[BundleItem], number_required: int) -> StardewRule:
         item_rules = []
         highest_quality_yet = 0
+        can_speak_junimo = self.can_reach_region(Region.wizard_tower)
         for bundle_item in bundle_requirements:
             if bundle_item.item.item_id == -1:
-                return self.can_spend_money(bundle_item.amount)
+                return can_speak_junimo & self.can_spend_money(bundle_item.amount)
             else:
                 item_rules.append(bundle_item.item.name)
                 if bundle_item.quality > highest_quality_yet:
                     highest_quality_yet = bundle_item.quality
-        return self.can_reach_region(Region.wizard_tower) & self.has(item_rules, number_required) & self.can_grow_gold_quality(highest_quality_yet)
+        return can_speak_junimo & self.has(item_rules, number_required) & self.can_grow_gold_quality(highest_quality_yet)
 
     def can_grow_gold_quality(self, quality: int) -> StardewRule:
         if quality <= 0:

--- a/worlds/stardew_valley/test/TestGeneration.py
+++ b/worlds/stardew_valley/test/TestGeneration.py
@@ -214,7 +214,7 @@ class TestLocationAndItemCount(SVTestBase):
         self.assertGreaterEqual(len(valid_locations), len(multiworld.itempool))
 
     def test_allsanity_without_mods_has_at_least_locations(self):
-        expected_locations = 993
+        expected_locations = 994
         allsanity_options = self.allsanity_options_without_mods()
         multiworld = setup_solo_multiworld(allsanity_options)
         number_locations = len(get_real_locations(self, multiworld))
@@ -227,7 +227,7 @@ class TestLocationAndItemCount(SVTestBase):
                   f"\n\t\tActual: {number_locations}")
 
     def test_allsanity_with_mods_has_at_least_locations(self):
-        expected_locations = 1245
+        expected_locations = 1246
         allsanity_options = self.allsanity_options_with_mods()
         multiworld = setup_solo_multiworld(allsanity_options)
         number_locations = len(get_real_locations(self, multiworld))


### PR DESCRIPTION
## What is this fixing or adding?
- The logic rule for meeting the wizard was "Forest" instead of "Wizard Tower", which means the generator could give you tasks related to him even if his entrance was randomized behind a lock
- The logic rule for completing bundles only had the wizard potion condition for item bundles. The money bundles were missing that rule.

Both those issues can cause a critical softlock when using "Entrance Randomizer: Buildings". A single user managed to hit both issues in a single seed and got his multiworld completely blocked because of it

## How was this tested?
Ran all the existing tests. I could not really think of good new tests to add for this case.
