### PR TITLE
Options: have as_dict return set values as lists to reduce JSON footprint

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -952,7 +952,7 @@ class CommonOptions(metaclass=OptionsMetaProperty):
                                      "Valid names are 'snake', 'camel', 'pascal', 'kebab'.")
                 value = getattr(self, option_name).value
                 if isinstance(value, set):
-                    value = list(value)
+                    value = sorted(value)
                 option_results[display_name] = value
             else:
                 raise ValueError(f"{option_name} not found in {tuple(type(self).type_hints)}")

--- a/Options.py
+++ b/Options.py
@@ -950,7 +950,10 @@ class CommonOptions(metaclass=OptionsMetaProperty):
                 else:
                     raise ValueError(f"{casing} is invalid casing for as_dict. "
                                      "Valid names are 'snake', 'camel', 'pascal', 'kebab'.")
-                option_results[display_name] = getattr(self, option_name).value
+                value = getattr(self, option_name).value
+                if isinstance(value, set):
+                    value = list(value)
+                option_results[display_name] = value
             else:
                 raise ValueError(f"{option_name} not found in {tuple(type(self).type_hints)}")
         return option_results


### PR DESCRIPTION
## What is this fixing or adding?
while sets are json serializable, they are slower, since the goal of this method is to quickly return needed options for slot_data, it only makes sense to have it convert sets to lists. 

## How was this tested?
tested with oot using break points

## If this makes graphical changes, please attach screenshots.
