### PR TITLE
ALttP: Update credits text for GT Big Key  when key drop shuffle is on.

### DIFF
--- a/worlds/alttp/Rom.py
+++ b/worlds/alttp/Rom.py
@@ -925,6 +925,10 @@ def patch_rom(world: MultiWorld, rom: LocalRom, player: int, enemized: bool):
         rom.write_byte(0x18700B, 10)  # Thieves Town
         rom.write_byte(0x18700C, 14)  # Turtle Rock
         rom.write_byte(0x18700D, 31)  # Ganons Tower
+        # update credits GT Big Key counter
+        gt_bigkey_top, gt_bigkey_bottom = credits_digit(5)
+        rom.write_byte(0x118B6A, gt_bigkey_top)
+        rom.write_byte(0x118B88, gt_bigkey_bottom)
 
 
 


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?

Making the number of checks before you get the GT big key accurate when key drop shuffle is enabled.  With it enabled, there are 25 check locations for the GT big key, rather than 22.

## How was this tested?

Rolled a seed with Key drop shuffle turned on, then did a game completion to get to the credits.

## If this makes graphical changes, please attach screenshots.

![image](https://github.com/ArchipelagoMW/Archipelago/assets/79097/df865600-b5fe-4aad-bd03-80f70b91de4a)

