### PR TITLE
Ocarina of Time: Increase function cache size for reading JSON data

### DIFF
--- a/worlds/oot/Utils.py
+++ b/worlds/oot/Utils.py
@@ -11,7 +11,7 @@ def data_path(*args):
     return os.path.join(os.path.dirname(__file__), 'data', *args)
 
 
-@lru_cache(maxsize=13)  # Cache Overworld.json and the 12 dungeons
+@lru_cache
 def read_json(file_path):
     json_string = ""
     with io.open(file_path, 'r') as file:


### PR DESCRIPTION
Ocarina of Time uses `lru_cache()` for caching JSON data being read for logic and hints with a `maxsize` of 13.

While there are 12 dungeon files and an overworld file, there are also Master Quest dungeons, glitched logic, etc. to cache as well.

For now, I removed the optional `maxsize` parameter, setting it to the default of 128.

From testing these changes on a multiworld with 9 OoT players, using various combinations of Glitchless, Glitchless MQ, and Glitched logic, the total files reads was brought from 126 to 40.