### PR TITLE
HK: Update Setup Guide to use/mention Lumafly

### DIFF
--- a/worlds/hk/docs/setup_en.md
+++ b/worlds/hk/docs/setup_en.md
@@ -1,27 +1,27 @@
 # Hollow Knight for Archipelago Setup Guide
 
 ## Required Software
-* Download and unzip the Scarab+ Mod Manager from the [Scarab+ website](https://themulhima.github.io/Scarab/).
+* Download and unzip the Lumafly Mod Manager from the [Lumafly website](https://themulhima.github.io/Lumafly/).
 * A legal copy of Hollow Knight.
 
-## Installing the Archipelago Mod using Scarab+
-1. Launch Scarab+ and ensure it locates your Hollow Knight installation directory.
+## Installing the Archipelago Mod using Lumafly
+1. Launch Lumafly and ensure it locates your Hollow Knight installation directory.
 2. Click the "Install" button near the "Archipelago" mod entry.
    * If desired, also install "Archipelago Map Mod" to use as an in-game tracker.
 3. Launch the game, you're all set!
 
-### What to do if Scarab+ fails to find your XBox Game Pass installation directory
+### What to do if Lumafly fails to find your XBox Game Pass installation directory
 1. Enter the XBox app and move your mouse over "Hollow Knight" on the left sidebar. 
 2. Click the three points then click "Manage".
 3. Go to the "Files" tab and select "Browse...". 
 4. Click "Hollow Knight", then "Content", then click the path bar and copy it.
-5. Run Scarab+ as an administrator and, when it asks you for the path, paste what you copied in step 4.
+5. Run Lumafly as an administrator and, when it asks you for the path, paste what you copied in step 4.
 
 #### Alternative Method:
 1. Click on your profile then "Settings". 
 2. Go to the "General" tab and select "CHANGE FOLDER".
 3. Look for a folder where you want to install the game (preferably inside a folder on your desktop) and copy the path.
-4. Run Scarab+ as an administrator and, when it asks you for the path, paste what you copied in step 3.
+4. Run Lumafly as an administrator and, when it asks you for the path, paste what you copied in step 3.
 
 Note: The path folder needs to have the "Hollow Knight_Data" folder inside. 
 


### PR DESCRIPTION
## What is this fixing or adding?

Updating the HK Setup Guide to mention Lumafly instead of Scarab+

## How was this tested?

Looking at it.