### PR TITLE
Fill: Crash if there are remaining unfilled locations

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -487,6 +487,8 @@ def distribute_items_restrictive(multiworld: MultiWorld) -> None:
         locations_counter.update(location.player for location in unfilled)
         print_data = {"items": items_counter, "locations": locations_counter}
         logging.info(f'Per-Player counts: {print_data})')
+        if unfilled:
+            raise FillError(f"Not enough items to fill all locations.")
 
 
 def flood_items(multiworld: MultiWorld) -> None:


### PR DESCRIPTION
## What is this fixing or adding?
Lots of various bugs that are a bit hard to track down arise from this issue so it's better to just crash loudly with a clear error.

## How was this tested?
commented out my filler gen and watched it crash

## If this makes graphical changes, please attach screenshots.
