### PR TITLE
Core: set consistent server defaults

### DIFF
--- a/WebHostLib/templates/generate.html
+++ b/WebHostLib/templates/generate.html
@@ -69,8 +69,8 @@
                                     </td>
                                     <td>
                                         <select name="collect_mode" id="collect_mode">
-                                            <option value="goal">Allow !collect after goal completion</option>
                                             <option value="auto">Automatic on goal completion</option>
+                                            <option value="goal">Allow !collect after goal completion</option>
                                             <option value="auto-enabled">
                                                 Automatic on goal completion and manual !collect
                                             </option>
@@ -93,9 +93,9 @@
                                             {% if race -%}
                                                 <option value="disabled">Disabled in Race mode</option>
                                             {%- else -%}
-                                                <option value="disabled">Disabled</option>
                                                 <option value="goal">Allow !remaining after goal completion</option>
                                                 <option value="enabled">Manual !remaining</option>
+                                                <option value="disabled">Disabled</option>
                                             {%- endif -%}
                                         </select>
                                     </td>
@@ -185,11 +185,11 @@ Warning: playthrough can take a significant amount of time for larger multiworld
                                             </span>
                                         </td>
                                         <td>
+                                            <input type="checkbox" id="plando_items" name="plando_items" value="items">
+                                            <label for="plando_items">Items</label><br>
+
                                             <input type="checkbox" id="plando_bosses" name="plando_bosses" value="bosses" checked>
                                             <label for="plando_bosses">Bosses</label><br>
-
-                                            <input type="checkbox" id="plando_items" name="plando_items" value="items" checked>
-                                            <label for="plando_items">Items</label><br>
 
                                             <input type="checkbox" id="plando_connections" name="plando_connections" value="connections" checked>
                                             <label for="plando_connections">Connections</label><br>

--- a/settings.py
+++ b/settings.py
@@ -597,8 +597,8 @@ class ServerOptions(Group):
     disable_item_cheat: Union[DisableItemCheat, bool] = False
     location_check_points: LocationCheckPoints = LocationCheckPoints(1)
     hint_cost: HintCost = HintCost(10)
-    release_mode: ReleaseMode = ReleaseMode("goal")
-    collect_mode: CollectMode = CollectMode("goal")
+    release_mode: ReleaseMode = ReleaseMode("auto")
+    collect_mode: CollectMode = CollectMode("auto")
     remaining_mode: RemainingMode = RemainingMode("goal")
     auto_shutdown: AutoShutdown = AutoShutdown(0)
     compatibility: Compatibility = Compatibility(2)
@@ -673,7 +673,7 @@ class GeneratorOptions(Group):
     spoiler: Spoiler = Spoiler(3)
     glitch_triforce_room: GlitchTriforceRoom = GlitchTriforceRoom(1)  # why is this here?
     race: Race = Race(0)
-    plando_options: PlandoOptions = PlandoOptions("bosses")
+    plando_options: PlandoOptions = PlandoOptions("bosses, connections, texts")
 
 
 class SNIOptions(Group):


### PR DESCRIPTION
## What is this fixing or adding?
set consistent server defaults
Some reasonings:
In general these should be reasonable defaults someone can just start a game with, and the other options should offer customization from there.

items plando allows modifying of other worlds, the others are world-local. It should therefore be opt in, preferably after the host has read the plando guide to know what to look out for.

Collect and Release on Auto, teaches that the systems exist, can be customized if changes are desired and is a reasonable default; as  well as a default encountered in say The Big Async.

Moved Items plando visually up, as it has the biggest impact and support.

## How was this tested?
I only tested the webhost changes

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/3189725/19510d00-6c17-4d0b-951c-e1109793600b)
