### PR TITLE
WebHost: provide None password to URI so it doesn't get stripped

### DIFF
--- a/WebHostLib/templates/macros.html
+++ b/WebHostLib/templates/macros.html
@@ -22,7 +22,7 @@
             {% for patch in room.seed.slots|list|sort(attribute="player_id") %}
                 <tr>
                     <td>{{ patch.player_id }}</td>
-                    <td data-tooltip="Connect via TextClient"><a href="archipelago://{{ patch.player_name | e}}:@{{ config['HOST_ADDRESS'] }}:{{ room.last_port }}">{{ patch.player_name }}</a></td>
+                    <td data-tooltip="Connect via TextClient"><a href="archipelago://{{ patch.player_name | e}}:None@{{ config['HOST_ADDRESS'] }}:{{ room.last_port }}">{{ patch.player_name }}</a></td>
                     <td>{{ patch.game }}</td>
                     <td>
                         {% if patch.data %}


### PR DESCRIPTION
## What is this fixing or adding?
Should make Firefox able to connect again

## How was this tested?
Not on Firefox yet.

## If this makes graphical changes, please attach screenshots.
