### PR TITLE
Lingo: Removed "Reached" event items

### DIFF
--- a/worlds/lingo/player_logic.py
+++ b/worlds/lingo/player_logic.py
@@ -79,12 +79,6 @@ class LingoPlayerLogic:
             raise Exception("You cannot have reduced location checks when door shuffle is on, because there would not "
                             "be enough locations for all of the door items.")
 
-        # Create an event for every room that represents being able to reach that room.
-        for room_name in ROOMS.keys():
-            roomloc_name = f"{room_name} (Reached)"
-            self.add_location(room_name, PlayerLocation(roomloc_name, None, []))
-            self.EVENT_LOC_TO_ITEM[roomloc_name] = roomloc_name
-
         # Create an event for every door, representing whether that door has been opened. Also create event items for
         # doors that are event-only.
         for room_name, room_data in DOORS_BY_ROOM.items():

--- a/worlds/lingo/rules.py
+++ b/worlds/lingo/rules.py
@@ -66,7 +66,7 @@ def _lingo_can_solve_panel(state: CollectionState, start_room: str, room: str, p
     """
     Determines whether a panel can be solved
     """
-    if start_room != room and not state.has(f"{room} (Reached)", world.player):
+    if start_room != room and not state.can_reach(room, "Region", world.player):
         return False
 
     if room == "Second Room" and panel == "ANOTHER TRY" \
@@ -76,7 +76,7 @@ def _lingo_can_solve_panel(state: CollectionState, start_room: str, room: str, p
 
     panel_object = PANELS_BY_ROOM[room][panel]
     for req_room in panel_object.required_rooms:
-        if not state.has(f"{req_room} (Reached)", world.player):
+        if not state.can_reach(req_room, "Region", world.player):
             return False
 
     for req_door in panel_object.required_doors:


### PR DESCRIPTION
## What is this fixing or adding?

I have been told that it is safe to use state.can_reach for Regions within the access rules of a Location (not an Entrance). Previously, I was using event items to determine whether a room had been reached within a Location access rule, but I've removed those items and switched to using state.can_reach. This has resulted in a 70-80% speedup in single world generations.

## How was this tested?

I ran multiple generations with 100 Lingo worlds, which succeeded (and there was a marked speedup in them).


## If this makes graphical changes, please attach screenshots.
