### PR TITLE
Docs: Terraria Setup Guide added information about the Upgraded Research Mod

### DIFF
--- a/worlds/terraria/docs/setup_en.md
+++ b/worlds/terraria/docs/setup_en.md
@@ -31,7 +31,7 @@ highly recommended to use utility mods and features to speed up gameplay, such a
     - (Can be used to break progression)
 - Reduced Grinding
 - Upgraded Research
-    - (Automatically researches certain items, removing them from your inventory initially)
+    - (NOTE: If items you pick up aren't showing up in your inventory, check your research menu. This mod automatically researches certain items.)
 
 ## Configuring your YAML File
 

--- a/worlds/terraria/docs/setup_en.md
+++ b/worlds/terraria/docs/setup_en.md
@@ -31,6 +31,7 @@ highly recommended to use utility mods and features to speed up gameplay, such a
     - (Can be used to break progression)
 - Reduced Grinding
 - Upgraded Research
+    - (Automatically researchers certain items so don't be afraid when they don't appear in your inventory)
 
 ## Configuring your YAML File
 

--- a/worlds/terraria/docs/setup_en.md
+++ b/worlds/terraria/docs/setup_en.md
@@ -31,6 +31,7 @@ highly recommended to use utility mods and features to speed up gameplay, such a
     - (Can be used to break progression)
 - Reduced Grinding
 - Upgraded Research
+    - (WARNING: Do not use without Journey mode)
     - (NOTE: If items you pick up aren't showing up in your inventory, check your research menu. This mod automatically researches certain items.)
 
 ## Configuring your YAML File

--- a/worlds/terraria/docs/setup_en.md
+++ b/worlds/terraria/docs/setup_en.md
@@ -31,7 +31,7 @@ highly recommended to use utility mods and features to speed up gameplay, such a
     - (Can be used to break progression)
 - Reduced Grinding
 - Upgraded Research
-    - (Automatically researchers certain items so don't be afraid when they don't appear in your inventory)
+    - (Automatically researches certain items, removing them from your inventory initially)
 
 ## Configuring your YAML File
 


### PR DESCRIPTION
## What is this fixing or adding?
a line to the Upgraded Research Mod that tells people that it can automatically research items to prevent people from reporting the mod not working cause they don't notice the item they received got automatically researched and did therefore not land in their inventory.

## How was this tested?
by reading it

## If this makes graphical changes, please attach screenshots.
![grafik](https://github.com/ArchipelagoMW/Archipelago/assets/30220696/47bab9cb-059e-4318-8731-f3af5d8adc56)
