### PR TITLE
DS3: Add cinders item group

### DIFF
--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -52,6 +52,14 @@ class DarkSouls3World(World):
     required_client_version = (0, 4, 2)
     item_name_to_id = DarkSouls3Item.get_name_to_id()
     location_name_to_id = DarkSouls3Location.get_name_to_id()
+    item_name_groups = {
+        "Cinders": {
+            "Cinders of a Lord - Abyss Watcher",
+            "Cinders of a Lord - Aldrich",
+            "Cinders of a Lord - Yhorm the Giant",
+            "Cinders of a Lord - Lothric Prince"
+        }
+    }
 
 
     def __init__(self, multiworld: MultiWorld, player: int):


### PR DESCRIPTION
## What is this fixing or adding?

@Marechal-L 

Adds a "Cinders" item group. These are all functionally the same, so there's no reason to hint for any specific one over another. Usually you just have to try to remember which ones you have and don't have before you hint for one.

## How was this tested?

Generating a seed and hinting for "Cinders".