### PR TITLE
Core: Fix creation of options for an item link group

### DIFF
--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -416,9 +416,9 @@ class World(metaclass=AutoWorldRegister):
         An example case is ItemLinks creating these."""
         # TODO remove loop when worlds use options dataclass
         for option_key, option in cls.options_dataclass.type_hints.items():
-            getattr(multiworld, option_key)[new_player_id] = option(option.default)
+            getattr(multiworld, option_key)[new_player_id] = option.from_any(option.default)
         group = cls(multiworld, new_player_id)
-        group.options = cls.options_dataclass(**{option_key: option(option.default)
+        group.options = cls.options_dataclass(**{option_key: option.from_any(option.default)
                                                  for option_key, option in cls.options_dataclass.type_hints.items()})
 
         return group


### PR DESCRIPTION
## What is this fixing or adding?
https://discord.com/channels/731205301247803413/1201171226886951022/1201171226886951022
calls the from_any for initialization of options of item links groups instead of the constructor, to support things like default = random

## How was this tested?
https://discord.com/channels/731205301247803413/1201171226886951022/1202004618889154570

## If this makes graphical changes, please attach screenshots.
