### PR TITLE
Multiserver: data store datapackage

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -461,10 +461,25 @@ class Context:
                 del data["location_name_groups"]
             del data["item_name_groups"]  # remove from data package, but keep in self.item_name_groups
         self._init_game_data()
+        for game_name, game_package in self.gamespackage.items():
+            key = f"datapackage_checksum_{game_name}"
+            self.public_stored_data_keys.add(key)
+            self.read_data[key] = lambda lgame=game_name: self.checksums.get(lgame, None)
+
+            key = f"item_name_to_id_{game_name}"
+            self.public_stored_data_keys.add(key)
+            self.read_data[key] = lambda lgame=game_name: self.gamespackage[lgame]["item_name_to_id"]
+
+            key = f"location_name_to_id_{game_name}"
+            self.public_stored_data_keys.add(key)
+            self.read_data[key] = lambda lgame=game_name: self.gamespackage[lgame]["location_name_to_id"]
+
         for game_name, data in self.item_name_groups.items():
-            self.read_data[f"item_name_groups_{game_name}"] = lambda lgame=game_name: self.item_name_groups[lgame]
+            self.read_data[f"item_name_groups_{game_name}"] = \
+                lambda lgame=game_name: self.item_name_groups[lgame]
         for game_name, data in self.location_name_groups.items():
-            self.read_data[f"location_name_groups_{game_name}"] = lambda lgame=game_name: self.location_name_groups[lgame]
+            self.read_data[f"location_name_groups_{game_name}"] = \
+                lambda lgame=game_name: self.location_name_groups[lgame]
 
     # saving
 


### PR DESCRIPTION
## What is this fixing or adding?
allows retrieval of datapackage via datastore read keys. In doing so allows retrieval of just checksum, just items, just locations and brings the existing just location name groups and just item name groups in line.


## How was this tested?
Not yet. Both testing and docs would be appreciated to be contributed.

## If this makes graphical changes, please attach screenshots.
