### PR TITLE
WebHost: Fix /api/generate

### DIFF
--- a/WebHostLib/api/generate.py
+++ b/WebHostLib/api/generate.py
@@ -20,8 +20,8 @@ def generate_api():
         race = False
         meta_options_source = {}
         if 'file' in request.files:
-            file = request.files['file']
-            options = get_yaml_data(file)
+            files = request.files.getlist('file')
+            options = get_yaml_data(files)
             if isinstance(options, Markup):
                 return {"text": options.striptags()}, 400
             if isinstance(options, str):

--- a/test/webhost/test_api_generate.py
+++ b/test/webhost/test_api_generate.py
@@ -1,5 +1,7 @@
+import io
 import unittest
 import json
+import yaml
 
 
 class TestDocs(unittest.TestCase):
@@ -23,7 +25,7 @@ class TestDocs(unittest.TestCase):
         response = self.client.post("/api/generate")
         self.assertIn("No options found. Expected file attachment or json weights.", response.text)
 
-    def test_generation_queued(self):
+    def test_generation_queued_weights(self):
         options = {
             "Tester1":
                 {
@@ -36,6 +38,22 @@ class TestDocs(unittest.TestCase):
             "/api/generate",
             data=json.dumps({"weights": options}),
             content_type='application/json'
+        )
+        json_data = response.get_json()
+        self.assertTrue(json_data["text"].startswith("Generation of seed "))
+        self.assertTrue(json_data["text"].endswith(" started successfully."))
+
+    def test_generation_queued_file(self):
+        options = {
+            "game": "Archipelago",
+            "name": "Tester",
+            "Archipelago": {}
+        }
+        response = self.client.post(
+            "/api/generate",
+            data={
+                'file': (io.BytesIO(yaml.dump(options, encoding="utf-8")), "test.yaml")
+            },
         )
         json_data = response.get_json()
         self.assertTrue(json_data["text"].startswith("Generation of seed "))


### PR DESCRIPTION
## What is this fixing or adding?

Fixes POSTing files to the `/api/generate` endpoint. This was broken because I missed updating this call to `get_yaml_data` in #2138.

## How was this tested?

Added a new test to validate posting a file. It failed before, it succeeds now. Also tried running the webhost locally. It raised an uncaught exception before, it succeeds now.

I tried to also add type hints to `get_yaml_data` by making `files` a `list[FileStorage]`, but this ended up with all sorts of type errors when trying to call `zipfile` functions:
```
Argument of type "FileStorage" cannot be assigned to parameter "filename" of type "StrOrBytesPath | _SupportsReadSeekTell" in function "is_zipfile"
  Type "FileStorage" cannot be assigned to type "StrOrBytesPath | _SupportsReadSeekTell"
    "FileStorage" is incompatible with "str"
    "FileStorage" is incompatible with "bytes"
    "FileStorage" is incompatible with protocol "PathLike[str]"
      "__fspath__" is not present
    "FileStorage" is incompatible with protocol "PathLike[bytes]"
      "__fspath__" is not present
    "FileStorage" is incompatible with protocol "_SupportsReadSeekTell"
    ...
```
so I gave up trying to do so. Either we would need to write out the file to disk first which is wasteful, or werkzeug would need to update FileStorage to make it compatible with one of those protocols. So I'm leaving `get_yaml_data` as-is.
