### PR TITLE
Core: add a new API for an itempool counter

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -374,6 +374,7 @@ class MultiWorld():
             return cached.copy()
 
         ret = CollectionState(self)
+        self.update_itempool()
 
         for item in self.itempool:
             self.worlds[item.player].collect(ret, item)
@@ -414,6 +415,16 @@ class MultiWorld():
 
     def create_item(self, item_name: str, player: int) -> Item:
         return self.worlds[player].create_item(item_name)
+
+    def update_itempool(self) -> None:
+        updated_itempools = {player for player, world in self.worlds.items()
+                             if isinstance(getattr(world, "itempool", None), Counter) and world.itempool}
+        items_to_add = []
+        for player in updated_itempools:
+            items_to_add += [self.create_item(item, player)
+                             for item, count in self.worlds[player].itempool.items() for _ in range(count)]
+            self.worlds[player].itempool = Counter()
+        self.itempool += items_to_add
 
     def push_precollected(self, item: Item):
         self.precollected_items[item.player].append(item)

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -368,7 +368,7 @@ class MultiWorld():
             self._recache()
             return self._location_cache[location, player]
 
-    def get_all_state(self, use_cache: bool) -> CollectionState:
+    def get_all_state(self, use_cache: bool = True) -> CollectionState:
         cached = getattr(self, "_all_state", None)
         if use_cache and cached:
             return cached.copy()

--- a/Fill.py
+++ b/Fill.py
@@ -383,6 +383,17 @@ def distribute_early_items(world: MultiWorld,
 def distribute_items_restrictive(world: MultiWorld) -> None:
     fill_locations = sorted(world.get_unfilled_locations())
     world.random.shuffle(fill_locations)
+
+    # create remaining items to equal locations left
+    items_needed = {
+        player:
+            len([loc for loc in fill_locations if loc.player == player])
+            - len([item for item in world.itempool if item.player == player])
+        for player in world.player_ids
+    }
+    call_all(world, "create_filler_items", items_needed)
+    world.update_itempool()
+
     # get items to distribute
     itempool = sorted(world.itempool)
     world.random.shuffle(itempool)

--- a/Main.py
+++ b/Main.py
@@ -164,6 +164,11 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
             player: world.start_inventory_from_pool[player].value.copy() for player in world.player_ids}
         for player, items in depletion_pool.items():
             player_world: AutoWorld.World = world.worlds[player]
+            if isinstance(getattr(player_world, "itempool", None), collections.Counter):
+                for item, count in items.items():
+                    player_world.itempool[item] = max(player_world.itempool[item] - count, 0)
+                continue
+        # TODO remove when all worlds use new API
             for count in items.values():
                 for _ in range(count):
                     new_items.append(player_world.create_filler())
@@ -277,6 +282,8 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
     logger.info('Running Pre Main Fill.')
 
     AutoWorld.call_all(world, "pre_fill")
+
+    AutoWorld.call_all(world, "create_filler_items")
 
     logger.info(f'Filling the world with {len(world.itempool)} items.')
 

--- a/Main.py
+++ b/Main.py
@@ -283,8 +283,6 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
 
     AutoWorld.call_all(world, "pre_fill")
 
-    AutoWorld.call_all(world, "create_filler_items")
-
     logger.info(f'Filling the world with {len(world.itempool)} items.')
 
     if world.algorithm == 'flood':

--- a/test/bases.py
+++ b/test/bases.py
@@ -301,6 +301,7 @@ class WorldTestBase(unittest.TestCase):
             return self.multiworld.has_beaten_game(state, 1)
 
         with self.subTest("Game", game=self.game, seed=self.multiworld.seed):
+            self.multiworld.update_itempool()
             distribute_items_restrictive(self.multiworld)
             call_all(self.multiworld, "post_fill")
             self.assertTrue(fulfills_accessibility(), "Collected all locations, but can't beat the game.")

--- a/test/general/__init__.py
+++ b/test/general/__init__.py
@@ -4,7 +4,7 @@ from typing import Type, Tuple
 from BaseClasses import MultiWorld, CollectionState
 from worlds.AutoWorld import call_all, World
 
