### PR TITLE
Bumper Stickers: Correcting logic error.

### DIFF
--- a/worlds/bumpstik/__init__.py
+++ b/worlds/bumpstik/__init__.py
@@ -117,10 +117,10 @@ class BumpStikWorld(World):
 
     def set_rules(self):
         for x in range(1, 32):
-            self.multiworld.get_location(f"Treasure Bumper {x + 1}", self.player).access_rule = \
+            self.multiworld.get_location(f"Treasure Bumper {x}", self.player).access_rule = \
                 lambda state, x = x: state.has("Treasure Bumper", self.player, x)
         for x in range(1, 5):
-            self.multiworld.get_location(f"Bonus Booster {x + 1}", self.player).access_rule = \
+            self.multiworld.get_location(f"Bonus Booster {x}", self.player).access_rule = \
                 lambda state, x = x: state.has("Booster Bumper", self.player, x)
         self.multiworld.get_location("Level 5 - Cleared all Hazards", self.player).access_rule = \
             lambda state: state.has("Hazard Bumper", self.player, 25)


### PR DESCRIPTION
## What is this fixing or adding?

Per discussion here: https://discord.com/channels/731205301247803413/1148330200891932742/1192138309120577646

At the moment, the logic expects Treasure Bumper 2 to require 1 bumper, Treasure Bumper 3 to require 2, etc., and for Treasure Bumper 1 to be in Sphere 1 with no requirements. This is incorrect, each Bumper check should require 1 Bumper item of it's type.

This corrects that. 

## How was this tested?

I've verified I was able to generate with it by editing my apworld locally, but I'm also not a programmer and don't know anything about tests. However, I'd think this is a simple change.
