### PR TITLE
BizHawkClient: Add lock for communicating with lua script

### DIFF
--- a/worlds/_bizhawk/context.py
+++ b/worlds/_bizhawk/context.py
@@ -13,8 +13,8 @@ from CommonClient import CommonContext, ClientCommandProcessor, get_base_parser,
 import Patch
 import Utils
 
-from . import BizHawkContext, ConnectionStatus, RequestFailedError, connect, disconnect, get_hash, get_script_version, \
-    get_system, ping
+from . import BizHawkContext, ConnectionStatus, NotConnectedError, RequestFailedError, connect, disconnect, get_hash, \
+    get_script_version, get_system, ping
 from .client import BizHawkClient, AutoBizHawkClientRegister
 
 
@@ -132,6 +132,8 @@ async def _game_watcher(ctx: BizHawkClientContext):
 
         except RequestFailedError as exc:
             logger.info(f"Lost connection to BizHawk: {exc.args[0]}")
+            continue
+        except NotConnectedError:
             continue
 
         # Get slot name and send `Connect`


### PR DESCRIPTION
## What is this fixing or adding?

If multiple coroutines try to make requests using the same `BizHawkContext`, one of them might try to read from the `StreamReader` while another one is already waiting on it, which seems to lead to one of the responses getting discarded because of the asyncio exception and the other gets passed to the wrong coroutine which bubbles up as a `SyncError`.

The connector script isn't built to service more than one connection, but multiple coroutines have access to the connection from the python side and may have reason to use it. For example, an `on_package` handler and a game watcher.

This adds a lock to `BizHawkContext` and shuffles code around a little. So now anything trying to communicate with the lua script will have to wait until nothing else is trying to.

This will simplify #2306 a bit and allow it to call `set_auth` from `server_auth`.

The extra `except` for `NotConnectedError`s is now necessary since we might hit a failure and timeout in one coroutine and then immediately try to make a new request in another. I'd be open to folding `NotConnectedError` into `RequestFailedError`. I'm sorta making the errors up as I go.

`EXPECTED_SCRIPT_VERSION` was just duplicated and unused here.

## How was this tested?

Grabbing a few items in an Emerald game, slightly reworking #2306 to see if it fixed the exceptions I was seeing when calling `set_auth` from `server_auth`, and forwarding `PrintJSON` commands to BizHawk, all without issue.
