### PR TITLE
WebHost: link to stats from the use statistics directly on landing

### DIFF
--- a/WebHostLib/static/styles/landing.css
+++ b/WebHostLib/static/styles/landing.css
@@ -235,9 +235,6 @@ html{
     line-height: 30px;
 }
 
-#landing .variable{
-    color: #ffff00;
-}
 
 .landing-deco{
     position: absolute;

--- a/WebHostLib/templates/landing.html
+++ b/WebHostLib/templates/landing.html
@@ -49,9 +49,9 @@
                     our crazy idea into a reality.
                 </p>
                 <p>
-                    <span class="variable">{{ seeds }}</span>
+                    <a href="{{ url_for("stats") }}">{{ seeds }}</a>
                     games were generated and
-                    <span class="variable">{{ rooms }}</span>
+                    <a href="{{ url_for("stats") }}">{{ rooms }}</a>
                     were hosted in the last 7 days.
                 </p>
             </div>


### PR DESCRIPTION
## What is this fixing or adding?
link to stats from the use statistics directly on landing

## How was this tested?
clicked

## If this makes graphical changes, please attach screenshots.
