### PR TITLE
WebHost: Make list options available from the player-options page

### DIFF
--- a/WebHostLib/options.py
+++ b/WebHostLib/options.py
@@ -117,6 +117,16 @@ def create():
                 logging.debug(f"{option} not exported to Web Options.")
 
         player_options["gameOptions"] = game_options
+        player_options["gameItems"] = tuple(world.item_names)
+        player_options["gameItemGroups"] = [
+            group for group in world.item_name_groups.keys() if group != "Everything"
+        ]
+        player_options["gameItemDescriptions"] = world.item_descriptions
+        player_options["gameLocations"] = tuple(world.location_names)
+        player_options["gameLocationGroups"] = [
+            group for group in world.location_name_groups.keys() if group != "Everywhere"
+        ]
+        player_options["gameLocationDescriptions"] = world.location_descriptions
 
         player_options["presetOptions"] = {}
         for preset_name, preset in world.web.options_presets.items():
@@ -170,17 +180,11 @@ def create():
 
             weighted_options["baseOptions"]["game"][game_name] = 0
             weighted_options["games"][game_name] = {
-                "gameSettings": game_options,
-                "gameItems": tuple(world.item_names),
-                "gameItemGroups": [
-                    group for group in world.item_name_groups.keys() if group != "Everything"
-                ],
-                "gameItemDescriptions": world.item_descriptions,
-                "gameLocations": tuple(world.location_names),
-                "gameLocationGroups": [
-                    group for group in world.location_name_groups.keys() if group != "Everywhere"
-                ],
-                "gameLocationDescriptions": world.location_descriptions,
+                key: player_options[key]
+                for key in [
+                    "gameOptions", "gameItems", "gameItemGroups", "gameItemDescriptions",
+                    "gameLocations", "gameLocationGroups", "gameLocationDescriptions",
+                ]
             }
 
     with open(os.path.join(target_folder, 'weighted-options.json'), "w") as f:

