### PR TITLE
The Witness: Progressive Symmetry

### DIFF
--- a/worlds/witness/WitnessItems.txt
+++ b/worlds/witness/WitnessItems.txt
@@ -16,6 +16,7 @@ Symbols:
 72 - Colored Squares
 80 - Arrows
 200 - Progressive Dots - Dots,Full Dots
+210 - Progressive Symmetry - Symmetry,Colored Dots
 260 - Progressive Stars - Stars,Stars + Same Colored Symbol
 
 Useful:

--- a/worlds/witness/hints.py
+++ b/worlds/witness/hints.py
@@ -219,7 +219,7 @@ def get_priority_hint_items(world: "WitnessWorld") -> List[str]:
             "Colored Squares",
             "Colored Dots",
             "Sound Dots",
-            "Symmetry"
+            "Progressive Symmetry"
         ]
 
         priority.update(world.random.sample(symbols, 5))

--- a/worlds/witness/settings/Symbol_Shuffle.txt
+++ b/worlds/witness/settings/Symbol_Shuffle.txt
@@ -3,7 +3,7 @@ Arrows
 Progressive Dots
 Colored Dots
 Sound Dots
-Symmetry
+Progressive Symmetry
 Triangles
 Eraser
 Shapers


### PR DESCRIPTION
Upon common request, made "Symmetry" and "Colored Dots" a progressive item called "Progressive Symmetry"
This is because there is no way for a panel to have Colored Dots without it also having Symmetry, so there is a strict locking relationship.