### PR TITLE
The Messenger: Use fill hook to help prevent early swap entering and failures

### DIFF
--- a/worlds/messenger/__init__.py
+++ b/worlds/messenger/__init__.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Counter, Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from BaseClasses import CollectionState, Item, ItemClassification, Location, Tutorial
 from worlds.AutoWorld import WebWorld, World

--- a/worlds/messenger/__init__.py
+++ b/worlds/messenger/__init__.py
@@ -150,6 +150,9 @@ class MessengerWorld(World):
     @classmethod
     def stage_fill_hook(cls, multiworld: MultiWorld, prog_items: List[Item], useful_items: List[Item],
                         filler_items: List[Item], locations: List[Location]) -> None:
+        # it's possible for both items to get placed near the end of the itempool causing swap to be entered early
+        # as more than half of the player's locations become unavailable immediately.
+        # Please don't copy this nightmare
         players = multiworld.get_game_players(cls.game)
         total_items = len(prog_items)
         items = {}

--- a/worlds/messenger/__init__.py
+++ b/worlds/messenger/__init__.py
@@ -156,7 +156,7 @@ class MessengerWorld(World):
         for index in range(int((total_items * .9)), total_items):
             item = prog_items[index]
             if item.player in players and item.name in {"Wingsuit", "Rope Dart"}:
-                items.setdefault(prog_items[index].player, []).append((index, prog_items[index]))
+                items.setdefault(item.player, []).append((index, item))
         for player, item_pairs in items.items():
             if len(item_pairs) > 1:
                 item_to_move = multiworld.random.choice(item_pairs)

--- a/worlds/messenger/__init__.py
+++ b/worlds/messenger/__init__.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Dict, List, Optional
 
-from BaseClasses import CollectionState, Item, ItemClassification, Location, Tutorial
+from BaseClasses import CollectionState, Item, ItemClassification, Location, MultiWorld, Tutorial
 from worlds.AutoWorld import WebWorld, World
 from .constants import ALL_ITEMS, ALWAYS_LOCATIONS, BOSS_LOCATIONS, FILLER, NOTES, PHOBEKINS
 from .options import Goal, Logic, MessengerOptions, NotesNeeded, PowerSeals
@@ -147,9 +147,10 @@ class MessengerWorld(World):
         else:
             MessengerOOBRules(self).set_messenger_rules()
 
-    def stage_fill_hook(self, prog_items: List[Item], useful_items: List[Item], filler_items: List[Item],
-                        locations: List[Location]) -> None:
-        players = self.multiworld.get_game_players(self.game)
+    @classmethod
+    def stage_fill_hook(cls, multiworld: MultiWorld, prog_items: List[Item], useful_items: List[Item],
+                        filler_items: List[Item], locations: List[Location]) -> None:
+        players = multiworld.get_game_players(cls.game)
         total_items = len(prog_items)
         items = {}
         for index in range(int((total_items * .9)), total_items):
@@ -158,8 +159,8 @@ class MessengerWorld(World):
                 items.setdefault(prog_items[index].player, []).append((index, prog_items[index]))
         for player, item_pairs in items.items():
             if len(item_pairs) > 1:
-                item_to_move = self.random.choice(item_pairs)
-                new_index = self.random.randrange(0, int((total_items * .1)))
+                item_to_move = multiworld.random.choice(item_pairs)
+                new_index = multiworld.random.randrange(0, int((total_items * .1)))
                 prog_items.pop(item_to_move[0])
                 prog_items.insert(new_index, item_to_move[1])
 

--- a/worlds/messenger/__init__.py
+++ b/worlds/messenger/__init__.py
@@ -1,7 +1,7 @@
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Counter, Dict, List, Optional
 
-from BaseClasses import CollectionState, Item, ItemClassification, Tutorial
+from BaseClasses import CollectionState, Item, ItemClassification, Location, Tutorial
 from worlds.AutoWorld import WebWorld, World
 from .constants import ALL_ITEMS, ALWAYS_LOCATIONS, BOSS_LOCATIONS, FILLER, NOTES, PHOBEKINS
 from .options import Goal, Logic, MessengerOptions, NotesNeeded, PowerSeals
@@ -146,6 +146,22 @@ class MessengerWorld(World):
             MessengerHardRules(self).set_messenger_rules()
         else:
             MessengerOOBRules(self).set_messenger_rules()
+
+    def stage_fill_hook(self, prog_items: List[Item], useful_items: List[Item], filler_items: List[Item],
+                        locations: List[Location]) -> None:
+        players = self.multiworld.get_game_players(self.game)
+        total_items = len(prog_items)
+        items = {}
+        for index in range(int((total_items * .9)), total_items):
+            item = prog_items[index]
+            if item.player in players and item.name in {"Wingsuit", "Rope Dart"}:
+                items.setdefault(prog_items[index].player, []).append((index, prog_items[index]))
+        for player, item_pairs in items.items():
+            if len(item_pairs) > 1:
+                item_to_move = self.random.choice(item_pairs)
+                new_index = self.random.randrange(0, int((total_items * .1)))
+                prog_items.pop(item_to_move[0])
+                prog_items.insert(new_index, item_to_move[1])
 
     def fill_slot_data(self) -> Dict[str, Any]:
         shop_prices = {SHOP_ITEMS[item].internal_name: price for item, price in self.shop_prices.items()}


### PR DESCRIPTION
## What is this fixing or adding?
https://discord.com/channels/731205301247803413/731214280439103580/1174536333818089482
Basically it's super uncommon and unlikely, but it's possible for the itempool to be shuffled in such a way where both of a player's main movement items get shuffled to the front of the queue, causing them to get placed early and block off most of the multiworld as valid placements. This is a super complicated fix to prevent that situation by moving one of the items but only if both of that players' items are near the very beginning of the queue. The only other solution I thought of is to use the early_items API and force it, but that would require me to do that *always* which I don't like so this is the path I took. Open to alternatives, but unable to think of something that doesn't just strictly rely on swap.

## How was this tested?
tested with following yaml and seed 32514211167490115829 
```yaml
game: The Messenger
The Messenger:
  shuffle_shards: true
  shop_price: 304
```
which fails without this change, and succeeds with this change.