### PR TITLE
Pokemon Emerald: Fix scorched slab missing surf requirement

### DIFF
--- a/worlds/pokemon_emerald/data/regions/routes.json
+++ b/worlds/pokemon_emerald/data/regions/routes.json
@@ -1074,19 +1074,29 @@
     "events": [],
     "exits": [
       "REGION_FORTREE_CITY/MAIN",
-      "REGION_ROUTE120/NORTH_POND",
+      "REGION_ROUTE120/NORTH_POND_SHORE",
       "REGION_ROUTE120/SOUTH"
     ],
     "warps": []
   },
-  "REGION_ROUTE120/NORTH_POND": {
+  "REGION_ROUTE120/NORTH_POND_SHORE": {
     "parent_map": "MAP_ROUTE120",
     "locations": [
       "ITEM_ROUTE_120_NEST_BALL"
     ],
     "events": [],
     "exits": [
-      "REGION_ROUTE120/NORTH"
+      "REGION_ROUTE120/NORTH",
+      "REGION_ROUTE120/NORTH_POND"
+    ],
+    "warps": []
+  },
+  "REGION_ROUTE120/NORTH_POND": {
+    "parent_map": "MAP_ROUTE120",
+    "locations": [],
+    "events": [],
+    "exits": [
+      "REGION_ROUTE120/NORTH_POND_SHORE"
     ],
     "warps": [
       "MAP_ROUTE120:1/MAP_SCORCHED_SLAB:0"

--- a/worlds/pokemon_emerald/rules.py
+++ b/worlds/pokemon_emerald/rules.py
@@ -615,12 +615,16 @@ def set_rules(world: "PokemonEmeraldWorld") -> None:
 
     # Route 120
     set_rule(
-        get_entrance("REGION_ROUTE120/NORTH -> REGION_ROUTE120/NORTH_POND"),
+        get_entrance("REGION_ROUTE120/NORTH -> REGION_ROUTE120/NORTH_POND_SHORE"),
         lambda state: state.has("Devon Scope", world.player)
     )
     set_rule(
-        get_entrance("REGION_ROUTE120/NORTH_POND -> REGION_ROUTE120/NORTH"),
+        get_entrance("REGION_ROUTE120/NORTH_POND_SHORE -> REGION_ROUTE120/NORTH"),
         lambda state: state.has("Devon Scope", world.player)
+    )
+    set_rule(
+        get_entrance("REGION_ROUTE120/NORTH_POND_SHORE -> REGION_ROUTE120/NORTH_POND"),
+        can_surf
     )
 
     # Route 121

--- a/worlds/pokemon_emerald/test/test_accessibility.py
+++ b/worlds/pokemon_emerald/test/test_accessibility.py
@@ -11,6 +11,37 @@ class TestBasic(PokemonEmeraldTestBase):
         self.assertTrue(self.can_reach_location(location_name_to_label("ITEM_ROUTE_115_SUPER_POTION")))
 
 
+class TestScorchedSlabPond(PokemonEmeraldTestBase):
+    options = {
+        "enable_ferry": Toggle.option_true,
+        "require_flash": Toggle.option_false
+    }
+
+    def test_with_neither(self) -> None:
+        self.collect_by_name(["S.S. Ticket", "Letter", "Stone Badge", "HM01 Cut"])
+        self.assertTrue(self.can_reach_region("REGION_ROUTE120/NORTH"))
+        self.assertFalse(self.can_reach_location(location_name_to_label("ITEM_ROUTE_120_NEST_BALL")))
+        self.assertFalse(self.can_reach_location(location_name_to_label("ITEM_SCORCHED_SLAB_TM11")))
+
+    def test_with_surf(self) -> None:
+        self.collect_by_name(["S.S. Ticket", "Letter", "Stone Badge", "HM01 Cut", "HM03 Surf", "Balance Badge"])
+        self.assertTrue(self.can_reach_region("REGION_ROUTE120/NORTH"))
+        self.assertFalse(self.can_reach_location(location_name_to_label("ITEM_ROUTE_120_NEST_BALL")))
+        self.assertFalse(self.can_reach_location(location_name_to_label("ITEM_SCORCHED_SLAB_TM11")))
+
+    def test_with_scope(self) -> None:
+        self.collect_by_name(["S.S. Ticket", "Letter", "Stone Badge", "HM01 Cut", "Devon Scope"])
+        self.assertTrue(self.can_reach_region("REGION_ROUTE120/NORTH"))
+        self.assertTrue(self.can_reach_location(location_name_to_label("ITEM_ROUTE_120_NEST_BALL")))
+        self.assertFalse(self.can_reach_location(location_name_to_label("ITEM_SCORCHED_SLAB_TM11")))
+
+    def test_with_both(self) -> None:
+        self.collect_by_name(["S.S. Ticket", "Letter", "Stone Badge", "HM01 Cut", "Devon Scope", "HM03 Surf", "Balance Badge"])
+        self.assertTrue(self.can_reach_region("REGION_ROUTE120/NORTH"))
+        self.assertTrue(self.can_reach_location(location_name_to_label("ITEM_ROUTE_120_NEST_BALL")))
+        self.assertTrue(self.can_reach_location(location_name_to_label("ITEM_SCORCHED_SLAB_TM11")))
+
+
 class TestSurf(PokemonEmeraldTestBase):
     options = {
         "npc_gifts": Toggle.option_true


### PR DESCRIPTION
## What is this fixing or adding?

Access to a particular cave requires Surf, but that requirement wasn't represented by existing regions and rules. This just splits the pond itself into a new region and adds the requirement.

`ITEM_ROUTE_120_NEST_BALL` is visible in the below screenshot
`ITEM_SCORCHED_SLAB_TM11` is inside the cave

<img src="https://github.com/ArchipelagoMW/Archipelago/assets/21088150/9f49afde-7c38-49cf-8096-6061a1168b00" width="400" />

## How was this tested?

Wrote a new test that fails on `main` and passes here.
