### PR TITLE
Pokémon R/B: Fix missing comma in Thunder Stone item groups

### DIFF
--- a/worlds/pokemon_rb/items.py
+++ b/worlds/pokemon_rb/items.py
@@ -42,7 +42,7 @@ item_table = {
     "Repel": ItemData(30, ItemClassification.filler, ["Consumables"]),
     "Old Amber": ItemData(31, ItemClassification.progression_skip_balancing, ["Unique", "Fossils", "Key Items"]),
     "Fire Stone": ItemData(32, ItemClassification.progression_skip_balancing, ["Unique", "Evolution Stones", "Key Items"]),
-    "Thunder Stone": ItemData(33, ItemClassification.progression_skip_balancing, ["Unique", "Evolution Stones" "Key Items"]),
+    "Thunder Stone": ItemData(33, ItemClassification.progression_skip_balancing, ["Unique", "Evolution Stones", "Key Items"]),
     "Water Stone": ItemData(34, ItemClassification.progression_skip_balancing, ["Unique", "Evolution Stones", "Key Items"]),
     "HP Up": ItemData(35, ItemClassification.filler, ["Consumables", "Vitamins"]),
     "Protein": ItemData(36, ItemClassification.filler, ["Consumables", "Vitamins"]),


### PR DESCRIPTION
## What is this fixing or adding?
Adds a missing comma in Thunder Stone's item groups list

## How was this tested?
Not