### PR TITLE
BizHawkClient: Improve updating component's suffix identifier

### DIFF
--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -89,9 +89,6 @@ components: List[Component] = [
     Component('SNI Client', 'SNIClient',
               file_identifier=SuffixIdentifier('.apz3', '.apm3', '.apsoe', '.aplttp', '.apsm', '.apsmz3', '.apdkc3',
                                                '.apsmw', '.apl2ac')),
-    # BizHawk
-    Component("BizHawk Client", "BizHawkClient", component_type=Type.CLIENT,
-              file_identifier=SuffixIdentifier()),
     Component('Links Awakening DX Client', 'LinksAwakeningClient',
               file_identifier=SuffixIdentifier('.apladx')),
     Component('LttP Adjuster', 'LttPAdjuster'),


### PR DESCRIPTION
## What is this fixing or adding?

Adds a new field for individual clients to specify the suffixes of their patch files. When the client is registered, the BizHawk Client component has its file identifier updated to include the new suffixes.

Also removes mentions of BizHawkClient from `LauncherComponents.py` entirely, which fixes some duplicated code. And now the component will _actually_ only load if a world imports it.

## How was this tested?

Tested with Emerald, and also made a dummy clients with each of `str`, `tuple[str, str]`, and `None` in their `patch_suffix` var, and then checked the listed file extensions in the "Open Patch" file selection dialog.
