### PR TITLE
Pokémon R/B: Flash forced-learnable logic fix

### DIFF
--- a/worlds/pokemon_rb/__init__.py
+++ b/worlds/pokemon_rb/__init__.py
@@ -414,7 +414,7 @@ class PokemonRedBlueWorld(World):
                     > 7) or (self.multiworld.door_shuffle[self.player] not in ("off", "simple")))):
                 intervene_move = "Cut"
             elif ((not logic.can_learn_hm(test_state, "Flash", self.player)) and self.multiworld.dark_rock_tunnel_logic[self.player]
-                    and (((self.multiworld.accessibility[self.player] != "minimal" and
+                    and (((self.multiworld.accessibility[self.player] != "minimal" or
                     (self.multiworld.trainersanity[self.player] or self.multiworld.extra_key_items[self.player])) or
                     self.multiworld.door_shuffle[self.player]))):
                 intervene_move = "Flash"


### PR DESCRIPTION
## What is this fixing or adding?
Fixes the logic used in determining if a Pokémon must be able to learn Flash.
If no Pokémon can learn Flash, and dark rock tunnel logic is on, then it should be forced on if minimal accessibility is not minimal, OR there are no location checks and no door shuffle. Not AND.

## How was this tested?
Generating with the yaml supplied in the bug report made by @Exempt-Medic 