### PR TITLE
Generate: Add `--skip_output` flag to bypass assertion and output stages.

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -20,7 +20,7 @@ import Options
 from BaseClasses import seeddigits, get_seed, PlandoOptions
 from Main import main as ERmain
 from settings import get_settings
-from Utils import parse_yamls, version_tuple, __version__, tuplize_version, user_path
+from Utils import parse_yamls, version_tuple, __version__, tuplize_version
 from worlds.alttp import Options as LttPOptions
 from worlds.alttp.EntranceRandomizer import parse_arguments
 from worlds.alttp.Text import TextTable
@@ -53,6 +53,9 @@ def mystery_argparse():
                         help='List of options that can be set manually. Can be combined, for example "bosses, items"')
     parser.add_argument("--skip_prog_balancing", action="store_true",
                         help="Skip progression balancing step during generation.")
+    parser.add_argument("--skip_output", action="store_true",
+                        help="Skips generation assertion and output stages and skips multidata and spoiler output. "
+                             "Intended for debugging and testing purposes.")
     args = parser.parse_args()
     if not os.path.isabs(args.weights_file_path):
         args.weights_file_path = os.path.join(args.player_files_path, args.weights_file_path)
@@ -143,6 +146,7 @@ def main(args=None, callback=ERmain):
     erargs.outputname = seed_name
     erargs.outputpath = args.outputpath
     erargs.skip_prog_balancing = args.skip_prog_balancing
+    erargs.skip_output = args.skip_output
 
     settings_cache: Dict[str, Tuple[argparse.Namespace, ...]] = \
         {fname: (tuple(roll_settings(yaml, args.plando) for yaml in yamls) if args.samesettings else None)

--- a/Main.py
+++ b/Main.py
@@ -13,8 +13,8 @@ import worlds
 from BaseClasses import CollectionState, Item, Location, LocationProgressType, MultiWorld, Region
 from Fill import balance_multiworld_progression, distribute_items_restrictive, distribute_planned, flood_items
 from Options import StartInventoryPool
-from settings import get_settings
 from Utils import __version__, output_path, version_tuple
+from settings import get_settings
 from worlds import AutoWorld
 from worlds.generic.Rules import exclusion_rules, locality_rules
 
@@ -101,7 +101,9 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
 
     del item_digits, location_digits, item_count, location_count
 
-    AutoWorld.call_stage(world, "assert_generate")
+    # This assertion method should not be necessary to run if we are not outputting any multidata.
+    if not args.skip_output:
+        AutoWorld.call_stage(world, "assert_generate")
 
     AutoWorld.call_all(world, "generate_early")
 
@@ -287,11 +289,14 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
     else:
         logger.info("Progression balancing skipped.")
 
-    logger.info(f'Beginning output...')
-
     # we're about to output using multithreading, so we're removing the global random state to prevent accidental use
     world.random.passthrough = False
 
+    if args.skip_output:
+        logger.info('Done. Skipped output/spoiler generation. Total Time: %s', time.perf_counter() - start)
+        return world
+
+    logger.info(f'Beginning output...')
     outfilebase = 'AP_' + world.seed_name
 
     output = tempfile.TemporaryDirectory()

--- a/WebHostLib/generate.py
+++ b/WebHostLib/generate.py
@@ -1,18 +1,18 @@
+import concurrent.futures
 import json
 import os
 import pickle
 import random
 import tempfile
 import zipfile
-import concurrent.futures
 from collections import Counter
-from typing import Dict, Optional, Any, Union, List
+from typing import Any, Dict, List, Optional, Union
 
-from flask import request, flash, redirect, url_for, session, render_template
+from flask import flash, redirect, render_template, request, session, url_for
 from pony.orm import commit, db_session
 
-from BaseClasses import seeddigits, get_seed
-from Generate import handle_name, PlandoOptions
+from BaseClasses import get_seed, seeddigits
+from Generate import PlandoOptions, handle_name
 from Main import main as ERmain
 from Utils import __version__
 from WebHostLib import app
@@ -131,6 +131,7 @@ def gen_game(gen_options: dict, meta: Optional[Dict[str, Any]] = None, owner=Non
         erargs.plando_options = PlandoOptions.from_set(meta.setdefault("plando_options",
                                                                        {"bosses", "items", "connections", "texts"}))
         erargs.skip_prog_balancing = False
+        erargs.skip_output = False
 
         name_counter = Counter()
         for player, (playerfile, settings) in enumerate(gen_options.items(), 1):


### PR DESCRIPTION
## What is this fixing or adding?
Adds a flag, `--skip_output`, intended for testing/debugging multiworld generation without running output stages. Also skips `assert_generate` stages as ROM output is not required.

`Generate.py --help` output:
```yaml
> python .\Generate.py --help             
[...]

options:
  [...]
  --skip_output         Skips generation assertion and output stages and skips multidata and spoiler output. Intended for debugging and testing purposes.
```

## How was this tested?
Ran test generation with default templates of all games currently in `main`, excluding `Archipelago` and `Sudoku`.

```yaml
> python .\Generate.py --skip_output

Archipelago (0.4.3) logging initialized on Windows-10-10.0.22621-SP0 running Python 3.11.4
[...]
Generating for 47 players, 97632999143129170817 Seed 16052371818855632864 with plando: items, connections, texts, bosses
Archipelago Version 0.4.3  -  Seed: 16052371818855632864

Found 50 World Types:
[...]

Creating World.
Creating Items.
Calculating Access Rules.
Running Item Plando
Running Pre Main Fill.
Took 1.7550411999982316 seconds in LinksAwakeningWorld.pre_fill for player 16, named Player16.
Took 4.4173094000143465 seconds in OOTWorld.pre_fill for player 23, named Player23.
Took 1.0802717999904417 seconds in SMZ3World.pre_fill for player 29, named Player29.
Took 1.0498637999990024 seconds in ALTTPWorld.stage_pre_fill.
Filling the world with 6730 items.
Current fill step (Progression) at 1000/2343 items placed.
Current fill step (Progression) at 2000/2343 items placed.
Current fill step (Progression) at 2343/2343 items placed.
Current fill step (Remaining) at 1000/4089 items placed.
Current fill step (Remaining) at 2000/4089 items placed.
Current fill step (Remaining) at 3000/4089 items placed.
Current fill step (Remaining) at 4000/4089 items placed.
Current fill step (Remaining) at 4089/4089 items placed.
Balancing multiworld progression for 47 Players.
Done. Skipped output/spoiler generation. Total Time: 153.442778800003
```

## If this makes graphical changes, please attach screenshots.
N/A