### PR TITLE
DLCQuest: logic speed up

### DIFF
--- a/worlds/dlcquest/Items.py
+++ b/worlds/dlcquest/Items.py
@@ -11,6 +11,8 @@ from . import Options, data
 
 class DLCQuestItem(Item):
     game: str = "DLCQuest"
+    coins: int = 0
+    freemium_coins: int = 0
 
 
 offset = 120_000

--- a/worlds/dlcquest/Items.py
+++ b/worlds/dlcquest/Items.py
@@ -12,7 +12,7 @@ from . import Options, data
 class DLCQuestItem(Item):
     game: str = "DLCQuest"
     coins: int = 0
-    freemium_coins: int = 0
+    coin_suffix: str = ""
 
 
 offset = 120_000

--- a/worlds/dlcquest/Regions.py
+++ b/worlds/dlcquest/Regions.py
@@ -14,7 +14,9 @@ def add_coin_freemium(region: Region, Coin: int, player: int):
     location_coin = f"{region.name} coins freemium"
     location = DLCQuestLocation(player, location_coin, None, region)
     region.locations.append(location)
-    location.place_locked_item(create_event(player, number_coin))
+    event = create_event(player, number_coin)
+    event.freemium_coins = Coin
+    location.place_locked_item(event)
 
 
 def add_coin_dlcquest(region: Region, Coin: int, player: int):
@@ -22,7 +24,9 @@ def add_coin_dlcquest(region: Region, Coin: int, player: int):
     location_coin = f"{region.name} coins"
     location = DLCQuestLocation(player, location_coin, None, region)
     region.locations.append(location)
-    location.place_locked_item(create_event(player, number_coin))
+    event = create_event(player, number_coin)
+    event.coins = Coin
+    location.place_locked_item(event)
 
 
 def create_regions(world: MultiWorld, player: int, World_Options: Options.DLCQuestOptions):

--- a/worlds/dlcquest/Regions.py
+++ b/worlds/dlcquest/Regions.py
@@ -24,7 +24,8 @@ def add_coin(region: Region, coin: int, player: int, suffix: str):
     location = DLCQuestLocation(player, location_coin, None, region)
     region.locations.append(location)
     event = create_event(player, number_coin)
-    event.freemium_coins = Coin
+    event.coins = coin
+    event.coin_suffix = suffix
     location.place_locked_item(event)
 
 

--- a/worlds/dlcquest/Rules.py
+++ b/worlds/dlcquest/Rules.py
@@ -7,34 +7,16 @@ from . import Options
 from .Items import DLCQuestItem
 
 
-def create_event(player, event: str):
+def create_event(player, event: str) -> DLCQuestItem:
     return DLCQuestItem(event, ItemClassification.progression, None, player)
 
 
 def set_rules(world, player, World_Options: Options.DLCQuestOptions):
     def has_enough_coin(player: int, coin: int):
-        def has_coin(state, player: int, coins: int):
-            coin_possessed = 0
-            for i in [4, 7, 9, 10, 46, 50, 60, 76, 89, 100, 171, 203]:
-                name_coin = f"{i} coins"
-                if state.has(name_coin, player):
-                    coin_possessed += i
-
-            return coin_possessed >= coins
-
-        return lambda state: has_coin(state, player, coin)
+        return lambda state: state.prog_items["COINS", player] >= coin
 
     def has_enough_coin_freemium(player: int, coin: int):
-        def has_coin(state, player: int, coins: int):
-            coin_possessed = 0
-            for i in [20, 50, 90, 95, 130, 150, 154, 200]:
-                name_coin = f"{i} coins freemium"
-                if state.has(name_coin, player):
-                    coin_possessed += i
-
-            return coin_possessed >= coins
-
-        return lambda state: has_coin(state, player, coin)
+        return lambda state: state.prog_items["COINS_FREEMIUM", player] >= coin
 
     set_basic_rules(World_Options, has_enough_coin, player, world)
     set_lfod_rules(World_Options, has_enough_coin_freemium, player, world)

--- a/worlds/dlcquest/Rules.py
+++ b/worlds/dlcquest/Rules.py
@@ -11,19 +11,21 @@ def create_event(player, event: str) -> DLCQuestItem:
     return DLCQuestItem(event, ItemClassification.progression, None, player)
 
 
+def has_enough_coin(player: int, coin: int):
+    return lambda state: state.prog_items[" coins", player] >= coin
+
+
+def has_enough_coin_freemium(player: int, coin: int):
+    return lambda state: state.prog_items[" coins freemium", player] >= coin
+
+
 def set_rules(world, player, World_Options: Options.DLCQuestOptions):
-    def has_enough_coin(player: int, coin: int):
-        return lambda state: state.prog_items["COINS", player] >= coin
-
-    def has_enough_coin_freemium(player: int, coin: int):
-        return lambda state: state.prog_items["COINS_FREEMIUM", player] >= coin
-
-    set_basic_rules(World_Options, has_enough_coin, player, world)
-    set_lfod_rules(World_Options, has_enough_coin_freemium, player, world)
+    set_basic_rules(World_Options, player, world)
+    set_lfod_rules(World_Options, player, world)
     set_completion_condition(World_Options, player, world)
 
 
-def set_basic_rules(World_Options, has_enough_coin, player, world):
+def set_basic_rules(World_Options, player, world):
     if World_Options.campaign == Options.Campaign.option_live_freemium_or_die:
         return
     set_basic_entrance_rules(player, world)
@@ -31,8 +33,8 @@ def set_basic_rules(World_Options, has_enough_coin, player, world):
     set_basic_shuffled_items_rules(World_Options, player, world)
     set_double_jump_glitchless_rules(World_Options, player, world)
     set_easy_double_jump_glitch_rules(World_Options, player, world)
