### PR TITLE
The Messenger: ease rule on key of strength a bit

### DIFF
--- a/worlds/messenger/rules.py
+++ b/worlds/messenger/rules.py
@@ -63,7 +63,10 @@ class MessengerRules:
             "Searing Crags Seal - Triple Ball Spinner": self.has_vertical,
             "Searing Crags - Astral Tea Leaves":
                 lambda state: state.can_reach("Ninja Village - Astral Seed", "Location", self.player),
-            "Searing Crags - Key of Strength": lambda state: state.has("Power Thistle", self.player),
+            "Searing Crags - Key of Strength": lambda state: state.has("Power Thistle", self.player)
+                                                             and (self.has_dart(state)
+                                                                  or (self.has_wingsuit(state)
+                                                                      and self.can_destroy_projectiles(state))),
             # glacial peak
             "Glacial Peak Seal - Ice Climbers": self.has_dart,
             "Glacial Peak Seal - Projectile Spike Pit": self.can_destroy_projectiles,


### PR DESCRIPTION
## What is this fixing or adding?
Makes the logic for accessing key of strength just a tiny bit easier since a few players said it was really difficult.

## How was this tested?
only adds an extra item requirement in a specific situation so unneeded

## If this makes graphical changes, please attach screenshots.
