### PR TITLE
RoR2: update options

### DIFF
--- a/worlds/ror2/Options.py
+++ b/worlds/ror2/Options.py
@@ -16,7 +16,7 @@ class Goal(Choice):
     display_name = "Game Mode"
     option_classic = 0
     option_explore = 1
-    default = 0
+    default = 1
 
 
 class TotalLocations(Range):
@@ -48,7 +48,8 @@ class ScavengersPerEnvironment(Range):
     display_name = "Scavenger per Environment"
     range_start = 0
     range_end = 1
-    default = 1
+    default = 0
+
 
 class ScannersPerEnvironment(Range):
     """Explore Mode: The number of scanners locations per environment."""

--- a/worlds/ror2/Options.py
+++ b/worlds/ror2/Options.py
@@ -57,12 +57,14 @@ class ScannersPerEnvironment(Range):
     range_end = 1
     default = 1
 
+
 class AltarsPerEnvironment(Range):
     """Explore Mode: The number of altars locations per environment."""
     display_name = "Newts Per Environment"
     range_start = 0
     range_end = 2
     default = 1
+
 
 class TotalRevivals(Range):
     """Total Percentage of `Dio's Best Friend` item put in the item pool."""
@@ -82,6 +84,7 @@ class ItemPickupStep(Range):
     range_start = 0
     range_end = 5
     default = 1
+
 
 class ShrineUseStep(Range):
     """
@@ -129,7 +132,6 @@ class DLC_SOTV(Toggle):
      Adds Void Items into the item pool
      """
     display_name = "Enable DLC - SOTV"
-
 
 
 class GreenScrap(Range):
@@ -274,25 +276,8 @@ class ItemWeights(Choice):
     option_void = 9
 
 
-
-
-# define a class for the weights of the generated item pool.
 @dataclass
-class ROR2Weights:
-    green_scrap: GreenScrap
-    red_scrap: RedScrap
-    yellow_scrap: YellowScrap
-    white_scrap: WhiteScrap
-    common_item: CommonItem
-    uncommon_item: UncommonItem
-    legendary_item: LegendaryItem
-    boss_item: BossItem
-    lunar_item: LunarItem
-    void_item: VoidItem
-    equipment: Equipment
-
-@dataclass
-class ROR2Options(PerGameCommonOptions, ROR2Weights):
+class ROR2Options(PerGameCommonOptions):
     goal: Goal
     total_locations: TotalLocations
     chests_per_stage: ChestsPerEnvironment
@@ -311,3 +296,15 @@ class ROR2Options(PerGameCommonOptions, ROR2Weights):
     enable_lunar: AllowLunarItems
     item_weights: ItemWeights
     item_pool_presets: ItemPoolPresetToggle
+    # define  the weights of the generated item pool.
+    green_scrap: GreenScrap
+    red_scrap: RedScrap
+    yellow_scrap: YellowScrap
+    white_scrap: WhiteScrap
+    common_item: CommonItem
+    uncommon_item: UncommonItem
+    legendary_item: LegendaryItem
+    boss_item: BossItem
+    lunar_item: LunarItem
+    void_item: VoidItem
+    equipment: Equipment

--- a/worlds/ror2/Options.py
+++ b/worlds/ror2/Options.py
@@ -297,7 +297,7 @@ class ROR2Options(PerGameCommonOptions):
     enable_lunar: AllowLunarItems
     item_weights: ItemWeights
     item_pool_presets: ItemPoolPresetToggle
-    # define  the weights of the generated item pool.
+    # define the weights of the generated item pool.
     green_scrap: GreenScrap
     red_scrap: RedScrap
     yellow_scrap: YellowScrap


### PR DESCRIPTION

## What is this fixing or adding?
With the new options I didn't notice that the item weights got moved to the beginning of the settings and I'd rather them be at the end.
This also changes the default game mode to explore, and turns scavengers off by default.

## How was this tested?
Ran Webhost

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/19377912/7c4df729-b9a8-45b6-9b93-93ed31f57c14)
