### PR TITLE
TUNIC: Fix duplicate entrance name in ER

### DIFF
--- a/worlds/tunic/er_rules.py
+++ b/worlds/tunic/er_rules.py
@@ -377,13 +377,13 @@ def set_er_region_rules(world: "TunicWorld", ability_unlocks: Dict[str, int], re
     # nmg: ice grapple through the big gold door, can do it both ways
     regions["Eastern Vault Fortress"].connect(
         connecting_region=regions["Eastern Vault Fortress Gold Door"],
-        name="Fortress Gold Door",
+        name="Fortress to Gold Door",
         rule=lambda state: state.has_all({"Activate Eastern Vault West Fuses",
                                           "Activate Eastern Vault East Fuse"}, player)
         or has_ice_grapple_logic(False, state, player, options, ability_unlocks))
     regions["Eastern Vault Fortress Gold Door"].connect(
         connecting_region=regions["Eastern Vault Fortress"],
-        name="Fortress Gold Door",
+        name="Gold Door to Fortress",
         rule=lambda state: has_ice_grapple_logic(True, state, player, options, ability_unlocks))
 
     regions["Fortress Grave Path"].connect(


### PR DESCRIPTION
## What is this fixing or adding?
Fix a duplicate entrance name, which fails the test here https://github.com/ArchipelagoMW/Archipelago/pull/2453

## How was this tested?
Fixed name, ran gen

## If this makes graphical changes, please attach screenshots.
N/A