### PR TITLE
Doc: add GM libs to network protocol.md

### DIFF
--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -27,6 +27,8 @@ There are also a number of community-supported libraries available that implemen
 | Haxe                          | [hxArchipelago](https://lib.haxe.org/p/hxArchipelago)                                              |                                                                                 |
 | Rust                          | [ArchipelagoRS](https://github.com/ryanisaacg/archipelago_rs)                                      |                                                                                 |
 | Lua                           | [lua-apclientpp](https://github.com/black-sliver/lua-apclientpp)                                   |                                                                                 |
+| Game Maker + Studio 1.x       | [gm-apclientpp](https://github.com/black-sliver/gm-apclientpp)                                     | For GM7, GM8 and GMS1.x, maybe older                                            |
+| GameMaker: Studio 2.x+        | [see Discord](https://discord.com/channels/731205301247803413/1166418532519653396)                 |                                                                                 |
 
 ## Synchronizing Items
 When the client receives a [ReceivedItems](#ReceivedItems) packet, if the `index` argument does not match the next index that the client expects then it is expected that the client will re-sync items with the server. This can be accomplished by sending the server a [Sync](#Sync) packet and then a [LocationChecks](#LocationChecks) packet.


### PR DESCRIPTION
## What is this fixing or adding?

We have a GM native ("C") lib (WIP) for older GM/GMS and an example GMS project for newer GMS (2.2.x) now. Add this to docs so people can maybe find it.

## How was this tested?

Reading.