### PR TITLE
Hollow Knight: Don't force mimics local

### DIFF
--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -170,7 +170,6 @@ class HKWorld(World):
         charm_costs = world.RandomCharmCosts[self.player].get_costs(world.random)
         self.charm_costs = world.PlandoCharmCosts[self.player].get_costs(charm_costs)
         # world.exclude_locations[self.player].value.update(white_palace_locations)
-        world.local_items[self.player].value.add("Mimic_Grub")
         for term, data in cost_terms.items():
             mini = getattr(world, f"Minimum{data.option}Price")[self.player]
             maxi = getattr(world, f"Maximum{data.option}Price")[self.player]


### PR DESCRIPTION
## What is this fixing or adding?

Some discussion here https://discord.com/channels/731205301247803413/1176684007061205074

In short there's 5 mimics, them being local or not doesn't really matter at all because there are so few that they're barely meaningful anyway except when it breaks setup in unexpected ways, especially since they can go in shops and such. Plus we have plans to improve the quality of traps in HK anyway https://github.com/ArchipelagoMW-HollowKnight/Archipelago.HollowKnight/issues/20

## How was this tested?

It wasn't but I can't see any possible way this would break anything 