-    self_basic_coinsanity_funded_purchase_rules(World_Options, has_enough_coin, player, world)
-    set_basic_self_funded_purchase_rules(World_Options, has_enough_coin, player, world)
+    self_basic_coinsanity_funded_purchase_rules(World_Options, player, world)
+    set_basic_self_funded_purchase_rules(World_Options, player, world)
     self_basic_win_condition(World_Options, player, world)
 
 
@@ -113,7 +115,7 @@ def set_easy_double_jump_glitch_rules(World_Options, player, world):
              lambda state: state.has("Double Jump Pack", player))
 
 
-def self_basic_coinsanity_funded_purchase_rules(World_Options, has_enough_coin, player, world):
+def self_basic_coinsanity_funded_purchase_rules(World_Options, player, world):
     if World_Options.coinsanity != Options.CoinSanity.option_coin:
         return
     number_of_bundle = math.floor(825 / World_Options.coinbundlequantity)
@@ -176,7 +178,7 @@ def self_basic_coinsanity_funded_purchase_rules(World_Options, has_enough_coin, 
                                      math.ceil(5 / World_Options.coinbundlequantity)))
 
 
-def set_basic_self_funded_purchase_rules(World_Options, has_enough_coin, player, world):
+def set_basic_self_funded_purchase_rules(World_Options, player, world):
     if World_Options.coinsanity != Options.CoinSanity.option_none:
         return
     set_rule(world.get_location("Movement Pack", player),
@@ -223,14 +225,14 @@ def self_basic_win_condition(World_Options, player, world):
                                                                                             player))
 
 
-def set_lfod_rules(World_Options, has_enough_coin_freemium, player, world):
+def set_lfod_rules(World_Options, player, world):
     if World_Options.campaign == Options.Campaign.option_basic:
         return
     set_lfod_entrance_rules(player, world)
     set_boss_door_requirements_rules(player, world)
     set_lfod_self_obtained_items_rules(World_Options, player, world)
     set_lfod_shuffled_items_rules(World_Options, player, world)
-    self_lfod_coinsanity_funded_purchase_rules(World_Options, has_enough_coin_freemium, player, world)
+    self_lfod_coinsanity_funded_purchase_rules(World_Options, player, world)
     set_lfod_self_funded_purchase_rules(World_Options, has_enough_coin_freemium, player, world)
 
 
@@ -309,7 +311,7 @@ def set_lfod_shuffled_items_rules(World_Options, player, world):
              lambda state: state.can_reach("Cut Content", 'region', player))
 
 
-def self_lfod_coinsanity_funded_purchase_rules(World_Options, has_enough_coin_freemium, player, world):
+def self_lfod_coinsanity_funded_purchase_rules(World_Options, player, world):
     if World_Options.coinsanity != Options.CoinSanity.option_coin:
         return
     number_of_bundle = math.floor(889 / World_Options.coinbundlequantity)

--- a/worlds/dlcquest/__init__.py
+++ b/worlds/dlcquest/__init__.py
@@ -90,13 +90,15 @@ class DLCqworld(World):
     def collect(self, state: CollectionState, item: DLCQuestItem) -> bool:
         change = super().collect(state, item)
         if change:
-            state.prog_items["COINS", self.player] += item.coins
-            state.prog_items["COINS_FREEMIUM", self.player] += item.freemium_coins
+            suffix = item.coin_suffix
+            if suffix:
+                state.prog_items[suffix,  self.player] += item.coins
         return change
 
     def remove(self, state: CollectionState, item: DLCQuestItem) -> bool:
         change = super().remove(state, item)
         if change:
-            state.prog_items["COINS", self.player] -= item.coins
-            state.prog_items["COINS_FREEMIUM", self.player] -= item.freemium_coins
+            suffix = item.coin_suffix
+            if suffix:
+                state.prog_items[suffix,  self.player] -= item.coins
         return change

--- a/worlds/dlcquest/__init__.py
+++ b/worlds/dlcquest/__init__.py
@@ -1,6 +1,6 @@
 from typing import Union
 
-from BaseClasses import Tutorial
+from BaseClasses import Tutorial, CollectionState
 from worlds.AutoWorld import WebWorld, World
 from . import Options
 from .Items import DLCQuestItem, ItemData, create_items, item_table
@@ -71,7 +71,6 @@ class DLCqworld(World):
             if self.options.coinsanity == Options.CoinSanity.option_coin and self.options.coinbundlequantity >= 5:
                 self.multiworld.push_precollected(self.create_item("Movement Pack"))
 
-
     def create_item(self, item: Union[str, ItemData]) -> DLCQuestItem:
         if isinstance(item, str):
             item = item_table[item]
@@ -87,3 +86,17 @@ class DLCqworld(World):
             "seed": self.random.randrange(99999999)
         })
         return options_dict
+
+    def collect(self, state: CollectionState, item: DLCQuestItem) -> bool:
+        change = super().collect(state, item)
+        if change:
+            state.prog_items["COINS", self.player] += item.coins
+            state.prog_items["COINS_FREEMIUM", self.player] += item.freemium_coins
+        return change
+
+    def remove(self, state: CollectionState, item: DLCQuestItem) -> bool:
+        change = super().remove(state, item)
+        if change:
+            state.prog_items["COINS", self.player] -= item.coins
+            state.prog_items["COINS_FREEMIUM", self.player] -= item.freemium_coins
+        return change


### PR DESCRIPTION
## What is this fixing or adding?
Makes DLCQuest logic go vroom

## How was this tested?
Grabbed the base yaml, enabled coinsanity, set it to 1, copied the file to a total of 3. Ran it, took 45 seconds. After applying my shenanigans it now ran in 10 seconds.

@axe-y @agilbert1412 