### PR TITLE
Tests: remove deprecated option access from `WorldTestBase`

### DIFF
--- a/test/bases.py
+++ b/test/bases.py
@@ -285,7 +285,7 @@ class WorldTestBase(unittest.TestCase):
         if not (self.run_default_tests and self.constructed):
             return
         with self.subTest("Game", game=self.game):
-            excluded = self.multiworld.exclude_locations[1].value
+            excluded = self.multiworld.worlds[1].options.exclude_locations.value
             state = self.multiworld.get_all_state(False)
             for location in self.multiworld.get_locations():
                 if location.name not in excluded:

--- a/test/general/test_reachability.py
+++ b/test/general/test_reachability.py
@@ -37,7 +37,7 @@ class TestBase(unittest.TestCase):
             unreachable_regions = self.default_settings_unreachable_regions.get(game_name, set())
             with self.subTest("Game", game=game_name):
                 world = setup_solo_multiworld(world_type)
-                excluded = world.exclude_locations[1].value
+                excluded = world.worlds[1].options.exclude_locations.value
                 state = world.get_all_state(False)
                 for location in world.get_locations():
                     if location.name not in excluded:


### PR DESCRIPTION
## What is this fixing or adding?

This old option access is deprecated.
This removes lots of deprecation warnings from a run of the unit tests.

## How was this tested?

just unit tests
