### PR TITLE
Lingo: Remove colors from Bearer SIXes

### DIFF
--- a/worlds/lingo/data/LL1.yaml
+++ b/worlds/lingo/data/LL1.yaml
@@ -4202,9 +4202,6 @@
       SIX:
         id: Backside Room/Panel_six_six_5
         tag: midwhite
-        colors:
-          - red
-          - yellow
         hunt: True
         required_door:
           room: Number Hunt
@@ -4280,9 +4277,6 @@
       SIX:
         id: Backside Room/Panel_six_six_6
         tag: midwhite
-        colors:
-          - red
-          - yellow
         hunt: True
         required_door:
           room: Number Hunt


### PR DESCRIPTION
## What is this fixing or adding?
The SIX panels in The Bearer are white, so they should not be marked as being red and yellow like they currently are. This is not urgent, because the client and generator are consistent about this incorrect logic, but it would be good to get this fixed for the future since it is unintuitive.

## How was this tested?
Ran the validate config script and pytest.


## If this makes graphical changes, please attach screenshots.
