### PR TITLE
Stardew Valley: speed up rules creation by 4%

### DIFF
--- a/worlds/stardew_valley/stardew_rule.py
+++ b/worlds/stardew_valley/stardew_rule.py
@@ -112,11 +112,12 @@ class Or(StardewRule):
         return f"({' | '.join(repr(rule) for rule in self.rules)})"
 
     def __or__(self, other):
-        if type(other) is True_:
+        t = type(other)
+        if t is True_:
             return other
-        if type(other) is False_:
+        if t is False_:
             return self
-        if type(other) is Or:
+        if t is Or:
             return Or(self.rules.union(other.rules))
 
         return Or(self.rules.union({other}))
@@ -179,11 +180,12 @@ class And(StardewRule):
         return f"({' & '.join(repr(rule) for rule in self.rules)})"
 
     def __and__(self, other):
-        if type(other) is True_:
+        t = type(other)
+        if t is True_:
             return self
-        if type(other) is False_:
+        if t is False_:
             return other
-        if type(other) is And:
+        if t is And:
             return And(self.rules.union(other.rules))
 
         return And(self.rules.union({other}))

--- a/worlds/stardew_valley/stardew_rule.py
+++ b/worlds/stardew_valley/stardew_rule.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable, Dict, List, Union, FrozenSet
+from typing import Iterable, Dict, List, Union, FrozenSet, Set
 
 from BaseClasses import CollectionState, ItemClassification
 from .items import item_table
@@ -90,24 +90,26 @@ class Or(StardewRule):
     rules: FrozenSet[StardewRule]
 
     def __init__(self, rule: Union[StardewRule, Iterable[StardewRule]], *rules: StardewRule):
-        rules_list = set()
+        rules_list: Set[StardewRule]
+
         if isinstance(rule, Iterable):
-            rules_list.update(rule)
+            rules_list = {*rule}
         else:
-            rules_list.add(rule)
+            rules_list = {rule}
 
         if rules is not None:
             rules_list.update(rules)
 
         assert rules_list, "Can't create a Or conditions without rules"
 
-        new_rules = set()
-        for rule in rules_list:
-            if type(rule) is Or:
-                new_rules.update(rule.rules)
-            else:
-                new_rules.add(rule)
-        rules_list = new_rules
+        if any(type(rule) is Or for rule in rules_list):
+            new_rules: Set[StardewRule] = set()
+            for rule in rules_list:
+                if type(rule) is Or:
+                    new_rules.update(rule.rules)
+                else:
+                    new_rules.add(rule)
+            rules_list = new_rules
 
         self.rules = frozenset(rules_list)
 
@@ -156,25 +158,26 @@ class And(StardewRule):
     rules: FrozenSet[StardewRule]
 
     def __init__(self, rule: Union[StardewRule, Iterable[StardewRule]], *rules: StardewRule):
-        rules_list = set()
+        rules_list: Set[StardewRule]
+
         if isinstance(rule, Iterable):
-            rules_list.update(rule)
+            rules_list = {*rule}
         else:
-            rules_list.add(rule)
+            rules_list = {rule}
 
         if rules is not None:
             rules_list.update(rules)
 
-        if len(rules_list) < 1:
+        if not rules_list:
             rules_list.add(true_)
-
-        new_rules = set()
-        for rule in rules_list:
-            if type(rule) is And:
-                new_rules.update(rule.rules)
-            else:
-                new_rules.add(rule)
-        rules_list = new_rules
+        elif any(type(rule) is And for rule in rules_list):
+            new_rules: Set[StardewRule] = set()
+            for rule in rules_list:
+                if type(rule) is And:
+                    new_rules.update(rule.rules)
+                else:
+                    new_rules.add(rule)
+            rules_list = new_rules
 
         self.rules = frozenset(rules_list)
 
@@ -224,11 +227,12 @@ class Count(StardewRule):
     rules: List[StardewRule]
 
     def __init__(self, count: int, rule: Union[StardewRule, Iterable[StardewRule]], *rules: StardewRule):
