### PR TITLE
Lingo: Tests no longer disable forced good item

### DIFF
--- a/worlds/lingo/__init__.py
+++ b/worlds/lingo/__init__.py
@@ -11,7 +11,6 @@ from .options import LingoOptions
 from .player_logic import LingoPlayerLogic
 from .regions import create_regions
 from .static_logic import Room, RoomEntrance
-from .testing import LingoTestOptions
 
 
 class LingoWebWorld(WebWorld):

--- a/worlds/lingo/player_logic.py
+++ b/worlds/lingo/player_logic.py
@@ -6,7 +6,6 @@ from .options import LocationChecks, ShuffleDoors, VictoryCondition
 from .static_logic import DOORS_BY_ROOM, Door, PAINTINGS, PAINTINGS_BY_ROOM, PAINTING_ENTRANCES, PAINTING_EXITS, \
     PANELS_BY_ROOM, PROGRESSION_BY_ROOM, REQUIRED_PAINTING_ROOMS, REQUIRED_PAINTING_WHEN_NO_DOORS_ROOMS, RoomAndDoor, \
     RoomAndPanel
-from .testing import LingoTestOptions
 
 if TYPE_CHECKING:
     from . import LingoWorld
@@ -224,7 +223,7 @@ class LingoPlayerLogic:
                                 "kind of logic error.")
 
         if door_shuffle != ShuffleDoors.option_none and location_classification != LocationClassification.insanity \
-                and not early_color_hallways and LingoTestOptions.disable_forced_good_item is False:
+                and not early_color_hallways is False:
             # If shuffle doors is on, force a useful item onto the HI panel. This may not necessarily get you out of BK,
             # but the goal is to allow you to reach at least one more check. The non-painting ones are hardcoded right
             # now. We only allow the entrance to the Pilgrim Room if color shuffle is off, because otherwise there are

--- a/worlds/lingo/test/TestDoors.py
+++ b/worlds/lingo/test/TestDoors.py
@@ -8,6 +8,8 @@ class TestRequiredRoomLogic(LingoTestBase):
     }
 
     def test_pilgrim_first(self) -> None:
+        self.remove_forced_good_item()
+
         self.assertFalse(self.multiworld.state.can_reach("The Seeker", "Region", self.player))
         self.assertFalse(self.multiworld.state.can_reach("Pilgrim Antechamber", "Region", self.player))
         self.assertFalse(self.multiworld.state.can_reach("Pilgrim Room", "Region", self.player))
@@ -28,6 +30,8 @@ class TestRequiredRoomLogic(LingoTestBase):
         self.assertTrue(self.can_reach_location("The Seeker - Achievement"))
 
     def test_hidden_first(self) -> None:
+        self.remove_forced_good_item()
+
         self.assertFalse(self.multiworld.state.can_reach("The Seeker", "Region", self.player))
         self.assertFalse(self.multiworld.state.can_reach("Pilgrim Room", "Region", self.player))
         self.assertFalse(self.can_reach_location("The Seeker - Achievement"))
@@ -55,6 +59,8 @@ class TestRequiredDoorLogic(LingoTestBase):
     }
 
     def test_through_rhyme(self) -> None:
+        self.remove_forced_good_item()
+
         self.assertFalse(self.can_reach_location("Rhyme Room - Circle/Looped Square Wall"))
 
         self.collect_by_name("Starting Room - Rhyme Room Entrance")
@@ -64,6 +70,8 @@ class TestRequiredDoorLogic(LingoTestBase):
         self.assertTrue(self.can_reach_location("Rhyme Room - Circle/Looped Square Wall"))
 
     def test_through_hidden(self) -> None:
+        self.remove_forced_good_item()
+
         self.assertFalse(self.can_reach_location("Rhyme Room - Circle/Looped Square Wall"))
 
         self.collect_by_name("Starting Room - Rhyme Room Entrance")
@@ -83,6 +91,8 @@ class TestSimpleDoors(LingoTestBase):
     }
 
     def test_requirement(self):
+        self.remove_forced_good_item()
+
         self.assertFalse(self.multiworld.state.can_reach("Outside The Wanderer", "Region", self.player))
         self.assertFalse(self.multiworld.state.can_reach("Orange Tower Third Floor", "Region", self.player))
 

