### PR TITLE
FFMQ: fix `__version__` import in Output.py

### DIFF
--- a/worlds/ffmq/Output.py
+++ b/worlds/ffmq/Output.py
@@ -3,7 +3,7 @@ import os
 import zipfile
 from copy import deepcopy
 from .Regions import object_id_table
-from Main import __version__
+from Utils import __version__
 from worlds.Files import APContainer
 import pkgutil
 


### PR DESCRIPTION
## What is this fixing or adding?

Importing from Main is a recursive import during Generate, also it's not listed in `Main.__all__` (and pycharm warns about this).

## How was this tested?

Only ran unit tests.