### PR TITLE
The Witness: Fix logic error with Symmetry Island Upper in doors: panels (broken seed reported)

### DIFF
--- a/worlds/witness/player_logic.py
+++ b/worlds/witness/player_logic.py
@@ -70,12 +70,18 @@ class WitnessPlayerLogic:
                 for items_option in these_items:
                     all_options.add(items_option.union(dependentItem))
 
-            # 0x28A0D depends on another entity for *non-power* reasons -> This dependency needs to be preserved...
-            if panel_hex != "0x28A0D":
-                return frozenset(all_options)
-            # ...except in Expert, where that dependency doesn't exist, but now there *is* a power dependency.
+            # 0x28A0D depends on another entity for *non-power* reasons -> This dependency needs to be preserved,
+            # except in Expert, where that dependency doesn't exist, but now there *is* a power dependency.
             # In the future, it would be wise to make a distinction between "power dependencies" and other dependencies.
-            if any("0x28998" in option for option in these_panels):
+            if panel_hex == "0x28A0D" and not any("0x28998" in option for option in these_panels):
+                these_items = all_options
+
+            # Another dependency that is not power-based: The Symmetry Island Upper Panel latches
+            elif panel_hex == 0x18269:
+                these_items = all_options
+
+            # For any other door entity, we just return a set with the item that opens it & disregard power dependencies
+            else:
                 return frozenset(all_options)
 
             these_items = all_options

--- a/worlds/witness/player_logic.py
+++ b/worlds/witness/player_logic.py
@@ -84,8 +84,6 @@ class WitnessPlayerLogic:
             else:
                 return frozenset(all_options)
 
-            these_items = all_options
-
         disabled_eps = {eHex for eHex in self.COMPLETELY_DISABLED_ENTITIES
                         if self.REFERENCE_LOGIC.ENTITIES_BY_HEX[eHex]["entityType"] == "EP"}
 


### PR DESCRIPTION
Door entities think they can be solved without any other panels needing to be solved.

Usually, this is true, because they no longer need to be "powered on" by a previous panel.
However, there are some entities that need another entity to be powered/solved for a different reason.
In this case, Symmetry Island Lower Left set opens the *latches* that *block your ability to solve* the panel. The panel itself actually *starts* on. Playing doors: panels does not change this, unlike usually where dependencies like this get removed by playing that mode.

In the long term, I want to somehow be able to "mark" dependencies as "environmental" or "power based" so I can distinguish them properly.

Shortest version ever: Colored Dots can be on Symmetry Island Upper Panel in a doors: panels seed, which creates an unbeatable seed

I also feel a little self-conscious about the amount of PRs I have been opening since the big content/refactor PR got merged.
Rest assured, all these bugs *pre-date* that big PR, they just haven't been discovered.
Which somehow makes me feel better, idk if it's supposed to. XD