### PR TITLE
CI: add missing core files to "affects: core" labelling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -27,4 +27,7 @@
     - '!WebHostLib/**'
   - any-glob-to-any-file: # exceptions to the above rules of "stuff that isn't core"
     - 'worlds/generic/**/*.py'
+    - 'worlds/Files.py'
+    - 'worlds/AutoWorld.py'
+    - 'worlds/__init__.py'
     - 'CommonClient.py'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -27,7 +27,5 @@
     - '!WebHostLib/**'
   - any-glob-to-any-file: # exceptions to the above rules of "stuff that isn't core"
     - 'worlds/generic/**/*.py'
-    - 'worlds/Files.py'
-    - 'worlds/AutoWorld.py'
-    - 'worlds/__init__.py'
+    - 'worlds/*.py'
     - 'CommonClient.py'


### PR DESCRIPTION
## What is this fixing or adding?
#2536 lost the "affects: core" tag after resolving conflicts, as the conflicts removed the changes to `Patch.py`, leaving the labeller to see the edits to `worlds/Files.py` and decide it wasn't core enough.

## How was this tested?
Wasn't. Not actually aware of how Github CI can be tested.

## If this makes graphical changes, please attach screenshots.