--- a/WebHostLib/static/assets/options.js
+++ b/WebHostLib/static/assets/options.js
@@ -1,0 +1,514 @@
+export const showUserMessage = (message) => {
+  const userMessage = document.getElementById('user-message');
+  userMessage.innerText = message;
+  userMessage.classList.add('visible');
+  window.scrollTo(0, 0);
+  userMessage.addEventListener('click', () => {
+    userMessage.classList.remove('visible');
+    userMessage.addEventListener('click', hideUserMessage);
+  });
+};
+
+const hideUserMessage = () => {
+  const userMessage = document.getElementById('user-message');
+  userMessage.classList.remove('visible');
+  userMessage.removeEventListener('click', hideUserMessage);
+};
+
+// Loads the options JSON for the game with the given name from the given root-relative url.
+//
+// If the user has options for this name in local storage and it's out-of-date relative to the
+// server data, displays a warning.
+//
+// The name may be a game name, or "weighted-settings" for the multi-game weighted options page.
+export const loadOptions = async (url, name) => {
+  const data = await fetch(new Request(`${window.location.origin}${url}`))
+      .then(response => response.json());
+
+  const newHash = md5(JSON.stringify(data));
+  const storedHash = localStorage.getItem(`${name}-hash`);
+  if (!storedHash) {
+    // If no hash data has been set before, set it now.
+    localStorage.setItem(`${name}-hash`, newHash);
+    localStorage.removeItem(name);
+  } else if (newHash !== storedHash) {
+    showUserMessage(
+        'Your options are out of date! Click here to update them! Be aware this will reset them ' +
+        'all to default.'
+    );
+    document.getElementById('user-message').addEventListener('click', () => {
+      localStorage.removeItem(name);
+      localStorage.removeItem(`${name}-hash`);
+      localStorage.removeItem(`${name}-preset`);
+      window.location.reload();
+    });
+  }
+
+  return data;
+};
+
+// Create an anchor and trigger a download of a text file.
+export const download = (filename, text) => {
+  const downloadLink = document.createElement('a');
+  downloadLink.setAttribute('href','data:text/yaml;charset=utf-8,'+ encodeURIComponent(text))
+  downloadLink.setAttribute('download', filename);
+  downloadLink.style.display = 'none';
+  document.body.appendChild(downloadLink);
+  downloadLink.click();
+  document.body.removeChild(downloadLink);
+};
+
+// An abstract class encapsulating options for an individual game.
+export class BaseGameOptions {
+  // The name of this game.
+  name;
+
+  // The data from the server describing the types of settings available for
+  // this game, as a JSON-safe blob.
+  get data() {
+    throw new Error("Child classes must override data().");
+  }
+
+  // The settings chosen by the user as they'd appear in the YAML file, stored
+  // to and retrieved from local storage.
+  get current() {
+    throw new Error("Child classes must override current().");
+  }
+
+  constructor(name) {
+    if (this.constructor === BaseGameOptions) {
+      throw new Error("BaseGameOptions is abstract and can't be instantiated directly.");
+    }
+
+    this.name = name;
+  }
+
+  // Saves the current settings to local storage.
+  save() {
+    throw new Error("Child classes must override save().");
+  }
+
+  // Builds and returns the options UI for this game.
+  buildUI() {
+    throw new Error("Child classes must override buildUI().");
+  }
+
+  // A protected method that adds common UI for options to the end of the given div.
+  buildBaseUI(div) {
+    this.current.start_inventory ??= {};
+    this.current.exclude_locations ??= [];
+    this.current.priority_locations ??= [];
+    this.current.local_items ??= [];
+    this.current.non_local_items ??= [];
+    this.current.start_hints ??= [];
+    this.current.start_location_hints ??= [];
+
+    const itemPoolDiv = this.#buildItemPoolDiv();
+    div.appendChild(itemPoolDiv);
+
+    const hintsDiv = this.#buildHintsDiv();
+    div.appendChild(hintsDiv);
+
+    const locationsDiv = this.#buildPriorityExclusionDiv();
+    div.appendChild(locationsDiv);
+  }
+
+  #buildItemPoolDiv() {
+    const itemsDiv = document.createElement('div');
+    itemsDiv.classList.add('items-div');
+
+    const itemsDivHeader = document.createElement('h3');
+    itemsDivHeader.innerText = 'Item Pool';
+    itemsDiv.appendChild(itemsDivHeader);
+
+    const itemsDescription = document.createElement('p');
+    itemsDescription.classList.add('setting-description');
+    itemsDescription.innerText = 'Choose if you would like to start with items, or control if they are placed in ' +
+      'your seed or someone else\'s.';
+    itemsDiv.appendChild(itemsDescription);
+
+    const itemsHint = document.createElement('p');
+    itemsHint.classList.add('hint-text');
+    itemsHint.innerText = 'Drag and drop items from one box to another.';
+    itemsDiv.appendChild(itemsHint);
+
+    const itemsWrapper = document.createElement('div');
+    itemsWrapper.classList.add('items-wrapper');
+
+    const itemDragoverHandler = (evt) => evt.preventDefault();
+    const itemDropHandler = (evt) => this.#itemDropHandler(evt);
+
+    // Create container divs for each category
+    const availableItemsWrapper = document.createElement('div');
+    availableItemsWrapper.classList.add('item-set-wrapper');
+    availableItemsWrapper.innerText = 'Available Items';
+    const availableItems = document.createElement('div');
+    availableItems.classList.add('item-container');
+    availableItems.setAttribute('id', `${this.name}-available_items`);
+    availableItems.addEventListener('dragover', itemDragoverHandler);
+    availableItems.addEventListener('drop', itemDropHandler);
+
+    const startInventoryWrapper = document.createElement('div');
+    startInventoryWrapper.classList.add('item-set-wrapper');
+    startInventoryWrapper.innerText = 'Start Inventory';
+    const startInventory = document.createElement('div');
+    startInventory.classList.add('item-container');
+    startInventory.setAttribute('id', `${this.name}-start_inventory`);
+    startInventory.setAttribute('data-setting', 'start_inventory');
+    startInventory.addEventListener('dragover', itemDragoverHandler);
+    startInventory.addEventListener('drop', itemDropHandler);
+
+    const localItemsWrapper = document.createElement('div');
+    localItemsWrapper.classList.add('item-set-wrapper');
+    localItemsWrapper.innerText = 'Local Items';
+    const localItems = document.createElement('div');
+    localItems.classList.add('item-container');
+    localItems.setAttribute('id', `${this.name}-local_items`);
+    localItems.setAttribute('data-setting', 'local_items')
+    localItems.addEventListener('dragover', itemDragoverHandler);
+    localItems.addEventListener('drop', itemDropHandler);
+
+    const nonLocalItemsWrapper = document.createElement('div');
+    nonLocalItemsWrapper.classList.add('item-set-wrapper');
+    nonLocalItemsWrapper.innerText = 'Non-Local Items';
+    const nonLocalItems = document.createElement('div');
+    nonLocalItems.classList.add('item-container');
+    nonLocalItems.setAttribute('id', `${this.name}-non_local_items`);
+    nonLocalItems.setAttribute('data-setting', 'non_local_items');
+    nonLocalItems.addEventListener('dragover', itemDragoverHandler);
+    nonLocalItems.addEventListener('drop', itemDropHandler);
+
+    // Populate the divs
+    this.data.gameItems.forEach((item) => {
+      if (this.current.start_inventory.hasOwnProperty(item)) {
+        const itemDiv = this.#buildItemQtyDiv(item);
+        itemDiv.setAttribute('data-setting', 'start_inventory');
+        startInventory.appendChild(itemDiv);
+      } else if (this.current.local_items.includes(item)) {
+        const itemDiv = this.#buildItemDiv(item);
+        itemDiv.setAttribute('data-setting', 'local_items');
+        localItems.appendChild(itemDiv);
+      } else if (this.current.non_local_items.includes(item)) {
+        const itemDiv = this.#buildItemDiv(item);
+        itemDiv.setAttribute('data-setting', 'non_local_items');
+        nonLocalItems.appendChild(itemDiv);
+      } else {
+        const itemDiv = this.#buildItemDiv(item);
+        availableItems.appendChild(itemDiv);
+      }
+    });
+
+    availableItemsWrapper.appendChild(availableItems);
+    startInventoryWrapper.appendChild(startInventory);
+    localItemsWrapper.appendChild(localItems);
+    nonLocalItemsWrapper.appendChild(nonLocalItems);
+    itemsWrapper.appendChild(availableItemsWrapper);
+    itemsWrapper.appendChild(startInventoryWrapper);
+    itemsWrapper.appendChild(localItemsWrapper);
+    itemsWrapper.appendChild(nonLocalItemsWrapper);
+    itemsDiv.appendChild(itemsWrapper);
+    return itemsDiv;
+  }
+
+  #buildItemDiv(item) {
+    const itemDiv = document.createElement('div');
+    itemDiv.classList.add('item-div');
+    itemDiv.setAttribute('id', `${this.name}-${item}`);
+    itemDiv.setAttribute('data-game', this.name);
+    itemDiv.setAttribute('data-item', item);
+    itemDiv.setAttribute('draggable', 'true');
+    itemDiv.innerText = item;
+    itemDiv.addEventListener('dragstart', (evt) => {
+      evt.dataTransfer.setData('text/plain', itemDiv.getAttribute('id'));
+    });
+    return itemDiv;
+  }
+
+  #buildItemQtyDiv(item) {
+    const itemQtyDiv = document.createElement('div');
+    itemQtyDiv.classList.add('item-qty-div');
+    itemQtyDiv.setAttribute('id', `${this.name}-${item}`);
+    itemQtyDiv.setAttribute('data-game', this.name);
+    itemQtyDiv.setAttribute('data-item', item);
+    itemQtyDiv.setAttribute('draggable', 'true');
+    itemQtyDiv.innerText = item;
+
+    const inputWrapper = document.createElement('div');
+    inputWrapper.classList.add('item-qty-input-wrapper')
+
+    const itemQty = document.createElement('input');
+    const startInventory = this.current.start_inventory ?? {};
+    itemQty.setAttribute('value', startInventory.hasOwnProperty(item) ? startInventory[item] : '1');
+    itemQty.setAttribute('data-game', this.name);
+    itemQty.setAttribute('data-setting', 'start_inventory');
+    itemQty.setAttribute('data-option', item);
+    itemQty.setAttribute('maxlength', '3');
+    itemQty.addEventListener('keyup', (evt) => {
+      evt.target.value = isNaN(parseInt(evt.target.value)) ? 0 : parseInt(evt.target.value);
+      this.#updateItemSetting(evt);
+    });
+    inputWrapper.appendChild(itemQty);
+    itemQtyDiv.appendChild(inputWrapper);
+
+    itemQtyDiv.addEventListener('dragstart', (evt) => {
+      evt.dataTransfer.setData('text/plain', itemQtyDiv.getAttribute('id'));
+    });
+    return itemQtyDiv;
+  }
+
+  #itemDropHandler(evt) {
+    evt.preventDefault();
+    const sourceId = evt.dataTransfer.getData('text/plain');
+    const sourceDiv = document.getElementById(sourceId);
+
+    const item = sourceDiv.getAttribute('data-item');
+
+    const oldSetting = sourceDiv.hasAttribute('data-setting') ? sourceDiv.getAttribute('data-setting') : null;
+    const newSetting = evt.target.hasAttribute('data-setting') ? evt.target.getAttribute('data-setting') : null;
+
+    const itemDiv = newSetting === 'start_inventory' ? this.#buildItemQtyDiv(item) : this.#buildItemDiv(item);
+
+    if (oldSetting) {
+      if (oldSetting === 'start_inventory') {
+        if (this.current[oldSetting].hasOwnProperty(item)) {
+          delete this.current[oldSetting][item];
+        }
+      } else {
+        if (this.current[oldSetting].includes(item)) {
+          this.current[oldSetting].splice(this.current[oldSetting].indexOf(item), 1);
+        }
+      }
+    }
+
+    if (newSetting) {
+      itemDiv.setAttribute('data-setting', newSetting);
+      document.getElementById(`${this.name}-${newSetting}`).appendChild(itemDiv);
+      if (newSetting === 'start_inventory') {
+        this.current[newSetting][item] = 1;
+      } else {
+        if (!this.current[newSetting].includes(item)){
+          this.current[newSetting].push(item);
+        }
+      }
+    } else {
+      // No setting was assigned, this item has been removed from the settings
+      document.getElementById(`${this.name}-available_items`).appendChild(itemDiv);
+    }
+
+    // Remove the source drag object
+    sourceDiv.parentElement.removeChild(sourceDiv);
+
+    // Save the updated settings
+    this.save();
+  }
+
+  #buildHintsDiv() {
+    const hintsDiv = document.createElement('div');
+    hintsDiv.classList.add('hints-div');
+    const hintsHeader = document.createElement('h3');
+    hintsHeader.innerText = 'Item & Location Hints';
+    hintsDiv.appendChild(hintsHeader);
+    const hintsDescription = document.createElement('p');
+    hintsDescription.classList.add('setting-description');
+    hintsDescription.innerText = 'Choose any items or locations to begin the game with the knowledge of where those ' +
+      ' items are, or what those locations contain.';
+    hintsDiv.appendChild(hintsDescription);
+
+    const itemHintsContainer = document.createElement('div');
+    itemHintsContainer.classList.add('hints-container');
+
+    // Item Hints
+    const itemHintsWrapper = document.createElement('div');
+    itemHintsWrapper.classList.add('hints-wrapper');
+    itemHintsWrapper.innerText = 'Starting Item Hints';
+
+    const itemHintsDiv = this.buildItemsDiv('start_hints');
+    itemHintsWrapper.appendChild(itemHintsDiv);
+    itemHintsContainer.appendChild(itemHintsWrapper);
+
+    // Starting Location Hints
+    const locationHintsWrapper = document.createElement('div');
+    locationHintsWrapper.classList.add('hints-wrapper');
+    locationHintsWrapper.innerText = 'Starting Location Hints';
+
+    const locationHintsDiv = this.buildLocationsDiv('start_location_hints');
+    locationHintsWrapper.appendChild(locationHintsDiv);
+    itemHintsContainer.appendChild(locationHintsWrapper);
+
+    hintsDiv.appendChild(itemHintsContainer);
+    return hintsDiv;
+  }
+
+  #buildPriorityExclusionDiv() {
+    const locationsDiv = document.createElement('div');
+    locationsDiv.classList.add('locations-div');
+    const locationsHeader = document.createElement('h3');
+    locationsHeader.innerText = 'Priority & Exclusion Locations';
+    locationsDiv.appendChild(locationsHeader);
+    const locationsDescription = document.createElement('p');
+    locationsDescription.classList.add('setting-description');
+    locationsDescription.innerText = 'Priority locations guarantee a progression item will be placed there while ' +
+      'excluded locations will not contain progression or useful items.';
+    locationsDiv.appendChild(locationsDescription);
+
+    const locationsContainer = document.createElement('div');
+    locationsContainer.classList.add('locations-container');
+
+    // Priority Locations
+    const priorityLocationsWrapper = document.createElement('div');
+    priorityLocationsWrapper.classList.add('locations-wrapper');
+    priorityLocationsWrapper.innerText = 'Priority Locations';
+
+    const priorityLocationsDiv = this.buildLocationsDiv('priority_locations');
+    priorityLocationsWrapper.appendChild(priorityLocationsDiv);
+    locationsContainer.appendChild(priorityLocationsWrapper);
+
+    // Exclude Locations
+    const excludeLocationsWrapper = document.createElement('div');
+    excludeLocationsWrapper.classList.add('locations-wrapper');
+    excludeLocationsWrapper.innerText = 'Exclude Locations';
+
+    const excludeLocationsDiv = this.buildLocationsDiv('exclude_locations');
+    excludeLocationsWrapper.appendChild(excludeLocationsDiv);
+    locationsContainer.appendChild(excludeLocationsWrapper);
+
+    locationsDiv.appendChild(locationsContainer);
+    return locationsDiv;
+  }
+
+  // Builds a div for a setting whose value is a list of locations.
+  buildLocationsDiv(setting) {
+    return this.buildListDiv(setting, this.data.gameLocations, {
+      groups: this.data.gameLocationGroups,
+      descriptions: this.data.gameLocationDescriptions,
+    });
+  }
+
+  // Builds a div for a setting whose value is a list of items.
+  buildItemsDiv(setting) {
+    return this.buildListDiv(setting, this.data.gameItems, {
+      groups: this.data.gameItemGroups,
+      descriptions: this.data.gameItemDescriptions
+    });
+  }
+
+  // Builds a div for a setting named `setting` with a list value that can
+  // contain `items`.
+  //
+  // The `groups` option can be a list of additional options for this list
+  // (usually `item_name_groups` or `location_name_groups`) that are displayed
+  // in a special section at the top of the list.
+  //
+  // The `descriptions` option can be a map from item names or group names to
+  // descriptions for the user's benefit.
+  buildListDiv(setting, items, {groups = [], descriptions = {}} = {}) {
+    const div = document.createElement('div');
+    div.classList.add('simple-list');
+
+    groups.forEach((group) => {
+      const row = this.#addListRow(setting, group, descriptions[group]);
+      div.appendChild(row);
+    });
+
+    if (groups.length > 0) {
+      div.appendChild(document.createElement('hr'));
+    }
+
+    items.forEach((item) => {
+      const row = this.#addListRow(setting, item, descriptions[item]);
+      div.appendChild(row);
+    });
+
+    return div;
+  }
+
+  // Builds and returns a row for a list of checkboxes.
+  //
+  // If `help` is passed, it's displayed as a help tooltip for this list item.
+  #addListRow(setting, item, help = undefined) {
+    const row = document.createElement('div');
+    row.classList.add('list-row');
+
+    const label = document.createElement('label');
+    label.setAttribute('for', `${this.name}-${setting}-${item}`);
+
+    const checkbox = document.createElement('input');
+    checkbox.setAttribute('type', 'checkbox');
+    checkbox.setAttribute('id', `${this.name}-${setting}-${item}`);
+    checkbox.setAttribute('data-game', this.name);
+    checkbox.setAttribute('data-setting', setting);
+    checkbox.setAttribute('data-option', item);
+    if (this.current[setting].includes(item)) {
+      checkbox.setAttribute('checked', '1');
+    }
+    checkbox.addEventListener('change', (evt) => this.#updateListSetting(evt));
+    label.appendChild(checkbox);
+
+    const name = document.createElement('span');
+    name.innerText = item;
+
+    if (help) {
+      const helpSpan = document.createElement('span');
+      helpSpan.classList.add('interactive');
+      helpSpan.setAttribute('data-tooltip', help);
+      helpSpan.innerText = '(?)';
+      name.innerText += ' ';
+      name.appendChild(helpSpan);
+
+      // Put the first 7 tooltips below their rows. CSS tooltips in scrolling
+      // containers can't be visible outside those containers, so this helps
+      // ensure they won't be pushed out the top.
+      if (helpSpan.parentNode.childNodes.length < 7) {
+        helpSpan.classList.add('tooltip-bottom');
+      }
+    }
+
+    label.appendChild(name);
+
+    row.appendChild(label);
+    return row;
+  }
+
+  #updateRangeSetting(evt) {
+    const setting = evt.target.getAttribute('data-setting');
+    const option = evt.target.getAttribute('data-option');
+    document.getElementById(`${this.name}-${setting}-${option}`).innerText = evt.target.value;
+    if (evt.action && evt.action === 'rangeDelete') {
+      delete this.current[setting][option];
+    } else {
+      this.current[setting][option] = parseInt(evt.target.value, 10);
+    }
+    this.save();
+  }
+
+  #updateListSetting(evt) {
+    const setting = evt.target.getAttribute('data-setting');
+    const option = evt.target.getAttribute('data-option');
+
+    if (evt.target.checked) {
+      // If the option is to be enabled and it is already enabled, do nothing
+      if (this.current[setting].includes(option)) { return; }
+
+      this.current[setting].push(option);
+    } else {
+      // If the option is to be disabled and it is already disabled, do nothing
+      if (!this.current[setting].includes(option)) { return; }
+
+      this.current[setting].splice(this.current[setting].indexOf(option), 1);
+    }
+    this.save();
+  }
+
+  #updateItemSetting(evt) {
+    const setting = evt.target.getAttribute('data-setting');
+    const option = evt.target.getAttribute('data-option');
+    if (setting === 'start_inventory') {
+      this.current[setting][option] = evt.target.value.trim() ? parseInt(evt.target.value) : 0;
+    } else {
+      this.current[setting][option] = isNaN(evt.target.value) ?
+        evt.target.value : parseInt(evt.target.value, 10);
+    }
+    this.save();
+  }
+}
+

