### PR TITLE
Core: Log the worlds still using the old options API

### DIFF
--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -79,8 +79,8 @@ class AutoWorldRegister(type):
         if "options_dataclass" not in dct and "option_definitions" in dct:
             # TODO - switch to deprecate after a version
             if __debug__:
-                from warnings import warn
-                warn("Assigning options through option_definitions is now deprecated. Use options_dataclass instead.")
+                logging.warning(f"{name} Assigned options through option_definitions which is now deprecated. "
+                                "Please use options_dataclass instead.")
             dct["options_dataclass"] = make_dataclass(f"{name}Options", dct["option_definitions"].items(),
                                                       bases=(PerGameCommonOptions,))
 


### PR DESCRIPTION
## What is this fixing or adding?
people were complaining about the message showing up and not specifying which world/s were actually the issue, which I initially left out to not shame people so by popular request ig 🤷 

## How was this tested?
ran a quick gen to make sure all the worlds that haven't updated yet were logged.

## If this makes graphical changes, please attach screenshots.
