### PR TITLE
Docs - Fix broken link in Landstalker setup Guide

### DIFF
--- a/worlds/landstalker/docs/landstalker_setup_en.md
+++ b/worlds/landstalker/docs/landstalker_setup_en.md
@@ -30,8 +30,8 @@ guide: [Basic Multiworld Setup Guide](/tutorial/Archipelago/setup/en)
 
 ### Where do I get a config file?
 
-The [Player Settings Page](../player-settings) on the website allows you to easily configure your personal settings 
-and export a config file from them.
+The [Player Settings Page](/games/Landstalker%20-%20The%20Treasures%20of%20King%20Nole/player-settings) on the website allows
+you to easily configure your personal settings 
 
 ## How-to-play
 


### PR DESCRIPTION

## What is this fixing or adding?
Fixing a link to the player options page that was setup incorrectly on the landstalker guide


## How was this tested?
Verified that the new link directed you to the correct page.

(PR reopened to check that I cleaned up my commit history correctly)