### PR TITLE
Options: Add NamedRange Option

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -1127,7 +1127,7 @@ def generate_yaml_templates(target_folder: typing.Union[str, "pathlib.Path"], ge
         if os.path.isfile(full_path) and full_path.endswith(".yaml"):
             os.unlink(full_path)
 
-    def dictify_range(option: typing.Union[Range, SpecialRange]):
+    def dictify_range(option: typing.Union[Range, NamedRange, SpecialRange]):
         data = {option.default: 50}
         for sub_option in ["random", "random-low", "random-high"]:
             if sub_option != option.default:

--- a/Options.py
+++ b/Options.py
@@ -696,8 +696,7 @@ class Range(NumericOption):
         return int(round(random.triangular(lower, end, tri), 0))
 
 
-class SpecialRange(Range):
-    special_range_cutoff = 0
+class NamedRange(Range):
     special_range_names: typing.Dict[str, int] = {}
     """Special Range names have to be all lowercase as matching is done with text.lower()"""
 
@@ -707,6 +706,29 @@ class SpecialRange(Range):
         if text in cls.special_range_names:
             return cls(cls.special_range_names[text])
         return super().from_text(text)
+
+    @classmethod
+    def weighted_range(cls, text) -> Range:
+        if text == "random-low":
+            return cls(cls.triangular(cls.range_start, cls.range_end, cls.range_start))
+        elif text == "random-high":
+            return cls(cls.triangular(cls.range_start, cls.range_end, cls.range_end))
+        elif text == "random-middle":
+            return cls(cls.triangular(cls.range_start, cls.range_end))
+        elif text.startswith("random-range-"):
+            return cls.custom_range(text)
+        elif text == "random":
+            return cls(random.randint(cls.range_start, cls.range_end))
+        else:
+            raise Exception(f"random text \"{text}\" did not resolve to a recognized pattern. "
+                            f"Acceptable values are: random, random-high, random-middle, random-low, "
+                            f"random-range-low-<min>-<max>, random-range-middle-<min>-<max>, "
+                            f"random-range-high-<min>-<max>, or random-range-<min>-<max>.")
+
+
+class SpecialRange(NamedRange):
+    special_range_cutoff = 0
+    """The cutoff value is used instead of range_start when using randomized values"""
 
     @classmethod
     def weighted_range(cls, text) -> Range:

--- a/WebHostLib/options.py
+++ b/WebHostLib/options.py
@@ -84,11 +84,13 @@ def create():
                     "max": option.range_end,
                 }
 
-                if issubclass(option, Options.SpecialRange):
-                    game_options[option_name]["type"] = 'special_range'
+                if issubclass(option, Options.NamedRange):
+                    game_options[option_name]["type"] = 'named_range'
                     game_options[option_name]["value_names"] = {}
                     for key, val in option.special_range_names.items():
                         game_options[option_name]["value_names"][key] = val
