### PR TITLE
SA2B: Add AP 0.4.4 Game Chao Names

### DIFF
--- a/worlds/sa2b/AestheticData.py
+++ b/worlds/sa2b/AestheticData.py
@@ -146,6 +146,10 @@ sample_chao_names = [
 	"Rin",
 	"Doomguy",
 	"Guide",
+	"May",
+	"Hubert",
+	"Corvus",
+	"Nigel",
 ]
 
 totally_real_item_names = [


### PR DESCRIPTION
## What is this fixing or adding?
Several games are getting added with AP 0.4.4; this adds a character name for those that seem to have named characters to work with to the default Chao names.

## How was this tested?
Ran some generations, saw the names.

## If this makes graphical changes, please attach screenshots.
