### PR TITLE
Wargroove: Fixed WargrooveClient retaining victory and location information and minor doc fix

### DIFF
--- a/WargrooveClient.py
+++ b/WargrooveClient.py
@@ -113,6 +113,9 @@ class WargrooveContext(CommonContext):
     async def connection_closed(self):
         await super(WargrooveContext, self).connection_closed()
         self.remove_communication_files()
+        self.checked_locations.clear()
+        self.server_locations.clear()
+        self.finished_game = False
 
     @property
     def endpoints(self):
@@ -124,6 +127,9 @@ class WargrooveContext(CommonContext):
     async def shutdown(self):
         await super(WargrooveContext, self).shutdown()
         self.remove_communication_files()
+        self.checked_locations.clear()
+        self.server_locations.clear()
+        self.finished_game = False
 
     def remove_communication_files(self):
         for root, dirs, files in os.walk(self.game_communication_path):
@@ -402,8 +408,10 @@ async def game_watcher(ctx: WargrooveContext):
                 if file.find("send") > -1:
                     st = file.split("send", -1)[1]
                     sending = sending+[(int(st))]
+                    os.remove(os.path.join(ctx.game_communication_path, file))
                 if file.find("victory") > -1:
                     victory = True
+                    os.remove(os.path.join(ctx.game_communication_path, file))
         ctx.locations_checked = sending
         message = [{"cmd": 'LocationChecks', "locations": sending}]
         await ctx.send_msgs(message)

--- a/worlds/wargroove/docs/wargroove_en.md
+++ b/worlds/wargroove/docs/wargroove_en.md
@@ -18,7 +18,7 @@ is strongly recommended in case they become corrupted.
 2. Open the `host.yaml` file in your favorite text editor (Notepad will work).
 3. Put your Wargroove root directory in the `root_directory:` under the `wargroove_options:` section.
    - The Wargroove root directory can be found by going to 
-   `Steam->Right Click Wargroove->Properties->Local Files->Browse Local Files` and copying the path in the address bar.
+   `Steam->Right Click Wargroove->Properties->Installed Files->Browse` and copying the path in the address bar.
    - Paste the path in between the quotes next to `root_directory:` in the `host.yaml`.
    - You may have to replace all single \\ with \\\\.
 4. Start the Wargroove client.


### PR DESCRIPTION
## What is this fixing or adding?

Wargroove: Fixed WargrooveClient retaining victory and location information during slot switching. Fixed Documentation wording around navigating steam menus. https://discord.com/channels/731205301247803413/1090824439710625822/1174041565170245742


## How was this tested?
I swapped between a slot with victory achieved and a slot with no victory yet. I verified the slot with no victory yet did not receive a victory in error.

## If this makes graphical changes, please attach screenshots.
