### PR TITLE
Fix weighted-settings page

### DIFF
--- a/WebHostLib/static/assets/weighted-options.js
+++ b/WebHostLib/static/assets/weighted-options.js
@@ -43,7 +43,7 @@ const resetSettings = () => {
 };
 
 const fetchSettingData = () => new Promise((resolve, reject) => {
-  fetch(new Request(`${window.location.origin}/static/generated/weighted-settings.json`)).then((response) => {
+  fetch(new Request(`${window.location.origin}/static/generated/weighted-options.json`)).then((response) => {
     try{ response.json().then((jsonObj) => resolve(jsonObj)); }
     catch(error){ reject(error); }
   });


### PR DESCRIPTION
## What is this fixing or adding?

The request for the JSON file that provides the setting data was missed during the rename in #2037, so prior to this the weighted settings page wasn't rendering at all.

## How was this tested?

I visited the weighted-settings page before and after.