-gen_steps = ("generate_early", "create_regions", "create_items", "set_rules", "generate_basic", "pre_fill", "create_filler_items")
+gen_steps = ("generate_early", "create_regions", "create_items", "set_rules", "generate_basic", "pre_fill")
 
 
 def setup_solo_multiworld(world_type: Type[World], steps: Tuple[str, ...] = gen_steps) -> MultiWorld:

--- a/test/general/__init__.py
+++ b/test/general/__init__.py
@@ -4,7 +4,7 @@ from typing import Type, Tuple
 from BaseClasses import MultiWorld, CollectionState
 from worlds.AutoWorld import call_all, World
 
-gen_steps = ("generate_early", "create_regions", "create_items", "set_rules", "generate_basic", "pre_fill")
+gen_steps = ("generate_early", "create_regions", "create_items", "set_rules", "generate_basic", "pre_fill", "create_filler_items")
 
 
 def setup_solo_multiworld(world_type: Type[World], steps: Tuple[str, ...] = gen_steps) -> MultiWorld:
@@ -13,7 +13,7 @@ def setup_solo_multiworld(world_type: Type[World], steps: Tuple[str, ...] = gen_
     
     :param world_type: Type of the world to generate a multiworld for
     :param steps: The gen steps that should be called on the generated multiworld before returning. Default calls
-    steps through pre_fill
+    steps through create_filler_items
     """
     multiworld = MultiWorld(1)
     multiworld.game[1] = world_type.game

--- a/test/general/test_items.py
+++ b/test/general/test_items.py
@@ -1,5 +1,5 @@
 import unittest
-from worlds.AutoWorld import AutoWorldRegister
+from worlds.AutoWorld import AutoWorldRegister, call_all
 from . import setup_solo_multiworld
 
 
@@ -47,6 +47,9 @@ class TestBase(unittest.TestCase):
         for game_name, world_type in AutoWorldRegister.world_types.items():
             with self.subTest("Game", game=game_name):
                 multiworld = setup_solo_multiworld(world_type)
+                call_all(multiworld, "create_filler_items",
+                         {1: len(multiworld.get_unfilled_locations(1)) - len(multiworld.itempool)})
+                multiworld.update_itempool()
                 self.assertGreaterEqual(
                     len(multiworld.itempool),
                     len(multiworld.get_unfilled_locations()),

--- a/worlds/messenger/test/test_shop.py
+++ b/worlds/messenger/test/test_shop.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Optional
 
 from . import MessengerTestBase
 from ..shop import SHOP_ITEMS, FIGURINES
@@ -9,6 +9,12 @@ class ShopCostTest(MessengerTestBase):
         "shop_price": "random",
         "shuffle_shards": "true",
     }
+
+    def world_setup(self, seed: Optional[int] = None) -> None:
+        super().world_setup(seed)
+        self.multiworld.worlds[self.player].create_filler_items(
+            len(self.multiworld.get_unfilled_locations()) - len(self.multiworld.itempool))
+        self.multiworld.update_itempool()
 
     def test_shop_rules(self) -> None:
         for loc in SHOP_ITEMS:
@@ -69,7 +75,7 @@ class ShopCostMinTest(ShopCostTest):
         pass
 
 
-class PlandoTest(MessengerTestBase):
+class PlandoTest(ShopCostTest):
     options = {
         "shop_price_plan": {
             "Karuta Plates": 50,
@@ -109,3 +115,6 @@ class PlandoTest(MessengerTestBase):
                 self.assertLessEqual(price, self.multiworld.get_location(loc, self.player).cost)
                 self.assertTrue(loc in FIGURINES)
         self.assertEqual(len(figures), len(FIGURINES))
+
+    def test_dboost(self) -> None:
+        pass


### PR DESCRIPTION
## What is this fixing or adding?
A new API where the World will create a `self.itempool: Counter[str]` instead of creating item objects and adding them to the multiworld itempool. Also adds a `create_filler_items` step where the amount of items still needed for that particular world is passed. This step takes place after plando and pre_fill, to give an accurate count, with the itempool being refreshed just before. 
This is currently lacking using the counter in reference for plando, and the items are being created as soon as the world's create_items is done so that state can collect them as necessary.

## How was this tested?
Moved messenger over to it and did some generations and ran unit tests

## If this makes graphical changes, please attach screenshots.
