### PR TITLE
CI: flake8: max-complexity=14

### DIFF
--- a/.github/workflows/analyze-modified-files.yml
+++ b/.github/workflows/analyze-modified-files.yml
@@ -71,7 +71,7 @@ jobs:
         continue-on-error: true
         if: env.diff != '' && matrix.task == 'flake8'
         run: |
-          flake8 --count --max-complexity=10 --max-doc-length=120 --max-line-length=120 --statistics ${{ env.diff }}
+          flake8 --count --max-complexity=14 --max-doc-length=120 --max-line-length=120 --statistics ${{ env.diff }}
 
       - name: "mypy: Type check modified files"
         continue-on-error: true


### PR DESCRIPTION
## What is this fixing or adding?

Changes the complexity limit of our flake8 CI action to 14.

The value of 10 does not really fit some of our world patterns and values up to 15 may be acceptable. Looking at some worlds, 14 seems to be achievable without too much work and reduces the noise in test output, making it more usable.

We should consider reworking some of core to fit this new limit and recommend it to world authors. It could make code easier to test and review. Maybe one day we get to enforce it for core and require explicit `# noqa: C901` for functions where it makes sense to go beyond this.

## How was this tested?

Looking at flake8 output.
