### PR TITLE
WebHost: offer combined yaml file on /check if successful

### DIFF
--- a/WebHostLib/templates/checkResult.html
+++ b/WebHostLib/templates/checkResult.html
@@ -28,6 +28,10 @@
                     {% endfor %}
                 </tbody>
             </table>
+        {% if combined_yaml %}
+            <h1>Combined File Download</h1>
+            <p><a href="data:text/yaml;base64,{{ combined_yaml }}" download="combined.yaml">Download</a></p>
+        {% endif %}
         </div>
     </div>
 {% endblock %}

--- a/worlds/alttp/docs/multiworld_de.md
+++ b/worlds/alttp/docs/multiworld_de.md
@@ -67,7 +67,7 @@ Wenn du eine Option nicht gewählt haben möchtest, setze ihren Wert einfach auf
 
 ### Überprüfung deiner YAML-Datei
 
-Wenn man sichergehen will, ob die YAML-Datei funktioniert, kann man dies bei der [YAML Validator](/mysterycheck) Seite
+Wenn man sichergehen will, ob die YAML-Datei funktioniert, kann man dies bei der [YAML Validator](/check) Seite
 tun.
 
 ## ein Einzelspielerspiel erstellen

--- a/worlds/alttp/docs/multiworld_es.md
+++ b/worlds/alttp/docs/multiworld_es.md
@@ -82,7 +82,7 @@ debe tener al menos un valor mayor que cero, si no la generación fallará.
 ### Verificando tu archivo YAML
 
 Si quieres validar que tu fichero YAML para asegurarte que funciona correctamente, puedes hacerlo en la pagina
-[YAML Validator](/mysterycheck).
+[YAML Validator](/check).
 
 ## Generar una partida para un jugador
 

--- a/worlds/alttp/docs/multiworld_fr.md
+++ b/worlds/alttp/docs/multiworld_fr.md
@@ -83,7 +83,7 @@ chaque paramètre il faut au moins une option qui soit paramétrée sur un nombr
 ### Vérifier son fichier YAML
 
 Si vous voulez valider votre fichier YAML pour être sûr qu'il fonctionne, vous pouvez le vérifier sur la page du
-[Validateur de YAML](/mysterycheck).
+[Validateur de YAML](/check).
 
 ## Générer une partie pour un joueur
 

