### PR TITLE
Docs, Various Games: Add Unique Local Commands to Game Page

### DIFF
--- a/worlds/checksfinder/docs/en_ChecksFinder.md
+++ b/worlds/checksfinder/docs/en_ChecksFinder.md
@@ -14,11 +14,18 @@ many checks as you have gained items, plus five to start with being available.
 ## When the player receives an item, what happens?
 
 When the player receives an item in ChecksFinder, it either can make the future boards they play be bigger in width or
-height, or add a new bomb to the future boards, with a limit to having up to one fifth of the _current_ board being 
-bombs. The items you have gained _before_ the current board was made will be said at the bottom of the screen as a number
+height, or add a new bomb to the future boards, with a limit to having up to one fifth of the _current_ board being
+bombs. The items you have gained _before_ the current board was made will be said at the bottom of the screen as a
+number
 next to an icon, the number is how many you have gotten and the icon represents which item it is.
 
 ## What is the victory condition?
 
 Victory is achieved when the player wins a board they were given after they have received all of their Map Width, Map
 Height, and Map Bomb items. The game will say at the bottom of the screen how many of each you have received.
+
+## Unique Local Commands
+
+The following command is only available when using the ChecksFinderClient to play with Archipelago.
+
+- `/resync` Manually trigger a resync.

--- a/worlds/ff1/docs/en_Final Fantasy.md
+++ b/worlds/ff1/docs/en_Final Fantasy.md
@@ -26,7 +26,7 @@ All local and remote items appear the same. Final Fantasy will say that you rece
 emulator will display what was found external to the in-game text box.
 
 ## Unique Local Commands
-The following command is only available when using the FF1Client for the Final Fantasy Randomizer.
+The following commands are only available when using the FF1Client for the Final Fantasy Randomizer.
 
 - `/nes` Shows the current status of the NES connection.
 - `/toggle_msgs` Toggle displaying messages in EmuHawk

--- a/worlds/ff1/docs/en_Final Fantasy.md
+++ b/worlds/ff1/docs/en_Final Fantasy.md
@@ -29,3 +29,4 @@ emulator will display what was found external to the in-game text box.
 The following command is only available when using the FF1Client for the Final Fantasy Randomizer.
 
 - `/nes` Shows the current status of the NES connection.
+- `/toggle_msgs` Toggle displaying messages in EmuHawk

--- a/worlds/mmbn3/docs/en_MegaMan Battle Network 3.md
+++ b/worlds/mmbn3/docs/en_MegaMan Battle Network 3.md
@@ -72,3 +72,10 @@ what item and what player is receiving the item
 
 Whenever you have an item pending, the next time you are not in a battle, menu, or dialog box, you will receive a
 message on screen notifying you of the item and sender, and the item will be added directly to your inventory.
+
+## Unique Local Commands
+
+The following commands are only available when using the MMBN3Client to play with Archipelago.
+
+- `/gba` Check GBA Connection State
+- `/debug` Toggle the Debug Text overlay in ROM

--- a/worlds/oot/docs/en_Ocarina of Time.md
+++ b/worlds/oot/docs/en_Ocarina of Time.md
@@ -31,3 +31,10 @@ Items belonging to other worlds are represented by the Zelda's Letter item.
 
 When the player receives an item, Link will hold the item above his head and display it to the world. It's good for
 business!
+
+## Local Unique Commands
+
+The following commands are only available when using the OoTClient to play with Archipelago.
+
+- `/n64` Check N64 Connection State
+- `/deathlink` Toggle deathlink from client. Overrides default setting.

--- a/worlds/oot/docs/en_Ocarina of Time.md
+++ b/worlds/oot/docs/en_Ocarina of Time.md
@@ -32,7 +32,7 @@ Items belonging to other worlds are represented by the Zelda's Letter item.
 When the player receives an item, Link will hold the item above his head and display it to the world. It's good for
 business!
 
-## Local Unique Commands
+## Unique Local Commands
 
 The following commands are only available when using the OoTClient to play with Archipelago.
 

--- a/worlds/pokemon_rb/docs/en_Pokemon Red and Blue.md
+++ b/worlds/pokemon_rb/docs/en_Pokemon Red and Blue.md
@@ -81,7 +81,7 @@ A "received item" sound effect will play. Currently, there is no in-game message
 If you are in battle, have menus or text boxes opened, or scripted events are occurring, the items will not be given to
 you until these have ended.
 
-## Local Unique Commands
+## Unique Local Commands
 
 The following command is only available when using the PokemonClient to play with Archipelago.
 

