### PR TITLE
The Messenger: remove old links and update relevant ones in docs

### DIFF
--- a/worlds/messenger/docs/en_The Messenger.md
+++ b/worlds/messenger/docs/en_The Messenger.md
@@ -1,12 +1,10 @@
 # The Messenger
 
 ## Quick Links
-- [Setup](../../../../tutorial/The%20Messenger/setup/en)
-- [Settings Page](../../../../games/The%20Messenger/player-settings)
+- [Setup](/tutorial/The%20Messenger/setup/en)
+- [Options Page](/games/The%20Messenger/player-options)
 - [Courier Github](https://github.com/Brokemia/Courier)
-- [The Messenger Randomizer Github](https://github.com/minous27/TheMessengerRandomizerMod)
 - [The Messenger Randomizer AP Github](https://github.com/alwaysintreble/TheMessengerRandomizerModAP)
-- [Jacksonbird8237's Item Tracker](https://github.com/Jacksonbird8237/TheMessengerItemTracker)
 - [PopTracker Pack](https://github.com/alwaysintreble/TheMessengerTrackPack)
 
 ## What does randomization do in this game?

--- a/worlds/messenger/docs/setup_en.md
+++ b/worlds/messenger/docs/setup_en.md
@@ -1,16 +1,15 @@
 # The Messenger Randomizer Setup Guide
 
 ## Quick Links
-- [Game Info](../../../../games/The%20Messenger/info/en)
-- [Settings Page](../../../../games/The%20Messenger/player-settings)
+- [Game Info](/games/The%20Messenger/info/en)
+- [Options Page](/games/The%20Messenger/player-options)
 - [Courier Github](https://github.com/Brokemia/Courier)
 - [The Messenger Randomizer AP Github](https://github.com/alwaysintreble/TheMessengerRandomizerModAP)
-- [Jacksonbird8237's Item Tracker](https://github.com/Jacksonbird8237/TheMessengerItemTracker)
 - [PopTracker Pack](https://github.com/alwaysintreble/TheMessengerTrackPack)
 
 ## Installation
 
-1. Read the [Game Info Page](../../../../games/The%20Messenger/info/en) for how the game works, caveats and known issues
+1. Read the [Game Info Page](/games/The%20Messenger/info/en) for how the game works, caveats and known issues
 2. Download and install Courier Mod Loader using the instructions on the release page
    * [Latest release is currently 0.7.1](https://github.com/Brokemia/Courier/releases)
 3. Download and install the randomizer mod


### PR DESCRIPTION
## What is this fixing or adding?
The alternative tracker hasn't been updated since the poptracker pack was made so doesn't contain most of the locations or items that exist in the rando now, and the logic is inaccurate. Cleans up some of the links a bit and renames settings to options.

## How was this tested?
Ran webhost and clicked stuff

## If this makes graphical changes, please attach screenshots.
