### PR TITLE
MMBN3: Small Bug Fixes

### DIFF
--- a/MMBN3Client.py
+++ b/MMBN3Client.py
@@ -58,7 +58,7 @@ class MMBN3CommandProcessor(ClientCommandProcessor):
 class MMBN3Context(CommonContext):
     command_processor = MMBN3CommandProcessor
     game = "MegaMan Battle Network 3"
-    items_handling = 0b001  # full local
+    items_handling = 0b101  # full local except starting items
 
     def __init__(self, server_address, password):
         super().__init__(server_address, password)

--- a/worlds/mmbn3/Locations.py
+++ b/worlds/mmbn3/Locations.py
@@ -208,7 +208,7 @@ overworlds = [
     LocationData(LocationName.ACDC_Class_5B_Bookshelf,            0xb3109e, 0x200024c, 0x40, 0x737634, 235, [5, 6]),
     LocationData(LocationName.SciLab_Garbage_Can,                 0xb3109f, 0x200024c, 0x8, 0x73AC20, 222, [4, 5]),
     LocationData(LocationName.Yoka_Inn_Jars,                      0xb310a0, 0x200024c, 0x80, 0x747B1C, 237, [4, 5]),
-    LocationData(LocationName.Yoka_Zoo_Garbage,                   0xb310a1, 0x200024d, 0x8, 0x749444, 226, [4]),
+    LocationData(LocationName.Yoka_Zoo_Garbage,                   0xb310a1, 0x200024d, 0x8, 0x749444, 226, [5]),
     LocationData(LocationName.Beach_Department_Store,             0xb310a2, 0x2000161, 0x40, 0x74C27C, 196, [0, 1]),
     LocationData(LocationName.Beach_Hospital_Plaque,              0xb310a3, 0x200024c, 0x4, 0x754394, 220, [3, 4]),
     LocationData(LocationName.Beach_Hospital_Pink_Door,           0xb310a4, 0x200024d, 0x4, 0x754D00, 220, [4]),

--- a/worlds/mmbn3/__init__.py
+++ b/worlds/mmbn3/__init__.py
@@ -92,7 +92,7 @@ class MMBN3World(World):
                 loc = MMBN3Location(self.player, location, self.location_name_to_id.get(location, None), region)
                 if location in self.excluded_locations:
                     loc.progress_type = LocationProgressType.EXCLUDED
-                # Do not place any progressive items on WWW Island
+                # Do not place any progression items on WWW Island
                 if region_info.name == RegionName.WWW_Island:
                     add_item_rule(loc, lambda item: not item.advancement)
                 region.locations.append(loc)

--- a/worlds/mmbn3/__init__.py
+++ b/worlds/mmbn3/__init__.py
@@ -15,6 +15,7 @@ from .Options import MMBN3Options
 from .Regions import regions, RegionName
 from .Names.ItemName import ItemName
 from .Names.LocationName import LocationName
+from ..generic.Rules import add_item_rule
 
 
 class MMBN3Settings(settings.Group):
@@ -91,6 +92,9 @@ class MMBN3World(World):
                 loc = MMBN3Location(self.player, location, self.location_name_to_id.get(location, None), region)
                 if location in self.excluded_locations:
                     loc.progress_type = LocationProgressType.EXCLUDED
+                # Do not place any progressive items on WWW Island
+                if region_info.name == RegionName.WWW_Island:
+                    add_item_rule(loc, lambda item: not item.advancement)
                 region.locations.append(loc)
             self.multiworld.regions.append(region)
         for region_info in regions:

--- a/worlds/mmbn3/__init__.py
+++ b/worlds/mmbn3/__init__.py
@@ -15,7 +15,7 @@ from .Options import MMBN3Options
 from .Regions import regions, RegionName
 from .Names.ItemName import ItemName
 from .Names.LocationName import LocationName
-from ..generic.Rules import add_item_rule
+from worlds.generic.Rules import add_item_rule
 
 
 class MMBN3Settings(settings.Group):


### PR DESCRIPTION
## What is this fixing or adding?
- Fixes a text box index causing the wrong message to be replaced in the Yoka Zoo Garbage Can, which led to getting both the randomizer item and the original Repair * Chip that is found there in vanilla
- Changes item handling mode so starting inventory is properly sent by the server
- Changes logic to prevent progressive items from ending up on WWW Island, so games can no longer be BK'd waiting for MMBN3 to completely finish the game

## How was this tested?
- Local seeds generated and checked manually