### PR TITLE
Lingo: Make The Colorful optionally progressive

### DIFF
--- a/worlds/lingo/data/LL1.yaml
+++ b/worlds/lingo/data/LL1.yaml
@@ -2676,6 +2676,28 @@
     paintings:
       - id: arrows_painting_12
         orientation: north
+    progression:
+      Progressive Colorful:
+        - room: The Colorful (White)
+          door: Progress Door
+        - room: The Colorful (Black)
+          door: Progress Door
+        - room: The Colorful (Red)
+          door: Progress Door
+        - room: The Colorful (Yellow)
+          door: Progress Door
+        - room: The Colorful (Blue)
+          door: Progress Door
+        - room: The Colorful (Purple)
+          door: Progress Door
+        - room: The Colorful (Orange)
+          door: Progress Door
+        - room: The Colorful (Green)
+          door: Progress Door
+        - room: The Colorful (Brown)
+          door: Progress Door
+        - room: The Colorful (Gray)
+          door: Progress Door
   Welcome Back Area:
     entrances:
       Starting Room:

--- a/worlds/lingo/data/ids.yaml
+++ b/worlds/lingo/data/ids.yaml
@@ -1452,3 +1452,4 @@ progression:
   Progressive Fearless: 444470
   Progressive Orange Tower: 444482
   Progressive Art Gallery: 444563
+  Progressive Colorful: 444580

--- a/worlds/lingo/items.py
+++ b/worlds/lingo/items.py
@@ -28,6 +28,10 @@ class ItemData(NamedTuple):
             # door shuffle is on and tower isn't progressive
             return world.options.shuffle_doors != ShuffleDoors.option_none \
                 and not world.options.progressive_orange_tower
+        elif self.mode == "the colorful":
+            # complex door shuffle is on and colorful isn't progressive
+            return world.options.shuffle_doors == ShuffleDoors.option_complex \
+                and not world.options.progressive_colorful
         elif self.mode == "complex door":
             return world.options.shuffle_doors == ShuffleDoors.option_complex
         elif self.mode == "door group":
@@ -70,6 +74,8 @@ def load_item_data():
             if room_name in PROGRESSION_BY_ROOM and door_name in PROGRESSION_BY_ROOM[room_name]:
                 if room_name == "Orange Tower":
                     door_mode = "orange tower"
+                elif room_name == "The Colorful":
+                    door_mode = "the colorful"
                 else:
                     door_mode = "special"
 

--- a/worlds/lingo/options.py
+++ b/worlds/lingo/options.py
@@ -21,6 +21,13 @@ class ProgressiveOrangeTower(DefaultOnToggle):
     display_name = "Progressive Orange Tower"
 
 
+class ProgressiveColorful(DefaultOnToggle):
+    """When "Shuffle Doors" is on "complex", this setting governs the manner in which The Colorful opens up.
+    If off, there is an item for each room of The Colorful, meaning that random rooms in the middle of the sequence can open up without giving you access to them.
+    If on, there are ten progressive items, which open up the sequence from White forward."""
+    display_name = "Progressive Colorful"
+
+
 class LocationChecks(Choice):
     """On "normal", there will be a location check for each panel set that would ordinarily open a door, as well as for
     achievement panels and a small handful of other panels.
@@ -117,6 +124,7 @@ class DeathLink(Toggle):
 class LingoOptions(PerGameCommonOptions):
     shuffle_doors: ShuffleDoors
     progressive_orange_tower: ProgressiveOrangeTower
+    progressive_colorful: ProgressiveColorful
     location_checks: LocationChecks
     shuffle_colors: ShuffleColors
     shuffle_panels: ShufflePanels

--- a/worlds/lingo/player_logic.py
+++ b/worlds/lingo/player_logic.py
@@ -83,7 +83,8 @@ class LingoPlayerLogic:
 
     def handle_non_grouped_door(self, room_name: str, door_data: Door, world: "LingoWorld"):
         if room_name in PROGRESSION_BY_ROOM and door_data.name in PROGRESSION_BY_ROOM[room_name]:
-            if room_name == "Orange Tower" and not world.options.progressive_orange_tower:
+            if (room_name == "Orange Tower" and not world.options.progressive_orange_tower)\
+                    or (room_name == "The Colorful" and not world.options.progressive_colorful):
                 self.set_door_item(room_name, door_data.name, door_data.item_name)
             else:
                 progressive_item_name = PROGRESSION_BY_ROOM[room_name][door_data.name].item_name


### PR DESCRIPTION
## What is this fixing or adding?
The Colorful is a linear set of 10 rooms with doors between them. It can be entered from the front or the back, but not in the middle. On complex door shuffle, each door is opened by a separate item, which often leads to receiving a lot of doors in the middle of The Colorful that cannot be accessed until later.

This change adds an option to convert The Colorful into a progressive item, similar to the option that does this for the Orange Tower. This removes the individual door items and adds ten Progressive Colorful items, which open the doors one-by-one from the front.


## How was this tested?
Test generations, and playing in the future branch client.

## If this makes graphical changes, please attach screenshots.
