### PR TITLE
TLOZ: Try accounting for non_local_items with the pool of starting weapons

### DIFF
--- a/worlds/tloz/ItemPool.py
+++ b/worlds/tloz/ItemPool.py
@@ -93,7 +93,11 @@ def get_pool_core(world):
 
     # Starting Weapon
     start_weapon_locations = starting_weapon_locations.copy()
-    starting_weapon = random.choice(starting_weapons)
+    final_starting_weapons = [weapon for weapon in starting_weapons
+                              if weapon not in world.multiworld.non_local_items[world.player]]
+    if not final_starting_weapons:
+        final_starting_weapons = starting_weapons
+    starting_weapon = random.choice(final_starting_weapons)
     if world.multiworld.StartingPosition[world.player] == StartingPosition.option_safe:
         placed_items[start_weapon_locations[0]] = starting_weapon
     elif world.multiworld.StartingPosition[world.player] in \


### PR DESCRIPTION
## What is this fixing or adding?

It was brought up that if you attempt to non_local any of the starting weapons, there is still a chance for it to get chosen as your starting weapon if you are on a StartingPosition value lower than very_dangerous. This fix will attempt to build the starting weapons list accounting for non_local items, but if all possible weapons have been set to non_local, force one of them to be your starting weapon anyway since the player is still expecting a starting weapon in their world if they have chosen one of the lower StartingPosition values.

## How was this tested?
Test genned with two yamls, one with just Magical Sword in non_local_items, and one with the weapons item group in non_local items. Confirmed that the Magical Sword yaml did properly remove the item from the possible starting weapons, and that the all weapons yaml repopulated the starting weapon list from the base list.

## If this makes graphical changes, please attach screenshots.
N/A