### PR TITLE
Timespinner: Fixed generation error caused by new options system

### DIFF
--- a/worlds/timespinner/__init__.py
+++ b/worlds/timespinner/__init__.py
@@ -49,11 +49,9 @@ class TimespinnerWorld(World):
 
     precalculated_weights: PreCalculatedWeights
 
-    def __init__(self, world: MultiWorld, player: int):
-        super().__init__(world, player)
-        self.precalculated_weights = PreCalculatedWeights(world, player)
-
     def generate_early(self) -> None:
+        self.precalculated_weights = PreCalculatedWeights(self.multiworld, self.player)
+
         # in generate_early the start_inventory isnt copied over to precollected_items yet, so we can still modify the options directly
         if self.multiworld.start_inventory[self.player].value.pop('Meyef', 0) > 0:
             self.multiworld.StartWithMeyef[self.player].value = self.multiworld.StartWithMeyef[self.player].option_true


### PR DESCRIPTION
## What is this fixing or adding?
In the new options system added in #993 the options on the multiworld instance are nolonger available inside the constructor, therefor i had to move my method that calculates logic constrains based on those options to generate_early

If the options do again become available at constructor time, than this can be close

## How was this tested?
Many local generations with one or multiple players
