### PR TITLE
CI: Add a workflow which automates some labeling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,6 @@
 'is: documentation':
 - changed-files:
-  - any-glob-to-all-files: '{**/docs/**,**/README.md}'
+  - all-globs-to-all-files: '{**/docs/**,**/README.md}'
 
 'affects: webhost':
 - changed-files:
@@ -25,5 +25,6 @@
     - '!worlds/**'
     - '!WebHost.py'
     - '!WebHostLib/**'
-  - any-glob-to-any-file:
+  - any-glob-to-any-file: # exceptions to the above rules of "stuff that isn't core"
     - 'worlds/generic/**/*.py'
+    - 'CommonClient.py'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,7 +1,8 @@
 'is: documentation':
 - changed-files:
-  - all-globs-to-any-file: '**/docs/**'
-  - all-globs-to-any-file: '**/README.md'
+  - any-glob-to-all-files:
+    - '**/docs/**'
+    - '**/README.md'
 
 'affects: webhost':
 - changed-files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -18,7 +18,7 @@
           - '!LICENSE'
           - '!*.yml'
           - '!.gitignore'
-          - '!docs/**'
+          - '!**/docs/**'
           - '!typings/kivy/**'
           - '!test/**'
           - '!data/**'
@@ -27,4 +27,4 @@
           - '!worlds_disabled/**'
           - '!worlds/**'
       - any-glob-to-any-file:
-          - 'worlds/generic/**'
+          - 'worlds/generic/**/*.py'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,9 +5,8 @@
 
 'affects: webhost':
 - changed-files:
-  - any-glob-to-any-file:
-    - 'WebHost.py'
-    - 'WebHostLib/**/*'
+  - all-globs-to-any-file: 'WebHost.py'
+  - all-globs-to-any-file: 'WebHostLib/**/*'
 
 'affects: core':
 - changed-files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,30 @@
+'is: documentation':
+  - changed-files:
+      - any-glob-to-all-files:
+          - '**/docs/**'
+          - '**/README.md'
+
+'affects: webhost':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'WebHost.py'
+          - 'WebHostLib/**/*'
+
+'affects: core':
+  - changed-files:
+      - all-globs-to-any-file:
+          - '!*Client.py'
+          - '!README.md'
+          - '!LICENSE'
+          - '!*.yml'
+          - '!.gitignore'
+          - '!docs/**'
+          - '!typings/kivy/**'
+          - '!test/**'
+          - '!data/**'
+          - '!.run/**'
+          - '!.github/**'
+          - '!worlds_disabled/**'
+          - '!worlds/**'
+      - any-glob-to-any-file:
+          - 'worlds/generic/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,8 +1,8 @@
 'is: documentation':
-  - changed-files:
-      - any-glob-to-all-files:
-          - '**/docs/**'
-          - '**/README.md'
+  - all:
+    - changed-files:
+        - all-globs-to-any-file: '**/docs/**'
+        - all-globs-to-any-file: '**/README.md'
 
 'affects: webhost':
   - changed-files:
@@ -26,5 +26,7 @@
           - '!.github/**'
           - '!worlds_disabled/**'
           - '!worlds/**'
+          - '!WebHost.py'
+          - '!WebHostLib/**'
       - any-glob-to-any-file:
           - 'worlds/generic/**/*.py'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,7 +1,6 @@
 'is: documentation':
 - changed-files:
-  - any-glob-to-all-files:
-    - '{**/docs/**,**/README.md}'
+  - any-glob-to-all-files: '{**/docs/**,**/README.md}'
 
 'affects: webhost':
 - changed-files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,32 +1,31 @@
 'is: documentation':
-  - all:
-    - changed-files:
-        - all-globs-to-any-file: '**/docs/**'
-        - all-globs-to-any-file: '**/README.md'
+- changed-files:
+  - all-globs-to-any-file: '**/docs/**'
+  - all-globs-to-any-file: '**/README.md'
 
 'affects: webhost':
-  - changed-files:
-      - any-glob-to-any-file:
-          - 'WebHost.py'
-          - 'WebHostLib/**/*'
+- changed-files:
+  - any-glob-to-any-file:
+    - 'WebHost.py'
+    - 'WebHostLib/**/*'
 
 'affects: core':
