### PR TITLE
Options: set old options api before the world is created

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -227,8 +227,8 @@ class MultiWorld():
 
     def set_options(self, args: Namespace) -> None:
         # TODO - remove this section once all worlds use options dataclasses
-        all_keys = {key for player in self.player_ids for key in
-                    AutoWorld.AutoWorldRegister.world_types[self.game[player]].options_dataclass.type_hints}
+        all_keys: Set[str] = {key for player in self.player_ids for key in
+                              AutoWorld.AutoWorldRegister.world_types[self.game[player]].options_dataclass.type_hints}
         for option_key in all_keys:
             option = Utils.DeprecateDict(f"Getting options from multiworld is now deprecated. "
                                          f"Please use `self.options.{option_key}` instead.")

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -232,6 +232,9 @@ class MultiWorld():
             # TODO - remove this loop once all worlds use options dataclasses
             for option_key in world_type.options_dataclass.type_hints:
                 option_values = getattr(args, option_key, {})
+                if getattr(self, option_key, None) is None:
+                    self.option_key = Utils.DeprecateDict(f"Getting options from multiworld is now deprecated. "
+                                                          f"Please use `self.options.{option_key}` instead.")
                 setattr(self, option_key, option_values)
             self.worlds[player] = world_type(self, player)
             self.worlds[player].random = self.per_slot_randoms[player]

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -226,18 +226,21 @@ class MultiWorld():
                                  range(1, self.players + 1)}
 
     def set_options(self, args: Namespace) -> None:
+        # TODO - remove this section once all worlds use options dataclasses
+        all_keys = {key for player in self.player_ids for key in
+                    AutoWorld.AutoWorldRegister.world_types[self.game[player]].options_dataclass.type_hints}
+        for option_key in all_keys:
+            option = Utils.DeprecateDict(f"Getting options from multiworld is now deprecated. "
+                                         f"Please use `self.options.{option_key}` instead.")
+            option.update(getattr(args, option_key, {}))
+            setattr(self, option_key, option)
+
         for player in self.player_ids:
             self.custom_data[player] = {}
             world_type = AutoWorld.AutoWorldRegister.world_types[self.game[player]]
-            # TODO - remove this loop once all worlds use options dataclasses
-            for option_key in world_type.options_dataclass.type_hints:
-                option = Utils.DeprecateDict(f"Getting options from multiworld is now deprecated. "
-                                             f"Please use `self.options.{option_key}` instead.")
-                option.update(getattr(args, option_key, {}))
-                setattr(self, option_key, option)
             self.worlds[player] = world_type(self, player)
             self.worlds[player].random = self.per_slot_randoms[player]
-            options_dataclass: typing.Type[Options.PerGameCommonOptions] = self.worlds[player].options_dataclass
+            options_dataclass: typing.Type[Options.PerGameCommonOptions] = world_type.options_dataclass
             self.worlds[player].options = options_dataclass(**{option_key: getattr(args, option_key)[player]
                                                                for option_key in options_dataclass.type_hints})
 

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -233,9 +233,10 @@ class MultiWorld():
             for option_key in world_type.options_dataclass.type_hints:
                 option_values = getattr(args, option_key, {})
                 if getattr(self, option_key, None) is None:
-                    self.option_key = Utils.DeprecateDict(f"Getting options from multiworld is now deprecated. "
-                                                          f"Please use `self.options.{option_key}` instead.")
-                setattr(self, option_key, option_values)
+                    option = Utils.DeprecateDict(f"Getting options from multiworld is now deprecated. "
+                                                 f"Please use `self.options.{option_key}` instead.")
+                    option.update(option_values)
+                    setattr(self, option_key, option)
             self.worlds[player] = world_type(self, player)
             self.worlds[player].random = self.per_slot_randoms[player]
             options_dataclass: typing.Type[Options.PerGameCommonOptions] = self.worlds[player].options_dataclass

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -231,12 +231,10 @@ class MultiWorld():
             world_type = AutoWorld.AutoWorldRegister.world_types[self.game[player]]
             # TODO - remove this loop once all worlds use options dataclasses
             for option_key in world_type.options_dataclass.type_hints:
