### PR TITLE
Lingo: Enable start_inventory_from_pool

### DIFF
--- a/worlds/lingo/__init__.py
+++ b/worlds/lingo/__init__.py
@@ -82,9 +82,8 @@ class LingoWorld(World):
                 skips = int(non_traps * skip_percentage / 100.0)
                 non_skips = non_traps - skips
 
-                filler_list = [":)", "The Feeling of Being Lost", "Wanderlust", "Empty White Hallways"]
                 for i in range(0, non_skips):
-                    pool.append(self.create_item(filler_list[i % len(filler_list)]))
+                    pool.append(self.create_item(self.get_filler_item_name()))
 
                 for i in range(0, skips):
                     pool.append(self.create_item("Puzzle Skip"))
@@ -130,3 +129,7 @@ class LingoWorld(World):
             slot_data["painting_entrance_to_exit"] = self.player_logic.painting_mapping
 
         return slot_data
+
+    def get_filler_item_name(self) -> str:
+        filler_list = [":)", "The Feeling of Being Lost", "Wanderlust", "Empty White Hallways"]
+        return self.random.choice(filler_list)

--- a/worlds/lingo/options.py
+++ b/worlds/lingo/options.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from Options import Toggle, Choice, DefaultOnToggle, Range, PerGameCommonOptions
+from Options import Toggle, Choice, DefaultOnToggle, Range, PerGameCommonOptions, StartInventoryPool
 
 
 class ShuffleDoors(Choice):
@@ -136,3 +136,4 @@ class LingoOptions(PerGameCommonOptions):
     trap_percentage: TrapPercentage
     puzzle_skip_percentage: PuzzleSkipPercentage
     death_link: DeathLink
+    start_inventory_from_pool: StartInventoryPool


### PR DESCRIPTION
## What is this fixing or adding?
Enables start_inventory_from_pool option. get_filler_item_name is also implemented now. Filler items are distributed differently now; they are chosen at random instead of sequentially, which has no impact on gameplay as all filler items are no-ops.

## How was this tested?
Test generation with a couple of different options.

## If this makes graphical changes, please attach screenshots.
