### PR TITLE
PEP8 current option_groups progress

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -1018,7 +1018,6 @@ class StartHints(ItemSet):
 class LocationSet(OptionSet):
     verify_location_name = True
     convert_name_groups = True
-    group_name = "Item & Location Options"
 
 
 class StartLocationHints(LocationSet):

--- a/WebHostLib/misc.py
+++ b/WebHostLib/misc.py
@@ -1,7 +1,6 @@
 import datetime
 import os
 from typing import List, Dict, Union
-import collections
 
 import jinja2.exceptions
 from flask import request, redirect, url_for, render_template, Response, session, abort, send_from_directory
@@ -63,24 +62,18 @@ def player_settings(game: str):
 def player_options(game: str):
     world = AutoWorldRegister.world_types[game]
     all_options: Dict[str, Options.AssembleOptions] = world.options_dataclass.type_hints
-    grouped_options = collections.defaultdict(dict)
+    grouped_options = {}
     for option_name, option in all_options.items():
-        if issubclass(option, Options.ItemDict) and not option.verify_item_name:
-            continue
-
-        if issubclass(option, Options.OptionList) and not hasattr(option, "valid_keys"):
+        if issubclass(option, (Options.ItemDict, Options.ItemSet)) and not option.verify_item_name:
             continue
 
         if issubclass(option, Options.LocationSet) and not option.verify_location_name:
             continue
 
-        if issubclass(option, Options.ItemSet) and not option.verify_item_name:
+        if issubclass(option, (Options.OptionList, Options.OptionSet)) and not hasattr(option, "valid_keys"):
             continue
 