+                    if issubclass(option, Options.SpecialRange):
+                        game_options[option_name]["type"] = 'special_range'
 
             elif issubclass(option, Options.ItemSet):
                 game_options[option_name] = {

--- a/WebHostLib/static/assets/player-settings.js
+++ b/WebHostLib/static/assets/player-settings.js
@@ -194,6 +194,7 @@ const buildOptionsTable = (settings, romOpts = false) => {
         element.appendChild(randomButton);
         break;
 
+      case 'named_range':
       case 'special_range':
         element = document.createElement('div');
         element.classList.add('special-range-container');

--- a/WebHostLib/static/assets/weighted-settings.js
+++ b/WebHostLib/static/assets/weighted-settings.js
@@ -77,6 +77,7 @@ const createDefaultSettings = (settingData) => {
             });
             break;
           case 'range':
+          case 'named_range':
           case 'special_range':
             newSettings[game][gameSetting]['random'] = 0;
             newSettings[game][gameSetting]['random-low'] = 0;
@@ -297,6 +298,7 @@ const buildWeightedSettingsDiv = (game, settings, gameItems, gameLocations) => {
         break;
 
       case 'range':
+      case 'named_range':
       case 'special_range':
         const rangeTable = document.createElement('table');
         const rangeTbody = document.createElement('tbody');

--- a/worlds/stardew_valley/options.py
+++ b/worlds/stardew_valley/options.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from Options import Range, NamedRange, Toggle, Choice, OptionSet, PerGameCommonOptions, DeathLink, Option
+from Options import Range, NamedRange, Toggle, Choice, OptionSet, PerGameCommonOptions, DeathLink, Option, SpecialRange
 from .mods.mod_data import ModNames
 
 
@@ -47,12 +47,13 @@ class Goal(Choice):
         return super().get_option_name(value)
 
 
-class StartingMoney(NamedRange):
+class StartingMoney(SpecialRange):
     """Amount of gold when arriving at the farm.
     Set to -1 or unlimited for infinite money in this playthrough"""
     internal_name = "starting_money"
     display_name = "Starting Gold"
     range_start = -1
+    special_range_cutoff = 0
     range_end = 50000
     default = 5000
 

--- a/worlds/stardew_valley/options.py
+++ b/worlds/stardew_valley/options.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
-from typing import Dict
 
-from Options import Range, SpecialRange, Toggle, Choice, OptionSet, PerGameCommonOptions, DeathLink, Option
+from Options import Range, NamedRange, Toggle, Choice, OptionSet, PerGameCommonOptions, DeathLink, Option
 from .mods.mod_data import ModNames
 
 
@@ -48,7 +47,7 @@ class Goal(Choice):
         return super().get_option_name(value)
 
 
-class StartingMoney(SpecialRange):
+class StartingMoney(NamedRange):
     """Amount of gold when arriving at the farm.
     Set to -1 or unlimited for infinite money in this playthrough"""
     internal_name = "starting_money"
@@ -67,7 +66,7 @@ class StartingMoney(SpecialRange):
     }
 
 
-class ProfitMargin(SpecialRange):
+class ProfitMargin(NamedRange):
     """Multiplier over all gold earned in-game by the player."""
     internal_name = "profit_margin"
     display_name = "Profit Margin"
@@ -286,7 +285,7 @@ class SpecialOrderLocations(Choice):
     option_board_qi = 2
 
 
-class HelpWantedLocations(SpecialRange):
+class HelpWantedLocations(NamedRange):
     """How many "Help Wanted" quests need to be completed as Archipelago Locations
     Out of every 7 quests, 4 will be item deliveries, and then 1 of each for: Fishing, Gathering and Slaying Monsters.
     Choosing a multiple of 7 is recommended."""
@@ -431,7 +430,7 @@ class MultipleDaySleepEnabled(Toggle):
     default = 1
 
 
-class MultipleDaySleepCost(SpecialRange):
+class MultipleDaySleepCost(NamedRange):
     """How much gold it will cost to use MultiSleep. You will have to pay that amount for each day skipped."""
     internal_name = "multiple_day_sleep_cost"
     display_name = "Multiple Day Sleep Cost"
@@ -447,7 +446,7 @@ class MultipleDaySleepCost(SpecialRange):
     }
 
 
-class ExperienceMultiplier(SpecialRange):
+class ExperienceMultiplier(NamedRange):
     """How fast you want to earn skill experience. A lower setting mean less experience.
     A higher setting means more experience."""
     internal_name = "experience_multiplier"
@@ -466,7 +465,7 @@ class ExperienceMultiplier(SpecialRange):
     }
 
 
-class FriendshipMultiplier(SpecialRange):
+class FriendshipMultiplier(NamedRange):
     """How fast you want to earn friendship points with villagers.
     A lower setting mean less friendship per action.
     A higher setting means more friendship per action."""

--- a/worlds/stardew_valley/test/TestOptions.py
+++ b/worlds/stardew_valley/test/TestOptions.py
@@ -3,7 +3,7 @@ from random import random
 from typing import Dict
 
 from BaseClasses import ItemClassification, MultiWorld
-from Options import SpecialRange
+from Options import NamedRange
 from . import setup_solo_multiworld, SVTestBase
 from .. import StardewItem, items_by_group, Group, StardewValleyWorld
 from ..locations import locations_by_tag, LocationTags, location_table
@@ -41,7 +41,7 @@ def check_no_ginger_island(tester: SVTestBase, multiworld: MultiWorld):
 
 
 def get_option_choices(option) -> Dict[str, int]:
