### PR TITLE
Doc: fix typo in commands_en.md

### DIFF
--- a/worlds/generic/docs/commands_en.md
+++ b/worlds/generic/docs/commands_en.md
@@ -42,9 +42,9 @@ including the exclamation point.
 
 ### Collect/Release
 - `!collect` Grants you all the remaining items for your world by collecting them from all games. Typically used after 
-goal completion.
-- `!release` Releases all items contained in your world to other worlds. Typically, done automatically by the sever, but
-can be configured to allow/require manual usage of this command.
+  goal completion.
+- `!release` Releases all items contained in your world to other worlds. Typically, done automatically by the server,
+  but can be configured to allow/require manual usage of this command.
 
 ### Cheats
 - `!getitem <item>` Cheats an item to the currently connected slot, if it is enabled in the server.


### PR DESCRIPTION
## What is this fixing or adding?

Fix typo in commands_en.md as reported here: https://discord.com/channels/731205301247803413/1200171058179874897/1200171058179874897

Also fixes indentation to match other sections.

## How was this tested?

:eyes: 