### PR TITLE
Docs: Better description for LocationScouts

### DIFF
--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -325,7 +325,7 @@ Sent to server to inform it of locations that the client has checked. Used to in
 | locations | list\[int\] | The ids of the locations checked by the client. May contain any number of checks, even ones sent before; duplicates do not cause issues with the Archipelago server. |
 
 ### LocationScouts
-Sent to the server to retrieve the items that are on a specified list of locations. The server will respond with a [LocationInfo](#LocationInfo) packet with the items located in the scouted locations.
+Sent to the server to retrieve the items that are on a specified list of locations. The server will respond with a [LocationInfo](#LocationInfo) packet containing the items located in the scouted locations.
 Fully remote clients without a patch file may use this to "place" items onto their in-game locations, most commonly to display their names or item classifications before/upon pickup.
 
 LocationScouts can also be used to inform the server of locations the client has seen, but not checked, to create a hint as if the player had run `!hint_location` on this location, but without deducting hint points.

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -326,7 +326,7 @@ Sent to server to inform it of locations that the client has checked. Used to in
 
 ### LocationScouts
 Sent to the server to retrieve the items that are on a specified list of locations. The server will respond with a [LocationInfo](#LocationInfo) packet with the items located in the scouted locations.
-Fully remote clients without a patch file may use this to "place" items on the in-game locations, such as displaying their names, items classification etc. before/upon pickup.
+Fully remote clients without a patch file may use this to "place" items onto the in-game locations, such as displaying their names, items classification etc. before/upon pickup.
 
 LocationScouts can also be used to inform the server of locations the client has seen, but not checked, to create a hint as if the player had run `!hint_location` on this location, but without deducing hint points.
 This is useful in cases in which the item may appear in the game world, such as 'ledge items' in A Link to the Past. To do this, set the "create_as_hint" parameter to a non-zero value.

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -328,7 +328,7 @@ Sent to server to inform it of locations that the client has checked. Used to in
 Sent to the server to retrieve the items that are on a specified list of locations. The server will respond with a [LocationInfo](#LocationInfo) packet containing the items located in the scouted locations.
 Fully remote clients without a patch file may use this to "place" items onto their in-game locations, most commonly to display their names or item classifications before/upon pickup.
 
-LocationScouts can also be used to inform the server of locations the client has seen, but not checked, to create a hint as if the player had run `!hint_location` on this location, but without deducting hint points.
+LocationScouts can also be used to inform the server of locations the client has seen, but not checked. This creates a hint as if the player had run `!hint_location` on a location, but without deducting hint points.
 This is useful in cases where an item appears in the game world, such as 'ledge items' in _A Link to the Past_. To do this, set the `create_as_hint` parameter to a non-zero value.
 
 #### Arguments

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -325,7 +325,11 @@ Sent to server to inform it of locations that the client has checked. Used to in
 | locations | list\[int\] | The ids of the locations checked by the client. May contain any number of checks, even ones sent before; duplicates do not cause issues with the Archipelago server. |
 
 ### LocationScouts
-Sent to the server to inform it of locations the client has seen, but not checked. Useful in cases in which the item may appear in the game world, such as 'ledge items' in A Link to the Past. The server will always respond with a [LocationInfo](#LocationInfo) packet with the items located in the scouted location.
+Sent to the server to retrieve the items that are on a specified list of locations. The server will respond with a [LocationInfo](#LocationInfo) packet with the items located in the scouted locations.
+Fully remote clients without a patch file may use this to "place" items on the in-game locations, such as displaying their names, items classification etc. before/upon pickup.
+
+LocationScouts can also be used to inform the server of locations the client has seen, but not checked, to create a hint as if the player had run `!hint_location` on this location, but without deducing hint points.
+This is useful in cases in which the item may appear in the game world, such as 'ledge items' in A Link to the Past. To do this, set the "create_as_hint" parameter to a non-zero value.
 
 #### Arguments
 | Name | Type | Notes |

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -328,7 +328,7 @@ Sent to server to inform it of locations that the client has checked. Used to in
 Sent to the server to retrieve the items that are on a specified list of locations. The server will respond with a [LocationInfo](#LocationInfo) packet with the items located in the scouted locations.
 Fully remote clients without a patch file may use this to "place" items onto the in-game locations, such as displaying their names, items classification etc. before/upon pickup.
 
-LocationScouts can also be used to inform the server of locations the client has seen, but not checked, to create a hint as if the player had run `!hint_location` on this location, but without deducing hint points.
+LocationScouts can also be used to inform the server of locations the client has seen, but not checked, to create a hint as if the player had run `!hint_location` on this location, but without deducting hint points.
 This is useful in cases in which the item may appear in the game world, such as 'ledge items' in A Link to the Past. To do this, set the "create_as_hint" parameter to a non-zero value.
 
 #### Arguments

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -326,7 +326,7 @@ Sent to server to inform it of locations that the client has checked. Used to in
 
 ### LocationScouts
 Sent to the server to retrieve the items that are on a specified list of locations. The server will respond with a [LocationInfo](#LocationInfo) packet with the items located in the scouted locations.
-Fully remote clients without a patch file may use this to "place" items onto the in-game locations, such as displaying their names, items classification etc. before/upon pickup.
+Fully remote clients without a patch file may use this to "place" items onto their in-game locations, most commonly to display their names or item classifications before/upon pickup.
 
 LocationScouts can also be used to inform the server of locations the client has seen, but not checked, to create a hint as if the player had run `!hint_location` on this location, but without deducting hint points.
 This is useful in cases where an item appears in the game world, such as 'ledge items' in _A Link to the Past_. To do this, set the `create_as_hint` parameter to a non-zero value.

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -329,7 +329,7 @@ Sent to the server to retrieve the items that are on a specified list of locatio
 Fully remote clients without a patch file may use this to "place" items onto the in-game locations, such as displaying their names, items classification etc. before/upon pickup.
 
 LocationScouts can also be used to inform the server of locations the client has seen, but not checked, to create a hint as if the player had run `!hint_location` on this location, but without deducting hint points.
-This is useful in cases in which the item may appear in the game world, such as 'ledge items' in A Link to the Past. To do this, set the "create_as_hint" parameter to a non-zero value.
+This is useful in cases where an item appears in the game world, such as 'ledge items' in _A Link to the Past_. To do this, set the `create_as_hint` parameter to a non-zero value.
 
 #### Arguments
 | Name | Type | Notes |


### PR DESCRIPTION
LocationScouts doc still talks exclusively about the "ledge items" case, which has now [provably](https://discord.com/channels/731205301247803413/731214280439103580/1192725919459192894) led to someone not considering them for retrieving location-item data for a fully remote client.

I am not a native English speaker, someone who is should look at this.