### PR TITLE
Multiserver, Docs: Datastorage error handling + docs

### DIFF
--- a/DataStorage.py
+++ b/DataStorage.py
@@ -50,9 +50,9 @@ class DataStorage:
     def __init__(self, stored_data: Dict[str, object]):
         self.stored_data = stored_data
 
-    def is_valid_set_cmd(set_cmd: Dict[str, object]) -> bool:
+    def is_valid_set_cmd(self, set_cmd: Dict[str, object]) -> bool:
         return "key" in set_cmd and type(set_cmd["key"]) == str and not set_cmd["key"].startswith("_read_") \
-            and "operations" in set_cmd and not type(set_cmd["operations"]) == list
+            and "operations" in set_cmd and type(set_cmd["operations"]) == list
 
     def set(self, set_cmd: Dict[str, object]) -> Dict[str, object]:
         value = self.stored_data.get(set_cmd["key"], set_cmd.get("default", 0))

--- a/DataStorage.py
+++ b/DataStorage.py
@@ -55,14 +55,13 @@ class DataStorage:
             and "operations" in set_cmd and not type(set_cmd["operations"]) == list
 
     def set(self, set_cmd: Dict[str, object]) -> Dict[str, object]:
-        response: Dict[str, object] = {
-            "cmd": "SetReply",
-            "key": set_cmd["key"]
-        }
-
         value = self.stored_data.get(set_cmd["key"], set_cmd.get("default", 0))
-        response["original_value"] = copy.copy(value)
         on_error =  set_cmd.get("on_error", "raise")
+
+        set_cmd.update({
+            "cmd": "SetReply",
+            "original_value": copy.copy(value)
+        })
 
         try:
             for operation in set_cmd["operations"]:
@@ -76,15 +75,15 @@ class DataStorage:
             if (on_error == "set_default"):
                 value = set_cmd.get("default", 0)
             elif (on_error == "undo"):
-                value =  response["original_value"]
+                value = set_cmd["original_value"]
             elif (on_error == "abort"):
                 pass # dont process further operations
             else:
                 raise
 
-        self.stored_data[set_cmd["key"]] = response["value"] = value
+        self.stored_data[set_cmd["key"]] = set_cmd["value"] = value
 
-        return response
+        return set_cmd
 
 
 

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1738,12 +1738,12 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
             await ctx.send_msgs(client, [args])
 
         elif cmd == "Set":
-            if not ctx.data_storage.is_set_cmd_valid(args):
+            if not ctx.data_storage.is_valid_set_cmd(args):
                 await ctx.send_msgs(client, [{'cmd': 'InvalidPacket', "type": "arguments",
                                               "text": 'Set', "original_cmd": cmd}])
                 return
             
-            ctx.data_storage.apply_set_cmd(args)
+            ctx.data_storage.set(args)
 
             targets = set(ctx.stored_data_notification_clients[args["key"]])
             if args.get("want_reply", True):

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1743,13 +1743,13 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
                                               "text": 'Set', "original_cmd": cmd}])
                 return
             
-            ctx.data_storage.set(args)
-
+            result: typing.Dict[str, object] = ctx.data_storage.set(args)
+            
             targets = set(ctx.stored_data_notification_clients[args["key"]])
             if args.get("want_reply", True):
                 targets.add(client)
             if targets:
-                ctx.broadcast(targets, [args])
+                ctx.broadcast(targets, [result])
             ctx.save()
 
         elif cmd == "SetNotify":

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -370,7 +370,7 @@ the server will forward the message to all those targets to which any one requir
 | data | dict | Any data you want to send |
 
 ### Get
