### PR TITLE
The Witness: Add Obelisk Side locations to always and priority hints

### DIFF
--- a/worlds/witness/hints.py
+++ b/worlds/witness/hints.py
@@ -275,7 +275,8 @@ def get_priority_hint_locations(world: "WitnessWorld") -> List[str]:
         "Boat Shipwreck Green EP",
         "Quarry Stoneworks Control Room Left",
     ]
-
+    
+    # Add Obelisk Sides that contain EPs that are meant to be hinted, if they are necessary to complete the Obelisk Side
     if world.options.EP_difficulty > 1:
         priority.append("Town Obelisk Side 6")  # Theater Flowers EP
         priority.append("Treehouse Obelisk Side 4")  # Shipwreck Green EP

--- a/worlds/witness/hints.py
+++ b/worlds/witness/hints.py
@@ -187,14 +187,24 @@ def get_always_hint_items(world: "WitnessWorld") -> List[str]:
     return always
 
 
-def get_always_hint_locations(_: "WitnessWorld") -> List[str]:
-    return [
+def get_always_hint_locations(world: "WitnessWorld") -> List[str]:
+    always = [
         "Challenge Vault Box",
         "Mountain Bottom Floor Discard",
         "Theater Eclipse EP",
         "Shipwreck Couch EP",
         "Mountainside Cloud Cycle EP",
     ]
+
+    # Add Obelisk Sides that contain EPs that are meant to be hinted, if they are necessary to complete the Obelisk Side
+    if world.options.EP_difficulty == "eclipse":
+        always.append("Town Obelisk Side 6")  # Eclipse EP
+
+    if world.options.EP_difficulty > 1:
+        always.append("Treehouse Obelisk Side 4")  # Couch EP
+        always.append("River Obelisk Side 1")  # Cloud Cycle EP. Needs to be changed to "Mountainside Obelisk" soon
+
+    return always
 
 
 def get_priority_hint_items(world: "WitnessWorld") -> List[str]:
@@ -249,8 +259,8 @@ def get_priority_hint_items(world: "WitnessWorld") -> List[str]:
     return sorted(priority)
 
 
-def get_priority_hint_locations(_: "WitnessWorld") -> List[str]:
-    return [
+def get_priority_hint_locations(world: "WitnessWorld") -> List[str]:
+    priority = [
         "Swamp Purple Underwater",
         "Shipwreck Vault Box",
         "Town RGB Room Left",
@@ -265,6 +275,12 @@ def get_priority_hint_locations(_: "WitnessWorld") -> List[str]:
         "Boat Shipwreck Green EP",
         "Quarry Stoneworks Control Room Left",
     ]
+
+    if world.options.EP_difficulty > 1:
+        priority.append("Town Obelisk Side 6")  # Theater Flowers EP
+        priority.append("Treehouse Obelisk Side 4")  # Shipwreck Green EP
+
+    return priority
 
 
 def make_hint_from_item(world: "WitnessWorld", item_name: str, own_itempool: List[Item]):

--- a/worlds/witness/hints.py
+++ b/worlds/witness/hints.py
@@ -200,7 +200,7 @@ def get_always_hint_locations(world: "WitnessWorld") -> List[str]:
     if world.options.EP_difficulty == "eclipse":
         always.append("Town Obelisk Side 6")  # Eclipse EP
 
-    if world.options.EP_difficulty > 1:
+    if world.options.EP_difficulty != "normal":
         always.append("Treehouse Obelisk Side 4")  # Couch EP
         always.append("River Obelisk Side 1")  # Cloud Cycle EP. Needs to be changed to "Mountainside Obelisk" soon
 

--- a/worlds/witness/hints.py
+++ b/worlds/witness/hints.py
@@ -277,7 +277,7 @@ def get_priority_hint_locations(world: "WitnessWorld") -> List[str]:
     ]
     
     # Add Obelisk Sides that contain EPs that are meant to be hinted, if they are necessary to complete the Obelisk Side
-    if world.options.EP_difficulty > 1:
+    if world.options.EP_difficulty != "normal":
         priority.append("Town Obelisk Side 6")  # Theater Flowers EP
         priority.append("Treehouse Obelisk Side 4")  # Shipwreck Green EP
 


### PR DESCRIPTION
There are certain EPs in the game that are supposed to be always and priority hints if you have the audio log hints enabled.

However, their corresponding Obelisk Side locations are never hinted, because I forgor.

This adds those.
Worth noting: "Does the location exist" is already checked elsewhere, so a check for obelisk_sides being enabled is not necessary.

Considered a bug because this was always supposed to be the case, I just forgot.