### PR TITLE
Core: APPatch interface

### DIFF
--- a/Patch.py
+++ b/Patch.py
@@ -8,7 +8,7 @@ if __name__ == "__main__":
     import ModuleUpdate
     ModuleUpdate.update()
 
-from worlds.Files import AutoPatchRegister, APDeltaPatch
+from worlds.Files import AutoPatchRegister, APPatch
 
 
 class RomMeta(TypedDict):
@@ -20,7 +20,7 @@ class RomMeta(TypedDict):
 def create_rom_file(patch_file: str) -> Tuple[RomMeta, str]:
     auto_handler = AutoPatchRegister.get_handler(patch_file)
     if auto_handler:
-        handler: APDeltaPatch = auto_handler(patch_file)
+        handler: APPatch = auto_handler(patch_file)
         target = os.path.splitext(patch_file)[0]+handler.result_file_ending
         handler.patch(target)
         return {"server": handler.server,


### PR DESCRIPTION
## What is this fixing or adding?

Whether https://github.com/ArchipelagoMW/Archipelago/pull/2536 is what we want or not,
if we are going to have different types of patch files, we should have an interface that defines what is required for them.

We can see in `Patch.create_rom_file` that, in addition to members from `APContainer`, the patch only needs to have a `result_file_ending`, and a `patch` method.

This interface would give a path for other implementations that don't need or want everything offered by `APProcedurePatch`.

Here is what it looks like combined with the `APProcedurePatch` PR: https://github.com/Silvris/Archipelago/pull/2

## How was this tested?

generated and played a rom file game that uses `APDeltaPatch` (Zillion)
