### PR TITLE
Setup: auto update vc redist

### DIFF
--- a/inno_setup.iss
+++ b/inno_setup.iss
@@ -194,7 +194,7 @@ begin
   begin
     // Is the installed version at least the packaged one ?
     Log('VC Redist x64 Version : found ' + strVersion);
-    Result := (CompareStr(strVersion, 'v14.32.31332') < 0);
+    Result := (CompareStr(strVersion, 'v14.38.33130') < 0);
   end
   else
   begin

--- a/setup.py
+++ b/setup.py
@@ -363,8 +363,8 @@ class BuildExeCommand(cx_Freeze.command.build_exe.BuildEXE):
                                         context=context) as download:
                 vc_redist = download.read()
             print(f"Download complete, {len(vc_redist) / 1024 / 1024:.2f} MBytes downloaded.", )
-            with open("VC_redist.x64.exe", "wb") as f:
-                f.write(vc_redist)
+            with open("VC_redist.x64.exe", "wb") as vc_file:
+                vc_file.write(vc_redist)
 
         for data in self.extra_data:
             self.installfile(Path(data))

--- a/setup.py
+++ b/setup.py
@@ -353,6 +353,18 @@ class BuildExeCommand(cx_Freeze.command.build_exe.BuildEXE):
             for folder in sdl2.dep_bins + glew.dep_bins:
                 shutil.copytree(folder, self.libfolder, dirs_exist_ok=True)
                 print(f"copying {folder} -> {self.libfolder}")
+            # windows needs Visual Studio C++ Redistributable
+            # Installer works for x64 and arm64
+            print("Downloading VC Redist")
+            import certifi
+            import ssl
+            context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH, cafile=certifi.where())
+            with urllib.request.urlopen(r"https://aka.ms/vs/17/release/vc_redist.x64.exe",
+                                        context=context) as download:
+                vc_redist = download.read()
+            print(f"Download complete, {len(vc_redist) / 1024 / 1024:.2f} MBytes downloaded.", )
+            with open("VC_redist.x64.exe", "wb") as f:
+                f.write(vc_redist)
 
         for data in self.extra_data:
             self.installfile(Path(data))


### PR DESCRIPTION
## What is this fixing or adding?
update the checked for VC Redist version to current as of now
always download up to date vc redist for x64 and arm64

## How was this tested?
on my Windows 10 x64

## If this makes graphical changes, please attach screenshots.
