### PR TITLE
Core: remove module level AutoWorld import from BaseClasses

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -18,11 +18,14 @@ import NetUtils
 import Options
 import Utils
 
+if typing.TYPE_CHECKING:
+    from worlds import AutoWorld
+
 
 class Group(TypedDict, total=False):
     name: str
     game: str
-    world: auto_world
+    world: "AutoWorld.World"
     players: Set[int]
     item_pool: Set[str]
     replacement_items: Dict[int, Optional[str]]
@@ -55,7 +58,7 @@ class MultiWorld():
     plando_texts: List[Dict[str, str]]
     plando_items: List[List[Dict[str, Any]]]
     plando_connections: List
-    worlds: Dict[int, auto_world]
+    worlds: Dict[int, "AutoWorld.World"]
     groups: Dict[int, Group]
     regions: RegionManager
     itempool: List[Item]
@@ -219,6 +222,8 @@ class MultiWorld():
     def add_group(self, name: str, game: str, players: Set[int] = frozenset()) -> Tuple[int, Group]:
         """Create a group with name and return the assigned player ID and group.
         If a group of this name already exists, the set of players is extended instead of creating a new one."""
+        from worlds import AutoWorld
+
         for group_id, group in self.groups.items():
             if group["name"] == name:
                 group["players"] |= players
@@ -253,6 +258,8 @@ class MultiWorld():
 
     def set_options(self, args: Namespace) -> None:
         # TODO - remove this section once all worlds use options dataclasses
+        from worlds import AutoWorld
+
         all_keys: Set[str] = {key for player in self.player_ids for key in
                               AutoWorld.AutoWorldRegister.world_types[self.game[player]].options_dataclass.type_hints}
         for option_key in all_keys:
@@ -270,6 +277,8 @@ class MultiWorld():
                                                                for option_key in options_dataclass.type_hints})
 
     def set_item_links(self):
+        from worlds import AutoWorld
+
         item_links = {}
         replacement_prio = [False, True, None]
         for player in self.player_ids:
@@ -1326,6 +1335,8 @@ class Spoiler:
                             get_path(state, multiworld.get_region('Inverted Big Bomb Shop', player))
 
     def to_file(self, filename: str) -> None:
+        from worlds import AutoWorld
+
         def write_option(option_key: str, option_obj: Options.AssembleOptions) -> None:
             res = getattr(self.multiworld.worlds[player].options, option_key)
             display_name = getattr(option_obj, "display_name", option_key)
@@ -1449,8 +1460,3 @@ def get_seed(seed: Optional[int] = None) -> int:
         random.seed(None)
         return random.randint(0, pow(10, seeddigits) - 1)
     return seed
-
-
-from worlds import AutoWorld
-
-auto_world = AutoWorld.World


### PR DESCRIPTION
## What is this fixing or adding?

With BaseClasses running `worlds/__init__.py` and worlds importing `from BaseClasses`, this is likely to result in some extra code being run because of partial recursive imports. This now lazily loads worlds when needed, at which point `sys.modules` should be properly populated.

Total time to run `python test/benchmark/load_worlds.py` is 50-100ms faster for me with this change, but that might be a fluke (noise level is pretty high).

## How was this tested?

Unit tests

Rolling a simple item_link and looking at the spoiler to see the link was created.