### PR TITLE
Pokémon R/B: Fix incompatible option combination

### DIFF
--- a/worlds/pokemon_rb/__init__.py
+++ b/worlds/pokemon_rb/__init__.py
@@ -468,14 +468,16 @@ class PokemonRedBlueWorld(World):
                 self.multiworld.get_location("Fossil - Choice B", self.player)}
 
         if not self.multiworld.key_items_only[self.player]:
+            rule = None
             if self.multiworld.fossil_check_item_types[self.player] == "key_items":
                 rule = lambda i: i.advancement
             elif self.multiworld.fossil_check_item_types[self.player] == "unique_items":
                 rule = lambda i: i.name in item_groups["Unique"]
             elif self.multiworld.fossil_check_item_types[self.player] == "no_key_items":
                 rule = lambda i: not i.advancement
-            for loc in locs:
-                add_item_rule(loc, rule)
+            if rule:
+                for loc in locs:
+                    add_item_rule(loc, rule)
 
         for mon in ([" ".join(self.multiworld.get_location(
                 f"Oak's Lab - Starter {i}", self.player).item.name.split(" ")[1:]) for i in range(1, 4)]

--- a/worlds/pokemon_rb/__init__.py
+++ b/worlds/pokemon_rb/__init__.py
@@ -467,13 +467,14 @@ class PokemonRedBlueWorld(World):
         locs = {self.multiworld.get_location("Fossil - Choice A", self.player),
                 self.multiworld.get_location("Fossil - Choice B", self.player)}
 
-        for loc in locs:
-            if self.multiworld.fossil_check_item_types[self.player] == "key_items":
-                add_item_rule(loc, lambda i: i.advancement)
-            elif self.multiworld.fossil_check_item_types[self.player] == "unique_items":
-                add_item_rule(loc, lambda i: i.name in item_groups["Unique"])
-            elif self.multiworld.fossil_check_item_types[self.player] == "no_key_items":
-                add_item_rule(loc, lambda i: not i.advancement)
+        if not self.multiworld.key_items_only[self.player]:
+            for loc in locs:
+                if self.multiworld.fossil_check_item_types[self.player] == "key_items":
+                    add_item_rule(loc, lambda i: i.advancement)
+                elif self.multiworld.fossil_check_item_types[self.player] == "unique_items":
+                    add_item_rule(loc, lambda i: i.name in item_groups["Unique"])
+                elif self.multiworld.fossil_check_item_types[self.player] == "no_key_items":
+                    add_item_rule(loc, lambda i: not i.advancement)
 
         for mon in ([" ".join(self.multiworld.get_location(
                 f"Oak's Lab - Starter {i}", self.player).item.name.split(" ")[1:]) for i in range(1, 4)]

--- a/worlds/pokemon_rb/__init__.py
+++ b/worlds/pokemon_rb/__init__.py
@@ -468,13 +468,14 @@ class PokemonRedBlueWorld(World):
                 self.multiworld.get_location("Fossil - Choice B", self.player)}
 
         if not self.multiworld.key_items_only[self.player]:
+            if self.multiworld.fossil_check_item_types[self.player] == "key_items":
+                rule = lambda i: i.advancement
+            elif self.multiworld.fossil_check_item_types[self.player] == "unique_items":
+                rule = lambda i: i.name in item_groups["Unique"]
+            elif self.multiworld.fossil_check_item_types[self.player] == "no_key_items":
+                rule = lambda i: not i.advancement
             for loc in locs:
-                if self.multiworld.fossil_check_item_types[self.player] == "key_items":
-                    add_item_rule(loc, lambda i: i.advancement)
-                elif self.multiworld.fossil_check_item_types[self.player] == "unique_items":
-                    add_item_rule(loc, lambda i: i.name in item_groups["Unique"])
-                elif self.multiworld.fossil_check_item_types[self.player] == "no_key_items":
-                    add_item_rule(loc, lambda i: not i.advancement)
+                add_item_rule(loc, rule)
 
         for mon in ([" ".join(self.multiworld.get_location(
                 f"Oak's Lab - Starter {i}", self.player).item.name.split(" ")[1:]) for i in range(1, 4)]


### PR DESCRIPTION
## What is this fixing or adding?
You can set `fossil_check_item_types` to `no_key_items` but then turn `key_items_only` on, resulting in no non-key-items to fill the fossil checks. This skips processing the `fossil_check_item_types` rules at all if `key_items_only` is on

## How was this tested?
Generating with same seed # of a previously failing generation