### PR TITLE
Core/GUI: Better fileselection error

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -604,13 +604,14 @@ def open_directory(title: str, suggest: str = "") -> typing.Optional[str]:
     if is_linux:
         # prefer native dialog
         from shutil import which
-        kdialog = None#which("kdialog")
+        kdialog = which("kdialog")
         if kdialog:
-            return run(kdialog, f"--title={title}", "--getexistingdirectory", suggest or ".")
-        zenity = None#which("zenity")
+            return run(kdialog, f"--title={title}", "--getexistingdirectory",
+                       os.path.abspath(suggest) if suggest else ".")
+        zenity = which("zenity")
         if zenity:
             z_filters = ("--directory",)
-            selection = (f'--filename="{suggest}',) if suggest else ()
+            selection = (f"--filename={os.path.abspath(suggest)}/",) if suggest else ()
             return run(zenity, f"--title={title}", "--file-selection", *z_filters, *selection)
 
     # fall back to tk

--- a/Utils.py
+++ b/Utils.py
@@ -576,7 +576,7 @@ def open_filename(title: str, filetypes: typing.Sequence[typing.Tuple[str, typin
         zenity = which("zenity")
         if zenity:
             z_filters = (f'--file-filter={text} ({", ".join(ext)}) | *{" *".join(ext)}' for (text, ext) in filetypes)
-            selection = (f'--filename="{suggest}',) if suggest else ()
+            selection = (f"--filename={suggest}",) if suggest else ()
             return run(zenity, f"--title={title}", "--file-selection", *z_filters, *selection)
 
     # fall back to tk

--- a/Utils.py
+++ b/Utils.py
@@ -588,7 +588,10 @@ def open_filename(title: str, filetypes: typing.Sequence[typing.Tuple[str, typin
                       f'This attempt was made because open_filename was used for "{title}".')
         raise e
     else:
-        root = tkinter.Tk()
+        try:
+            root = tkinter.Tk()
+        except tkinter.TclError:
+            return None  # GUI not available. None is the same as a user clicking "cancel"
         root.withdraw()
         return tkinter.filedialog.askopenfilename(title=title, filetypes=((t[0], ' '.join(t[1])) for t in filetypes),
                                                   initialfile=suggest or None)
@@ -619,7 +622,10 @@ def open_directory(title: str, suggest: str = "") -> typing.Optional[str]:
                       f'This attempt was made because open_filename was used for "{title}".')
         raise e
     else:
-        root = tkinter.Tk()
+        try:
+            root = tkinter.Tk()
+        except tkinter.TclError:
+            return None  # GUI not available. None is the same as a user clicking "cancel"
         root.withdraw()
         return tkinter.filedialog.askdirectory(title=title, mustexist=True, initialdir=suggest or None)
 


### PR DESCRIPTION
## What is this fixing or adding?
```
$ DISPLAY="" python Generate.py
# ...
_tkinter.TclError: couldn't connect to display ""
```
```
$ DISPLAY="" python Generate.py
# ...
FileNotFoundError: Pokemon Red (UE) [S][!].gb does not exist, but PokemonSettings.red_rom_file is required
```
Also fixes and enables kdialog and zenity for `open_directory()`. This was tested with latest kdialog and zenity.

Also fixes the suggestion not working with zenity in `open_filename()`

## How was this tested?

* `TclError` as shown above

* `open_directory` with `import Utils; print(Utils.open_directory('test', '../with space'))`

* zenity fix in `open_filename` with `import Utils; print(Utils.open_filename('test', [], '../with space/a.bin'))`