### PR TITLE
Core: Text Processor Echo

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1086,8 +1086,11 @@ def mark_raw(function: typing.Callable[[typing.Any], _Return]) -> typing.Callabl
 
 class CommandProcessor(metaclass=CommandMeta):
     commands: typing.Dict[str, typing.Callable]
-    client = None
+    client: typing.Optional[Client] = None
     marker = "/"
+    echo_commands = False
+    echo_command_prefix = '$ '
+    echo_command_suffix = ''
 
     def output(self, text: str):
         print(text)
@@ -1096,6 +1099,8 @@ class CommandProcessor(metaclass=CommandMeta):
         if not raw:
             return
         try:
+            if self.echo_commands:
+                self.output(f"{self.echo_command_prefix}{raw}{self.echo_command_suffix}")
             command = raw.split()
             basecommand = command[0]
             if basecommand[0] == self.marker:

--- a/test/programs/test_multi_server.py
+++ b/test/programs/test_multi_server.py
@@ -39,7 +39,9 @@ class TestResolvePlayerName(unittest.TestCase):
         assert p.resolve_player("ABC") == (1, 2, "abc"), "case insensitive resolves when 1 match"
         assert p.resolve_player("abcd") == (1, 3, "abCD"), "case insensitive resolves when 1 match"
         assert not p.resolve_player("aB"), "partial name shouldn't resolve to player"
-    
+
+
+class TestTextProcessor(unittest.TestCase):
     def test_echo_commands_on_request(self) -> None:
         processor = CommandProcessor()
         processor.echo_commands = False

--- a/test/programs/test_multi_server.py
+++ b/test/programs/test_multi_server.py
@@ -50,8 +50,8 @@ class TestResolvePlayerName(unittest.TestCase):
         command = '/help'
 
         processor(command)
-        assert f'>{command}<' not in logged_outputs
+        self.assertNotIn(f'>{command}<', logged_outputs)
 
         processor.echo_commands = True
         processor(command)
-        assert f'>{command}<' in logged_outputs
+        self.assertIn(f'>{command}<', logged_outputs)

--- a/test/programs/test_multi_server.py
+++ b/test/programs/test_multi_server.py
@@ -1,5 +1,6 @@
 import unittest
-from MultiServer import Context, ServerCommandProcessor
+import typing
+from MultiServer import Context, ServerCommandProcessor, CommandProcessor
 
 
 class TestResolvePlayerName(unittest.TestCase):
@@ -38,3 +39,19 @@ class TestResolvePlayerName(unittest.TestCase):
         assert p.resolve_player("ABC") == (1, 2, "abc"), "case insensitive resolves when 1 match"
         assert p.resolve_player("abcd") == (1, 3, "abCD"), "case insensitive resolves when 1 match"
         assert not p.resolve_player("aB"), "partial name shouldn't resolve to player"
+    
+    def test_echo_commands_on_request(self) -> None:
+        processor = CommandProcessor()
+        processor.echo_commands = False
+        processor.echo_command_prefix = '>'
+        processor.echo_command_suffix = '<'
+        logged_outputs: typing.List[str] = []
+        processor.output = lambda x: logged_outputs.append(x)
+        command = '/help'
+
+        processor(command)
+        assert f'>{command}<' not in logged_outputs
+
+        processor.echo_commands = True
+        processor(command)
+        assert f'>{command}<' in logged_outputs


### PR DESCRIPTION
## What is this fixing or adding?
This is a small change to core / MultiServer.py, to the text command processor. I'm noticing while working on the starcraft 2 client that it's very difficult to tell where output in response to one command ends and the next starts. I've started putting little markers to help me see things while testing, and decided before adding it to a second or third command I should probably try to turn this into a global feature instead.
![image](https://github.com/Ziktofel/Archipelago/assets/31861583/751b79e3-096a-42c0-bc43-e907deef962e)

I've made this feature opt-in by setting the `echo_commands` property to true, with the possibility of adding prefixes and suffixes to the output (defaults to `"$ "` prefix and no suffix).

_Note_: I go by "Phanerus" on the discord if you need to contact me there. I've mostly only worked on starcraft 2 development.

## How was this tested?
I've added a unit test for this that monkey-patches `CommandProcessor.output` to collect output messages and analyze it's behaving correctly.

Locally, I tried setting `StarcraftClientProcessor.echo_commands` to true, and playing around with some output. Commands were echoed as expected.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/31861583/3896eca4-0f05-4a41-bc44-ae46814c0dc0)

## If this makes graphical changes, please attach screenshots.
