### PR TITLE
TUNIC: Add aliases to LogicRules, slightly update description

### DIFF
--- a/worlds/tunic/options.py
+++ b/worlds/tunic/options.py
@@ -36,8 +36,8 @@ class AbilityShuffling(Toggle):
 class LogicRules(Choice):
     """Set which logic rules to use for your world.
     Restricted: Standard logic, no glitches.
-    No Major Glitches: Ice grapples through doors, shooting the west bell, and boss quick kills are included in logic.
-    * Ice grappling through the Ziggurat door is not in logic since you will get stuck in there without Prayer
+    No Major Glitches: Sneaky Laurels zips, ice grapples through doors, shooting the west bell, and boss quick kills are included in logic.
+    * Ice grappling through the Ziggurat door is not in logic since you will get stuck in there without Prayer.
     Unrestricted: Logic in No Major Glitches, as well as ladder storage to get to certain places early.
     *Special Shop is not in logic without the Hero's Laurels due to soft lock potential.
     *Using Ladder Storage to get to individual chests is not in logic to avoid tedium.
@@ -47,7 +47,9 @@ class LogicRules(Choice):
     display_name = "Logic Rules"
     option_restricted = 0
     option_no_major_glitches = 1
+    alias_nmg = 1
     option_unrestricted = 2
+    alias_ur = 2
     default = 0
 
 


### PR DESCRIPTION
## What is this fixing or adding?
Adding a couple of aliases to logic rules, because I keep manually writing in logic_rules: nmg into my yaml and it keeps not working. Also slightly updated the description for this option to include that tricky laurels zips (through certain gates, doors, etc.) are in logic in NMG.

## How was this tested?
Reading

## If this makes graphical changes, please attach screenshots.
N/A