-  - changed-files:
-      - all-globs-to-any-file:
-          - '!*Client.py'
-          - '!README.md'
-          - '!LICENSE'
-          - '!*.yml'
-          - '!.gitignore'
-          - '!**/docs/**'
-          - '!typings/kivy/**'
-          - '!test/**'
-          - '!data/**'
-          - '!.run/**'
-          - '!.github/**'
-          - '!worlds_disabled/**'
-          - '!worlds/**'
-          - '!WebHost.py'
-          - '!WebHostLib/**'
-      - any-glob-to-any-file:
-          - 'worlds/generic/**/*.py'
+- changed-files:
+  - all-globs-to-any-file:
+    - '!*Client.py'
+    - '!README.md'
+    - '!LICENSE'
+    - '!*.yml'
+    - '!.gitignore'
+    - '!**/docs/**'
+    - '!typings/kivy/**'
+    - '!test/**'
+    - '!data/**'
+    - '!.run/**'
+    - '!.github/**'
+    - '!worlds_disabled/**'
+    - '!worlds/**'
+    - '!WebHost.py'
+    - '!WebHostLib/**'
+  - any-glob-to-any-file:
+    - 'worlds/generic/**/*.py'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,8 +1,7 @@
 'is: documentation':
 - changed-files:
   - any-glob-to-all-files:
-    - '**/docs/**'
-    - '**/README.md'
+    - '{**/docs/**,**/README.md}'
 
 'affects: webhost':
 - changed-files:

--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/labeler@v5
+        with:
+          sync-labels: true
   peer_review:
     name: 'Apply peer review label'
     if: >-

--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -2,7 +2,7 @@ name: Label Pull Request
 on:
   pull_request_target:
     types: ['opened', 'reopened', 'synchronize', 'ready_for_review', 'converted_to_draft', 'closed']
-    branches: ['main']
+    # branches: ['main']
 permissions:
   contents: read
   pull-requests: write
@@ -13,7 +13,6 @@ jobs:
     if: github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
       - uses: actions/labeler@v5
         with:
           sync-labels: true

--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -2,6 +2,7 @@ name: Label Pull Request
 on:
   pull_request_target:
     types: ['opened', 'reopened', 'synchronize', 'ready_for_review', 'converted_to_draft', 'closed']
+    branches: ['main']
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -2,7 +2,7 @@ name: Label Pull Request
 on:
   pull_request_target:
     types: ['opened', 'reopened', 'synchronize', 'ready_for_review', 'converted_to_draft', 'closed']
-    # branches: ['main']
+    branches: ['main']
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -1,7 +1,7 @@
 name: Label Pull Request
 on:
   pull_request_target:
-    types: ['opened', 'reopened', 'edited', 'ready_for_review', 'converted_to_draft']
+    types: ['opened', 'reopened', 'edited', 'ready_for_review', 'converted_to_draft', 'closed']
 permissions:
   contents: read
   pull-requests: write
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/labeler@v5
   peer_review:
-    name: 'Apply peer review tag'
+    name: 'Apply peer review label'
     if: >-
       (github.event.action == 'opened' || github.event.action == 'reopened' || 
       github.event.action == 'ready_for_review') && !github.event.pull_request.draft
@@ -27,8 +27,8 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   unblock_draft_prs:
-    name: 'Remove waiting-on labels for drafts'
-    if: github.event.action == 'converted_to_draft'
+    name: 'Remove waiting-on labels'
+    if: github.event.action == 'converted_to_draft' || github.event.action == 'closed'
     runs-on: ubuntu-latest
     steps:
       - name: 'Remove labels'

--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -1,7 +1,7 @@
 name: Label Pull Request
 on:
   pull_request_target:
-    types: ['opened', 'reopened', 'edited', 'ready_for_review', 'converted_to_draft', 'closed']
+    types: ['opened', 'reopened', 'synchronize', 'ready_for_review', 'converted_to_draft', 'closed']
 permissions:
   contents: read
   pull-requests: write
@@ -9,7 +9,7 @@ permissions:
 jobs:
   labeler:
     name: 'Apply content-based labels'
-    if: github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'edited'
+    if: github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -1,14 +1,40 @@
 name: Label Pull Request
 on:
   pull_request_target:
-    types: ['opened', 'edited']
+    types: ['opened', 'edited', 'ready_for_review', 'converted_to_draft']
 permissions:
   contents: read
   pull-requests: write
 
 jobs:
