### PR TITLE
Pokemon R/B: Avoid a case of repeatedly checking of state in ER

### DIFF
--- a/worlds/pokemon_rb/regions.py
+++ b/worlds/pokemon_rb/regions.py
@@ -2289,8 +2289,8 @@ def create_regions(self):
             check_warps.update(region.exits)
             check_warps.remove(e)
             for location in region.locations:
-                if location.item and location.item.name in relevant_events \
-                    and adds_reachable_entrances(entrances_copy, location.item, dead_end_cache):
+                if location.item and location.item.name in relevant_events and \
+                                 adds_reachable_entrances(entrances_copy, location.item, dead_end_cache):
                     return False
             while check_warps:
                 warp = check_warps.pop()

--- a/worlds/pokemon_rb/regions.py
+++ b/worlds/pokemon_rb/regions.py
@@ -1594,7 +1594,7 @@ def create_regions(self):
     connect(multiworld, player, "Menu", "Pallet Town", one_way=True)
     connect(multiworld, player, "Menu", "Pokedex", one_way=True)
     connect(multiworld, player, "Menu", "Evolution", one_way=True)
-    connect(multiworld, player, "Menu", "Fossil", lambda state: logic.fossil_checks(state, 
+    connect(multiworld, player, "Menu", "Fossil", lambda state: logic.fossil_checks(state,
         state.multiworld.second_fossil_check_condition[player].value, player), one_way=True)
     connect(multiworld, player, "Pallet Town", "Route 1")
     connect(multiworld, player, "Route 1", "Viridian City")
@@ -2269,23 +2269,28 @@ def create_regions(self):
 
         event_locations = self.multiworld.get_filled_locations(player)
 
-        def adds_reachable_entrances(entrances_copy, item):
+        def adds_reachable_entrances(entrances_copy, item, dead_end_cache):
+            ret = dead_end_cache.get(item.name)
+            if (ret != None):
+                return ret
+
             state_copy = state.copy()
             state_copy.collect(item, True)
             state.sweep_for_events(locations=event_locations)
             ret = len([entrance for entrance in entrances_copy if entrance in reachable_entrances or
                       entrance.parent_region.can_reach(state_copy)]) > len(reachable_entrances)
+            dead_end_cache[item.name] = ret
             return ret
 
-        def dead_end(entrances_copy, e):
+        def dead_end(entrances_copy, e, dead_end_cache):
             region = e.parent_region
             check_warps = set()
             checked_regions = {region}
             check_warps.update(region.exits)
             check_warps.remove(e)
             for location in region.locations:
-                if location.item and location.item.name in relevant_events and adds_reachable_entrances(entrances_copy,
-                                                                                                        location.item):
+                if location.item and location.item.name in relevant_events \
+                    and adds_reachable_entrances(entrances_copy, location.item, dead_end_cache):
                     return False
             while check_warps:
                 warp = check_warps.pop()
@@ -2302,7 +2307,7 @@ def create_regions(self):
                                 check_warps.update(warp.connected_region.exits)
                                 for location in warp.connected_region.locations:
                                     if (location.item and location.item.name in relevant_events and
-                                            adds_reachable_entrances(entrances_copy, location.item)):
+                                            adds_reachable_entrances(entrances_copy, location.item, dead_end_cache)):
                                         return False
             return True
 
@@ -2332,6 +2337,8 @@ def create_regions(self):
             if multiworld.door_shuffle[player] == "full" or len(entrances) != len(reachable_entrances):
                 entrances.sort(key=lambda e: e.name not in entrance_only)
 
+                dead_end_cache = {}
+
                 # entrances list is empty while it's being sorted, must pass a copy to iterate through
                 entrances_copy = entrances.copy()
                 if multiworld.door_shuffle[player] == "decoupled":
@@ -2342,10 +2349,10 @@ def create_regions(self):
                 elif len(reachable_entrances) > (1 if multiworld.door_shuffle[player] == "insanity" else 8) and len(
                         entrances) <= (starting_entrances - 3):
                     entrances.sort(key=lambda e: 0 if e in reachable_entrances else 2 if
-                                   dead_end(entrances_copy, e) else 1)
+                                   dead_end(entrances_copy, e, dead_end_cache) else 1)
                 else:
                     entrances.sort(key=lambda e: 0 if e in reachable_entrances else 1 if
-                                   dead_end(entrances_copy, e) else 2)
+                                   dead_end(entrances_copy, e, dead_end_cache) else 2)
                 if multiworld.door_shuffle[player] == "full":
                     outdoor = outdoor_map(entrances[0].parent_region.name)
                     if len(entrances) < 48 and not outdoor:


### PR DESCRIPTION
## What is this fixing or adding?
This PR changes Pokemon ER to not constantly check state inside the `dead_ends()` function for cases where it should already know the outcome. This PR should not change any actual logic within ER.

