### PR TITLE
The Messenger: Fix items accessibility region rule

### DIFF
--- a/worlds/messenger/Rules.py
+++ b/worlds/messenger/Rules.py
@@ -263,5 +263,6 @@ def set_self_locking_items(multiworld: MultiWorld, player: int) -> None:
         allow_self_locking_items(multiworld.get_location("Elemental Skylands Seal - Water", player), "Currents Master")
     # add these locations when seals and shards aren't shuffled
     elif not multiworld.shuffle_shards[player]:
-        allow_self_locking_items(multiworld.get_region("Cloud Ruins Right", player), "Ruxxtin's Amulet")
+        for entrance in multiworld.get_region("Cloud Ruins", player).entrances:
+            entrance.access_rule = lambda state: state.has("Wingsuit", player) or state.has("Rope Dart", player)
         allow_self_locking_items(multiworld.get_region("Forlorn Temple", player), *PHOBEKINS)

--- a/worlds/messenger/test/TestAccess.py
+++ b/worlds/messenger/test/TestAccess.py
@@ -163,6 +163,8 @@ class ItemsAccessTest(MessengerTestBase):
             "Forlorn Temple - Demon King": PHOBEKINS
         }
 
+        self.multiworld.state = self.multiworld.get_all_state(True)
+        self.remove_by_name(location_lock_pairs.values())
         for loc in location_lock_pairs:
             for item_name in location_lock_pairs[loc]:
                 item = self.get_item_by_name(item_name)


### PR DESCRIPTION
## What is this fixing or adding?
Caught this from the item fill unit test branch. When I added a separate cloud ruins region, I didn't properly change the access rule for the singular location in cloud ruins under these specific settings. The location is in Cloud Ruins Right, but the only way to reach it is from Cloud Ruins, and the entrance to that region are where the actual limiting rule is. Instead of doing the whole nonsense to allow the item, I just removed the item requirement.

## How was this tested?
unit tests and plandoing the item.

## If this makes graphical changes, please attach screenshots.
