### PR TITLE
FFMQR: Fix Empty Kaeli Companion Event Location and Spellbook option

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -117,6 +117,17 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
         for item_name, count in world.start_inventory_from_pool.setdefault(player, StartInventoryPool({})).value.items():
             for _ in range(count):
                 world.push_precollected(world.create_item(item_name, player))
+            # remove from_pool items also from early items handling, as starting is plenty early.
+            early = world.early_items[player].get(item_name, 0)
+            if early:
+                world.early_items[player][item_name] = max(0, early-count)
+                remaining_count = count-early
+                if remaining_count > 0:
+                    local_early = world.early_local_items[player].get(item_name, 0)
+                    if local_early:
+                        world.early_items[player][item_name] = max(0, local_early - remaining_count)
+                    del local_early
+            del early
 
     logger.info('Creating World.')
     AutoWorld.call_all(world, "create_regions")


### PR DESCRIPTION
## What is this fixing or adding?
Seems the Kaeli Mom Fight Minotaur option is causing failures. I do not know how this got past my initial generation testing. But it seems it results in a rooms.yaml that has this location specified but with no on_trigger which leads it to being created as an empty location (it is an event).

~~I am awaiting wildham's confirmation that this fix is the correct one, but there will need to be a fix.~~ Should be good.

Fixes the Companion Spellbook option as one of the choice's names was not what FFMQR expected, which apparently broke the Progressive Gear option somehow.

## How was this tested?
Generating with the options on and ensuring patching succeeds and progressive gear works