### PR TITLE
FFMQ: Reset protection

### DIFF
--- a/worlds/ffmq/Client.py
+++ b/worlds/ffmq/Client.py
@@ -71,7 +71,7 @@ class FFMQClient(SNIClient):
         received = await snes_read(ctx, RECEIVED_DATA[0], RECEIVED_DATA[1])
         data = await snes_read(ctx, READ_DATA_START, READ_DATA_END - READ_DATA_START)
         check_2 = await snes_read(ctx, 0xF53749, 1)
-        if check_1 == b'\x00' or check_2 == b'\x00':
+        if check_1 in (b'\x00', b'\x55') or check_2 in (b'\x00', b'\x55'):
             return
 
         def get_range(data_range):


### PR DESCRIPTION
## What is this fixing or adding?
Bizhawk's "hard reset" option fills RAM with 0x55s. This causes game completion to be erroneously flagged, and likely many erroneous location checks with it. This fix checks for 0x55 and will not proceed to process anything if present.

## How was this tested?
Resetting.