### PR TITLE
TLOZ: Fix starting weapon possibly getting overwritten by triforce fragments

### DIFF
--- a/worlds/tloz/ItemPool.py
+++ b/worlds/tloz/ItemPool.py
@@ -117,6 +117,9 @@ def get_pool_core(world):
     else:
         possible_level_locations = [location for location in standard_level_locations
                                     if location not in level_locations[8]]
+    for location in placed_items.keys():
+        if location in possible_level_locations:
+            possible_level_locations.remove(location)
     for level in range(1, 9):
         if world.multiworld.TriforceLocations[world.player] == TriforceLocations.option_vanilla:
             placed_items[f"Level {level} Triforce"] = fragment


### PR DESCRIPTION
## What is this fixing or adding?
As discovered by this bug report https://discord.com/channels/731205301247803413/1182522267687731220 it's currently possible to accidentally have the starting weapon of a player overwritten by a triforce fragment if TriforceLocations is set to dungeons and StartingPosition is set to dangerous. This fix makes sure to remove the location of a placed starting weapon if said location is in a dungeon from the pool of possible locations that triforce fragments can be placed in this circumstance.

## How was this tested?
rolled with the yamls and seed given in the bug report and confirmed that the starting weapon did not get overwritten by a triforce fragment.

## If this makes graphical changes, please attach screenshots.
