### PR TITLE
Core/Subnautica: demonstrate a way to on-demand specify WebWorld

### DIFF
--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -39,7 +39,8 @@ class AutoWorldRegister(type):
 
     def __new__(mcs, name: str, bases: Tuple[type, ...], dct: Dict[str, Any]) -> AutoWorldRegister:
         if "web" in dct:
-            assert isinstance(dct["web"], WebWorld), "WebWorld has to be instantiated."
+            assert isinstance(dct["web"], WebWorld) or isinstance(dct["web"], staticproperty), \
+                "WebWorld has to be instantiated."
         # filter out any events
         dct["item_name_to_id"] = {name: id for name, id in dct["item_name_to_id"].items() if id}
         dct["location_name_to_id"] = {name: id for name, id in dct["location_name_to_id"].items() if id}
@@ -482,6 +483,11 @@ class World(metaclass=AutoWorldRegister):
 # please use a prefix as all of them get clobbered together
 class LogicMixin(metaclass=AutoLogicRegister):
     pass
+
+
+class staticproperty(staticmethod):
+    def __get__(self, *args):
+        return self.__func__()
 
 
 def data_package_checksum(data: "GamesPackage") -> str:

--- a/worlds/subnautica/__init__.py
+++ b/worlds/subnautica/__init__.py
@@ -5,7 +5,8 @@ import itertools
 from typing import List, Dict, Any, cast
 
 from BaseClasses import Region, Entrance, Location, Item, Tutorial, ItemClassification
-from worlds.AutoWorld import World, WebWorld
+from worlds.AutoWorld import World, WebWorld, staticproperty
+from Utils import cache_argsless
 from . import items
 from . import locations
 from . import creatures
@@ -16,19 +17,24 @@ from .rules import set_rules
 logger = logging.getLogger("Subnautica")
 
 
-class SubnaticaWeb(WebWorld):
-    tutorials = [Tutorial(
-        "Multiworld Setup Guide",
-        "A guide to setting up the Subnautica randomizer connected to an Archipelago Multiworld",
-        "English",
-        "setup_en.md",
-        "setup/en",
-        ["Berserker"]
-    )]
-
-
 all_locations = {data["name"]: loc_id for loc_id, data in locations.location_table.items()}
 all_locations.update(creatures.creature_locations)
+
+
+@staticproperty
+@cache_argsless
+def web():
+    class SubnaticaWeb(WebWorld):
+        tutorials = [Tutorial(
+            "Multiworld Setup Guide",
+            "A guide to setting up the Subnautica randomizer connected to an Archipelago Multiworld",
+            "English",
+            "setup_en.md",
+            "setup/en",
+            ["Berserker"]
+        )]
+
+    return SubnaticaWeb()
 
 
 class SubnauticaWorld(World):
@@ -38,7 +44,7 @@ class SubnauticaWorld(World):
     You must find a cure for yourself, build an escape rocket, and leave the planet.
     """
     game = "Subnautica"
-    web = SubnaticaWeb()
+    web = web
 
     item_name_to_id = {data.name: item_id for item_id, data in items.item_table.items()}
     location_name_to_id = all_locations


### PR DESCRIPTION
## What is this fixing or adding?
lazy-load/on-demand WebWorld

## How was this tested?
locally.

Moved the definition outside the World class to get the PyCharm linter to not complain about lack of self, the assert in AutoWorld remains a bit mutilated, not sure if that can be improved upon or should just be axed in favor of a unittest.

## If this makes graphical changes, please attach screenshots.
