### PR TITLE
Adventure: Fix iterable copy error when freeincarnate_max is tuned low

### DIFF
--- a/worlds/adventure/__init__.py
+++ b/worlds/adventure/__init__.py
@@ -271,7 +271,7 @@ class AdventureWorld(World):
         overworld_locations_copy = overworld.locations.copy()
         all_locations = self.multiworld.get_locations(self.player)
 
-        locations_copy = all_locations.copy()
+        locations_copy = list(all_locations)
         for loc in all_locations:
             if loc.item is not None or loc.progress_type != LocationProgressType.DEFAULT:
                 locations_copy.remove(loc)


### PR DESCRIPTION
## What is this fixing or adding?
Fixing errors in Adventure pre_fill due to calling .copy on what is now an iterable and not a list.  Would hit this code if there were not enough items to fill all locations, mainly when max_freeincarnate is set to a low value.

## How was this tested?
Generated full-random 1050 Adventure multiworld, 100 full-random individual single-adventure multiworlds, and generated and played some of a 4 Adventure world with low random max_freeincarnate settings

## If this makes graphical changes, please attach screenshots.
N/A
