### PR TITLE
PyCharm: ship a working unittest run config

### DIFF
--- a/.run/Archipelago Unittests.run.xml
+++ b/.run/Archipelago Unittests.run.xml
@@ -1,0 +1,18 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Archipelago Unittests" type="tests" factoryName="Unittests">
+    <module name="Archipelago" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <option name="SDK_HOME" value="" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="IS_MODULE_SDK" value="true" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
+    <option name="_new_pattern" value="&quot;&quot;" />
+    <option name="_new_additionalArguments" value="&quot;&quot;" />
+    <option name="_new_target" value="&quot;$PROJECT_DIR$/test&quot;" />
+    <option name="_new_targetType" value="&quot;PATH&quot;" />
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
## What is this fixing or adding?
Includes a run config for unittests that PyCharm should pick up on automatically.

## How was this tested?
Only locally, which isn't that useful, as it doesn't test if another PyCharm finds this config and can run it.

## If this makes graphical changes, please attach screenshots.
