### PR TITLE
SoE: fix naming of atlas medallion

### DIFF
--- a/worlds/soe/__init__.py
+++ b/worlds/soe/__init__.py
@@ -81,7 +81,7 @@ for _loc in _locations:
 # item helpers
 _ingredients = (
     'Wax', 'Water', 'Vinegar', 'Root', 'Oil', 'Mushroom', 'Mud Pepper', 'Meteorite', 'Limestone', 'Iron',
-    'Gunpowder', 'Grease', 'Feather', 'Ethanol', 'Dry Ice', 'Crystal', 'Clay', 'Brimstone', 'Bone', 'Atlas Amulet',
+    'Gunpowder', 'Grease', 'Feather', 'Ethanol', 'Dry Ice', 'Crystal', 'Clay', 'Brimstone', 'Bone', 'Atlas Medallion',
     'Ash', 'Acorn'
 )
 _other_items = (

--- a/worlds/soe/test/test_item_mapping.py
+++ b/worlds/soe/test/test_item_mapping.py
@@ -1,0 +1,21 @@
+from unittest import TestCase
+from .. import SoEWorld
+
+
+class TestMapping(TestCase):
+    def test_atlas_medallion_name_group(self) -> None:
+        """
+        Test that we used the pyevermizer name for Atlas Medallion (not Amulet) in item groups.
+        """
+        self.assertIn("Any Atlas Medallion", SoEWorld.item_name_groups)
+
+    def test_atlas_medallion_name_items(self) -> None:
+        """
+        Test that we used the pyevermizer name for Atlas Medallion (not Amulet) in items.
+        """
+        found_medallion = False
+        for name in SoEWorld.item_name_to_id:
+            self.assertNotIn("Atlas Amulet", name, "Expected Atlas Medallion, not Amulet")
+            if "Atlas Medallion" in name:
+                found_medallion = True
+        self.assertTrue(found_medallion, "Did not find Atlas Medallion in items")


### PR DESCRIPTION
## What is this fixing or adding?

In pyevermizer, it's called Atlas Medallion, not Amulet, leading to an empty group and to code not considering them as an alchemy ingredient when swapping out for a trap or an energy core fragment.

Also adds a test.

Bug was reported [on Discord](https://discord.com/channels/731205301247803413/909605724190019645/1198142248102141952).

## How was this tested?

Unit tests.
