### PR TITLE
Pokemon Emerald: Fix missing rule for 2 items on Route 120

### DIFF
--- a/worlds/pokemon_emerald/data/regions/routes.json
+++ b/worlds/pokemon_emerald/data/regions/routes.json
@@ -1106,20 +1106,29 @@
     "parent_map": "MAP_ROUTE120",
     "locations": [
       "ITEM_ROUTE_120_NUGGET",
-      "ITEM_ROUTE_120_FULL_HEAL",
       "ITEM_ROUTE_120_REVIVE",
       "ITEM_ROUTE_120_HYPER_POTION",
-      "HIDDEN_ITEM_ROUTE_120_RARE_CANDY_2",
       "HIDDEN_ITEM_ROUTE_120_ZINC"
     ],
     "events": [],
     "exits": [
       "REGION_ROUTE120/NORTH",
+      "REGION_ROUTE120/SOUTH_PONDS",
       "REGION_ROUTE121/WEST"
     ],
     "warps": [
       "MAP_ROUTE120:0/MAP_ANCIENT_TOMB:0"
     ]
+  },
+  "REGION_ROUTE120/SOUTH_PONDS": {
+    "parent_map": "MAP_ROUTE120",
+    "locations": [
+      "HIDDEN_ITEM_ROUTE_120_RARE_CANDY_2",
+      "ITEM_ROUTE_120_FULL_HEAL"
+    ],
+    "events": [],
+    "exits": [],
+    "warps": []
   },
   "REGION_ROUTE121/WEST": {
     "parent_map": "MAP_ROUTE121",

--- a/worlds/pokemon_emerald/rules.py
+++ b/worlds/pokemon_emerald/rules.py
@@ -626,6 +626,10 @@ def set_rules(world: "PokemonEmeraldWorld") -> None:
         get_entrance("REGION_ROUTE120/NORTH_POND_SHORE -> REGION_ROUTE120/NORTH_POND"),
         can_surf
     )
+    set_rule(
+        get_entrance("REGION_ROUTE120/SOUTH -> REGION_ROUTE120/SOUTH_PONDS"),
+        can_surf
+    )
 
     # Route 121
     set_rule(

--- a/worlds/pokemon_emerald/test/test_accessibility.py
+++ b/worlds/pokemon_emerald/test/test_accessibility.py
@@ -44,13 +44,17 @@ class TestScorchedSlabPond(PokemonEmeraldTestBase):
 
 class TestSurf(PokemonEmeraldTestBase):
     options = {
-        "npc_gifts": Toggle.option_true
+        "npc_gifts": Toggle.option_true,
+        "hidden_items": Toggle.option_true,
+        "require_itemfinder": Toggle.option_false
     }
 
     def test_inaccessible_with_no_surf(self) -> None:
         self.assertFalse(self.can_reach_location(location_name_to_label("ITEM_PETALBURG_CITY_ETHER")))
         self.assertFalse(self.can_reach_location(location_name_to_label("NPC_GIFT_RECEIVED_SOOTHE_BELL")))
         self.assertFalse(self.can_reach_location(location_name_to_label("ITEM_LILYCOVE_CITY_MAX_REPEL")))
+        self.assertFalse(self.can_reach_location(location_name_to_label("HIDDEN_ITEM_ROUTE_120_RARE_CANDY_2")))
+        self.assertFalse(self.can_reach_location(location_name_to_label("ITEM_ROUTE_120_FULL_HEAL")))
         self.assertFalse(self.can_reach_entrance("REGION_ROUTE118/WATER -> REGION_ROUTE118/EAST"))
         self.assertFalse(self.can_reach_entrance("REGION_ROUTE119/UPPER -> REGION_FORTREE_CITY/MAIN"))
         self.assertFalse(self.can_reach_entrance("MAP_FORTREE_CITY:3/MAP_FORTREE_CITY_MART:0"))
@@ -60,6 +64,8 @@ class TestSurf(PokemonEmeraldTestBase):
         self.assertTrue(self.can_reach_location(location_name_to_label("ITEM_PETALBURG_CITY_ETHER")))
         self.assertTrue(self.can_reach_location(location_name_to_label("NPC_GIFT_RECEIVED_SOOTHE_BELL")))
         self.assertTrue(self.can_reach_location(location_name_to_label("ITEM_LILYCOVE_CITY_MAX_REPEL")))
+        self.assertTrue(self.can_reach_location(location_name_to_label("HIDDEN_ITEM_ROUTE_120_RARE_CANDY_2")))
+        self.assertTrue(self.can_reach_location(location_name_to_label("ITEM_ROUTE_120_FULL_HEAL")))
         self.assertTrue(self.can_reach_entrance("REGION_ROUTE118/WATER -> REGION_ROUTE118/EAST"))
         self.assertTrue(self.can_reach_entrance("REGION_ROUTE119/UPPER -> REGION_FORTREE_CITY/MAIN"))
         self.assertTrue(self.can_reach_entrance("MAP_FORTREE_CITY:3/MAP_FORTREE_CITY_MART:0"))


### PR DESCRIPTION
## What is this fixing or adding?

Two items on Route 120 are on the other side of a pond but were considered accessible in logic without Surf.

<img width=250 src="https://github.com/ArchipelagoMW/Archipelago/assets/21088150/9da86c85-3683-4068-83dc-8291d2fe0fcd" />

Creates a new separate region for these two items and adds a rule for being able to Surf to get to this region. Also adds the items to the existing surf test.

## How was this tested?

Adding the items to a test
