### PR TITLE
BizHawkClient: Restore use of ConnectorErrors

### DIFF
--- a/worlds/_bizhawk/__init__.py
+++ b/worlds/_bizhawk/__init__.py
@@ -9,6 +9,7 @@ import asyncio
 import base64
 import enum
 import json
+import sys
 import typing
 
 
@@ -114,10 +115,18 @@ async def send_requests(ctx: BizHawkContext, req_list: typing.List[typing.Dict[s
 
     It's likely you want to use the wrapper functions instead of this."""
     responses = json.loads(await ctx._send_message(json.dumps(req_list)))
+    errors: typing.List[ConnectorError] = []
+
     for response in responses:
         if response["type"] == "ERROR":
-            raise ConnectorError(response["err"])
-    
+            errors.append(ConnectorError(response["err"]))
+
+    if errors:
+        if sys.version_info >= (3, 11, 0):
+            raise ExceptionGroup("Connector script returned errors", errors)
+        else:
+            raise errors[0]
+
     return responses
 
 

--- a/worlds/_bizhawk/__init__.py
+++ b/worlds/_bizhawk/__init__.py
@@ -113,7 +113,12 @@ async def send_requests(ctx: BizHawkContext, req_list: typing.List[typing.Dict[s
     """Sends a list of requests to the BizHawk connector and returns their responses.
 
     It's likely you want to use the wrapper functions instead of this."""
-    return json.loads(await ctx._send_message(json.dumps(req_list)))
+    responses = json.loads(await ctx._send_message(json.dumps(req_list)))
+    for response in responses:
+        if response["type"] == "ERROR":
+            raise ConnectorError(response["err"])
+    
+    return responses
 
 
 async def ping(ctx: BizHawkContext) -> None:

--- a/worlds/_bizhawk/__init__.py
+++ b/worlds/_bizhawk/__init__.py
@@ -123,7 +123,7 @@ async def send_requests(ctx: BizHawkContext, req_list: typing.List[typing.Dict[s
 
     if errors:
         if sys.version_info >= (3, 11, 0):
-            raise ExceptionGroup("Connector script returned errors", errors)
+            raise ExceptionGroup("Connector script returned errors", errors)  # noqa
         else:
             raise errors[0]
 


### PR DESCRIPTION
## What is this fixing or adding?

In #2369, some code was deduped between `get_script_version` and `send_requests`, but in doing that I forgot to retain the error checking that was specific to `send_requests`. Right now, when the connector sends back an `ERROR` response, it bubbles up in the python code as a `SyncError` and whatever message the connector attached isn't displayed.

This just adds back the check that will raise a `ConnectorError` with the relevant error message.

## How was this tested?

Playing some Emerald with the change, and editing the connector to intentionally send back an `ERROR` response to see that the error message showed up in the log.
