### PR TITLE
Core: write playthrough is disabled, rather than an empty section

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1087,14 +1087,16 @@ class Spoiler:
     playthrough: Dict[str, Union[List[str], Dict[str, str]]]  # sphere "0" is list, others are dict
     unreachables: Set[Location]
     paths: Dict[str, List[Union[Tuple[str, str], Tuple[str, None]]]]  # last step takes no further exits
+    level: int
 
-    def __init__(self, multiworld: MultiWorld) -> None:
+    def __init__(self, multiworld: MultiWorld, level: int = 0) -> None:
         self.multiworld = multiworld
         self.hashes = {}
         self.entrances = {}
         self.playthrough = {}
         self.unreachables = set()
         self.paths = {}
+        self.level = level
 
     def set_entrance(self, entrance: str, exit_: str, direction: str, player: int) -> None:
         if self.multiworld.players == 1:
@@ -1296,11 +1298,13 @@ class Spoiler:
             outfile.write('\n\nLocations:\n\n')
             outfile.write('\n'.join(
                 ['%s: %s' % (location, item) for location, item in locations]))
-
-            outfile.write('\n\nPlaythrough:\n\n')
-            outfile.write('\n'.join(['%s: {\n%s\n}' % (sphere_nr, '\n'.join(
-                [f"  {location}: {item}" for (location, item) in sphere.items()] if isinstance(sphere, dict) else
-                [f"  {item}" for item in sphere])) for (sphere_nr, sphere) in self.playthrough.items()]))
+            if self.level > 1:
+                outfile.write('\n\nPlaythrough:\n\n')
+                outfile.write('\n'.join(['%s: {\n%s\n}' % (sphere_nr, '\n'.join(
+                    [f"  {location}: {item}" for (location, item) in sphere.items()] if isinstance(sphere, dict) else
+                    [f"  {item}" for item in sphere])) for (sphere_nr, sphere) in self.playthrough.items()]))
+            else:
+                outfile.write('\n\nPlaythrough is disabled.\n\n')
             if self.unreachables:
                 outfile.write('\n\nUnreachable Items:\n\n')
                 outfile.write(

--- a/Main.py
+++ b/Main.py
@@ -36,7 +36,7 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
     logger = logging.getLogger()
     world.set_seed(seed, args.race, str(args.outputname) if args.outputname else None)
     world.plando_options = args.plando_options
-
+    world.spoiler.level = args.spoiler
     world.shuffle = args.shuffle.copy()
     world.logic = args.logic.copy()
     world.mode = args.mode.copy()


### PR DESCRIPTION
## What is this fixing or adding?
write playthrough is disabled, rather than an empty section

I'm not super happy about how I routed through the spoiler level, but the existing Spoiler object has no access to args


## How was this tested?
yes

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/3189725/ef2cd02c-4c7d-4c4a-b3e2-8d33154f7fec)
is turned to 
![image](https://github.com/ArchipelagoMW/Archipelago/assets/3189725/6602c3bc-aa24-47c5-af42-a7dec4da5a82)
