### PR TITLE
FF1: Fix terminated_event.access_rule not getting set

### DIFF
--- a/worlds/ff1/__init__.py
+++ b/worlds/ff1/__init__.py
@@ -74,6 +74,7 @@ class FF1World(World):
         items = get_options(self.multiworld, 'items', self.player)
         goal_rule = generate_rule([[name for name in items.keys() if name in FF1_PROGRESSION_LIST and name != "Shard"]],
                                   self.player)
+        terminated_event.access_rule = goal_rule
         if "Shard" in items.keys():
             def goal_rule_and_shards(state):
                 return goal_rule(state) and state.has("Shard", self.player, 32)


### PR DESCRIPTION
## What is this fixing or adding?
terminated_event.access_rule wasn't always set, meaning that the terminated_event was sometime accessible from the very start. See: https://github.com/ArchipelagoMW/Archipelago/issues/2647

## How was this tested?
Generated a test game with yamls known for triggering that issue and confirmed with the spoiler log that the terminated_event wasn't in sphere 1.