### PR TITLE
Tests: create sane cov defaults

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[report]
+exclude_lines = 
+    pragma: no cover
+    if TYPE_CHECKING:
+    if typing.TYPE_CHECKING:


### PR DESCRIPTION
## What is this fixing or adding?

Makes pytest-cov not report `if TYPE_CHECKING:` blocks as untested (they are not covered by unit tests and will instead be tested with mypy).

## How was this tested?

```bash
pip install pytest pytest-xdist pytest-cov
pytest -nauto --cov-report term-missing --cov=worlds/soe
``` 