### PR TITLE
Webhost: implement option groups on webworld to allow dev sorting

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1407,6 +1407,14 @@ class Tutorial(NamedTuple):
     authors: List[str]
 
 
+class OptionGroup(NamedTuple):
+    """Define a grouping of options"""
+    name: str
+    """Name of the group to categorize this option in for display on the WebHost and in generated YAMLS."""
+    options: List[Type[Options.Option]]
+    """Options to be in the defined group. """
+
+
 class PlandoOptions(IntFlag):
     none = 0b0000
     items = 0b0001

--- a/WebHostLib/misc.py
+++ b/WebHostLib/misc.py
@@ -66,20 +66,13 @@ def player_settings(game: str):
 @cache.cached()
 def player_options(game: str, message: str = None):
     world = AutoWorldRegister.world_types[game]
-    all_options: Dict[str, Options.AssembleOptions] = world.options_dataclass.type_hints
-    grouped_options = {}
-    for option_name, option in all_options.items():
-        if issubclass(option, (Options.ItemDict, Options.ItemSet)) and not option.verify_item_name:
-            continue
-
-        if issubclass(option, Options.LocationSet) and not option.verify_location_name:
-            continue
-
-        if issubclass(option, (Options.OptionList, Options.OptionSet)) and not hasattr(option, "valid_keys"):
-            continue
-
-        grouped_options.setdefault(getattr(option, "group_name", "Game Options"), {})[option_name] = option
-
+    option_groups = {option: option_group.name
+                     for option_group in world.web.option_groups
+                     for option in option_group.options}
+    ordered_groups = ["Game Options", *[group.name for group in world.web.option_groups]]
+    grouped_options = {group: {} for group in ordered_groups}
+    for option_name, option in world.options_dataclass.type_hints.items():
+        grouped_options[option_groups.get(option, "Game Options")][option_name] = option
     return render_template(
         "playerOptions/playerOptions.html",
         message=message,

--- a/WebHostLib/templates/playerOptions/playerOptions.html
+++ b/WebHostLib/templates/playerOptions/playerOptions.html
@@ -61,7 +61,7 @@
             </div>
 
             <div id="option-groups">
-                {% for group_name, group_options in option_groups | dictsort %}
+                {% for group_name, group_options in option_groups.items() %}
                     <div class="group-container">
                         <h2>
                             <label for="{{ group_name }}-toggle">


### PR DESCRIPTION
## What is this fixing or adding?
moves option group definitions to webworld so that devs can determine the order to allow for their own custom sorting. This currently forces game options to always be at the top, doesn't allow devs to "add" to it, but it's the default group where options go if they aren't in a separate group. This ensures an option can't be defined in multiple separate groups, and can't appear multiple times in the same group. Items & Location Options is also default filled and put at the end. A world can add custom classes to it and move it to a separate spot if desired, but can't remove the pre-defined options from it.

## How was this tested?
Set up a few option groups in my world and checked all the above cases worked, as well as moved groups around to check the webhost reflected the changes.

## If this makes graphical changes, please attach screenshots.
![Screenshot_193](https://github.com/ArchipelagoMW/Archipelago/assets/13184667/c27ca2f0-7dc3-4a9d-afc0-b3512cb0d215)
![Screenshot_194](https://github.com/ArchipelagoMW/Archipelago/assets/13184667/348d59a5-7652-4b0d-9683-96c93bdc92c1)
