### PR TITLE
LTTP: Boss Rule Fix

### DIFF
--- a/worlds/alttp/Rules.py
+++ b/worlds/alttp/Rules.py
@@ -136,7 +136,8 @@ def mirrorless_path_to_castle_courtyard(world, player):
 
 def set_defeat_dungeon_boss_rule(location):
     # Lambda required to defer evaluation of dungeon.boss since it will change later if boss shuffle is used
-    set_rule(location, lambda state: location.parent_region.dungeon.boss.can_defeat(state))
+    add_rule(location, lambda state: location.parent_region.dungeon.boss.can_defeat(state))
+
 
 def set_always_allow(spot, rule):
     spot.always_allow = rule


### PR DESCRIPTION
## What is this fixing or adding?
Changes `set_defeat_dungeon_boss_rule` to use `add_rule` so it will not overwrite existing boss rules. I believe this only affects Swamp Palace and could have also been solved by moving the boss rules to the entrance to a new boss room region, as is how other boss room access rules work, are but this fix should be less likely to screw up and break something else.

## How was this tested?
Generating with Small Key (Swamp Palace) plando'd to the Boss, with and without this fix, and seeing it fail only on this branch.