### PR TITLE
TUNIC: Rename ability item

### DIFF
--- a/worlds/tunic/__init__.py
+++ b/worlds/tunic/__init__.py
@@ -171,7 +171,7 @@ class TunicWorld(World):
                 passthrough = self.multiworld.re_gen_passthrough["TUNIC"]
                 self.ability_unlocks["Pages 24-25 (Prayer)"] = passthrough["Hexagon Quest Prayer"]
                 self.ability_unlocks["Pages 42-43 (Holy Cross)"] = passthrough["Hexagon Quest Holy Cross"]
-                self.ability_unlocks["Pages 52-53 (Ice Rod)"] = passthrough["Hexagon Quest Ice Rod"]
+                self.ability_unlocks["Pages 52-53 (Icebolt)"] = passthrough["Hexagon Quest Icebolt"]
             
         if self.options.entrance_rando:
             portal_pairs, portal_hints = create_er_regions(self)
@@ -229,7 +229,7 @@ class TunicWorld(World):
             "entrance_rando": self.options.entrance_rando.value,
             "Hexagon Quest Prayer": self.ability_unlocks["Pages 24-25 (Prayer)"],
             "Hexagon Quest Holy Cross": self.ability_unlocks["Pages 42-43 (Holy Cross)"],
-            "Hexagon Quest Ice Rod": self.ability_unlocks["Pages 52-53 (Ice Rod)"],
+            "Hexagon Quest Icebolt": self.ability_unlocks["Pages 52-53 (Icebolt)"],
             "Hexagon Quest Goal": self.options.hexagon_goal.value,
             "Entrance Rando": self.tunic_portal_pairs
         }

--- a/worlds/tunic/er_rules.py
+++ b/worlds/tunic/er_rules.py
@@ -16,7 +16,7 @@ fairies = "Fairy"
 coins = "Golden Coin"
 prayer = "Pages 24-25 (Prayer)"
 holy_cross = "Pages 42-43 (Holy Cross)"
-ice_bolt = "Pages 52-53 (Icebolt)"
+icebolt = "Pages 52-53 (Icebolt)"
 key = "Key"
 house_key = "Old House Key"
 vault_key = "Fortress Vault Key"
