### PR TITLE
ALTTP: Restore allow_excluded to fill_restrictive call

### DIFF
--- a/worlds/alttp/Dungeons.py
+++ b/worlds/alttp/Dungeons.py
@@ -264,7 +264,7 @@ def fill_dungeons_restrictive(multiworld: MultiWorld):
 
                         if loc in all_state_base.events:
                             all_state_base.events.remove(loc)
-            fill_restrictive(multiworld, all_state_base, locations, in_dungeon_items, True, True,
+            fill_restrictive(multiworld, all_state_base, locations, in_dungeon_items, True, True, allow_excluded=True,
                              name="LttP Dungeon Items")
 
 


### PR DESCRIPTION
## What is this fixing or adding?
Restores allow_excluded to the dungeon fill_restrictive call, which was apparently removed by mistake during merge conflict resolution

## How was this tested?
Generating