--- a/worlds/lingo/test/TestOrangeTower.py
+++ b/worlds/lingo/test/TestOrangeTower.py
@@ -8,6 +8,8 @@ class TestProgressiveOrangeTower(LingoTestBase):
     }
 
     def test_from_welcome_back(self) -> None:
+        self.remove_forced_good_item()
+
         self.assertFalse(self.multiworld.state.can_reach("Orange Tower First Floor", "Region", self.player))
         self.assertFalse(self.multiworld.state.can_reach("Orange Tower Second Floor", "Region", self.player))
         self.assertFalse(self.multiworld.state.can_reach("Orange Tower Third Floor", "Region", self.player))
@@ -83,6 +85,8 @@ class TestProgressiveOrangeTower(LingoTestBase):
         self.assertTrue(self.multiworld.state.can_reach("Orange Tower Seventh Floor", "Region", self.player))
 
     def test_from_hub_room(self) -> None:
+        self.remove_forced_good_item()
+
         self.assertFalse(self.multiworld.state.can_reach("Orange Tower First Floor", "Region", self.player))
         self.assertFalse(self.multiworld.state.can_reach("Orange Tower Second Floor", "Region", self.player))
         self.assertFalse(self.multiworld.state.can_reach("Orange Tower Third Floor", "Region", self.player))

--- a/worlds/lingo/test/TestProgressive.py
+++ b/worlds/lingo/test/TestProgressive.py
@@ -7,6 +7,8 @@ class TestComplexProgressiveHallwayRoom(LingoTestBase):
     }
 
     def test_item(self):
+        self.remove_forced_good_item()
+
         self.assertFalse(self.multiworld.state.can_reach("Outside The Agreeable", "Region", self.player))
         self.assertFalse(self.multiworld.state.can_reach("Hallway Room (2)", "Region", self.player))
         self.assertFalse(self.multiworld.state.can_reach("Hallway Room (3)", "Region", self.player))
@@ -58,6 +60,8 @@ class TestSimpleHallwayRoom(LingoTestBase):
     }
 
     def test_item(self):
+        self.remove_forced_good_item()
+
         self.assertFalse(self.multiworld.state.can_reach("Outside The Agreeable", "Region", self.player))
         self.assertFalse(self.multiworld.state.can_reach("Hallway Room (2)", "Region", self.player))
         self.assertFalse(self.multiworld.state.can_reach("Hallway Room (3)", "Region", self.player))
@@ -86,6 +90,8 @@ class TestProgressiveArtGallery(LingoTestBase):
     }
 
     def test_item(self):
+        self.remove_forced_good_item()
+
         self.assertFalse(self.multiworld.state.can_reach("Art Gallery", "Region", self.player))
         self.assertFalse(self.multiworld.state.can_reach("Art Gallery (Second Floor)", "Region", self.player))
         self.assertFalse(self.multiworld.state.can_reach("Art Gallery (Third Floor)", "Region", self.player))

--- a/worlds/lingo/test/__init__.py
+++ b/worlds/lingo/test/__init__.py
@@ -1,7 +1,6 @@
 from typing import ClassVar
 
 from test.bases import WorldTestBase
-from .. import LingoTestOptions
 
 
 class LingoTestBase(WorldTestBase):
@@ -9,5 +8,10 @@ class LingoTestBase(WorldTestBase):
     player: ClassVar[int] = 1
 
     def world_setup(self, *args, **kwargs):
-        LingoTestOptions.disable_forced_good_item = True
         super().world_setup(*args, **kwargs)
+
+    def remove_forced_good_item(self):
+        location = self.multiworld.get_location("Second Room - Good Luck", self.player)
+        self.remove(location.item)
+        self.multiworld.itempool.append(location.item)
+        self.multiworld.state.events.add(location)

--- a/worlds/lingo/testing.py
+++ b/worlds/lingo/testing.py
@@ -1,2 +1,0 @@
-class LingoTestOptions:
-    disable_forced_good_item: bool = False


### PR DESCRIPTION
## What is this fixing or adding?

The static class with the "disable forced good item" field is gone. Now, certain tests that want to check for specific access progression can run a method that removes the forced good item and adds it back to the pool. Tests that don't care about this will collect the forced good item like normal. This should prevent the intermittent fill failures on complex doors unit tests, since the forced good item should provide enough locations to fill in.

## How was this tested?

Unit tests were run many times. The previously failing seed (windows, 3.11, 98257536790111663995) has been shown to pass now.


## If this makes graphical changes, please attach screenshots.
