### PR TITLE
CommonClient: Fix item link group name when member slot name contains brackets

### DIFF
--- a/kvui.py
+++ b/kvui.py
@@ -709,7 +709,7 @@ class KivyJSONtoTextParser(JSONtoTextParser):
                    f"Type: {SlotType(slot_info.type).name}"
             if slot_info.group_members:
                 text += f"<br>Members:<br> " + "<br> ".join(
-                    self.ctx.player_names[player].replace("[", "&bl;").replace("]", "&br;")
+                    escape_markup(self.ctx.player_names[player])
                     for player in slot_info.group_members
                 )
             node.setdefault("refs", []).append(text)

--- a/kvui.py
+++ b/kvui.py
@@ -708,8 +708,10 @@ class KivyJSONtoTextParser(JSONtoTextParser):
             text = f"Game: {slot_info.game}<br>" \
                    f"Type: {SlotType(slot_info.type).name}"
             if slot_info.group_members:
-                text += f"<br>Members:<br> " + \
-                        "<br> ".join(self.ctx.player_names[player] for player in slot_info.group_members)
+                text += f"<br>Members:<br> " + "<br> ".join(
+                    self.ctx.player_names[player].replace("[", "&bl;").replace("]", "&br;")
+                    for player in slot_info.group_members
+                )
             node.setdefault("refs", []).append(text)
         return super(KivyJSONtoTextParser, self)._handle_player_id(node)
 


### PR DESCRIPTION
## What is this fixing or adding?

Previously a close bracket was interpreted as ending the tooltip, causing the remainder of the text to spill into the log. Now it does  not.

Fixes https://discord.com/channels/731205301247803413/1203150255982518384

## How was this tested?

Created an item link group where a member's slot name contained brackets. Observed bug. Created a new room with the same seed and the fix in this PR. Confirmed it's fixed.

## If this makes graphical changes, please attach screenshots.

Before:

![image](https://github.com/ArchipelagoMW/Archipelago/assets/2065960/a496eb56-de80-4f0c-8043-f11a45a53d22)

After:

![image](https://github.com/ArchipelagoMW/Archipelago/assets/2065960/7219af35-4f2f-4cbf-bdc6-ba8a8f2ea8a2)
