### PR TITLE
WebHost: flash each message only once

### DIFF
--- a/WebHostLib/templates/pageWrapper.html
+++ b/WebHostLib/templates/pageWrapper.html
@@ -16,7 +16,7 @@
 {% with messages = get_flashed_messages() %}
     {% if messages %}
         <div>
-            {% for message in messages %}
+            {% for message in messages | unique %}
                 <div class="user-message">{{ message }}</div>
             {% endfor %}
         </div>


### PR DESCRIPTION
## What is this fixing or adding?
flash() can emit the same message multiple times, for example if @app.after_request is used and static files are served through flask, each static file will trigger the after request, which in turn can run a flash() which accumulate.

## How was this tested?
on https://berserkermulti.world

## If this makes graphical changes, please attach screenshots.
Before:
![image](https://github.com/ArchipelagoMW/Archipelago/assets/3189725/97a9f73f-1f8b-449f-9867-d0b83df37e18)


After:
![image](https://github.com/ArchipelagoMW/Archipelago/assets/3189725/bcb597c5-4115-425f-8030-6f820fe9ba27)
