### PR TITLE
DOOM II: Add to `CODEOWNERS`

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -46,6 +46,9 @@
 # DOOM 1993
 /worlds/doom_1993/ @Daivuk
 
+# DOOM II
+/worlds/doom_ii/ @Daivuk
+
 # Factorio
 /worlds/factorio/ @Berserker66
 


### PR DESCRIPTION
## What is this fixing or adding?
DOOM II merged, but dev/world not added to `CODEOWNERS` doc.

## How was this tested?
Yes.

## If this makes graphical changes, please attach screenshots.
N/A