### PR TITLE
OoT: fix enhanced_map_compass generation failure

### DIFF
--- a/worlds/oot/Patches.py
+++ b/worlds/oot/Patches.py
@@ -2182,7 +2182,7 @@ def patch_rom(world, rom):
             'Shadow Temple':      ("the \x05\x45Shadow Temple",      'Bongo Bongo',   0x7f, 0xa3),
         }
         for dungeon in world.dungeon_mq:
-            if dungeon in ['Gerudo Training Ground', 'Ganons Castle']:
+            if dungeon in ['Thieves Hideout', 'Gerudo Training Ground', 'Ganons Castle']:
                 pass
             elif dungeon in ['Bottom of the Well', 'Ice Cavern']:
                 dungeon_name, boss_name, compass_id, map_id = dungeon_list[dungeon]


### PR DESCRIPTION
99 bugs on the wall
take one down, patch it around
99 bugs on the wall

(this is caused by a fix that allowed you to start with thieves hideout keys, which broke the only place that the variable is blindly iterated over, hidden by one setting)