### PR TITLE
Zillion: change test detection for running tests with multiprocessing

### DIFF
--- a/worlds/zillion/__init__.py
+++ b/worlds/zillion/__init__.py
@@ -10,7 +10,6 @@ import logging
 
 from BaseClasses import ItemClassification, LocationProgressType, \
     MultiWorld, Item, CollectionState, Entrance, Tutorial
-from .config import detect_test
 from .logic import cs_to_zz_locs
 from .region import ZillionLocation, ZillionRegion
 from .options import ZillionStartChar, zillion_options, validate
@@ -25,6 +24,7 @@ from zilliandomizer.system import System
 from zilliandomizer.logic_components.items import RESCUE, items as zz_items, Item as ZzItem
 from zilliandomizer.logic_components.locations import Location as ZzLocation, Req
 from zilliandomizer.options import Chars
+from zilliandomizer.patch import detect_test
 
 from ..AutoWorld import World, WebWorld
 

--- a/worlds/zillion/config.py
+++ b/worlds/zillion/config.py
@@ -2,20 +2,3 @@ import os
 
 base_id = 8675309
 zillion_map = os.path.join(os.path.dirname(__file__), "empty-zillion-map-row-col-labels-281.png")
-
-
-def detect_test() -> bool:
-    """
-    Parts of generation that are in unit tests need the rom.
-    This is to detect whether we are running unit tests
-    so we can work around the need for the rom.
-    """
-    import __main__
-    try:
-        if "test" in __main__.__file__:
-            return True
-    except AttributeError:
-        # In some environments, __main__ doesn't have __file__
-        # We'll assume that's not unit tests.
-        pass
-    return False

--- a/worlds/zillion/requirements.txt
+++ b/worlds/zillion/requirements.txt
@@ -1,1 +1,1 @@
-zilliandomizer @ git+https://github.com/beauxq/zilliandomizer@4b27d115269db25fe73b0471b73495f41df1323c#0.5.3
+zilliandomizer @ git+https://github.com/beauxq/zilliandomizer@d7122bcbeda40da5db26d60fad06246a1331706f#0.5.4


### PR DESCRIPTION
## What is this fixing or adding?

change test detection for running tests with multiprocessing
As requested by @black-sliver 

In addition to the changes to the detection, I also moved the detection function into the zilliandomizer package so it can use the same detection in both places.

## How was this tested?

unit tests in both places and generated and played through a 1-player game in both places
