### PR TITLE
Lingo: Split up Color Hunt and Champion's Rest

### DIFF
--- a/worlds/lingo/data/LL1.yaml
+++ b/worlds/lingo/data/LL1.yaml
@@ -1166,7 +1166,7 @@
         group: Color Hunt Barriers
         skip_location: True
         panels:
-          - room: Champion's Rest
+          - room: Color Hunt
             panel: PURPLE
       Hallway Door:
         id: Red Blue Purple Room Area Doors/Door_room_2
@@ -1957,7 +1957,7 @@
         group: Color Hunt Barriers
         skip_location: True
         panels:
-          - room: Champion's Rest
+          - room: Color Hunt
             panel: RED
       Rhyme Room Entrance:
         id: Double Room Area Doors/Door_room_entry_stairs2
@@ -1975,9 +1975,9 @@
           - Color Arrow Room Doors/Door_orange_hider_1
           - Color Arrow Room Doors/Door_orange_hider_2
           - Color Arrow Room Doors/Door_orange_hider_3
-        location_name: Color Hunt - RED and YELLOW
-        group: Champion's Rest - Color Barriers
-        item_name: Champion's Rest - Orange Barrier
+        location_name: Color Barriers - RED and YELLOW
+        group: Color Hunt Barriers
+        item_name: Color Hunt - Orange Barrier
         panels:
           - RED
           - room: Directional Gallery
@@ -2382,7 +2382,7 @@
         group: Color Hunt Barriers
         skip_location: True
         panels:
-          - room: Champion's Rest
+          - room: Color Hunt
             panel: GREEN
     paintings:
       - id: flower_painting_7
@@ -2893,14 +2893,14 @@
         group: Color Hunt Barriers
         skip_location: True
         panels:
-          - room: Champion's Rest
+          - room: Color Hunt
             panel: BLUE
       Orange Barrier:
         id: Color Arrow Room Doors/Door_orange_3
         group: Color Hunt Barriers
         skip_location: True
         panels:
-          - room: Champion's Rest
+          - room: Color Hunt
             panel: ORANGE
       Initiated Entrance:
         id: Red Blue Purple Room Area Doors/Door_locked_knocked
@@ -2912,9 +2912,9 @@
       # containing region.
       Green Barrier:
         id: Color Arrow Room Doors/Door_green_hider_1
-        location_name: Color Hunt - BLUE and YELLOW
-        item_name: Champion's Rest - Green Barrier
-        group: Champion's Rest - Color Barriers
+        location_name: Color Barriers - BLUE and YELLOW
+        item_name: Color Hunt - Green Barrier
+        group: Color Hunt Barriers
         panels:
           - BLUE
           - room: Directional Gallery
@@ -2924,9 +2924,9 @@
           - Color Arrow Room Doors/Door_purple_hider_1
           - Color Arrow Room Doors/Door_purple_hider_2
           - Color Arrow Room Doors/Door_purple_hider_3
-        location_name: Color Hunt - RED and BLUE
-        item_name: Champion's Rest - Purple Barrier
-        group: Champion's Rest - Color Barriers
+        location_name: Color Barriers - RED and BLUE
+        item_name: Color Hunt - Purple Barrier
+        group: Color Hunt Barriers
         panels:
           - BLUE
           - room: Orange Tower Third Floor
@@ -2936,7 +2936,7 @@
           - Color Arrow Room Doors/Door_all_hider_1
           - Color Arrow Room Doors/Door_all_hider_2
           - Color Arrow Room Doors/Door_all_hider_3
-        location_name: Color Hunt - GREEN, ORANGE and PURPLE
+        location_name: Color Barriers - GREEN, ORANGE and PURPLE
         item_name: Champion's Rest - Entrance
         panels:
           - ORANGE
@@ -3176,8 +3176,8 @@
   Outside The Bold:
     entrances:
       Color Hallways: True
-      Champion's Rest:
-        room: Champion's Rest
+      Color Hunt:
+        room: Color Hunt
         door: Shortcut to The Steady
       The Bearer:
         room: The Bearer
@@ -4002,7 +4002,7 @@
         group: Color Hunt Barriers
         skip_location: True
         panels:
-          - room: Champion's Rest
+          - room: Color Hunt
             panel: YELLOW
     paintings:
       - id: smile_painting_7
@@ -4020,12 +4020,15 @@
         orientation: south
       - id: cherry_painting
         orientation: east
-  Champion's Rest:
+  Color Hunt:
     entrances:
       Outside The Bold:
         door: Shortcut to The Steady
       Orange Tower Fourth Floor: True # sunwarp
       Roof: True # through ceiling of sunwarp
+      Champion's Rest:
+        room: Outside The Initiated
+        door: Entrance
     panels:
       EXIT:
         id: Rock Room/Panel_red_red
@@ -4066,41 +4069,6 @@
         required_door:
           room: Orange Tower Third Floor
           door: Orange Barrier
