### PR TITLE
Core: fix unittest world discovery

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -13,5 +13,6 @@ ModuleUpdate.update_ran = True  # don't upgrade
 
 import Utils
 
-Utils.local_path.cached_path = pathlib.Path(__file__).parent.parent
+file_path = pathlib.Path(__file__).parent.parent
+Utils.local_path.cached_path = file_path
 Utils.user_path()  # initialize cached_path

--- a/test/worlds/__init__.py
+++ b/test/worlds/__init__.py
@@ -1,7 +1,7 @@
 def load_tests(loader, standard_tests, pattern):
     import os
     import unittest
-    from ..TestBase import file_path
+    from .. import file_path
     from worlds.AutoWorld import AutoWorldRegister
 
     suite = unittest.TestSuite()


### PR DESCRIPTION
## What is this fixing or adding?

An import got broked when changing imports for pytest-xdist. This should fix it.

## How was this tested?

running unittests