### PR TITLE
Docs: Clarify which kinds of options actually support "random"

### DIFF
--- a/docs/options api.md
+++ b/docs/options api.md
@@ -27,6 +27,8 @@ Choice, and defining `alias_true = option_full`.
 - All options with a fixed set of possible values (i.e. those which inherit from `Toggle`, `(Text)Choice` or
 `(Named/Special)Range`) support `random` as a generic option. `random` chooses from any of the available values for that
 option, and is reserved by AP. You can set this as your default value, but you cannot define your own `option_random`.
+However, you can override `from_text` and handle `text == "random"` to customize its behavior or
+implement it for additional option types.
 
 As an example, suppose we want an option that lets the user start their game with a sword in their inventory, an option
 to let the player choose the difficulty, and an option to choose how much health the final boss has. Let's create our

--- a/docs/options api.md
+++ b/docs/options api.md
@@ -24,8 +24,9 @@ display as `Value1` on the webhost.
 (i.e. `alias_value_1 = option_value1`) which will allow users to use either `value_1` or `value1` in their yaml
 files, and both will resolve as `value1`. This should be used when changing options around, i.e. changing a Toggle to a
 Choice, and defining `alias_true = option_full`.
-- All options support `random` as a generic option. `random` chooses from any of the available values for that option,
-and is reserved by AP. You can set this as your default value, but you cannot define your own `option_random`.
+- All options with a fixed set of possible values (i.e. those which inherit from `Toggle`, `(Text)Choice` or
+`(Named/Special)Range`) support `random` as a generic option. `random` chooses from any of the available values for that
+option, and is reserved by AP. You can set this as your default value, but you cannot define your own `option_random`.
 
 As an example, suppose we want an option that lets the user start their game with a sword in their inventory, an option
 to let the player choose the difficulty, and an option to choose how much health the final boss has. Let's create our


### PR DESCRIPTION
## What is this fixing or adding?

The current phrasing of this sentence made me expect "random" to work on literally all options, even my `OptionsDict` option. After asking `#archipelago-dev` and checking the `Options.py` code, it's become clear that many option kinds don't (and can't) support "random". After reading `Options.py` a bit more, I believe this wording would be correct.

## How was this tested?

The change itself, N/A. It's just docs.

If you mean how I ran into this, I tried writing a test for my world with all options set to `"random"`, and got `NotImplementedError: Cannot Convert from non-dictionary, got <class 'str'>` on the `OptionsDict` one.

## If this makes graphical changes, please attach screenshots.

N/A