-      YOU:
-        id: Color Arrow Room/Panel_you
-        required_door:
-          room: Outside The Initiated
-          door: Entrance
-        check: True
-        colors: gray
-        tag: forbid
-      ME:
-        id: Color Arrow Room/Panel_me
-        colors: gray
-        tag: forbid
-        required_door:
-          room: Outside The Initiated
-          door: Entrance
-      SECRET BLUE:
-        # Pretend this and the other two are white, because they are snipes.
-        # TODO: Extract them and randomize them?
-        id: Color Arrow Room/Panel_secret_blue
-        tag: forbid
-        required_door:
-          room: Outside The Initiated
-          door: Entrance
-      SECRET YELLOW:
-        id: Color Arrow Room/Panel_secret_yellow
-        tag: forbid
-        required_door:
-          room: Outside The Initiated
-          door: Entrance
-      SECRET RED:
-        id: Color Arrow Room/Panel_secret_red
-        tag: forbid
-        required_door:
-          room: Outside The Initiated
-          door: Entrance
     doors:
       Shortcut to The Steady:
         id: Rock Room Doors/Door_hint
@@ -4115,12 +4083,35 @@
         required_door:
           room: Outside The Initiated
           door: Entrance
+  Champion's Rest:
+    entrances:
+      Color Hunt:
+        room: Outside The Initiated
+        door: Entrance
+    panels:
+      YOU:
+        id: Color Arrow Room/Panel_you
+        check: True
+        colors: gray
+        tag: forbid
+      ME:
+        id: Color Arrow Room/Panel_me
+        colors: gray
+        tag: forbid
+      SECRET BLUE:
+        # Pretend this and the other two are white, because they are snipes.
+        # TODO: Extract them and randomize them?
+        id: Color Arrow Room/Panel_secret_blue
+        tag: forbid
+      SECRET YELLOW:
+        id: Color Arrow Room/Panel_secret_yellow
+        tag: forbid
+      SECRET RED:
+        id: Color Arrow Room/Panel_secret_red
+        tag: forbid
+    paintings:
       - id: colors_painting
         orientation: south
-        enter_only: True
-        required_door:
-          room: Outside The Initiated
-          door: Entrance
   The Bearer:
     entrances:
       Outside The Bold:

--- a/worlds/lingo/data/ids.yaml
+++ b/worlds/lingo/data/ids.yaml
@@ -489,7 +489,7 @@ panels:
     WINDWARD: 444803
     LIGHT: 444804
     REWIND: 444805
-  Champion's Rest:
+  Color Hunt:
     EXIT: 444806
     HUES: 444807
     RED: 444808
@@ -498,6 +498,7 @@ panels:
     GREEN: 444811
     PURPLE: 444812
     ORANGE: 444813
+  Champion's Rest:
     YOU: 444814
     ME: 444815
     SECRET BLUE: 444816
@@ -1286,7 +1287,7 @@ doors:
       location: 445246
     Yellow Barrier:
       item: 444538
-  Champion's Rest:
+  Color Hunt:
     Shortcut to The Steady:
       item: 444539
       location: 444806
@@ -1442,7 +1443,6 @@ door_groups:
   Fearless Doors: 444469
   Backside Doors: 444473
   Orange Tower First Floor - Shortcuts: 444484
-  Champion's Rest - Color Barriers: 444489
   Welcome Back Doors: 444492
   Colorful Doors: 444498
   Directional Gallery Doors: 444531

--- a/worlds/lingo/player_logic.py
+++ b/worlds/lingo/player_logic.py
@@ -196,9 +196,8 @@ class LingoPlayerLogic:
             ["Orange Tower Fourth Floor", "Hot Crusts Door"], ["Outside The Initiated", "Shortcut to Hub Room"],
             ["Orange Tower First Floor", "Shortcut to Hub Room"], ["Directional Gallery", "Shortcut to The Undeterred"],
             ["Orange Tower First Floor", "Salt Pepper Door"], ["Hub Room", "Crossroads Entrance"],
-            ["Champion's Rest", "Shortcut to The Steady"], ["The Bearer", "Shortcut to The Bold"],
-            ["Art Gallery", "Exit"], ["The Tenacious", "Shortcut to Hub Room"],
-            ["Outside The Agreeable", "Tenacious Entrance"]
+            ["Color Hunt", "Shortcut to The Steady"], ["The Bearer", "Shortcut to The Bold"], ["Art Gallery", "Exit"],
+            ["The Tenacious", "Shortcut to Hub Room"], ["Outside The Agreeable", "Tenacious Entrance"]
         ]
         pilgrimage_reqs = AccessRequirements()
         for door in fake_pilgrimage:


### PR DESCRIPTION
## What is this fixing or adding?
"Color Hunt" and "Champion's Rest" are now two separate rooms. The resulting logic is similar to before, with the exception that the painting inside of Champion's Rest is now a possible exit, meaning that the room can be accessed and the panels solved without accessing Color Hunt.


## How was this tested?
validate_config.rb, pytest, and a test playthrough.


## If this makes graphical changes, please attach screenshots.
