### PR TITLE
core: fix item/location descriptions test

### DIFF
--- a/test/bases.py
+++ b/test/bases.py
@@ -333,24 +333,3 @@ class WorldTestBase(unittest.TestCase):
             placed_items = [loc.item for loc in self.multiworld.get_locations() if loc.item and loc.item.code]
             self.assertLessEqual(len(self.multiworld.itempool), len(placed_items),
                                  "Unplaced Items remaining in itempool")
-
-    def test_descriptions_have_valid_names(self):
-        """Ensure all item and location descriptions match a name of the corresponding type"""
-        if not (self.run_default_tests and self.constructed):
-            return
-        with self.subTest("Game", game=self.game):
-            with self.subTest("Items"):
-                world = self.multiworld.worlds[1]
-                valid_names = world.item_names.union(world.item_name_groups)
-                for name in world.item_descriptions.keys():
-                    with self.subTest("Name should be valid", name=name):
-                        self.assertIn(name, valid_names,
-                                      """All item descriptions must match defined item names""")
-
-            with self.subTest("Locations"):
-                world = self.multiworld.worlds[1]
-                valid_names = world.location_names.union(world.location_name_groups)
-                for name in world.location_descriptions.keys():
-                    with self.subTest("Name should be valid", name=name):
-                        self.assertIn(name, valid_names,
-                                      """All item descriptions must match defined item names""")

--- a/test/general/test_items.py
+++ b/test/general/test_items.py
@@ -60,3 +60,12 @@ class TestBase(unittest.TestCase):
                 multiworld = setup_solo_multiworld(world_type)
                 for item in multiworld.itempool:
                     self.assertIn(item.name, world_type.item_name_to_id)
+
+    def test_item_descriptions_have_valid_names(self):
+        """Ensure all item descriptions match an item name or item group name"""
+        for game_name, world_type in AutoWorldRegister.world_types.items():
+            valid_names = world_type.item_names.union(world_type.item_name_groups)
+            for name in world_type.item_descriptions:
+                with self.subTest("Name should be valid", game=game_name, item=name):
+                    self.assertIn(name, valid_names,
+                                  "All item descriptions must match defined item names")

--- a/test/general/test_locations.py
+++ b/test/general/test_locations.py
@@ -66,3 +66,12 @@ class TestBase(unittest.TestCase):
                         for location in locations:
                             self.assertIn(location, world_type.location_name_to_id)
                         self.assertNotIn(group_name, world_type.location_name_to_id)
+
+    def test_location_descriptions_have_valid_names(self):
+        """Ensure all location descriptions match a location name or location group name"""
+        for game_name, world_type in AutoWorldRegister.world_types.items():
+            valid_names = world_type.location_names.union(world_type.location_name_groups)
+            for name in world_type.location_descriptions:
+                with self.subTest("Name should be valid", game=game_name, location=name):
+                    self.assertIn(name, valid_names,
+                                  "All location descriptions must match defined location names")


### PR DESCRIPTION
## What is this fixing or adding?

As part of #2409, `test_descriptions_have_valid_names` was added to `WorldTestBase`. The implementation has various disadvantages:
- The identical test is run over and over again, once for every non-default world test class.
- The test does not run at all for worlds that do not define any non-default world test classes.
- (The test creates a world instance and runs various generation steps, even though the behavior being tested is that of the world type.)

This PR removes the descriptions test from bases.py and adds two new tests, in test\_items.py and test\_locations.py, which test all registered world types while not creating any multiworlds or world instances.

## How was this tested?

- Observed that the number of tests discovered by pytest goes down by about 150 when switching to the new tests.
- Verified that adding a description for an invalid item or location fails one of the new tests, even if being added on a world that has zero world-specific tests.