### PR TITLE
Factorio: fix wrong parent class for FactorioStartItems

### DIFF
--- a/worlds/factorio/Options.py
+++ b/worlds/factorio/Options.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import typing
 import datetime
 
-from Options import Choice, OptionDict, OptionSet, ItemDict, Option, DefaultOnToggle, Range, DeathLink, Toggle, \
+from Options import Choice, OptionDict, OptionSet, Option, DefaultOnToggle, Range, DeathLink, Toggle, \
     StartInventoryPool
 from schema import Schema, Optional, And, Or
 
@@ -207,10 +207,9 @@ class RecipeIngredientsOffset(Range):
     range_end = 5
 
 
-class FactorioStartItems(ItemDict):
+class FactorioStartItems(OptionDict):
     """Mapping of Factorio internal item-name to amount granted on start."""
     display_name = "Starting Items"
-    verify_item_name = False
     default = {"burner-mining-drill": 19, "stone-furnace": 19}
 
 


### PR DESCRIPTION
## What is this fixing or adding?
fix wrong parent class for FactorioStartItems

## How was this tested?
no

## If this makes graphical changes, please attach screenshots.