--- a/WebHostLib/static/assets/player-options.js
+++ b/WebHostLib/static/assets/player-options.js
@@ -94,7 +94,8 @@ class GameOptions extends BaseGameOptions {
     document.getElementById('game-options-right')
         .appendChild(this.#buildSmallOptions(rightOptions));
 
-    this.buildBaseUI(document.getElementById('game-options-center'));
+    // Uncomment this to show shared item and location options:
+    // this.buildBaseUI(document.getElementById('game-options-center'));
   }
 
   save() {
@@ -291,17 +292,18 @@ class GameOptions extends BaseGameOptions {
           namedRangeWrapper.appendChild(randomButton);
           break;
 
-        case 'items-list':
-          element = this.buildItemsDiv(option);
-          break;
-
-        case 'locations-list':
-          element = this.buildLocationsDiv(option);
-          break;
-
-        case 'custom-list':
-          element = this.buildListDiv(option, options[option].options);
-          break;
+        // Uncomment the following cases to show list options on this page:
+        // case 'items-list':
+        //   element = this.buildItemsDiv(option);
+        //   break;
+        //
+        // case 'locations-list':
+        //   element = this.buildLocationsDiv(option);
+        //   break;
+        //
+        // case 'custom-list':
+        //   element = this.buildListDiv(option, options[option].options);
+        //   break;
 
         default:
           console.error(`Ignoring unknown option type: ${options[option].type} with name ${option}`);

--- a/WebHostLib/static/assets/player-options.js
+++ b/WebHostLib/static/assets/player-options.js
@@ -1,523 +1,497 @@
+import {download, loadOptions, showUserMessage, BaseGameOptions} from './options.js';
+
 let gameName = null;
 
-window.addEventListener('load', () => {
+window.addEventListener('load', async () => {
   gameName = document.getElementById('player-options').getAttribute('data-game');
 
   // Update game name on page
   document.getElementById('game-name').innerText = gameName;
 
-  fetchOptionData().then((results) => {
-    let optionHash = localStorage.getItem(`${gameName}-hash`);
-    if (!optionHash) {
-      // If no hash data has been set before, set it now
-      optionHash = md5(JSON.stringify(results));
-      localStorage.setItem(`${gameName}-hash`, optionHash);
-      localStorage.removeItem(gameName);
-    }
-
-    if (optionHash !== md5(JSON.stringify(results))) {
-      showUserMessage(
-          'Your options are out of date! Click here to update them! Be aware this will reset them all to default.'
-      );
-      document.getElementById('user-message').addEventListener('click', resetOptions);
-    }
+  try {
+    const data = await loadOptions(`/static/generated/player-options/${gameName}.json`, gameName);
 
     // Page setup
-    createDefaultOptions(results);
-    buildUI(results);
+    const options = new GameOptions(data, gameName);
+    options.buildUI();
     adjustHeaderWidth();
 
     // Event listeners
-    document.getElementById('export-options').addEventListener('click', () => exportOptions());
-    document.getElementById('generate-race').addEventListener('click', () => generateGame(true));
-    document.getElementById('generate-game').addEventListener('click', () => generateGame());
+    document.getElementById('export-options').addEventListener('click', () => options.export());
+    document.getElementById('generate-race')
+        .addEventListener('click', () => options.generateGame(true));
+    document.getElementById('generate-game')
+        .addEventListener('click', () => options.generateGame());
 
     // Name input field
-    const playerOptions = JSON.parse(localStorage.getItem(gameName));
     const nameInput = document.getElementById('player-name');
-    nameInput.addEventListener('keyup', (event) => updateBaseOption(event));
-    nameInput.value = playerOptions.name;
+    nameInput.addEventListener('keyup', (event) => options.updateBaseOption(event));
+    nameInput.value = options.playerName;
 
     // Presets
+    if (!localStorage.getItem(`${gameName}-preset`)) {
+      localStorage.setItem(`${gameName}-preset`, '__default');
+    }
+
     const presetSelect = document.getElementById('game-options-preset');
-    presetSelect.addEventListener('change', (event) => setPresets(results, event.target.value));
-    for (const preset in results['presetOptions']) {
+    presetSelect.addEventListener('change', (event) => options.setPresets(event.target.value));
+    for (const preset in data['presetOptions']) {
       const presetOption = document.createElement('option');
       presetOption.innerText = preset;
       presetSelect.appendChild(presetOption);
     }
     presetSelect.value = localStorage.getItem(`${gameName}-preset`);
-    results['presetOptions']['__default'] = {};
-  }).catch((e) => {
+    data['presetOptions']['__default'] = {};
+  } catch (e) {
     console.error(e);
     const url = new URL(window.location.href);
-    window.location.replace(`${url.protocol}//${url.hostname}/page-not-found`);
-  })
+    window.location.replace(`${window.origin}/page-not-found`);
+  }
 });
 
-const resetOptions = () => {
-  localStorage.removeItem(gameName);
-  localStorage.removeItem(`${gameName}-hash`);
-  localStorage.removeItem(`${gameName}-preset`);
-  window.location.reload();
-};
+// Non-weighted options for the sole game displayed on the page.
+class GameOptions extends BaseGameOptions {
+  // The data from the server describing the types of settings available for
+  // this game, as a JSON-safe blob.
+  #data;
 
-const fetchOptionData = () => new Promise((resolve, reject) => {
-  const ajax = new XMLHttpRequest();
-  ajax.onreadystatechange = () => {
-    if (ajax.readyState !== 4) { return; }
-    if (ajax.status !== 200) {
-      reject(ajax.responseText);
+  // The settings chosen by the user as they'd appear in the YAML file, stored
+  // to and retrieved from local storage.
+  #current;
+
+  get data() {
+    return this.#data;
+  }
+
+  get current() {
+    return this.#current[this.name];
+  }
+
+  // The name of the player for this game.
+  get playerName() {
+    return this.#current.name;
+  }
+
+  constructor(data, name) {
+    super(name);
+    this.#data = data;
+    this.#current = JSON.parse(localStorage.getItem(name)) ?? {
+      [name]: Object.fromEntries(
+        Object.entries(data.gameOptions)
+            .map(([name, option]) => [name, option.defaultValue])
+      ),
+      ...data.baseOptions,
+    };
+  }
+
+  buildUI() {
+    // Game Options
+    // Divide options that can be rendered small into two columns
+    const entries = Object.entries(this.data.gameOptions);
+    const leftOptions = Object.fromEntries(entries.slice(0, Math.floor(entries.length / 2)));
+    const rightOptions = Object.fromEntries(entries.slice(Math.floor(entries.length / 2) + 1));
+    document.getElementById('game-options-left').appendChild(this.#buildSmallOptions(leftOptions));
+    document.getElementById('game-options-right')
+        .appendChild(this.#buildSmallOptions(rightOptions));
+
+    this.buildBaseUI(document.getElementById('game-options-center'));
+  }
+
+  save() {
+    localStorage.setItem(this.name, JSON.stringify(this.#current));
+  }
+
+  #buildSmallOptions(options, romOpts = false) {
+    const table = document.createElement('table');
+    const tbody = document.createElement('tbody');
+
+    Object.keys(options).forEach((option) => {
+      const tr = document.createElement('tr');
+
+      // td Left
+      const tdl = document.createElement('td');
+      const label = document.createElement('label');
+      label.textContent = `${options[option].displayName}: `;
+      label.setAttribute('for', option);
+
+      const questionSpan = document.createElement('span');
+      questionSpan.classList.add('interactive');
+      questionSpan.setAttribute('data-tooltip', options[option].description);
+      questionSpan.innerText = '(?)';
+
+      label.appendChild(questionSpan);
+      tdl.appendChild(label);
+      tr.appendChild(tdl);
+
+      // td Right
+      const tdr = document.createElement('td');
+      let element = null;
+
+      const randomButton = document.createElement('button');
+
+      switch(options[option].type) {
+        case 'select':
+          element = document.createElement('div');
+          element.classList.add('select-container');
+          let select = document.createElement('select');
+          select.setAttribute('id', option);
+          select.setAttribute('data-key', option);
+          if (romOpts) { select.setAttribute('data-romOpt', '1'); }
+          options[option].options.forEach((opt) => {
+            const optionElement = document.createElement('option');
+            optionElement.setAttribute('value', opt.value);
+            optionElement.innerText = opt.name;
+
+            if ((isNaN(this.current[option]) &&
+              (parseInt(opt.value, 10) === parseInt(this.current[option]))) ||
+              (opt.value === this.current[option]))
+            {
+              optionElement.selected = true;
+            }
+            select.appendChild(optionElement);
+          });
+          select.addEventListener('change', (event) => this.#updateGameOption(event.target));
+          element.appendChild(select);
+
+          // Randomize button
+          randomButton.innerText = '🎲';
+          randomButton.classList.add('randomize-button');
+          randomButton.setAttribute('data-key', option);
+          randomButton.setAttribute('data-tooltip', 'Toggle randomization for this option!');
+          randomButton.addEventListener('click', (event) => toggleRandomize(event, select));
+          if (this.current[option] === 'random') {
+            randomButton.classList.add('active');
+            select.disabled = true;
+          }
+
+          element.appendChild(randomButton);
+          break;
+
+        case 'range':
+          element = document.createElement('div');
+          element.classList.add('range-container');
+
+          let range = document.createElement('input');
+          range.setAttribute('id', option);
+          range.setAttribute('type', 'range');
+          range.setAttribute('data-key', option);
+          range.setAttribute('min', options[option].min);
+          range.setAttribute('max', options[option].max);
+          range.value = this.current[option];
+          range.addEventListener('change', (event) => {
+            document.getElementById(`${option}-value`).innerText = event.target.value;
+            this.#updateGameOption(event.target);
+          });
+          element.appendChild(range);
+
+          let rangeVal = document.createElement('span');
+          rangeVal.classList.add('range-value');
+          rangeVal.setAttribute('id', `${option}-value`);
+          rangeVal.innerText = this.current[option] !== 'random' ?
+            this.current[option] : options[option].defaultValue;
+          element.appendChild(rangeVal);
+
+          // Randomize button
+          randomButton.innerText = '🎲';
+          randomButton.classList.add('randomize-button');
+          randomButton.setAttribute('data-key', option);
+          randomButton.setAttribute('data-tooltip', 'Toggle randomization for this option!');
+          randomButton.addEventListener('click', (event) => toggleRandomize(event, range));
+          if (this.current[option] === 'random') {
+            randomButton.classList.add('active');
+            range.disabled = true;
+          }
+
+          element.appendChild(randomButton);
+          break;
+
+        case 'named_range':
+          element = document.createElement('div');
+          element.classList.add('named-range-container');
+
+          // Build the select element
+          let namedRangeSelect = document.createElement('select');
+          namedRangeSelect.setAttribute('data-key', option);
+          Object.keys(options[option].value_names).forEach((presetName) => {
+            let presetOption = document.createElement('option');
+            presetOption.innerText = presetName;
+            presetOption.value = options[option].value_names[presetName];
+            const words = presetOption.innerText.split('_');
+            for (let i = 0; i < words.length; i++) {
+              words[i] = words[i][0].toUpperCase() + words[i].substring(1);
+            }
+            presetOption.innerText = words.join(' ');
+            namedRangeSelect.appendChild(presetOption);
+          });
+          let customOption = document.createElement('option');
+          customOption.innerText = 'Custom';
+          customOption.value = 'custom';
+          customOption.selected = true;
+          namedRangeSelect.appendChild(customOption);
+          if (Object.values(options[option].value_names).includes(Number(this.current[option]))) {
+            namedRangeSelect.value = Number(this.current[option]);
+          }
+
+          // Build range element
+          let namedRangeWrapper = document.createElement('div');
+          namedRangeWrapper.classList.add('named-range-wrapper');
+          let namedRange = document.createElement('input');
+          namedRange.setAttribute('type', 'range');
+          namedRange.setAttribute('data-key', option);
+          namedRange.setAttribute('min', options[option].min);
+          namedRange.setAttribute('max', options[option].max);
+          namedRange.value = this.current[option];
+
+          // Build rage value element
+          let namedRangeVal = document.createElement('span');
+          namedRangeVal.classList.add('range-value');
+          namedRangeVal.setAttribute('id', `${option}-value`);
+          namedRangeVal.innerText = this.current[option] !== 'random' ?
+            this.current[option] : options[option].defaultValue;
+
+          // Configure select event listener
+          namedRangeSelect.addEventListener('change', (event) => {
+            if (event.target.value === 'custom') { return; }
+
+            // Update range slider
+            namedRange.value = event.target.value;
+            document.getElementById(`${option}-value`).innerText = event.target.value;
+            this.#updateGameOption(event.target);
+          });
+
+          // Configure range event handler
+          namedRange.addEventListener('change', (event) => {
+            // Update select element
+            namedRangeSelect.value =
+              (Object.values(options[option].value_names).includes(parseInt(event.target.value))) ?
+              parseInt(event.target.value) : 'custom';
+            document.getElementById(`${option}-value`).innerText = event.target.value;
+            this.#updateGameOption(event.target);
+          });
+
+          element.appendChild(namedRangeSelect);
+          namedRangeWrapper.appendChild(namedRange);
+          namedRangeWrapper.appendChild(namedRangeVal);
+          element.appendChild(namedRangeWrapper);
+
+          // Randomize button
+          randomButton.innerText = '🎲';
+          randomButton.classList.add('randomize-button');
+          randomButton.setAttribute('data-key', option);
+          randomButton.setAttribute('data-tooltip', 'Toggle randomization for this option!');
+          randomButton.addEventListener('click', (event) => toggleRandomize(
+              event, namedRange, namedRangeSelect)
+          );
+          if (this.current[option] === 'random') {
+            randomButton.classList.add('active');
+            namedRange.disabled = true;
+            namedRangeSelect.disabled = true;
+          }
+
+          namedRangeWrapper.appendChild(randomButton);
+          break;
+
+        case 'items-list':
+          element = this.buildItemsDiv(option);
+          break;
+
+        case 'locations-list':
+          element = this.buildLocationsDiv(option);
+          break;
+
+        case 'custom-list':
+          element = this.buildListDiv(option, options[option].options);
+          break;
+
+        default:
+          console.error(`Ignoring unknown option type: ${options[option].type} with name ${option}`);
+          return;
+      }
+
+      tdr.appendChild(element);
+      tr.appendChild(tdr);
+      tbody.appendChild(tr);
+    });
+
+    table.appendChild(tbody);
+    return table;
+  }
+
+  #toggleRandomize(event, inputElement, optionalSelectElement = null) {
+    const active = event.target.classList.contains('active');
+    const randomButton = event.target;
+
+    if (active) {
+      randomButton.classList.remove('active');
+      inputElement.disabled = undefined;
+      if (optionalSelectElement) {
+        optionalSelectElement.disabled = undefined;
+      }
+    } else {
+      randomButton.classList.add('active');
+      inputElement.disabled = true;
+      if (optionalSelectElement) {
+        optionalSelectElement.disabled = true;
+      }
+    }
+    this.#updateGameOption(active ? inputElement : randomButton);
+  }
+
+  setPresets(presetName) {
+    const defaults = this.data.gameOptions;
+    const preset = this.data.presetOptions[presetName];
+
+    localStorage.setItem(`${gameName}-preset`, presetName);
+
+    if (!preset) {
+      console.error(`No presets defined for preset name: '${presetName}'`);
       return;
     }
-    try{ resolve(JSON.parse(ajax.responseText)); }
-    catch(error){ reject(error); }
-  };
-  ajax.open('GET', `${window.location.origin}/static/generated/player-options/${gameName}.json`, true);
-  ajax.send();
-});
 
-const createDefaultOptions = (optionData) => {
-  if (!localStorage.getItem(gameName)) {
-    const newOptions = {
-      [gameName]: {},
+    const updateOptionElement = (option, presetValue) => {
+      const optionElement = document.querySelector(`#${option}[data-key='${option}']`);
+      const randomElement = document.querySelector(`.randomize-button[data-key='${option}']`);
+
+      if (presetValue === 'random') {
+        randomElement.classList.add('active');
+        optionElement.disabled = true;
+        this.#updateGameOption(randomElement, false);
+      } else {
+        optionElement.value = presetValue;
+        randomElement.classList.remove('active');
+        optionElement.disabled = undefined;
+        this.#updateGameOption(optionElement, false);
+      }
     };
-    for (let baseOption of Object.keys(optionData.baseOptions)){
-      newOptions[baseOption] = optionData.baseOptions[baseOption];
+
+    for (const option in defaults) {
+      let presetValue = preset[option];
+      if (presetValue === undefined) {
+        // Using the default value if not set in presets.
+        presetValue = defaults[option]['defaultValue'];
+      }
+
+      switch (defaults[option].type) {
+        case 'range':
+          const numberElement = document.querySelector(`#${option}-value`);
+          if (presetValue === 'random') {
+            numberElement.innerText = defaults[option]['defaultValue'] === 'random'
+                ? defaults[option]['min'] // A fallback so we don't print 'random' in the UI.
+                : defaults[option]['defaultValue'];
+          } else {
+            numberElement.innerText = presetValue;
+          }
+
+          updateOptionElement(option, presetValue);
+          break;
+
+        case 'select': {
+          updateOptionElement(option, presetValue);
+          break;
+        }
+
+        case 'named_range': {
+          const selectElement = document.querySelector(`select[data-key='${option}']`);
+          const rangeElement = document.querySelector(`input[data-key='${option}']`);
+          const randomElement = document.querySelector(`.randomize-button[data-key='${option}']`);
+
+          if (presetValue === 'random') {
+            randomElement.classList.add('active');
+            selectElement.disabled = true;
+            rangeElement.disabled = true;
+            this.#updateGameOption(randomElement, false);
+          } else {
+            rangeElement.value = presetValue;
+            selectElement.value = Object.values(defaults[option]['value_names']).includes(parseInt(presetValue)) ?
+                parseInt(presetValue) : 'custom';
+            document.getElementById(`${option}-value`).innerText = presetValue;
+
+            randomElement.classList.remove('active');
+            selectElement.disabled = undefined;
+            rangeElement.disabled = undefined;
+            this.#updateGameOption(rangeElement, false);
+          }
+          break;
+        }
+
+        default:
+          console.warn(`Ignoring preset value for unknown option type: ${defaults[option].type} with name ${option}`);
+          break;
+      }
     }
-    for (let gameOption of Object.keys(optionData.gameOptions)){
-      newOptions[gameName][gameOption] = optionData.gameOptions[gameOption].defaultValue;
-    }
-    localStorage.setItem(gameName, JSON.stringify(newOptions));
   }
 
-  if (!localStorage.getItem(`${gameName}-preset`)) {
-    localStorage.setItem(`${gameName}-preset`, '__default');
+  updateBaseOption(event) {
+    this.#current[event.target.getAttribute('data-key')] =
+        isNaN(event.target.value) ? event.target.value : parseInt(event.target.value);
+    this.save();
   }
-};
 
-const buildUI = (optionData) => {
-  // Game Options
-  const leftGameOpts = {};
-  const rightGameOpts = {};
-  Object.keys(optionData.gameOptions).forEach((key, index) => {
-    if (index < Object.keys(optionData.gameOptions).length / 2) {
-      leftGameOpts[key] = optionData.gameOptions[key];
+  #updateGameOption(optionElement, toggleCustomPreset = true) {
+    if (toggleCustomPreset) {
+      localStorage.setItem(`${gameName}-preset`, '__custom');
+      const presetElement = document.getElementById('game-options-preset');
+      presetElement.value = '__custom';
+    }
+
+    if (optionElement.classList.contains('randomize-button')) {
+      // If the event passed in is the randomize button, then we know what we must do.
+      this.current[optionElement.getAttribute('data-key')] = 'random';
     } else {
-      rightGameOpts[key] = optionData.gameOptions[key];
+      this.current[optionElement.getAttribute('data-key')] =
+          isNaN(optionElement.value) ? optionElement.value : parseInt(optionElement.value, 10);
     }
-  });
-  document.getElementById('game-options-left').appendChild(buildOptionsTable(leftGameOpts));
-  document.getElementById('game-options-right').appendChild(buildOptionsTable(rightGameOpts));
-};
 
-const buildOptionsTable = (options, romOpts = false) => {
-  const currentOptions = JSON.parse(localStorage.getItem(gameName));
-  const table = document.createElement('table');
-  const tbody = document.createElement('tbody');
+    this.save();
+  }
 
-  Object.keys(options).forEach((option) => {
-    const tr = document.createElement('tr');
-
-    // td Left
-    const tdl = document.createElement('td');
-    const label = document.createElement('label');
-    label.textContent = `${options[option].displayName}: `;
-    label.setAttribute('for', option);
-
-    const questionSpan = document.createElement('span');
-    questionSpan.classList.add('interactive');
-    questionSpan.setAttribute('data-tooltip', options[option].description);
-    questionSpan.innerText = '(?)';
-
-    label.appendChild(questionSpan);
-    tdl.appendChild(label);
-    tr.appendChild(tdl);
-
-    // td Right
-    const tdr = document.createElement('td');
-    let element = null;
-
-    const randomButton = document.createElement('button');
-
-    switch(options[option].type) {
-      case 'select':
-        element = document.createElement('div');
-        element.classList.add('select-container');
-        let select = document.createElement('select');
-        select.setAttribute('id', option);
-        select.setAttribute('data-key', option);
-        if (romOpts) { select.setAttribute('data-romOpt', '1'); }
-        options[option].options.forEach((opt) => {
-          const optionElement = document.createElement('option');
-          optionElement.setAttribute('value', opt.value);
-          optionElement.innerText = opt.name;
-
-          if ((isNaN(currentOptions[gameName][option]) &&
-            (parseInt(opt.value, 10) === parseInt(currentOptions[gameName][option]))) ||
-            (opt.value === currentOptions[gameName][option]))
-          {
-            optionElement.selected = true;
-          }
-          select.appendChild(optionElement);
-        });
-        select.addEventListener('change', (event) => updateGameOption(event.target));
-        element.appendChild(select);
-
-        // Randomize button
-        randomButton.innerText = '🎲';
-        randomButton.classList.add('randomize-button');
-        randomButton.setAttribute('data-key', option);
-        randomButton.setAttribute('data-tooltip', 'Toggle randomization for this option!');
-        randomButton.addEventListener('click', (event) => toggleRandomize(event, select));
-        if (currentOptions[gameName][option] === 'random') {
-          randomButton.classList.add('active');
-          select.disabled = true;
-        }
-
-        element.appendChild(randomButton);
+  export() {
+    const options = {...this.#current};
+    const preset = localStorage.getItem(`${gameName}-preset`);
+    switch (preset) {
+      case '__default':
+        options['description'] = `Generated by https://archipelago.gg with the default preset.`;
         break;
 
-      case 'range':
-        element = document.createElement('div');
-        element.classList.add('range-container');
-
-        let range = document.createElement('input');
-        range.setAttribute('id', option);
-        range.setAttribute('type', 'range');
-        range.setAttribute('data-key', option);
-        range.setAttribute('min', options[option].min);
-        range.setAttribute('max', options[option].max);
-        range.value = currentOptions[gameName][option];
-        range.addEventListener('change', (event) => {
-          document.getElementById(`${option}-value`).innerText = event.target.value;
-          updateGameOption(event.target);
-        });
-        element.appendChild(range);
-
-        let rangeVal = document.createElement('span');
-        rangeVal.classList.add('range-value');
-        rangeVal.setAttribute('id', `${option}-value`);
-        rangeVal.innerText = currentOptions[gameName][option] !== 'random' ?
-          currentOptions[gameName][option] : options[option].defaultValue;
-        element.appendChild(rangeVal);
-
-        // Randomize button
-        randomButton.innerText = '🎲';
-        randomButton.classList.add('randomize-button');
-        randomButton.setAttribute('data-key', option);
-        randomButton.setAttribute('data-tooltip', 'Toggle randomization for this option!');
-        randomButton.addEventListener('click', (event) => toggleRandomize(event, range));
-        if (currentOptions[gameName][option] === 'random') {
-          randomButton.classList.add('active');
-          range.disabled = true;
-        }
-
-        element.appendChild(randomButton);
-        break;
-
-      case 'named_range':
-        element = document.createElement('div');
-        element.classList.add('named-range-container');
-
-        // Build the select element
-        let namedRangeSelect = document.createElement('select');
-        namedRangeSelect.setAttribute('data-key', option);
-        Object.keys(options[option].value_names).forEach((presetName) => {
-          let presetOption = document.createElement('option');
-          presetOption.innerText = presetName;
-          presetOption.value = options[option].value_names[presetName];
-          const words = presetOption.innerText.split('_');
-          for (let i = 0; i < words.length; i++) {
-            words[i] = words[i][0].toUpperCase() + words[i].substring(1);
-          }
-          presetOption.innerText = words.join(' ');
-          namedRangeSelect.appendChild(presetOption);
-        });
-        let customOption = document.createElement('option');
-        customOption.innerText = 'Custom';
-        customOption.value = 'custom';
-        customOption.selected = true;
-        namedRangeSelect.appendChild(customOption);
-        if (Object.values(options[option].value_names).includes(Number(currentOptions[gameName][option]))) {
-          namedRangeSelect.value = Number(currentOptions[gameName][option]);
-        }
-
-        // Build range element
-        let namedRangeWrapper = document.createElement('div');
-        namedRangeWrapper.classList.add('named-range-wrapper');
-        let namedRange = document.createElement('input');
-        namedRange.setAttribute('type', 'range');
-        namedRange.setAttribute('data-key', option);
-        namedRange.setAttribute('min', options[option].min);
-        namedRange.setAttribute('max', options[option].max);
-        namedRange.value = currentOptions[gameName][option];
-
-        // Build rage value element
-        let namedRangeVal = document.createElement('span');
-        namedRangeVal.classList.add('range-value');
-        namedRangeVal.setAttribute('id', `${option}-value`);
-        namedRangeVal.innerText = currentOptions[gameName][option] !== 'random' ?
-          currentOptions[gameName][option] : options[option].defaultValue;
-
-        // Configure select event listener
-        namedRangeSelect.addEventListener('change', (event) => {
-          if (event.target.value === 'custom') { return; }
-
-          // Update range slider
-          namedRange.value = event.target.value;
-          document.getElementById(`${option}-value`).innerText = event.target.value;
-          updateGameOption(event.target);
-        });
-
-        // Configure range event handler
-        namedRange.addEventListener('change', (event) => {
-          // Update select element
-          namedRangeSelect.value =
-            (Object.values(options[option].value_names).includes(parseInt(event.target.value))) ?
-            parseInt(event.target.value) : 'custom';
-          document.getElementById(`${option}-value`).innerText = event.target.value;
-          updateGameOption(event.target);
-        });
-
-        element.appendChild(namedRangeSelect);
-        namedRangeWrapper.appendChild(namedRange);
-        namedRangeWrapper.appendChild(namedRangeVal);
-        element.appendChild(namedRangeWrapper);
-
-        // Randomize button
-        randomButton.innerText = '🎲';
-        randomButton.classList.add('randomize-button');
-        randomButton.setAttribute('data-key', option);
-        randomButton.setAttribute('data-tooltip', 'Toggle randomization for this option!');
-        randomButton.addEventListener('click', (event) => toggleRandomize(
-            event, namedRange, namedRangeSelect)
-        );
-        if (currentOptions[gameName][option] === 'random') {
-          randomButton.classList.add('active');
-          namedRange.disabled = true;
-          namedRangeSelect.disabled = true;
-        }
-
-        namedRangeWrapper.appendChild(randomButton);
+      case '__custom':
+        options['description'] = `Generated by https://archipelago.gg.`;
         break;
 
       default:
-        console.error(`Ignoring unknown option type: ${options[option].type} with name ${option}`);
-        return;
+        options['description'] = `Generated by https://archipelago.gg with the ${preset} preset.`;
     }
 
-    tdr.appendChild(element);
-    tr.appendChild(tdr);
-    tbody.appendChild(tr);
-  });
-
-  table.appendChild(tbody);
-  return table;
-};
-
-const setPresets = (optionsData, presetName) => {
-  const defaults = optionsData['gameOptions'];
-  const preset = optionsData['presetOptions'][presetName];
-
-  localStorage.setItem(`${gameName}-preset`, presetName);
-
-  if (!preset) {
-    console.error(`No presets defined for preset name: '${presetName}'`);
-    return;
-  }
-
-  const updateOptionElement = (option, presetValue) => {
-    const optionElement = document.querySelector(`#${option}[data-key='${option}']`);
-    const randomElement = document.querySelector(`.randomize-button[data-key='${option}']`);
-
-    if (presetValue === 'random') {
-      randomElement.classList.add('active');
-      optionElement.disabled = true;
-      updateGameOption(randomElement, false);
-    } else {
-      optionElement.value = presetValue;
-      randomElement.classList.remove('active');
-      optionElement.disabled = undefined;
-      updateGameOption(optionElement, false);
+    if (!options.name || options.name.toString().trim().length === 0) {
+      showUserMessage('You must enter a player name!');
+      return;
     }
+
+    const yamlText = jsyaml.safeDump(options, { noCompatMode: true }).replaceAll(/'(\d+)':/g, (x, y) => `${y}:`);
+    download(`${document.getElementById('player-name').value}.yaml`, yamlText);
   };
 
-  for (const option in defaults) {
-    let presetValue = preset[option];
-    if (presetValue === undefined) {
-      // Using the default value if not set in presets.
-      presetValue = defaults[option]['defaultValue'];
+  async generateGame(raceMode = false) {
+    if (!this.#current.name ||
+        this.#current.name.toLowerCase() === 'player' ||
+        this.#current.name.trim().length === 0) {
+      return showUserMessage('You must enter a player name!');
     }
 
-    switch (defaults[option].type) {
-      case 'range':
-        const numberElement = document.querySelector(`#${option}-value`);
-        if (presetValue === 'random') {
-          numberElement.innerText = defaults[option]['defaultValue'] === 'random'
-              ? defaults[option]['min'] // A fallback so we don't print 'random' in the UI.
-              : defaults[option]['defaultValue'];
-        } else {
-          numberElement.innerText = presetValue;
-        }
-
-        updateOptionElement(option, presetValue);
-        break;
-
-      case 'select': {
-        updateOptionElement(option, presetValue);
-        break;
+    try {
+      window.location.href = await axios.post('/api/generate', {
+        weights: { player: this.#current },
+        presetData: { player: this.#current },
+        playerCount: 1,
+        spoiler: 3,
+        race: raceMode ? '1' : '0',
+      }).data.url;
+    } catch (error) {
+      let userMessage = 'Something went wrong and your game could not be generated.';
+      if (error.response.data.text) {
+        userMessage += ' ' + error.response.data.text;
       }
-
-      case 'named_range': {
-        const selectElement = document.querySelector(`select[data-key='${option}']`);
-        const rangeElement = document.querySelector(`input[data-key='${option}']`);
-        const randomElement = document.querySelector(`.randomize-button[data-key='${option}']`);
-
-        if (presetValue === 'random') {
-          randomElement.classList.add('active');
-          selectElement.disabled = true;
-          rangeElement.disabled = true;
-          updateGameOption(randomElement, false);
-        } else {
-          rangeElement.value = presetValue;
-          selectElement.value = Object.values(defaults[option]['value_names']).includes(parseInt(presetValue)) ?
-              parseInt(presetValue) : 'custom';
-          document.getElementById(`${option}-value`).innerText = presetValue;
-
-          randomElement.classList.remove('active');
-          selectElement.disabled = undefined;
-          rangeElement.disabled = undefined;
-          updateGameOption(rangeElement, false);
-        }
-        break;
-      }
-
-      default:
-        console.warn(`Ignoring preset value for unknown option type: ${defaults[option].type} with name ${option}`);
-        break;
+      showUserMessage(userMessage);
+      console.error(error);
     }
   }
-};
-
-const toggleRandomize = (event, inputElement, optionalSelectElement = null) => {
-  const active = event.target.classList.contains('active');
-  const randomButton = event.target;
-
-  if (active) {
-    randomButton.classList.remove('active');
-    inputElement.disabled = undefined;
-    if (optionalSelectElement) {
-      optionalSelectElement.disabled = undefined;
-    }
-  } else {
-    randomButton.classList.add('active');
-    inputElement.disabled = true;
-    if (optionalSelectElement) {
-      optionalSelectElement.disabled = true;
-    }
-  }
-    updateGameOption(active ? inputElement : randomButton);
-};
-
-const updateBaseOption = (event) => {
-  const options = JSON.parse(localStorage.getItem(gameName));
-  options[event.target.getAttribute('data-key')] = isNaN(event.target.value) ?
-    event.target.value : parseInt(event.target.value);
-  localStorage.setItem(gameName, JSON.stringify(options));
-};
-
-const updateGameOption = (optionElement, toggleCustomPreset = true) => {
-  const options = JSON.parse(localStorage.getItem(gameName));
-
-  if (toggleCustomPreset) {
-    localStorage.setItem(`${gameName}-preset`, '__custom');
-    const presetElement = document.getElementById('game-options-preset');
-    presetElement.value = '__custom';
-  }
-
-  if (optionElement.classList.contains('randomize-button')) {
-    // If the event passed in is the randomize button, then we know what we must do.
-    options[gameName][optionElement.getAttribute('data-key')] = 'random';
-  } else {
-    options[gameName][optionElement.getAttribute('data-key')] = isNaN(optionElement.value) ?
-      optionElement.value : parseInt(optionElement.value, 10);
-  }
-
-  localStorage.setItem(gameName, JSON.stringify(options));
-};
-
-const exportOptions = () => {
-  const options = JSON.parse(localStorage.getItem(gameName));
-  const preset = localStorage.getItem(`${gameName}-preset`);
-  switch (preset) {
-    case '__default':
-      options['description'] = `Generated by https://archipelago.gg with the default preset.`;
-      break;
-
-    case '__custom':
-      options['description'] = `Generated by https://archipelago.gg.`;
-      break;
-
-    default:
-      options['description'] = `Generated by https://archipelago.gg with the ${preset} preset.`;
-  }
-
-  if (!options.name || options.name.toString().trim().length === 0) {
-    return showUserMessage('You must enter a player name!');
-  }
-  const yamlText = jsyaml.safeDump(options, { noCompatMode: true }).replaceAll(/'(\d+)':/g, (x, y) => `${y}:`);
-  download(`${document.getElementById('player-name').value}.yaml`, yamlText);
-};
-
-/** Create an anchor and trigger a download of a text file. */
-const download = (filename, text) => {
-  const downloadLink = document.createElement('a');
-  downloadLink.setAttribute('href','data:text/yaml;charset=utf-8,'+ encodeURIComponent(text))
-  downloadLink.setAttribute('download', filename);
-  downloadLink.style.display = 'none';
-  document.body.appendChild(downloadLink);
-  downloadLink.click();
-  document.body.removeChild(downloadLink);
-};
-
-const generateGame = (raceMode = false) => {
-  const options = JSON.parse(localStorage.getItem(gameName));
-  if (!options.name || options.name.toLowerCase() === 'player' || options.name.trim().length === 0) {
-    return showUserMessage('You must enter a player name!');
-  }
-
-  axios.post('/api/generate', {
-    weights: { player: options },
-    presetData: { player: options },
-    playerCount: 1,
-    spoiler: 3,
-    race: raceMode ? '1' : '0',
-  }).then((response) => {
-    window.location.href = response.data.url;
-  }).catch((error) => {
-    let userMessage = 'Something went wrong and your game could not be generated.';
-    if (error.response.data.text) {
-      userMessage += ' ' + error.response.data.text;
-    }
-    showUserMessage(userMessage);
-    console.error(error);
-  });
-};
-
-const showUserMessage = (message) => {
-  const userMessage = document.getElementById('user-message');
-    userMessage.innerText = message;
-    userMessage.classList.add('visible');
-    window.scrollTo(0, 0);
-    userMessage.addEventListener('click', () => {
-      userMessage.classList.remove('visible');
-      userMessage.addEventListener('click', hideUserMessage);
-    });
-};
-
-const hideUserMessage = () => {
-  const userMessage = document.getElementById('user-message');
-  userMessage.classList.remove('visible');
-  userMessage.removeEventListener('click', hideUserMessage);
-};
+}

--- a/WebHostLib/static/styles/options.css
+++ b/WebHostLib/static/styles/options.css
@@ -1,0 +1,213 @@
+html{
+    background-image: url('../static/backgrounds/grass.png');
+    background-repeat: repeat;
+    background-size: 650px 650px;
+}
+
+.options {
+    box-sizing: border-box;
+    max-width: 1024px;
+    margin-left: auto;
+    margin-right: auto;
+    background-color: rgba(0, 0, 0, 0.15);
+    border-radius: 8px;
+    padding: 1rem;
+    color: #eeffeb;
+}
+
+.options code{
+    background-color: #d9cd8e;
+    border-radius: 4px;
+    padding-left: 0.25rem;
+    padding-right: 0.25rem;
+    color: #000000;
+}
+
+.options #user-message{
+    display: none;
+    width: calc(100% - 8px);
+    background-color: #ffe86b;
+    border-radius: 4px;
+    color: #000000;
+    padding: 4px;
+    text-align: center;
+}
+
+.options #user-message.visible{
+    display: block;
+    cursor: pointer;
+}
+
+.options a{
+    color: #ffef00;
+    cursor: pointer;
+}
+
+.options h1{
+    font-size: 2.5rem;
+    font-weight: normal;
+    border-bottom: 1px solid #ffffff;
+    width: 100%;
+    margin-bottom: 0.5rem;
+    color: #ffffff;
+    text-shadow: 1px 1px 4px #000000;
+}
+
+.options h2{
+    font-size: 2rem;
+    font-weight: normal;
+    border-bottom: 1px solid #ffffff;
+    width: 100%;
+    margin-bottom: 0.5rem;
+    color: #ffe993;
+    text-transform: none;
+    text-shadow: 1px 1px 2px #000000;
+}
+
+.options h3, .options h4, .options h5, .options h6{
+    color: #ffffff;
+    text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.5);
+    text-transform: none;
+}
+
+.options input:not([type]){
+    border: 1px solid #000000;
+    padding: 3px;
+    border-radius: 3px;
+    min-width: 150px;
+}
+
+.options input:not([type]):focus{
+    border: 1px solid #ffffff;
+}
+
+.options select{
+    border: 1px solid #000000;
+    padding: 3px;
+    border-radius: 3px;
+    min-width: 150px;
+    background-color: #ffffff;
+}
+
+.options .items-wrapper{
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+}
+
+.options .items-div h3{
+    margin-bottom: 0.5rem;
+}
+
+.options .items-wrapper .item-set-wrapper{
+    width: 24%;
+    font-weight: bold;
+}
+
+.options .item-container{
+    border: 1px solid #ffffff;
+    border-radius: 2px;
+    width: 100%;
+    height: 300px;
+    overflow-y: auto;
+    overflow-x: hidden;
+    margin-top: 0.125rem;
+    font-weight: normal;
+}
+
+.options .item-container .item-div{
+    padding: 0.125rem 0.5rem;
+    cursor: pointer;
+}
+
+.options .item-container .item-div:hover{
+    background-color: rgba(0, 0, 0, 0.1);
+}
+
+.options .item-container .item-qty-div{
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    padding: 0.125rem 0.5rem;
+    cursor: pointer;
+}
+
+.options .item-container .item-qty-div .item-qty-input-wrapper{
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+}
+
+.options .item-container .item-qty-div input{
+    min-width: unset;
+    width: 1.5rem;
+    text-align: center;
+}
+
+.options .item-container .item-qty-div:hover{
+    background-color: rgba(0, 0, 0, 0.1);
+}
+
+.options .hints-div, .options .locations-div{
+    margin-top: 2rem;
+}
+
+.options .hints-div h3, .options .locations-div h3{
+    margin-bottom: 0.5rem;
+}
+
+.options .hints-container, .options .locations-container{
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+}
+
+.options .hints-wrapper, .options .locations-wrapper{
+    width: calc(50% - 0.5rem);
+    font-weight: bold;
+}
+
+.options .hints-wrapper .simple-list, .options .locations-wrapper .simple-list{
+    margin-top: 0.25rem;
+    height: 300px;
+    font-weight: normal;
+}
+
+.options .simple-list{
+    display: flex;
+    flex-direction: column;
+
+    max-height: 300px;
+    overflow-y: auto;
+    border: 1px solid #ffffff;
+    border-radius: 4px;
+}
+
+.options .simple-list .list-row label{
+    display: block;
+    width: calc(100% - 0.5rem);
+    padding: 0.0625rem 0.25rem;
+}
+
+.options .simple-list .list-row label:hover{
+    background-color: rgba(0, 0, 0, 0.1);
+}
+
+.options .simple-list .list-row label input[type=checkbox]{
+    margin-right: 0.5rem;
+}
+
+.options .simple-list hr{
+    width: calc(100% - 2px);
+    margin: 2px auto;
+    border-bottom: 1px solid rgb(255 255 255 / 0.6);
+}
+
+.options p.setting-description{
+    margin: 0 0 1rem;
+}
+
+.options p.hint-text{
+    margin: 0 0 1rem;
+    font-style: italic;
+}

--- a/WebHostLib/static/styles/player-options.css
+++ b/WebHostLib/static/styles/player-options.css
@@ -1,20 +1,3 @@
-html{
-    background-image: url('../static/backgrounds/grass.png');
-    background-repeat: repeat;
-    background-size: 650px 650px;
-}
-
-#player-options{
-    box-sizing: border-box;
-    max-width: 1024px;
-    margin-left: auto;
-    margin-right: auto;
-    background-color: rgba(0, 0, 0, 0.15);
-    border-radius: 8px;
-    padding: 1rem;
-    color: #eeffeb;
-}
-
 #player-options #player-options-button-row{
     display: flex;
     flex-direction: row;
@@ -22,84 +5,11 @@ html{
     margin-top: 15px;
 }
 
-#player-options code{
-    background-color: #d9cd8e;
-    border-radius: 4px;
-    padding-left: 0.25rem;
-    padding-right: 0.25rem;
-    color: #000000;
-}
-
-#player-options #user-message{
-    display: none;
-    width: calc(100% - 8px);
-    background-color: #ffe86b;
-    border-radius: 4px;
-    color: #000000;
-    padding: 4px;
-    text-align: center;
-}
-
-#player-options #user-message.visible{
-    display: block;
-    cursor: pointer;
-}
-
-#player-options h1{
-    font-size: 2.5rem;
-    font-weight: normal;
-    width: 100%;
-    margin-bottom: 0.5rem;
-    text-shadow: 1px 1px 4px #000000;
-}
-
-#player-options h2{
-    font-size: 40px;
-    font-weight: normal;
-    width: 100%;
-    margin-bottom: 0.5rem;
-    text-transform: lowercase;
-    text-shadow: 1px 1px 2px #000000;
-}
-
-#player-options h3, #player-options h4, #player-options h5, #player-options h6{
-    text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.5);
-}
-
-#player-options input:not([type]){
-    border: 1px solid #000000;
-    padding: 3px;
-    border-radius: 3px;
-    min-width: 150px;
-}
-
-#player-options input:not([type]):focus{
-    border: 1px solid #ffffff;
-}
-
-#player-options select{
-    border: 1px solid #000000;
-    padding: 3px;
-    border-radius: 3px;
-    min-width: 150px;
-    background-color: #ffffff;
-}
-
-#player-options #game-options, #player-options #rom-options{
-    display: flex;
-    flex-direction: row;
-}
-
 #player-options #meta-options {
     display: flex;
     justify-content: space-between;
     gap: 20px;
     padding: 3px;
-}
-
-#player-options div {
-    display: flex;
-    flex-grow: 1;
 }
 
 #player-options #meta-options label {
@@ -116,19 +26,25 @@ html{
 }
 
 #player-options .left, #player-options .right{
-    flex-grow: 1;
+    width: 50%;
+    box-sizing: border-box;
 }
 
 #player-options .left{
-    margin-right: 10px;
+    float: left;
+    padding-right: 10px;
 }
 
 #player-options .right{
-    margin-left: 10px;
+    float: right;
+    padding-left: 10px;
+}
+
+#game-options-center {
+    clear: both;
 }
 
 #player-options table{
-    margin-bottom: 30px;
     width: 100%;
 }
 
@@ -208,6 +124,14 @@ html{
     vertical-align: top;
 }
 
+#player-options table .simple-list{
+    max-height: 120px;
+}
+
+#game-options-center{
+    margin-bottom: 30px;
+}
+
 @media all and (max-width: 1024px) {
     #player-options {
         border-radius: 0;
@@ -221,7 +145,6 @@ html{
 
     #player-options #game-options{
         justify-content: flex-start;
-        flex-wrap: wrap;
     }
 
     #player-options .left,

--- a/WebHostLib/static/styles/weighted-options.css
+++ b/WebHostLib/static/styles/weighted-options.css
@@ -1,18 +1,5 @@
 html{
-    background-image: url('../static/backgrounds/grass.png');
-    background-repeat: repeat;
-    background-size: 650px 650px;
     scroll-padding-top: 90px;
-}
-
-#weighted-settings{
-    max-width: 1000px;
-    margin-left: auto;
-    margin-right: auto;
-    background-color: rgba(0, 0, 0, 0.15);
-    border-radius: 8px;
-    padding: 1rem;
-    color: #eeffeb;
 }
 
 #weighted-settings #games-wrapper{
