### PR TITLE
CommonClient: handle Firefox removing the password part of userinfo

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -612,6 +612,10 @@ async def server_loop(ctx: CommonContext, address: typing.Optional[str] = None) 
 
     address = f"ws://{address}" if "://" not in address \
         else address.replace("archipelago://", "ws://")
+    uri = urllib.parse.urlparse(address)
+    if uri.username and uri.password is None:
+        # Fix for Firefox stripping empty password https://bugzilla.mozilla.org/show_bug.cgi?id=1876952
+        address = address.replace("@", ":@")
 
     server_url = urllib.parse.urlparse(address)
     if server_url.username:


### PR DESCRIPTION
## What is this fixing or adding?
Firefox's mistake
More details in https://discord.com/channels/731205301247803413/1201031114400210984

## How was this tested?
by copying a link Firefox imagined into existence.

## If this makes graphical changes, please attach screenshots.
