### PR TITLE
The Witness: Fix Itemlinks

### DIFF
--- a/worlds/witness/__init__.py
+++ b/worlds/witness/__init__.py
@@ -248,6 +248,9 @@ class WitnessWorld(World):
 
         return WitnessItem(item_name, item_data.classification, item_data.ap_code, player=self.player)
 
+    def get_filler_item_name(self) -> str:
+        return "Speed Boost"
+
 
 class WitnessLocation(Location):
     """


### PR DESCRIPTION
Define a get_filler_item_name for the Witness world.

For the record, this [used to exist](https://github.com/NewSoupVi/Archipelago/blob/18c97798158ccd07a352deec10c8760ba9838556/worlds/witness/__init__.py#L315-L320) but was then [removed](https://github.com/ArchipelagoMW/Archipelago/pull/1953).

Bringing back the old way of how it worked would be more trouble than it's worth now probably.