### PR TITLE
The Witness: Fix Logic Error for Keep Pressure Plates 2 EP in puzzle_randomization: none

### DIFF
--- a/worlds/witness/WitnessLogicVanilla.txt
+++ b/worlds/witness/WitnessLogicVanilla.txt
@@ -430,7 +430,7 @@ Door - 0x04F8F (Tower Shortcut) - 0x0361B
 158705 - 0x03317 (Laser Panel Pressure Plates) - 0x033EA & 0x01BE9 & 0x01CD3 & 0x01D3F - Shapers & Black/White Squares & Rotated Shapers
 Laser - 0x014BB (Laser) - 0x0360E | 0x03317
 159240 - 0x033BE (Pressure Plates 1 EP) - 0x033EA - True
-159241 - 0x033BF (Pressure Plates 2 EP) - 0x01BE9 - True
+159241 - 0x033BF (Pressure Plates 2 EP) - 0x01BE9 & 0x01BEA - True
 159242 - 0x033DD (Pressure Plates 3 EP) - 0x01CD3 & 0x01CD5 - True
 159243 - 0x033E5 (Pressure Plates 4 Left Exit EP) - 0x01D3F - True
 159244 - 0x018B6 (Pressure Plates 4 Right Exit EP) - 0x01D3F - True

--- a/worlds/witness/items.py
+++ b/worlds/witness/items.py
@@ -134,7 +134,7 @@ class WitnessPlayerItems:
                                "Caves Elevator Controls (Panel)"}:
                 # Downgrade doors that don't gate progress.
                 item_data.classification = ItemClassification.useful
-            elif item_name == "Keep Pressure Plates 2 Exit (Door)" and difficulty = "none":
+            elif item_name == "Keep Pressure Plates 2 Exit (Door)" and difficulty == "none":
                 # PP2EP requires the door in vanilla puzzles
                 item_data.classification = ItemClassification.useful
 

--- a/worlds/witness/items.py
+++ b/worlds/witness/items.py
@@ -135,7 +135,7 @@ class WitnessPlayerItems:
                 # Downgrade doors that don't gate progress.
                 item_data.classification = ItemClassification.useful
             elif item_name == "Keep Pressure Plates 2 Exit (Door)" and difficulty == "none":
-                # PP2EP requires the door in vanilla puzzles
+                # PP2EP requires the door in vanilla puzzles, otherwise it's unnecessary
                 item_data.classification = ItemClassification.useful
 
         # Build the mandatory item list.

--- a/worlds/witness/items.py
+++ b/worlds/witness/items.py
@@ -134,7 +134,7 @@ class WitnessPlayerItems:
                                "Caves Elevator Controls (Panel)"}:
                 # Downgrade doors that don't gate progress.
                 item_data.classification = ItemClassification.useful
-            elif item_name == "Keep Pressure Plates 2 Exit (Door)" and difficulty == "none":
+            elif item_name == "Keep Pressure Plates 2 Exit (Door)" and difficulty != "none":
                 # PP2EP requires the door in vanilla puzzles, otherwise it's unnecessary
                 item_data.classification = ItemClassification.useful
 

--- a/worlds/witness/items.py
+++ b/worlds/witness/items.py
@@ -115,6 +115,7 @@ class WitnessPlayerItems:
         # Adjust item classifications based on game settings.
         eps_shuffled = self._world.options.shuffle_EPs
         come_to_you = self._world.options.elevators_come_to_you
+        difficulty = self._world.options.puzzle_randomization
         for item_name, item_data in self.item_data.items():
             if not eps_shuffled and item_name in {"Monastery Garden Entry (Door)",
                                                   "Monastery Shortcuts",
@@ -130,9 +131,11 @@ class WitnessPlayerItems:
                                "Monastery Laser Shortcut (Door)",
                                "Orchard Second Gate (Door)",
                                "Jungle Bamboo Laser Shortcut (Door)",
-                               "Keep Pressure Plates 2 Exit (Door)",
                                "Caves Elevator Controls (Panel)"}:
                 # Downgrade doors that don't gate progress.
+                item_data.classification = ItemClassification.useful
+            elif item_name == "Keep Pressure Plates 2 Exit (Door)" and difficulty = "none":
+                # PP2EP requires the door in vanilla puzzles
                 item_data.classification = ItemClassification.useful
 
         # Build the mandatory item list.

--- a/worlds/witness/items.py
+++ b/worlds/witness/items.py
@@ -134,7 +134,7 @@ class WitnessPlayerItems:
                                "Caves Elevator Controls (Panel)"}:
                 # Downgrade doors that don't gate progress.
                 item_data.classification = ItemClassification.useful
-            elif item_name == "Keep Pressure Plates 2 Exit (Door)" and difficulty != "none":
+            elif item_name == "Keep Pressure Plates 2 Exit (Door)" and not (difficulty == "none" and eps_shuffled):
                 # PP2EP requires the door in vanilla puzzles, otherwise it's unnecessary
                 item_data.classification = ItemClassification.useful
 


### PR DESCRIPTION
Ok so for being a PR that changes 10 characters, explaining it is actually quite involved, so stay with me here

Some EPs (Environmental Puzzles) require you to use alternate solutions to specific panels that affect the environment.
When EP shuffle was introduced, we had to make certain puzzles remove their symbols after solving them for the first time, because the solvability of related EPs is not guaranteed in Sigma Rando.

However, when "puzzle_randomization: None" was introduced, the client added a check for it on whether to remove panel symbols, because it is not necessary if the panels have their vanilla contents - The vanilla panels were made with EP solvability in mind (obviously)

HOWEVER.
The specific solution to Keep Pressure Plates 2 that allows you to solve Keep Pressure Plates 2 EP requires solving the panel in a particular way that requires the Pressure Plates 2 exit door.

Hence, the logic needs to actually change.
Right now, it is possible to get "Keep Pressure Plates 2 Exit (Door)" on "Keep Pressure Plates 2 EP" in a "puzzle_randomization: none" seed, which would be unobtainable.