### PR TITLE
Core: fix some memory leak sources

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -303,15 +303,12 @@ class MultiWorld():
     def player_ids(self) -> Tuple[int, ...]:
         return tuple(range(1, self.players + 1))
 
-    @functools.lru_cache()
     def get_game_players(self, game_name: str) -> Tuple[int, ...]:
         return tuple(player for player in self.player_ids if self.game[player] == game_name)
 
-    @functools.lru_cache()
     def get_game_groups(self, game_name: str) -> Tuple[int, ...]:
         return tuple(group_id for group_id in self.groups if self.game[group_id] == game_name)
 
-    @functools.lru_cache()
     def get_game_worlds(self, game_name: str):
         return tuple(world for player, world in self.worlds.items() if
                      player not in self.groups and self.game[player] == game_name)

--- a/Generate.py
+++ b/Generate.py
@@ -7,8 +7,8 @@ import random
 import string
 import urllib.parse
 import urllib.request
-from collections import ChainMap, Counter
-from typing import Any, Callable, Dict, Tuple, Union
+from collections import Counter
+from typing import Any, Dict, Tuple, Union
 
 import ModuleUpdate
 
@@ -225,7 +225,7 @@ def main(args=None, callback=ERmain):
         with open(os.path.join(args.outputpath if args.outputpath else ".", f"generate_{seed_name}.yaml"), "wt") as f:
             yaml.dump(important, f)
 
-    callback(erargs, seed)
+    return callback(erargs, seed)
 
 
 def read_weights_yamls(path) -> Tuple[Any, ...]:
@@ -639,6 +639,10 @@ def roll_alttp_settings(ret: argparse.Namespace, weights, plando_options):
 if __name__ == '__main__':
     import atexit
     confirmation = atexit.register(input, "Press enter to close.")
-    main()
+    multiworld = main()
+    import weakref
+    weak = weakref.ref(multiworld)
+    del multiworld
+    assert not weak(), "Multiworld object was not de-allocated. This would be a memory leak."
     # in case of error-free exit should not need confirmation
     atexit.unregister(confirmation)


### PR DESCRIPTION
## What is this fixing or adding?
removes 3 eternal bindings to multiworld, which keeps the whole thing in memory. found  via  gc.get_referrers which pointed directly at functools.lru_cache. There is more still binding the multiworld though, but the referrers output is not giving me enough of a hint to find them.

## How was this tested?
There's a new assert
