### PR TITLE
Lingo: Detach Art Gallery Exit from Progressive Art Gallery

### DIFF
--- a/worlds/lingo/data/LL1.yaml
+++ b/worlds/lingo/data/LL1.yaml
@@ -6193,6 +6193,7 @@
       Exit:
         id: Tower Room Area Doors/Door_painting_exit
         include_reduce: True
+        item_name: Orange Tower Fifth Floor - Quadruple Intersection
         panels:
           - ONE ROAD MANY TURNS
     paintings:
@@ -6212,7 +6213,6 @@
         - Third Floor
         - Fourth Floor
         - Fifth Floor
-        - Exit
   Art Gallery (Second Floor):
     entrances:
       Art Gallery:

--- a/worlds/lingo/test/TestProgressive.py
+++ b/worlds/lingo/test/TestProgressive.py
@@ -142,7 +142,7 @@ class TestProgressiveArtGallery(LingoTestBase):
         self.assertTrue(self.can_reach_location("Art Gallery - ONE ROAD MANY TURNS"))
         self.assertFalse(self.multiworld.state.can_reach("Orange Tower Fifth Floor", "Region", self.player))
 
-        self.collect(progressive_gallery_room[4])
+        self.collect_by_name("Orange Tower Fifth Floor - Quadruple Intersection")
         self.assertTrue(self.multiworld.state.can_reach("Art Gallery", "Region", self.player))
         self.assertTrue(self.multiworld.state.can_reach("Art Gallery (Second Floor)", "Region", self.player))
         self.assertTrue(self.multiworld.state.can_reach("Art Gallery (Third Floor)", "Region", self.player))


### PR DESCRIPTION
## What is this fixing or adding?
The final stage of Progressive Art Gallery opens up the four-way intersection between the Art Gallery, Orange Tower Fifth Floor, The Bearer, and Outside The Initiated. This is a very useful door, and it would be cool to be able to open it without having to get five progressive items. The original reason this was included in the progression was because getting into the back of Art Gallery early would cause sequence breaks. At this point, the way the client handles the Art Gallery has changed enough that it does not matter if the player can go through this door before getting all progressive art galleries.

## How was this tested?
pytest, validate_config.py, and a test run.

## If this makes graphical changes, please attach screenshots.
