### PR TITLE
TUNIC: Fix for nmg logic bug

### DIFF
--- a/worlds/tunic/er_data.py
+++ b/worlds/tunic/er_data.py
@@ -37,7 +37,7 @@ portal_mapping: List[Portal] = [
            destination="Furnace_gyro_lower"),
     Portal(name="Caustic Light Cave Entrance", region="Overworld",
            destination="Overworld Cave_"),
-    Portal(name="Swamp Upper Entrance", region="Overworld Laurels",
+    Portal(name="Swamp Upper Entrance", region="Overworld Swamp Upper Entry",
            destination="Swamp Redux 2_wall"),
     Portal(name="Swamp Lower Entrance", region="Overworld",
            destination="Swamp Redux 2_conduit"),
@@ -49,7 +49,7 @@ portal_mapping: List[Portal] = [
            destination="Atoll Redux_upper"),
     Portal(name="Atoll Lower Entrance", region="Overworld",
            destination="Atoll Redux_lower"),
-    Portal(name="Special Shop Entrance", region="Overworld Laurels",
+    Portal(name="Special Shop Entrance", region="Overworld Special Shop Entry",
            destination="ShopSpecial_"),
     Portal(name="Maze Cave Entrance", region="Overworld",
            destination="Maze Room_"),
@@ -57,7 +57,7 @@ portal_mapping: List[Portal] = [
            destination="Archipelagos Redux_upper"),
     Portal(name="West Garden Entrance from Furnace", region="Overworld to West Garden from Furnace",
            destination="Archipelagos Redux_lower"),
-    Portal(name="West Garden Laurels Entrance", region="Overworld Laurels",
+    Portal(name="West Garden Laurels Entrance", region="Overworld West Garden Laurels Entry",
            destination="Archipelagos Redux_lowest"),
     Portal(name="Temple Door Entrance", region="Overworld Temple Door",
            destination="Temple_main"),
@@ -533,7 +533,9 @@ tunic_er_regions: Dict[str, RegionInfo] = {
     "Overworld": RegionInfo("Overworld Redux"),
     "Overworld Holy Cross": RegionInfo("Fake", dead_end=DeadEnd.all_cats),
     "Overworld Belltower": RegionInfo("Overworld Redux"),  # the area with the belltower and chest
-    "Overworld Laurels": RegionInfo("Overworld Redux"),  # all spots in Overworld that you need laurels to reach
+    "Overworld Swamp Upper Entry": RegionInfo("Overworld Redux"),  # upper swamp entry spot
+    "Overworld Special Shop Entry": RegionInfo("Overworld Redux"),  # special shop entry spot
+    "Overworld West Garden Laurels Entry": RegionInfo("Overworld Redux"),  # west garden laurels entry
     "Overworld to West Garden from Furnace": RegionInfo("Overworld Redux", hint=Hint.region),
     "Overworld Well to Furnace Rail": RegionInfo("Overworld Redux"),  # the tiny rail passageway
     "Overworld Ruined Passage Door": RegionInfo("Overworld Redux"),  # the small space betweeen the door and the portal
@@ -710,7 +712,7 @@ for p1, p2 in hallways.items():
     hallway_helper[p2] = p1
 
 # so we can just loop over this instead of doing some complicated thing to deal with hallways in the hints
-hallways_nmg: Dict[str, str] = {
+hallways_ur: Dict[str, str] = {
     "Ruins Passage, Overworld Redux_east": "Ruins Passage, Overworld Redux_west",
     "East Forest Redux Interior, East Forest Redux_upper": "East Forest Redux Interior, East Forest Redux_lower",
     "Forest Boss Room, East Forest Redux Laddercave_": "Forest Boss Room, Forest Belltower_",
@@ -720,20 +722,22 @@ hallways_nmg: Dict[str, str] = {
     "ziggurat2020_0, Quarry Redux_": "ziggurat2020_0, ziggurat2020_1_",
     "Purgatory, Purgatory_bottom": "Purgatory, Purgatory_top",
 }
-hallway_helper_nmg: Dict[str, str] = {}
-for p1, p2 in hallways.items():
-    hallway_helper[p1] = p2
-    hallway_helper[p2] = p1
+hallway_helper_ur: Dict[str, str] = {}
+for p1, p2 in hallways_ur.items():
+    hallway_helper_ur[p1] = p2
+    hallway_helper_ur[p2] = p1
 
 
 # the key is the region you have, the value is the regions you get for having that region
 # this is mostly so we don't have to do something overly complex to get this information
 dependent_regions: Dict[Tuple[str, ...], List[str]] = {
-    ("Overworld", "Overworld Belltower", "Overworld Laurels", "Overworld Southeast Cross Door", "Overworld Temple Door",
+    ("Overworld", "Overworld Belltower", "Overworld Swamp Upper Entry", "Overworld Special Shop Entry",
+     "Overworld West Garden Laurels Entry", "Overworld Southeast Cross Door", "Overworld Temple Door",
      "Overworld Fountain Cross Door", "Overworld Town Portal", "Overworld Spawn Portal"):
-         ["Overworld", "Overworld Belltower", "Overworld Laurels", "Overworld Ruined Passage Door",
-          "Overworld Southeast Cross Door", "Overworld Old House Door", "Overworld Temple Door",
-          "Overworld Fountain Cross Door", "Overworld Town Portal", "Overworld Spawn Portal"],
+         ["Overworld", "Overworld Belltower", "Overworld Swamp Upper Entry", "Overworld Special Shop Entry",
+          "Overworld West Garden Laurels Entry", "Overworld Ruined Passage Door", "Overworld Southeast Cross Door",
+          "Overworld Old House Door", "Overworld Temple Door", "Overworld Fountain Cross Door", "Overworld Town Portal",
+          "Overworld Spawn Portal"],
     ("Old House Front",):
         ["Old House Front", "Old House Back"],
     ("Furnace Fuse", "Furnace Ladder Area", "Furnace Walking Path"):
@@ -818,12 +822,14 @@ dependent_regions: Dict[Tuple[str, ...], List[str]] = {
 
 
 dependent_regions_nmg: Dict[Tuple[str, ...], List[str]] = {
-    ("Overworld", "Overworld Belltower", "Overworld Laurels", "Overworld Southeast Cross Door", "Overworld Temple Door",
+    ("Overworld", "Overworld Belltower", "Overworld Swamp Upper Entry", "Overworld Special Shop Entry",
+     "Overworld West Garden Laurels Entry", "Overworld Southeast Cross Door", "Overworld Temple Door",
      "Overworld Fountain Cross Door", "Overworld Town Portal", "Overworld Spawn Portal",
      "Overworld Ruined Passage Door"):
-         ["Overworld", "Overworld Belltower", "Overworld Laurels", "Overworld Ruined Passage Door",
-          "Overworld Southeast Cross Door", "Overworld Old House Door", "Overworld Temple Door",
-          "Overworld Fountain Cross Door", "Overworld Town Portal", "Overworld Spawn Portal"],
+         ["Overworld", "Overworld Belltower", "Overworld Swamp Upper Entry", "Overworld Special Shop Entry",
+          "Overworld West Garden Laurels Entry", "Overworld Ruined Passage Door", "Overworld Southeast Cross Door",
+          "Overworld Old House Door", "Overworld Temple Door", "Overworld Fountain Cross Door", "Overworld Town Portal",
+          "Overworld Spawn Portal"],
     # can laurels through the gate
     ("Old House Front", "Old House Back"):
         ["Old House Front", "Old House Back"],
@@ -908,13 +914,14 @@ dependent_regions_nmg: Dict[Tuple[str, ...], List[str]] = {
 
 dependent_regions_ur: Dict[Tuple[str, ...], List[str]] = {
     # can use ladder storage to get to the well rail
-    ("Overworld", "Overworld Belltower", "Overworld Laurels", "Overworld Southeast Cross Door", "Overworld Temple Door",
+    ("Overworld", "Overworld Belltower", "Overworld Swamp Upper Entry", "Overworld Special Shop Entry",
+     "Overworld West Garden Laurels Entry", "Overworld Southeast Cross Door", "Overworld Temple Door",
      "Overworld Fountain Cross Door", "Overworld Town Portal", "Overworld Spawn Portal",
      "Overworld Ruined Passage Door"):
-         ["Overworld", "Overworld Belltower", "Overworld Laurels", "Overworld Ruined Passage Door",
-          "Overworld Southeast Cross Door", "Overworld Old House Door", "Overworld Temple Door",
-          "Overworld Fountain Cross Door", "Overworld Town Portal", "Overworld Spawn Portal",
-          "Overworld Well to Furnace Rail"],
+         ["Overworld", "Overworld Belltower", "Overworld Swamp Upper Entry", "Overworld Special Shop Entry",
+          "Overworld West Garden Laurels Entry", "Overworld Ruined Passage Door", "Overworld Southeast Cross Door",
+          "Overworld Old House Door", "Overworld Temple Door", "Overworld Fountain Cross Door", "Overworld Town Portal",
+          "Overworld Spawn Portal", "Overworld Well to Furnace Rail"],
     # can laurels through the gate
     ("Old House Front", "Old House Back"):
         ["Old House Front", "Old House Back"],

--- a/worlds/tunic/er_rules.py
+++ b/worlds/tunic/er_rules.py
@@ -53,9 +53,23 @@ def set_er_region_rules(world: "TunicWorld", ability_unlocks: Dict[str, int], re
         or (state.has(laurels, player) and options.logic_rules))
 
     regions["Overworld"].connect(
-        connecting_region=regions["Overworld Laurels"],
+        connecting_region=regions["Overworld Swamp Upper Entry"],
         rule=lambda state: state.has(laurels, player))
-    regions["Overworld Laurels"].connect(
+    regions["Overworld Swamp Upper Entry"].connect(
+        connecting_region=regions["Overworld"],
+        rule=lambda state: state.has(laurels, player))
+
+    regions["Overworld"].connect(
+        connecting_region=regions["Overworld Special Shop Entry"],
+        rule=lambda state: state.has(laurels, player))
+    regions["Overworld Special Shop Entry"].connect(
+        connecting_region=regions["Overworld"],
+        rule=lambda state: state.has(laurels, player))
+
+    regions["Overworld"].connect(
+        connecting_region=regions["Overworld West Garden Laurels Entry"],
+        rule=lambda state: state.has(laurels, player))
+    regions["Overworld West Garden Laurels Entry"].connect(
         connecting_region=regions["Overworld"],
         rule=lambda state: state.has(laurels, player))
 
@@ -230,7 +244,6 @@ def set_er_region_rules(world: "TunicWorld", ability_unlocks: Dict[str, int], re
         connecting_region=regions["West Garden Laurels Exit"],
         rule=lambda state: state.has(laurels, player))
 
-    # todo: can you wake the boss, then grapple to it, then kill it?
     regions["West Garden after Boss"].connect(
         connecting_region=regions["West Garden"],
         rule=lambda state: state.has(laurels, player))

--- a/worlds/tunic/er_scripts.py
+++ b/worlds/tunic/er_scripts.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Set, Tuple, TYPE_CHECKING
 from BaseClasses import Region, ItemClassification, Item, Location
 from .locations import location_table
-from .er_data import Portal, tunic_er_regions, portal_mapping, hallway_helper, hallway_helper_nmg, \
+from .er_data import Portal, tunic_er_regions, portal_mapping, hallway_helper, hallway_helper_ur, \
     dependent_regions, dependent_regions_nmg, dependent_regions_ur
 from .er_rules import set_er_region_rules
 
@@ -28,8 +28,8 @@ def create_er_regions(world: "TunicWorld") -> Tuple[Dict[Portal, Portal], Dict[i
         if hint_string == "":
             hint_string = portal.name
 
-        if logic_rules:
-            hallways = hallway_helper_nmg
+        if logic_rules == "unrestricted":
+            hallways = hallway_helper_ur
         else:
             hallways = hallway_helper
 


### PR DESCRIPTION
## What is this fixing or adding?
Fixes a logic bug where the "Overworlds Laurels Region" basically just connected some irrelevant entrances to each other, creating a (very rare) potential for a logic bug. This splits that region into three separate regions.
Also the hallway helper (for generating ER hint paths) wasn't working properly for NMG (it wasn't supposed to take the same hints as UR).

## How was this tested?
Ran generation a few times with varied settings.

## If this makes graphical changes, please attach screenshots.
N/A