### PR TITLE
Core: check if a location is an event before excluding it

### DIFF
--- a/worlds/generic/Rules.py
+++ b/worlds/generic/Rules.py
@@ -1,4 +1,5 @@
 import collections
+import logging
 import typing
 
 from BaseClasses import LocationProgressType, MultiWorld, Location, Region, Entrance
@@ -81,15 +82,16 @@ def locality_rules(world: MultiWorld):
                     i.name not in sending_blockers[i.player] and old_rule(i)
 
 
-def exclusion_rules(world: MultiWorld, player: int, exclude_locations: typing.Set[str]) -> None:
+def exclusion_rules(multiworld: MultiWorld, player: int, exclude_locations: typing.Set[str]) -> None:
     for loc_name in exclude_locations:
         try:
-            location = world.get_location(loc_name, player)
+            location = multiworld.get_location(loc_name, player)
         except KeyError as e:  # failed to find the given location. Check if it's a legitimate location
-            if loc_name not in world.worlds[player].location_name_to_id:
+            if loc_name not in multiworld.worlds[player].location_name_to_id:
                 raise Exception(f"Unable to exclude location {loc_name} in player {player}'s world.") from e
         else:
             if not location.event:
+                logging.warning(f"Unable to exclude location {loc_name} in player {player}'s world.")
                 location.progress_type = LocationProgressType.EXCLUDED
 
 

--- a/worlds/generic/Rules.py
+++ b/worlds/generic/Rules.py
@@ -89,7 +89,8 @@ def exclusion_rules(world: MultiWorld, player: int, exclude_locations: typing.Se
             if loc_name not in world.worlds[player].location_name_to_id:
                 raise Exception(f"Unable to exclude location {loc_name} in player {player}'s world.") from e
         else:
-            location.progress_type = LocationProgressType.EXCLUDED
+            if not location.event:
+                location.progress_type = LocationProgressType.EXCLUDED
 
 
 def set_rule(spot: typing.Union["BaseClasses.Location", "BaseClasses.Entrance"], rule: CollectionRule):

--- a/worlds/generic/Rules.py
+++ b/worlds/generic/Rules.py
@@ -91,8 +91,9 @@ def exclusion_rules(multiworld: MultiWorld, player: int, exclude_locations: typi
                 raise Exception(f"Unable to exclude location {loc_name} in player {player}'s world.") from e
         else:
             if not location.event:
-                logging.warning(f"Unable to exclude location {loc_name} in player {player}'s world.")
                 location.progress_type = LocationProgressType.EXCLUDED
+            else:
+                logging.warning(f"Unable to exclude location {loc_name} in player {player}'s world.")
 
 
 def set_rule(spot: typing.Union["BaseClasses.Location", "BaseClasses.Entrance"], rule: CollectionRule):


### PR DESCRIPTION
## What is this fixing or adding?
Checks if a location is already flagged as an event before excluding it during exclusion rule setting. It's possible that a progression item has already been placed on the location by the world, so excluding that location can break things.

## How was this tested?
:)

## If this makes graphical changes, please attach screenshots.
