### PR TITLE
Factorio: fix files from mod base directory not being grabbed correctly in non-apworld

### DIFF
--- a/worlds/factorio/Mod.py
+++ b/worlds/factorio/Mod.py
@@ -177,7 +177,7 @@ def generate_mod(world: "Factorio", output_directory: str):
     else:
         basepath = os.path.join(os.path.dirname(__file__), "data", "mod")
         for dirpath, dirnames, filenames in os.walk(basepath):
-            base_arc_path = versioned_mod_name+"/"+os.path.relpath(dirpath, basepath)
+            base_arc_path = (versioned_mod_name+"/"+os.path.relpath(dirpath, basepath)).rstrip("/.\\")
             for filename in filenames:
                 mod.writing_tasks.append(lambda arcpath=base_arc_path+"/"+filename,
                                                 file_path=os.path.join(dirpath, filename):


### PR DESCRIPTION
## What is this fixing or adding?
When running source form (non-.apworld) on some OS it would not correctly build the arc_path for the files in the  base directory, due to trailing /, \ or ., this fixes that.

## How was this tested?
By loading the mod into Factorio and seeing if it complains.

## If this makes graphical changes, please attach screenshots.
