### PR TITLE
LTTP: fix incorrect type passing causing itempool generation to crash

### DIFF
--- a/worlds/alttp/Dungeons.py
+++ b/worlds/alttp/Dungeons.py
@@ -180,7 +180,7 @@ def get_dungeon_item_pool(multiworld: MultiWorld) -> typing.List[ALttPItem]:
             for item in get_dungeon_item_pool_player(world)]
 
 
-def get_dungeon_item_pool_player(world) -> typing.List[ALttPItem]:
+def get_dungeon_item_pool_player(world: ALTTPWorld) -> typing.List[ALttPItem]:
     return [item
             for dungeon in world.dungeons.values()
             for item in dungeon.all_items]

--- a/worlds/alttp/ItemPool.py
+++ b/worlds/alttp/ItemPool.py
@@ -1,8 +1,11 @@
 from collections import namedtuple
 import logging
+from typing import TYPE_CHECKING
 
 from BaseClasses import ItemClassification
 from Fill import FillError
+if TYPE_CHECKING:
+    from . import ALTTPWorld
 
 from .SubClasses import ALttPLocation, LTTPRegion, LTTPRegionType
 from .Shops import TakeAny, total_shop_slots, set_up_shops, shuffle_shops, create_dynamic_shop_locations
@@ -225,7 +228,7 @@ for diff in {'easy', 'normal', 'hard', 'expert'}:
     )
 
 
-def generate_itempool(world):
+def generate_itempool(world: "ALTTPWorld"):
     player = world.player
     multiworld = world.multiworld
 
@@ -399,11 +402,11 @@ def generate_itempool(world):
             loc.address = None
         elif multiworld.goal[player] == 'icerodhunt':
             # key drop item removed because of icerodhunt
-            multiworld.itempool.append(ItemFactory(GetBeemizerItem(world, player, 'Nothing'), player))
+            multiworld.itempool.append(ItemFactory(GetBeemizerItem(multiworld, player, 'Nothing'), player))
             multiworld.push_precollected(drop_item)
         elif "Small" in key_data[3] and multiworld.smallkey_shuffle[player] == smallkey_shuffle.option_universal:
             # key drop shuffle and universal keys are on. Add universal keys in place of key drop keys.
-            multiworld.itempool.append(ItemFactory(GetBeemizerItem(world, player, 'Small Key (Universal)'), player))
+            multiworld.itempool.append(ItemFactory(GetBeemizerItem(multiworld, player, 'Small Key (Universal)'), player))
     dungeon_item_replacements = sum(difficulties[multiworld.difficulty[player]].extras, []) * 2
     multiworld.random.shuffle(dungeon_item_replacements)
     if multiworld.goal[player] == 'icerodhunt':

--- a/worlds/alttp/Items.py
+++ b/worlds/alttp/Items.py
@@ -1,23 +1,23 @@
 import typing
 
-from BaseClasses import ItemClassification as IC
+from BaseClasses import ItemClassification as IC, MultiWorld
 
 
-def GetBeemizerItem(world, player: int, item):
+def GetBeemizerItem(multiworld: MultiWorld, player: int, item):
     item_name = item if isinstance(item, str) else item.name
 
     if item_name not in trap_replaceable:
         return item
 
     # first roll - replaceable item should be replaced, within beemizer_total_chance
-    if not world.beemizer_total_chance[player] or world.random.random() > (world.beemizer_total_chance[player] / 100):
+    if not multiworld.beemizer_total_chance[player] or multiworld.random.random() > (multiworld.beemizer_total_chance[player] / 100):
         return item
 
     # second roll - bee replacement should be trap, within beemizer_trap_chance
-    if not world.beemizer_trap_chance[player] or world.random.random() > (world.beemizer_trap_chance[player] / 100):
-        return "Bee" if isinstance(item, str) else world.create_item("Bee", player)
+    if not multiworld.beemizer_trap_chance[player] or multiworld.random.random() > (multiworld.beemizer_trap_chance[player] / 100):
+        return "Bee" if isinstance(item, str) else multiworld.create_item("Bee", player)
     else:
-        return "Bee Trap" if isinstance(item, str) else world.create_item("Bee Trap", player)        
+        return "Bee Trap" if isinstance(item, str) else multiworld.create_item("Bee Trap", player)
 
 
 # should be replaced with direct world.create_item(item) call in the future


### PR DESCRIPTION
## What is this fixing or adding?
world = multiworld despite there also being usage of multiworld right next to it.

## How was this tested?
added type hints ran unit tests plus the option combinations that were found to be broken

## If this makes graphical changes, please attach screenshots.
