### PR TITLE
Core: guard against plandoing items onto event locations

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -897,19 +897,22 @@ def distribute_planned(world: MultiWorld) -> None:
             for item_name in items:
                 item = world.worlds[player].create_item(item_name)
                 for location in reversed(candidates):
-                    if not location.item:
-                        if location.item_rule(item):
-                            if location.can_fill(world.state, item, False):
-                                successful_pairs.append((item, location))
-                                candidates.remove(location)
-                                count = count + 1
-                                break
+                    if location.address is not None:
+                        if not location.item:
+                            if location.item_rule(item):
+                                if location.can_fill(world.state, item, False):
+                                    successful_pairs.append((item, location))
+                                    candidates.remove(location)
+                                    count = count + 1
+                                    break
+                                else:
+                                    err.append(f"Can't place item at {location} due to fill condition not met.")
                             else:
-                                err.append(f"Can't place item at {location} due to fill condition not met.")
+                                err.append(f"{item_name} not allowed at {location}.")
                         else:
-                            err.append(f"{item_name} not allowed at {location}.")
+                            err.append(f"Cannot place {item_name} into already filled location {location}.")
                     else:
-                        err.append(f"Cannot place {item_name} into already filled location {location}.")
+                        err.append(f"Cannot place {item_name} into event location {location}.")
                 if count == maxcount:
                     break
             if count < placement['count']['min']:

--- a/Fill.py
+++ b/Fill.py
@@ -748,8 +748,6 @@ def distribute_planned(world: MultiWorld) -> None:
     early_locations: typing.Dict[int, typing.List[str]] = collections.defaultdict(list)
     non_early_locations: typing.Dict[int, typing.List[str]] = collections.defaultdict(list)
     for loc in world.get_unfilled_locations():
-        if loc.address is None:  # handles edge case with randomized event locations
-            continue
         if loc in reachable:
             early_locations[loc.player].append(loc.name)
         else:  # not reachable with swept state
@@ -897,7 +895,7 @@ def distribute_planned(world: MultiWorld) -> None:
             for item_name in items:
                 item = world.worlds[player].create_item(item_name)
                 for location in reversed(candidates):
-                    if location.address is not None:
+                    if (location.address is None) == (item.code is None):  # either both None or both not None
                         if not location.item:
                             if location.item_rule(item):
                                 if location.can_fill(world.state, item, False):
@@ -912,7 +910,7 @@ def distribute_planned(world: MultiWorld) -> None:
                         else:
                             err.append(f"Cannot place {item_name} into already filled location {location}.")
                     else:
-                        err.append(f"Cannot place {item_name} into event location {location}.")
+                        err.append(f"Mismatch between {item_name} and {location}, only one is an event.")
                 if count == maxcount:
                     break
             if count < placement['count']['min']:

--- a/Fill.py
+++ b/Fill.py
@@ -748,6 +748,8 @@ def distribute_planned(world: MultiWorld) -> None:
     early_locations: typing.Dict[int, typing.List[str]] = collections.defaultdict(list)
     non_early_locations: typing.Dict[int, typing.List[str]] = collections.defaultdict(list)
     for loc in world.get_unfilled_locations():
+        if loc.address is None:  # handles edge case with randomized event locations
+            continue
         if loc in reachable:
             early_locations[loc.player].append(loc.name)
         else:  # not reachable with swept state


### PR DESCRIPTION
OoT has randomized shop locations which are considered events, but are only filled during prefill. Since plando runs first, the consequence is that plando could place items into these locations. Usually this isn't a problem, but `early_items` acquired all locations including unfilled events, which could cause items to be placed on event locations. This adds multiple safeguards against this occurring.