### PR TITLE
Core: limit perf logger to 4 post-point places

### DIFF
--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -113,10 +113,10 @@ def _timed_call(method: Callable[..., Any], *args: Any,
     taken = time.perf_counter() - start
     if taken > 1.0:
         if player and multiworld:
-            perf_logger.info(f"Took {taken} seconds in {method.__qualname__} for player {player}, "
+            perf_logger.info(f"Took {taken:.4f} seconds in {method.__qualname__} for player {player}, "
                              f"named {multiworld.player_name[player]}.")
         else:
-            perf_logger.info(f"Took {taken} seconds in {method.__qualname__}.")
+            perf_logger.info(f"Took {taken:.4f} seconds in {method.__qualname__}.")
     return ret
 
 


### PR DESCRIPTION
## What is this fixing or adding?
limit perf logger to 4 post-point places
I meant to do that, but kind of forgot.

## How was this tested?
nope

## If this makes graphical changes, please attach screenshots.
