### PR TITLE
Lingo: Turn The Colorful into a countdown achievement

### DIFF
--- a/worlds/lingo/data/LL1.yaml
+++ b/worlds/lingo/data/LL1.yaml
@@ -2635,12 +2635,6 @@
         panels:
           - OBSTACLE
   The Colorful:
-    # The set of required_doors in the achievement panel should prevent
-    # generation from asking you to solve The Colorful before opening all of the
-    # doors. Access from the roof is included so that the painting here could be
-    # an entrance. The client will have to be hardcoded to not open the door to
-    # the achievement until all of the doors are open, whether by solving the
-    # panels or through receiving items.
     entrances:
       The Colorful (Gray):
         room: The Colorful (Gray)
@@ -2651,27 +2645,27 @@
         id: Countdown Panels/Panel_colorful_colorful
         check: True
         tag: forbid
-        required_door:
+        required_panel:
           - room: The Colorful (White)
-            door: Progress Door
+            panel: BEGIN
           - room: The Colorful (Black)
-            door: Progress Door
+            panel: FOUND
           - room: The Colorful (Red)
-            door: Progress Door
+            panel: LOAF
           - room: The Colorful (Yellow)
-            door: Progress Door
+            panel: CREAM
           - room: The Colorful (Blue)
-            door: Progress Door
+            panel: SUN
           - room: The Colorful (Purple)
-            door: Progress Door
+            panel: SPOON
           - room: The Colorful (Orange)
-            door: Progress Door
+            panel: LETTERS
           - room: The Colorful (Green)
-            door: Progress Door
+            panel: WALLS
           - room: The Colorful (Brown)
-            door: Progress Door
+            panel: IRON
           - room: The Colorful (Gray)
-            door: Progress Door
+            panel: OBSTACLE
         achievement: The Colorful
     paintings:
       - id: arrows_painting_12


### PR DESCRIPTION
## What is this fixing or adding?
The Colorful currently, in logic, does not expect you to solve the achievement panel until all of the doors are opened. This is not enforced by the client in complex door shuffle (in which the panel is revealed once the grey door is open). It is also not typical of how achievements in Lingo usually work, and it ended up this way because of the fact that THE COLORFUL is, uniquely, not a countdown panel.

This change modifies logic so that solving each panel within The Colorful is required in order to access the achievement, rather than opening all of the doors. This will be accompanied by a change to the client that will turn THE COLORFUL into a countdown panel. (https://code.fourisland.com/lingo-archipelago/commit/?h=future&id=78789475f9cbbfc4015219fbf218e24599809c91)

## How was this tested?
Test generations.

## If this makes graphical changes, please attach screenshots.
