### PR TITLE
WebHost: fix room shutdown

### DIFF
--- a/WebHostLib/customserver.py
+++ b/WebHostLib/customserver.py
@@ -205,6 +205,12 @@ def run_server_process(room_id, ponyconfig: dict, static_server_data: dict,
             ctx.auto_shutdown = Room.get(id=room_id).timeout
         ctx.shutdown_task = asyncio.create_task(auto_shutdown(ctx, []))
         await ctx.shutdown_task
+
+        # ensure auto launch is on the same page in regard to room activity.
+        with db_session:
+            room: Room = Room.get(id=ctx.room_id)
+            room.last_activity = datetime.datetime.utcnow() - datetime.timedelta(seconds=room.timeout + 60)
+
         logging.info("Shutting down")
 
     with Locker(room_id):


### PR DESCRIPTION
## What is this fixing or adding?
Currently when a room shuts down while clients are connected it instantly spins back up. This fixes that behaviour categorically.
I still don't know why or when this problem started, but it's certainly wreaking havok on prod.

## How was this tested?
I set room timeout quite low, connected a text client. Without this change, I would get a disconnect, the room would start back up and the auto reconnect would succeed. With this change, I get a disconnect and then nothing happens other than the text client  trying to reconnect but is not let in.

## If this makes graphical changes, please attach screenshots.