@@ -42,15 +29,6 @@ html{
 
 #weighted-settings .setting-wrapper .add-option-div button:active{
     margin-bottom: 1px;
-}
-
-#weighted-settings p.setting-description{
-    margin: 0 0 1rem;
-}
-
-#weighted-settings p.hint-text{
-    margin: 0 0 1rem;
-    font-style: italic;
 }
 
 #weighted-settings .jump-link{
@@ -98,90 +76,6 @@ html{
     cursor: pointer;
 }
 
-#weighted-settings .items-wrapper{
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-}
-
-#weighted-settings .items-div h3{
-    margin-bottom: 0.5rem;
-}
-
-#weighted-settings .items-wrapper .item-set-wrapper{
-    width: 24%;
-    font-weight: bold;
-}
-
-#weighted-settings .item-container{
-    border: 1px solid #ffffff;
-    border-radius: 2px;
-    width: 100%;
-    height: 300px;
-    overflow-y: auto;
-    overflow-x: hidden;
-    margin-top: 0.125rem;
-    font-weight: normal;
-}
-
-#weighted-settings .item-container .item-div{
-    padding: 0.125rem 0.5rem;
-    cursor: pointer;
-}
-
-#weighted-settings .item-container .item-div:hover{
-    background-color: rgba(0, 0, 0, 0.1);
-}
-
-#weighted-settings .item-container .item-qty-div{
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    padding: 0.125rem 0.5rem;
-    cursor: pointer;
-}
-
-#weighted-settings .item-container .item-qty-div .item-qty-input-wrapper{
-    display: flex;
-    flex-direction: column;
-    justify-content: space-around;
-}
-
-#weighted-settings .item-container .item-qty-div input{
-    min-width: unset;
-    width: 1.5rem;
-    text-align: center;
-}
-
-#weighted-settings .item-container .item-qty-div:hover{
-    background-color: rgba(0, 0, 0, 0.1);
-}
-
-#weighted-settings .hints-div, #weighted-settings .locations-div{
-    margin-top: 2rem;
-}
-
-#weighted-settings .hints-div h3, #weighted-settings .locations-div h3{
-    margin-bottom: 0.5rem;
-}
-
-#weighted-settings .hints-container, #weighted-settings .locations-container{
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-}
-
-#weighted-settings .hints-wrapper, #weighted-settings .locations-wrapper{
-    width: calc(50% - 0.5rem);
-    font-weight: bold;
-}
-
-#weighted-settings .hints-wrapper .simple-list, #weighted-settings .locations-wrapper .simple-list{
-    margin-top: 0.25rem;
-    height: 300px;
-    font-weight: normal;
-}
-
 #weighted-settings #weighted-settings-button-row{
     display: flex;
     flex-direction: row;
