### PR TITLE
Shivers: Fixes rule logic for location 'puzzle solved three floor elevator'

### DIFF
--- a/worlds/shivers/Rules.py
+++ b/worlds/shivers/Rules.py
@@ -157,7 +157,7 @@ def get_rules_lookup(player: int):
             "Puzzle Solved Underground Elevator": lambda state: ((state.can_reach("Underground Lake", "Region", player) or state.can_reach("Office", "Region", player)
                                                                   and state.has("Key for Office Elevator", player))),
             "Puzzle Solved Bedroom Elevator": lambda state: (state.can_reach("Office", "Region", player) and state.has_all({"Key for Bedroom Elevator","Crawling"}, player)),
-            "Puzzle Solved Three Floor Elevator": lambda state: ((state.can_reach("Maintenance Tunnels", "Region", player) or state.can_reach("Blue Maze", "Region", player)
+            "Puzzle Solved Three Floor Elevator": lambda state: (((state.can_reach("Maintenance Tunnels", "Region", player) or state.can_reach("Blue Maze", "Region", player))
                                                                   and state.has("Key for Three Floor Elevator", player)))
             },
         "lightning": {


### PR DESCRIPTION

Shivers: Bug Fix

## What is this fixing or adding?

Fixes rule logic for location 'puzzle solved three floor elevator'.

## How was this tested?

Universal tracker showed I had access to a location I did not. Looking in the logic a missing set of parenthesis was found for that locations rules. Universal tracker no longer shows access to the location.

## If this makes graphical changes, please attach screenshots.

N/A