### PR TITLE
SM: fix missing option import

### DIFF
--- a/worlds/sm/__init__.py
+++ b/worlds/sm/__init__.py
@@ -1,18 +1,17 @@
 from __future__ import annotations
 
-import logging
-import copy
-import os
-import threading
 import base64
-import settings
+import copy
+import logging
+import threading
 import typing
 from typing import Any, Dict, Iterable, List, Set, TextIO, TypedDict
 
-from BaseClasses import Region, Entrance, Location, MultiWorld, Item, ItemClassification, CollectionState, Tutorial
-from Fill import fill_restrictive
-from worlds.AutoWorld import World, AutoLogicRegister, WebWorld
-from worlds.generic.Rules import set_rule, add_rule, add_item_rule
+import settings
+from BaseClasses import CollectionState, Entrance, Item, ItemClassification, Location, MultiWorld, Region, Tutorial
+from Options import Accessibility
+from worlds.AutoWorld import AutoLogicRegister, WebWorld, World
+from worlds.generic.Rules import add_rule, set_rule
 
 logger = logging.getLogger("Super Metroid")
 


### PR DESCRIPTION
## What is this fixing or adding?
Missing an import for Accessibility that was being used in generate_early
