### PR TITLE
Pokémon R/B: Badge Plando Fix

### DIFF
--- a/worlds/pokemon_rb/__init__.py
+++ b/worlds/pokemon_rb/__init__.py
@@ -281,18 +281,20 @@ class PokemonRedBlueWorld(World):
                     self.multiworld.itempool.remove(badge)
                     progitempool.remove(badge)
                 for _ in range(5):
-                    badgelocs = [self.multiworld.get_location(loc, self.player) for loc in [
-                        "Pewter Gym - Brock Prize", "Cerulean Gym - Misty Prize",
-                        "Vermilion Gym - Lt. Surge Prize", "Celadon Gym - Erika Prize",
-                        "Fuchsia Gym - Koga Prize", "Saffron Gym - Sabrina Prize",
-                        "Cinnabar Gym - Blaine Prize", "Viridian Gym - Giovanni Prize"]]
+                    badgelocs = [
+                        self.multiworld.get_location(loc, self.player) for loc in [
+                            "Pewter Gym - Brock Prize", "Cerulean Gym - Misty Prize",
+                            "Vermilion Gym - Lt. Surge Prize", "Celadon Gym - Erika Prize",
+                            "Fuchsia Gym - Koga Prize", "Saffron Gym - Sabrina Prize",
+                            "Cinnabar Gym - Blaine Prize", "Viridian Gym - Giovanni Prize"
+                        ] if self.multiworld.get_location(loc, self.player).item is None]
                     state = self.multiworld.get_all_state(False)
                     self.multiworld.random.shuffle(badges)
                     self.multiworld.random.shuffle(badgelocs)
                     badgelocs_copy = badgelocs.copy()
                     # allow_partial so that unplaced badges aren't lost, for debugging purposes
                     fill_restrictive(self.multiworld, state, badgelocs_copy, badges, True, True, allow_partial=True)
-                    if badges:
+                    if len(badges) > 8 - len(badgelocs):
                         for location in badgelocs:
                             if location.item:
                                 badges.append(location.item)
@@ -302,6 +304,7 @@ class PokemonRedBlueWorld(World):
                         for location in badgelocs:
                             if location.item:
                                 fill_locations.remove(location)
+                        progitempool += badges
                         break
                 else:
                     raise FillError(f"Failed to place badges for player {self.player}")


### PR DESCRIPTION
## What is this fixing or adding?
Only attempt to place badges in badge locations if they are empty. Return unplaced badges to the item pool if fewer than 8 locations are being filled.
This should fix errors that occur when items are placed into badge locations via plando, or whatever other worlds may do.

## How was this tested?
By doing the thing.