### PR TITLE
BizHawkClient: Add SGB to systems using explicit vblank callback

### DIFF
--- a/data/lua/connector_bizhawk_generic.lua
+++ b/data/lua/connector_bizhawk_generic.lua
@@ -585,7 +585,7 @@ else
     -- misaligned, so for GB and GBC we explicitly set the callback on
     -- vblank instead.
     -- https://github.com/TASEmulators/BizHawk/issues/3711
-    if emu.getsystemid() == "GB" or emu.getsystemid() == "GBC" then
+    if emu.getsystemid() == "GB" or emu.getsystemid() == "GBC" or emu.getsystemid() == "SGB" then
         event.onmemoryexecute(tick, 0x40, "tick", "System Bus")
     else
         event.onframeend(tick)


### PR DESCRIPTION
## What is this fixing or adding?

The problem addressed in this block of code should account for SGB as well as GB and GBC, since it also uses Gambatte and so has the same problematic setting.

See https://github.com/TASEmulators/BizHawk/issues/3711 for more context

## How was this tested?

Ran Pokemon Red from source, picked up a couple items, used `getitem`. Ran with the Gambatte setting on both equal length frames and vblank frames. Nothing unexpected happened.

Did not try to reproduce the issue. It was noticed by someone playing Wario Land 1, which I don't own.
