### PR TITLE
MultiServer: Create read-only data storage key for client statuses.

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import copy
 import collections
+import copy
 import datetime
 import functools
 import hashlib
@@ -412,6 +412,8 @@ class Context:
             self.player_name_lookup[slot_info.name] = 0, slot_id
             self.read_data[f"hints_{0}_{slot_id}"] = lambda local_team=0, local_player=slot_id: \
                 list(self.get_rechecked_hints(local_team, local_player))
+            self.read_data[f"client_status_{0}_{slot_id}"] = lambda local_team=0, local_player=slot_id: \
+                self.client_game_state[local_team, local_player]
 
         self.seed_name = decoded_obj["seed_name"]
         self.random.seed(self.seed_name)
@@ -706,6 +708,12 @@ class Context:
             "cmd": "RoomUpdate",
             "hint_points": get_slot_points(self, team, slot)
         }])
+
+    def on_client_status_change(self, team: int, slot: int):
+        key: str = f"_read_client_status_{team}_{slot}"
+        targets: typing.Set[Client] = set(self.stored_data_notification_clients[key])
+        if targets:
+            self.broadcast(targets, [{"cmd": "SetReply", "key": key, "value": self.client_game_state[team, slot]}])
 
 
 def update_aliases(ctx: Context, team: int):
@@ -1814,6 +1822,7 @@ def update_client_status(ctx: Context, client: Client, new_status: ClientStatus)
             ctx.on_goal_achieved(client)
 
         ctx.client_game_state[client.team, client.slot] = new_status
+        ctx.on_client_status_change(client.team, client.slot)
         ctx.save()
 
 

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -380,11 +380,12 @@ Additional arguments sent in this package will also be added to the [Retrieved](
 
 Some special keys exist with specific return data, all of them have the prefix `_read_`, so `hints_{team}_{slot}` is `_read_hints_{team}_{slot}`.
 
-| Name                          | Type                     | Notes                                             |
-|-------------------------------|--------------------------|---------------------------------------------------|
-| hints_{team}_{slot}           | list\[[Hint](#Hint)\]    | All Hints belonging to the requested Player.      |
-| slot_data_{slot}              | dict\[str, any\]         | slot_data belonging to the requested slot.        |
-| item_name_groups_{game_name}  | dict\[str, list\[str\]\] | item_name_groups belonging to the requested game. |
+| Name                         | Type                          | Notes                                             |
+|------------------------------|-------------------------------|---------------------------------------------------|
+| hints_{team}_{slot}          | list\[[Hint](#Hint)\]         | All Hints belonging to the requested Player.      |
+| slot_data_{slot}             | dict\[str, any\]              | slot_data belonging to the requested slot.        |
+| item_name_groups_{game_name} | dict\[str, list\[str\]\]      | item_name_groups belonging to the requested game. |
+| client_status_{team}_{slot}  | [ClientStatus](#ClientStatus) | The current game status of the requested player.  |
 
 ### Set
 Used to write data to the server's data storage, that data can then be shared across worlds or just saved for later. Values for keys in the data storage can be retrieved with a [Get](#Get) package, or monitored with a [SetNotify](#SetNotify) package.
@@ -556,7 +557,7 @@ Color options:
 `player` marks owning player id for location/item, 
 `flags` contains the [NetworkItem](#NetworkItem) flags that belong to the item
 
-### Client States
+### ClientStatus
 An enumeration containing the possible client states that may be used to inform
 the server in [StatusUpdate](#StatusUpdate). The MultiServer automatically sets
 the client state to `ClientStatus.CLIENT_CONNECTED` on the first active connection


### PR DESCRIPTION
## What is this fixing or adding?
Implements a new read-only data storage key `_read_client_status_{team}_{slot}` which returns the `ClientStatus` of a particular slot. Also adds the relevant documentation.

## How was this tested?
Tested with a test client using Archipelago.js.

Retrieve:
![image](https://github.com/ArchipelagoMW/Archipelago/assets/11338376/e7148d09-d11d-4548-9c1e-20538a5996af)

SetNotify & StatusUpdate:
![image](https://github.com/ArchipelagoMW/Archipelago/assets/11338376/398ebba7-f40b-46f3-833f-76f84757e05d)
![image](https://github.com/ArchipelagoMW/Archipelago/assets/11338376/f5202f5a-bc5e-4e29-bea4-14351e4878c8)

SetNotify & StatusUpdate from another client, SetNotify event fired:
![image](https://github.com/ArchipelagoMW/Archipelago/assets/11338376/cfdf47d5-e541-4cc6-82ee-a4e4946489f9)

![image](https://github.com/ArchipelagoMW/Archipelago/assets/11338376/6f8f541f-2a0e-4dac-8dd8-90d289f8364c)

## If this makes graphical changes, please attach screenshots.
N/A