### PR TITLE
Stardew Valley: Fix option that was accidentally renamed in 993

### DIFF
--- a/worlds/stardew_valley/items.py
+++ b/worlds/stardew_valley/items.py
@@ -368,8 +368,8 @@ def create_arcade_machine_items(item_factory: StardewItemFactory, options: Stard
 
 
 def create_player_buffs(item_factory: StardewItemFactory, options: StardewValleyOptions, items: List[Item]):
-    items.extend(item_factory(item) for item in [Buff.movement] * options.number_of_movement_buffs.value)
-    items.extend(item_factory(item) for item in [Buff.luck] * options.number_of_luck_buffs.value)
+    items.extend(item_factory(item) for item in [Buff.movement] * options.movement_buff_number.value)
+    items.extend(item_factory(item) for item in [Buff.luck] * options.luck_buff_number.value)
 
 
 def create_traveling_merchant_items(item_factory: StardewItemFactory, items: List[Item]):

--- a/worlds/stardew_valley/logic.py
+++ b/worlds/stardew_valley/logic.py
@@ -927,7 +927,7 @@ class StardewLogic:
         return region_rule & ((tool_rule & foraging_rule) | magic_rule)
 
     def has_max_buffs(self) -> StardewRule:
-        return self.received(Buff.movement, self.options.number_of_movement_buffs.value) & self.received(Buff.luck, self.options.number_of_luck_buffs.value)
+        return self.received(Buff.movement, self.options.movement_buff_number.value) & self.received(Buff.luck, self.options.luck_buff_number.value)
 
     def get_weapon_rule_for_floor_tier(self, tier: int):
         if tier >= 4:
@@ -1376,7 +1376,7 @@ class StardewLogic:
         return self.received(Wallet.rusty_key)
 
     def can_win_egg_hunt(self) -> StardewRule:
-        number_of_movement_buffs = self.options.number_of_movement_buffs.value
+        number_of_movement_buffs = self.options.movement_buff_number.value
         if self.options.festival_locations == FestivalLocations.option_hard or number_of_movement_buffs < 2:
             return True_()
         return self.received(Buff.movement, number_of_movement_buffs // 2)

--- a/worlds/stardew_valley/options.py
+++ b/worlds/stardew_valley/options.py
@@ -556,8 +556,8 @@ class StardewValleyOptions(PerGameCommonOptions):
     museumsanity: Museumsanity
     friendsanity: Friendsanity
     friendsanity_heart_size: FriendsanityHeartSize
-    number_of_movement_buffs: NumberOfMovementBuffs
-    number_of_luck_buffs: NumberOfLuckBuffs
+    movement_buff_number: NumberOfMovementBuffs
+    luck_buff_number: NumberOfLuckBuffs
     exclude_ginger_island: ExcludeGingerIsland
     trap_items: TrapItems
     multiple_day_sleep_enabled: MultipleDaySleepEnabled


### PR DESCRIPTION
## What is this fixing or adding?
During the shenanigans with 993, I had to make new fields for Stardew Valley options. I was not aware that the name of these fields needed to match the internal names of the options, so I wasn't particularly careful about that. Turns out they need to, and I have no clue why, but I was told it causes problems. So I renamed the ones that didn't match.

## How was this tested?
Ran unit tests