### PR TITLE
Core: check that only unsendable items are on unsendable locations

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -295,7 +295,7 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
     outfilebase = 'AP_' + world.seed_name
 
     output = tempfile.TemporaryDirectory()
-    with output as temp_dir:
+    with (output as temp_dir):
         output_players = [player for player in world.player_ids if AutoWorld.World.generate_output.__code__
                           is not world.worlds[player].generate_output.__code__]
         with concurrent.futures.ThreadPoolExecutor(len(output_players) + 2) as pool:
@@ -363,6 +363,9 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
                         elif any([location.item.name in world.worlds[player].options.start_hints
                                   for player in world.groups.get(location.item.player, {}).get("players", [])]):
                             precollect_hint(location)
+                    elif __debug__ and location.item.code is not None:
+                        raise Exception(f"Intended to be sendable item {location.item}, "
+                                        f"was placed on never sendable location {location} of {location.game}.")
 
                 # embedded data package
                 data_package = {

--- a/worlds/alttp/ItemPool.py
+++ b/worlds/alttp/ItemPool.py
@@ -313,6 +313,7 @@ def generate_itempool(world):
     for location_name, event_name in event_pairs:
         location = multiworld.get_location(location_name, player)
         event = ItemFactory(event_name, player)
+        event.code = None
         multiworld.push_item(location, event, False)
         location.event = location.locked = True
 

--- a/worlds/alttp/Regions.py
+++ b/worlds/alttp/Regions.py
@@ -447,7 +447,6 @@ def mark_light_world_regions(world, player: int):
                 queue.append(exit.connected_region)
 
 
-
 old_location_address_to_new_location_address = {
     0x2eb18: 0x18001b,   # Bottle Merchant
     0x33d68: 0x18001a,   # Purple Chest


### PR DESCRIPTION
## What is this fixing or adding?
check that only unsendable items are on unsendable locations

## How was this tested?
With Factorio and Subnautica, which worked fine, and LttP which currently breaks on keydropshuffle specialties. If we want this, we should let Alchav know, as I did not find where this is even defined on cursory look.

## If this makes graphical changes, please attach screenshots.