@@ -189,113 +83,9 @@ html{
     margin-top: 15px;
 }
 
-#weighted-settings code{
-    background-color: #d9cd8e;
-    border-radius: 4px;
-    padding-left: 0.25rem;
-    padding-right: 0.25rem;
-    color: #000000;
-}
-
-#weighted-settings #user-message{
-    display: none;
-    width: calc(100% - 8px);
-    background-color: #ffe86b;
-    border-radius: 4px;
-    color: #000000;
-    padding: 4px;
-    text-align: center;
-}
-
-#weighted-settings #user-message.visible{
-    display: block;
-    cursor: pointer;
-}
-
-#weighted-settings h1{
-    font-size: 2.5rem;
-    font-weight: normal;
-    border-bottom: 1px solid #ffffff;
-    width: 100%;
-    margin-bottom: 0.5rem;
-    color: #ffffff;
-    text-shadow: 1px 1px 4px #000000;
-}
-
-#weighted-settings h2{
-    font-size: 2rem;
-    font-weight: normal;
-    border-bottom: 1px solid #ffffff;
-    width: 100%;
-    margin-bottom: 0.5rem;
-    color: #ffe993;
-    text-transform: none;
-    text-shadow: 1px 1px 2px #000000;
-}
-
-#weighted-settings h3, #weighted-settings h4, #weighted-settings h5, #weighted-settings h6{
-    color: #ffffff;
-    text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.5);
-    text-transform: none;
-}
-
-#weighted-settings a{
-    color: #ffef00;
-    cursor: pointer;
-}
-
-#weighted-settings input:not([type]){
-    border: 1px solid #000000;
-    padding: 3px;
-    border-radius: 3px;
-    min-width: 150px;
-}
-
-#weighted-settings input:not([type]):focus{
-    border: 1px solid #ffffff;
-}
-
-#weighted-settings select{
-    border: 1px solid #000000;
-    padding: 3px;
-    border-radius: 3px;
-    min-width: 150px;
-    background-color: #ffffff;
-}
-
 #weighted-settings .game-options, #weighted-settings .rom-options{
     display: flex;
     flex-direction: column;
