### PR TITLE
Factorio: inflate location pool

### DIFF
--- a/worlds/factorio/Locations.py
+++ b/worlds/factorio/Locations.py
@@ -3,18 +3,13 @@ from typing import Dict, List
 from .Technologies import factorio_base_id
 from .Options import MaxSciencePack
 
-boundary: int = 0xff
-total_locations: int = 0xff
-
-assert total_locations <= boundary
-
 
 def make_pools() -> Dict[str, List[str]]:
     pools: Dict[str, List[str]] = {}
     for i, pack in enumerate(MaxSciencePack.get_ordered_science_packs(), start=1):
-        max_needed: int = 0xff
+        max_needed: int = 999
         prefix: str = f"AP-{i}-"
-        pools[pack] = [prefix + hex(x)[2:].upper().zfill(2) for x in range(1, max_needed + 1)]
+        pools[pack] = [prefix + str(x).upper().zfill(3) for x in range(1, max_needed + 1)]
     return pools
 
 

--- a/worlds/factorio/__init__.py
+++ b/worlds/factorio/__init__.py
@@ -541,7 +541,7 @@ class FactorioScienceLocation(FactorioLocation):
         super(FactorioScienceLocation, self).__init__(player, name, address, parent)
         # "AP-{Complexity}-{Cost}"
         self.complexity = int(self.name[3]) - 1
-        self.rel_cost = int(self.name[5:], 16)
+        self.rel_cost = int(self.name[5:])
 
         self.ingredients = {Factorio.ordered_science_packs[self.complexity]: 1}
         for complexity in range(self.complexity):


### PR DESCRIPTION
## What is this fixing or adding?
Gives almost 1000 locations per science pack.
I've received the occasional bug report of failed gens when  using max traps with red science. I don't understand why people do it, but now they can. It also switched from hex to dec, which  seemed  to have confused some people.

## How was this tested?
sending and receiving some Factorio stuff

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/3189725/dbb3f6fe-0c70-4638-9d39-70fea0ff8980)
