### PR TITLE
The Witness: Allow 8-11 Mountain Lasers as a yaml-only feature

### DIFF
--- a/worlds/witness/Options.py
+++ b/worlds/witness/Options.py
@@ -139,6 +139,12 @@ class MountainLasers(Range):
     range_end = 7
     default = 7
 
+    def __init__(self, value: int) -> None:
+        if 8 <= value <= 11:  # undocumented advanced difficulty options
+            self.value = value
+        else:
+            super().__init__(value)
+
 
 class ChallengeLasers(Range):
     """Sets the amount of beams required to enter the Caves through the Mountain Bottom Floor Discard."""

--- a/worlds/witness/Options.py
+++ b/worlds/witness/Options.py
@@ -134,8 +134,8 @@ class PuzzleRandomization(Choice):
 
 class MountainLasers(Range):
     """Sets the amount of lasers required to enter the Mountain.
-    You can set this to a value higher than 7 by editing your .yaml directly,
-    but it will require doing an advanced trick."""
+    You can set this to a value higher than 7, but doing so will require doing an advanced trick. So, as a safety
+    measure, this is only possible by editing your yaml directly."""
     display_name = "Required Lasers for Mountain Entry"
     range_start = 1
     range_end = 7

--- a/worlds/witness/Options.py
+++ b/worlds/witness/Options.py
@@ -133,7 +133,9 @@ class PuzzleRandomization(Choice):
 
 
 class MountainLasers(Range):
-    """Sets the amount of beams required to enter the final area."""
+    """Sets the amount of lasers required to enter the Mountain.
+    You can set this to a value higher than 7 by editing your .yaml directly,
+    but it will require doing an advanced trick."""
     display_name = "Required Lasers for Mountain Entry"
     range_start = 1
     range_end = 7

--- a/worlds/witness/player_logic.py
+++ b/worlds/witness/player_logic.py
@@ -322,7 +322,9 @@ class WitnessPlayerLogic:
         elif victory == 3:
             self.VICTORY_LOCATION = "0xFFF00"
 
-        if chal_lasers <= 7:
+        # Long box can usually only be solved by opening the mountain entry. If it's 7 lasers or less, that's no longer
+        # true. Also, if the user used the secret ">7 mountain lasers", they are expecting to have to do the snipe.
+        if chal_lasers <= 7 or mnt_lasers > 7:
             adjustment_linesets_in_order.append([
                 "Requirement Changes:",
                 "0xFFF00 - 11 Lasers - True",


### PR DESCRIPTION
Have a feeling this might be controversial.
Basically, Mountain Lasers can't go over 7 for logical reasons, **except** for the fact that there is an **advanced trick** that someone can do to make it possible.
Advanced players have been asking for this feature forever, because 11 mountain lasers is genuinely a transformative & good feature. But, I've rejected it so far because I don't want new players to "accidentally stumble upon it"

So, I want to make it a secret yaml-only feature. Well, not necessarily secret tbh, in fact I added a line to the option tooltip pointing out this possibility, but I wanted add a step to it so it can't happen "accidentally" and can't be rolled into randomly in mystery settings.

**Tested:**
Generated some seeds to see if it works. All the logic seems to behave as expected (snipe is expected if mountain lasers > 7).
The random range syntax doesn't work on the yaml side, but defining a weight for each value between 1 and 11 individually works, which makes sense.

Also, I went in-game to make sure it's actually possible to solve an 11 laser shortbox and an 11 laser longbox in the same game (i.e., checked that it's possible to "distinguish" between the exits while doing the snipe)