### PR TITLE
Pokemon RB: Fix exceptions raised by /bank

### DIFF
--- a/worlds/pokemon_rb/client.py
+++ b/worlds/pokemon_rb/client.py
@@ -206,7 +206,7 @@ class PokemonRBClient(BizHawkClient):
             money = int(original_money.hex())
             if self.banking_command > money:
                 logger.warning(f"You do not have ${self.banking_command} to deposit!")
-            elif (-self.banking_command * BANK_EXCHANGE_RATE) > ctx.stored_data[f"EnergyLink{ctx.team}"]:
+            elif (-self.banking_command * BANK_EXCHANGE_RATE) > (ctx.stored_data[f"EnergyLink{ctx.team}"] or 0):
                 logger.warning("Not enough money in the EnergyLink storage!")
             else:
                 if self.banking_command + money > 999999:
@@ -258,11 +258,12 @@ def cmd_bank(self, cmd: str = "", amount: str = ""):
     if self.ctx.game != "Pokemon Red and Blue":
         logger.warning("This command can only be used while playing Pokémon Red and Blue")
         return
-    if not cmd:
-        logger.info(f"Money available: {int(self.ctx.stored_data[f'EnergyLink{self.ctx.team}'] / BANK_EXCHANGE_RATE)}")
-        return
-    elif (not self.ctx.server) or self.ctx.server.socket.closed or not self.ctx.client_handler.game_state:
+    if (not self.ctx.server) or self.ctx.server.socket.closed or not self.ctx.client_handler.game_state:
         logger.info(f"Must be connected to server and in game.")
+        return
+    elif not cmd:
+        logger.info(f"Money available: {int((self.ctx.stored_data[f'EnergyLink{self.ctx.team}'] or 0) / BANK_EXCHANGE_RATE)}")
+        return
     elif not amount:
         logger.warning("You must specify an amount.")
     elif cmd == "withdraw":


### PR DESCRIPTION
## What is this fixing or adding?

* If the user tried to run `/bank` with no arguments to see the current value while disconnected, previously it threw an exception `KeyError: 'EnergyLinkNone'`. Now it informs the user that they must be connected and in-game, like `/bank deposit` and `/bank withdraw` do.

  I'm also open to adding another `if` branch to make `/bank` only check for `ctx.server` instead of combining it with the other bank commands, to allow connecting to check the bank before the game save is loaded. If that's preferred let me know.

* If the user tried to run `/bank` or `/bank deposit` when the EnergyLink hadn't been used yet, they would get a `TypeError` exception. Trying `/bank withdraw` would give no output and would crash the lua connector script. Now it treats a `None` EnergyLink as `0` and works properly.

## How was this tested?

Ran the following commands before and after my change. See screenshots for output:
```
/bank
/connect archipelago.gg:<port>
/bank
/bank withdraw 4
/bank deposit 10
/bank withdraw 4
```

## If this makes graphical changes, please attach screenshots.
Before
![bankexception](https://github.com/ArchipelagoMW/Archipelago/assets/2065960/e121a09d-9cd7-4d4b-9cfc-e4d4496cc99b)

After
![fixed](https://github.com/ArchipelagoMW/Archipelago/assets/2065960/52299051-426d-45fd-94c7-d32988a68d1b)

Fixes https://discord.com/channels/731205301247803413/1206405229227155499