### PR TITLE
TextClient: fix logging not always showing up

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -941,4 +941,5 @@ def run_as_textclient():
 
 
 if __name__ == '__main__':
+    logging.getLogger().setLevel(logging.INFO)  # force log-level to work around log level resetting to WARNING
     run_as_textclient()


### PR DESCRIPTION
## What is this fixing or adding?

For whatever reason, log level resets to default (30) an makes `CommonClient.py --nogui` unusable for me. I spent some time looking for the culprit and haven't found it, so this is a work-around by forcing the log level at the end of the file to the expected value.

Any one of those imports destroys log level for me:
`from MultiServer import ...`, `from NetUtils import ...` and `from worlds import ...`


## How was this tested?

Looking at stdout and in the log folder.