### PR TITLE
Core: Provide worlds a fill error hook for debugging

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -507,6 +507,8 @@ def flood_items(world: MultiWorld) -> None:
             if candidate_item_to_place is not None:
                 item_to_place = candidate_item_to_place
             else:
+                for subworld in world.worlds.values():
+                    subworld.fill_error()
                 raise FillError('No more progress items left to place.')
 
         # find item to replace with progress item

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -407,6 +407,9 @@ class World(metaclass=AutoWorldRegister):
 
     def create_filler(self) -> "Item":
         return self.create_item(self.get_filler_item_name())
+    
+    def fill_error(self) -> None:
+        pass
 
     @classmethod
     def get_data_package_data(cls) -> "GamesPackage":


### PR DESCRIPTION
## What is this fixing or adding?
adds a world method that gets called when fill fails.

## How was this tested?
wasn't