-}
-
-#weighted-settings .simple-list{
-    display: flex;
-    flex-direction: column;
-
-    max-height: 300px;
-    overflow-y: auto;
-    border: 1px solid #ffffff;
-    border-radius: 4px;
-}
-
-#weighted-settings .simple-list .list-row label{
-    display: block;
-    width: calc(100% - 0.5rem);
-    padding: 0.0625rem 0.25rem;
-}
-
-#weighted-settings .simple-list .list-row label:hover{
-    background-color: rgba(0, 0, 0, 0.1);
-}
-
-#weighted-settings .simple-list .list-row label input[type=checkbox]{
-    margin-right: 0.5rem;
-}
-
-#weighted-settings .simple-list hr{
-    width: calc(100% - 2px);
-    margin: 2px auto;
-    border-bottom: 1px solid rgb(255 255 255 / 0.6);
 }
 
 #weighted-settings .invisible{

--- a/WebHostLib/templates/player-options.html
+++ b/WebHostLib/templates/player-options.html
@@ -3,16 +3,17 @@
 {% block head %}
     <title>{{ game }} Options</title>
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename="styles/markdown.css") }}" />
+    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename="styles/options.css") }}" />
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename="styles/player-options.css") }}" />
     <script type="application/ecmascript" src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
     <script type="application/ecmascript" src="{{ url_for('static', filename="assets/md5.min.js") }}"></script>
     <script type="application/ecmascript" src="{{ url_for('static', filename="assets/js-yaml.min.js") }}"></script>
