### PR TITLE
pytest: run tests on non-windows with new names

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-python_files = Test*.py
+python_files = test_*.py Test*.py  # TODO: remove Test* once all worlds have been ported
 python_classes = Test
 python_functions = test


### PR DESCRIPTION
We forgot to update pytest.ini in #2298 

---

Want to leave both test_\*.py and Test\*.py in for now so pytest discovers world test that have not been renamed yet until we have the test that tests that tests are named test_.