### PR TITLE
Plando: Prevent duplicate candidate locations

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -845,7 +845,7 @@ def distribute_planned(world: MultiWorld) -> None:
                 for target_player in worlds:
                     locations += non_early_locations[target_player]
 
-            block['locations'] = locations
+            block['locations'] = list(dict.fromkeys(locations))
 
             if not block['count']:
                 block['count'] = (min(len(block['items']), len(block['locations'])) if


### PR DESCRIPTION
## What is this fixing or adding?
https://discord.com/channels/731205301247803413/1161022518631608320/1161022518631608320
If a user specifies early_locations, non_early_locations, or manually puts the same location name multiple times in the locations field, plando can place items onto non-existent duplicate locations, leading to unfilled locations.

## How was this tested?
Added the following plando to a default DS3 yaml, and generated alongside 2 LttP yamls.
```
  plando_items:
    - items:
        - Small Lothric Banner
        - Basin of Vows
      locations:
        - Mushroom
        - Mushroom
      from_pool: true
      world: true
      force: true
```
Checked that the issue was no longer present. It should be noted that in the case of specific duplication, it treats the length of the list as the number of unique locations.

## If this makes graphical changes, please attach screenshots.
