### PR TITLE
KH2: Fix grammar to clarify which locations can have a bounty

### DIFF
--- a/worlds/kh2/docs/en_Kingdom Hearts 2.md
+++ b/worlds/kh2/docs/en_Kingdom Hearts 2.md
@@ -77,7 +77,7 @@ The list of possible locations that can contain a bounty:
 - Lingering Will
 - Starry Hill
 - Transport to Remembrance
-- Each of the Goddess of Fate and Paradox Cups
+- Godess of Fate cup and Hades Paradox cup
 
 <h2 style="text-transform:none";>Quality of life:</h2>
 


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?
changes "Each of the 8 cups can have a bounty" to Godess of Fate cup and Hades Paradox cup

## How was this tested?
I read it

## If this makes graphical changes, please attach screenshots.
