### PR TITLE
WebHost: Fix weighted-options outer range being rejected

### DIFF
--- a/WebHostLib/static/assets/weighted-options.js
+++ b/WebHostLib/static/assets/weighted-options.js
@@ -576,7 +576,7 @@ class GameSettings {
             option = parseInt(option, 10);
 
             let optionAcceptable = false;
-            if ((option > setting.min) && (option < setting.max)) {
+            if ((option >= setting.min) && (option <= setting.max)) {
               optionAcceptable = true;
             }
             if (setting.hasOwnProperty('value_names') && Object.values(setting.value_names).includes(option)){


### PR DESCRIPTION
## What is this fixing or adding?
This change fixes a bug causing input values used to create a new row for a range entry to be considered invalid if the entered value sits on the edge of the range.

## How was this tested?
Tested locally.
