### PR TITLE
Pokémon R/B: Halve Bank Exchange Rate

### DIFF
--- a/worlds/pokemon_rb/client.py
+++ b/worlds/pokemon_rb/client.py
@@ -10,7 +10,7 @@ from .locations import location_data
 
 logger = logging.getLogger("Client")
 
-BANK_EXCHANGE_RATE = 100000000
+BANK_EXCHANGE_RATE = 50000000
 
 DATA_LOCATIONS = {
     "ItemIndex": (0x1A6E, 0x02),


### PR DESCRIPTION
## What is this fixing or adding?
After playing a game with Pokémon Red and Blue with Stardew Valley, I believe the exchange rate between the two of 10:1 is excessive. This changes it to a 5:1 ratio which I hope will be more reasonable

## How was this tested?
Checking bank balance on both games and ensuring a 5:1 ratio between the reported numbers.