### PR TITLE
BizHawkClient: Add autostart setting

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -694,6 +694,25 @@ does nothing if not found
     snes_rom_start: Union[SnesRomStart, bool] = True
 
 
+class BizHawkClientOptions(Group):
+    class EmuHawkPath(UserFilePath):
+        """
+        The location of the EmuHawk you want to auto launch patched ROMs with
+        """
+        is_exe = True
+        description = "EmuHawk Executable"
+
+    class RomStart(str):
+        """
+        Set this to true to autostart a patched ROM in BizHawk with the connector script,
+        to false to never open the patched rom automatically,
+        or to a path to an external program to open the ROM file with that instead.
+        """
+
+    emuhawk_path: EmuHawkPath = EmuHawkPath(None)
+    rom_start: Union[RomStart, bool] = True
+
+
 # Top-level group with lazy loading of worlds
 
 class Settings(Group):
@@ -701,6 +720,7 @@ class Settings(Group):
     server_options: ServerOptions = ServerOptions()
     generator: GeneratorOptions = GeneratorOptions()
     sni_options: SNIOptions = SNIOptions()
+    bizhawkclient_options: BizHawkClientOptions = BizHawkClientOptions()
 
     _filename: Optional[str] = None
 

--- a/worlds/_bizhawk/context.py
+++ b/worlds/_bizhawk/context.py
@@ -150,7 +150,7 @@ async def _run_game(rom: str):
     import os
     auto_start = Utils.get_settings().bizhawkclient_options.rom_start
 
-    if auto_start == True:
+    if auto_start is True:
         emuhawk_path = Utils.get_settings().bizhawkclient_options.emuhawk_path
         subprocess.Popen([emuhawk_path, "--lua=data/lua/connector_bizhawk_generic.lua", os.path.realpath(rom)],
                          cwd=Utils.local_path("."),

--- a/worlds/_bizhawk/context.py
+++ b/worlds/_bizhawk/context.py
@@ -5,6 +5,7 @@ checking or launching the client, otherwise it will probably cause circular impo
 
 
 import asyncio
+import subprocess
 import traceback
 from typing import Any, Dict, Optional
 
@@ -146,8 +147,24 @@ async def _game_watcher(ctx: BizHawkClientContext):
 
 
 async def _run_game(rom: str):
-    import webbrowser
-    webbrowser.open(rom)
+    import os
+    auto_start = Utils.get_settings().bizhawkclient_options.rom_start
+
+    if auto_start == True:
+        emuhawk_path = Utils.get_settings().bizhawkclient_options.emuhawk_path
+        subprocess.Popen([emuhawk_path, "--lua=data/lua/connector_bizhawk_generic.lua", os.path.realpath(rom)],
+                         cwd=Utils.local_path("."),
+                         stdin=subprocess.DEVNULL,
+                         stdout=subprocess.DEVNULL,
+                         stderr=subprocess.DEVNULL)
+    elif isinstance(auto_start, str):
+        import shlex
+
+        subprocess.Popen([*shlex.split(auto_start), os.path.realpath(rom)],
+                         cwd=Utils.local_path("."),
+                         stdin=subprocess.DEVNULL,
+                         stdout=subprocess.DEVNULL,
+                         stderr=subprocess.DEVNULL)
 
 
 async def _patch_and_run_game(patch_file: str):


### PR DESCRIPTION
## What is this fixing or adding?

Adds autostart settings to BizHawkClient.

`rom_start` behaves the same way as most other `rom_start` settings. `true` for enabling autostart, `false` for disabling it, and a custom string as a path to a specific program.

`emuhawk_path` is the exe the player intends to use with BizHawkClient, and what we launch the ROM with when `rom_start` is `true`. Getting the user to tell us where this is instead of using `webbrowser.open` means we can pass the `lua` arg and autostart the connector script in BizHawk as well. We'd lose automatically opening in the system default program, but to use this client, the user has to use BizHawk anyway, and an adept user can just override `rom_start` to use a different program if they still want to.

## How was this tested?

Opening a patch file with all three possible `rom_start` options, trying BizHawk 2.7 and 2.9.1, and trying in both source and a frozen build.
