### PR TITLE
BizHawkClient: Fix crash on mac

### DIFF
--- a/worlds/_bizhawk/__init__.py
+++ b/worlds/_bizhawk/__init__.py
@@ -97,7 +97,7 @@ async def connect(ctx: BizHawkContext) -> bool:
 
     for port in ports:
         try:
-            ctx.streams = await asyncio.open_connection("localhost", port)
+            ctx.streams = await asyncio.open_connection("127.0.0.1", port)
             ctx.connection_status = ConnectionStatus.TENTATIVE
             ctx._port = port
             return True


### PR DESCRIPTION
## What is this fixing or adding?

Supplants #2498 now that the problem is better-understood.

When an error is raised during `asyncio.open_connection` (or more specifically `asyncio`'s `loop.create_connection`), it checks if `all(str(exc) == model for exc in exceptions)` where `model = str(exceptions[0])`, and if that's true, it just raises `exceptions[0]` and drops the others. If all the `exceptions` don't "look the same" here, it instead raises a single newly-created `OSError` with an error message that just concatenates the messages of all the errors.

If you do `asyncio.open_connection("localhost", port)`, it tries both ipv4 and ipv6. If the script is not running, both are refused and asyncio receives two errors. On Windows, both messages are the same (`[WinError 1225] The remote computer refused the network connection`), and it just raises one of them as its original `ConnectionRefusedError`. On Mac, the address info is included in the error message, so `create_connection` treats them as different, squashes them into a generic `OSError`, and the result is instead this: `OSError: Multiple exceptions: [Errno 61] Connect call failed ('::1', 43055, 0, 0), [Errno 61] Connect call failed ('127.0.0.1', 43055)`.

By being specific and using `asyncio.open_connection("127.0.0.1", port)`, only one error is ever raised to `create_connection`, so it should always re-raise it as-is, and it can actually be handled by `except ConnectionRefusedError` without trying to regex match the error message or something.

The lua connector is also explicit about using ipv4 instead of just "localhost" so that it will actually give errors when trying to bind to an in-use socket instead of just trying the other protocol and thinking it succeeded. So there's no loss in current functionality by doing this.

In python 3.12, `create_connection` (and by extension `open_connection`) got the `all_errors` argument, which lets you specify that you want errors to always be raised as an `ExceptionGroup` instead, which would make this problem a little easier to design around in the future if necessary.

## How was this tested?

On both Windows and Ubuntu, ran the client both with and without the connector script already running, and also causing timeouts intentionally or closing the script to make sure it recovered. No regressions on those platforms as far as I can tell. Unfortunately I don't have access to a Mac to actually test this on.
