### PR TITLE
Fix usage of `__new__` for `SpecialRange` compatibility fallback

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -727,7 +727,7 @@ class SpecialRange(NamedRange):
                   "Consider switching to NamedRange, which supports all use-cases of SpecialRange, and more. In "
                   "NamedRange, range_start specifies the lower end of the regular range, while special values can be "
                   "placed anywhere (below, inside, or above the regular range).")
-        return super().__new__(cls, value)
+        return super().__new__(cls)
 
     @classmethod
     def weighted_range(cls, text) -> Range:


### PR DESCRIPTION
## What is this fixing or adding?
As it stands right now, the compatibility fallback for `SpecialRange` now that it has been deprecated in favor of `NamedRange` won't work under any circumstances. While `__new__` needs to have the same signature as `__init__`, `NamedRange` and its parent classes (`Range`, `NumericOption` etc.) are not overriding `__new__` themselves and their `__init__` has a different signature, so you can't pass arguments in your `super()` invocation.

This PR simply fixes that usage of `__new__`. Other option could be to avoid using `__new__` at all and place the deprecation notice elsewhere.

**Before**
![image](https://github.com/ArchipelagoMW/Archipelago/assets/35039/8ad44f51-600f-4faf-976a-23d28cdedf04)

**After**
![image](https://github.com/ArchipelagoMW/Archipelago/assets/35039/5e862efe-7fb0-49f7-b334-ca30a1077e63)

## How was this tested?
With an APWorld that uses `SpecialRange` and was working prior to the introduction of `NamedRange`