-        rules_list = []
+        rules_list: List[StardewRule]
+
         if isinstance(rule, Iterable):
-            rules_list.extend(rule)
+            rules_list = [*rule]
         else:
-            rules_list.append(rule)
+            rules_list = [rule]
 
         if rules is not None:
             rules_list.extend(rules)
@@ -266,11 +270,12 @@ class TotalReceived(StardewRule):
     player: int
 
     def __init__(self, count: int, items: Union[str, Iterable[str]], player: int):
-        items_list = []
+        items_list: List[str]
+
         if isinstance(items, Iterable):
-            items_list.extend(items)
+            items_list = [*items]
         else:
-            items_list.append(items)
+            items_list = [items]
 
         assert items_list, "Can't create a Total Received conditions without items"
         for item in items_list:

--- a/worlds/stardew_valley/stardew_rule.py
+++ b/worlds/stardew_valley/stardew_rule.py
@@ -140,14 +140,14 @@ class Or(StardewRule):
         if true_ in self.rules:
             return true_
 
-        simplified_rules = {rule.simplify() for rule in self.rules}
-        simplified_rules = {rule for rule in simplified_rules if rule is not False_()}
+        simplified_rules = [simplified for simplified in {rule.simplify() for rule in self.rules}
+                            if simplified is not false_]
 
         if not simplified_rules:
             return false_
 
         if len(simplified_rules) == 1:
-            return next(iter(simplified_rules))
+            return simplified_rules[0]
 
         return Or(simplified_rules)
 
@@ -207,14 +207,14 @@ class And(StardewRule):
         if false_ in self.rules:
             return false_
 
-        simplified_rules = {rule.simplify() for rule in self.rules}
-        simplified_rules = {rule for rule in simplified_rules if rule is not True_()}
+        simplified_rules = [simplified for simplified in {rule.simplify() for rule in self.rules}
+                            if simplified is not true_]
 
         if not simplified_rules:
             return true_
 
         if len(simplified_rules) == 1:
-            return next(iter(simplified_rules))
+            return simplified_rules[0]
 
         return And(simplified_rules)
 

--- a/worlds/stardew_valley/stardew_rule.py
+++ b/worlds/stardew_valley/stardew_rule.py
@@ -80,6 +80,12 @@ class False_(StardewRule):  # noqa
         return 999999999
 
 
+false_ = False_()
+true_ = True_()
+assert false_ is False_()
+assert true_ is True_()
+
+
 class Or(StardewRule):
     rules: FrozenSet[StardewRule]
 
@@ -112,12 +118,11 @@ class Or(StardewRule):
         return f"({' | '.join(repr(rule) for rule in self.rules)})"
 
     def __or__(self, other):
-        t = type(other)
-        if t is True_:
+        if other is true_:
             return other
-        if t is False_:
+        if other is false_:
             return self
-        if t is Or:
+        if type(other) is Or:
             return Or(self.rules.union(other.rules))
 
         return Or(self.rules.union({other}))
@@ -132,14 +137,14 @@ class Or(StardewRule):
         return min(rule.get_difficulty() for rule in self.rules)
 
     def simplify(self) -> StardewRule:
-        if any((type(rule) is True_) for rule in self.rules):
-            return True_()
+        if true_ in self.rules:
+            return true_
 
         simplified_rules = {rule.simplify() for rule in self.rules}
         simplified_rules = {rule for rule in simplified_rules if rule is not False_()}
 
         if not simplified_rules:
-            return False_()
+            return false_
 
         if len(simplified_rules) == 1:
             return next(iter(simplified_rules))
@@ -161,7 +166,7 @@ class And(StardewRule):
             rules_list.update(rules)
 
         if len(rules_list) < 1:
-            rules_list.add(True_())
+            rules_list.add(true_)
 
         new_rules = set()
         for rule in rules_list:
@@ -180,12 +185,11 @@ class And(StardewRule):
         return f"({' & '.join(repr(rule) for rule in self.rules)})"
 
     def __and__(self, other):
-        t = type(other)
-        if t is True_:
+        if other is true_:
             return self
