### PR TITLE
Rogue Legacy: Fix a preset including an option that prevents generation.

### DIFF
--- a/worlds/rogue_legacy/Presets.py
+++ b/worlds/rogue_legacy/Presets.py
@@ -35,7 +35,7 @@ rl_options_presets: Dict[str, Dict[str, Any]] = {
         "equip_pool":               "random",
         "crit_chance_pool":         "random",
         "crit_damage_pool":         "random",
-        "allow_default_names":      False,
+        "allow_default_names":      True,
         "death_link":               "random",
     },
     # A preset I actually use, using some literal values and some from the option itself.


### PR DESCRIPTION
## What is this fixing or adding?
`False` to `True`. I'm not smart.

## How was this tested?
It previously wasn't. Now it was. Generation success!

## If this makes graphical changes, please attach screenshots.
![r_6617413_R5XSc](https://github.com/ArchipelagoMW/Archipelago/assets/11338376/fbc0b0b0-87ab-4376-a0d6-3964de669fcc)
