### PR TITLE
BizHawkClient: Add some handling for non-string errors

### DIFF
--- a/data/lua/connector_bizhawk_generic.lua
+++ b/data/lua/connector_bizhawk_generic.lua
@@ -456,6 +456,7 @@ function send_receive ()
                         failed_guard_response = response
                     end
                 else
+                    if type(response) ~= "string" then response = "Unknown error" end
                     res[i] = {type = "ERROR", err = response}
                 end
             end


### PR DESCRIPTION
## What is this fixing or adding?

Someone reported an error

```
ERROR: .\json.lua:115: unexpected type 'function'
Consider reporting this crash.

NLua.Exceptions.LuaScriptException: tableConnection to client closed
Client timed out
```

Essentially the `pcall` for `process_request` caught an error, and that error was type `function`, so when the script tried to convert it to JSON to tell the client there was an error, it caused another error.

The actual error was an out of bounds write on GBA, and I guess BizHawk's response is to just throw your own function back at you when you cause an error. So in the case of

```lua
local status, response = pcall(process_request, req)
```

if `process_request` does an out of bounds write on GBA, `response` will be set to `process_request`. I tried letting it bubble up in BizHawk to see if maybe they used it to print meaningful information about where you did something wrong, but you ultimately just get `NLua.Exceptions.LuaException: unprotected error in call to Lua API (0)`. So I don't really think there's anything more to be gleaned from the fact that the error is a function.

Out of bounds reads on GBA behave similarly.

## How was this tested?

Triggering the error intentionally with Pokemon Emerald and seeing it get passed back to the client as expected.

Didn't do any testing on other systems.

