### PR TITLE
Pokemon Emerald: Add missed locations to postgame locations group

### DIFF
--- a/worlds/pokemon_emerald/locations.py
+++ b/worlds/pokemon_emerald/locations.py
@@ -114,8 +114,10 @@ LOCATION_GROUPS = {
         "Littleroot Town - S.S. Ticket from Norman",
         "SS Tidal - Hidden Item in Lower Deck Trash Can",
         "SS Tidal - TM49 from Thief",
+        "Safari Zone NE - Item on Ledge",
         "Safari Zone NE - Hidden Item North",
         "Safari Zone NE - Hidden Item East",
+        "Safari Zone SE - Item in Grass",
         "Safari Zone SE - Hidden Item in South Grass 1",
         "Safari Zone SE - Hidden Item in South Grass 2",
     }


### PR DESCRIPTION
## What is this fixing or adding?

Adds a couple items to a location group which were missed.

Context: This location group isn't directly used anywhere; it's meant as a shortcut for excluding certain locations which may require you to beat the game before accessing them (most can still be accessed early based on other options, and the list is only relevant to the champion goal)).

## How was this tested?

Generating with the group in `exclude_locations` and checking the spoiler log for their inclusion in excluded locations.
