### PR TITLE
Core: allow a world to make a yaml template with options from its instance

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -684,6 +684,10 @@ class Range(NumericOption):
             return cls(data)
         return cls.from_text(str(data))
 
+    @property
+    def current_key(self) -> str:
+        return str(self.value)
+
     @classmethod
     def get_option_name(cls, value: int) -> str:
         return str(value)

--- a/Utils.py
+++ b/Utils.py
@@ -940,10 +940,8 @@ def visualize_regions(root_region: Region, file_name: str, *,
         f.write("\n".join(uml))
 
 
-def generate_world_template(
-    world: World,
-    target_folder: typing.Optional[typing.Union[str, "pathlib.Path"]] = None,
-) -> None:
+def generate_world_template(world: World,
+                            target_folder: typing.Optional[typing.Union[str, "pathlib.Path"]] = None) -> None:
     """
     Generates a single YAML template for the provided world instance with its options
     :param world: world to generate a template for. If an instance is passed will use the options currently set on that
@@ -976,15 +974,12 @@ def generate_world_template(
         options=all_options,
         __version__=__version__,
         game=game_name,
-        name=f"Player{world.player}",
-        description="Test",
+        name=world.multiworld.get_player_name(world.player),
     )
 
     del file_data
 
-    with open(
-        os.path.join(target_folder, game_name + ".yaml"), "w", encoding="utf-8-sig"
-    ) as f:
+    with open(os.path.join(target_folder, game_name + ".yaml"), "w", encoding="utf-8-sig") as f:
         f.write(res)
 
 

--- a/Utils.py
+++ b/Utils.py
@@ -21,6 +21,10 @@ from settings import Settings, get_settings
 from typing import BinaryIO, Coroutine, Optional, Set, Dict, Any, Union
 from yaml import load, load_all, dump, SafeLoader
 
+if typing.TYPE_CHECKING:
+    from worlds.AutoWorld import World
+    from Options import Range
+
 try:
     from yaml import CLoader as UnsafeLoader
     from yaml import CDumper as Dumper
@@ -62,7 +66,12 @@ def int16_as_bytes(value: int) -> typing.List[int]:
 
 def int32_as_bytes(value: int) -> typing.List[int]:
     value = value & 0xFFFFFFFF
-    return [value & 0xFF, (value >> 8) & 0xFF, (value >> 16) & 0xFF, (value >> 24) & 0xFF]
+    return [
+        value & 0xFF,
+        (value >> 8) & 0xFF,
+        (value >> 16) & 0xFF,
+        (value >> 24) & 0xFF,
+    ]
 
 
 def pc_to_snes(value: int) -> int:
@@ -78,8 +87,12 @@ S = typing.TypeVar("S")
 T = typing.TypeVar("T")
 
 
-def cache_argsless(function: typing.Callable[[], RetType]) -> typing.Callable[[], RetType]:
-    assert not function.__code__.co_argcount, "Can only cache 0 argument functions with this cache."
+def cache_argsless(
+    function: typing.Callable[[], RetType]
+) -> typing.Callable[[], RetType]:
+    assert (
+        not function.__code__.co_argcount
+    ), "Can only cache 0 argument functions with this cache."
 
     sentinel = object()
     result: typing.Union[object, RetType] = sentinel
@@ -93,17 +106,22 @@ def cache_argsless(function: typing.Callable[[], RetType]) -> typing.Callable[[]
     return _wrap
 
 
-def cache_self1(function: typing.Callable[[S, T], RetType]) -> typing.Callable[[S, T], RetType]:
+def cache_self1(
+    function: typing.Callable[[S, T], RetType]
+) -> typing.Callable[[S, T], RetType]:
     """Specialized cache for self + 1 arg. Does not keep global ref to self and skips building a dict key tuple."""
 
-    assert function.__code__.co_argcount == 2, "Can only cache 2 argument functions with this cache."
+    assert (
+        function.__code__.co_argcount == 2
+    ), "Can only cache 2 argument functions with this cache."
 
     cache_name = f"__cache_{function.__name__}__"
 
     @functools.wraps(function)
     def wrap(self: S, arg: T) -> RetType:
-        cache: Optional[Dict[T, RetType]] = typing.cast(Optional[Dict[T, RetType]],
-                                                        getattr(self, cache_name, None))
+        cache: Optional[Dict[T, RetType]] = typing.cast(
+            Optional[Dict[T, RetType]], getattr(self, cache_name, None)
+        )
         if cache is None:
             res = function(self, arg)
             setattr(self, cache_name, {arg: res})
@@ -119,7 +137,7 @@ def cache_self1(function: typing.Callable[[S, T], RetType]) -> typing.Callable[[
 
 
 def is_frozen() -> bool:
-    return typing.cast(bool, getattr(sys, 'frozen', False))
+    return typing.cast(bool, getattr(sys, "frozen", False))
 
 
 def local_path(*path: str) -> str:
@@ -127,17 +145,20 @@ def local_path(*path: str) -> str:
     Returns path to a file in the local Archipelago installation or source.
     This might be read-only and user_path should be used instead for ROMs, configuration, etc.
     """
-    if hasattr(local_path, 'cached_path'):
+    if hasattr(local_path, "cached_path"):
         pass
     elif is_frozen():
         if hasattr(sys, "_MEIPASS"):
             # we are running in a PyInstaller bundle
-            local_path.cached_path = sys._MEIPASS  # pylint: disable=protected-access,no-member
+            local_path.cached_path = (
+                sys._MEIPASS
+            )  # pylint: disable=protected-access,no-member
         else:
             # cx_Freeze
             local_path.cached_path = os.path.dirname(os.path.abspath(sys.argv[0]))
     else:
         import __main__
+
         if hasattr(__main__, "__file__") and os.path.isfile(__main__.__file__):
             # we are running in a normal Python environment
             local_path.cached_path = os.path.dirname(os.path.abspath(__main__.__file__))
@@ -150,14 +171,16 @@ def local_path(*path: str) -> str:
 
 def home_path(*path: str) -> str:
     """Returns path to a file in the user home's Archipelago directory."""
-    if hasattr(home_path, 'cached_path'):
+    if hasattr(home_path, "cached_path"):
         pass
-    elif sys.platform.startswith('linux'):
-        home_path.cached_path = os.path.expanduser('~/Archipelago')
+    elif sys.platform.startswith("linux"):
+        home_path.cached_path = os.path.expanduser("~/Archipelago")
         os.makedirs(home_path.cached_path, 0o700, exist_ok=True)
     else:
         # not implemented
-        home_path.cached_path = local_path()  # this will generate the same exceptions we got previously
+        home_path.cached_path = (
+            local_path()
+        )  # this will generate the same exceptions we got previously
 
     return os.path.join(home_path.cached_path, *path)
 
@@ -173,16 +196,28 @@ def user_path(*path: str) -> str:
         # populate home from local
         if user_path.cached_path != local_path():
             import filecmp
-            if not os.path.exists(user_path("manifest.json")) or \
-                    not os.path.exists(local_path("manifest.json")) or \
-                    not filecmp.cmp(local_path("manifest.json"), user_path("manifest.json"), shallow=True):
+
+            if (
+                not os.path.exists(user_path("manifest.json"))
+                or not os.path.exists(local_path("manifest.json"))
+                or not filecmp.cmp(
+                    local_path("manifest.json"),
+                    user_path("manifest.json"),
+                    shallow=True,
+                )
+            ):
                 import shutil
+
                 for dn in ("Players", "data/sprites", "data/lua"):
                     shutil.copytree(local_path(dn), user_path(dn), dirs_exist_ok=True)
                 if not os.path.exists(local_path("manifest.json")):
-                    warnings.warn(f"Upgrading {user_path()} from something that is not a proper install")
+                    warnings.warn(
+                        f"Upgrading {user_path()} from something that is not a proper install"
+                    )
                 else:
-                    shutil.copy2(local_path("manifest.json"), user_path("manifest.json"))
+                    shutil.copy2(
+                        local_path("manifest.json"), user_path("manifest.json")
+                    )
             os.makedirs(user_path("worlds"), exist_ok=True)
 
     return os.path.join(user_path.cached_path, *path)
@@ -194,13 +229,14 @@ def cache_path(*path: str) -> str:
         pass
     else:
         import platformdirs
+
         cache_path.cached_path = platformdirs.user_cache_dir("Archipelago", False)
 
     return os.path.join(cache_path.cached_path, *path)
 
 
 def output_path(*path: str) -> str:
-    if hasattr(output_path, 'cached_path'):
+    if hasattr(output_path, "cached_path"):
         return os.path.join(output_path.cached_path, *path)
     output_path.cached_path = user_path(get_options()["general_options"]["output_path"])
     path = os.path.join(output_path.cached_path, *path)
@@ -213,7 +249,12 @@ def open_file(filename: typing.Union[str, "pathlib.Path"]) -> None:
         os.startfile(filename)
     else:
         from shutil import which
-        open_command = which("open") if is_macos else (which("xdg-open") or which("gnome-open") or which("kde-open"))
+
+        open_command = (
+            which("open")
+            if is_macos
+            else (which("xdg-open") or which("gnome-open") or which("kde-open"))
+        )
         subprocess.call([open_command, filename])
 
 
@@ -224,8 +265,12 @@ class UniqueKeyLoader(SafeLoader):
         for key_node, value_node in node.value:
             key = self.construct_object(key_node, deep=deep)
             if key in mapping:
-                logging.error(f"YAML duplicates sanity check failed{key_node.start_mark}")
-                raise KeyError(f"Duplicate key {key} found in YAML. Already found keys: {mapping}.")
+                logging.error(
+                    f"YAML duplicates sanity check failed{key_node.start_mark}"
+                )
+                raise KeyError(
+                    f"Duplicate key {key} found in YAML. Already found keys: {mapping}."
+                )
             mapping.add(key)
         return super().construct_mapping(node, deep)
 
@@ -239,6 +284,7 @@ del load, load_all  # should not be used. don't leak their names
 
 def get_cert_none_ssl_context():
     import ssl
+
     ctx = ssl.create_default_context()
     ctx.check_hostname = False
     ctx.verify_mode = ssl.CERT_NONE
@@ -249,6 +295,7 @@ def get_cert_none_ssl_context():
 def get_public_ipv4() -> str:
     import socket
     import urllib.request
+
     try:
         ip = socket.gethostbyname(socket.gethostname())
     except socket.gaierror:
@@ -258,11 +305,23 @@ def get_public_ipv4() -> str:
 
     ctx = get_cert_none_ssl_context()
     try:
-        ip = urllib.request.urlopen("https://checkip.amazonaws.com/", context=ctx, timeout=10).read().decode("utf8").strip()
+        ip = (
+            urllib.request.urlopen(
+                "https://checkip.amazonaws.com/", context=ctx, timeout=10
+            )
+            .read()
+            .decode("utf8")
+            .strip()
+        )
     except Exception as e:
         # noinspection PyBroadException
         try:
-            ip = urllib.request.urlopen("https://v4.ident.me", context=ctx, timeout=10).read().decode("utf8").strip()
+            ip = (
+                urllib.request.urlopen("https://v4.ident.me", context=ctx, timeout=10)
+                .read()
+                .decode("utf8")
+                .strip()
+            )
         except Exception:
             logging.exception(e)
             pass  # we could be offline, in a local game, so no point in erroring out
@@ -273,6 +332,7 @@ def get_public_ipv4() -> str:
 def get_public_ipv6() -> str:
     import socket
     import urllib.request
+
     try:
         ip = socket.gethostbyname(socket.gethostname())
     except socket.gaierror:
@@ -282,7 +342,12 @@ def get_public_ipv6() -> str:
 
     ctx = get_cert_none_ssl_context()
     try:
-        ip = urllib.request.urlopen("https://v6.ident.me", context=ctx, timeout=10).read().decode("utf8").strip()
+        ip = (
+            urllib.request.urlopen("https://v6.ident.me", context=ctx, timeout=10)
+            .read()
+            .decode("utf8")
+            .strip()
+        )
     except Exception as e:
         logging.exception(e)
         pass  # we could be offline, in a local game, or ipv6 may not be available
@@ -294,7 +359,10 @@ OptionsType = Settings  # TODO: remove when removing get_options
 
 def get_options() -> Settings:
     # TODO: switch to Utils.deprecate after 0.4.4
-    warnings.warn("Utils.get_options() is deprecated. Use the settings API instead.", DeprecationWarning)
+    warnings.warn(
+        "Utils.get_options() is deprecated. Use the settings API instead.",
+        DeprecationWarning,
+    )
     return get_settings()
 
 
@@ -329,7 +397,9 @@ def get_file_safe_name(name: str) -> str:
     return "".join(c for c in name if c not in '<>:"/\\|?*')
 
 
-def load_data_package_for_checksum(game: str, checksum: typing.Optional[str]) -> Dict[str, Any]:
+def load_data_package_for_checksum(
+    game: str, checksum: typing.Optional[str]
+) -> Dict[str, Any]:
     if checksum and game:
         if checksum != get_file_safe_name(checksum):
             raise ValueError(f"Bad symbols in checksum: {checksum}")
@@ -358,13 +428,17 @@ def store_data_package_for_checksum(game: str, data: typing.Dict[str, Any]) -> N
         game_folder = cache_path("datapackage", get_file_safe_name(game))
         os.makedirs(game_folder, exist_ok=True)
         try:
-            with open(os.path.join(game_folder, f"{checksum}.json"), "w", encoding="utf-8-sig") as f:
+            with open(
+                os.path.join(game_folder, f"{checksum}.json"), "w", encoding="utf-8-sig"
+            ) as f:
                 json.dump(data, f, ensure_ascii=False, separators=(",", ":"))
         except Exception as e:
             logging.debug(f"Could not store data package: {e}")
 
+
 def get_default_adjuster_settings(game_name: str) -> Namespace:
     import LttPAdjuster
+
     adjuster_settings = Namespace()
     if game_name == LttPAdjuster.GAME_ALTTP:
         return LttPAdjuster.get_argparser().parse_known_args(args=[])[0]
@@ -381,7 +455,14 @@ def get_adjuster_settings(game_name: str) -> Namespace:
     default_settings = get_default_adjuster_settings(game_name)
 
     # Fill in any arguments from the argparser that we haven't seen before
-    return Namespace(**vars(adjuster_settings), **{k:v for k,v in vars(default_settings).items() if k not in vars(adjuster_settings)})
+    return Namespace(
+        **vars(adjuster_settings),
+        **{
+            k: v
+            for k, v in vars(default_settings).items()
+            if k not in vars(adjuster_settings)
+        },
+    )
 
 
 @cache_argsless
@@ -391,15 +472,18 @@ def get_unique_identifier():
         return uuid
 
     import uuid
+
     uuid = uuid.getnode()
     persistent_store("client", "uuid", uuid)
     return uuid
 
 
-safe_builtins = frozenset((
-    'set',
-    'frozenset',
-))
+safe_builtins = frozenset(
+    (
+        "set",
+        "frozenset",
+    )
+)
 
 
 class RestrictedUnpickler(pickle.Unpickler):
@@ -415,12 +499,20 @@ class RestrictedUnpickler(pickle.Unpickler):
         if module == "builtins" and name in safe_builtins:
             return getattr(builtins, name)
         # used by MultiServer -> savegame/multidata
-        if module == "NetUtils" and name in {"NetworkItem", "ClientStatus", "Hint", "SlotType", "NetworkSlot"}:
+        if module == "NetUtils" and name in {
+            "NetworkItem",
+            "ClientStatus",
+            "Hint",
+            "SlotType",
+            "NetworkSlot",
+        }:
             return getattr(self.net_utils_module, name)
         # Options and Plando are unpickled by WebHost -> Generate
         if module == "worlds.generic" and name in {"PlandoItem", "PlandoConnection"}:
             if not self.generic_properties_module:
-                self.generic_properties_module = importlib.import_module("worlds.generic")
+                self.generic_properties_module = importlib.import_module(
+                    "worlds.generic"
+                )
             return getattr(self.generic_properties_module, name)
         # pep 8 specifies that modules should have "all-lowercase names" (options, not Options)
         if module.lower().endswith("options"):
@@ -445,12 +537,14 @@ class ByValue:
     Mixin for enums to pickle value instead of name (restores pre-3.11 behavior). Use as left-most parent.
     See https://github.com/python/cpython/pull/26658 for why this exists.
     """
+
     def __reduce_ex__(self, prot):
-        return self.__class__, (self._value_, )
+        return self.__class__, (self._value_,)
 
 
 class KeyedDefaultDict(collections.defaultdict):
     """defaultdict variant that uses the missing key as argument to default_factory"""
+
     default_factory: typing.Callable[[typing.Any], typing.Any]
 
     def __missing__(self, key):
@@ -459,20 +553,30 @@ class KeyedDefaultDict(collections.defaultdict):
 
 
 def get_text_between(text: str, start: str, end: str) -> str:
-    return text[text.index(start) + len(start): text.rindex(end)]
+    return text[text.index(start) + len(start) : text.rindex(end)]
 
 
 def get_text_after(text: str, start: str) -> str:
-    return text[text.index(start) + len(start):]
+    return text[text.index(start) + len(start) :]
 
 
-loglevel_mapping = {'error': logging.ERROR, 'info': logging.INFO, 'warning': logging.WARNING, 'debug': logging.DEBUG}
+loglevel_mapping = {
+    "error": logging.ERROR,
+    "info": logging.INFO,
+    "warning": logging.WARNING,
+    "debug": logging.DEBUG,
+}
 
 
-def init_logging(name: str, loglevel: typing.Union[str, int] = logging.INFO, write_mode: str = "w",
-                 log_format: str = "[%(name)s at %(asctime)s]: %(message)s",
-                 exception_logger: typing.Optional[str] = None):
+def init_logging(
+    name: str,
+    loglevel: typing.Union[str, int] = logging.INFO,
+    write_mode: str = "w",
+    log_format: str = "[%(name)s at %(asctime)s]: %(message)s",
+    exception_logger: typing.Optional[str] = None,
+):
     import datetime
+
     loglevel: int = loglevel_mapping.get(loglevel, loglevel)
     log_folder = user_path("logs")
     os.makedirs(log_folder, exist_ok=True)
@@ -481,13 +585,14 @@ def init_logging(name: str, loglevel: typing.Union[str, int] = logging.INFO, wri
         root_logger.removeHandler(handler)
         handler.close()
     root_logger.setLevel(loglevel)
-    logging.getLogger("websockets").setLevel(loglevel)  # make sure level is applied for websockets
+    logging.getLogger("websockets").setLevel(
+        loglevel
+    )  # make sure level is applied for websockets
     if "a" not in write_mode:
         name += f"_{datetime.datetime.now().strftime('%Y_%m_%d_%H_%M_%S')}"
     file_handler = logging.FileHandler(
-        os.path.join(log_folder, f"{name}.txt"),
-        write_mode,
-        encoding="utf-8-sig")
+        os.path.join(log_folder, f"{name}.txt"), write_mode, encoding="utf-8-sig"
+    )
     file_handler.setFormatter(logging.Formatter(log_format))
 
     class Filter(logging.Filter):
@@ -498,11 +603,15 @@ def init_logging(name: str, loglevel: typing.Union[str, int] = logging.INFO, wri
         def filter(self, record: logging.LogRecord) -> bool:
             return self.condition(record)
 
-    file_handler.addFilter(Filter("NoStream", lambda record: not getattr(record,  "NoFile", False)))
+    file_handler.addFilter(
+        Filter("NoStream", lambda record: not getattr(record, "NoFile", False))
+    )
     root_logger.addHandler(file_handler)
     if sys.stdout:
         stream_handler = logging.StreamHandler(sys.stdout)
-        stream_handler.addFilter(Filter("NoFile", lambda record: not getattr(record, "NoStream", False)))
+        stream_handler.addFilter(
+            Filter("NoFile", lambda record: not getattr(record, "NoStream", False))
+        )
         root_logger.addHandler(stream_handler)
 
     # Relay unhandled exceptions to logger.
@@ -513,8 +622,9 @@ def init_logging(name: str, loglevel: typing.Union[str, int] = logging.INFO, wri
             if issubclass(exc_type, KeyboardInterrupt):
                 sys.__excepthook__(exc_type, exc_value, exc_traceback)
                 return
-            logging.getLogger(exception_logger).exception("Uncaught exception",
-                                                          exc_info=(exc_type, exc_value, exc_traceback))
+            logging.getLogger(exception_logger).exception(
+                "Uncaught exception", exc_info=(exc_type, exc_value, exc_traceback)
+            )
             return orig_hook(exc_type, exc_value, exc_traceback)
 
         handle_exception._wrapped = True
@@ -532,9 +642,12 @@ def init_logging(name: str, loglevel: typing.Union[str, int] = logging.INFO, wri
                         logging.exception(e)
                     else:
                         logging.debug(f"Deleted old logfile {file.path}")
+
     import threading
+
     threading.Thread(target=_cleanup, name="LogCleaner").start()
     import platform
+
     logging.info(
         f"Archipelago ({__version__}) logging initialized"
         f" on {platform.platform()}"
@@ -554,7 +667,10 @@ def stream_input(stream, queue):
                     queue.put_nowait(text)
 
     from threading import Thread
-    thread = Thread(target=queuer, name=f"Stream handler for {stream.name}", daemon=True)
+
+    thread = Thread(
+        target=queuer, name=f"Stream handler for {stream.name}", daemon=True
+    )
     thread.start()
     return thread
 
@@ -580,9 +696,12 @@ def chaining_prefix(index: int, labels: typing.Tuple[str]) -> str:
 
 
 # noinspection PyPep8Naming
-def format_SI_prefix(value, power=1000, power_labels=("", "k", "M", "G", "T", "P", "E", "Z", "Y")) -> str:
+def format_SI_prefix(
+    value, power=1000, power_labels=("", "k", "M", "G", "T", "P", "E", "Z", "Y")
+) -> str:
     """Formats a value into a value + metric/si prefix. More info at https://en.wikipedia.org/wiki/Metric_prefix"""
     import decimal
+
     n = 0
     value = decimal.Decimal(value)
     limit = power - decimal.Decimal("0.005")
@@ -590,138 +709,215 @@ def format_SI_prefix(value, power=1000, power_labels=("", "k", "M", "G", "T", "P
         value /= power
         n += 1
 
-    return f"{value.quantize(decimal.Decimal('1.00'))} {chaining_prefix(n, power_labels)}"
+    return (
+        f"{value.quantize(decimal.Decimal('1.00'))} {chaining_prefix(n, power_labels)}"
+    )
 
 
-def get_fuzzy_results(input_word: str, wordlist: typing.Sequence[str], limit: typing.Optional[int] = None) \
-        -> typing.List[typing.Tuple[str, int]]:
+def get_fuzzy_results(
+    input_word: str, wordlist: typing.Sequence[str], limit: typing.Optional[int] = None
+) -> typing.List[typing.Tuple[str, int]]:
     import jellyfish
 
     def get_fuzzy_ratio(word1: str, word2: str) -> float:
-        return (1 - jellyfish.damerau_levenshtein_distance(word1.lower(), word2.lower())
-                / max(len(word1), len(word2)))
+        return 1 - jellyfish.damerau_levenshtein_distance(
+            word1.lower(), word2.lower()
+        ) / max(len(word1), len(word2))
 
     limit: int = limit if limit else len(wordlist)
     return list(
         map(
-            lambda container: (container[0], int(container[1]*100)),  # convert up to limit to int %
+            lambda container: (
+                container[0],
+                int(container[1] * 100),
+            ),  # convert up to limit to int %
             sorted(
-                map(lambda candidate:
-                    (candidate,  get_fuzzy_ratio(input_word, candidate)),
-                    wordlist),
+                map(
+                    lambda candidate: (
+                        candidate,
+                        get_fuzzy_ratio(input_word, candidate),
+                    ),
+                    wordlist,
+                ),
                 key=lambda element: element[1],
-                reverse=True)[0:limit]
+                reverse=True,
+            )[0:limit],
         )
     )
 
 
-def open_filename(title: str, filetypes: typing.Sequence[typing.Tuple[str, typing.Sequence[str]]], suggest: str = "") \
-        -> typing.Optional[str]:
+def open_filename(
+    title: str,
+    filetypes: typing.Sequence[typing.Tuple[str, typing.Sequence[str]]],
+    suggest: str = "",
+) -> typing.Optional[str]:
     def run(*args: str):
-        return subprocess.run(args, capture_output=True, text=True).stdout.split("\n", 1)[0] or None
+        return (
+            subprocess.run(args, capture_output=True, text=True).stdout.split("\n", 1)[
+                0
+            ]
+            or None
+        )
 
     if is_linux:
         # prefer native dialog
         from shutil import which
+
         kdialog = which("kdialog")
         if kdialog:
-            k_filters = '|'.join((f'{text} (*{" *".join(ext)})' for (text, ext) in filetypes))
-            return run(kdialog, f"--title={title}", "--getopenfilename", suggest or ".", k_filters)
+            k_filters = "|".join(
+                (f'{text} (*{" *".join(ext)})' for (text, ext) in filetypes)
+            )
+            return run(
+                kdialog,
+                f"--title={title}",
+                "--getopenfilename",
+                suggest or ".",
+                k_filters,
+            )
         zenity = which("zenity")
         if zenity:
-            z_filters = (f'--file-filter={text} ({", ".join(ext)}) | *{" *".join(ext)}' for (text, ext) in filetypes)
+            z_filters = (
+                f'--file-filter={text} ({", ".join(ext)}) | *{" *".join(ext)}'
+                for (text, ext) in filetypes
+            )
             selection = (f"--filename={suggest}",) if suggest else ()
-            return run(zenity, f"--title={title}", "--file-selection", *z_filters, *selection)
+            return run(
+                zenity, f"--title={title}", "--file-selection", *z_filters, *selection
+            )
 
     # fall back to tk
     try:
         import tkinter
         import tkinter.filedialog
     except Exception as e:
-        logging.error('Could not load tkinter, which is likely not installed. '
-                      f'This attempt was made because open_filename was used for "{title}".')
+        logging.error(
+            "Could not load tkinter, which is likely not installed. "
+            f'This attempt was made because open_filename was used for "{title}".'
+        )
         raise e
     else:
         try:
             root = tkinter.Tk()
         except tkinter.TclError:
-            return None  # GUI not available. None is the same as a user clicking "cancel"
+            return (
+                None  # GUI not available. None is the same as a user clicking "cancel"
+            )
         root.withdraw()
-        return tkinter.filedialog.askopenfilename(title=title, filetypes=((t[0], ' '.join(t[1])) for t in filetypes),
-                                                  initialfile=suggest or None)
+        return tkinter.filedialog.askopenfilename(
+            title=title,
+            filetypes=((t[0], " ".join(t[1])) for t in filetypes),
+            initialfile=suggest or None,
+        )
 
 
 def open_directory(title: str, suggest: str = "") -> typing.Optional[str]:
     def run(*args: str):
-        return subprocess.run(args, capture_output=True, text=True).stdout.split("\n", 1)[0] or None
+        return (
+            subprocess.run(args, capture_output=True, text=True).stdout.split("\n", 1)[
+                0
+            ]
+            or None
+        )
 
     if is_linux:
         # prefer native dialog
         from shutil import which
+
         kdialog = which("kdialog")
         if kdialog:
-            return run(kdialog, f"--title={title}", "--getexistingdirectory",
-                       os.path.abspath(suggest) if suggest else ".")
+            return run(
+                kdialog,
+                f"--title={title}",
+                "--getexistingdirectory",
+                os.path.abspath(suggest) if suggest else ".",
+            )
         zenity = which("zenity")
         if zenity:
             z_filters = ("--directory",)
             selection = (f"--filename={os.path.abspath(suggest)}/",) if suggest else ()
-            return run(zenity, f"--title={title}", "--file-selection", *z_filters, *selection)
+            return run(
+                zenity, f"--title={title}", "--file-selection", *z_filters, *selection
+            )
 
     # fall back to tk
     try:
         import tkinter
         import tkinter.filedialog
     except Exception as e:
-        logging.error('Could not load tkinter, which is likely not installed. '
-                      f'This attempt was made because open_filename was used for "{title}".')
+        logging.error(
+            "Could not load tkinter, which is likely not installed. "
+            f'This attempt was made because open_filename was used for "{title}".'
+        )
         raise e
     else:
         try:
             root = tkinter.Tk()
         except tkinter.TclError:
-            return None  # GUI not available. None is the same as a user clicking "cancel"
+            return (
+                None  # GUI not available. None is the same as a user clicking "cancel"
+            )
         root.withdraw()
-        return tkinter.filedialog.askdirectory(title=title, mustexist=True, initialdir=suggest or None)
+        return tkinter.filedialog.askdirectory(
+            title=title, mustexist=True, initialdir=suggest or None
+        )
 
 
 def messagebox(title: str, text: str, error: bool = False) -> None:
     def run(*args: str):
-        return subprocess.run(args, capture_output=True, text=True).stdout.split("\n", 1)[0] or None
+        return (
+            subprocess.run(args, capture_output=True, text=True).stdout.split("\n", 1)[
+                0
+            ]
+            or None
+        )
 
     def is_kivy_running():
         if "kivy" in sys.modules:
             from kivy.app import App
+
             return App.get_running_app() is not None
         return False
 
     if is_kivy_running():
         from kvui import MessageBox
+
         MessageBox(title, text, error).open()
         return
 
     if is_linux and "tkinter" not in sys.modules:
         # prefer native dialog
         from shutil import which
+
         kdialog = which("kdialog")
         if kdialog:
-            return run(kdialog, f"--title={title}", "--error" if error else "--msgbox", text)
+            return run(
+                kdialog, f"--title={title}", "--error" if error else "--msgbox", text
+            )
         zenity = which("zenity")
         if zenity:
-            return run(zenity, f"--title={title}", f"--text={text}", "--error" if error else "--info")
+            return run(
+                zenity,
+                f"--title={title}",
+                f"--text={text}",
+                "--error" if error else "--info",
+            )
 
     elif is_windows:
         import ctypes
+
         style = 0x10 if error else 0x0
         return ctypes.windll.user32.MessageBoxW(0, text, title, style)
-    
+
     # fall back to tk
     try:
         import tkinter
         from tkinter.messagebox import showerror, showinfo
     except Exception as e:
-        logging.error('Could not load tkinter, which is likely not installed. '
-                      f'This attempt was made because messagebox was used for "{title}".')
+        logging.error(
+            "Could not load tkinter, which is likely not installed. "
+            f'This attempt was made because messagebox was used for "{title}".'
+        )
         raise e
     else:
         root = tkinter.Tk()
@@ -730,10 +926,13 @@ def messagebox(title: str, text: str, error: bool = False) -> None:
         root.update()
 
 
-def title_sorted(data: typing.Sequence, key=None, ignore: typing.Set = frozenset(("a", "the"))):
+def title_sorted(
+    data: typing.Sequence, key=None, ignore: typing.Set = frozenset(("a", "the"))
+):
     """Sorts a sequence of text ignoring typical articles like "a" or "the" in the beginning."""
+
     def sorter(element: Union[str, Dict[str, Any]]) -> str:
-        if (not isinstance(element, str)):
+        if not isinstance(element, str):
             element = element["title"]
 
         parts = element.split(maxsplit=1)
@@ -741,6 +940,7 @@ def title_sorted(data: typing.Sequence, key=None, ignore: typing.Set = frozenset
             return parts[1].lower()
         else:
             return element.lower()
+
     return sorted(data, key=lambda i: sorter(key(i)) if key else sorter(i))
 
 
@@ -755,7 +955,9 @@ def read_snes_rom(stream: BinaryIO, strip_header: bool = True) -> bytearray:
 _faf_tasks: "Set[asyncio.Task[typing.Any]]" = set()
 
 
-def async_start(co: Coroutine[None, None, typing.Any], name: Optional[str] = None) -> None:
+def async_start(
+    co: Coroutine[None, None, typing.Any], name: Optional[str] = None
+) -> None:
     """
     Use this to start a task when you don't keep a reference to it or immediately await it,
     to prevent early garbage collection. "fire-and-forget"
@@ -777,7 +979,9 @@ def deprecate(message: str):
     if __debug__:
         raise Exception(message)
     import warnings
+
     warnings.warn(message)
+
 
 def _extend_freeze_support() -> None:
     """Extend multiprocessing.freeze_support() to also work on Non-Windows for spawn."""
@@ -795,11 +999,16 @@ def _extend_freeze_support() -> None:
 
         # Handle the first process that MP will create
         if (
-            len(sys.argv) >= 2 and sys.argv[-2] == '-c' and sys.argv[-1].startswith((
-                'from multiprocessing.semaphore_tracker import main',  # Py<3.8
-                'from multiprocessing.resource_tracker import main',  # Py>=3.8
-                'from multiprocessing.forkserver import main'
-            )) and set(sys.argv[1:-2]) == set(_args_from_interpreter_flags())
+            len(sys.argv) >= 2
+            and sys.argv[-2] == "-c"
+            and sys.argv[-1].startswith(
+                (
+                    "from multiprocessing.semaphore_tracker import main",  # Py<3.8
+                    "from multiprocessing.resource_tracker import main",  # Py>=3.8
+                    "from multiprocessing.forkserver import main",
+                )
+            )
+            and set(sys.argv[1:-2]) == set(_args_from_interpreter_flags())
         ):
             exec(sys.argv[-1])
             sys.exit()
@@ -808,8 +1017,8 @@ def _extend_freeze_support() -> None:
         if multiprocessing.spawn.is_forking(sys.argv):
             kwargs = {}
             for arg in sys.argv[2:]:
-                name, value = arg.split('=')
-                if value == 'None':
+                name, value = arg.split("=")
+                if value == "None":
                     kwargs[name] = None
                 else:
                     kwargs[name] = int(value)
@@ -817,19 +1026,28 @@ def _extend_freeze_support() -> None:
             sys.exit()
 
     if not is_windows and is_frozen():
-        multiprocessing.freeze_support = multiprocessing.spawn.freeze_support = _freeze_support
+        multiprocessing.freeze_support = (
+            multiprocessing.spawn.freeze_support
+        ) = _freeze_support
 
 
 def freeze_support() -> None:
     """This behaves like multiprocessing.freeze_support but also works on Non-Windows."""
     import multiprocessing
+
     _extend_freeze_support()
     multiprocessing.freeze_support()
 
 
-def visualize_regions(root_region: Region, file_name: str, *,
-                      show_entrance_names: bool = False, show_locations: bool = True, show_other_regions: bool = True,
-                      linetype_ortho: bool = True) -> None:
+def visualize_regions(
+    root_region: Region,
+    file_name: str,
+    *,
+    show_entrance_names: bool = False,
+    show_locations: bool = True,
+    show_other_regions: bool = True,
+    linetype_ortho: bool = True,
+) -> None:
     """Visualize the layout of a world as a PlantUML diagram.
 
     :param root_region: The region from which to start the diagram from. (Usually the "Menu" region of your world.)
@@ -855,8 +1073,17 @@ def visualize_regions(root_region: Region, file_name: str, *,
     for player in world.player_ids:
         visualize_regions(world.get_region("Menu", player), f"{world.get_out_file_name_base(player)}.puml")
     """
-    assert root_region.multiworld, "The multiworld attribute of root_region has to be filled"
-    from BaseClasses import Entrance, Item, Location, LocationProgressType, MultiWorld, Region
+    assert (
+        root_region.multiworld
+    ), "The multiworld attribute of root_region has to be filled"
+    from BaseClasses import (
+        Entrance,
+        Item,
+        Location,
+        LocationProgressType,
+        MultiWorld,
+        Region,
+    )
     from collections import deque
     import re
 
@@ -880,43 +1107,63 @@ def visualize_regions(root_region: Region, file_name: str, *,
                 name = f"--{name}--"
             if obj.address is None:
                 name = f"//{name}//"
-        return re.sub("[\".:]", "", name)
+        return re.sub('[".:]', "", name)
 
     def visualize_exits(region: Region) -> None:
         for exit_ in region.exits:
             if exit_.connected_region:
                 if show_entrance_names:
-                    uml.append(f"\"{fmt(region)}\" --> \"{fmt(exit_.connected_region)}\" : \"{fmt(exit_)}\"")
+                    uml.append(
+                        f'"{fmt(region)}" --> "{fmt(exit_.connected_region)}" : "{fmt(exit_)}"'
+                    )
                 else:
                     try:
-                        uml.remove(f"\"{fmt(exit_.connected_region)}\" --> \"{fmt(region)}\"")
-                        uml.append(f"\"{fmt(exit_.connected_region)}\" <--> \"{fmt(region)}\"")
+                        uml.remove(
+                            f'"{fmt(exit_.connected_region)}" --> "{fmt(region)}"'
+                        )
+                        uml.append(
+                            f'"{fmt(exit_.connected_region)}" <--> "{fmt(region)}"'
+                        )
                     except ValueError:
-                        uml.append(f"\"{fmt(region)}\" --> \"{fmt(exit_.connected_region)}\"")
+                        uml.append(
+                            f'"{fmt(region)}" --> "{fmt(exit_.connected_region)}"'
+                        )
             else:
-                uml.append(f"circle \"unconnected exit:\\n{fmt(exit_)}\"")
-                uml.append(f"\"{fmt(region)}\" --> \"unconnected exit:\\n{fmt(exit_)}\"")
+                uml.append(f'circle "unconnected exit:\\n{fmt(exit_)}"')
+                uml.append(f'"{fmt(region)}" --> "unconnected exit:\\n{fmt(exit_)}"')
 
     def visualize_locations(region: Region) -> None:
         any_lock = any(location.locked for location in region.locations)
         for location in region.locations:
-            lock = "<&lock-locked> " if location.locked else "<&lock-unlocked,color=transparent> " if any_lock else ""
+            lock = (
+                "<&lock-locked> "
+                if location.locked
+                else "<&lock-unlocked,color=transparent> "
+                if any_lock
+                else ""
+            )
             if location.item:
-                uml.append(f"\"{fmt(region)}\" : {{method}} {lock}{fmt(location)}: {fmt(location.item)}")
+                uml.append(
+                    f'"{fmt(region)}" : {{method}} {lock}{fmt(location)}: {fmt(location.item)}'
+                )
             else:
-                uml.append(f"\"{fmt(region)}\" : {{field}} {lock}{fmt(location)}")
+                uml.append(f'"{fmt(region)}" : {{field}} {lock}{fmt(location)}')
 
     def visualize_region(region: Region) -> None:
-        uml.append(f"class \"{fmt(region)}\"")
+        uml.append(f'class "{fmt(region)}"')
         if show_locations:
             visualize_locations(region)
         visualize_exits(region)
 
     def visualize_other_regions() -> None:
-        if other_regions := [region for region in multiworld.get_regions(root_region.player) if region not in seen]:
-            uml.append("package \"other regions\" <<Cloud>> {")
+        if other_regions := [
+            region
+            for region in multiworld.get_regions(root_region.player)
+            if region not in seen
+        ]:
+            uml.append('package "other regions" <<Cloud>> {')
             for region in other_regions:
-                uml.append(f"class \"{fmt(region)}\"")
+                uml.append(f'class "{fmt(region)}"')
             uml.append("}")
 
     uml.append("@startuml")
@@ -928,13 +1175,73 @@ def visualize_regions(root_region: Region, file_name: str, *,
         if (current_region := regions.popleft()) not in seen:
             seen.add(current_region)
             visualize_region(current_region)
-            regions.extend(exit_.connected_region for exit_ in current_region.exits if exit_.connected_region)
+            regions.extend(
+                exit_.connected_region
+                for exit_ in current_region.exits
+                if exit_.connected_region
+            )
     if show_other_regions:
         visualize_other_regions()
     uml.append("@enduml")
 
     with open(file_name, "wt", encoding="utf-8") as f:
         f.write("\n".join(uml))
+
+
+def generate_world_template(world: typing.Union[World, typing.Type[World]],
+                            target_folder: typing.Optional[typing.Union[str, "pathlib.Path"]] = None) -> None:
+    """
+    Generates a single YAML template for the provided world instance with its options
+    :param world: world to generate a template for. If an instance is passed will use the options currently set on that
+     world
+    :param target_folder: directory to output the YAML template to
+    """
+    import yaml
+    from jinja2 import Template
+
+    def dictify_range(option: Range):
+        data = {option.default: 50}
+        for sub_option in ["random", "random-low", "random-high"]:
+            if sub_option != option.default:
+                data[sub_option] = 0
+
+        notes = {}
+        for name, number in getattr(option, "special_range_names", {}).items():
+            notes[name] = f"equivalent to {number}"
+            if number in data:
+                data[name] = data[number]
+                del data[number]
+            else:
+                data[name] = 0
+
+        return data, notes
+
+    if not target_folder:
+        target_folder = user_path("Players", "Templates")
+    game_name = world.game
+    
+    if isinstance(world, type):
+        all_options = world.options_dataclass.type_hints
+    else:
+        all_options = world.options.as_dict(*world.options_dataclass.type_hints.keys())
+        os.makedirs(target_folder, exist_ok=True)
+
+    with open(local_path("data", "options.yaml")) as f:
+        file_data = f.read()
+    res = Template(file_data).render(
+        options=all_options,
+        __version__=__version__,
+        game=game_name,
+        yaml_dump=yaml.dump,
+        dictify_range=dictify_range,
+    )
+
+    del file_data
+
+    with open(
+        os.path.join(target_folder, game_name + ".yaml"), "w", encoding="utf-8-sig"
+    ) as f:
+        f.write(res)
 
 
 class RepeatableChain:

--- a/data/specified_options.yaml
+++ b/data/specified_options.yaml
@@ -1,0 +1,11 @@
+name: {{ name }}
+game: {{ game }}
+requires:
+  version: {{ __version__ }}
+{% if description %}
+description: {{ description }}
+{% endif %}
+{{ game }}:
+  {%- for option_key, value in options.items() %}
+  {{ option_key }}: {{ value }}
+  {%- endfor %}


### PR DESCRIPTION
## What is this fixing or adding?
Adds a template that can generate a yaml from a `dict[str, Any]` of the option names to their values, and adds a method that can be called to generate a yaml template with a provided world instance. This can potentially be used during error handling to help get more information for reproducibility, and the template should be reusable for the webhost.

## How was this tested?
Called the class during a generation step in my world and verified the output looked correct. Currently can't be run from unit tests if that's a desired outcome.

## If this makes graphical changes, please attach screenshots.
