### PR TITLE
The Witness: Allow Mountain Lasers to go up to 11 instead of 7.

### DIFF
--- a/worlds/witness/Options.py
+++ b/worlds/witness/Options.py
@@ -139,6 +139,12 @@ class MountainLasers(Range):
     range_end = 7
     default = 7
 
+    def __init__(self, value: int) -> None:
+        if 8 <= value <= 11:  # undocumented advanced difficulty options
+            self.value = value
+        else:
+            super().__init__(value)
+
 
 class ChallengeLasers(Range):
     """Sets the amount of beams required to enter the Caves through the Mountain Bottom Floor Discard."""

--- a/worlds/witness/Options.py
+++ b/worlds/witness/Options.py
@@ -134,18 +134,12 @@ class PuzzleRandomization(Choice):
 
 class MountainLasers(Range):
     """Sets the amount of lasers required to enter the Mountain.
-    You can set this to a value higher than 7, but doing so will require doing an advanced trick. So, as a safety
-    measure, this is only possible by editing your yaml directly."""
+    If set to a higher amount than 7, the mountaintop box will be slightly rotated to make it possible to solve.
+    This will then also change the logic for the long solution ("Challenge Lasers" option)."""
     display_name = "Required Lasers for Mountain Entry"
     range_start = 1
-    range_end = 7
+    range_end = 11
     default = 7
-
-    def __init__(self, value: int) -> None:
-        if 8 <= value <= 11:  # undocumented advanced difficulty options
-            self.value = value
-        else:
-            super().__init__(value)
 
 
 class ChallengeLasers(Range):

--- a/worlds/witness/Options.py
+++ b/worlds/witness/Options.py
@@ -134,8 +134,8 @@ class PuzzleRandomization(Choice):
 
 class MountainLasers(Range):
     """Sets the amount of lasers required to enter the Mountain.
-    You can set this to a value higher than 7 by editing your .yaml directly,
-    but it will require doing an advanced trick."""
+    You can set this to a value higher than 7, but doing so will require doing an advanced trick. So, as a safety
+    measure, this is only possible by editing your yaml directly."""
     display_name = "Required Lasers for Mountain Entry"
     range_start = 1
     range_end = 7

--- a/worlds/witness/Options.py
+++ b/worlds/witness/Options.py
@@ -134,8 +134,9 @@ class PuzzleRandomization(Choice):
 
 class MountainLasers(Range):
     """Sets the amount of lasers required to enter the Mountain.
-    If set to a higher amount than 7, the mountaintop box will be slightly rotated to make it possible to solve.
-    This will then also change the logic for the long solution ("Challenge Lasers" option)."""
+    If set to a higher amount than 7, the mountaintop box will be slightly rotated to make it possible to solve without
+    the hatch being opened.
+    This change will also be applied logically to the long solution ("Challenge Lasers" setting)."""
     display_name = "Required Lasers for Mountain Entry"
     range_start = 1
     range_end = 11

--- a/worlds/witness/Options.py
+++ b/worlds/witness/Options.py
@@ -133,7 +133,9 @@ class PuzzleRandomization(Choice):
 
 
 class MountainLasers(Range):
-    """Sets the amount of beams required to enter the final area."""
+    """Sets the amount of lasers required to enter the Mountain.
+    You can set this to a value higher than 7 by editing your .yaml directly,
+    but it will require doing an advanced trick."""
     display_name = "Required Lasers for Mountain Entry"
     range_start = 1
     range_end = 7

--- a/worlds/witness/player_logic.py
+++ b/worlds/witness/player_logic.py
@@ -322,7 +322,9 @@ class WitnessPlayerLogic:
         elif victory == 3:
             self.VICTORY_LOCATION = "0xFFF00"
 
-        if chal_lasers <= 7:
+        # Long box can usually only be solved by opening the mountain entry. If it's 7 lasers or less, that's no longer
+        # true. Also, if the user used the secret ">7 mountain lasers", they are expecting to have to do the snipe.
+        if chal_lasers <= 7 or mnt_lasers > 7:
             adjustment_linesets_in_order.append([
                 "Requirement Changes:",
                 "0xFFF00 - 11 Lasers - True",


### PR DESCRIPTION
So up until now, it has been forbidden to put mountain_lasers at a number greater than 7.
This is because the solution is on the *bottom* of the box, which looks like this:

![image](https://github.com/ArchipelagoMW/Archipelago/assets/57900059/9088f210-bcba-4739-a6fb-170bd7c8930c)

It is required to first open the hatch to be able to step onto the staircase under the box.

However, I have managed to rotate the mountaintop box in such a way that makes this no longer a requirement:

![image](https://github.com/ArchipelagoMW/Archipelago/assets/57900059/d257dd52-c805-428c-b9b3-b6515baf95f4)

Important note:
The way I've chosen to implement this is that this only happens if mountain lasers is greater than 7. I do not want there to be any difference for the default 7-11 laser settings.
This means that the logic for challenge lasers also has to change based on how many mountain lasers there are. I've implemented that as well.

**Tested**
Generated some seeds and checked that the spoiler logs make sense, and tested in-game whether lower solutions are now easily solvable