--- a/worlds/dkc3/docs/setup_en.md
+++ b/worlds/dkc3/docs/setup_en.md
@@ -50,7 +50,7 @@ them. Player settings page: [Donkey Kong Country 3 Player Settings Page](/games/
 ### Verifying your config file
 
 If you would like to validate your config file to make sure it works, you may do so on the YAML Validator page. YAML
-validator page: [YAML Validation page](/mysterycheck)
+validator page: [YAML Validation page](/check)
 
 ## Generating a Single-Player Game
 

--- a/worlds/factorio/docs/setup_en.md
+++ b/worlds/factorio/docs/setup_en.md
@@ -31,7 +31,7 @@ them. Factorio player settings page: [Factorio Settings Page](/games/Factorio/pl
 ### Verifying your config file
 
 If you would like to validate your config file to make sure it works, you may do so on the YAML Validator page. YAML
-Validator page: [Yaml Validation Page](/mysterycheck)
+Validator page: [Yaml Validation Page](/check)
 
 ## Connecting to Someone Else's Factorio Game
 

--- a/worlds/generic/docs/setup_en.md
+++ b/worlds/generic/docs/setup_en.md
@@ -40,7 +40,7 @@ game you will be playing as well as the settings you would like for that game.
 
 YAML is a format very similar to JSON however it is made to be more human-readable. If you are ever unsure of the
 validity of your YAML file you may check the file by uploading it to the check page on the Archipelago website:
-[YAML Validation Page](/mysterycheck)
+[YAML Validation Page](/check)
 
 ### Creating a YAML
 

--- a/worlds/ladx/docs/setup_en.md
+++ b/worlds/ladx/docs/setup_en.md
@@ -40,7 +40,7 @@ your personal settings and export a config file from them.
 ### Verifying your config file
 
 If you would like to validate your config file to make sure it works, you may do so on the
-[YAML Validator](/mysterycheck) page.
+[YAML Validator](/check) page.
 
 ## Generating a Single-Player Game
 

--- a/worlds/lufia2ac/docs/setup_en.md
+++ b/worlds/lufia2ac/docs/setup_en.md
@@ -44,7 +44,7 @@ your personal settings and export a config file from them.
 ### Verifying your config file
 
 If you would like to validate your config file to make sure it works, you may do so on the
-[YAML Validator](/mysterycheck) page.
+[YAML Validator](/check) page.
 
 ## Generating a Single-Player Game
 

--- a/worlds/sm/docs/multiworld_en.md
+++ b/worlds/sm/docs/multiworld_en.md
@@ -49,7 +49,7 @@ them. Player settings page: [Super Metroid Player Settings Page](/games/Super%20
 ### Verifying your config file
 
 If you would like to validate your config file to make sure it works, you may do so on the YAML Validator page. YAML
-validator page: [YAML Validation page](/mysterycheck)
+validator page: [YAML Validation page](/check)
 
 ## Generating a Single-Player Game
 

--- a/worlds/smw/docs/setup_en.md
+++ b/worlds/smw/docs/setup_en.md
@@ -50,7 +50,7 @@ them. Player settings page: [Super Mario World Player Settings Page](/games/Supe
 ### Verifying your config file
 
 If you would like to validate your config file to make sure it works, you may do so on the YAML Validator page. YAML
-validator page: [YAML Validation page](/mysterycheck)
+validator page: [YAML Validation page](/check)
 
 ## Joining a MultiWorld Game
 

--- a/worlds/smz3/docs/multiworld_en.md
+++ b/worlds/smz3/docs/multiworld_en.md
@@ -47,7 +47,7 @@ them. Player settings page: [SMZ3 Player Settings Page](/games/SMZ3/player-setti
 ### Verifying your config file
 
 If you would like to validate your config file to make sure it works, you may do so on the YAML Validator page. YAML
-validator page: [YAML Validation page](/mysterycheck)
+validator page: [YAML Validation page](/check)
 
 ## Generating a Single-Player Game
 

--- a/worlds/soe/docs/multiworld_en.md
+++ b/worlds/soe/docs/multiworld_en.md
@@ -29,7 +29,7 @@ them. Player settings page: [Secret of Evermore Player Settings PAge](/games/Sec
 ### Verifying your config file
 
 If you would like to validate your config file to make sure it works, you may do so on the YAML Validator
-page: [YAML Validation page](/mysterycheck)
+page: [YAML Validation page](/check)
 
 ## Generating a Single-Player Game
 

--- a/worlds/tloz/docs/multiworld_en.md
+++ b/worlds/tloz/docs/multiworld_en.md
@@ -44,7 +44,7 @@ them. Player settings page: [The Legend of Zelda Player Settings Page](/games/Th
 ### Verifying your config file
 
 If you would like to validate your config file to make sure it works, you may do so on the YAML Validator page. YAML
-validator page: [YAML Validation page](/mysterycheck)
+validator page: [YAML Validation page](/check)
 
 ## Generating a Single-Player Game
 

--- a/worlds/zillion/docs/setup_en.md
+++ b/worlds/zillion/docs/setup_en.md
@@ -51,7 +51,7 @@ them.
 
 ### Verifying your config file
 
-If you would like to validate your config file to make sure it works, you may do so on the [YAML Validator page](/mysterycheck).
+If you would like to validate your config file to make sure it works, you may do so on the [YAML Validator page](/check).
 
 ## Generating a Single-Player Game
 


### PR DESCRIPTION
## What is this fixing or adding?
adds a  combined yaml file as download to a succesful /check run with multiple files
bonus inclusions:
fixes many guides hitting a redirect
fixes import * in check.py

## How was this tested?
on Vivaldi

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/3189725/96bd8903-02ac-4259-b3ef-ace4d2636d64)
![image](https://github.com/ArchipelagoMW/Archipelago/assets/3189725/4c5ee13c-34e3-4d4d-9105-06ebc66c1f2b)
![image](https://github.com/ArchipelagoMW/Archipelago/assets/3189725/c505e2c4-1efe-4ed9-94d3-b26d51d8caff)
