### PR TITLE
TUNIC: Update game page for blurb about playing vanilla first

### DIFF
--- a/worlds/tunic/docs/en_Tunic.md
+++ b/worlds/tunic/docs/en_Tunic.md
@@ -4,6 +4,11 @@
 
 The [player options page for this game](../player-options) contains all the options you need to configure and export a config file.
 
+## I haven't played TUNIC before.
+
+**Play vanilla first.** It is **_heavily discouraged_** to play this randomizer before playing the vanilla game, moreso than most other games in Archipelago.
+It is recommended that you achieve both endings in the vanilla game before playing the randomizer.
+
 ## What does randomization do to this game?
 
 In the TUNIC Randomizer, every item in the game is randomized. All chests, key item pickups, instruction manual pages, hero relics,
@@ -33,11 +38,6 @@ chest with the original chest texture for that item.
 
 Items belonging to non-TUNIC players will either appear as a question-mark block (if in a freestanding location) or in a chest with
 a question mark symbol on it. Additionally, non-TUNIC items are color-coded by classification, with green for filler, blue for useful, and gold for progression.
-
-## I haven't played TUNIC before.
-
-**Play vanilla first.** It is **_heavily discouraged_** to play this randomizer before playing the vanilla game, moreso than most other games in Archipelago.
-It is recommended that you achieve both endings in the vanilla game before playing the randomizer.
 
 ## Is there a tracker pack?
 There is a [tracker pack](https://github.com/SapphireSapphic/TunicTracker/releases/latest). It is compatible with both Poptracker and Emotracker. Using Poptracker, it will automatically track checked locations and important items received. It can also automatically tab between maps as you traverse the world. This tracker was originally created by SapphireSapphic and ScoutJD, and has been extensively updated by Br00ty.

--- a/worlds/tunic/docs/en_Tunic.md
+++ b/worlds/tunic/docs/en_Tunic.md
@@ -6,7 +6,7 @@ The [player options page for this game](../player-options) contains all the opti
 
 ## I haven't played TUNIC before.
 
-**Play vanilla first.** It is **_heavily discouraged_** to play this randomizer before playing the vanilla game, moreso than most other games in Archipelago.
+**Play vanilla first.** It is **_heavily discouraged_** to play this randomizer before playing the vanilla game.
 It is recommended that you achieve both endings in the vanilla game before playing the randomizer.
 
 ## What does randomization do to this game?

--- a/worlds/tunic/docs/en_Tunic.md
+++ b/worlds/tunic/docs/en_Tunic.md
@@ -1,8 +1,8 @@
 # TUNIC
 
-## Where is the settings page?
+## Where is the options page?
 
-The [player settings page for this game](../player-settings) contains all the options you need to configure and export a config file.
+The [player options page for this game](../player-options) contains all the options you need to configure and export a config file.
 
 ## What does randomization do to this game?
 
@@ -33,6 +33,11 @@ chest with the original chest texture for that item.
 
 Items belonging to non-TUNIC players will either appear as a question-mark block (if in a freestanding location) or in a chest with
 a question mark symbol on it. Additionally, non-TUNIC items are color-coded by classification, with green for filler, blue for useful, and gold for progression.
+
+## I haven't played TUNIC before.
+
+**It is heavily discouraged to play this randomizer before playing the vanilla game, moreso than most other games in Archipelago.**
+**It is recommended that you achieve both endings in the vanilla game before playing the randomizer.**
 
 ## Is there a tracker pack?
 There is a [tracker pack](https://github.com/SapphireSapphic/TunicTracker/releases/latest). It is compatible with both Poptracker and Emotracker. Using Poptracker, it will automatically track checked locations and important items received. It can also automatically tab between maps as you traverse the world. This tracker was originally created by SapphireSapphic and ScoutJD, and has been extensively updated by Br00ty.

--- a/worlds/tunic/docs/en_Tunic.md
+++ b/worlds/tunic/docs/en_Tunic.md
@@ -14,7 +14,7 @@ It is recommended that you achieve both endings in the vanilla game before playi
 In the TUNIC Randomizer, every item in the game is randomized. All chests, key item pickups, instruction manual pages, hero relics,
 and other unique items are shuffled.<br>
 
-Ability shuffling is an option available from the settings page to shuffle certain abilities (prayer, holy cross, and the ice rod combo),
+Ability shuffling is an option available from the options page to shuffle certain abilities (prayer, holy cross, and the ice rod combo),
 preventing them from being used until they are unlocked.<br>
 
 Enemy randomization and other options are also available and can be turned on in the client mod.

--- a/worlds/tunic/docs/en_Tunic.md
+++ b/worlds/tunic/docs/en_Tunic.md
@@ -36,8 +36,8 @@ a question mark symbol on it. Additionally, non-TUNIC items are color-coded by c
 
 ## I haven't played TUNIC before.
 
-**It is heavily discouraged to play this randomizer before playing the vanilla game, moreso than most other games in Archipelago.**
-**It is recommended that you achieve both endings in the vanilla game before playing the randomizer.**
+**Play vanilla first.** It is **_heavily discouraged_** to play this randomizer before playing the vanilla game, moreso than most other games in Archipelago.
+It is recommended that you achieve both endings in the vanilla game before playing the randomizer.
 
 ## Is there a tracker pack?
 There is a [tracker pack](https://github.com/SapphireSapphic/TunicTracker/releases/latest). It is compatible with both Poptracker and Emotracker. Using Poptracker, it will automatically track checked locations and important items received. It can also automatically tab between maps as you traverse the world. This tracker was originally created by SapphireSapphic and ScoutJD, and has been extensively updated by Br00ty.

--- a/worlds/tunic/docs/setup_en.md
+++ b/worlds/tunic/docs/setup_en.md
@@ -48,19 +48,17 @@ The filepath to the mod should look like `BepInEx/plugins/Tunic Archipelago/Tuni
 
 Launch the game, and if everything was installed correctly you should see `Randomizer + Archipelago Mod Ver. x.y.z` in the top left corner of the title screen!
 
-## Configure Archipelago Settings
+## Configure Archipelago Options
 
 ### Configure Your YAML File
 
-Visit the [TUNIC settings page](/games/Tunic/player-settings) to generate a YAML with your selected settings.
+Visit the [TUNIC options page](/games/Tunic/player-options) to generate a YAML with your selected options.
 
 ### Configure Your Mod Settings
-Launch the game and click the button labeled `Open Settings File` on the Title Screen. 
-This will open the settings file in your default text editor, allowing you to edit your connection info.
-At the top of the file, fill in *Player*, *Hostname*, *Port*, and *Password* (if required) with the correct information for your room. 
-The rest of the settings that appear in this file can be changed in the `Randomizer Settings` submenu of the in-game options menu.
+Launch the game and click the button labeled `Open AP Config` on the Title Screen.
+In the menu that opens, fill in *Player*, *Hostname*, *Port*, and *Password* (if required) with the correct information for your room.
 
-Once your player settings have been saved, press `Connect`. If everything was configured properly, you should see `Status: Connected!` and your chosen game options will be shown under `World Settings`.
+Once you've input your information, click on Close. If everything was configured properly, you should see `Status: Connected!` and your chosen game options will be shown under `World Settings`.
 
 An error message will display if the game fails to connect to the server.
 


### PR DESCRIPTION
## What is this fixing or adding?
Add a section to the game page discouraging the player from playing the rando before playing vanilla, as that is a terrible idea.
Also changing settings -> options

## How was this tested?
Reading

## If this makes graphical changes, please attach screenshots.
N/A