### PR TITLE
Pokemon Emerald: Un-exclude locations that must contain progression

### DIFF
--- a/worlds/pokemon_emerald/__init__.py
+++ b/worlds/pokemon_emerald/__init__.py
@@ -330,6 +330,7 @@ class PokemonEmeraldWorld(World):
             for location in locations:
                 if location.tags is not None and tag in location.tags:
                     location.place_locked_item(self.create_event(self.item_id_to_name[location.default_item_code]))
+                    location.progress_type = LocationProgressType.DEFAULT
                     location.address = None
 
         if self.options.badges == RandomizeBadges.option_vanilla:

--- a/worlds/pokemon_emerald/__init__.py
+++ b/worlds/pokemon_emerald/__init__.py
@@ -366,6 +366,12 @@ class PokemonEmeraldWorld(World):
             }
             badge_items.sort(key=lambda item: badge_priority.get(item.name, 0))
 
+            # Un-exclude badge locations, since we need to put progression items on them
+            for location in badge_locations:
+                location.progress_type = LocationProgressType.DEFAULT \
+                    if location.progress_type == LocationProgressType.EXCLUDED \
+                    else location.progress_type
+
             collection_state = self.multiworld.get_all_state(False)
             if self.hm_shuffle_info is not None:
                 for _, item in self.hm_shuffle_info:
@@ -409,6 +415,12 @@ class PokemonEmeraldWorld(World):
                 "HM02 Fly": 5
             }
             hm_items.sort(key=lambda item: hm_priority.get(item.name, 0))
+
+            # Un-exclude HM locations, since we need to put progression items on them
+            for location in hm_locations:
+                location.progress_type = LocationProgressType.DEFAULT \
+                    if location.progress_type == LocationProgressType.EXCLUDED \
+                    else location.progress_type
 
             collection_state = self.multiworld.get_all_state(False)
 


### PR DESCRIPTION
## What is this fixing or adding?

Caused/revealed by #2655 and found in the recent beta test. If one or more of the badge/hm locations is excluded, when Emerald's `pre_fill` tries to place shuffled badges or HMs onto those locations, it ignores them, doesn't place every badge/hm, and causes a lot of locations/items to become inaccessible. I thought setting `allow_excluded=True` would protect against this, but I think I misunderstood what it does.

This will prevent those locations from being excluded just before trying to give them to `fill_restrictive`, which will catch both the automatic exclusion of a couple post-goal locations in Petalburg and the manual exclusion by players.

The same problem seems to appear if you exclude a location that Emerald converts to unrandomized event locations, like badges or key items like bikes.

## How was this tested?

Generated a few seeds before and after the change with either `norman` goal and `shuffle` badges or manually excluding a badge location with `shuffle` badges. Also for `vanilla` badges with a badge location manually excluded. Seeds that fail without the change don't fail with the change.
