### PR TITLE
SA2B: Fix KeyError on Unexpected Characters in Slot Names

### DIFF
--- a/worlds/sa2b/__init__.py
+++ b/worlds/sa2b/__init__.py
@@ -619,10 +619,7 @@ class SA2BWorld(World):
         for name in name_list_base:
             for char_idx in range(7):
                 if char_idx < len(name):
-                    if name[char_idx] in chao_name_conversion:
-                        name_list_s.append(chao_name_conversion[name[char_idx]])
-                    else:
-                        name_list_s.append(0x5F)
+                    name_list_s.append(chao_name_conversion.get(name[char_idx], 0x5F))
                 else:
                     name_list_s.append(0x00)
 


### PR DESCRIPTION
## What is this fixing or adding?
There were no safeguards on characters being used as keys into a conversion dict. Now there are.

## How was this tested?
Ran generations with known and expected failure states; names generated as expected.

## If this makes graphical changes, please attach screenshots.
