### PR TITLE
Tests: use strict equality in some tests

### DIFF
--- a/test/general/test_items.py
+++ b/test/general/test_items.py
@@ -43,15 +43,15 @@ class TestBase(unittest.TestCase):
                     with self.subTest(group_name, group_name=group_name):
                         self.assertNotIn(group_name, world_type.item_name_to_id)
 
-    def test_item_count_greater_equal_locations(self):
-        """Test that by the pre_fill step under default settings, each game submits items >= locations"""
+    def test_item_count_equal_locations(self):
+        """Test that by the pre_fill step under default settings, each game submits items == locations"""
         for game_name, world_type in AutoWorldRegister.world_types.items():
             with self.subTest("Game", game=game_name):
                 multiworld = setup_solo_multiworld(world_type)
-                self.assertGreaterEqual(
+                self.assertEqual(
                     len(multiworld.itempool),
                     len(multiworld.get_unfilled_locations()),
-                    f"{game_name} Item count MUST meet or exceed the number of locations",
+                    f"{game_name} Item count MUST match the number of locations",
                 )
 
     def test_items_in_datapackage(self):

--- a/test/general/test_locations.py
+++ b/test/general/test_locations.py
@@ -11,14 +11,14 @@ class TestBase(unittest.TestCase):
             multiworld = setup_solo_multiworld(world_type)
             locations = Counter(location.name for location in multiworld.get_locations())
             if locations:
-                self.assertLessEqual(locations.most_common(1)[0][1], 1,
-                                     f"{world_type.game} has duplicate of location name {locations.most_common(1)}")
+                self.assertEqual(locations.most_common(1)[0][1], 1,
+                                 f"{world_type.game} has duplicate of location name {locations.most_common(1)}")
 
             locations = Counter(location.address for location in multiworld.get_locations()
                                 if type(location.address) is int)
             if locations:
-                self.assertLessEqual(locations.most_common(1)[0][1], 1,
-                                     f"{world_type.game} has duplicate of location ID {locations.most_common(1)}")
+                self.assertEqual(locations.most_common(1)[0][1], 1,
+                                 f"{world_type.game} has duplicate of location ID {locations.most_common(1)}")
 
     def test_locations_in_datapackage(self):
         """Tests that created locations not filled before fill starts exist in the datapackage."""


### PR DESCRIPTION
## What is this fixing or adding?

As the title says, make two tests' comparisons strict equality instead of less/greater than or equal.

In particular, `test_item_count[_greater]_equal_locations` becomes a very useful test for catching simple off-by-N errors once its comparison is made strict. I've already caught multiple bugs in my (unsupported) world with this change. `#archipelago-dev` believes this test started out with .assertGreaterEqual() only because .assertEqual() would not have passed at the time, but today it does.

## How was this tested?

Ran all unittests in PyCharm on my machine on this branch

<img width="570" alt="image" src="https://github.com/ArchipelagoMW/Archipelago/assets/5285357/aebab4f3-8ec3-48ac-a852-730fe4b9281a">
