### PR TITLE
Core: update modules, move orjson to core

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,13 @@
 colorama>=0.4.5
 websockets>=11.0.3
 PyYAML>=6.0.1
-jellyfish>=1.0.1
+jellyfish>=1.0.3
 jinja2>=3.1.2
 schema>=0.7.5
 kivy>=2.2.0
 bsdiff4>=1.2.4
-platformdirs>=3.9.1
-certifi>=2023.7.22
+platformdirs>=4.0.0
+certifi>=2023.11.17
 cython>=3.0.5
 cymem>=2.0.8
+orjson>=3.9.10

--- a/worlds/factorio/requirements.txt
+++ b/worlds/factorio/requirements.txt
@@ -1,2 +1,1 @@
 factorio-rcon-py>=2.0.1
-orjson>=3.9.7


### PR DESCRIPTION
## What is this fixing or adding?
fixes emerald importing orjson without it having it in its requirements, by moving it from Factorio to core
updates modules

## How was this tested?
quickly, no implosion yet

## If this makes graphical changes, please attach screenshots.
