### PR TITLE
Lingo: Fix non-progressive The Colorful

### DIFF
--- a/worlds/lingo/items.py
+++ b/worlds/lingo/items.py
@@ -24,14 +24,6 @@ class ItemData(NamedTuple):
             return world.options.shuffle_colors > 0
         elif self.mode == "doors":
             return world.options.shuffle_doors != ShuffleDoors.option_none
-        elif self.mode == "orange tower":
-            # door shuffle is on and tower isn't progressive
-            return world.options.shuffle_doors != ShuffleDoors.option_none \
-                and not world.options.progressive_orange_tower
-        elif self.mode == "the colorful":
-            # complex door shuffle is on and colorful isn't progressive
-            return world.options.shuffle_doors == ShuffleDoors.option_complex \
-                and not world.options.progressive_colorful
         elif self.mode == "complex door":
             return world.options.shuffle_doors == ShuffleDoors.option_complex
         elif self.mode == "door group":
@@ -72,12 +64,7 @@ def load_item_data():
                 door_groups.setdefault(door.group, []).extend(door.door_ids)
 
             if room_name in PROGRESSION_BY_ROOM and door_name in PROGRESSION_BY_ROOM[room_name]:
-                if room_name == "Orange Tower":
-                    door_mode = "orange tower"
-                elif room_name == "The Colorful":
-                    door_mode = "the colorful"
-                else:
-                    door_mode = "special"
+                door_mode = "special"
 
             ALL_ITEM_TABLE[door.item_name] = \
                 ItemData(get_door_item_id(room_name, door_name),

--- a/worlds/lingo/player_logic.py
+++ b/worlds/lingo/player_logic.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Dict, List, NamedTuple, Optional, Set, Tuple, TYPE_CHECKING
 
 from .items import ALL_ITEM_TABLE
@@ -34,6 +35,27 @@ class PlayerLocation(NamedTuple):
     name: str
     code: Optional[int]
     access: AccessRequirements
+
+
+class ProgressiveItemBehavior(Enum):
+    DISABLE = 1
+    SPLIT = 2
+    PROGRESSIVE = 3
+
+
+def should_split_progression(progression_name: str, world: "LingoWorld") -> ProgressiveItemBehavior:
+    if progression_name == "Progressive Orange Tower":
+        if world.options.progressive_orange_tower:
+            return ProgressiveItemBehavior.PROGRESSIVE
+        else:
+            return ProgressiveItemBehavior.SPLIT
+    elif progression_name == "Progressive Colorful":
+        if world.options.progressive_colorful:
+            return ProgressiveItemBehavior.PROGRESSIVE
+        else:
+            return ProgressiveItemBehavior.SPLIT
+
+    return ProgressiveItemBehavior.PROGRESSIVE
 
 
 class LingoPlayerLogic:
@@ -83,10 +105,13 @@ class LingoPlayerLogic:
 
     def handle_non_grouped_door(self, room_name: str, door_data: Door, world: "LingoWorld"):
         if room_name in PROGRESSION_BY_ROOM and door_data.name in PROGRESSION_BY_ROOM[room_name]:
-            if (room_name == "Orange Tower" and not world.options.progressive_orange_tower)\
-                    or (room_name == "The Colorful" and not world.options.progressive_colorful):
+            progression_name = PROGRESSION_BY_ROOM[room_name][door_data.name].item_name
+            progression_handling = should_split_progression(progression_name, world)
+
+            if progression_handling == ProgressiveItemBehavior.SPLIT:
                 self.set_door_item(room_name, door_data.name, door_data.item_name)
-            else:
+                self.real_items.append(door_data.item_name)
+            elif progression_handling == ProgressiveItemBehavior.PROGRESSIVE:
                 progressive_item_name = PROGRESSION_BY_ROOM[room_name][door_data.name].item_name
                 self.set_door_item(room_name, door_data.name, progressive_item_name)
                 self.real_items.append(progressive_item_name)


### PR DESCRIPTION
## What is this fixing or adding?
The Colorful did not actually properly split into individual doors when progressive colorful was off. This change refactors the code that handles special cases with progressive items to make things clearer (which is important because I will be introducing another one).

## How was this tested?
Test generations and pytest.

## If this makes graphical changes, please attach screenshots.
