### PR TITLE
FF1: Fix items getting resent on disconnect/connect

### DIFF
--- a/data/lua/connector_ff1.lua
+++ b/data/lua/connector_ff1.lua
@@ -322,7 +322,7 @@ function processBlock(block)
                 end
             end
         end
-        if #itemsBlock ~= itemIndex then
+        if #itemsBlock > itemIndex then
             wU8(ITEM_INDEX, #itemsBlock)
         end
 


### PR DESCRIPTION
## What is this fixing or adding?
When the client would disconnect during gameplay, the internal count of items would get reset to 0; upon reconnecting to the client, AP would resend every items received creating duplicate of all items.

## How was this tested?
Beta tested over the course of 2 weeks by 3 players without any issue.
