### PR TITLE
TUNIC: Add an ER static connection, modify an nmg rule

### DIFF
--- a/worlds/tunic/er_rules.py
+++ b/worlds/tunic/er_rules.py
@@ -444,6 +444,13 @@ def set_er_region_rules(world: "TunicWorld", ability_unlocks: Dict[str, int], re
     regions["Quarry"].connect(
         connecting_region=regions["Quarry Monastery Entry"])
 
+    regions["Quarry Monastery Entry"].connect(
+        connecting_region=regions["Quarry Back"],
+        rule=lambda state: state.has(laurels, player))
+    regions["Quarry Back"].connect(
+        connecting_region=regions["Quarry Monastery Entry"],
+        rule=lambda state: state.has(laurels, player))
+
     regions["Monastery Rope"].connect(
         connecting_region=regions["Quarry Back"])
 

--- a/worlds/tunic/options.py
+++ b/worlds/tunic/options.py
@@ -37,8 +37,9 @@ class LogicRules(Choice):
     """Set which logic rules to use for your world.
     Restricted: Standard logic, no glitches.
     No Major Glitches: Ice grapples through doors, shooting the west bell, and boss quick kills are included in logic.
+    * Ice grappling through the Ziggurat door is not in logic since you will get stuck in there without Prayer
     Unrestricted: Logic in No Major Glitches, as well as ladder storage to get to certain places early.
-    *Special Shop is not in logic without the Hero's Laurels in Unrestricted due to soft lock potential.
+    *Special Shop is not in logic without the Hero's Laurels due to soft lock potential.
     *Using Ladder Storage to get to individual chests is not in logic to avoid tedium.
     *Getting knocked out of the air by enemies during Ladder Storage to reach places is not in logic, except for in
     Rooted Ziggurat Lower. This is so you're not punished for playing with enemy rando on."""

--- a/worlds/tunic/rules.py
+++ b/worlds/tunic/rules.py
@@ -130,8 +130,7 @@ def set_region_rules(world: "TunicWorld", ability_unlocks: Dict[str, int]) -> No
     multiworld.get_entrance("Quarry -> Lower Quarry", player).access_rule = \
         lambda state: has_mask(state, player, options)
     multiworld.get_entrance("Lower Quarry -> Rooted Ziggurat", player).access_rule = \
-        lambda state: (state.has(grapple, player) and has_ability(state, player, prayer, options, ability_unlocks)) \
-        or has_ice_grapple_logic(False, state, player, options, ability_unlocks)
+        lambda state: state.has(grapple, player) and has_ability(state, player, prayer, options, ability_unlocks)
     multiworld.get_entrance("Quarry -> Rooted Ziggurat", player).access_rule = \
         lambda state: has_ice_grapple_logic(False, state, player, options, ability_unlocks)
     multiworld.get_entrance("Swamp -> Cathedral", player).access_rule = \


### PR DESCRIPTION
## What is this fixing or adding?
Adds entrances between the Monastery Front region (the space in front of Monastery) and Quarry Back (the mountain stairs down to where the miasma starts), with a rule of having Laurels. This is just an easy connection to make since no combat is required, so you don't need a sword/wand for it.
This is for Entrance Rando only, since non-entrance rando does not split up Quarry to this degree.

Also removed an access rule from an entrance, as we changed our minds on having the player causing a potential soft lock.

## How was this tested?
A few test generations.

## If this makes graphical changes, please attach screenshots.
N/A