### PR TITLE
Factorio: Fix unbeatable seeds where a science pack needs chemical plant

### DIFF
--- a/worlds/factorio/__init__.py
+++ b/worlds/factorio/__init__.py
@@ -246,7 +246,8 @@ class Factorio(World):
                 location.access_rule = lambda state, ingredient=ingredient, custom_recipe=custom_recipe: \
                     (ingredient not in technology_table or state.has(ingredient, player)) and \
                     all(state.has(technology.name, player) for sub_ingredient in custom_recipe.ingredients
-                        for technology in required_technologies[sub_ingredient])
+                        for technology in required_technologies[sub_ingredient]) and \
+                    all(state.has(technology.name, player) for technology in required_technologies[custom_recipe.crafting_machine])
             else:
                 location.access_rule = lambda state, ingredient=ingredient: \
                     all(state.has(technology.name, player) for technology in required_technologies[ingredient])


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?

Fixes issue #2612
Chemical plant requires two stages of progressive processing.  However, the rules didn't actually check for the player having all of the required technologies for the required crafting machine for the recipe.  so in some instances, it might only put one, or maybe even none of the first two processing technologies before the science pack requiring the chemical plant.

## How was this tested?

Regenerated a known seed where this bug existed with the fix to verify that the issue was in fact fixed.


## If this makes graphical changes, please attach screenshots.