This seems to save roughly 30%-50% of time spent within `create_regions`. Though the time will still grow as more players are in the generation, and it seemingly does less as more players are completed.

Time Before/After running 32 Insanity ER + Trainer Sanity
```
Took 8.56065619999572/2.9293287999971653 seconds in PokemonRedBlueWorld.create_regions for player 1, named DeamonPoke1.
Took 7.143686400006118/3.29854239999986 seconds in PokemonRedBlueWorld.create_regions for player 2, named DeamonPoke2.
Took 6.896408300002804/2.74106490000122 seconds in PokemonRedBlueWorld.create_regions for player 3, named DeamonPoke3.
Took 7.425772599999618/3.879308800002036 seconds in PokemonRedBlueWorld.create_regions for player 4, named DeamonPoke4.
Took 7.371204299997771/3.8762186000021757 seconds in PokemonRedBlueWorld.create_regions for player 5, named DeamonPoke5.
Took 7.299927499996556/4.339967199994135 seconds in PokemonRedBlueWorld.create_regions for player 6, named DeamonPoke6.
Took 9.710574600001564/3.6646945999964373 seconds in PokemonRedBlueWorld.create_regions for player 7, named DeamonPoke7.
Took 7.391483999999764/4.658047500000976 seconds in PokemonRedBlueWorld.create_regions for player 8, named DeamonPoke8.
Took 9.03062779999891/4.743314999999711 seconds in PokemonRedBlueWorld.create_regions for player 9, named DeamonPoke9.
Took 8.786249099997804/4.909083099999407 seconds in PokemonRedBlueWorld.create_regions for player 10, named DeamonPoke10.
Took 8.239895099999558/4.663943200001086 seconds in PokemonRedBlueWorld.create_regions for player 11, named DeamonPoke11.
Took 8.038863000001584/5.164306799997576 seconds in PokemonRedBlueWorld.create_regions for player 12, named DeamonPoke12.
Took 8.229623200000788/5.3458471999983885 seconds in PokemonRedBlueWorld.create_regions for player 13, named DeamonPoke13.
Took 9.547204100003/4.990577700002177 seconds in PokemonRedBlueWorld.create_regions for player 14, named DeamonPoke14.
Took 10.02850749999925/5.462006800000381 seconds in PokemonRedBlueWorld.create_regions for player 15, named DeamonPoke15.
Took 9.299213799997233/5.410809099994367 seconds in PokemonRedBlueWorld.create_regions for player 16, named DeamonPoke16.
Took 12.253399599998374/6.160892200001399 seconds in PokemonRedBlueWorld.create_regions for player 17, named DeamonPoke17.
Took 11.063624300004449/6.0270673999984865 seconds in PokemonRedBlueWorld.create_regions for player 18, named DeamonPoke18.
Took 9.021901699998125/6.195926100001088 seconds in PokemonRedBlueWorld.create_regions for player 19, named DeamonPoke19.
Took 8.610390299996652/6.080402200001117 seconds in PokemonRedBlueWorld.create_regions for player 20, named DeamonPoke20.
Took 8.950030599997262/5.970319799998833 seconds in PokemonRedBlueWorld.create_regions for player 21, named DeamonPoke21.
Took 9.67881650000345/7.346182000001136 seconds in PokemonRedBlueWorld.create_regions for player 22, named DeamonPoke22.
Took 11.279455000003509/6.902511199994478 seconds in PokemonRedBlueWorld.create_regions for player 23, named DeamonPoke23.
Took 14.597166300001845/7.4322421999968356 seconds in PokemonRedBlueWorld.create_regions for player 24, named DeamonPoke24.
Took 12.776494300000195/8.053918999998132 seconds in PokemonRedBlueWorld.create_regions for player 25, named DeamonPoke25.
Took 12.21953680000297/7.173849800004973 seconds in PokemonRedBlueWorld.create_regions for player 26, named DeamonPoke26.
Took 9.828148599997803/8.035678799999005 seconds in PokemonRedBlueWorld.create_regions for player 27, named DeamonPoke27.
Took 14.274174500002118/7.92050670000026 seconds in PokemonRedBlueWorld.create_regions for player 28, named DeamonPoke28.
Took 16.490372600004775/7.320013299999118 seconds in PokemonRedBlueWorld.create_regions for player 29, named DeamonPoke29.
Took 11.913644500004011/7.762926600000355 seconds in PokemonRedBlueWorld.create_regions for player 30, named DeamonPoke30.
Took 12.522948100006033/9.004914600001939 seconds in PokemonRedBlueWorld.create_regions for player 31, named DeamonPoke31.
Took 14.019620300001407/9.611287599997013 seconds in PokemonRedBlueWorld.create_regions for player 32, named DeamonPoke32.
```

## How was this tested?
Tests + Generations (32 Insanity ER run, 32 Full ER run, 32 Simple ER run, 32 No ER run, and my combined yaml for the big async.)

