### PR TITLE
Lingo: NORTH requires hint panels

### DIFF
--- a/worlds/lingo/data/LL1.yaml
+++ b/worlds/lingo/data/LL1.yaml
@@ -1118,7 +1118,13 @@
         id: Cross Room/Panel_north_missing
         colors: green
         tag: forbid
-        required_room: Outside The Bold
+        required_panel:
+          - room: Outside The Bold
+            panel: MOUTH
+          - room: Outside The Bold
+            panel: YEAST
+          - room: Outside The Bold
+            panel: WET
       DIAMONDS:
         id: Cross Room/Panel_diamonds_missing
         colors: green
@@ -4414,9 +4420,14 @@
         colors: blue
         tag: forbid
         required_panel:
-          room: The Bearer (West)
-          panel: SMILE
-        required_room: Outside The Bold
+          - room: The Bearer (West)
+            panel: SMILE
+          - room: Outside The Bold
+            panel: MOUTH
+          - room: Outside The Bold
+            panel: YEAST
+          - room: Outside The Bold
+            panel: WET
   Cross Tower (South):
     entrances: # No roof access
       The Bearer (North):


### PR DESCRIPTION
## What is this fixing or adding?
Cross Tower (North) - NORTH and Outside The Agreeable - NORTH shouldn't be logically solvable if the player cannot access and solve the three hint panels in Outside The Bold. Previously, both NORTH panels were marked as just requiring access to Outside The Bold, but this is insufficient as the three hint panels have colours and thus may not be solvable even if the player has access to that room. Thus, both NORTHs have been changed to require the individual hint panels rather than the room.

This issue does not apply to the other set-of-four puzzles because the hints for them are all white panels.

## How was this tested?
Ran validate_config.rb and pytest.

## If this makes graphical changes, please attach screenshots.
