### PR TITLE
BizHawkClient: Add connection refused handling for mac

### DIFF
--- a/worlds/_bizhawk/__init__.py
+++ b/worlds/_bizhawk/__init__.py
@@ -103,7 +103,11 @@ async def connect(ctx: BizHawkContext) -> bool:
             return True
         except (TimeoutError, ConnectionRefusedError):
             continue
-    
+        except OSError as e:
+            if e.errno == 61:  # Connection refused (darwin raises this error instead)
+                continue
+            raise e
+
     # No ports worked
     ctx.streams = None
     ctx.connection_status = ConnectionStatus.NOT_CONNECTED


### PR DESCRIPTION
## What is this fixing or adding?

Prevents a crash on Mac if the client is open when there's no script running (or it's running on a port other than the default).

## How was this tested?

Verified that it continues to work correctly on Windows, but I don't have a Mac to test. Currently enlisting someone to verify.
