### PR TITLE
KH2:Update Client stat increases and fix promise charm logic

### DIFF
--- a/worlds/kh2/Rules.py
+++ b/worlds/kh2/Rules.py
@@ -83,7 +83,10 @@ class KH2Rules:
         return state.has(ItemName.TornPages, self.player, amount)
 
     def level_locking_unlock(self, state: CollectionState, amount):
-        return amount <= sum([state.count(item_name, self.player) for item_name in visit_locking_dict["2VisitLocking"]])
+        if state.has(ItemName.PromiseCharm, self.player):
+            return True
+        else:
+            return amount <= sum([state.count(item_name, self.player) for item_name in visit_locking_dict["2VisitLocking"]])
 
     def summon_levels_unlocked(self, state: CollectionState, amount) -> bool:
         return amount <= sum([state.count(item_name, self.player) for item_name in summons])
@@ -268,7 +271,6 @@ class KH2WorldRules(KH2Rules):
                 add_item_rule(location, lambda item: item.player == self.player and item.name in DonaldAbility_Table.keys())
 
     def set_kh2_goal(self):
-
         final_xemnas_location = self.multiworld.get_location(LocationName.FinalXemnas, self.player)
         if self.multiworld.Goal[self.player] == "three_proofs":
             final_xemnas_location.access_rule = lambda state: self.kh2_has_all(three_proofs, state)
@@ -291,8 +293,8 @@ class KH2WorldRules(KH2Rules):
             else:
                 self.multiworld.completion_condition[self.player] = lambda state: state.has(ItemName.Bounty, self.player, self.multiworld.BountyRequired[self.player].value)
         else:
-            final_xemnas_location.access_rule = lambda state: state.has(ItemName.Bounty, self.player, self.multiworld.BountyRequired[self.player].value) and\
-                                  state.has(ItemName.LuckyEmblem, self.player, self.multiworld.LuckyEmblemsRequired[self.player].value)
+            final_xemnas_location.access_rule = lambda state: state.has(ItemName.Bounty, self.player, self.multiworld.BountyRequired[self.player].value) and \
+                                                              state.has(ItemName.LuckyEmblem, self.player, self.multiworld.LuckyEmblemsRequired[self.player].value)
             if self.multiworld.FinalXemnas[self.player]:
                 self.multiworld.completion_condition[self.player] = lambda state: state.has(ItemName.Victory, self.player, 1)
             else:


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?
Makes the client make sure the player has the correct amount of stat increase instead of letting the goa mod (apcompanion) do it
Fixes the logic of having all leveling not be in logic when having promise charm
## How was this tested?
Gave myself all the stat increases, delete the apsave, reboot the server. it removed the old increases since they were "duped"
returns true if state.has promise charm else do the normal logic

## If this makes graphical changes, please attach screenshots.
