### PR TITLE
Pokemon Emerald: Change "settings" to "options" in docs

### DIFF
--- a/worlds/pokemon_emerald/docs/en_Pokemon Emerald.md
+++ b/worlds/pokemon_emerald/docs/en_Pokemon Emerald.md
@@ -28,7 +28,7 @@ randomizer. Here are some of the more important ones:
 - You can have both bikes simultaneously
 - You can run or bike (almost) anywhere
 - The Wally catching tutorial is skipped
-- All text is instant, and with an option it can be automatically progressed by holding A
+- All text is instant and, with an option, can be automatically progressed by holding A
 - When a Repel runs out, you will be prompted to use another
 - Many more minor improvements…
 

--- a/worlds/pokemon_emerald/docs/en_Pokemon Emerald.md
+++ b/worlds/pokemon_emerald/docs/en_Pokemon Emerald.md
@@ -1,15 +1,15 @@
 # Pokémon Emerald
 
-## Where is the settings page?
+## Where is the options page?
 
-You can read through all the settings and generate a YAML [here](../player-settings).
+You can read through all the options and generate a YAML [here](../player-options).
 
 ## What does randomization do to this game?
 
 This randomizer handles both item randomization and pokémon randomization. Badges, HMs, gifts from NPCs, and items on
 the ground can all be randomized. There are also many options for randomizing wild pokémon, starters, opponent pokémon,
 abilities, types, etc… You can even change a percentage of single battles into double battles. Check the
-[settings page](../player-settings) for a more comprehensive list of what can be changed.
+[options page](../player-options) for a more comprehensive list of what can be changed.
 
 ## What items and locations get randomized?
 

--- a/worlds/pokemon_emerald/docs/en_Pokemon Emerald.md
+++ b/worlds/pokemon_emerald/docs/en_Pokemon Emerald.md
@@ -28,7 +28,7 @@ randomizer. Here are some of the more important ones:
 - You can have both bikes simultaneously
 - You can run or bike (almost) anywhere
 - The Wally catching tutorial is skipped
-- All text is instant, and with a setting it can be automatically progressed by holding A
+- All text is instant, and with an option it can be automatically progressed by holding A
 - When a Repel runs out, you will be prompted to use another
 - Many more minor improvements…
 
@@ -44,7 +44,7 @@ your inventory.
 ## When the player receives an item, what happens?
 
 You will only receive items while in the overworld and not during battles. Depending on your `Receive Item Messages`
-setting, the received item will either be silently added to your bag or you will be shown a text box with the item's
+option, the received item will either be silently added to your bag or you will be shown a text box with the item's
 name and the item will be added to your bag while a fanfare plays.
 
 ## Can I play offline?

--- a/worlds/pokemon_emerald/docs/setup_en.md
+++ b/worlds/pokemon_emerald/docs/setup_en.md
@@ -26,8 +26,8 @@ clear it.
 
 ## Generating and Patching a Game
 
-1. Create your settings file (YAML). You can make one on the
-[Pokémon Emerald settings page](../../../games/Pokemon%20Emerald/player-settings).
+1. Create your options file (YAML). You can make one on the
+[Pokémon Emerald options page](../../../games/Pokemon%20Emerald/player-options).
 2. Follow the general Archipelago instructions for [generating a game](../../Archipelago/setup/en#generating-a-game).
 This will generate an output file for you. Your patch file will have the `.apemerald` file extension.
 3. Open `ArchipelagoLauncher.exe`


### PR DESCRIPTION
## What is this fixing or adding?

Brings the Emerald docs in line with #2037.

## How was this tested?

Ran web host, checked pages, clicked links.

## If this makes graphical changes, please attach screenshots.

<img src="https://github.com/ArchipelagoMW/Archipelago/assets/21088150/cc0f5b53-d428-413a-9aac-0d087398ed73" />
<img src="https://github.com/ArchipelagoMW/Archipelago/assets/21088150/a9e591b4-e17b-436f-af3e-74c8e6bc11bf" />