-        if t is False_:
+        if other is false_:
             return other
-        if t is And:
+        if type(other) is And:
             return And(self.rules.union(other.rules))
 
         return And(self.rules.union({other}))
@@ -200,14 +204,14 @@ class And(StardewRule):
         return max(rule.get_difficulty() for rule in self.rules)
 
     def simplify(self) -> StardewRule:
-        if any((type(rule) is False_) for rule in self.rules):
-            return False_()
+        if false_ in self.rules:
+            return false_
 
         simplified_rules = {rule.simplify() for rule in self.rules}
         simplified_rules = {rule for rule in simplified_rules if rule is not True_()}
 
         if not simplified_rules:
-            return True_()
+            return true_
 
         if len(simplified_rules) == 1:
             return next(iter(simplified_rules))

--- a/worlds/stardew_valley/stardew_rule.py
+++ b/worlds/stardew_valley/stardew_rule.py
@@ -14,13 +14,13 @@ class StardewRule:
         raise NotImplementedError
 
     def __or__(self, other) -> StardewRule:
-        if isinstance(other, Or):
+        if type(other) is Or:
             return Or(self, *other.rules)
 
         return Or(self, other)
 
     def __and__(self, other) -> StardewRule:
-        if isinstance(other, And):
+        if type(other) is And:
             return And(other.rules.union({self}))
 
         return And(self, other)
@@ -97,7 +97,7 @@ class Or(StardewRule):
 
         new_rules = set()
         for rule in rules_list:
-            if isinstance(rule, Or):
+            if type(rule) is Or:
                 new_rules.update(rule.rules)
             else:
                 new_rules.add(rule)
@@ -112,11 +112,11 @@ class Or(StardewRule):
         return f"({' | '.join(repr(rule) for rule in self.rules)})"
 
     def __or__(self, other):
-        if isinstance(other, True_):
+        if type(other) is True_:
             return other
-        if isinstance(other, False_):
+        if type(other) is False_:
             return self
-        if isinstance(other, Or):
+        if type(other) is Or:
             return Or(self.rules.union(other.rules))
 
         return Or(self.rules.union({other}))
@@ -131,7 +131,7 @@ class Or(StardewRule):
         return min(rule.get_difficulty() for rule in self.rules)
 
     def simplify(self) -> StardewRule:
-        if any(isinstance(rule, True_) for rule in self.rules):
+        if any((type(rule) is True_) for rule in self.rules):
             return True_()
 
         simplified_rules = {rule.simplify() for rule in self.rules}
@@ -164,7 +164,7 @@ class And(StardewRule):
 
         new_rules = set()
         for rule in rules_list:
-            if isinstance(rule, And):
+            if type(rule) is And:
                 new_rules.update(rule.rules)
             else:
                 new_rules.add(rule)
@@ -179,11 +179,11 @@ class And(StardewRule):
         return f"({' & '.join(repr(rule) for rule in self.rules)})"
 
     def __and__(self, other):
-        if isinstance(other, True_):
+        if type(other) is True_:
             return self
-        if isinstance(other, False_):
+        if type(other) is False_:
             return other
-        if isinstance(other, And):
+        if type(other) is And:
             return And(self.rules.union(other.rules))
 
         return And(self.rules.union({other}))
@@ -198,7 +198,7 @@ class And(StardewRule):
         return max(rule.get_difficulty() for rule in self.rules)
 
     def simplify(self) -> StardewRule:
-        if any(isinstance(rule, False_) for rule in self.rules):
+        if any((type(rule) is False_) for rule in self.rules):
             return False_()
 
         simplified_rules = {rule.simplify() for rule in self.rules}


### PR DESCRIPTION
No class should ever inherit from And, Or, False_ or True_ and isinstance is not free. Sadly there is no cheap way to forbid inheritance, but it was tested using metaclass.


## What is this fixing or adding?

Speed up overall rule creation in Stardew Valley by ~4%, hopefully without interfering with upstream changes.

## How was this tested?

Unittests and verifying that no class inherits from Or, And, True_ or False_
