### PR TITLE
Pokemon Emerald: Shuffle TMs for `diverse_balanced` option

### DIFF
--- a/worlds/pokemon_emerald/__init__.py
+++ b/worlds/pokemon_emerald/__init__.py
@@ -225,6 +225,7 @@ class PokemonEmeraldWorld(World):
             def refresh_tm_choices() -> None:
                 fill_item_candidates_by_category["TM"] = all_tm_choices.copy()
                 self.random.shuffle(fill_item_candidates_by_category["TM"])
+            refresh_tm_choices()
 
             # Create items
             for item in default_itempool:


### PR DESCRIPTION
## What is this fixing or adding?

When `item_pool_type` is `diverse_balanced`, duplicate TMs shouldn't be added until all TMs are represented, so it has special handling to shuffle the TMs and then pop them as needed. But I forgot to shuffle the list on the first go, so it will always add TM50 and count down.

This adds an initial shuffle.

## How was this tested?

Generating with the option set and seeing a randomized list of TMs in the pool.
