### PR TITLE
Shivers: Fixes issue with office elevator rule logic.

### DIFF
--- a/worlds/shivers/Rules.py
+++ b/worlds/shivers/Rules.py
@@ -154,11 +154,11 @@ def get_rules_lookup(player: int):
             "Final Riddle: Guillotine Dropped": lambda state: state.can_reach("Underground Lake", "Region", player)
             },
         "elevators": {
-            "Puzzle Solved Underground Elevator": lambda state: ((state.can_reach("Underground Lake", "Region", player) or state.can_reach("Office", "Region", player)
-                                                                  and state.has("Key for Office Elevator", player))),
+            "Puzzle Solved Office Elevator": lambda state: ((state.can_reach("Underground Lake", "Region", player) or state.can_reach("Office", "Region", player))
+                                                                  and state.has("Key for Office Elevator", player)),
             "Puzzle Solved Bedroom Elevator": lambda state: (state.can_reach("Office", "Region", player) and state.has_all({"Key for Bedroom Elevator","Crawling"}, player)),
-            "Puzzle Solved Three Floor Elevator": lambda state: (((state.can_reach("Maintenance Tunnels", "Region", player) or state.can_reach("Blue Maze", "Region", player))
-                                                                  and state.has("Key for Three Floor Elevator", player)))
+            "Puzzle Solved Three Floor Elevator": lambda state: ((state.can_reach("Maintenance Tunnels", "Region", player) or state.can_reach("Blue Maze", "Region", player))
+                                                                  and state.has("Key for Three Floor Elevator", player))
             },
         "lightning": {
             "Ixupi Captured Lightning": lambda state: lightning_capturable(state, player)

--- a/worlds/shivers/data/excluded_locations.json
+++ b/worlds/shivers/data/excluded_locations.json
@@ -42,7 +42,7 @@
 		"Information Plaque: Aliens (UFO)"
 	],
 	"elevators": [
-		"Puzzle Solved Underground Elevator",
+		"Puzzle Solved Office Elevator",
 		"Puzzle Solved Bedroom Elevator",
 		"Puzzle Solved Three Floor Elevator"
 	],

--- a/worlds/shivers/data/locations.json
+++ b/worlds/shivers/data/locations.json
@@ -110,7 +110,7 @@
     "Information Plaque: Astronomical Construction (UFO)",
     "Information Plaque: Guillotine (Torture)",
     "Information Plaque: Aliens (UFO)",
-    "Puzzle Solved Underground Elevator",
+    "Puzzle Solved Office Elevator",
     "Puzzle Solved Bedroom Elevator",
     "Puzzle Solved Three Floor Elevator",
     "Ixupi Captured Lightning"
@@ -129,7 +129,7 @@
       "Ixupi Captured Sand",
       "Ixupi Captured Metal",
       "Ixupi Captured Lightning",
-      "Puzzle Solved Underground Elevator",
+      "Puzzle Solved Office Elevator",
       "Puzzle Solved Three Floor Elevator",
       "Puzzle Hint Found: Combo Lock in Mailbox",
       "Puzzle Hint Found: Orange Symbol",


### PR DESCRIPTION
## What is this fixing or adding?
Office elevator logic was written as
`can reach Underground Tunnels OR can reach Office AND have Key for Office Elevator`

Meaning that key for office elevator was not required if Underground Tunnels could be reached when it should be.

Changed to
`(can reach Underground Tunnels OR can reach Office) AND have Key for Office Elevator`

## How was this tested?
Wasn't, simple issue and same as [2657](https://github.com/ArchipelagoMW/Archipelago/pull/2657)
Until this fix is out either `normal` should not be used for lobby access or elevators stay solved should not be used.