--- a/worlds/pokemon_rb/docs/en_Pokemon Red and Blue.md
+++ b/worlds/pokemon_rb/docs/en_Pokemon Red and Blue.md
@@ -80,3 +80,9 @@ All items for other games will display simply as "AP ITEM," including those for 
 A "received item" sound effect will play. Currently, there is no in-game message informing you of what the item is.
 If you are in battle, have menus or text boxes opened, or scripted events are occurring, the items will not be given to
 you until these have ended.
+
+## Local Unique Commands
+
+The following command is only available when using the PokemonClient to play with Archipelago.
+
+- `/gb` Check Gameboy Connection State

--- a/worlds/sc2wol/docs/en_Starcraft 2 Wings of Liberty.md
+++ b/worlds/sc2wol/docs/en_Starcraft 2 Wings of Liberty.md
@@ -32,3 +32,23 @@ The goal is to beat the final mission: 'All In'. The config file determines whic
 By default, any of StarCraft 2's items (specified above) can be in another player's world. See the
 [Advanced YAML Guide](https://archipelago.gg/tutorial/Archipelago/advanced_settings/en)
 for more information on how to change this.
+
+## Unique Local Commands
+
+The following commands are only available when using the Starcraft 2 Client to play with Archipelago.
+
+- `/difficulty [difficulty]` Overrides the difficulty set for the world.
+  - Options: casual, normal, hard, brutal
+- `/game_speed [game_speed]` Overrides the game speed for the world
+  - Options: default, slower, slow, normal, fast, faster
+- `/color [color]` Changes your color (Currently has no effect)
+  - Options: white, red, blue, teal, purple, yellow, orange, green, lightpink, violet, lightgrey, darkgreen, brown,
+    lightgreen, darkgrey, pink, rainbow, random, default
+- `/disable_mission_check` Disables the check to see if a mission is available to play. Meant for co-op runs where one
+  player can play the next mission in a chain the other player is doing.
+- `/play [mission_id]` Starts a Starcraft 2 mission based off of the mission_id provided
+- `/available` Get what missions are currently available to play
+- `/unfinished` Get what missions are currently available to play and have not had all locations checked
+- `/set_path [path]` Menually set the SC2 install directory (if the automatic detection fails)
+- `/download_data` Download the most recent release of the necassry files for playing SC2 with Archipelago. Will
+  overwrite existing files

--- a/worlds/tloz/docs/en_The Legend of Zelda.md
+++ b/worlds/tloz/docs/en_The Legend of Zelda.md
@@ -35,9 +35,17 @@ filler and useful items will cost less, and uncategorized items will be in the m
 
 ## Are there any other changes made?
 
-- The map and compass for each dungeon start already acquired, and other items can be found in their place. 
+- The map and compass for each dungeon start already acquired, and other items can be found in their place.
 - The Recorder will warp you between all eight levels regardless of Triforce count
-    - It's possible for this to be your route to level 4! 
+  - It's possible for this to be your route to level 4!
 - Pressing Select will cycle through your inventory.
 - Shop purchases are tracked within sessions, indicated by the item being elevated from its normal position.
 - What slots from a Take Any Cave have been chosen are similarly tracked.
+-
+
+## Local Unique Commands
+
+The following commands are only available when using the Zelda1Client to play with Archipelago.
+
+- `/nes` Check NES Connection State
+- `/toggle_msgs` Toggle displaying messages in EmuHawk

--- a/worlds/undertale/docs/en_Undertale.md
+++ b/worlds/undertale/docs/en_Undertale.md
@@ -42,11 +42,22 @@ In the Pacifist run, you are not required to go to the Ruins to spare Toriel. Th
 Undyne, and Mettaton EX. Just as it is in the vanilla game, you cannot kill anyone. You are also required to complete 
 the date/hangout with Papyrus, Undyne, and Alphys, in that order, before entering the True Lab.
 
-Additionally, custom items are required to hang out with Papyrus, Undyne, to enter the True Lab, and to fight 
-Mettaton EX/NEO. The respective items for each interaction are `Complete Skeleton`, `Fish`, `DT Extractor`, 
+Additionally, custom items are required to hang out with Papyrus, Undyne, to enter the True Lab, and to fight
+Mettaton EX/NEO. The respective items for each interaction are `Complete Skeleton`, `Fish`, `DT Extractor`,
 and `Mettaton Plush`.
 
-The Riverperson will only take you to locations you have seen them at, meaning they will only take you to 
+The Riverperson will only take you to locations you have seen them at, meaning they will only take you to
 Waterfall if you have seen them at Waterfall at least once.
 
 If you press `W` while in the save menu, you will teleport back to the flower room, for quick access to the other areas.
+
+## Local Unique Commands
+
+The following commands are only available when using the UndertaleClient to play with Archipelago.
+
+- `/resync` Manually trigger a resync.
+- `/patch` Patch the game.
+- `/savepath` Redirect to proper save data folder. (Use before connecting!)
+- `/auto_patch` Patch the game automatically.
+- `/online` Makes you no longer able to see other Undertale players.
+- `/deathlink` Toggles deathlink

--- a/worlds/undertale/docs/en_Undertale.md
+++ b/worlds/undertale/docs/en_Undertale.md
@@ -51,7 +51,7 @@ Waterfall if you have seen them at Waterfall at least once.
 
 If you press `W` while in the save menu, you will teleport back to the flower room, for quick access to the other areas.
 
-## Local Unique Commands
+## Unique Local Commands
 
 The following commands are only available when using the UndertaleClient to play with Archipelago.
 

--- a/worlds/wargroove/docs/en_Wargroove.md
+++ b/worlds/wargroove/docs/en_Wargroove.md
@@ -26,9 +26,16 @@ Any of the above items can be in another player's world.
 
 ## When the player receives an item, what happens?
 
-When the player receives an item, a message will appear in Wargroove with the item name and sender name, once an action 
+When the player receives an item, a message will appear in Wargroove with the item name and sender name, once an action
 is taken in game.
 
 ## What is the goal of this game when randomized?
 
 The goal is to beat the level titled `The End` by finding the `Final Bridges`, `Final Walls`, and `Final Sickle`.
+
+## Local Unique Commands
+
+The following commands are only available when using the WargrooveClient to play with Archipelago.
+
+- `/resync` Manually trigger a resync.
+- `/commander` Set the current commander to the given commander.

--- a/worlds/wargroove/docs/en_Wargroove.md
+++ b/worlds/wargroove/docs/en_Wargroove.md
@@ -33,7 +33,7 @@ is taken in game.
 
 The goal is to beat the level titled `The End` by finding the `Final Bridges`, `Final Walls`, and `Final Sickle`.
 
-## Local Unique Commands
+## Unique Local Commands
 
 The following commands are only available when using the WargrooveClient to play with Archipelago.
 

--- a/worlds/zillion/docs/en_Zillion.md
+++ b/worlds/zillion/docs/en_Zillion.md
@@ -67,8 +67,16 @@ Note that in "restrictive" mode, Champ is the only one that can get Zillion powe
 
 Canisters retain their original appearance, so you won't know if an item belongs to another player until you collect it.
 
-When you collect an item, you see the name of the player it goes to. You can see in the client log what item was collected.
+When you collect an item, you see the name of the player it goes to. You can see in the client log what item was
+collected.
 
 ## When the player receives an item, what happens?
 
 The item collect sound is played. You can see in the client log what item was received.
+
+## Local Unique Commands
+
+The following commands are only available when using the ZillionClient to play with Archipelago.
+
+- `/sms` Tell the client that Zillion is running in RetroArch.
+- `/map` Toggle view of the map tracker.

--- a/worlds/zillion/docs/en_Zillion.md
+++ b/worlds/zillion/docs/en_Zillion.md
@@ -74,7 +74,7 @@ collected.
 
 The item collect sound is played. You can see in the client log what item was received.
 
-## Local Unique Commands
+## Unique Local Commands
 
 The following commands are only available when using the ZillionClient to play with Archipelago.
 


### PR DESCRIPTION
## What is this fixing or adding?
Adds the commands unique to various clients to the appropriate game page.
This PR is in response to the discussion on #2213 concerning where these client commands should be documented.

Commands were pulled from their respective client python files. If any were missed, please let me know so that I can add them.

Additionally, it might be in our interest to require that world maintainers include these commands to their game page. This is not enforced in this PR, but I figured this would be a good place to spark that discussion.

Affected Games and CodeOwners:

- [ ] ChecksFinder @jonloveslegos 
- [x] Final Fantasy 1 @jtoyoda
- [x] The Legend of Zelda @Rosalie-A @t3hf1gm3nt 
- [ ] Megaman Battle Network 3 @digiholic 
- [ ] Ocarina of Time @espeon65536 
- [ ] Pokemon Red and Blue @Alchav 
- [ ] Starcraft 2 Wings of Liberty @Ziktofel
- [ ] Undertale @jonloveslegos 
- [x] Wargroove @FlySniper 
- [x] Zillion @beauxq 


## How was this tested?
Was not, doc change