### PR TITLE
Zillion: fix retrieved packet processing

### DIFF
--- a/ZillionClient.py
+++ b/ZillionClient.py
@@ -278,7 +278,7 @@ class ZillionContext(CommonContext):
                 logger.warning(f"invalid Retrieved packet to ZillionClient: {args}")
                 return
             keys = cast(Dict[str, Optional[str]], args["keys"])
-            doors_b64 = keys[f"zillion-{self.auth}-doors"]
+            doors_b64 = keys.get(f"zillion-{self.auth}-doors", None)
             if doors_b64:
                 logger.info("received door data from server")
                 doors = base64.b64decode(doors_b64)


### PR DESCRIPTION
## What is this fixing or adding?

Fix processing a retrieved packet when it doesn't have the expected key.

This is the fix from https://github.com/ArchipelagoMW/Archipelago/pull/2560 so that it doesn't have to wait on review of another game.

## How was this tested?

On the https://github.com/ArchipelagoMW/Archipelago/pull/2560 branch, I played through a game, testing the feature that this touches.
