### PR TITLE
Core: remove start_inventory_from_pool from early_items

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -117,6 +117,15 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
         for item_name, count in world.start_inventory_from_pool.setdefault(player, StartInventoryPool({})).value.items():
             for _ in range(count):
                 world.push_precollected(world.create_item(item_name, player))
+            # remove from_pool items also from early items handling, as starting is plenty early.
+            early = world.early_items[player].get(item_name, 0)
+            if early:
+                world.early_items[player][item_name] = max(0, early-count)
+                remaining_count = count-early
+                if remaining_count > 0:
+                    early = world.early_local_items[player].get(item_name, 0)
+                    if early:
+                        world.early_items[player][item_name] = max(0, early - remaining_count)
 
     logger.info('Creating World.')
     AutoWorld.call_all(world, "create_regions")

--- a/Main.py
+++ b/Main.py
@@ -123,9 +123,11 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
                 world.early_items[player][item_name] = max(0, early-count)
                 remaining_count = count-early
                 if remaining_count > 0:
-                    early = world.early_local_items[player].get(item_name, 0)
-                    if early:
-                        world.early_items[player][item_name] = max(0, early - remaining_count)
+                    local_early = world.early_local_items[player].get(item_name, 0)
+                    if local_early:
+                        world.early_items[player][item_name] = max(0, local_early - remaining_count)
+                    del local_early
+            del early
 
     logger.info('Creating World.')
     AutoWorld.call_all(world, "create_regions")


### PR DESCRIPTION
## What is this fixing or adding?
Exhausts start_inventory_from_pool items from early_items as well, which fixes:
1. Cases where say early Seaglide has 2 early items, but player could start with 4, making AP search for them to place early but never finding them, wasting time. I believe this would  also crash SDV.
2. Cases where too much would be early. Early Seaglide in Subnautica places 2 Fragments out of 4 into sphere 1, if you have 2 as start_inventory_from_pool you actually have 2 start and 2 in sphere 1, which technically means 4 "early", when 2 was desired.

## How was this tested?
With Subnautica Seaglide Fragments

## If this makes graphical changes, please attach screenshots.
