### PR TITLE
Hollow Knight: Add additional DeathLink option and add ExtraPlatforms option.

### DIFF
--- a/worlds/hk/Options.py
+++ b/worlds/hk/Options.py
@@ -411,9 +411,11 @@ class DeathLinkShade(Choice):
 
     vanilla: DeathLink deaths function like any other death and overrides your existing shade (including geo), if any.
     shadeless: DeathLink deaths do not spawn shades. Your existing shade (including geo), if any, is untouched.
-    shade: DeathLink deaths spawn a shade if you do not have an existing shade. Otherwise, acts like shadeless.
+    shade: DeathLink deaths spawn a shade if you do not have an existing shade. Otherwise, it acts like shadeless.
 
     * This option has no effect if DeathLink is disabled.
+    ** Self-death shade behavior is not changed; if a self-death normally creates a shade in vanilla, it will override
+        your existing shade, if any.
     """
     option_vanilla = 0
     option_shadeless = 1
@@ -422,9 +424,11 @@ class DeathLinkShade(Choice):
 
 
 class DeathLinkBreaksFragileCharms(Toggle):
-    """Sets if fragile charms break when you are killed by a DeathLink. All other deaths still break fragile charms.
+    """Sets if fragile charms break when you are killed by a DeathLink.
 
     * This option has no effect if DeathLink is disabled.
+    ** Self-death fragile charm behavior is not changed; if a self-death normally breaks fragile charms in vanilla, it
+        will continue to do so.
     """
 
 

--- a/worlds/hk/Options.py
+++ b/worlds/hk/Options.py
@@ -2,7 +2,7 @@ import typing
 from .ExtractedData import logic_options, starts, pool_options
 from .Rules import cost_terms
 
-from Options import Option, DefaultOnToggle, Toggle, Choice, Range, OptionDict, NamedRange
+from Options import Option, DefaultOnToggle, Toggle, Choice, Range, OptionDict, NamedRange, DeathLink
 from .Charms import vanilla_costs, names as charm_names
 
 if typing.TYPE_CHECKING:
@@ -402,22 +402,30 @@ class WhitePalace(Choice):
     default = 0
 
 
-class DeathLink(Choice):
+class ExtraPlatforms(DefaultOnToggle):
+    """Places additional platforms to make traveling throughout Hallownest more convenient."""
+
+
+class DeathLinkShade(Choice):
+    """Sets whether to create a shade when you are killed by a DeathLink and how to handle your existing shade, if any.
+
+    vanilla: DeathLink deaths function like any other death and overrides your existing shade (including geo), if any.
+    shadeless: DeathLink deaths do not spawn shades. Your existing shade (including geo), if any, is untouched.
+    shade: DeathLink deaths spawn a shade if you do not have an existing shade. Otherwise, acts like shadeless.
+
+    * This option has no effect if DeathLink is disabled.
     """
-    When you die, everyone dies. Of course the reverse is true too.
-    When enabled, choose how incoming deathlinks are handled:
-    vanilla: DeathLink kills you and is just like any other death.  RIP your previous shade and geo.
-    shadeless: DeathLink kills you, but no shade spawns and no geo is lost.  Your previous shade, if any, is untouched.
-    shade: DeathLink functions like a normal death if you do not already have a shade, shadeless otherwise.
-    """
-    option_off = 0
-    alias_no = 0
-    alias_true = 1
-    alias_on = 1
-    alias_yes = 1
+    option_vanilla = 0
     option_shadeless = 1
-    option_vanilla = 2
-    option_shade = 3
+    option_shade = 2
+    default = 2
+
+
+class DeathLinkBreaksFragileCharms(Toggle):
+    """Sets if fragile charms break when you are killed by a DeathLink. All other deaths still break fragile charms.
+
+    * This option has no effect if DeathLink is disabled.
+    """
 
 
 class StartingGeo(Range):
@@ -476,7 +484,8 @@ hollow_knight_options: typing.Dict[str, type(Option)] = {
     **{
         option.__name__: option
         for option in (
-            StartLocation, Goal, WhitePalace, StartingGeo, DeathLink,
+            StartLocation, Goal, WhitePalace, ExtraPlatforms, StartingGeo,
+            DeathLink, DeathLinkShade, DeathLinkBreaksFragileCharms,
             MinimumGeoPrice, MaximumGeoPrice,
             MinimumGrubPrice, MaximumGrubPrice,
             MinimumEssencePrice, MaximumEssencePrice,
@@ -488,7 +497,7 @@ hollow_knight_options: typing.Dict[str, type(Option)] = {
             LegEaterShopSlots, GrubfatherRewardSlots,
             SeerRewardSlots, ExtraShopSlots,
             SplitCrystalHeart, SplitMothwingCloak, SplitMantisClaw,
-            CostSanity, CostSanityHybridChance,
+            CostSanity, CostSanityHybridChance
         )
     },
     **cost_sanity_weights


### PR DESCRIPTION
## What is this fixing or adding?
https://github.com/ArchipelagoMW-HollowKnight/Archipelago.HollowKnight/issues/157 - Splits DeathLink options up to allow more configuration of behavior on death without needing to program all possible combinations in existing DeathLink option.

https://github.com/ArchipelagoMW-HollowKnight/Archipelago.HollowKnight/issues/58 - Also adds an "ExtraPlatforms" option to create additional platforms in Hallownest to make moving around easier.

@BadMagic100 - Leaving in Draft until client-side can be updated and verified they work with these changes.

## How was this tested?
No logic changes were made, but verified output on WebHost. Awaiting client-side tests before pulling out of Draft state.

## If this makes graphical changes, please attach screenshots.
N/A