### PR TITLE
Setup: don't install webhost dependencies

### DIFF
--- a/ModuleUpdate.py
+++ b/ModuleUpdate.py
@@ -4,14 +4,29 @@ import subprocess
 import multiprocessing
 import warnings
 
-local_dir = os.path.dirname(__file__)
-requirements_files = {os.path.join(local_dir, 'requirements.txt')}
 
 if sys.version_info < (3, 8, 6):
     raise RuntimeError("Incompatible Python Version. 3.8.7+ is supported.")
 
 # don't run update if environment is frozen/compiled or if not the parent process (skip in subprocess)
-update_ran = getattr(sys, "frozen", False) or multiprocessing.parent_process()
+_skip_update = bool(getattr(sys, "frozen", False) or multiprocessing.parent_process())
+update_ran = _skip_update
+
+
+class RequirementsSet(set):
+    def add(self, e):
+        global update_ran
+        update_ran &= _skip_update
+        super().add(e)
+
+    def update(self, *s):
+        global update_ran
+        update_ran &= _skip_update
+        super().update(*s)
+
+
+local_dir = os.path.dirname(__file__)
+requirements_files = RequirementsSet((os.path.join(local_dir, 'requirements.txt'),))
 
 if not update_ran:
     for entry in os.scandir(os.path.join(local_dir, "worlds")):

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ if __name__ == "__main__":
     # TODO: move stuff to not require this
     import ModuleUpdate
     ModuleUpdate.update(yes="--yes" in sys.argv or "-y" in sys.argv)
-    ModuleUpdate.update_ran = False  # restore for later
 
 from worlds.LauncherComponents import components, icon_paths
 from Utils import version_tuple, is_windows, is_linux
@@ -304,7 +303,6 @@ class BuildExeCommand(cx_Freeze.command.build_exe.BuildEXE):
         print(f"Outputting to: {self.buildfolder}")
         os.makedirs(self.buildfolder, exist_ok=True)
         import ModuleUpdate
-        ModuleUpdate.requirements_files.add(os.path.join("WebHostLib", "requirements.txt"))
         ModuleUpdate.update(yes=self.yes)
 
         # auto-build cython modules


### PR DESCRIPTION
## What is this fixing or adding?
It looks like WebHostLib is not required anymore for setup.py, so we can remove the requirements.
Also adds some code to avoid the `update_ran = False` hack we currently have in setup.py

## How was this tested?
CI