### PR TITLE
WebHost/World: Use `location_descriptions` in more places

### DIFF
--- a/WebHostLib/static/styles/tablepage.css
+++ b/WebHostLib/static/styles/tablepage.css
@@ -34,3 +34,8 @@ table.dataTable tbody tr{
 table.dataTable tbody tr:hover{
     /* background-color: #e2eabb; */
 }
+
+.table-wrapper{
+    overflow: auto;
+    margin-bottom: 1rem;
+}

--- a/WebHostLib/static/styles/tracker.css
+++ b/WebHostLib/static/styles/tracker.css
@@ -13,10 +13,9 @@
     cursor: pointer;
 }
 
-.table-wrapper{
-    overflow-y: auto;
-    overflow-x: auto;
-    margin-bottom: 1rem;
+#tracker-wrapper .table-wrapper{
+    /* Necessary so location descriptions aren't cut off. */
+    overflow: visible;
 }
 
 #tracker-header-bar{
@@ -66,6 +65,10 @@ table.dataTable tbody tr:hover, table.dataTable tfoot tr:hover{
 
 table.dataTable tbody td, table.dataTable tfoot td{
     padding: 4px 6px;
+}
+
+table.dataTable .interactive{
+    color: rgb(47, 96, 0);
 }
 
 table.dataTable, table.dataTable.no-footer{

--- a/WebHostLib/templates/genericTracker.html
+++ b/WebHostLib/templates/genericTracker.html
@@ -45,15 +45,25 @@
                     </tr>
                     </thead>
                     <tbody>
-                        {% for name in checked_locations %}
+                        {% for id in checked_locations %}
                         <tr>
-                            <td>{{ name | location_name}}</td>
+                            <td>{{ id | location_name}}
+                              {%- if id | location_description %}
+                                <span class="interactive"
+                                      data-tooltip="{{ id | location_description }}">(?)</span>
+                              {%- endif %}
+                            </td>
                             <td>✔</td>
                         </tr>
                         {%- endfor -%}
-                        {% for name in not_checked_locations %}
+                        {% for id in not_checked_locations %}
                         <tr>
-                            <td>{{ name | location_name}}</td>
+                            <td>{{ id | location_name}}
+                              {%- if id | location_description %}
+                                <span class="interactive"
+                                      data-tooltip="{{ id | location_description }}">(?)</span>
+                              {%- endif %}
+                            </td>
                             <td></td>
                         </tr>
                         {%- endfor -%}

--- a/WebHostLib/tracker.py
+++ b/WebHostLib/tracker.py
@@ -11,7 +11,7 @@ from werkzeug.exceptions import abort
 from MultiServer import Context, get_saving_second
 from NetUtils import ClientStatus, SlotType, NetworkSlot
 from Utils import restricted_loads
-from worlds import lookup_any_item_id_to_name, lookup_any_location_id_to_name, network_data_package, games
+from worlds import lookup_any_item_id_to_name, lookup_any_location_id_to_description, lookup_any_location_id_to_name, network_data_package, games
 from worlds.alttp import Items
 from . import app, cache
 from .models import GameDataPackage, Room
@@ -235,12 +235,18 @@ def get_location_name(context: runtime.Context, loc: int) -> str:
 
 
 @pass_context
+def get_location_description(context: runtime.Context, loc: int) -> str:
+    return lookup_any_location_id_to_description.get(loc, None)
+
+
+@pass_context
 def get_item_name(context: runtime.Context, item: int) -> str:
     context_items = context.get("custom_items", {})
     return collections.ChainMap(context_items, lookup_any_item_id_to_name).get(item, item)
 
 
 app.jinja_env.filters["location_name"] = get_location_name
+app.jinja_env.filters["location_description"] = get_location_description
 app.jinja_env.filters["item_name"] = get_item_name
 
 

--- a/docs/world api.md
+++ b/docs/world api.md
@@ -124,9 +124,17 @@ required, and will prevent progression and useful items from being placed at exc
 #### Documenting Locations
 
 Worlds can optionally provide a `location_descriptions` map which contains
-human-friendly descriptions of locations or location groups. These descriptions
-will show up in location-selection options in the Weighted Options page. Extra
-indentation and single newlines will be collapsed into spaces.
+human-friendly descriptions of locations or location groups. Extra indentation
+and single newlines will be collapsed into spaces. These descriptions are used
+in various places:
+
+* They appear next to the location-selection options in the Weighted Options
+  page.
+
+* They appear next to locations on the built-in tracker page.
+
+* By default, they appear in location hints, although these can be customized by
+  overriding `World.extend_hint_information`.
 
 ```python
 # Locations.py

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -368,9 +368,21 @@ class World(metaclass=AutoWorldRegister):
         return {}
 
     def extend_hint_information(self, hint_data: Dict[int, Dict[int, str]]):
-        """Fill in additional entrance information text into locations, which is displayed when hinted.
-        structure is {player_id: {location_id: text}} You will need to insert your own player_id."""
-        pass
+        """Add additional information to display when locations are hinted.
+
+        The structure of hint_data is {player_id: {location_id: text}}. You will need to insert
+        your own player_id.
+
+        By default, if this world specifies location_descriptions, those are added for each location
+        ID. Otherwise, the hint_data is left unchanged.
+        """
+
+        if self.location_descriptions:
+            hint_data[self.player] = {
+                self.location_name_to_id[name]: description
+                for name, description in self.location_descriptions.items()
+                if name in self.location_name_to_id
+            }
 
     def modify_multidata(self, multidata: Dict[str, Any]) -> None:  # TODO: TypedDict for multidata?
         """For deeper modification of server multidata."""

--- a/worlds/__init__.py
+++ b/worlds/__init__.py
@@ -107,6 +107,7 @@ for world_source in world_sources:
 
 lookup_any_item_id_to_name = {}
 lookup_any_location_id_to_name = {}
+lookup_any_location_id_to_description = {}
 games: typing.Dict[str, GamesPackage] = {}
 
 from .AutoWorld import AutoWorldRegister  # noqa: E402
@@ -116,6 +117,11 @@ for world_name, world in AutoWorldRegister.world_types.items():
     games[world_name] = world.get_data_package_data()
     lookup_any_item_id_to_name.update(world.item_id_to_name)
     lookup_any_location_id_to_name.update(world.location_id_to_name)
+    lookup_any_location_id_to_description.update({
+        world.location_name_to_id[name]: description
+        for name, description in world.location_descriptions.items()
+        if name in world.location_name_to_id
+    })
 
 network_data_package: DataPackage = {
     "games": games,


### PR DESCRIPTION
## What is this fixing or adding?

Location descriptions are now automatically displayed on the generic
tracker and used to generate a default set of hint descriptions if
`extend_hint_information` isn't overridden.

## How was this tested?

I added a location description for Dark Souls III and manually tested
that it showed up on the tracker and in hints.

## If this makes graphical changes, please attach screenshots.

![image](https://github.com/ArchipelagoMW/Archipelago/assets/188/a750b2a4-6926-4466-9264-e330dce3f13b)