### PR TITLE
LTTP: Create Hyrule Castle Big Key Rule On Universal Small Keys Option

### DIFF
--- a/worlds/alttp/Rules.py
+++ b/worlds/alttp/Rules.py
@@ -968,6 +968,9 @@ def standard_rules(world, player):
 
         set_rule(world.get_location('Sewers - Key Rat Key Drop', player),
                  lambda state: state._lttp_has_key('Small Key (Hyrule Castle)', player, 3))
+    else:
+        set_rule(world.get_location('Hyrule Castle - Zelda\'s Chest', player),
+                 lambda state: state.has('Big Key (Hyrule Castle)', player))
 
 def toss_junk_item(world, player):
     items = ['Rupees (20)', 'Bombs (3)', 'Arrows (10)', 'Rupees (5)', 'Rupee (1)', 'Bombs (10)',


### PR DESCRIPTION
## What is this fixing or adding?
Fixes a bug in which the Zelda's Chest rule requiring the Big Key is skipped if Universal Small Keys is on, which also causes the Throne Room entrance, and by extension the rest of the outside world, to be in logic without the Hyrule Castle Big Key.

## How was this tested?
Generating and observing spoiler playthrough showing the Hyrule Castle Big Key in sphere 1 and everything beyond the Throne Room in sphere 2 or later.