### PR TITLE
The Witness: Fix Symmetry Island Upper Panel logic (2nd try)

### DIFF
--- a/worlds/witness/player_logic.py
+++ b/worlds/witness/player_logic.py
@@ -77,7 +77,7 @@ class WitnessPlayerLogic:
                 these_items = all_options
 
             # Another dependency that is not power-based: The Symmetry Island Upper Panel latches
-            elif panel_hex == 0x18269:
+            elif panel_hex == "0x1C349":
                 these_items = all_options
 
             # For any other door entity, we just return a set with the item that opens it & disregard power dependencies


### PR DESCRIPTION
https://github.com/ArchipelagoMW/Archipelago/pull/2565 didn't actually fix what it was supposed to fix.

I got lazy and didn't properly test the last fix, I just tested that it doesn't break anything, but not whether it actually fixes the problem.

Big apologies, I got a bit panicked with all the logic errors that were being found inbetween being busy with other stuff. Not an excuse though.

This iteration is tested - Medic plandoed Colored Dots onto Symmetry Island Upper Panel and it didn't generate (which is correct)