### PR TITLE
BizHawkClient: Use `local_path` when autolaunching BizHawk with lua script

### DIFF
--- a/worlds/_bizhawk/context.py
+++ b/worlds/_bizhawk/context.py
@@ -208,19 +208,30 @@ async def _run_game(rom: str):
 
     if auto_start is True:
         emuhawk_path = Utils.get_settings().bizhawkclient_options.emuhawk_path
-        subprocess.Popen([emuhawk_path, f"--lua={Utils.local_path(os.path.join('data', 'lua', 'connector_bizhawk_generic.lua'))}", os.path.realpath(rom)],
-                         cwd=Utils.local_path("."),
-                         stdin=subprocess.DEVNULL,
-                         stdout=subprocess.DEVNULL,
-                         stderr=subprocess.DEVNULL)
+        subprocess.Popen(
+            [
+                emuhawk_path,
+                f"--lua={Utils.local_path('data', 'lua', 'connector_bizhawk_generic.lua')}",
+                os.path.realpath(rom),
+            ],
+            cwd=Utils.local_path("."),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
     elif isinstance(auto_start, str):
         import shlex
 
-        subprocess.Popen([*shlex.split(auto_start), os.path.realpath(rom)],
-                         cwd=Utils.local_path("."),
-                         stdin=subprocess.DEVNULL,
-                         stdout=subprocess.DEVNULL,
-                         stderr=subprocess.DEVNULL)
+        subprocess.Popen(
+            [
+                *shlex.split(auto_start),
+                os.path.realpath(rom)
+            ],
+            cwd=Utils.local_path("."),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL
+        )
 
 
 async def _patch_and_run_game(patch_file: str):

--- a/worlds/_bizhawk/context.py
+++ b/worlds/_bizhawk/context.py
@@ -208,7 +208,7 @@ async def _run_game(rom: str):
 
     if auto_start is True:
         emuhawk_path = Utils.get_settings().bizhawkclient_options.emuhawk_path
-        subprocess.Popen([emuhawk_path, "--lua=data/lua/connector_bizhawk_generic.lua", os.path.realpath(rom)],
+        subprocess.Popen([emuhawk_path, f"--lua={Utils.local_path(os.path.join('data', 'lua', 'connector_bizhawk_generic.lua'))}", os.path.realpath(rom)],
                          cwd=Utils.local_path("."),
                          stdin=subprocess.DEVNULL,
                          stdout=subprocess.DEVNULL,


### PR DESCRIPTION
## What is this fixing or adding?

Makes the `--lua` arg to BizHawk use an absolute path to the connector instead of a relative one. Previously on Linux the relative path would be interpreted to be from the BizHawk install directory instead of the AP install directory.

## How was this tested?

Running the client with autolaunching on both Windows and Ubuntu to see it launched with the lua script running.
