### PR TITLE
Core/LttP: remove initialize_regions

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -328,11 +328,6 @@ class MultiWorld():
         """ the base name (without file extension) for each player's output file for a seed """
         return f"AP_{self.seed_name}_P{player}_{self.get_file_safe_player_name(player).replace(' ', '_')}"
 
-    def initialize_regions(self, regions=None):
-        for region in regions if regions else self.regions:
-            region.multiworld = self
-            self._region_cache[region.player][region.name] = region
-
     @functools.cached_property
     def world_name_lookup(self):
         return {self.player_name[player_id]: player_id for player_id in self.player_ids}

--- a/worlds/alttp/InvertedRegions.py
+++ b/worlds/alttp/InvertedRegions.py
@@ -477,8 +477,6 @@ def create_inverted_regions(world, player):
         create_lw_region(world, player, 'Death Mountain Bunny Descent Area')
     ]
 
-    world.initialize_regions()
-
 
 def mark_dark_world_regions(world, player):
     # cross world caves may have some sections marked as both in_light_world, and in_dark_work.

--- a/worlds/alttp/ItemPool.py
+++ b/worlds/alttp/ItemPool.py
@@ -535,8 +535,6 @@ def set_up_take_anys(world, player):
         take_any.shop.add_inventory(0, 'Blue Potion', 0, 0)
         take_any.shop.add_inventory(1, 'Boss Heart Container', 0, 0, create_location=True)
 
-    world.initialize_regions()
-
 
 def get_pool_core(world, player: int):
     shuffle = world.shuffle[player]

--- a/worlds/alttp/Regions.py
+++ b/worlds/alttp/Regions.py
@@ -382,8 +382,6 @@ def create_regions(world, player):
         create_dw_region(world, player, 'Dark Death Mountain Bunny Descent Area')
     ]
 
-    world.initialize_regions()
-
 
 def create_lw_region(world: MultiWorld, player: int, name: str, locations=None, exits=None):
     return _create_region(world, player, name, LTTPRegionType.LightWorld, 'Light World', locations, exits)


### PR DESCRIPTION
## What is this fixing or adding?
removes initialize_regions. Should generate faster without it as well.

## How was this tested?
an LttP template and unittests. During which my SoE apparently died.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/3189725/9314d1a0-e7c3-4f09-8a4a-c9bac5085874)

