### PR TITLE
LttP: Adjuster no longer breaks when sprite path doesn't exist.

### DIFF
--- a/LttPAdjuster.py
+++ b/LttPAdjuster.py
@@ -1004,6 +1004,7 @@ class SpriteSelector():
                 self.add_to_sprite_pool(sprite)
 
     def icon_section(self, frame_label, path, no_results_label):
+        os.makedirs(path, exist_ok=True)
         frame = LabelFrame(self.window, labelwidget=frame_label, padx=5, pady=5)
         frame.pack(side=TOP, fill=X)
 


### PR DESCRIPTION
## What is this fixing or adding?
https://github.com/ArchipelagoMW/Archipelago/pull/2268#issuecomment-1748228270

## How was this tested?
having it die by following the steps. Fixing it, then not having it die.

## If this makes graphical changes, please attach screenshots.
