### PR TITLE
CommonClient: Add commands to view Item/Location Groups

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -115,6 +115,15 @@ class ClientCommandProcessor(CommandProcessor):
         for item_name in AutoWorldRegister.world_types[self.ctx.game].item_name_to_id:
             self.output(item_name)
 
+    def _cmd_item_groups(self):
+        """List all item group names for the currently running game."""
+        if not self.ctx.game:
+            self.output("No game set, cannot determine existing item groups.")
+            return False
+        self.output(f"Item Group Names for {self.ctx.game}")
+        for group_name in AutoWorldRegister.world_types[self.ctx.game].item_name_groups:
+            self.output(group_name)
+
     def _cmd_locations(self):
         """List all location names for the currently running game."""
         if not self.ctx.game:
@@ -123,6 +132,15 @@ class ClientCommandProcessor(CommandProcessor):
         self.output(f"Location Names for {self.ctx.game}")
         for location_name in AutoWorldRegister.world_types[self.ctx.game].location_name_to_id:
             self.output(location_name)
+
+    def _cmd_location_groups(self):
+        """List all location group names for the currently running game."""
+        if not self.ctx.game:
+            self.output("No game set, cannot determine existing location groups.")
+            return False
+        self.output(f"Location Group Names for {self.ctx.game}")
+        for group_name in AutoWorldRegister.world_types[self.ctx.game].location_name_groups:
+            self.output(group_name)
 
     def _cmd_ready(self):
         """Send ready status to server."""


### PR DESCRIPTION

## What is this fixing or adding?
adds commands to commonClient to see what item and location groups your current game has avaliable

## How was this tested?
ran the commands against a default hollow knight and tunic game and noted the UI output matched expected groups

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/4809984/37b55704-717b-47dd-881d-18b609bcb236)
![image](https://github.com/ArchipelagoMW/Archipelago/assets/4809984/cb3c5ce1-c5f3-421c-88ff-367257052548)
