### PR TITLE
OoT: create and copy less useless data state

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -311,6 +311,10 @@ class MultiWorld():
         return tuple(player for player in self.player_ids if self.game[player] == game_name)
 
     @functools.lru_cache()
+    def get_game_groups(self, game_name: str) -> Tuple[int, ...]:
+        return tuple(group_id for group_id in self.groups if self.game[group_id] == game_name)
+
+    @functools.lru_cache()
     def get_game_worlds(self, game_name: str):
         return tuple(world for player, world in self.worlds.items() if
                      player not in self.groups and self.game[player] == game_name)

--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -43,7 +43,7 @@ i_o_limiter = threading.Semaphore(2)
 
 class OOTCollectionState(metaclass=AutoLogicRegister):
     def init_mixin(self, parent: MultiWorld):
-        oot_ids = parent.get_game_players(OOTWorld.game)
+        oot_ids = parent.get_game_players(OOTWorld.game) + parent.get_game_groups(OOTWorld.game)
         self.child_reachable_regions = {player: set() for player in oot_ids}
         self.adult_reachable_regions = {player: set() for player in oot_ids}
         self.child_blocked_connections = {player: set() for player in oot_ids}

--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -43,14 +43,14 @@ i_o_limiter = threading.Semaphore(2)
 
 class OOTCollectionState(metaclass=AutoLogicRegister):
     def init_mixin(self, parent: MultiWorld):
-        all_ids = parent.get_all_ids()
-        self.child_reachable_regions = {player: set() for player in all_ids}
-        self.adult_reachable_regions = {player: set() for player in all_ids}
-        self.child_blocked_connections = {player: set() for player in all_ids}
-        self.adult_blocked_connections = {player: set() for player in all_ids}
-        self.day_reachable_regions = {player: set() for player in all_ids}
-        self.dampe_reachable_regions = {player: set() for player in all_ids}
-        self.age = {player: None for player in all_ids}
+        oot_ids = parent.get_game_players(OOTWorld.game)
+        self.child_reachable_regions = {player: set() for player in oot_ids}
+        self.adult_reachable_regions = {player: set() for player in oot_ids}
+        self.child_blocked_connections = {player: set() for player in oot_ids}
+        self.adult_blocked_connections = {player: set() for player in oot_ids}
+        self.day_reachable_regions = {player: set() for player in oot_ids}
+        self.dampe_reachable_regions = {player: set() for player in oot_ids}
+        self.age = {player: None for player in oot_ids}
 
     def copy_mixin(self, ret) -> CollectionState:
         ret.child_reachable_regions = {player: copy.copy(self.child_reachable_regions[player]) for player in


### PR DESCRIPTION
## What is this fixing or adding?
Made a 300 world Factorio gen take 132 seconds instead of 160  seconds.

## How was this tested?
With 300 Factorio worlds

## If this makes graphical changes, please attach screenshots.
