### PR TITLE
SM: fix missed SMWorld.spheres in #2400

### DIFF
--- a/worlds/sm/__init__.py
+++ b/worlds/sm/__init__.py
@@ -389,7 +389,7 @@ class SMWorld(World):
         escapeTrigger = None
         if self.variaRando.randoExec.randoSettings.restrictions["EscapeTrigger"]:
             #used to simulate received items
-            first_local_collected_loc = next(itemLoc for itemLoc in SMWorld.spheres if itemLoc.player == self.player)
+            first_local_collected_loc = next(itemLoc for itemLoc in spheres if itemLoc.player == self.player)
 
             playerItemsItemLocs = get_player_ItemLocation(False)
             playerProgItemsItemLocs = get_player_ItemLocation(True)


### PR DESCRIPTION
## What is this fixing or adding?

In #2400 i failed to update one of the lines that accessSMWorld.spheres. This PR fixes that by updating the missed line.

## How was this tested?

Generating with [this yaml](https://discord.com/channels/731205301247803413/1169643213787779212/1169643213787779212) and a couple of random yamls and not seeing the error anymore.