### PR TITLE
Docs: Make all guide titles say Guide, for my sanity (and the webhost)

### DIFF
--- a/worlds/alttp/__init__.py
+++ b/worlds/alttp/__init__.py
@@ -42,7 +42,7 @@ class ALTTPSettings(settings.Group):
 
 class ALTTPWeb(WebWorld):
     setup_en = Tutorial(
-        "Multiworld Setup Tutorial",
+        "Multiworld Setup Guide",
         "A guide to setting up the Archipelago ALttP Software on your computer. This guide covers single-player, multiworld, and related software.",
         "English",
         "multiworld_en.md",
@@ -78,7 +78,7 @@ class ALTTPWeb(WebWorld):
     )
 
     msu = Tutorial(
-        "MSU-1 Setup Tutorial",
+        "MSU-1 Setup Guide",
         "A guide to setting up MSU-1, which allows for custom in-game music.",
         "English",
         "msu1_en.md",
@@ -105,7 +105,7 @@ class ALTTPWeb(WebWorld):
     )
 
     plando = Tutorial(
-        "Plando Tutorial",
+        "Plando Guide",
         "A guide to creating Multiworld Plandos with LTTP",
         "English",
         "plando_en.md",

--- a/worlds/bumpstik/__init__.py
+++ b/worlds/bumpstik/__init__.py
@@ -14,7 +14,7 @@ from worlds.generic.Rules import forbid_item
 
 class BumpStikWeb(WebWorld):
     tutorials = [Tutorial(
-        "Bumper Stickers Setup Tutorial",
+        "Bumper Stickers Setup Guide",
         "A guide to setting up the Archipelago Bumper Stickers software on your computer.",
         "English",
         "setup_en.md",

--- a/worlds/checksfinder/__init__.py
+++ b/worlds/checksfinder/__init__.py
@@ -10,7 +10,7 @@ client_version = 7
 
 class ChecksFinderWeb(WebWorld):
     tutorials = [Tutorial(
-        "Multiworld Setup Tutorial",
+        "Multiworld Setup Guide",
         "A guide to setting up the Archipelago ChecksFinder software on your computer. This guide covers "
         "single-player, multiworld, and related software.",
         "English",

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -15,7 +15,7 @@ from .Options import RandomizeWeaponLevelOption, PoolTypeOption, dark_souls_opti
 class DarkSouls3Web(WebWorld):
     bug_report_page = "https://github.com/Marechal-L/Dark-Souls-III-Archipelago-client/issues"
     setup_en = Tutorial(
-        "Multiworld Setup Tutorial",
+        "Multiworld Setup Guide",
         "A guide to setting up the Archipelago Dark Souls III randomizer on your computer.",
         "English",
         "setup_en.md",

--- a/worlds/dlcquest/__init__.py
+++ b/worlds/dlcquest/__init__.py
@@ -14,7 +14,7 @@ client_version = 0
 
 class DLCqwebworld(WebWorld):
     tutorials = [Tutorial(
-        "Multiworld Setup Tutorial",
+        "Multiworld Setup Guide",
         "A guide to setting up the Archipelago DLCQuest game on your computer.",
         "English",
         "setup_en.md",

--- a/worlds/factorio/__init__.py
+++ b/worlds/factorio/__init__.py
@@ -53,7 +53,7 @@ If this file does exist, then it will be used.
 
 class FactorioWeb(WebWorld):
     tutorials = [Tutorial(
-        "Multiworld Setup Tutorial",
+        "Multiworld Setup Guide",
         "A guide to setting up the Archipelago Factorio software on your computer.",
         "English",
         "setup_en.md",

--- a/worlds/meritous/__init__.py
+++ b/worlds/meritous/__init__.py
@@ -17,7 +17,7 @@ client_version = 1
 
 class MeritousWeb(WebWorld):
     tutorials = [Tutorial(
-        "Meritous Setup Tutorial",
+        "Meritous Setup Guide",
         "A guide to setting up the Archipelago Meritous software on your computer.",
         "English",
         "setup_en.md",

--- a/worlds/messenger/__init__.py
+++ b/worlds/messenger/__init__.py
@@ -17,7 +17,7 @@ class MessengerWeb(WebWorld):
     bug_report_page = "https://github.com/alwaysintreble/TheMessengerRandomizerModAP/issues"
 
     tut_en = Tutorial(
-        "Multiworld Setup Tutorial",
+        "Multiworld Setup Guide",
         "A guide to setting up The Messenger randomizer on your computer.",
         "English",
         "setup_en.md",

--- a/worlds/minecraft/__init__.py
+++ b/worlds/minecraft/__init__.py
@@ -37,7 +37,7 @@ class MinecraftWebWorld(WebWorld):
     bug_report_page = "https://github.com/KonoTyran/Minecraft_AP_Randomizer/issues/new?assignees=&labels=bug&template=bug_report.yaml&title=%5BBug%5D%3A+Brief+Description+of+bug+here"
 
     setup = Tutorial(
-        "Multiworld Setup Tutorial",
+        "Multiworld Setup Guide",
         "A guide to setting up the Archipelago Minecraft software on your computer. This guide covers"
         "single-player, multiworld, and related software.",
         "English",

--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -92,7 +92,7 @@ class OOTSettings(settings.Group):
 
 class OOTWeb(WebWorld):
     setup = Tutorial(
-        "Multiworld Setup Tutorial",
+        "Multiworld Setup Guide",
         "A guide to setting up the Archipelago Ocarina of Time software on your computer.",
         "English",
         "setup_en.md",

--- a/worlds/overcooked2/__init__.py
+++ b/worlds/overcooked2/__init__.py
@@ -16,7 +16,7 @@ class Overcooked2Web(WebWorld):
 
     bug_report_page = "https://github.com/toasterparty/oc2-modding/issues"
     setup_en = Tutorial(
-        "Multiworld Setup Tutorial",
+        "Multiworld Setup Guide",
         "A guide to setting up the Overcooked! 2 randomizer on your computer.",
         "English",
         "setup_en.md",

--- a/worlds/tloz/__init__.py
+++ b/worlds/tloz/__init__.py
@@ -45,7 +45,7 @@ class TLoZSettings(settings.Group):
 class TLoZWeb(WebWorld):
     theme = "stone"
     setup = Tutorial(
-        "Multiworld Setup Tutorial",
+        "Multiworld Setup Guide",
         "A guide to setting up The Legend of Zelda for Archipelago on your computer.",
         "English",
         "multiworld_en.md",

--- a/worlds/undertale/__init__.py
+++ b/worlds/undertale/__init__.py
@@ -29,7 +29,7 @@ def data_path(file_name: str):
 
 class UndertaleWeb(WebWorld):
     tutorials = [Tutorial(
-        "Multiworld Setup Tutorial",
+        "Multiworld Setup Guide",
         "A guide to setting up the Archipelago Undertale software on your computer. This guide covers "
         "single-player, multiworld, and related software.",
         "English",


### PR DESCRIPTION
## What is this fixing or adding?
Change all guide titles to "Guide" from "Tutorial" for standardization

## How was this tested?
Ran Webhost, made sure it opened.

## If this makes graphical changes, please attach screenshots.
Changed from
![image](https://github.com/ArchipelagoMW/Archipelago/assets/102177943/7cab884a-2e2b-4fae-8fa7-4538f1004749)

to
![image](https://github.com/ArchipelagoMW/Archipelago/assets/102177943/b5f35f21-39ba-4eb5-8b91-e70de4f66c0f)
