### PR TITLE
Pokémon R/B: Fix move intervention

### DIFF
--- a/worlds/pokemon_rb/__init__.py
+++ b/worlds/pokemon_rb/__init__.py
@@ -353,7 +353,9 @@ class PokemonRedBlueWorld(World):
                 location.show_in_spoiler = False
 
         def intervene(move, test_state):
-            if self.multiworld.randomize_wild_pokemon[self.player]:
+            move_bit = pow(2, poke_data.hm_moves.index(move) + 2)
+            viable_mons = [mon for mon in self.local_poke_data if self.local_poke_data[mon]["tms"][6] & move_bit]
+            if self.multiworld.randomize_wild_pokemon[self.player] and viable_mons:
                 accessible_slots = [loc for loc in self.multiworld.get_reachable_locations(test_state, self.player) if
                                     loc.type == "Wild Encounter"]
 
@@ -363,8 +365,6 @@ class PokemonRedBlueWorld(World):
                         zones.add(loc.name.split(" - ")[0])
                     return len(zones)
 
-                move_bit = pow(2, poke_data.hm_moves.index(move) + 2)
-                viable_mons = [mon for mon in self.local_poke_data if self.local_poke_data[mon]["tms"][6] & move_bit]
                 placed_mons = [slot.item.name for slot in accessible_slots]
 
                 if self.multiworld.area_1_to_1_mapping[self.player]:


### PR DESCRIPTION
## What is this fixing or adding?
If no Pokémon know a move required move, fix by changing that instead of attempting to find such a Pokémon when it does not exist.
For masochists setting their HM compatibility to 0% or extremely low.

## How was this tested?
Generating the EvieRed yaml in https://discordapp.com/channels/731205301247803413/1193142272338952272