### PR TITLE
SA2B: Fix Weapons Bed - Omochao 2 Logic

### DIFF
--- a/worlds/sa2b/Rules.py
+++ b/worlds/sa2b/Rules.py
@@ -638,7 +638,7 @@ def set_mission_upgrade_rules_standard(multiworld: MultiWorld, world: World, pla
         add_rule(multiworld.get_location(LocationName.radical_highway_omo_2, player),
                  lambda state: state.has(ItemName.shadow_air_shoes, player))
         add_rule(multiworld.get_location(LocationName.weapons_bed_omo_2, player),
-                 lambda state: state.has(ItemName.eggman_jet_engine, player))
+                 lambda state: state.has(ItemName.eggman_large_cannon, player))
 
         add_rule(multiworld.get_location(LocationName.mission_street_omo_3, player),
                  lambda state: state.has(ItemName.tails_booster, player))


### PR DESCRIPTION
## What is this fixing or adding?
The `Weapons Bed - Omochao 2` location required the incorrect Eggman upgrade for standard logic difficulty.

## How was this tested?
Generations with Omosanity on, sanity check. Double checked tracker, data spreadsheet, and in-game.

## If this makes graphical changes, please attach screenshots.
