### PR TITLE
Installer: Add `_bizhawk.apworld` to installer deleted files

### DIFF
--- a/inno_setup.iss
+++ b/inno_setup.iss
@@ -80,6 +80,7 @@ Filename: "{app}\ArchipelagoLauncher"; Description: "{cm:LaunchProgram,{#StringC
 Type: dirifempty; Name: "{app}"
 
 [InstallDelete]
+Type: files; Name: "{app}\lib\worlds\_bizhawk.apworld"
 Type: files; Name: "{app}\ArchipelagoLttPClient.exe"
 Type: filesandordirs; Name: "{app}\lib\worlds\rogue-legacy*"
 Type: filesandordirs; Name: "{app}\SNI\lua*"


### PR DESCRIPTION
## What is this fixing or adding?

Installer will delete `_bizhawk.apworld`, which was in use for versions 0.4.2 and 0.4.3. Unsupported implementations which relied on `_bizhawk.apworld` should continue to work with no modification (assuming they followed the examples given), but if `_bizhawk.apworld` exists, it seems like it's possible that it gets imported over the version that came in the installer (may depend on import order). Whatever the case, it's redundant at best to keep the apworld version around.

Progress on creating apworlds out of lib worlds and importing them would make this unnecessary, but until then, I think this line should be included.

## How was this tested?

Creating and running an installer to watch it delete the file. Also running the currently released Pokemon Emerald apworld with and without `_bizhawk.apworld` to make sure it still worked.
