### PR TITLE
WebHost: Avoid KeyError in LttP multitracker when non-LttP games are present

### DIFF
--- a/WebHostLib/tracker.py
+++ b/WebHostLib/tracker.py
@@ -1683,7 +1683,7 @@ def get_LttP_multiworld_tracker(tracker: UUID):
             for item_id in precollected:
                 attribute_item(team, player, item_id)
         for location in locations_checked:
-            if location not in player_locations or location not in player_location_to_area[player]:
+            if location not in player_locations or location not in player_location_to_area.get(player, {}):
                 continue
             item, recipient, flags = player_locations[location]
             recipients = groups.get(recipient, [recipient])


### PR DESCRIPTION
## What is this fixing or adding?

If you navigate to the LttP mutlitracker in a multiworld with non-LttP games, the non-LttP game will cause a KeyError because `player_location_to_area` only contains the LttP games:

```
File "\WebHostLib\tracker.py", line 1686, in get_LttP_multiworld_tracker
    if location not in player_locations or location not in player_location_to_area[player]:
KeyError: 1
```

Reported in the replies of https://discord.com/channels/731205301247803413/1152293234677133324

## How was this tested?

Loaded WebHost.py after this change, the page loads again.