### PR TITLE
Git: Added file type .smc to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 *.z64
 *.n64
 *.nes
+*.smc
 *.sms
 *.gb
 *.gbc


### PR DESCRIPTION
## What is this fixing or adding?
After a local mess up, adding a file to the git that is probably illegal to add to a git, and having to clean up the resulting mess, I figured maybe gitignore should prevent it.
