### PR TITLE
filter early locations

### DIFF
--- a/test/general/TestReachability.py
+++ b/test/general/TestReachability.py
@@ -1,8 +1,9 @@
 import unittest
 
 from BaseClasses import CollectionState
+from Fill import distribute_early_items
 from worlds.AutoWorld import AutoWorldRegister
-from . import setup_solo_multiworld
+from . import setup_duo_multiworld, setup_solo_multiworld
 
 
 class TestBase(unittest.TestCase):
@@ -67,3 +68,18 @@ class TestBase(unittest.TestCase):
                             locations.add(location)
                     self.assertGreater(len(locations), 0,
                                        msg="Need to be able to reach at least one location to get started.")
+
+    def testEarlyItemsFilterDoesNotCrash(self) -> None:
+        """
+        This makes sure `filter_early_locations` is run in every world (within `distribute_early_items`).
+
+        That function has an assert in it to ensure the correct length of filter.
+        """
+        for game_name, world_type in AutoWorldRegister.world_types.items():
+            with self.subTest("Game", game=game_name):
+                multiworld = setup_duo_multiworld(world_type)
+                multiworld.early_items[2]["Feeling of Satisfaction"] = 1  # to make sure the early_items code is run
+                fill_locations = multiworld.get_unfilled_locations()
+                itempool = multiworld.itempool
+
+                fill_locations, itempool = distribute_early_items(multiworld, fill_locations, itempool)

--- a/test/general/__init__.py
+++ b/test/general/__init__.py
@@ -2,7 +2,9 @@ from argparse import Namespace
 from typing import Type, Tuple
 
 from BaseClasses import MultiWorld
+from Options import Option
 from worlds.AutoWorld import call_all, World
+from worlds.clique import CliqueWorld
 
 gen_steps = ("generate_early", "create_regions", "create_items", "set_rules", "generate_basic", "pre_fill")
 
@@ -15,6 +17,29 @@ def setup_solo_multiworld(world_type: Type[World], steps: Tuple[str, ...] = gen_
     args = Namespace()
     for name, option in world_type.option_definitions.items():
         setattr(args, name, {1: option.from_any(option.default)})
+    multiworld.set_options(args)
+    multiworld.set_default_common_options()
+    for step in steps:
+        call_all(multiworld, step)
+    return multiworld
+
+
+def setup_duo_multiworld(world_type: Type[World], steps: Tuple[str, ...] = gen_steps) -> MultiWorld:
+    """ player 2 is a Clique World """
+    multiworld = MultiWorld(2)
+    multiworld.game[1] = world_type.game
+    multiworld.game[2] = "Clique"
+    multiworld.player_name = {1: "Tester 1", 2: "Tester 2"}
+    multiworld.set_seed()
+    args = Namespace()
+    for name, option in world_type.option_definitions.items():
+        assert issubclass(option, Option)
+        setattr(args, name, {1: option.from_any(option.default)})
+    for name, option in CliqueWorld.option_definitions.items():
+        assert issubclass(option, Option)
+        set_from_player_1 = getattr(args, name, {})
+        set_from_player_1.update({2: option.from_any(option.default)})
+        setattr(args, name, set_from_player_1)
     multiworld.set_options(args)
     multiworld.set_default_common_options()
     for step in steps:

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -4,8 +4,8 @@ import hashlib
 import logging
 import pathlib
 import sys
-from typing import Any, Callable, ClassVar, Dict, FrozenSet, List, Optional, Set, TYPE_CHECKING, TextIO, Tuple, Type, \
-    Union
+from typing import Any, Callable, ClassVar, Dict, FrozenSet, List, Optional, \
+    Sequence, Set, TYPE_CHECKING, TextIO, Tuple, Type, Union
 
 from BaseClasses import CollectionState
 from Options import AssembleOptions
@@ -387,6 +387,19 @@ class World(metaclass=AutoWorldRegister):
     # called to create all_state, return Items that are created during pre_fill
     def get_pre_fill_items(self) -> List["Item"]:
         return []
+
+    def filter_early_locations(self, loc_list: Sequence[Location]) -> Sequence[bool]:
+        """
+        `loc_list` is a sequence (`list`) of `Location`s for your game
+        that our algorithms have guessed are "early" locations.
+
+        Return a sequence of `bool` for whether each location should be considered an early location.
+
+        The default includes all of these locations.
+        You should only need to override this
+        if someone is complaining about where early items are placed in your world.
+        """
+        return [True for _ in loc_list]
 
     # following methods should not need to be overridden.
     def collect(self, state: "CollectionState", item: "Item") -> bool:

--- a/worlds/zillion/__init__.py
+++ b/worlds/zillion/__init__.py
@@ -4,11 +4,11 @@ import functools
 import settings
 import threading
 import typing
-from typing import Any, Dict, List, Literal, Set, Tuple, Optional, cast
+from typing import Any, Dict, List, Literal, Sequence, Set, Tuple, Optional, cast
 import os
 import logging
 
-from BaseClasses import ItemClassification, LocationProgressType, \
+from BaseClasses import ItemClassification, Location, LocationProgressType, \
     MultiWorld, Item, CollectionState, Entrance, Tutorial
 from .config import detect_test
 from .logic import cs_to_zz_locs
@@ -461,3 +461,7 @@ class ZillionWorld(World):
     def get_filler_item_name(self) -> str:
         """Called when the item pool needs to be filled with additional items to match location count."""
         return "Empty"
+
+    def filter_early_locations(self, loc_list: Sequence[Location]) -> Sequence[bool]:
+        # the first 4 rows of the base
+        return [loc.name[0] in {"A", "B", "C", "D"} for loc in loc_list]


### PR DESCRIPTION
## What is this fixing or adding?

As discussed in discord, sometimes locations chosen for `early_items` aren't really early.
In some games, with some options, they can be almost anywhere in the game, and they can take a long time to get to.
This adds an API so that worlds can filter which locations are considered early.

## How was this tested?

I made a Zillion yaml with options that open up most of the game to sphere 1.
Then I stepped through the `early_items` code with the debugger and watched how it filtered 101 locations down to 33.

unit test added to make sure `filter_early_locations` is run on every world