-    if issubclass(option, SpecialRange):
+    if issubclass(option, NamedRange):
         return option.special_range_names
     elif option.options:
         return option.options
@@ -52,7 +52,7 @@ class TestGenerateDynamicOptions(SVTestBase):
     def test_given_special_range_when_generate_then_basic_checks(self):
         options = self.world.options_dataclass.type_hints
         for option_name, option in options.items():
-            if not isinstance(option, SpecialRange):
+            if not issubclass(option, NamedRange):
                 continue
             for value in option.special_range_names:
                 with self.subTest(f"{option_name}: {value}"):
@@ -151,7 +151,7 @@ class TestGenerateAllOptionsWithExcludeGingerIsland(SVTestBase):
     def test_given_special_range_when_generate_exclude_ginger_island(self):
         options = self.world.options_dataclass.type_hints
         for option_name, option in options.items():
-            if not isinstance(option, SpecialRange) or option_name == ExcludeGingerIsland.internal_name:
+            if not issubclass(option, NamedRange) or option_name == ExcludeGingerIsland.internal_name:
                 continue
             for value in option.special_range_names:
                 with self.subTest(f"{option_name}: {value}"):

--- a/worlds/stardew_valley/test/long/TestOptionsLong.py
+++ b/worlds/stardew_valley/test/long/TestOptionsLong.py
@@ -1,7 +1,7 @@
 from typing import Dict
 
 from BaseClasses import MultiWorld
-from Options import SpecialRange
+from Options import NamedRange
 from .option_names import options_to_include
 from worlds.stardew_valley.test.checks.world_checks import assert_can_win, assert_same_number_items_locations
 from .. import setup_solo_multiworld, SVTestBase
@@ -13,7 +13,7 @@ def basic_checks(tester: SVTestBase, multiworld: MultiWorld):
 
 
 def get_option_choices(option) -> Dict[str, int]:
-    if issubclass(option, SpecialRange):
+    if issubclass(option, NamedRange):
         return option.special_range_names
     elif option.options:
         return option.options

--- a/worlds/stardew_valley/test/long/TestRandomWorlds.py
+++ b/worlds/stardew_valley/test/long/TestRandomWorlds.py
@@ -2,7 +2,7 @@ from typing import Dict
 import random
 
 from BaseClasses import MultiWorld
-from Options import SpecialRange, Range
+from Options import NamedRange, Range
 from .option_names import options_to_include
 from .. import setup_solo_multiworld, SVTestBase
 from ..checks.goal_checks import assert_perfection_world_is_valid, assert_goal_world_is_valid
@@ -12,7 +12,7 @@ from ..checks.world_checks import assert_same_number_items_locations, assert_vic
 
 
 def get_option_choices(option) -> Dict[str, int]:
-    if issubclass(option, SpecialRange):
+    if issubclass(option, NamedRange):
         return option.special_range_names
     if issubclass(option, Range):
         return {f"{val}": val for val in range(option.range_start, option.range_end + 1)}


### PR DESCRIPTION
## What is this fixing or adding?
Right now, the Option type "SpecialRange" is used for two separate use cases

1: Creating a range with some named values, for user convenience
2: Creating a range with some special values, like "use -1 for this special case"

This PR separates these use cases into two separate option classes
- 1 is handled by the new NamedRange(Range)
- 2 is handled by SpecialRange, which now inherits from NamedRange

This way, worlds that only care about names and do not wish the extra behavior introduced by special_range_cutoff can do so without worrying about it. When using NamedRange, the intuitive range_start and range_end values are sufficient to describe the behavior of the option.

The change should be backward compatible, using the previous definition of SpecialRange. Anyone who was using SpecialRange before should see no change in behavior from this PR, but they can now move to NamedRange if they wish to simplify their code and reduce the likelyhood of a cutoff bug. Anyone using SpecialRange "properly", and therefore using cutoff, do not need (or want) to change anything and the behavior should stay exactly the same as before.

I also applied the switch to NamedRange for relevant Stardew Valley options, as it is my world. It serves as a proof of concept for the intended behavior as well.

## How was this tested?
Ran all tests for all worlds.