### PR TITLE
Muse Dash: Make which .net to download more explicit in setup guides.

### DIFF
--- a/worlds/musedash/docs/setup_en.md
+++ b/worlds/musedash/docs/setup_en.md
@@ -8,7 +8,7 @@
 
 - Windows 8 or Newer.
 - Muse Dash: [Available on Steam](https://store.steampowered.com/app/774171/Muse_Dash/)
-  - \[Optional\] [Just as Planned] DLC: [Also Available on Steam](https://store.steampowered.com/app/1055810/Muse_Dash__Just_as_planned/)
+  - \[Optional\] [Muse Plus] DLC: [Also Available on Steam](https://store.steampowered.com/app/2593750/Muse_Dash__Muse_Plus/)
 - Melon Loader: [GitHub](https://github.com/LavaGang/MelonLoader/releases/latest)
   - .Net Framework 4.8 may be needed for the installer: [Download](https://dotnet.microsoft.com/en-us/download/dotnet-framework/net48)
 - .NET Desktop Runtime 6.0.XX (If not already installed): [Download](https://dotnet.microsoft.com/en-us/download/dotnet/6.0)

--- a/worlds/musedash/docs/setup_en.md
+++ b/worlds/musedash/docs/setup_en.md
@@ -11,7 +11,7 @@
   - \[Optional\] [Just as Planned] DLC: [Also Available on Steam](https://store.steampowered.com/app/1055810/Muse_Dash__Just_as_planned/)
 - Melon Loader: [GitHub](https://github.com/LavaGang/MelonLoader/releases/latest)
   - .Net Framework 4.8 may be needed for the installer: [Download](https://dotnet.microsoft.com/en-us/download/dotnet-framework/net48)
-- .NET Desktop Runtime 6.0.XX (If not already installed): [Download](https://dotnet.microsoft.com/en-us/download/dotnet/6.0#runtime-6.0.15)
+- .NET Desktop Runtime 6.0.XX (If not already installed): [Download](https://dotnet.microsoft.com/en-us/download/dotnet/6.0)
 - Muse Dash Archipelago Mod: [GitHub](https://github.com/DeamonHunter/ArchipelagoMuseDash/releases/latest)
 
 ## Installing the Archipelago mod to Muse Dash

--- a/worlds/musedash/docs/setup_en.md
+++ b/worlds/musedash/docs/setup_en.md
@@ -11,7 +11,7 @@
   - \[Optional\] [Just as Planned] DLC: [Also Available on Steam](https://store.steampowered.com/app/1055810/Muse_Dash__Just_as_planned/)
 - Melon Loader: [GitHub](https://github.com/LavaGang/MelonLoader/releases/latest)
   - .Net Framework 4.8 may be needed for the installer: [Download](https://dotnet.microsoft.com/en-us/download/dotnet-framework/net48)
-- .Net 6.0 (If not already installed): [Download](https://dotnet.microsoft.com/en-us/download/dotnet/6.0#runtime-6.0.15)
+- .NET Desktop Runtime 6.0.XX (If not already installed): [Download](https://dotnet.microsoft.com/en-us/download/dotnet/6.0#runtime-6.0.15)
 - Muse Dash Archipelago Mod: [GitHub](https://github.com/DeamonHunter/ArchipelagoMuseDash/releases/latest)
 
 ## Installing the Archipelago mod to Muse Dash

--- a/worlds/musedash/docs/setup_es.md
+++ b/worlds/musedash/docs/setup_es.md
@@ -11,7 +11,7 @@
   - \[Opcional\] [Just as Planned] DLC: [tambien disponible on Steam](https://store.steampowered.com/app/1055810/Muse_Dash__Just_as_planned/)
 - Melon Loader: [GitHub](https://github.com/LavaGang/MelonLoader/releases/latest)
   - .Net Framework 4.8 podría ser necesario para el instalador: [Descarga](https://dotnet.microsoft.com/en-us/download/dotnet-framework/net48)
-- Entorno de ejecución de escritorio de .NET 6.0.XX (si aún no está instalado): [Descarga](https://dotnet.microsoft.com/en-us/download/dotnet/6.0#runtime-6.0.15)
+- Entorno de ejecución de escritorio de .NET 6.0.XX (si aún no está instalado): [Descarga](https://dotnet.microsoft.com/en-us/download/dotnet/6.0)
 - Muse Dash Archipelago Mod: [GitHub](https://github.com/DeamonHunter/ArchipelagoMuseDash/releases/latest)
 
 ## Instalar el mod de Archipelago en Muse Dash

--- a/worlds/musedash/docs/setup_es.md
+++ b/worlds/musedash/docs/setup_es.md
@@ -11,7 +11,7 @@
   - \[Opcional\] [Just as Planned] DLC: [tambien disponible on Steam](https://store.steampowered.com/app/1055810/Muse_Dash__Just_as_planned/)
 - Melon Loader: [GitHub](https://github.com/LavaGang/MelonLoader/releases/latest)
   - .Net Framework 4.8 podría ser necesario para el instalador: [Descarga](https://dotnet.microsoft.com/en-us/download/dotnet-framework/net48)
-- .Net 6.0 (si aún no está instalado): [Descarga](https://dotnet.microsoft.com/en-us/download/dotnet/6.0#runtime-6.0.15)
+- Entorno de ejecución de escritorio de .NET 6.0.XX (si aún no está instalado): [Descarga](https://dotnet.microsoft.com/en-us/download/dotnet/6.0#runtime-6.0.15)
 - Muse Dash Archipelago Mod: [GitHub](https://github.com/DeamonHunter/ArchipelagoMuseDash/releases/latest)
 
 ## Instalar el mod de Archipelago en Muse Dash

--- a/worlds/musedash/docs/setup_es.md
+++ b/worlds/musedash/docs/setup_es.md
@@ -10,8 +10,8 @@
 - Muse Dash: [Disponible en Steam](https://store.steampowered.com/app/774171/Muse_Dash/)
   - \[Opcional\] [Just as Planned] DLC: [tambien disponible on Steam](https://store.steampowered.com/app/1055810/Muse_Dash__Just_as_planned/)
 - Melon Loader: [GitHub](https://github.com/LavaGang/MelonLoader/releases/latest)
-  - .Net Framework 4.8 podría ser necesario para el instalador: [Descarga](https://dotnet.microsoft.com/en-us/download/dotnet-framework/net48)
-- Entorno de ejecución de escritorio de .NET 6.0.XX (si aún no está instalado): [Descarga](https://dotnet.microsoft.com/en-us/download/dotnet/6.0)
+  - .Net Framework 4.8 podría ser necesario para el instalador: [Descarga](https://dotnet.microsoft.com/es-es/download/dotnet-framework/net48)
+- Entorno de ejecución de escritorio de .NET 6.0.XX (si aún no está instalado): [Descarga](https://dotnet.microsoft.com/es-es/download/dotnet/6.0)
 - Muse Dash Archipelago Mod: [GitHub](https://github.com/DeamonHunter/ArchipelagoMuseDash/releases/latest)
 
 ## Instalar el mod de Archipelago en Muse Dash

--- a/worlds/musedash/docs/setup_es.md
+++ b/worlds/musedash/docs/setup_es.md
@@ -8,7 +8,7 @@
 
 - Windows 8 o más reciente.
 - Muse Dash: [Disponible en Steam](https://store.steampowered.com/app/774171/Muse_Dash/)
-  - \[Opcional\] [Just as Planned] DLC: [tambien disponible on Steam](https://store.steampowered.com/app/1055810/Muse_Dash__Just_as_planned/)
+  - \[Opcional\] [Muse Plus] DLC: [tambien disponible on Steam](https://store.steampowered.com/app/2593750/Muse_Dash__Muse_Plus/)
 - Melon Loader: [GitHub](https://github.com/LavaGang/MelonLoader/releases/latest)
   - .Net Framework 4.8 podría ser necesario para el instalador: [Descarga](https://dotnet.microsoft.com/es-es/download/dotnet-framework/net48)
 - Entorno de ejecución de escritorio de .NET 6.0.XX (si aún no está instalado): [Descarga](https://dotnet.microsoft.com/es-es/download/dotnet/6.0)


### PR DESCRIPTION
## What is this fixing or adding?
The .net 6.0 downloads page has a lot of downloads which can make it a bit difficult to determine which to download. The guide now explicitly references one of them.

## How was this tested?
Not Tested. Docs change.

Paging @ShinyNT to double check the spanish translation.