### PR TITLE
Lingo: Demote warpless painting items to filler

### DIFF
--- a/worlds/lingo/__init__.py
+++ b/worlds/lingo/__init__.py
@@ -1,7 +1,7 @@
 """
 Archipelago init file for Lingo
 """
-from BaseClasses import Item, Tutorial
+from BaseClasses import Item, ItemClassification, Tutorial
 from worlds.AutoWorld import WebWorld, World
 from .items import ALL_ITEM_TABLE, LingoItem
 from .locations import ALL_LOCATION_TABLE
@@ -90,7 +90,15 @@ class LingoWorld(World):
 
     def create_item(self, name: str) -> Item:
         item = ALL_ITEM_TABLE[name]
-        return LingoItem(name, item.classification, item.code, self.player)
+
+        classification = item.classification
+        if self.options.shuffle_paintings and len(item.painting_ids) > 0 and len(item.door_ids) == 0\
+                and all(painting_id not in self.player_logic.PAINTING_MAPPING for painting_id in item.painting_ids):
+            # If this is a "door" that just moves one or more paintings, and painting shuffle is on and those paintings
+            # go nowhere, then this item should not be progression.
+            classification = ItemClassification.filler
+
+        return LingoItem(name, classification, item.code, self.player)
 
     def set_rules(self):
         self.multiworld.completion_condition[self.player] = lambda state: state.has("Victory", self.player)

--- a/worlds/lingo/__init__.py
+++ b/worlds/lingo/__init__.py
@@ -92,8 +92,9 @@ class LingoWorld(World):
         item = ALL_ITEM_TABLE[name]
 
         classification = item.classification
-        if self.options.shuffle_paintings and len(item.painting_ids) > 0 and len(item.door_ids) == 0\
-                and all(painting_id not in self.player_logic.PAINTING_MAPPING for painting_id in item.painting_ids):
+        if hasattr(self, "options") and self.options.shuffle_paintings and len(item.painting_ids) > 0\
+                and len(item.door_ids) == 0 and all(painting_id not in self.player_logic.PAINTING_MAPPING
+                                                    for painting_id in item.painting_ids):
             # If this is a "door" that just moves one or more paintings, and painting shuffle is on and those paintings
             # go nowhere, then this item should not be progression.
             classification = ItemClassification.filler


### PR DESCRIPTION
## What is this fixing or adding?

When door shuffle is on, some progression items reveal paintings that you can use to warp to other places. When painting shuffle is on, it is possible for some of those paintings to not lead anywhere. In this circumstance, those items should be marked as filler rather than progression.

This is not important; it is just a nicety for the player.


## How was this tested?

pytest, as well as a single playthrough of the game on the settings described above.


## If this makes graphical changes, please attach screenshots.
