### PR TITLE
MultiServer: Support location name groups in !missing and !checked commands

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1337,6 +1337,7 @@ class ClientMessageProcessor(CommonCommandProcessor):
                     "Sorry, !remaining requires you to have beaten the game on this server")
                 return False
 
+    @mark_raw
     def _cmd_missing(self, filter_text="") -> bool:
         """List all missing location checks from the server's perspective.
         Can be given text, which will be used as filter."""
@@ -1346,7 +1347,11 @@ class ClientMessageProcessor(CommonCommandProcessor):
         if locations:
             names = [self.ctx.location_names[location] for location in locations]
             if filter_text:
-                names = [name for name in names if filter_text in name]
+                location_groups = self.ctx.location_name_groups[self.ctx.games[self.client.slot]]
+                if filter_text in location_groups:  # location group name
+                    names = [name for name in names if name in location_groups[filter_text]]
+                else:
+                    names = [name for name in names if filter_text in name]
             texts = [f'Missing: {name}' for name in names]
             if filter_text:
                 texts.append(f"Found {len(locations)} missing location checks, displaying {len(names)} of them.")
@@ -1357,6 +1362,7 @@ class ClientMessageProcessor(CommonCommandProcessor):
             self.output("No missing location checks found.")
         return True
 
+    @mark_raw
     def _cmd_checked(self, filter_text="") -> bool:
         """List all done location checks from the server's perspective.
         Can be given text, which will be used as filter."""
@@ -1366,7 +1372,11 @@ class ClientMessageProcessor(CommonCommandProcessor):
         if locations:
             names = [self.ctx.location_names[location] for location in locations]
             if filter_text:
-                names = [name for name in names if filter_text in name]
+                location_groups = self.ctx.location_name_groups[self.ctx.games[self.client.slot]]
+                if filter_text in location_groups:  # location group name
+                    names = [name for name in names if name in location_groups[filter_text]]
+                else:
+                    names = [name for name in names if filter_text in name]
             texts = [f'Checked: {name}' for name in names]
             if filter_text:
                 texts.append(f"Found {len(locations)} done location checks, displaying {len(names)} of them.")


### PR DESCRIPTION
If the second argument of "!missing" or "!checked" is a valid location group, return all missing/checked locations from that group.

This also means adding @mark_raw to _cmd_missing and _cmd_checked, as there are location groups with spaces in them.

Tested:
Tried it with the new location groups in Witness, don't know what else to test