### PR TITLE
Pokemon Emerald: Fix opponent trainer moves sometimes being MOVE_NONE

### DIFF
--- a/worlds/pokemon_emerald/__init__.py
+++ b/worlds/pokemon_emerald/__init__.py
@@ -677,7 +677,7 @@ class PokemonEmeraldWorld(World):
                     level_up_movepool = list({
                         move.move_id
                         for move in new_species.learnset
-                        if move.level <= pokemon.level
+                        if move.move_id != 0 and move.level <= pokemon.level
                     })
 
                     new_moves = (


### PR DESCRIPTION
## What is this fixing or adding?

The first 0-4 moves in a pokemon's learnset are empty placeholders so that there's room for extra moves if the player sets `level_up_moves` to `start_with_four_moves`. When picking moves to give to a trainer's pokemon, it should pick from the learnset but exclude these placeholders.

A species' learnset is guaranteed in the game data to have at least 1 non-zero move starting at level 1, so there is never a situation where `level_up_movepool` will be empty.

## How was this tested?

Running a couple generations to make sure no opponents ever have a 0 in their pokemon's moveset.