-                option_values = getattr(args, option_key, {})
-                if getattr(self, option_key, None) is None:
-                    option = Utils.DeprecateDict(f"Getting options from multiworld is now deprecated. "
-                                                 f"Please use `self.options.{option_key}` instead.")
-                    option.update(option_values)
-                    setattr(self, option_key, option)
+                option = Utils.DeprecateDict(f"Getting options from multiworld is now deprecated. "
+                                             f"Please use `self.options.{option_key}` instead.")
+                option.update(getattr(args, option_key, {}))
+                setattr(self, option_key, option)
             self.worlds[player] = world_type(self, player)
             self.worlds[player].random = self.per_slot_randoms[player]
             options_dataclass: typing.Type[Options.PerGameCommonOptions] = self.worlds[player].options_dataclass

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -229,12 +229,12 @@ class MultiWorld():
         for player in self.player_ids:
             self.custom_data[player] = {}
             world_type = AutoWorld.AutoWorldRegister.world_types[self.game[player]]
-            self.worlds[player] = world_type(self, player)
-            self.worlds[player].random = self.per_slot_randoms[player]
+            # TODO - remove this loop once all worlds use options dataclasses
             for option_key in world_type.options_dataclass.type_hints:
                 option_values = getattr(args, option_key, {})
                 setattr(self, option_key, option_values)
-                # TODO - remove this loop once all worlds use options dataclasses
+            self.worlds[player] = world_type(self, player)
+            self.worlds[player].random = self.per_slot_randoms[player]
             options_dataclass: typing.Type[Options.PerGameCommonOptions] = self.worlds[player].options_dataclass
             self.worlds[player].options = options_dataclass(**{option_key: getattr(args, option_key)[player]
                                                                for option_key in options_dataclass.type_hints})

--- a/Utils.py
+++ b/Utils.py
@@ -749,6 +749,25 @@ def deprecate(message: str):
     import warnings
     warnings.warn(message)
 
+
+class DeprecateDict(dict):
+    log_message: str
+    should_error: bool
+
+    def __init__(self, message, error: bool = False) -> None:
+        self.log_message = message
+        self.should_error = error
+        super().__init__()
+
+    def __getitem__(self, item: Any) -> Any:
+        if self.should_error:
+            deprecate(self.log_message)
+        else:
+            import warnings
+            warnings.warn(self.log_message)
+        return super().__getitem__(item)
+
+
 def _extend_freeze_support() -> None:
     """Extend multiprocessing.freeze_support() to also work on Non-Windows for spawn."""
     # upstream issue: https://github.com/python/cpython/issues/76327

--- a/Utils.py
+++ b/Utils.py
@@ -762,7 +762,7 @@ class DeprecateDict(dict):
     def __getitem__(self, item: Any) -> Any:
         if self.should_error:
             deprecate(self.log_message)
-        else:
+        elif __debug__:
             import warnings
             warnings.warn(self.log_message)
         return super().__getitem__(item)

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -67,6 +67,9 @@ class AutoWorldRegister(type):
         # create missing options_dataclass from legacy option_definitions
         # TODO - remove this once all worlds use options dataclasses
         if "options_dataclass" not in dct and "option_definitions" in dct:
+            # TODO - switch to deprecate after a version
+            from warnings import warn
+            warn("Assigning options through option_definitions is now deprecated. Use options_dataclass instead.")
             dct["options_dataclass"] = make_dataclass(f"{name}Options", dct["option_definitions"].items(),
                                                       bases=(PerGameCommonOptions,))
 

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -68,8 +68,8 @@ class AutoWorldRegister(type):
         # TODO - remove this once all worlds use options dataclasses
         if "options_dataclass" not in dct and "option_definitions" in dct:
             # TODO - switch to deprecate after a version
-            from warnings import warn
             if __debug__:
+                from warnings import warn
                 warn("Assigning options through option_definitions is now deprecated. Use options_dataclass instead.")
             dct["options_dataclass"] = make_dataclass(f"{name}Options", dct["option_definitions"].items(),
                                                       bases=(PerGameCommonOptions,))

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -69,7 +69,8 @@ class AutoWorldRegister(type):
         if "options_dataclass" not in dct and "option_definitions" in dct:
             # TODO - switch to deprecate after a version
             from warnings import warn
-            warn("Assigning options through option_definitions is now deprecated. Use options_dataclass instead.")
+            if __debug__:
+                warn("Assigning options through option_definitions is now deprecated. Use options_dataclass instead.")
             dct["options_dataclass"] = make_dataclass(f"{name}Options", dct["option_definitions"].items(),
                                                       bases=(PerGameCommonOptions,))
 


### PR DESCRIPTION
## What is this fixing or adding?
Old options API had options being set before worlds were created and some worlds relied on that. That behavior has been purposefully deprecated, but old API should still use it for back compat.

Also deprecates the old options API. these can be dropped and wait a version if *really* desired but we've already made the effort of making everyone aware and I'd prefer to properly deprecate it next version.

## How was this tested?
unit tests. Also very low risk.

## If this makes graphical changes, please attach screenshots.
