### PR TITLE
Probably fix generation error that palex had

### DIFF
--- a/worlds/ladx/LADXR/locations/droppedKey.py
+++ b/worlds/ladx/LADXR/locations/droppedKey.py
@@ -19,7 +19,7 @@ class DroppedKey(ItemInfo):
             extra = 0x01F8
         super().__init__(room, extra)
     def patch(self, rom, option, *, multiworld=None):
-        if (option.startswith(MAP) and option != MAP) or (option.startswith(COMPASS) and option != COMPASS) or option.startswith(STONE_BEAK) or (option.startswith(NIGHTMARE_KEY) and option != NIGHTMARE_KEY )or (option.startswith(KEY) and option != KEY):
+        if (option.startswith(MAP) and option != MAP) or (option.startswith(COMPASS) and option != COMPASS) or (option.startswith(STONE_BEAK) and option != STONE_BEAK) or (option.startswith(NIGHTMARE_KEY) and option != NIGHTMARE_KEY )or (option.startswith(KEY) and option != KEY):
             if option[-1] == 'P':
                 print(option)
             if self._location.dungeon == int(option[-1]) and multiworld is None and self.room not in {0x166, 0x223}:


### PR DESCRIPTION
This needs further testing. The theory is that putting a STONE_BEAK on a dropped key causes this - but I don't remember how or why a regular STONE_BEAK can get put here instead of a STONE_BEAK3, etc.

Edit: this is almost certainly a foreign player's item that got put as a STONE_BEAK item icon.