### PR TITLE
Noita: Don't allow impossible slot names

### DIFF
--- a/worlds/noita/__init__.py
+++ b/worlds/noita/__init__.py
@@ -35,6 +35,10 @@ class NoitaWorld(World):
 
     web = NoitaWeb()
 
+    def generate_early(self):
+        if not self.multiworld.get_player_name(self.player).isascii():
+            raise Exception("Error: Noita yaml's slot name has invalid character(s).")
+    
     # Returned items will be sent over to the client
     def fill_slot_data(self):
         return {name: getattr(self.multiworld, name)[self.player].value for name in self.option_definitions}

--- a/worlds/noita/__init__.py
+++ b/worlds/noita/__init__.py
@@ -37,7 +37,7 @@ class NoitaWorld(World):
 
     def generate_early(self):
         if not self.multiworld.get_player_name(self.player).isascii():
-            raise Exception("Error: Noita yaml's slot name has invalid character(s).")
+            raise Exception("Noita yaml's slot name has invalid character(s).")
     
     # Returned items will be sent over to the client
     def fill_slot_data(self):

--- a/worlds/noita/docs/setup_en.md
+++ b/worlds/noita/docs/setup_en.md
@@ -40,6 +40,8 @@ or try restarting your game.
 ### What is a YAML and why do I need one?
 You can see the [basic multiworld setup guide](/tutorial/Archipelago/setup/en) here on the Archipelago website to learn
 about why Archipelago uses YAML files and what they're for.
+Please note that Noita only allows you to type certain characters for your slot name.
+These characters are: %-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz~
 
 ### Where do I get a YAML?
 You can use the [game settings page for Noita](/games/Noita/player-settings) here on the Archipelago website to

--- a/worlds/noita/docs/setup_en.md
+++ b/worlds/noita/docs/setup_en.md
@@ -41,7 +41,7 @@ or try restarting your game.
 You can see the [basic multiworld setup guide](/tutorial/Archipelago/setup/en) here on the Archipelago website to learn
 about why Archipelago uses YAML files and what they're for.
 Please note that Noita only allows you to type certain characters for your slot name.
-These characters are: %-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz~
+These characters are: `` !#$%&'()+,-.0123456789;=@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{}~<>|\/``
 
 ### Where do I get a YAML?
 You can use the [game settings page for Noita](/games/Noita/player-settings) here on the Archipelago website to


### PR DESCRIPTION
## What is this fixing or adding?
Adds a note about what characters can be used in slot names. I am currently trying to figure out a good way to not need this note, but in the mean time this note should help avoid issues.

## How was this tested?
Attempting to generate with yamls with ä in them

## If this makes graphical changes, please attach screenshots.
N/A