### PR TITLE
The Witness: Fix unreachable locations on certain settings (Keep PP2 EP, Theater Flowers EP)

### DIFF
--- a/worlds/witness/player_logic.py
+++ b/worlds/witness/player_logic.py
@@ -487,7 +487,6 @@ class WitnessPlayerLogic:
         for event_hex, event_name in self.EVENT_NAMES_BY_HEX.items():
             if event_hex in self.COMPLETELY_DISABLED_ENTITIES or event_hex in self.IRRELEVANT_BUT_NOT_DISABLED_ENTITIES:
                 continue
-
             self.EVENT_PANELS.add(event_hex)
 
         for panel in self.EVENT_PANELS:

--- a/worlds/witness/player_logic.py
+++ b/worlds/witness/player_logic.py
@@ -371,7 +371,7 @@ class WitnessPlayerLogic:
         if lasers:
             adjustment_linesets_in_order.append(get_laser_shuffle())
 
-        if world.options.shuffle_EPs:
+        if world.options.shuffle_EPs == 2:
             ep_gen = ((ep_hex, ep_obj) for (ep_hex, ep_obj) in self.REFERENCE_LOGIC.ENTITIES_BY_HEX.items()
                       if ep_obj["entityType"] == "EP")
 

--- a/worlds/witness/player_logic.py
+++ b/worlds/witness/player_logic.py
@@ -485,8 +485,9 @@ class WitnessPlayerLogic:
         self.EVENT_NAMES_BY_HEX[self.VICTORY_LOCATION] = "Victory"
 
         for event_hex, event_name in self.EVENT_NAMES_BY_HEX.items():
-            if event_hex in self.COMPLETELY_DISABLED_ENTITIES:
+            if event_hex in self.COMPLETELY_DISABLED_ENTITIES or event_hex in self.IRRELEVANT_BUT_NOT_DISABLED_ENTITIES:
                 continue
+
             self.EVENT_PANELS.add(event_hex)
 
         for panel in self.EVENT_PANELS:

--- a/worlds/witness/player_logic.py
+++ b/worlds/witness/player_logic.py
@@ -371,7 +371,7 @@ class WitnessPlayerLogic:
         if lasers:
             adjustment_linesets_in_order.append(get_laser_shuffle())
 
-        if world.options.shuffle_EPs == 2:
+        if world.options.shuffle_EPs == "obelisk_sides":
             ep_gen = ((ep_hex, ep_obj) for (ep_hex, ep_obj) in self.REFERENCE_LOGIC.ENTITIES_BY_HEX.items()
                       if ep_obj["entityType"] == "EP")
 

--- a/worlds/witness/regions.py
+++ b/worlds/witness/regions.py
@@ -71,7 +71,7 @@ class WitnessRegions:
         source_region.exits.append(connection)
         connection.connect(target_region)
 
-        self.created_entrances[(source, target)].append(connection)
+        self.created_entrances[source, target].append(connection)
 
         # Register any necessary indirect connections
         mentioned_regions = {

--- a/worlds/witness/rules.py
+++ b/worlds/witness/rules.py
@@ -67,7 +67,7 @@ def _can_solve_panel(panel: str, world: "WitnessWorld", player: int, player_logi
 
 def _can_move_either_direction(state: CollectionState, source: str, target: str, regio: WitnessRegions) -> bool:
     entrance_forward = regio.created_entrances[(source, target)]
-    entrance_backward = regio.created_entrances[(source, target)]
+    entrance_backward = regio.created_entrances[(target, source)]
 
     return (
         any(entrance.can_reach(state) for entrance in entrance_forward)

--- a/worlds/witness/rules.py
+++ b/worlds/witness/rules.py
@@ -66,8 +66,8 @@ def _can_solve_panel(panel: str, world: "WitnessWorld", player: int, player_logi
 
 
 def _can_move_either_direction(state: CollectionState, source: str, target: str, regio: WitnessRegions) -> bool:
-    entrance_forward = regio.created_entrances[(source, target)]
-    entrance_backward = regio.created_entrances[(target, source)]
+    entrance_forward = regio.created_entrances[source, target]
+    entrance_backward = regio.created_entrances[target, source]
 
     return (
         any(entrance.can_reach(state) for entrance in entrance_forward)


### PR DESCRIPTION
Basically, the function for "checking entrances both ways" only checked one way. This resulted in unreachable locations.

This affects Expert seeds with (non-remote doors and specific types of EP Shuffle), as well as seeds with non-remote doors + specific types of disabled panels + specific types of EP Shuffle.

Also includes two changes that makes spoiler logs nicer (not creating unnecessary events).