### PR TITLE
Setup: also delete old disabled worlds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -371,7 +371,7 @@ class BuildExeCommand(cx_Freeze.command.build_exe.BuildEXE):
             f"Unknown world {non_apworlds - set(AutoWorldRegister.world_types)} designated for .apworld"
         folders_to_remove: typing.List[str] = []
         disabled_worlds_folder = "worlds_disabled"
-        for entry in os.listdir("worlds_disabled"):
+        for entry in os.listdir(disabled_worlds_folder):
             if os.path.isdir(os.path.join(disabled_worlds_folder, entry)):
                 folders_to_remove.append(entry)
         generate_yaml_templates(self.buildfolder / "Players" / "Templates", False)

--- a/setup.py
+++ b/setup.py
@@ -370,6 +370,10 @@ class BuildExeCommand(cx_Freeze.command.build_exe.BuildEXE):
         assert not non_apworlds - set(AutoWorldRegister.world_types), \
             f"Unknown world {non_apworlds - set(AutoWorldRegister.world_types)} designated for .apworld"
         folders_to_remove: typing.List[str] = []
+        disabled_worlds_folder = "worlds_disabled"
+        for entry in os.listdir("worlds_disabled"):
+            if os.path.isdir(os.path.join(disabled_worlds_folder, entry)):
+                folders_to_remove.append(entry)
         generate_yaml_templates(self.buildfolder / "Players" / "Templates", False)
         for worldname, worldtype in AutoWorldRegister.world_types.items():
             if worldname not in non_apworlds:


### PR DESCRIPTION
## What is this fixing or adding?
I've seen several user logs that start with an import failure on the old Ori world, this cleans that finally up.

## How was this tested?
oribf shows up in installdelete.iss

## If this makes graphical changes, please attach screenshots.
