### PR TITLE
Multiserver: implement hint gifting

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1562,6 +1562,9 @@ class ClientMessageProcessor(CommonCommandProcessor):
             self.ctx.on_new_hint(recipient_team, recipient_slot)
             self.ctx.hint_points[self.client.team, self.client.slot] -= cost
             self.ctx.on_new_hint(self.client.team, self.client.slot)
+            self.output(f"Gave {recipient} {recipient_cost} points. Deducted {cost} from own points.")
+            for client in self.ctx.clients[recipient_team][recipient_slot]:
+                self.ctx.notify_client(client, f"Received {recipient_cost} hint points from {self.client.name}.")
             return True
         self.output(f"Unable to gift hint. You have {points_available} points and need at least {cost}.")
         return False
@@ -2151,6 +2154,9 @@ class ServerCommandProcessor(CommonCommandProcessor):
                 self.ctx.on_new_hint(recipient_team, recipient_slot)
                 self.ctx.hint_points[team, slot] -= cost
                 self.ctx.on_new_hint(self.client.team, self.client.slot)
+                self.output(f"Gave {recipient} {recipient_cost} points. Deducted {cost} from own points.")
+                for client in self.ctx.clients[recipient_team][recipient_slot]:
+                    self.ctx.notify_client(client, f"Received {recipient_cost} hint points from {self.client.name}.")
                 return True
             self.output(f"Unable to gift hint. You have {points_available} points and need at least {cost}.")
             return False

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1549,7 +1549,7 @@ class ClientMessageProcessor(CommonCommandProcessor):
         cost = self.ctx.get_hint_cost(self.client.slot)
         can_pay = int(points_available // cost > 0)
         if can_pay:
-            recipient, usable, response = get_intended_text(recipient, self.ctx.player_names.values())
+            recipient, usable, response = get_intended_text(recipient, self.ctx.connect_names.values())
             if not usable:
                 self.output(response)
                 return False
@@ -2134,14 +2134,14 @@ class ServerCommandProcessor(CommonCommandProcessor):
     
     def _cmd_hint_gift(self, gifting_player: str, recipient: str) -> bool:
         """Gift a player's points for a full hint to another player"""
-        gifting_player, usable, response = get_intended_text(gifting_player, self.ctx.player_names.values())
+        gifting_player, usable, response = get_intended_text(gifting_player, self.ctx.connect_names.values())
         if usable:
             team, slot = self.ctx.player_name_lookup[gifting_player]
             points_available = get_slot_points(self.ctx, team, slot)
             cost = self.ctx.get_hint_cost(slot)
             can_pay = int(points_available // cost > 0)
             if can_pay:
-                recipient, usable, response = get_intended_text(recipient, self.ctx.player_names.values())
+                recipient, usable, response = get_intended_text(recipient, self.ctx.connect_names.values())
                 if not usable:
                     self.output(response)
                     return False
@@ -2176,6 +2176,9 @@ class ServerCommandProcessor(CommonCommandProcessor):
                     if input_text.lower() in {"null", "none", '""', "''"}:
                         return None
                     return input_text
+            if option_name == "location_check_points":
+                self.ctx.hint_points = {(team, slot): points / self.ctx.location_check_points * int(option)
+                                        for (team, slot), points in self.ctx.hint_points.items()}
             setattr(self.ctx, option_name, attrtype(option))
             self.output(f"Set option {option_name} to {getattr(self.ctx, option_name)}")
             if option_name in {"release_mode", "remaining_mode", "collect_mode"}:


### PR DESCRIPTION
## What is this fixing or adding?
Allows players with extra hint points to give those points to other players. A player can only give points if they have enough to "buy" a hint, and the conversion rate is a single hint. i.e. if player 1 has a cost of 10, and player 2 has a cost of 5, and player 1 gives a hint to player 2, player 1 will lose 10 points and player 2 will gain 5 points. Also tracks each slot's current hint points instead of calculating them on the fly. Should allow future features to use hint points, and should be slightly faster.

## How was this tested?
Used old multidata to test backwards compatibility. Tested giving hints to self with and without enough points, tested giving hints to another player with and without enough points, and tested attempting to give points with an invalid slot name.

## If this makes graphical changes, please attach screenshots.

https://github.com/ArchipelagoMW/Archipelago/assets/13184667/a459922a-fe64-4b00-b2e5-229b75549c40

