### PR TITLE
Shivers: Fix rule logic for location 'Final Riddle: Guillotine Dropped'

### DIFF
--- a/worlds/shivers/Rules.py
+++ b/worlds/shivers/Rules.py
@@ -151,7 +151,7 @@ def get_rules_lookup(player: int):
             "Puzzle Solved Maze Door": lambda state: state.can_reach("Projector Room", "Region", player),
             "Puzzle Solved Theater Door": lambda state: state.can_reach("Underground Lake", "Region", player),
             "Puzzle Solved Columns of RA": lambda state: state.can_reach("Underground Lake", "Region", player),
-            "Final Riddle: Guillotine Dropped": lambda state: state.can_reach("Underground Lake", "Region", player)
+            "Final Riddle: Guillotine Dropped": lambda state: (beths_body_available(state, player) and state.can_reach("Underground Lake", "Region", player))
             },
         "elevators": {
             "Puzzle Solved Underground Elevator": lambda state: ((state.can_reach("Underground Lake", "Region", player) or state.can_reach("Office", "Region", player)


### PR DESCRIPTION
## What is this fixing or adding?
Fixing logic rule for location 'Final Riddle: Guillotine Dropped'

## How was this tested?
-Broken seed found. Spoiler logic checked
-Incorrect logic found with location 'Final Riddle: Guillotine Dropped'
-Several seeds generated including the broken seed
-Spoiler log checked to ensure steps to check that check were now correct.

## If this makes graphical changes, please attach screenshots.
N/A