### PR TITLE
CommonClient: Improve commands

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -119,12 +119,13 @@ class ClientCommandProcessor(CommandProcessor):
                     self.output('Checked: ' + location)
                     count += 1
                     checked_count += 1
-
+        filter_match = f" matching '{filter_text}'" if filter_text else ""
         if count:
+            check_str = f". {checked_count} location checks previously visited." if checked_count else ""
             self.output(
-                f"Found {count} missing location checks{f" matching '{filter_text}'" if filter_text else ""}{f'. {checked_count} location checks previously visited.' if checked_count else ''}")
+                f"Found {count} missing location checks{filter_match}{check_str}")
         else:
-            self.output(f"No missing location checks{f" matching '{filter_text}'" if filter_text else ""} found.")
+            self.output(f"No missing location checks{filter_match} found.")
         return True
 
     @mark_raw

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1346,7 +1346,8 @@ class ClientMessageProcessor(CommonCommandProcessor):
                 self.output(
                     "Sorry, !remaining requires you to have beaten the game on this server")
                 return False
-
+    
+    @mark_raw
     def _cmd_missing(self, filter_text="") -> bool:
         """List all missing location checks from the server's perspective.
         Can be given text, which will be used as filter."""
@@ -1356,10 +1357,10 @@ class ClientMessageProcessor(CommonCommandProcessor):
         if locations:
             names = [self.ctx.location_names[location] for location in locations]
             if filter_text:
-                names = [name for name in names if filter_text in name]
+                names = [name for name in names if filter_text.lower() in name.lower()]
             texts = [f'Missing: {name}' for name in names]
             if filter_text:
-                texts.append(f"Found {len(locations)} missing location checks, displaying {len(names)} of them.")
+                texts.append(f"Found {len(names)} missing location checks matching '{filter_text}'")
             else:
                 texts.append(f"Found {len(locations)} missing location checks")
             self.output_multiple(texts)
@@ -1367,6 +1368,7 @@ class ClientMessageProcessor(CommonCommandProcessor):
             self.output("No missing location checks found.")
         return True
 
+    @mark_raw
     def _cmd_checked(self, filter_text="") -> bool:
         """List all done location checks from the server's perspective.
         Can be given text, which will be used as filter."""
@@ -1376,10 +1378,10 @@ class ClientMessageProcessor(CommonCommandProcessor):
         if locations:
             names = [self.ctx.location_names[location] for location in locations]
             if filter_text:
-                names = [name for name in names if filter_text in name]
+                names = [name for name in names if filter_text.lower() in name.lower()]
             texts = [f'Checked: {name}' for name in names]
             if filter_text:
-                texts.append(f"Found {len(locations)} done location checks, displaying {len(names)} of them.")
+                texts.append(f"Found {len(names)} done location checks matching '{filter_text}'")
             else:
                 texts.append(f"Found {len(locations)} done location checks")
             self.output_multiple(texts)


### PR DESCRIPTION
## What is this fixing or adding?
Modified some basic CommonClient commands to be more useful.
'/missing' now properly can take multi-word filter text (instead of giving an error for invalid param count), and is case-insensitive.
'/received', '/items', and '/locations' now also take optional filter text.
Feedback from all changed commands also slightly improved (ex. now repeats the filter text used, indicating the results only include those that match that filter; where it previously showed a number of results, that now only counts those that match the filter, instead of all)

MultiServer's '!missing' and '!checked' have also received similar improvements.

## How was this tested?
Ran all of the changed commands, checking for expected output. Some examples shown below.
Commands were tested both with and without filter text.

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/35015090/ba2f4a75-2f02-42a3-b5c1-b4a3ac04dc5c)
(/received: Finding the days of the traveling cart in Stardew Valley that have been received was the main driving factor in this addition, and works flawlessly)
![image](https://github.com/ArchipelagoMW/Archipelago/assets/35015090/25e1fe62-2940-42af-83e2-dad2f375f17c)
(!missing - the MultiServer command)
![image](https://github.com/ArchipelagoMW/Archipelago/assets/35015090/aa24b722-7771-40b7-8333-060b8260634c)
(!checked - the MultiServer command)
![image](https://github.com/ArchipelagoMW/Archipelago/assets/35015090/dc2e35bd-bab2-4208-a17c-cfc8815ca0c2)
(/missing - the CommonClient command)
![image](https://github.com/ArchipelagoMW/Archipelago/assets/35015090/0105d640-295c-47e0-a056-e81707028799)
(/items)
![image](https://github.com/ArchipelagoMW/Archipelago/assets/35015090/9b008ab9-6f29-43e3-b309-eedca0a9301b)
(/locations)