### PR TITLE
Tests: test that World.options is not set on the class

### DIFF
--- a/test/general/test_options.py
+++ b/test/general/test_options.py
@@ -10,3 +10,9 @@ class TestOptions(unittest.TestCase):
                 for option_key, option in world_type.options_dataclass.type_hints.items():
                     with self.subTest(game=gamename, option=option_key):
                         self.assertTrue(option.__doc__)
+
+    def test_options_are_not_set_by_world(self):
+        """Test that options attribute is not already set"""
+        for gamename, world_type in AutoWorldRegister.world_types.items():
+            with self.subTest(game=gamename):
+                self.assertFalse(hasattr(world_type, "options"))

--- a/test/general/test_options.py
+++ b/test/general/test_options.py
@@ -15,4 +15,5 @@ class TestOptions(unittest.TestCase):
         """Test that options attribute is not already set"""
         for gamename, world_type in AutoWorldRegister.world_types.items():
             with self.subTest(game=gamename):
-                self.assertFalse(hasattr(world_type, "options"))
+                self.assertFalse(hasattr(world_type, "options"),
+                                 f"Unexpected assignment to {world_type.__name__}.options!")


### PR DESCRIPTION
## What is this fixing or adding?
In https://github.com/ArchipelagoMW/Archipelago/pull/2714 snuck in a options = instead of options :, which is an easy mistake to make and one I overlooked. So let's test for it.

## How was this tested?
It's a test.
