### PR TITLE
Zillion: some typing fixes

### DIFF
--- a/ZillionClient.py
+++ b/ZillionClient.py
@@ -1,7 +1,7 @@
 import asyncio
 import base64
 import platform
-from typing import Any, ClassVar, Coroutine, Dict, List, Optional, Protocol, Tuple, Type, cast
+from typing import Any, ClassVar, Coroutine, Dict, List, Optional, Protocol, Tuple, cast
 
 # CommonClient import first to trigger ModuleUpdater
 from CommonClient import CommonContext, server_loop, gui_enabled, \
@@ -10,7 +10,7 @@ from NetUtils import ClientStatus
 import Utils
 from Utils import async_start
 
-import colorama  # type: ignore
+import colorama
 
 from zilliandomizer.zri.memory import Memory
 from zilliandomizer.zri import events
@@ -45,7 +45,7 @@ class SetRoomCallback(Protocol):
 
 class ZillionContext(CommonContext):
     game = "Zillion"
-    command_processor: Type[ClientCommandProcessor] = ZillionCommandProcessor
+    command_processor = ZillionCommandProcessor
     items_handling = 1  # receive items from other players
 
     known_name: Optional[str]

--- a/worlds/zillion/__init__.py
+++ b/worlds/zillion/__init__.py
@@ -33,6 +33,7 @@ class ZillionSettings(settings.Group):
         """File name of the Zillion US rom"""
         description = "Zillion US ROM File"
         copy_to = "Zillion (UE) [!].sms"
+        assert ZillionDeltaPatch.hash
         md5s = [ZillionDeltaPatch.hash]
 
     class RomStart(str):
@@ -70,9 +71,11 @@ class ZillionWorld(World):
     web = ZillionWebWorld()
 
     options_dataclass = ZillionOptions
-    options: ZillionOptions
+    options: ZillionOptions  # type: ignore
 
-    settings: typing.ClassVar[ZillionSettings]
+    settings: typing.ClassVar[ZillionSettings]  # type: ignore
+    # these type: ignore are because of this issue: https://github.com/python/typing/discussions/1486
+
     topology_present = True  # indicate if world type has any meaningful layout/pathing
 
     # map names to their IDs

--- a/worlds/zillion/logic.py
+++ b/worlds/zillion/logic.py
@@ -41,7 +41,7 @@ def item_counts(cs: CollectionState, p: int) -> Tuple[Tuple[str, int], ...]:
     return tuple((item_name, cs.count(item_name, p)) for item_name in item_name_to_id)
 
 
-LogicCacheType = Dict[int, Tuple[_Counter[Tuple[str, int]], FrozenSet[Location]]]
+LogicCacheType = Dict[int, Tuple[Dict[int, _Counter[str]], FrozenSet[Location]]]
 """ { hash: (cs.prog_items, accessible_locations) } """
 
 

--- a/worlds/zillion/test/__init__.py
+++ b/worlds/zillion/test/__init__.py
@@ -1,5 +1,5 @@
 from typing import cast
-from test.TestBase import WorldTestBase
+from test.bases import WorldTestBase
 from worlds.zillion import ZillionWorld
 
 


### PR DESCRIPTION
## What is this fixing or adding?

`colorama` has type stubs when it didn't before

`ZillionDeltaPatch.hash` annotated type could be `None` but md5s doesn't allow `None`

type of `CollectionState.prog_items` changed

`WorldTestBase` moved

all of the following are related to this issue:
https://github.com/python/typing/discussions/1486

`CommonContext` for `command_processor` (is invalid without specifying immutable - but I don't need it anyway)

`ZillionWorld` `options` and `settings` (is invalid without specifying immutable - but I do need it)

## How was this tested?

unit tests and type checkers
