### PR TITLE
Lingo: Disable forced good item when early color hallways is on

### DIFF
--- a/worlds/lingo/player_logic.py
+++ b/worlds/lingo/player_logic.py
@@ -223,7 +223,7 @@ class LingoPlayerLogic:
                                 "kind of logic error.")
 
         if door_shuffle != ShuffleDoors.option_none and location_classification != LocationClassification.insanity \
-                and not early_color_hallways is False:
+                and not early_color_hallways:
             # If shuffle doors is on, force a useful item onto the HI panel. This may not necessarily get you out of BK,
             # but the goal is to allow you to reach at least one more check. The non-painting ones are hardcoded right
             # now. We only allow the entrance to the Pilgrim Room if color shuffle is off, because otherwise there are


### PR DESCRIPTION
## What is this fixing or adding?
This was supposed to be the case before, but a programming error caused the conditional clause to always be true.

## How was this tested?
Test run.

## If this makes graphical changes, please attach screenshots.