-    <script type="application/ecmascript" src="{{ url_for('static', filename="assets/player-options.js") }}"></script>
+    <script type="module" src="{{ url_for('static', filename="assets/player-options.js") }}"></script>
 {% endblock %}
 
 {% block body %}
     {% include 'header/'+theme+'Header.html' %}
-    <div id="player-options" class="markdown" data-game="{{ game }}">
+    <div id="player-options" class="markdown options" data-game="{{ game }}">
         <div id="user-message"></div>
         <h1><span id="game-name">Player</span> Options</h1>
         <p>Choose the options you would like to play with! You may generate a single-player game from this page,
@@ -51,6 +52,7 @@
         <div id="game-options">
             <div id="game-options-left" class="left"></div>
             <div id="game-options-right" class="right"></div>
+            <div id="game-options-center"></div>
         </div>
 
         <div id="player-options-button-row">

--- a/WebHostLib/templates/weighted-options.html
+++ b/WebHostLib/templates/weighted-options.html
@@ -3,16 +3,17 @@
 {% block head %}
     <title>{{ game }} Options</title>
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename="styles/markdown.css") }}" />
+    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename="styles/options.css") }}" />
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename="styles/weighted-options.css") }}" />
     <script type="application/ecmascript" src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
     <script type="application/ecmascript" src="{{ url_for('static', filename="assets/md5.min.js") }}"></script>
     <script type="application/ecmascript" src="{{ url_for('static', filename="assets/js-yaml.min.js") }}"></script>
