### PR TITLE
WebHost: Don't count groups in the summary row completed worlds

### DIFF
--- a/WebHostLib/tracker.py
+++ b/WebHostLib/tracker.py
@@ -9,7 +9,7 @@ from jinja2 import pass_context, runtime
 from werkzeug.exceptions import abort
 
 from MultiServer import Context, get_saving_second
-from NetUtils import SlotType, NetworkSlot
+from NetUtils import ClientStatus, SlotType, NetworkSlot
 from Utils import restricted_loads
 from worlds import lookup_any_item_id_to_name, lookup_any_location_id_to_name, network_data_package, games
 from worlds.alttp import Items
@@ -1548,7 +1548,7 @@ def _get_multiworld_tracker_data(tracker: UUID) -> typing.Optional[typing.Dict[s
         for player, name in enumerate(names, 1):
             player_names[team, player] = name
             states[team, player] = multisave.get("client_game_state", {}).get((team, player), 0)
-            if states[team, player] == 30:  # Goal Completed
+            if states[team, player] == ClientStatus.CLIENT_GOAL and player not in groups:
                 completed_worlds += 1
     long_player_names = player_names.copy()
     for (team, player), alias in multisave.get("name_aliases", {}).items():


### PR DESCRIPTION
## What is this fixing or adding?

The summary row feature added in #1965 did not filter out group slots when calculating `completed_worlds`, so item links would always make the numerator too high.

Fixes bug reported in https://discord.com/channels/731205301247803413/1152293234677133324
## How was this tested?

Ran WebHost.py before and after my change.

## If this makes graphical changes, please attach screenshots.

Before:

![image](https://github.com/ArchipelagoMW/Archipelago/assets/2065960/410db536-e3f8-4f23-8254-dfe043bc6478)

After:

![image](https://github.com/ArchipelagoMW/Archipelago/assets/2065960/75bbc3e0-f47e-429b-91f0-43ee275aa43d)
