### PR TITLE
Pokemon Emerald: Fix tracker flags being reset in menus

### DIFF
--- a/worlds/pokemon_emerald/client.py
+++ b/worlds/pokemon_emerald/client.py
@@ -254,7 +254,7 @@ class PokemonEmeraldClient(BizHawkClient):
                     "key": f"pokemon_emerald_events_{ctx.team}_{ctx.slot}",
                     "default": 0,
                     "want_reply": False,
-                    "operations": [{"operation": "replace", "value": event_bitfield}]
+                    "operations": [{"operation": "or", "value": event_bitfield}]
                 }])
                 self.local_set_events = local_set_events
 
@@ -269,7 +269,7 @@ class PokemonEmeraldClient(BizHawkClient):
                     "key": f"pokemon_emerald_keys_{ctx.team}_{ctx.slot}",
                     "default": 0,
                     "want_reply": False,
-                    "operations": [{"operation": "replace", "value": key_bitfield}]
+                    "operations": [{"operation": "or", "value": key_bitfield}]
                 }])
                 self.local_found_key_items = local_found_key_items
         except bizhawk.RequestFailedError:


### PR DESCRIPTION
## What is this fixing or adding?

Sometimes if the menu is opened or a battle is started between the two separate reads of the save data, the second half of the flags aren't included while checking locations and events, so they're essentially determined to be not set. This isn't a problem for locations, but for the events used by the tracker, it means the flags are temporarily assumed to be unset.

Using `or` instead of `replace` should retain the flags that were already set. And will also prevent fighting between two clients playing in the same slot which will have different event flags set.

## How was this tested?

Ran a seed until 2 event triggers to see them get sent and tracked correctly.