-    <script type="application/ecmascript" src="{{ url_for('static', filename="assets/weighted-options.js") }}"></script>
+    <script type="module" src="{{ url_for('static', filename="assets/weighted-options.js") }}"></script>
 {% endblock %}
 
 {% block body %}
     {% include 'header/grassHeader.html' %}
-    <div id="weighted-settings" class="markdown" data-game="{{ game }}">
+    <div id="weighted-settings" class="markdown options" data-game="{{ game }}">
         <div id="user-message"></div>
         <h1>Weighted Options</h1>
         <p>Weighted options allow you to choose how likely a particular option is to be used in game generation.


### PR DESCRIPTION
With this, players no longer need to go to the weighted options page
to set (or even discover) the Item Pool, Item & Location Hints, and
Priority & Exclusion Locations options, or any list-based options
defined for an individual game.

This also unifies more of the rendering code for player and weighted
options, so it'll be easier to share UI for new option types between
them in the future.

In a follow-up PR, I intend to make it possible for individual options
to specify whether they're visible on both options pages, the
weighted-options page only, or only usable from YAML.

## How was this tested?

I manually tested loading up several pages, setting options,
refreshing to ensure that the options persisted in local storage, and
exporting the options as YAML.

## If this makes graphical changes, please attach screenshots.

![image](https://github.com/ArchipelagoMW/Archipelago/assets/188/dfc7a5b1-21f6-4db5-86cc-ada599abd655)