-  apply_content_based_labels:
+  labeler:
+    name: 'Apply content-based labels'
+    if: contains(['opened', 'edited'], github.event.action)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/labeler@v5
+  peer_review:
+    name: 'Apply peer review tag'
+    if: contains(['opened', 'ready_for_review'], github.event.action) && !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Add label'
+        run: "gh pr edit \"$PR_URL\" --add-label 'waiting-on: peer-review'"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  unblock_draft_prs:
+    name: 'Remove waiting-on labels for drafts'
+    if: github.event.action == 'converted_to_draft'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Remove labels'
+        run: >-
+          gh pr edit "$PR_URL" --remove-label 'waiting-on: peer-review'
+            --remove-label 'waiting-on: core-review'
+            --remove-label 'waiting-on: world-maintainer'
+            --remove-label 'waiting-on: author'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -30,10 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Remove labels'
-        run: >-
-          gh pr edit "$PR_URL" --remove-label 'waiting-on: peer-review'
-            --remove-label 'waiting-on: core-review'
-            --remove-label 'waiting-on: world-maintainer'
+        run: |-
+          gh pr edit "$PR_URL" --remove-label 'waiting-on: peer-review' \
+            --remove-label 'waiting-on: core-review' \
+            --remove-label 'waiting-on: world-maintainer' \
             --remove-label 'waiting-on: author'
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -1,7 +1,7 @@
 name: Label Pull Request
 on:
   pull_request_target:
-    types: ['opened', 'edited', 'ready_for_review', 'converted_to_draft']
+    types: ['opened', 'reopened', 'edited', 'ready_for_review', 'converted_to_draft']
 permissions:
   contents: read
   pull-requests: write
@@ -9,14 +9,16 @@ permissions:
 jobs:
   labeler:
     name: 'Apply content-based labels'
-    if: github.event.action == 'opened' || github.event.action == 'edited'
+    if: github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'edited'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/labeler@v5
   peer_review:
     name: 'Apply peer review tag'
-    if: (github.event.action == 'opened' || github.event.action == 'ready_for_review') && !github.event.pull_request.draft
+    if: >-
+      (github.event.action == 'opened' || github.event.action == 'reopened' || 
+      github.event.action == 'ready_for_review') && !github.event.pull_request.draft
     runs-on: ubuntu-latest
     steps:
       - name: 'Add label'

--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -9,14 +9,14 @@ permissions:
 jobs:
   labeler:
     name: 'Apply content-based labels'
-    if: contains(['opened', 'edited'], github.event.action)
+    if: github.event.action == 'opened' || github.event.action == 'edited'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/labeler@v5
   peer_review:
     name: 'Apply peer review tag'
-    if: contains(['opened', 'ready_for_review'], github.event.action) && !github.event.pull_request.draft
+    if: (github.event.action == 'opened' || github.event.action == 'ready_for_review') && !github.event.pull_request.draft
     runs-on: ubuntu-latest
     steps:
       - name: 'Add label'

--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -1,0 +1,14 @@
+name: Label Pull Request
+on:
+  pull_request_target:
+    types: ['opened', 'edited']
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  apply_content_based_labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/labeler@v5


### PR DESCRIPTION
## What is this fixing or adding?

First and foremost, a lot of commits. You should probably squash merge this.

There are 2 categories of automated labeling described below.

### Content-based labeling

Several labels are applied based on the content of the PR. When the PR is updated, labels may be added and removed accordingly  with the changes.

* the `is: documentation` label is added to any PRs which only affects things in docs folders, or any README.md file.
* the `affects: webhost` label is added if any change to WebHost.py or any content in the WebHostLib folder.
* the `affects: core` label is added if any non-world file is modified, with a large handful of exceptions. Changes to .py files in worlds/generic are also counted.

### State-based labeling

The `waiting-on:` labels are added and removed during certain PR events.

* When a non-draft PR is opened or reopened, the `waiting-on: peer-review` label is automatically added. The same applies when a draft PR is marked ready for review.
* When a PR is converted to draft or closed, all `waiting-on:` labels are removed.

## How was this tested?
Through numerous PRs against my own fork, the most notable of which is this one: https://github.com/BadMagic100/Archipelago/pull/18