-        if issubclass(option, Options.OptionSet) and not hasattr(option, "valid_keys"):
-            continue
-
-        grouped_options[getattr(option, "group_name", "Game Options")][option_name] = option
+        grouped_options.setdefault(getattr(option, "group_name", "Game Options"), {})[option_name] = option
 
     return render_template(
         "playerOptions/playerOptions.html",

--- a/WebHostLib/options.py
+++ b/WebHostLib/options.py
@@ -2,7 +2,6 @@ import json
 import logging
 import os
 import typing
-import collections
 
 import Options
 from Utils import local_path
@@ -34,11 +33,6 @@ def create():
 
     for game_name, world in AutoWorldRegister.world_types.items():
 
-        all_options: typing.Dict[str, Options.AssembleOptions] = world.options_dataclass.type_hints
-        grouped_options = collections.defaultdict(dict)
-        for option_name, option in all_options.items():
-            grouped_options[getattr(option, "group_name", "Game Options")][option_name] = option
-
         # Generate JSON files for player-options pages
         player_options = {
             "baseOptions": {
@@ -48,87 +42,72 @@ def create():
             },
         }
 
+        all_options = world.options_dataclass.type_hints
         game_option_groups = {}
 
-        for group_name, group_options in grouped_options.items():
-            if not hasattr(game_option_groups, group_name):
-                game_option_groups[group_name] = {}
+        for option_name, option in all_options.items():
+            if option_name in handled_in_js:
+                continue
 
-            for option_name, option in group_options.items():
-                if option_name in handled_in_js:
-                    pass
+            this_option = game_option_groups.setdefault(option.group_name, {}).setdefault(option_name, {})
+            if issubclass(option, Options.Choice) or issubclass(option, Options.Toggle):
+                this_option.update({
+                    "type": "select",
+                    "groupName": option.group_name,
+                    "displayName": getattr(option, "display_name", option_name),
+                    "description": get_html_doc(option),
+                    "defaultValue": None,
+                    "options": [],
+                })
 
-                elif issubclass(option, Options.Choice) or issubclass(option, Options.Toggle):
-                    game_option_groups[group_name][option_name] = this_option = {
-                        "type": "select",
-                        "groupName": option.group_name if hasattr(option, "group_name") else None,
-                        "displayName": option.display_name if hasattr(option, "display_name") else option_name,
+                for sub_option_id, sub_option_name in option.name_lookup.items():
+                    if sub_option_name != "random":
+                        this_option["options"].append({
+                            "name": option.get_option_name(sub_option_id),
+                            "value": sub_option_name,
+                        })
+                this_option["defaultValue"] = option.default
+
+            elif issubclass(option, Options.Range):
+                this_option.update({
+                    "type": "range",
+                    "groupName": option.group_name,
+                    "displayName": getattr(option, "display_name", option_name),
+                    "description": get_html_doc(option),
+                    "defaultValue": getattr(option, "default", option.range_start),
+                    "min": option.range_start,
+                    "max": option.range_end,
+                })
+
+                if issubclass(option, Options.NamedRange):
+                    this_option["type"] = 'named_range'
+                    this_option["value_names"] = option.special_range_names.copy()
+
+            elif issubclass(option, (Options.ItemSet, Options.LocationSet)):
+                this_option.update({
+                    "type": "items-list",
+                    "groupName": option.group_name,
+                    "displayName": getattr(option, "display_name", option_name),
+                    "description": get_html_doc(option),
+                    "defaultValue": list(option.default),
+                })
+
+            elif issubclass(option, Options.VerifyKeys) and not issubclass(option, Options.OptionDict):
+                if option.valid_keys:
+                    this_option.update({
+                        "type": "custom-list",
+                        "groupName": getattr(option, "group_name", "Game Options"),
+                        "displayName": getattr(option, "display_name", option_name),
                         "description": get_html_doc(option),
-                        "defaultValue": None,
-                        "options": []
-                    }
-
-                    for sub_option_id, sub_option_name in option.name_lookup.items():
-                        if sub_option_name != "random":
-                            this_option["options"].append({
-                                "name": option.get_option_name(sub_option_id),
-                                "value": sub_option_name,
-                            })
-                        if sub_option_id == option.default:
-                            this_option["defaultValue"] = sub_option_name
-
-                    if not this_option["defaultValue"]:
-                        this_option["defaultValue"] = "random"
-
-                elif issubclass(option, Options.Range):
-                    game_option_groups[group_name][option_name] = {
-                        "type": "range",
-                        "groupName": option.group_name if hasattr(option, "group_name") else None,
-                        "displayName": option.display_name if hasattr(option, "display_name") else option_name,
-                        "description": get_html_doc(option),
-                        "defaultValue": option.default if hasattr(
-                            option, "default") and option.default != "random" else option.range_start,
-                        "min": option.range_start,
-                        "max": option.range_end,
-                    }
-
-                    if issubclass(option, Options.NamedRange):
-                        game_option_groups[group_name][option_name]["type"] = 'named_range'
-                        game_option_groups[group_name][option_name]["value_names"] = {}
-                        for key, val in option.special_range_names.items():
-                            game_option_groups[group_name][option_name]["value_names"][key] = val
-
-                elif issubclass(option, Options.ItemSet):
-                    game_option_groups[group_name][option_name] = {
-                        "type": "items-list",
-                        "groupName": option.group_name if hasattr(option, "group_name") else None,
-                        "displayName": option.display_name if hasattr(option, "display_name") else option_name,
-                        "description": get_html_doc(option),
-                        "defaultValue": list(option.default)
-                    }
-
-                elif issubclass(option, Options.LocationSet):
-                    game_option_groups[group_name][option_name] = {
-                        "type": "locations-list",
-                        "groupName": option.group_name if hasattr(option, "group_name") else None,
-                        "displayName": option.display_name if hasattr(option, "display_name") else option_name,
-                        "description": get_html_doc(option),
-                        "defaultValue": list(option.default)
-                    }
-
-                elif issubclass(option, Options.VerifyKeys) and not issubclass(option, Options.OptionDict):
-                    if option.valid_keys:
-                        game_option_groups[group_name][option_name] = {
-                            "type": "custom-list",
-                            "groupName": option.group_name if hasattr(option, "group_name") else None,
-                            "displayName": option.display_name if hasattr(option, "display_name") else option_name,
-                            "description": get_html_doc(option),
-                            "options": list(option.valid_keys),
-                            "defaultValue": list(option.default) if hasattr(option, "default") else []
-                        }
-
+                        "options": list(option.valid_keys),
+                        "defaultValue": list(getattr(option, "default", [])),
+                    })
                 else:
-                    logging.debug(f"{option} not exported to Web Options.")
+                    del game_option_groups[option.group_name][option_name]
+
+            else:
+                del game_option_groups[option.group_name][option_name]
+                logging.debug(f"{option} not exported to Web Options.")
 
         player_options["gameOptionGroups"] = game_option_groups
 

--- a/docs/options api.md
+++ b/docs/options api.md
@@ -73,8 +73,8 @@ from Options import Toggle
 
 class StartingSword(Toggle):
     """Adds a sword to your starting inventory"""
-    display_name: 'Start With Sword'
-    group_name: 'Inventory Options'
+    display_name = 'Start With Sword'
+    group_name = 'Inventory Options'
 ```
 
 ### Option Checking


### PR DESCRIPTION
## What is this fixing or adding?
Makes the python code PEP8, uses `setdefault` instead of importing `defaultdict`, and cleans up most of `WebHostLib\options.py` (i know you barely modified that but it bothered me)

## How was this tested?
Ran webhost, changed my game options, and checked that it worked.

## If this makes graphical changes, please attach screenshots.
