### PR TITLE
WebHost: Some refactors and additional checks when uploading files.

### DIFF
--- a/WebHostLib/upload.py
+++ b/WebHostLib/upload.py
@@ -19,7 +19,22 @@ from worlds.Files import AutoPatchRegister
 from . import app
 from .models import Seed, Room, Slot, GameDataPackage
 
-banned_zip_contents = (".sfc", ".z64", ".n64", ".sms", ".gb")
+banned_extensions = (".sfc", ".z64", ".n64", ".nes", ".smc", ".sms", ".gb", ".gbc", ".gba")
+allowed_options_extensions = (".yaml", ".json", ".yml", ".txt", ".zip")
+allowed_generation_extensions = (".archipelago", ".zip")
+
+
+def allowed_options(filename: str) -> bool:
+    return filename.endswith(allowed_options_extensions)
+
+
+def allowed_generation(filename: str) -> bool:
+    return filename.endswith(allowed_generation_extensions)
+
+
+def banned_file(filename: str) -> bool:
+    return filename.endswith(banned_extensions)
+
 
 def process_multidata(compressed_multidata, files={}):
     decompressed_multidata = MultiServer.Context.decompress(compressed_multidata)
@@ -61,8 +76,8 @@ def upload_zip_to_db(zfile: zipfile.ZipFile, owner=None, meta={"race": False}, s
     if not owner:
         owner = session["_id"]
     infolist = zfile.infolist()
-    if all(file.filename.endswith((".yaml", ".yml")) or file.is_dir() for file in infolist):
-        flash(Markup("Error: Your .zip file only contains .yaml files. "
+    if all(allowed_options(file.filename) or file.is_dir() for file in infolist):
+        flash(Markup("Error: Your .zip file only contains options files. "
                      'Did you mean to <a href="/generate">generate a game</a>?'))
         return
 
@@ -73,7 +88,7 @@ def upload_zip_to_db(zfile: zipfile.ZipFile, owner=None, meta={"race": False}, s
     # Load files.
     for file in infolist:
         handler = AutoPatchRegister.get_handler(file.filename)
-        if file.filename.endswith(banned_zip_contents):
+        if banned_file(file.filename):
             return "Uploaded data contained a rom file, which is likely to contain copyrighted material. " \
                    "Your file was deleted."
 
@@ -136,35 +151,34 @@ def upload_zip_to_db(zfile: zipfile.ZipFile, owner=None, meta={"race": False}, s
         flash("No multidata was found in the zip file, which is required.")
 
 
-@app.route('/uploads', methods=['GET', 'POST'])
+@app.route("/uploads", methods=["GET", "POST"])
 def uploads():
-    if request.method == 'POST':
-        # check if the post request has the file part
-        if 'file' not in request.files:
-            flash('No file part')
+    if request.method == "POST":
+        # check if the POST request has a file part.
+        if "file" not in request.files:
+            flash("No file part in POST request.")
         else:
-            file = request.files['file']
-            # if user does not select file, browser also
-            # submit an empty part without filename
-            if file.filename == '':
-                flash('No selected file')
-            elif file and allowed_file(file.filename):
-                if zipfile.is_zipfile(file):
-                    with zipfile.ZipFile(file, 'r') as zfile:
+            uploaded_file = request.files["file"]
+            # If the user does not select file, the browser will still submit an empty string without a file name.
+            if uploaded_file.filename == "":
+                flash("No selected file.")
+            elif uploaded_file and allowed_generation(uploaded_file.filename):
+                if zipfile.is_zipfile(uploaded_file):
+                    with zipfile.ZipFile(uploaded_file, "r") as zfile:
                         try:
                             res = upload_zip_to_db(zfile)
                         except VersionException:
                             flash(f"Could not load multidata. Wrong Version detected.")
                         else:
-                            if type(res) == str:
+                            if res is str:
                                 return res
                             elif res:
                                 return redirect(url_for("view_seed", seed=res.id))
                 else:
-                    file.seek(0)  # offset from is_zipfile check
+                    uploaded_file.seek(0)  # offset from is_zipfile check
                     # noinspection PyBroadException
                     try:
-                        multidata = file.read()
+                        multidata = uploaded_file.read()
                         slots, multidata = process_multidata(multidata)
                     except Exception as e:
                         flash(f"Could not load multidata. File may be corrupted or incompatible. ({e})")
@@ -182,7 +196,3 @@ def user_content():
     rooms = select(room for room in Room if room.owner == session["_id"])
     seeds = select(seed for seed in Seed if seed.owner == session["_id"])
     return render_template("userContent.html", rooms=rooms, seeds=seeds)
-
-
-def allowed_file(filename):
-    return filename.endswith(('.archipelago', ".zip"))


### PR DESCRIPTION
## What is this fixing or adding?
Does some refactoring and adds additional checks for files that are uploaded to the WebHost.

Additional checks include:

- Screening for additional known ROM extensions.
- Validation that `.zip` files are proper zip files (e.g. not renamed `.rar`/`.7z` files).
- Checks filenames inside subfolders within zips correctly.
- Ignores dot files (i.e. starts with `.`).
- Prevents nested zips from being uploaded (protection against zip fork-bombs).
- Allows additional supported known options extensions.

Also tweaks some of the error messages to be a bit more clear and list all known valid option files if files are submitted without them.

## How was this tested?

- Uploaded an archive containing dot files inside a `__MACOSX` folder.
- Uploaded a zip containing a `.zip` file.
- Uploaded a zip containing no files.
- Uploaded a zip containing no supported files.
- Uploaded a pre-generated `.zip` to `/generate` and options to `/hostGame`.
- Uploaded a `.png`.
- Uploaded a `.7z` file renamed as a `.zip` file

All of these would have given unclear (or thrown 500) error on current, but do not with these changes.

- Uploaded a valid file.

This one still succeeds. :P

## If this makes graphical changes, please attach screenshots.

Host Game
![image](https://github.com/ArchipelagoMW/Archipelago/assets/11338376/24d1a578-dedb-44ff-bbf7-4ccd72f48263)
![image](https://github.com/ArchipelagoMW/Archipelago/assets/11338376/d78f4070-ecd2-4c98-976e-c2e83122ebae)
![image](https://github.com/ArchipelagoMW/Archipelago/assets/11338376/5d9ded5f-56cb-43d2-8819-8f771f8e5b2c)

Generate Game
![image](https://github.com/ArchipelagoMW/Archipelago/assets/11338376/5af12edf-4960-45ed-ac7d-0b0354b96869)
![image](https://github.com/ArchipelagoMW/Archipelago/assets/11338376/5777445e-ea39-4f25-8cea-e075b9aea987)
![image](https://github.com/ArchipelagoMW/Archipelago/assets/11338376/f43c2310-de18-44aa-a43d-4871992d2a66)
![image](https://github.com/ArchipelagoMW/Archipelago/assets/11338376/757688e4-f943-4f96-bbdd-c8ec9eface62)
