### PR TITLE
LttP: fix Ganons Tower - Compass Room - Bottom Left being listed twice in Ganons Tower location group and add missing Ganons Tower - Compass Room - Bottom Right

### DIFF
--- a/worlds/alttp/__init__.py
+++ b/worlds/alttp/__init__.py
@@ -195,7 +195,7 @@ class ALTTPWorld(World):
         "Ganons Tower": {"Ganons Tower - Bob's Torch", "Ganons Tower - Hope Room - Left",
                          "Ganons Tower - Hope Room - Right", "Ganons Tower - Tile Room",
                          "Ganons Tower - Compass Room - Top Left", "Ganons Tower - Compass Room - Top Right",
-                         "Ganons Tower - Compass Room - Bottom Left", "Ganons Tower - Compass Room - Bottom Left",
+                         "Ganons Tower - Compass Room - Bottom Left", "Ganons Tower - Compass Room - Bottom Right",
                          "Ganons Tower - DMs Room - Top Left", "Ganons Tower - DMs Room - Top Right",
                          "Ganons Tower - DMs Room - Bottom Left", "Ganons Tower - DMs Room - Bottom Right",
                          "Ganons Tower - Map Chest", "Ganons Tower - Firesnake Room",


### PR DESCRIPTION
## What is this fixing or adding?
 fix Ganons Tower - Compass Room - Bottom Left being listed twice in Ganons Tower location group and add missing Ganons Tower - Compass Room - Bottom Right

## How was this tested?
I think there is a unittest that makes sure the bottom right chest exists?

## If this makes graphical changes, please attach screenshots.