-Used to request a single or multiple values from the server's data storage, see the [Set](#Set) package for how to write values to the data storage. A Get package will be answered with a [Retrieved](#Retrieved) package.
+Used to request a single or multiple values from the [server's data storage](server%20datastorage.md), see the [Set](#Set) package for how to write values to the data storage. A Get package will be answered with a [Retrieved](#Retrieved) package.
 #### Arguments
 | Name | Type | Notes |
 | ------ | ----- | ------ |
@@ -387,7 +387,7 @@ Some special keys exist with specific return data, all of them have the prefix `
 | item_name_groups_{game_name}  | dict\[str, list\[str\]\] | item_name_groups belonging to the requested game. |
 
 ### Set
-Used to write data to the server's data storage, that data can then be shared across worlds or just saved for later. Values for keys in the data storage can be retrieved with a [Get](#Get) package, or monitored with a [SetNotify](#SetNotify) package.
+Used to write data to the [server's data storage](server%20datastorage.md), that data can then be shared across worlds or just saved for later. Values for keys in the data storage can be retrieved with a [Get](#Get) package, or monitored with a [SetNotify](#SetNotify) package.
 Keys that start with `_read_` cannot be set.
 #### Arguments
 | Name       | Type                                                  | Notes                                                                                                                  |
@@ -407,7 +407,7 @@ DataStorageOperations consist of an object containing both the operation to be a
 {"operation": "add", "value": 12}
 ```
 
-The following operations can be applied to a datastorage key
+The following operations can be applied to a data storage key
 | Operation | Effect |
 | ------ | ----- |
 | replace | Sets the current value of the key to `value`. |

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -396,6 +396,7 @@ Keys that start with `_read_` cannot be set.
 | default    | any                                                   | The default value to use in case the key has no value on the server.                                                   |
 | want_reply | bool                                                  | If true, the server will send a [SetReply](#SetReply) response back to the client.                                     |
 | operations | list\[[DataStorageOperation](#DataStorageOperation)\] | Operations to apply to the value, multiple operations can be present and they will be executed in order of appearance. |
+| on_error   | str                                                   | Optional (defaults to `raise`). When provided, should contain any of the [DataStorageErrorHandlingOptions](#DataStorageErrorHandlingOptions)
 
 Additional arguments sent in this package will also be added to the [SetReply](#SetReply) package it triggers.
 
@@ -423,8 +424,18 @@ The following operations can be applied to a datastorage key
 | left_shift | Applies a bitwise left-shift to the current value of the key by `value`. |
 | right_shift | Applies a bitwise right-shift to the current value of the key by `value`. |
 | remove | List only: removes the first instance of `value` found in the list. |
-| pop | List or Dict: for lists it will remove the index of the `value` given. for dicts it removes the element with the specified key of `value`. |
+| pop | List or Dict: for lists it will remove the index of the `value` given. for dicts it removes the element with the specified key of `value`. will error in index or key does not exist |
 | update | Dict only: Updates the dictionary with the specified elements given in `value` creating new keys, or updating old ones if they previously existed. |
+
+#### DataStorageErrorHandlingOptions
+What should be done when an data storage operation fails, for example when an `pow` operation is attempted on a string value. Only with the option `raise` an stack trace will be preserved, with all other options the error is invisible
+
+| Option      | On Error Effect |
+| raise       | An error is raised on the server, causing a stacktrace to be logged and the client to be kicked |
+| set_default | Sets the value of the key to `default` of the [Set](#Set)'s package |
+| undo        | Undo's any modifications done to the key's value by previous `operations` part of this [Set](#Set)'s package |
+| abort       | Stops further processing of `operations` part of this [Set](#Set)'s package |
+| ignore      | Ignore errors and continue processing of remaining `operations` part of this [Set](#Set)'s package |
 
 ### SetNotify
 Used to register your current session for receiving all [SetReply](#SetReply) packages of certain keys to allow your client to keep track of changes.

--- a/docs/server datastorage.md
+++ b/docs/server datastorage.md
@@ -1,0 +1,137 @@
+# Serverside Data Storage
+
+This document covers some of the patterns and tips and tricks used to communicate with data storage, communication with the data storage is don't through the `Get\Received`, `Set\SetReply` and `SetNotify` commands described inside the [Network Protocol](network%20protocol.md). The data storage is meant to preserve some date on the server that spans across the lifecycle of the server and is shared with all clients (on any team). 
+
+### Keys
+The data storage works by keys and is internally stored as a dictionary. note that the whole data storage is accessible by all clients so if you want to store data specifically for your team, game or slot you will have to make your key unique, this is often done by add the team number, game name or slot id to the key. Some examples:
+| EneryLink{team} |                 |
+| `EnergyLink1` | Energy for team 1 |
+| `EnergyLink2` | Energy for team 2 |
+
+| GiftBoxes;{team} |                                            |
+| `GiftBoxes;0`    | Giftbox metadata for all giftbox on team 0 |
+| `GiftBoxes;1`    | Giftbox metadata for all giftbox on team 1 |
+
+| GiftBox;{team};{slot} |                                             |
+| `GiftBox;0;1`         | Slot specific giftbox for slot 1 on team 0  |
+| `GiftBox;5;13`        | Slot specific giftbox for slot 13 on team 5 |
+
+### Thread Safety
+Because any client can read and write to the data storage at any time you can never assume that value you read is still the same 1 second later. So a 
+easy mistake to make is for example retrieving a value using a `Get` command, then processing the value, altering it, and then writing it back to the store with an `Set`-`replace` command.
+
+There are a few given aspects to the data storage that we can use to our advantage to ensure thread safety. 
+* Any additional data given to the `Set` command will be passed along to the `SetReply` response. this can be used to "tag" a certain `SetReply` by for-example adding a specific random value to your `Set` then when you receive the `SetReply` you can check that value to match it back up to your `Set` command. 
+* All operations in your `Set` command are executed in order without interruption from others and the final result will only trigger one `SetRely`.
+
+Its a lot simpler to stay thread save with basic types such a numbers as shown below in [EnergyLink](#EnergyLink), therefor it can useful to spread your data across multiple data storage keys just holding a basic value like a number, for example if you want to safely update the following data structure 
+Key `Fruit`: `json { "Apple": 3, "Cherry": 7 }` it will be a lot more easy to safely update as two separated keys `FruitApple`: 3 and `FruitCherry`: 7
+
+Lets look at a few examples:
+
+#### EnergyLink
+Energylink wants to share the current energy value across multiple clients and games, it uses a team specific key of `EneryLink{team}`. The Energy value is a numeric value and its important that games can add and take energy from it in a thread safe way.
+
+Adding is easy, just a `Set-add` operation, for example to add 20:
+```json
+{
+    "cmd": "Set",
+    "key": "EnergyLink0",
+    "default": 0,
+    "operations": [
+        {"operation": "add", "value": 20},
+    ]
+}
+```
+Depleting, however is more complicated, in this scenario we use both the fact that multiple operations are executed together aswel as tagging the Set.
+First we subtract our value, them we set the value back to 0 if it went below 0. Lastly we will look for the corresponding `SetReply` command with the tag we specified, inside the `SetReply` we compare the `original_value` to the `value` to know how much energy we where actually able to subtract
+```json
+{
+    "cmd": "Set",
+    "key": "EnergyLink0",
+    "tag": "7cc04194-b491-4cba-a89e-ef754502f3ff",
+    "default": 0,
+    "want_reply": true,
+    "operations": [
+        {"operation": "add", "value": -50},
+        {"operation": "max", "value": 0},
+    ]
+}
+```
+response
+```json
+{
+    "cmd": "Set",
+    "key": "EnergyLink0",
+    "tag": "7cc04194-b491-4cba-a89e-ef754502f3ff",
+    "default": 0,
+    "want_reply": true,
+    "operations": [
+        {"operation": "add", "value": -50},
+        {"operation": "max", "value": 0},
+    ],
+    "original_value": 20,
+    "value": 0
+
+}
+```
+So we only where able to subtract `original_value` - `value` = 20 Energy
+
+#### Gifting
+Gifting allow players to gift items they don't need to other games, like if you get a health potion but you are at no risk of dieing someone else might have more use for it. Gifting works by slot specific giftboxes, any client can gift add a gift to the giftbox, and only the client of the slot the giftbox belongs to is supposed to remove gifts from it. Now it might seem easy with an array of gift objects however while appending to an array is thread safe, removing entries from an array cannot be done thread safe. Giftboxes are implemented as dictionaries where each gift has its own unique key. new gifts can safely be added using the `update` operation and removal of specific gifts can be done on their unique keys using the `pop` operation. 
+
+Adding gifts
+```json
+{
+    "cmd": "Set",
+    "key": "GiftBox;0;1",
+    "default": {},
+    "operations": [
+        {"operation": "update", "value": {
+            "1a4a169f-de12-45cf-a7d9-f77c1c2ebc31": {
+                "gift": "json"
+            }
+        }}
+    ]
+}
+```
+Removing gifts, note we are ignoring the errors here as pop-ing an non existing key will raise an error otherwise
+```json
+{
+    "cmd": "Set",
+    "key": "GiftBox;0;1",
+    "default": {},
+    "on_error": "ignore",
+    "operations": [
+        {"operation": "pop", "value": "1a4a169f-de12-45cf-a7d9-f77c1c2ebc31" },
+    ]
+}
+```
+
+#### Locking
+This is not an actual used example but if you want an even more complex thread safety you can implement such a thing yourself using the techniques aboves. it is possible to use a `pop` operation on specific dictionary keys along with a tagging your `Set` command to see if you client can obtain a lock, for example:
+```json
+{
+    "cmd": "Set",
+    "key": "MyStoreAvailableKeys",
+    "default": { "Key1": true, "Key2": true },
+    "on_error": "ignore",
+    "tag": "2c14b824-f274-40e2-ab88-e3ce643683c1",
+    "want_reply": true,
+    "operations": [
+        {"operation": "pop", "value": "Key1" },
+    ]
+}
+```
+Than inside the `SetReply` check by looking in the `original_value` and 'value' if `Key1` got removed and by tag if this was done as a result to you pop-int it, if thats all true, you know you now got the lock and can do whatever you want to the key `MyStoreAvailableKeys:Key1`. and when your done with it you write back `Key1` to the `MyStoreAvailableKeys` using an update
+```json
+{
+    "cmd": "Set",
+    "key": "MyStoreAvailableKeys",
+    "default": {},
+    "operations": [
+        {"operation": "update", "value": { "Key1": true }}
+    ]
+}
+```
+Ofcourse this is not perfect, its only safe if all clients trying to alter `MyStoreAvailableKeys:Key1` respect this locking mechanism, and if the client who obtained the lock disconnects or otherwise fails to release it you need to somehow time that out, like you could have a separated dict storing the last times for each key a lock was obtained

--- a/docs/server datastorage.md
+++ b/docs/server datastorage.md
@@ -4,35 +4,38 @@ This document covers some of the patterns and tips and tricks used to communicat
 
 ### Keys
 The data storage works by keys and is internally stored as a dictionary. note that the whole data storage is accessible by all clients so if you want to store data specifically for your team, game or slot you will have to make your key unique, this is often done by add the team number, game name or slot id to the key. Some examples:
-| EneryLink{team} |                 |
-| `EnergyLink1` | Energy for team 1 |
-| `EnergyLink2` | Energy for team 2 |
+| EneryLink{team} |                   |
+| ---             | ---               |
+| `EnergyLink1`   | Energy for team 1 |
+| `EnergyLink2`   | Energy for team 2 |
 
 | GiftBoxes;{team} |                                            |
+| ---              | ---                                        |
 | `GiftBoxes;0`    | Giftbox metadata for all giftbox on team 0 |
 | `GiftBoxes;1`    | Giftbox metadata for all giftbox on team 1 |
 
 | GiftBox;{team};{slot} |                                             |
+| ---                   | ---                                         |
 | `GiftBox;0;1`         | Slot specific giftbox for slot 1 on team 0  |
 | `GiftBox;5;13`        | Slot specific giftbox for slot 13 on team 5 |
 
 ### Thread Safety
-Because any client can read and write to the data storage at any time you can never assume that value you read is still the same 1 second later. So a 
-easy mistake to make is for example retrieving a value using a `Get` command, then processing the value, altering it, and then writing it back to the store with an `Set`-`replace` command.
+Because any client can read and write to the data storage at any time you can never assume that value you read is still the same 1 second later. So an 
+easy mistake is for example retrieving a value using a `Get` command, then processing the value, altering it, and then writing it back to the store with an `Set`-`replace` command. The `Set`-`replace` command will simply override the value discarding any possible changes by any other clients.
 
-There are a few given aspects to the data storage that we can use to our advantage to ensure thread safety. 
+There are a few aspects to the data storage that we can use to our advantage to ensure thread safety:
 * Any additional data given to the `Set` command will be passed along to the `SetReply` response. this can be used to "tag" a certain `SetReply` by for-example adding a specific random value to your `Set` then when you receive the `SetReply` you can check that value to match it back up to your `Set` command. 
 * All operations in your `Set` command are executed in order without interruption from others and the final result will only trigger one `SetRely`.
 
-Its a lot simpler to stay thread save with basic types such a numbers as shown below in [EnergyLink](#EnergyLink), therefor it can useful to spread your data across multiple data storage keys just holding a basic value like a number, for example if you want to safely update the following data structure 
-Key `Fruit`: `json { "Apple": 3, "Cherry": 7 }` it will be a lot more easy to safely update as two separated keys `FruitApple`: 3 and `FruitCherry`: 7
+Its a lot simpler to stay thread safe with basic types such a numbers as shown below in [EnergyLink](#EnergyLink), therefor it can useful to spread your data across multiple data storage keys just holding a basic value like a number in each, for example if you want to safely update the following data structure 
+Key `Fruit`: `{ "Apple": 3, "Cherry": 7 }` it will be a lot more easy to safely update as two separated keys `FruitApple`: `3` and `FruitCherry`: `7`.
 
 Lets look at a few examples:
 
 #### EnergyLink
-Energylink wants to share the current energy value across multiple clients and games, it uses a team specific key of `EneryLink{team}`. The Energy value is a numeric value and its important that games can add and take energy from it in a thread safe way.
+Energylink lets you share you excess energy with across multiple clients and games, it uses a team specific key of `EneryLink{team}`. The Energy value is a numeric value and its important that games can add and take energy from it in a thread safe way.
 
-Adding is easy, just a `Set-add` operation, for example to add 20:
+Adding is easy, just a `Set`-`add` operation, for example to add 20:
 ```json
 {
     "cmd": "Set",
@@ -44,7 +47,7 @@ Adding is easy, just a `Set-add` operation, for example to add 20:
 }
 ```
 Depleting, however is more complicated, in this scenario we use both the fact that multiple operations are executed together aswel as tagging the Set.
-First we subtract our value, them we set the value back to 0 if it went below 0. Lastly we will look for the corresponding `SetReply` command with the tag we specified, inside the `SetReply` we compare the `original_value` to the `value` to know how much energy we where actually able to subtract
+First we subtract our value, them we set the value back to 0 if it went below 0. Lastly we will look for the corresponding `SetReply` command with the tag we specified, inside the `SetReply` we compare the `original_value` to the `value` to know how much energy we where actually able to subtract.
 ```json
 {
     "cmd": "Set",
@@ -58,7 +61,7 @@ First we subtract our value, them we set the value back to 0 if it went below 0.
     ]
 }
 ```
-response
+Response:
 ```json
 {
     "cmd": "Set",
@@ -75,12 +78,12 @@ response
 
 }
 ```
-So we only where able to subtract `original_value` - `value` = 20 Energy
+So we only where able to subtract `original_value` - `value` = 20 Energy.
 
 #### Gifting
-Gifting allow players to gift items they don't need to other games, like if you get a health potion but you are at no risk of dieing someone else might have more use for it. Gifting works by slot specific giftboxes, any client can gift add a gift to the giftbox, and only the client of the slot the giftbox belongs to is supposed to remove gifts from it. Now it might seem easy with an array of gift objects however while appending to an array is thread safe, removing entries from an array cannot be done thread safe. Giftboxes are implemented as dictionaries where each gift has its own unique key. new gifts can safely be added using the `update` operation and removal of specific gifts can be done on their unique keys using the `pop` operation. 
+Gifting allows players to gift items they don't need to other games, like if you get a health potion but you are at no risk of dieing someone else might have more use for it. Gifting works by slot specific giftboxes, any client can add a gift to the giftbox, and only the client of the slot the giftbox belongs to is supposed to remove gifts from it. Now it might seem easy with an array of gift objects however while appending to an array is thread safe, removing entries from an array cannot be done thread safe. Therefor giftboxes are implemented as dictionaries where each gift has its own unique key. new gifts can safely be added using the `update` operation and removal of specific gifts can be done using their unique keys with the `pop` operation. (for more imformation visit the [gifting api documentation](https://github.com/agilbert1412/Archipelago.Gifting.Net/blob/main/Documentation/Gifting%20API.md)).
 
-Adding gifts
+Adding gifts:
 ```json
 {
     "cmd": "Set",
@@ -95,7 +98,7 @@ Adding gifts
     ]
 }
 ```
-Removing gifts, note we are ignoring the errors here as pop-ing an non existing key will raise an error otherwise
+Removing gifts, note we are ignoring the errors here as pop-ing an non existing key will raise an error otherwise.
 ```json
 {
     "cmd": "Set",
@@ -109,7 +112,7 @@ Removing gifts, note we are ignoring the errors here as pop-ing an non existing 
 ```
 
 #### Locking
-This is not an actual used example but if you want an even more complex thread safety you can implement such a thing yourself using the techniques aboves. it is possible to use a `pop` operation on specific dictionary keys along with a tagging your `Set` command to see if you client can obtain a lock, for example:
+This is not an actual used example but if you want an even more complex thread safe way you can implement using the techniques aboves. it is possible to use a `pop` operation on specific dictionary keys along with a tagging your `Set` command to see if you client can obtain a lock, for example:
 ```json
 {
     "cmd": "Set",
@@ -123,7 +126,7 @@ This is not an actual used example but if you want an even more complex thread s
     ]
 }
 ```
-Than inside the `SetReply` check by looking in the `original_value` and 'value' if `Key1` got removed and by tag if this was done as a result to you pop-int it, if thats all true, you know you now got the lock and can do whatever you want to the key `MyStoreAvailableKeys:Key1`. and when your done with it you write back `Key1` to the `MyStoreAvailableKeys` using an update
+Than inside the `SetReply` check by looking in the `original_value` and 'value' if `Key1` got removed and by tag if this was done as a result to you pop-int it, if thats all true, you know you now got the lock and can do whatever you want to the key `MyStoreAvailableKeys:Key1`. and when your done with it, you write back `Key1` to the `MyStoreAvailableKeys` using an update.
 ```json
 {
     "cmd": "Set",
@@ -134,4 +137,4 @@ Than inside the `SetReply` check by looking in the `original_value` and 'value' 
     ]
 }
 ```
-Ofcourse this is not perfect, its only safe if all clients trying to alter `MyStoreAvailableKeys:Key1` respect this locking mechanism, and if the client who obtained the lock disconnects or otherwise fails to release it you need to somehow time that out, like you could have a separated dict storing the last times for each key a lock was obtained
+Ofcourse this is not perfect, its only safe if all clients trying to alter `MyStoreAvailableKeys:Key1` respect this locking mechanism, and if the client who obtained the lock disconnects or otherwise fails to release it you need to somehow timeout that lock, like you could have a separated dict storing the last timestamps for each key a lock was obtained.

--- a/docs/server datastorage.md
+++ b/docs/server datastorage.md
@@ -1,6 +1,6 @@
 # Serverside Data Storage
 
-This document covers some of the patterns and tips and tricks used to communicate with data storage, communication with the data storage is don't through the `Get\Received`, `Set\SetReply` and `SetNotify` commands described inside the [Network Protocol](network%20protocol.md). The data storage is meant to preserve some date on the server that spans across the lifecycle of the server and is shared with all clients (on any team). 
+This document covers some of the patterns and tips and tricks used to communicate with data storage, communication with the data storage is don't through the [`Get`](network%20protocol.md#Get)\[`Retrieved`](network%20protocol.md#Retrieved), [`Set`](network%20protocol.md#Set)\[`SetReply`](network%20protocol.md#SetReply) and [`SetNotify`](network%20protocol.md#SetNotify) commands described inside the [Network Protocol](network%20protocol.md). The data storage is meant to preserve some date on the server that spans across the lifecycle of the server and is shared with all clients (on any team). 
 
 ### Keys
 The data storage works by keys and is internally stored as a dictionary. note that the whole data storage is accessible by all clients so if you want to store data specifically for your team, game or slot you will have to make your key unique, this is often done by add the team number, game name or slot id to the key. Some examples:

--- a/docs/server datastorage.md
+++ b/docs/server datastorage.md
@@ -1,6 +1,6 @@
 # Serverside Data Storage
 
-This document covers some of the patterns and tips and tricks used to communicate with data storage, communication with the data storage is don't through the [`Get`](network%20protocol.md#Get)\[`Retrieved`](network%20protocol.md#Retrieved), [`Set`](network%20protocol.md#Set)\[`SetReply`](network%20protocol.md#SetReply) and [`SetNotify`](network%20protocol.md#SetNotify) commands described inside the [Network Protocol](network%20protocol.md). The data storage is meant to preserve some date on the server that spans across the lifecycle of the server and is shared with all clients (on any team). 
+This document covers some of the patterns and tips and tricks used to communicate with data storage, communication with the data storage is don't through the [`Get`](network%20protocol.md#Get) \ [`Retrieved`](network%20protocol.md#Retrieved), [`Set`](network%20protocol.md#Set) \ [`SetReply`](network%20protocol.md#SetReply) and [`SetNotify`](network%20protocol.md#SetNotify) commands described inside the [Network Protocol](network%20protocol.md). The data storage is meant to preserve some date on the server that spans across the lifecycle of the server and is shared with all clients (on any team). 
 
 ### Keys
 The data storage works by keys and is internally stored as a dictionary. note that the whole data storage is accessible by all clients so if you want to store data specifically for your team, game or slot you will have to make your key unique, this is often done by add the team number, game name or slot id to the key. Some examples:

--- a/test/multi_server/TestDataStorage.py
+++ b/test/multi_server/TestDataStorage.py
@@ -1,0 +1,71 @@
+from typing import Dict
+import unittest
+from DataStorage import DataStorage
+
+class TestDataStorage(unittest.TestCase):
+    storage: DataStorage
+
+    def setup_storage(self, initial_data: Dict[str, object]) -> None:
+        self.data: Dict[str, object] = initial_data
+        self.storage: DataStorage = DataStorage(self.data)
+
+    def assert_result(self, result: Dict[str, object], key: str, value: object, original_value: object) -> None:
+        self.assertEqual(self.data[key], value)
+        self.assertEqual(result["cmd"], "SetReply")
+        self.assertEqual(result["key"], key)
+        self.assertEqual(result["value"], value)
+        self.assertEqual(result["original_value"], original_value)
+
+    def test_adding_number(self):
+        self.setup_storage({ "BasicAdd": 10 })
+
+        set_cmd: Dict[str, object] = { 
+            "key": "BasicAdd", 
+            "operations": [{"operation": "add", "value": 12}] 
+        }
+
+        result: Dict[str, object] = self.storage.apply_set_cmd(set_cmd)
+
+        self.assert_result(result, "BasicAdd", 22, 10)
+
+    def test_adding_number_with_default(self):
+        self.setup_storage({})
+
+        set_cmd: Dict[str, object] = { 
+            "key": "AddWithDefault", 
+            "default": 35,
+            "operations": [{"operation": "add", "value": 6}]
+        }
+
+        result: Dict[str, object] = self.storage.apply_set_cmd(set_cmd)
+
+        self.assert_result(result, "AddWithDefault", 41, 35)
+
+    # Default is currently weird in two ways:
+    # * The operation requires a "value" but its contents is ignored
+    # * The original_value is also updated to the value
+    def test_default_operation(self):
+        self.setup_storage({})
+
+        set_cmd: Dict[str, object] = { 
+            "key": "Default", 
+            "default": "Hello",
+            "operations": [{"operation": "default", "value": None}]
+        }
+
+        result: Dict[str, object] = self.storage.apply_set_cmd(set_cmd)
+
+        self.assert_result(result, "Default", "Hello", "Hello")
+
+    def test_default_should_not_override_existing_value(self):
+        self.setup_storage({ "DefaultWithExistingValue": "ExistingValue" })
+
+        set_cmd: Dict[str, object] = { 
+            "key": "DefaultWithExistingValue", 
+            "default": "NewValue",
+            "operations": [{"operation": "default", "value": "Ignored"}]
+        }
+
+        result: Dict[str, object] = self.storage.apply_set_cmd(set_cmd)
+
+        self.assert_result(result, "DefaultWithExistingValue", "ExistingValue", "ExistingValue")

--- a/test/multi_server/TestDataStorage.py
+++ b/test/multi_server/TestDataStorage.py
@@ -57,6 +57,40 @@ class TestDataStorage(unittest.TestCase):
 
         self.assert_result(result, "Default", "Hello", "Hello")
 
+    def test_energy_link_depletion_pattern(self):
+        self.setup_storage({ "EnergyLink1": 20 })
+
+        set_cmd: Dict[str, object] = { 
+            "key": "EnergyLink1", 
+            "default": 0,
+            "operations": [
+                {"operation": "add", "value": -50},
+                {"operation": "max", "value": 0}
+            ]
+        }
+
+        result: Dict[str, object] = self.storage.set(set_cmd)
+
+        self.assert_result(result, "EnergyLink1", 0, 20)
+
+    def test_should_preserve_fields_from_set(self):
+        self.setup_storage({})
+
+        set_cmd: Dict[str, object] = { 
+            "key": "NewKey", 
+            "default": 100,
+            "want_reply": True,
+            "operations": [{"operation": "replace", "value": 10}],
+            "10GbMovieData": "MTBHYk1vdmllRGF0YQ=="
+        }
+
+        result: Dict[str, object] = self.storage.set(set_cmd)
+
+        self.assert_result(result, "NewKey", 10, 100)
+        self.assertEqual(result["default"], 100)
+        self.assertEqual(result["want_reply"], True)
+        self.assertEqual(result["10GbMovieData"], "MTBHYk1vdmllRGF0YQ==")
+
     def test_default_should_not_override_existing_value(self):
         self.setup_storage({ "DefaultWithExistingValue": "ExistingValue" })
 


### PR DESCRIPTION
## What is this fixing or adding?
* An `on_error` argument to datastorage `Set` operations, that allow the implementer to specify how errors should be handed
* Docs on how to work with the datastorage in a thread safe way

## How was this tested?
unit tests + a few manual full stack tests with running a local server
