### PR TITLE
Core: more gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,11 +32,14 @@ setups
 build
 bundle/components.wxs
 dist
+/prof/
 README.html
 .vs/
 EnemizerCLI/
 /Players/
 /SNI/
+/sni-*/
+/appimagetool*
 /host.yaml
 /options.yaml
 /config.yaml
@@ -139,6 +142,7 @@ ipython_config.py
 .venv*
 env/
 venv/
+/venv*/
 ENV/
 env.bak/
 venv.bak/


### PR DESCRIPTION
## What is this fixing or adding?

gitignore stuff that is likely to exist in a working AP directory
* versioned venvs (i.e. `/venv312/`)
* profiler output (`/prof/`)
* appimagetool (`/appimagetool` or `/appimagetool-XXX.AppImage`)
* unzipped versioned sni downloads that were not renamed to `SNI` (`/sni-xxx/`)