### PR TITLE
Muse Dash: Update song list to v3.12.0 and fix up a missing song

### DIFF
--- a/worlds/musedash/MuseDashCollection.py
+++ b/worlds/musedash/MuseDashCollection.py
@@ -34,6 +34,7 @@ class MuseDashCollections:
         "Rush-Hour",
         "Find this Month's Featured Playlist",
         "PeroPero in the Universe",
+        "umpopoff"
     ]
 
     album_items: Dict[str, AlbumData] = {}
@@ -81,11 +82,22 @@ class MuseDashCollections:
             steamer_mode = sections[3] == "True"
 
             if song_name in self.DIFF_OVERRIDES:
-                # Note: These difficulties may not actually be representative of these songs.
-                # The game does not provide these difficulties so they have to be filled in.
-                diff_of_easy = 4
-                diff_of_hard = 7
-                diff_of_master = 10
+                # These songs use non-standard difficulty values. Which are being overriden with standard values.
+                # But also avoid filling any missing difficulties (i.e. 0s) with a difficulty value.
+                if sections[4] is not '0':
+                    diff_of_easy = 4
+                else:
+                    diff_of_easy = None
+
+                if sections[5] is not '0':
+                    diff_of_hard = 7
+                else:
+                    diff_of_hard = None
+
+                if sections[6] is not '0':
+                    diff_of_master = 10
+                else:
+                    diff_of_master = None
             else:
                 diff_of_easy = self.parse_song_difficulty(sections[4])
                 diff_of_hard = self.parse_song_difficulty(sections[5])

--- a/worlds/musedash/MuseDashCollection.py
+++ b/worlds/musedash/MuseDashCollection.py
@@ -84,17 +84,17 @@ class MuseDashCollections:
             if song_name in self.DIFF_OVERRIDES:
                 # These songs use non-standard difficulty values. Which are being overriden with standard values.
                 # But also avoid filling any missing difficulties (i.e. 0s) with a difficulty value.
-                if sections[4] is not '0':
+                if sections[4] != '0':
                     diff_of_easy = 4
                 else:
                     diff_of_easy = None
 
-                if sections[5] is not '0':
+                if sections[5] != '0':
                     diff_of_hard = 7
                 else:
                     diff_of_hard = None
 
-                if sections[6] is not '0':
+                if sections[6] != '0':
                     diff_of_master = 10
                 else:
                     diff_of_master = None

--- a/worlds/musedash/MuseDashData.txt
+++ b/worlds/musedash/MuseDashData.txt
@@ -119,7 +119,7 @@ Prestige and Vestige|56-4|Give Up TREATMENT Vol.11|True|6|8|11|
 Tiny Fate|56-5|Give Up TREATMENT Vol.11|False|7|9|11|
 Tsuki ni Murakumo Hana ni Kaze|55-0|Touhou Mugakudan -2-|False|3|5|7|
 Patchouli's - Best Hit GSK|55-1|Touhou Mugakudan -2-|False|3|5|8|
-Monosugoi Space Shuttle de Koishi ga Monosugoi uta|55-2|Touhou Mugakudan -2-|False|3|5|7|
+Monosugoi Space Shuttle de Koishi ga Monosugoi uta|55-2|Touhou Mugakudan -2-|False|3|5|7|11
 Kakoinaki Yo wa Ichigo no Tsukikage|55-3|Touhou Mugakudan -2-|False|3|6|8|
 Psychedelic Kizakura Doumei|55-4|Touhou Mugakudan -2-|False|4|7|10|
 Mischievous Sensation|55-5|Touhou Mugakudan -2-|False|5|7|9|
@@ -502,3 +502,11 @@ Fuzzy-Navel|68-2|Gambler's Tricks|True|6|8|10|11
 Swing Edge|68-3|Gambler's Tricks|True|4|8|10|
 Twisted Escape|68-4|Gambler's Tricks|True|5|8|10|11
 Swing Sweet Twee Dance|68-5|Gambler's Tricks|False|4|7|10|
+Sanyousei SAY YA!!!|43-42|MD Plus Project|False|4|6|8|
+YUKEMURI TAMAONSEN II|43-43|MD Plus Project|False|3|6|9|
+Samayoi no mei Amatsu|69-0|Touhou Mugakudan -3-|False|4|6|9|
+INTERNET SURVIVOR|69-1|Touhou Mugakudan -3-|False|5|8|10|
+Shuki*RaiRai|69-2|Touhou Mugakudan -3-|False|5|7|9|
+HELLOHELL|69-3|Touhou Mugakudan -3-|False|4|7|10|
+Calamity Fortune|69-4|Touhou Mugakudan -3-|True|6|8|10|11
+Tsurupettan|69-5|Touhou Mugakudan -3-|True|2|5|8|

--- a/worlds/musedash/Options.py
+++ b/worlds/musedash/Options.py
@@ -36,7 +36,7 @@ class AdditionalSongs(Range):
     - The final song count may be lower due to other settings.
     """
     range_start = 15
-    range_end = 500  # Note will probably not reach this high if any other settings are done.
+    range_end = 508  # Note will probably not reach this high if any other settings are done.
     default = 40
     display_name = "Additional Song Count"
 

--- a/worlds/musedash/__init__.py
+++ b/worlds/musedash/__init__.py
@@ -357,5 +357,6 @@ class MuseDashWorld(World):
             "victoryLocation": self.victory_song_name,
             "deathLink": self.options.death_link.value,
             "musicSheetWinCount": self.get_music_sheet_win_count(),
-            "gradeNeeded": self.options.grade_needed.value
+            "gradeNeeded": self.options.grade_needed.value,
+            "hasFiller": True,
         }

--- a/worlds/musedash/test/TestDifficultyRanges.py
+++ b/worlds/musedash/test/TestDifficultyRanges.py
@@ -66,5 +66,11 @@ class DifficultyRanges(MuseDashTestBase):
         for song_name in muse_dash_world.md_collection.DIFF_OVERRIDES:
             song = muse_dash_world.md_collection.song_items[song_name]
 
-            self.assertTrue(song.easy is not None and song.hard is not None and song.master is not None,
+            # umpopoff is a one time weird song. Its currently the only song in the game
+            # with non-standard difficulties and also doesn't have 3 or more difficulties.
+            if song_name is 'umpopoff':
+                self.assertTrue(song.easy is None and song.hard is not None and song.master is None,
+                                f"Song '{song_name}' difficulty not set when it should be.")
+            else:
+                self.assertTrue(song.easy is not None and song.hard is not None and song.master is not None,
                 f"Song '{song_name}' difficulty not set when it should be.")

--- a/worlds/musedash/test/TestDifficultyRanges.py
+++ b/worlds/musedash/test/TestDifficultyRanges.py
@@ -68,7 +68,7 @@ class DifficultyRanges(MuseDashTestBase):
 
             # umpopoff is a one time weird song. Its currently the only song in the game
             # with non-standard difficulties and also doesn't have 3 or more difficulties.
-            if song_name is 'umpopoff':
+            if song_name == 'umpopoff':
                 self.assertTrue(song.easy is None and song.hard is not None and song.master is None,
                                 f"Song '{song_name}' difficulty not set when it should be.")
             else:


### PR DESCRIPTION
## What is this fixing or adding?
Adds all the songs from the Touhou Mugakudan -Ⅲ- update. Increases the upper limit of additional songs to 508 as we now have broken the 500 barrier for songs.

Also finally fixes umpopoff. As it was the only song that had less than 3 difficulties but also didn't have proper difficulty values

## How was this tested?
Tests. And double checked via debugging the umpopoff was now getting difficulty values.
