### PR TITLE
Setup: fix orjson import on frozen py3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -620,7 +620,7 @@ cx_Freeze.setup(
             "excludes": ["numpy", "Cython", "PySide2", "PIL",
                          "pandas"],
             "zip_include_packages": ["*"],
-            "zip_exclude_packages": ["worlds", "sc2"],
+            "zip_exclude_packages": ["worlds", "sc2", "orjson"],  # TODO: remove orjson here once we drop py3.8 support
             "include_files": [],  # broken in cx 6.14.0, we use more special sauce now
             "include_msvcr": False,
             "replace_paths": ["*."],


### PR DESCRIPTION
orjson has a .py entry point that imports `from .orjson` (from the DLL), which does not work on 3.8 if the DLL is not in the same folder as the .py. The changed import system in 3.9+ seems to allow this. Excluding it from libraries.zip will put both files into the same folder.