@@ -884,7 +884,7 @@ def set_er_location_rules(world: "TunicWorld", ability_unlocks: Dict[str, int]) 
              lambda state: state.has_all({grapple, laurels}, player))
     set_rule(multiworld.get_location("East Forest - Ice Rod Grapple Chest", player), lambda state: (
             state.has_all({grapple, ice_dagger, fire_wand}, player) and
-            has_ability(state, player, ice_bolt, options, ability_unlocks)))
+            has_ability(state, player, icebolt, options, ability_unlocks)))
 
     # West Garden
     set_rule(multiworld.get_location("West Garden - [North] Across From Page Pickup", player),

--- a/worlds/tunic/er_rules.py
+++ b/worlds/tunic/er_rules.py
@@ -16,7 +16,7 @@ fairies = "Fairy"
 coins = "Golden Coin"
 prayer = "Pages 24-25 (Prayer)"
 holy_cross = "Pages 42-43 (Holy Cross)"
-ice_rod = "Pages 52-53 (Ice Rod)"
+ice_bolt = "Pages 52-53 (Icebolt)"
 key = "Key"
 house_key = "Old House Key"
 vault_key = "Fortress Vault Key"
@@ -884,7 +884,7 @@ def set_er_location_rules(world: "TunicWorld", ability_unlocks: Dict[str, int]) 
              lambda state: state.has_all({grapple, laurels}, player))
     set_rule(multiworld.get_location("East Forest - Ice Rod Grapple Chest", player), lambda state: (
             state.has_all({grapple, ice_dagger, fire_wand}, player) and
-            has_ability(state, player, ice_rod, options, ability_unlocks)))
+            has_ability(state, player, ice_bolt, options, ability_unlocks)))
 
     # West Garden
     set_rule(multiworld.get_location("West Garden - [North] Across From Page Pickup", player),

--- a/worlds/tunic/items.py
+++ b/worlds/tunic/items.py
@@ -141,7 +141,7 @@ item_table: Dict[str, TunicItemData] = {
     "Pages 46-47": TunicItemData(ItemClassification.useful, 1, 125, "pages"),
     "Pages 48-49": TunicItemData(ItemClassification.useful, 1, 126, "pages"),
     "Pages 50-51": TunicItemData(ItemClassification.useful, 1, 127, "pages"),
-    "Pages 52-53 (Ice Rod)": TunicItemData(ItemClassification.progression, 1, 128, "pages"),
+    "Pages 52-53 (Icebolt)": TunicItemData(ItemClassification.progression, 1, 128, "pages"),
     "Pages 54-55": TunicItemData(ItemClassification.useful, 1, 129, "pages"),
 }
 
@@ -176,7 +176,7 @@ slot_data_item_names = [
     "Hero Relic - MP",
     "Pages 24-25 (Prayer)",
     "Pages 42-43 (Holy Cross)",
-    "Pages 52-53 (Ice Rod)",
+    "Pages 52-53 (Icebolt)",
     "Red Questagon",
     "Green Questagon",
     "Blue Questagon",
@@ -204,10 +204,10 @@ extra_groups: Dict[str, Set[str]] = {
     "magic rod": {"Magic Wand"},
     "holy cross": {"Pages 42-43 (Holy Cross)"},
     "prayer": {"Pages 24-25 (Prayer)"},
-    "ice rod": {"Pages 52-53 (Ice Rod)"},
+    "icebolt": {"Pages 52-53 (Icebolt)"},
     "melee weapons": {"Stick", "Sword", "Sword Upgrade"},
     "progressive sword": {"Sword Upgrade"},
-    "abilities": {"Pages 24-25 (Prayer)", "Pages 42-43 (Holy Cross)", "Pages 52-53 (Ice Rod)"},
+    "abilities": {"Pages 24-25 (Prayer)", "Pages 42-43 (Holy Cross)", "Pages 52-53 (Icebolt)"},
     "questagons": {"Red Questagon", "Green Questagon", "Blue Questagon", "Gold Questagon"}
 }
 

--- a/worlds/tunic/items.py
+++ b/worlds/tunic/items.py
@@ -205,6 +205,7 @@ extra_groups: Dict[str, Set[str]] = {
     "holy cross": {"Pages 42-43 (Holy Cross)"},
     "prayer": {"Pages 24-25 (Prayer)"},
     "icebolt": {"Pages 52-53 (Icebolt)"},
+    "ice rod": {"Pages 52-53 (Icebolt)"},
     "melee weapons": {"Stick", "Sword", "Sword Upgrade"},
     "progressive sword": {"Sword Upgrade"},
     "abilities": {"Pages 24-25 (Prayer)", "Pages 42-43 (Holy Cross)", "Pages 52-53 (Icebolt)"},

--- a/worlds/tunic/options.py
+++ b/worlds/tunic/options.py
@@ -23,7 +23,7 @@ class KeysBehindBosses(Toggle):
 
 
 class AbilityShuffling(Toggle):
-    """Locks the usage of Prayer, Holy Cross*, and Ice Rod until the relevant pages of the manual have been found.
+    """Locks the usage of Prayer, Holy Cross*, and the Icebolt combo until the relevant pages of the manual have been found.
     If playing Hexagon Quest, abilities are instead randomly unlocked after obtaining 25%, 50%, and 75% of the required
     Hexagon goal amount.
     *Certain Holy Cross usages are still allowed, such as the free bomb codes, the seeking spell, and other

--- a/worlds/tunic/rules.py
+++ b/worlds/tunic/rules.py
@@ -16,7 +16,7 @@ fairies = "Fairy"
 coins = "Golden Coin"
 prayer = "Pages 24-25 (Prayer)"
 holy_cross = "Pages 42-43 (Holy Cross)"
-ice_bolt = "Pages 52-53 (Icebolt)"
+icebolt = "Pages 52-53 (Icebolt)"
 key = "Key"
 house_key = "Old House Key"
 vault_key = "Fortress Vault Key"
@@ -33,7 +33,7 @@ def randomize_ability_unlocks(random: Random, options: TunicOptions) -> Dict[str
         hexagon_goal = options.hexagon_goal.value
         # Set ability unlocks to 25, 50, and 75% of goal amount
         ability_requirement = [hexagon_goal // 4, hexagon_goal // 2, hexagon_goal * 3 // 4]
-    abilities = [prayer, holy_cross, ice_bolt]
+    abilities = [prayer, holy_cross, icebolt]
     random.shuffle(abilities)
     return dict(zip(abilities, ability_requirement))
 
@@ -65,7 +65,7 @@ def has_ice_grapple_logic(long_range: bool, state: CollectionState, player: int,
         return state.has_all({ice_dagger, grapple}, player)
     else:
         return state.has_all({ice_dagger, fire_wand, grapple}, player) and \
-            has_ability(state, player, ice_bolt, options, ability_unlocks)
+            has_ability(state, player, icebolt, options, ability_unlocks)
 
 
 def can_ladder_storage(state: CollectionState, player: int, options: TunicOptions) -> bool:
@@ -251,7 +251,7 @@ def set_location_rules(world: "TunicWorld", ability_unlocks: Dict[str, int]) -> 
              lambda state: state.has_all({grapple, laurels}, player))
     set_rule(multiworld.get_location("East Forest - Ice Rod Grapple Chest", player),
              lambda state: state.has_all({grapple, ice_dagger, fire_wand}, player)
-             and has_ability(state, player, ice_bolt, options, ability_unlocks))
+             and has_ability(state, player, icebolt, options, ability_unlocks))
 
     # West Garden
     set_rule(multiworld.get_location("West Garden - [North] Across From Page Pickup", player),

--- a/worlds/tunic/rules.py
+++ b/worlds/tunic/rules.py
@@ -16,7 +16,7 @@ fairies = "Fairy"
 coins = "Golden Coin"
 prayer = "Pages 24-25 (Prayer)"
 holy_cross = "Pages 42-43 (Holy Cross)"
-ice_rod = "Pages 52-53 (Ice Rod)"
+ice_bolt = "Pages 52-53 (Icebolt)"
 key = "Key"
 house_key = "Old House Key"
 vault_key = "Fortress Vault Key"
@@ -33,7 +33,7 @@ def randomize_ability_unlocks(random: Random, options: TunicOptions) -> Dict[str
         hexagon_goal = options.hexagon_goal.value
         # Set ability unlocks to 25, 50, and 75% of goal amount
         ability_requirement = [hexagon_goal // 4, hexagon_goal // 2, hexagon_goal * 3 // 4]
-    abilities = [prayer, holy_cross, ice_rod]
+    abilities = [prayer, holy_cross, ice_bolt]
     random.shuffle(abilities)
     return dict(zip(abilities, ability_requirement))
 
@@ -65,7 +65,7 @@ def has_ice_grapple_logic(long_range: bool, state: CollectionState, player: int,
         return state.has_all({ice_dagger, grapple}, player)
     else:
         return state.has_all({ice_dagger, fire_wand, grapple}, player) and \
-            has_ability(state, player, ice_rod, options, ability_unlocks)
+            has_ability(state, player, ice_bolt, options, ability_unlocks)
 
 
 def can_ladder_storage(state: CollectionState, player: int, options: TunicOptions) -> bool:
@@ -251,7 +251,7 @@ def set_location_rules(world: "TunicWorld", ability_unlocks: Dict[str, int]) -> 
              lambda state: state.has_all({grapple, laurels}, player))
     set_rule(multiworld.get_location("East Forest - Ice Rod Grapple Chest", player),
              lambda state: state.has_all({grapple, ice_dagger, fire_wand}, player)
-             and has_ability(state, player, ice_rod, options, ability_unlocks))
+             and has_ability(state, player, ice_bolt, options, ability_unlocks))
 
     # West Garden
     set_rule(multiworld.get_location("West Garden - [North] Across From Page Pickup", player),


### PR DESCRIPTION
## What is this fixing or adding?
Renames the Ice Rod ability to Icebolt, a more recently adopted name for it by the community.

## How was this tested?
Generating locally and testing with an in-development client mod update.

## If this makes graphical changes, please attach screenshots.
