### PR TITLE
Core: deprecate Utils.get_options and remove Utils.get_default_options

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -257,15 +257,13 @@ def get_public_ipv6() -> str:
     return ip
 
 
-OptionsType = Settings  # TODO: remove ~2 versions after 0.4.1
+OptionsType = Settings  # TODO: remove when removing get_options
 
 
-@cache_argsless
-def get_default_options() -> Settings:  # TODO: remove ~2 versions after 0.4.1
-    return Settings(None)
-
-
-get_options = get_settings  # TODO: add a warning ~2 versions after 0.4.1 and remove once all games are ported
+def get_options() -> Settings:
+    # TODO: switch to Utils.deprecate after 0.4.4
+    warnings.warn("Utils.get_options() is deprecated. Use the settings API instead.", DeprecationWarning)
+    return get_settings()
 
 
 def persistent_store(category: str, key: typing.Any, value: typing.Any):

--- a/test/general/test_host_yaml.py
+++ b/test/general/test_host_yaml.py
@@ -16,7 +16,7 @@ class TestIDs(unittest.TestCase):
 
     def test_utils_in_yaml(self) -> None:
         """Tests that the auto generated host.yaml has default settings in it"""
-        for option_key, option_set in Utils.get_default_options().items():
+        for option_key, option_set in Settings(None).items():
             with self.subTest(option_key):
                 self.assertIn(option_key, self.yaml_options)
                 for sub_option_key in option_set:
@@ -24,7 +24,7 @@ class TestIDs(unittest.TestCase):
 
     def test_yaml_in_utils(self) -> None:
         """Tests that the auto generated host.yaml shows up in reference calls"""
-        utils_options = Utils.get_default_options()
+        utils_options = Settings(None)
         for option_key, option_set in self.yaml_options.items():
             with self.subTest(option_key):
                 self.assertIn(option_key, utils_options)

--- a/worlds/adventure/Rom.py
+++ b/worlds/adventure/Rom.py
@@ -6,9 +6,8 @@ from typing import Optional, Any
 
 import Utils
 from .Locations import AdventureLocation, LocationData
-from Utils import OptionsType
+from settings import get_settings
 from worlds.Files import APDeltaPatch, AutoPatchRegister, APContainer
-from itertools import chain
 
 import bsdiff4
 
@@ -313,9 +312,8 @@ def get_base_rom_bytes(file_name: str = "") -> bytes:
 
 
 def get_base_rom_path(file_name: str = "") -> str:
-    options: OptionsType = Utils.get_options()
     if not file_name:
-        file_name = options["adventure_options"]["rom_file"]
+        file_name = get_settings()["adventure_options"]["rom_file"]
     if not os.path.exists(file_name):
         file_name = Utils.user_path(file_name)
     return file_name

--- a/worlds/lufia2ac/Rom.py
+++ b/worlds/lufia2ac/Rom.py
@@ -3,7 +3,7 @@ import os
 from typing import Optional
 
 import Utils
-from Utils import OptionsType
+from settings import get_settings
 from worlds.Files import APDeltaPatch
 
 L2USHASH: str = "6efc477d6203ed2b3b9133c1cd9e9c5d"
@@ -35,9 +35,8 @@ def get_base_rom_bytes(file_name: str = "") -> bytes:
 
 
 def get_base_rom_path(file_name: str = "") -> str:
-    options: OptionsType = Utils.get_options()
     if not file_name:
-        file_name = options["lufia2ac_options"]["rom_file"]
+        file_name = get_settings()["lufia2ac_options"]["rom_file"]
     if not os.path.exists(file_name):
         file_name = Utils.user_path(file_name)
     return file_name


### PR DESCRIPTION
Also changed the two games in main that were using Utils.OptionsType, so dropping that is easier when we drop it.