### PR TITLE
Lingo: Default color shuffle to on

### DIFF
--- a/worlds/lingo/__init__.py
+++ b/worlds/lingo/__init__.py
@@ -1,6 +1,8 @@
 """
 Archipelago init file for Lingo
 """
+from logging import warning
+
 from BaseClasses import Item, ItemClassification, Tutorial
 from worlds.AutoWorld import WebWorld, World
 from .items import ALL_ITEM_TABLE, LingoItem
@@ -49,6 +51,14 @@ class LingoWorld(World):
     player_logic: LingoPlayerLogic
 
     def generate_early(self):
+        if not (self.options.shuffle_doors or self.options.shuffle_colors):
+            if self.multiworld.players == 1:
+                warning(f"{self.multiworld.get_player_name(self.player)}'s Lingo world doesn't have any progression"
+                        f" items. Please turn on Door Shuffle or Color Shuffle if that doesn't seem right.")
+            else:
+                raise Exception(f"{self.multiworld.get_player_name(self.player)}'s Lingo world doesn't have any"
+                                f" progression items. Please turn on Door Shuffle or Color Shuffle.")
+
         self.player_logic = LingoPlayerLogic(self)
 
     def create_regions(self):

--- a/worlds/lingo/options.py
+++ b/worlds/lingo/options.py
@@ -32,7 +32,7 @@ class LocationChecks(Choice):
     option_insanity = 2
 
 
-class ShuffleColors(Toggle):
+class ShuffleColors(DefaultOnToggle):
     """If on, an item is added to the pool for every puzzle color (besides White).
     You will need to unlock the requisite colors in order to be able to solve puzzles of that color."""
     display_name = "Shuffle Colors"

--- a/worlds/lingo/test/TestDoors.py
+++ b/worlds/lingo/test/TestDoors.py
@@ -3,7 +3,8 @@ from . import LingoTestBase
 
 class TestRequiredRoomLogic(LingoTestBase):
     options = {
-        "shuffle_doors": "complex"
+        "shuffle_doors": "complex",
+        "shuffle_colors": "false",
     }
 
     def test_pilgrim_first(self) -> None:
@@ -49,7 +50,8 @@ class TestRequiredRoomLogic(LingoTestBase):
 
 class TestRequiredDoorLogic(LingoTestBase):
     options = {
-        "shuffle_doors": "complex"
+        "shuffle_doors": "complex",
+        "shuffle_colors": "false",
     }
 
     def test_through_rhyme(self) -> None:
@@ -76,7 +78,8 @@ class TestRequiredDoorLogic(LingoTestBase):
 
 class TestSimpleDoors(LingoTestBase):
     options = {
-        "shuffle_doors": "simple"
+        "shuffle_doors": "simple",
+        "shuffle_colors": "false",
     }
 
     def test_requirement(self):

--- a/worlds/lingo/test/TestProgressive.py
+++ b/worlds/lingo/test/TestProgressive.py
@@ -81,7 +81,8 @@ class TestSimpleHallwayRoom(LingoTestBase):
 
 class TestProgressiveArtGallery(LingoTestBase):
     options = {
-        "shuffle_doors": "complex"
+        "shuffle_doors": "complex",
+        "shuffle_colors": "false",
     }
 
     def test_item(self):


### PR DESCRIPTION
## What is this fixing or adding?

Previously, the default Lingo settings would create a world with no progression. This change defaults Color Shuffle to on. It also raises a warning if there is no progression in a solo game, and an error if there is no progression in a multiworld.


## How was this tested?
Generated worlds with no progression to see if they failed. Also ran pytest.


## If this makes graphical changes, please attach screenshots.
