### PR TITLE
SNIClient/LttP: modern SNI prevents payload overflow

### DIFF
--- a/SNIClient.py
+++ b/SNIClient.py
@@ -564,16 +564,12 @@ async def snes_write(ctx: SNIContext, write_list: typing.List[typing.Tuple[int, 
         PutAddress_Request: SNESRequest = {"Opcode": "PutAddress", "Operands": [], 'Space': 'SNES'}
         try:
             for address, data in write_list:
-                while data:
-                    # Divide the write into packets of 256 bytes.
-                    PutAddress_Request['Operands'] = [hex(address)[2:], hex(min(len(data), 256))[2:]]
-                    if ctx.snes_socket is not None:
-                        await ctx.snes_socket.send(dumps(PutAddress_Request))
-                        await ctx.snes_socket.send(data[:256])
-                        address += 256
-                        data = data[256:]
-                    else:
-                        snes_logger.warning(f"Could not send data to SNES: {data}")
+                PutAddress_Request['Operands'] = [hex(address)[2:], hex(min(len(data), 256))[2:]]
+                if ctx.snes_socket is not None:
+                    await ctx.snes_socket.send(dumps(PutAddress_Request))
+                    await ctx.snes_socket.send(data)
+                else:
+                    snes_logger.warning(f"Could not send data to SNES: {data}")
         except ConnectionClosed:
             return False
 

--- a/worlds/alttp/Options.py
+++ b/worlds/alttp/Options.py
@@ -426,9 +426,8 @@ class BeemizerTrapChance(BeemizerRange):
     display_name = "Beemizer Trap Chance"
 
 
-class AllowCollect(Toggle):
-    """Allows for !collect / co-op to auto-open chests containing items for other players.
-    Off by default, because it currently crashes on real hardware."""
+class AllowCollect(DefaultOnToggle):
+    """Allows for !collect / co-op to auto-open chests containing items for other players."""
     display_name = "Allow Collection of checks for other players"
 
 


### PR DESCRIPTION
## What is this fixing or adding?
SNI for over a month now prevents the payload overflow that crashed hardware on its end, so we can get rid of it on ours.

## How was this tested?
I haven't tested it for this PR recently, so someone with hardware and a full !release probably should.

## If this makes graphical changes, please attach screenshots.
