### PR TITLE
TUNIC: Revise ER path hints to be more generous

### DIFF
--- a/worlds/tunic/__init__.py
+++ b/worlds/tunic/__init__.py
@@ -227,6 +227,8 @@ class TunicWorld(World):
                 name, connection = paths[location.parent_region]
                 while connection != ("Menu", None):
                     name, connection = connection
+                    if name.endswith("(LS)"):
+                        name = name.replace(" (LS)", "")
                     # was getting some cases like Library Grave -> Library Grave -> other place
                     if name in portal_names and name != previous_name:
                         previous_name = name

--- a/worlds/tunic/er_data.py
+++ b/worlds/tunic/er_data.py
@@ -520,13 +520,6 @@ class DeadEnd(IntEnum):
     # there's no dead ends that are only in unrestricted
 
 
-class Hint(IntEnum):
-    none = 0  # big areas, empty hallways, etc.
-    region = 1  # at least one of the portals must not be a dead end
-    scene = 2  # multiple regions in the scene, so using region could mean no valid hints
-    special = 3  # for if there's a weird case of specific regions being viable
-
-
 # key is the AP region name. "Fake" in region info just means the mod won't receive that info at all
 tunic_er_regions: Dict[str, RegionInfo] = {
     "Menu": RegionInfo("Fake", dead_end=DeadEnd.all_cats),
@@ -536,7 +529,7 @@ tunic_er_regions: Dict[str, RegionInfo] = {
     "Overworld Swamp Upper Entry": RegionInfo("Overworld Redux"),  # upper swamp entry spot
     "Overworld Special Shop Entry": RegionInfo("Overworld Redux"),  # special shop entry spot
     "Overworld West Garden Laurels Entry": RegionInfo("Overworld Redux"),  # west garden laurels entry
-    "Overworld to West Garden from Furnace": RegionInfo("Overworld Redux", hint=Hint.region),
+    "Overworld to West Garden from Furnace": RegionInfo("Overworld Redux"),
     "Overworld Well to Furnace Rail": RegionInfo("Overworld Redux"),  # the tiny rail passageway
     "Overworld Ruined Passage Door": RegionInfo("Overworld Redux"),  # the small space betweeen the door and the portal
     "Overworld Old House Door": RegionInfo("Overworld Redux"),  # the too-small space between the door and the portal
@@ -545,7 +538,7 @@ tunic_er_regions: Dict[str, RegionInfo] = {
     "Overworld Temple Door": RegionInfo("Overworld Redux"),  # the small space betweeen the door and the portal
     "Overworld Town Portal": RegionInfo("Overworld Redux"),
     "Overworld Spawn Portal": RegionInfo("Overworld Redux"),
-    "Stick House": RegionInfo("Sword Cave", dead_end=DeadEnd.all_cats, hint=Hint.region),
+    "Stick House": RegionInfo("Sword Cave", dead_end=DeadEnd.all_cats),
     "Windmill": RegionInfo("Windmill"),
     "Old House Back": RegionInfo("Overworld Interiors"),  # part with the hc door
     "Old House Front": RegionInfo("Overworld Interiors"),  # part with the bedroom
@@ -553,21 +546,21 @@ tunic_er_regions: Dict[str, RegionInfo] = {
     "Furnace Fuse": RegionInfo("Furnace"),  # top of the furnace
     "Furnace Ladder Area": RegionInfo("Furnace"),  # the two portals accessible by the ladder
     "Furnace Walking Path": RegionInfo("Furnace"),  # dark tomb to west garden
-    "Secret Gathering Place": RegionInfo("Waterfall", dead_end=DeadEnd.all_cats, hint=Hint.region),
-    "Changing Room": RegionInfo("Changing Room", dead_end=DeadEnd.all_cats, hint=Hint.region),
-    "Patrol Cave": RegionInfo("PatrolCave", dead_end=DeadEnd.all_cats, hint=Hint.region),
-    "Ruined Shop": RegionInfo("Ruined Shop", dead_end=DeadEnd.all_cats, hint=Hint.region),
-    "Ruined Passage": RegionInfo("Ruins Passage", hint=Hint.region),
-    "Special Shop": RegionInfo("ShopSpecial", dead_end=DeadEnd.all_cats, hint=Hint.region),
-    "Caustic Light Cave": RegionInfo("Overworld Cave", dead_end=DeadEnd.all_cats, hint=Hint.region),
-    "Maze Cave": RegionInfo("Maze Room", dead_end=DeadEnd.all_cats, hint=Hint.region),
-    "Cube Cave": RegionInfo("CubeRoom", dead_end=DeadEnd.all_cats, hint=Hint.region),
-    "Southeast Cross Room": RegionInfo("EastFiligreeCache", dead_end=DeadEnd.all_cats, hint=Hint.region),
-    "Fountain Cross Room": RegionInfo("Town_FiligreeRoom", dead_end=DeadEnd.all_cats, hint=Hint.region),
-    "Hourglass Cave": RegionInfo("Town Basement", dead_end=DeadEnd.all_cats, hint=Hint.region),
-    "Sealed Temple": RegionInfo("Temple", hint=Hint.scene),
-    "Sealed Temple Rafters": RegionInfo("Temple", hint=Hint.scene),
-    "Forest Belltower Upper": RegionInfo("Forest Belltower", hint=Hint.region),
+    "Secret Gathering Place": RegionInfo("Waterfall", dead_end=DeadEnd.all_cats),
+    "Changing Room": RegionInfo("Changing Room", dead_end=DeadEnd.all_cats),
+    "Patrol Cave": RegionInfo("PatrolCave", dead_end=DeadEnd.all_cats),
+    "Ruined Shop": RegionInfo("Ruined Shop", dead_end=DeadEnd.all_cats),
+    "Ruined Passage": RegionInfo("Ruins Passage"),
+    "Special Shop": RegionInfo("ShopSpecial", dead_end=DeadEnd.all_cats),
+    "Caustic Light Cave": RegionInfo("Overworld Cave", dead_end=DeadEnd.all_cats),
+    "Maze Cave": RegionInfo("Maze Room", dead_end=DeadEnd.all_cats),
+    "Cube Cave": RegionInfo("CubeRoom", dead_end=DeadEnd.all_cats),
+    "Southeast Cross Room": RegionInfo("EastFiligreeCache", dead_end=DeadEnd.all_cats),
+    "Fountain Cross Room": RegionInfo("Town_FiligreeRoom", dead_end=DeadEnd.all_cats),
+    "Hourglass Cave": RegionInfo("Town Basement", dead_end=DeadEnd.all_cats),
+    "Sealed Temple": RegionInfo("Temple"),
+    "Sealed Temple Rafters": RegionInfo("Temple"),
+    "Forest Belltower Upper": RegionInfo("Forest Belltower"),
     "Forest Belltower Main": RegionInfo("Forest Belltower"),
     "Forest Belltower Lower": RegionInfo("Forest Belltower"),
     "East Forest": RegionInfo("East Forest Redux"),
@@ -590,9 +583,9 @@ tunic_er_regions: Dict[str, RegionInfo] = {
     "Beneath the Well Main": RegionInfo("Sewer"),
     "Beneath the Well Back": RegionInfo("Sewer"),
     "West Garden": RegionInfo("Archipelagos Redux"),
-    "Magic Dagger House": RegionInfo("archipelagos_house", dead_end=DeadEnd.all_cats, hint=Hint.region),
+    "Magic Dagger House": RegionInfo("archipelagos_house", dead_end=DeadEnd.all_cats),
     "West Garden Portal": RegionInfo("Archipelagos Redux", dead_end=DeadEnd.restricted),
-    "West Garden Portal Item": RegionInfo("Archipelagos Redux", dead_end=DeadEnd.restricted, hint=Hint.special),
+    "West Garden Portal Item": RegionInfo("Archipelagos Redux", dead_end=DeadEnd.restricted),
     "West Garden Laurels Exit": RegionInfo("Archipelagos Redux"),
     "West Garden after Boss": RegionInfo("Archipelagos Redux"),
     "West Garden Hero's Grave": RegionInfo("Archipelagos Redux"),
@@ -601,8 +594,8 @@ tunic_er_regions: Dict[str, RegionInfo] = {
     "Ruined Atoll Frog Mouth": RegionInfo("Atoll Redux"),
     "Ruined Atoll Portal": RegionInfo("Atoll Redux"),
     "Frog's Domain Entry": RegionInfo("Frog Stairs"),
-    "Frog's Domain": RegionInfo("frog cave main", hint=Hint.region),
-    "Frog's Domain Back": RegionInfo("frog cave main", hint=Hint.scene),
+    "Frog's Domain": RegionInfo("frog cave main"),
+    "Frog's Domain Back": RegionInfo("frog cave main"),
     "Library Exterior Tree": RegionInfo("Library Exterior"),
     "Library Exterior Ladder": RegionInfo("Library Exterior"),
     "Library Hall": RegionInfo("Library Hall"),
@@ -611,28 +604,28 @@ tunic_er_regions: Dict[str, RegionInfo] = {
     "Library Lab": RegionInfo("Library Lab"),
     "Library Lab Lower": RegionInfo("Library Lab"),
     "Library Portal": RegionInfo("Library Lab"),
-    "Library Arena": RegionInfo("Library Arena", dead_end=DeadEnd.all_cats, hint=Hint.region),
+    "Library Arena": RegionInfo("Library Arena", dead_end=DeadEnd.all_cats),
     "Fortress Exterior from East Forest": RegionInfo("Fortress Courtyard"),
     "Fortress Exterior from Overworld": RegionInfo("Fortress Courtyard"),
     "Fortress Exterior near cave": RegionInfo("Fortress Courtyard"),  # where the shop and beneath the earth entry are
     "Fortress Courtyard": RegionInfo("Fortress Courtyard"),
     "Fortress Courtyard Upper": RegionInfo("Fortress Courtyard"),
-    "Beneath the Vault Front": RegionInfo("Fortress Basement", hint=Hint.scene),  # the vanilla entry point
-    "Beneath the Vault Back": RegionInfo("Fortress Basement", hint=Hint.scene),  # the vanilla exit point
+    "Beneath the Vault Front": RegionInfo("Fortress Basement"),  # the vanilla entry point
+    "Beneath the Vault Back": RegionInfo("Fortress Basement"),  # the vanilla exit point
     "Eastern Vault Fortress": RegionInfo("Fortress Main"),
     "Eastern Vault Fortress Gold Door": RegionInfo("Fortress Main"),
     "Fortress East Shortcut Upper": RegionInfo("Fortress East"),
     "Fortress East Shortcut Lower": RegionInfo("Fortress East"),
     "Fortress Grave Path": RegionInfo("Fortress Reliquary"),
-    "Fortress Grave Path Upper": RegionInfo("Fortress Reliquary", dead_end=DeadEnd.restricted, hint=Hint.region),
+    "Fortress Grave Path Upper": RegionInfo("Fortress Reliquary", dead_end=DeadEnd.restricted),
     "Fortress Grave Path Dusty Entrance": RegionInfo("Fortress Reliquary"),
     "Fortress Hero's Grave": RegionInfo("Fortress Reliquary"),
-    "Fortress Leaf Piles": RegionInfo("Dusty", dead_end=DeadEnd.all_cats, hint=Hint.region),
+    "Fortress Leaf Piles": RegionInfo("Dusty", dead_end=DeadEnd.all_cats),
     "Fortress Arena": RegionInfo("Fortress Arena"),
     "Fortress Arena Portal": RegionInfo("Fortress Arena"),
     "Lower Mountain": RegionInfo("Mountain"),
     "Lower Mountain Stairs": RegionInfo("Mountain"),
-    "Top of the Mountain": RegionInfo("Mountaintop", dead_end=DeadEnd.all_cats, hint=Hint.region),
+    "Top of the Mountain": RegionInfo("Mountaintop", dead_end=DeadEnd.all_cats),
     "Quarry Connector": RegionInfo("Darkwoods Tunnel"),
     "Quarry Entry": RegionInfo("Quarry Redux"),
     "Quarry": RegionInfo("Quarry Redux"),
@@ -663,7 +656,7 @@ tunic_er_regions: Dict[str, RegionInfo] = {
     "Swamp Hero's Grave": RegionInfo("Swamp Redux 2"),
     "Back of Swamp Laurels Area": RegionInfo("Swamp Redux 2"),  # the spots you need laurels to traverse
     "Cathedral": RegionInfo("Cathedral Redux"),
-    "Cathedral Secret Legend Room": RegionInfo("Cathedral Redux", dead_end=DeadEnd.all_cats, hint=Hint.region),
+    "Cathedral Secret Legend Room": RegionInfo("Cathedral Redux", dead_end=DeadEnd.all_cats),
     "Cathedral Gauntlet Checkpoint": RegionInfo("Cathedral Arena"),
     "Cathedral Gauntlet": RegionInfo("Cathedral Arena"),
     "Cathedral Gauntlet Exit": RegionInfo("Cathedral Arena"),
@@ -674,12 +667,12 @@ tunic_er_regions: Dict[str, RegionInfo] = {
     "Far Shore to Fortress": RegionInfo("Transit"),
     "Far Shore to Library": RegionInfo("Transit"),
     "Far Shore to West Garden": RegionInfo("Transit"),
-    "Hero Relic - Fortress": RegionInfo("RelicVoid", dead_end=DeadEnd.all_cats, hint=Hint.region),
-    "Hero Relic - Quarry": RegionInfo("RelicVoid", dead_end=DeadEnd.all_cats, hint=Hint.region),
-    "Hero Relic - West Garden": RegionInfo("RelicVoid", dead_end=DeadEnd.all_cats, hint=Hint.region),
-    "Hero Relic - East Forest": RegionInfo("RelicVoid", dead_end=DeadEnd.all_cats, hint=Hint.region),
-    "Hero Relic - Library": RegionInfo("RelicVoid", dead_end=DeadEnd.all_cats, hint=Hint.region),
-    "Hero Relic - Swamp": RegionInfo("RelicVoid", dead_end=DeadEnd.all_cats, hint=Hint.region),
+    "Hero Relic - Fortress": RegionInfo("RelicVoid", dead_end=DeadEnd.all_cats),
+    "Hero Relic - Quarry": RegionInfo("RelicVoid", dead_end=DeadEnd.all_cats),
+    "Hero Relic - West Garden": RegionInfo("RelicVoid", dead_end=DeadEnd.all_cats),
+    "Hero Relic - East Forest": RegionInfo("RelicVoid", dead_end=DeadEnd.all_cats),
+    "Hero Relic - Library": RegionInfo("RelicVoid", dead_end=DeadEnd.all_cats),
+    "Hero Relic - Swamp": RegionInfo("RelicVoid", dead_end=DeadEnd.all_cats),
     "Purgatory": RegionInfo("Purgatory"),
     "Shop Entrance 1": RegionInfo("Shop", dead_end=DeadEnd.all_cats),
     "Shop Entrance 2": RegionInfo("Shop", dead_end=DeadEnd.all_cats),
@@ -688,45 +681,9 @@ tunic_er_regions: Dict[str, RegionInfo] = {
     "Shop Entrance 5": RegionInfo("Shop", dead_end=DeadEnd.all_cats),
     "Shop Entrance 6": RegionInfo("Shop", dead_end=DeadEnd.all_cats),
     "Shop": RegionInfo("Shop", dead_end=DeadEnd.all_cats),
-    "Spirit Arena": RegionInfo("Spirit Arena", dead_end=DeadEnd.all_cats, hint=Hint.region),
+    "Spirit Arena": RegionInfo("Spirit Arena", dead_end=DeadEnd.all_cats),
     "Spirit Arena Victory": RegionInfo("Spirit Arena", dead_end=DeadEnd.all_cats)
 }
-
-
-# so we can just loop over this instead of doing some complicated thing to deal with hallways in the hints
-hallways: Dict[str, str] = {
-    "Overworld Redux, Furnace_gyro_west": "Overworld Redux, Archipelagos Redux_lower",
-    "Overworld Redux, Furnace_gyro_upper_north": "Overworld Redux, Sewer_west_aqueduct",
-    "Ruins Passage, Overworld Redux_east": "Ruins Passage, Overworld Redux_west",
-    "East Forest Redux Interior, East Forest Redux_upper": "East Forest Redux Interior, East Forest Redux_lower",
-    "Forest Boss Room, East Forest Redux Laddercave_": "Forest Boss Room, Forest Belltower_",
-    "Library Exterior, Atoll Redux_": "Library Exterior, Library Hall_",
-    "Library Rotunda, Library Lab_": "Library Rotunda, Library Hall_",
-    "Darkwoods Tunnel, Quarry Redux_": "Darkwoods Tunnel, Overworld Redux_",
-    "ziggurat2020_0, Quarry Redux_": "ziggurat2020_0, ziggurat2020_1_",
-    "Purgatory, Purgatory_bottom": "Purgatory, Purgatory_top",
-}
-hallway_helper: Dict[str, str] = {}
-for p1, p2 in hallways.items():
-    hallway_helper[p1] = p2
-    hallway_helper[p2] = p1
-
-# so we can just loop over this instead of doing some complicated thing to deal with hallways in the hints
-hallways_ur: Dict[str, str] = {
-    "Ruins Passage, Overworld Redux_east": "Ruins Passage, Overworld Redux_west",
-    "East Forest Redux Interior, East Forest Redux_upper": "East Forest Redux Interior, East Forest Redux_lower",
-    "Forest Boss Room, East Forest Redux Laddercave_": "Forest Boss Room, Forest Belltower_",
-    "Library Exterior, Atoll Redux_": "Library Exterior, Library Hall_",
-    "Library Rotunda, Library Lab_": "Library Rotunda, Library Hall_",
-    "Darkwoods Tunnel, Quarry Redux_": "Darkwoods Tunnel, Overworld Redux_",
-    "ziggurat2020_0, Quarry Redux_": "ziggurat2020_0, ziggurat2020_1_",
-    "Purgatory, Purgatory_bottom": "Purgatory, Purgatory_top",
-}
-hallway_helper_ur: Dict[str, str] = {}
-for p1, p2 in hallways_ur.items():
-    hallway_helper_ur[p1] = p2
-    hallway_helper_ur[p2] = p1
-
 
 # the key is the region you have, the value is the regions you get for having that region
 # this is mostly so we don't have to do something overly complex to get this information

--- a/worlds/tunic/er_data.py
+++ b/worlds/tunic/er_data.py
@@ -193,9 +193,9 @@ portal_mapping: List[Portal] = [
            destination="Overworld Redux_upper"),
     Portal(name="West Garden Shop", region="West Garden",
            destination="Shop_"),
-    Portal(name="West Garden Laurels Exit", region="West Garden Laurels Exit",
+    Portal(name="West Garden Laurels Exit", region="West Garden Laurels Exit Region",
            destination="Overworld Redux_lowest"),
-    Portal(name="West Garden Hero's Grave", region="West Garden Hero's Grave",
+    Portal(name="West Garden Hero's Grave", region="West Garden Hero's Grave Region",
            destination="RelicVoid_teleporter_relic plinth"),
     Portal(name="West Garden to Far Shore", region="West Garden Portal",
            destination="Transit_teleporter_archipelagos_teleporter"),
@@ -232,14 +232,14 @@ portal_mapping: List[Portal] = [
     Portal(name="Frog's Domain Orb Exit", region="Frog's Domain Back",
            destination="Frog Stairs_Exit"),
     
-    Portal(name="Library Exterior Tree", region="Library Exterior Tree",
+    Portal(name="Library Exterior Tree", region="Library Exterior Tree Region",
            destination="Atoll Redux_"),
-    Portal(name="Library Exterior Ladder", region="Library Exterior Ladder",
+    Portal(name="Library Exterior Ladder", region="Library Exterior Ladder Region",
            destination="Library Hall_"),
     
     Portal(name="Library Hall Bookshelf Exit", region="Library Hall",
            destination="Library Exterior_"),
-    Portal(name="Library Hero's Grave", region="Library Hero's Grave",
+    Portal(name="Library Hero's Grave", region="Library Hero's Grave Region",
            destination="RelicVoid_teleporter_relic plinth"),
     Portal(name="Library Hall to Rotunda", region="Library Hall",
            destination="Library Rotunda_"),
@@ -357,11 +357,11 @@ portal_mapping: List[Portal] = [
     
     Portal(name="Fortress Grave Path Lower Exit", region="Fortress Grave Path",
            destination="Fortress Courtyard_Lower"),
-    Portal(name="Fortress Hero's Grave", region="Fortress Grave Path",
+    Portal(name="Fortress Hero's Grave", region="Fortress Hero's Grave Region",
            destination="RelicVoid_teleporter_relic plinth"),
     Portal(name="Fortress Grave Path Upper Exit", region="Fortress Grave Path Upper",
            destination="Fortress Courtyard_Upper"),
-    Portal(name="Fortress Grave Path Dusty Entrance", region="Fortress Grave Path Dusty Entrance",
+    Portal(name="Fortress Grave Path Dusty Entrance", region="Fortress Grave Path Dusty Entrance Region",
            destination="Dusty_"),
 
     Portal(name="Dusty Exit", region="Fortress Leaf Piles",
@@ -406,7 +406,7 @@ portal_mapping: List[Portal] = [
            destination="Quarry Redux_back"),
     Portal(name="Monastery Front Exit", region="Monastery Front",
            destination="Quarry Redux_front"),
-    Portal(name="Monastery Hero's Grave", region="Monastery Hero's Grave",
+    Portal(name="Monastery Hero's Grave", region="Monastery Hero's Grave Region",
            destination="RelicVoid_teleporter_relic plinth"),
     
     Portal(name="Ziggurat Entry Hallway to Ziggurat Upper", region="Rooted Ziggurat Entry",
@@ -436,7 +436,7 @@ portal_mapping: List[Portal] = [
     
     Portal(name="Swamp Lower Exit", region="Swamp",
            destination="Overworld Redux_conduit"),
-    Portal(name="Swamp to Cathedral Main Entrance", region="Swamp to Cathedral Main Entrance",
+    Portal(name="Swamp to Cathedral Main Entrance", region="Swamp to Cathedral Main Entrance Region",
            destination="Cathedral Redux_main"),
     Portal(name="Swamp to Cathedral Secret Legend Room Entrance", region="Swamp to Cathedral Treasure Room",
            destination="Cathedral Redux_secret"),
@@ -446,7 +446,7 @@ portal_mapping: List[Portal] = [
            destination="Shop_"),
     Portal(name="Swamp Upper Exit", region="Back of Swamp Laurels Area",
            destination="Overworld Redux_wall"),
-    Portal(name="Swamp Hero's Grave", region="Swamp Hero's Grave",
+    Portal(name="Swamp Hero's Grave", region="Swamp Hero's Grave Region",
            destination="RelicVoid_teleporter_relic plinth"),
     
     Portal(name="Cathedral Main Exit", region="Cathedral",
@@ -476,15 +476,15 @@ portal_mapping: List[Portal] = [
     Portal(name="Hero's Grave to Swamp", region="Hero Relic - Swamp",
            destination="Swamp Redux 2_teleporter_relic plinth"),
     
-    Portal(name="Far Shore to West Garden", region="Far Shore to West Garden",
+    Portal(name="Far Shore to West Garden", region="Far Shore to West Garden Region",
            destination="Archipelagos Redux_teleporter_archipelagos_teleporter"),
-    Portal(name="Far Shore to Library", region="Far Shore to Library",
+    Portal(name="Far Shore to Library", region="Far Shore to Library Region",
            destination="Library Lab_teleporter_library teleporter"),
-    Portal(name="Far Shore to Quarry", region="Far Shore to Quarry",
+    Portal(name="Far Shore to Quarry", region="Far Shore to Quarry Region",
            destination="Quarry Redux_teleporter_quarry teleporter"),
-    Portal(name="Far Shore to East Forest", region="Far Shore to East Forest",
+    Portal(name="Far Shore to East Forest", region="Far Shore to East Forest Region",
            destination="East Forest Redux_teleporter_forest teleporter"),
-    Portal(name="Far Shore to Fortress", region="Far Shore to Fortress",
+    Portal(name="Far Shore to Fortress", region="Far Shore to Fortress Region",
            destination="Fortress Arena_teleporter_spidertank"),
     Portal(name="Far Shore to Atoll", region="Far Shore",
            destination="Atoll Redux_teleporter_atoll"),
@@ -494,7 +494,7 @@ portal_mapping: List[Portal] = [
            destination="Spirit Arena_teleporter_spirit arena"),
     Portal(name="Far Shore to Town", region="Far Shore",
            destination="Overworld Redux_teleporter_town"),
-    Portal(name="Far Shore to Spawn", region="Far Shore to Spawn",
+    Portal(name="Far Shore to Spawn", region="Far Shore to Spawn Region",
            destination="Overworld Redux_teleporter_starting island"),
     
     Portal(name="Heir Arena Exit", region="Spirit Arena",
@@ -586,9 +586,9 @@ tunic_er_regions: Dict[str, RegionInfo] = {
     "Magic Dagger House": RegionInfo("archipelagos_house", dead_end=DeadEnd.all_cats),
     "West Garden Portal": RegionInfo("Archipelagos Redux", dead_end=DeadEnd.restricted),
     "West Garden Portal Item": RegionInfo("Archipelagos Redux", dead_end=DeadEnd.restricted),
-    "West Garden Laurels Exit": RegionInfo("Archipelagos Redux"),
+    "West Garden Laurels Exit Region": RegionInfo("Archipelagos Redux"),
     "West Garden after Boss": RegionInfo("Archipelagos Redux"),
-    "West Garden Hero's Grave": RegionInfo("Archipelagos Redux"),
+    "West Garden Hero's Grave Region": RegionInfo("Archipelagos Redux"),
     "Ruined Atoll": RegionInfo("Atoll Redux"),
     "Ruined Atoll Lower Entry Area": RegionInfo("Atoll Redux"),
     "Ruined Atoll Frog Mouth": RegionInfo("Atoll Redux"),
@@ -596,10 +596,10 @@ tunic_er_regions: Dict[str, RegionInfo] = {
     "Frog's Domain Entry": RegionInfo("Frog Stairs"),
     "Frog's Domain": RegionInfo("frog cave main"),
     "Frog's Domain Back": RegionInfo("frog cave main"),
-    "Library Exterior Tree": RegionInfo("Library Exterior"),
-    "Library Exterior Ladder": RegionInfo("Library Exterior"),
+    "Library Exterior Tree Region": RegionInfo("Library Exterior"),
+    "Library Exterior Ladder Region": RegionInfo("Library Exterior"),
     "Library Hall": RegionInfo("Library Hall"),
-    "Library Hero's Grave": RegionInfo("Library Hall"),
+    "Library Hero's Grave Region": RegionInfo("Library Hall"),
     "Library Rotunda": RegionInfo("Library Rotunda"),
     "Library Lab": RegionInfo("Library Lab"),
     "Library Lab Lower": RegionInfo("Library Lab"),
@@ -618,8 +618,8 @@ tunic_er_regions: Dict[str, RegionInfo] = {
     "Fortress East Shortcut Lower": RegionInfo("Fortress East"),
     "Fortress Grave Path": RegionInfo("Fortress Reliquary"),
     "Fortress Grave Path Upper": RegionInfo("Fortress Reliquary", dead_end=DeadEnd.restricted),
-    "Fortress Grave Path Dusty Entrance": RegionInfo("Fortress Reliquary"),
-    "Fortress Hero's Grave": RegionInfo("Fortress Reliquary"),
+    "Fortress Grave Path Dusty Entrance Region": RegionInfo("Fortress Reliquary"),
+    "Fortress Hero's Grave Region": RegionInfo("Fortress Reliquary"),
     "Fortress Leaf Piles": RegionInfo("Dusty", dead_end=DeadEnd.all_cats),
     "Fortress Arena": RegionInfo("Fortress Arena"),
     "Fortress Arena Portal": RegionInfo("Fortress Arena"),
@@ -634,7 +634,7 @@ tunic_er_regions: Dict[str, RegionInfo] = {
     "Quarry Monastery Entry": RegionInfo("Quarry Redux"),
     "Monastery Front": RegionInfo("Monastery"),
     "Monastery Back": RegionInfo("Monastery"),
-    "Monastery Hero's Grave": RegionInfo("Monastery"),
+    "Monastery Hero's Grave Region": RegionInfo("Monastery"),
     "Monastery Rope": RegionInfo("Quarry Redux"),
     "Lower Quarry": RegionInfo("Quarry Redux"),
     "Lower Quarry Zig Door": RegionInfo("Quarry Redux"),
@@ -651,9 +651,9 @@ tunic_er_regions: Dict[str, RegionInfo] = {
     "Rooted Ziggurat Portal Room Exit": RegionInfo("ziggurat2020_FTRoom"),
     "Swamp": RegionInfo("Swamp Redux 2"),
     "Swamp to Cathedral Treasure Room": RegionInfo("Swamp Redux 2"),
-    "Swamp to Cathedral Main Entrance": RegionInfo("Swamp Redux 2"),
+    "Swamp to Cathedral Main Entrance Region": RegionInfo("Swamp Redux 2"),
     "Back of Swamp": RegionInfo("Swamp Redux 2"),  # the area with hero grave and gauntlet entrance
-    "Swamp Hero's Grave": RegionInfo("Swamp Redux 2"),
+    "Swamp Hero's Grave Region": RegionInfo("Swamp Redux 2"),
     "Back of Swamp Laurels Area": RegionInfo("Swamp Redux 2"),  # the spots you need laurels to traverse
     "Cathedral": RegionInfo("Cathedral Redux"),
     "Cathedral Secret Legend Room": RegionInfo("Cathedral Redux", dead_end=DeadEnd.all_cats),
@@ -661,12 +661,12 @@ tunic_er_regions: Dict[str, RegionInfo] = {
     "Cathedral Gauntlet": RegionInfo("Cathedral Arena"),
     "Cathedral Gauntlet Exit": RegionInfo("Cathedral Arena"),
     "Far Shore": RegionInfo("Transit"),
-    "Far Shore to Spawn": RegionInfo("Transit"),
-    "Far Shore to East Forest": RegionInfo("Transit"),
-    "Far Shore to Quarry": RegionInfo("Transit"),
-    "Far Shore to Fortress": RegionInfo("Transit"),
-    "Far Shore to Library": RegionInfo("Transit"),
-    "Far Shore to West Garden": RegionInfo("Transit"),
+    "Far Shore to Spawn Region": RegionInfo("Transit"),
+    "Far Shore to East Forest Region": RegionInfo("Transit"),
+    "Far Shore to Quarry Region": RegionInfo("Transit"),
+    "Far Shore to Fortress Region": RegionInfo("Transit"),
+    "Far Shore to Library Region": RegionInfo("Transit"),
+    "Far Shore to West Garden Region": RegionInfo("Transit"),
     "Hero Relic - Fortress": RegionInfo("RelicVoid", dead_end=DeadEnd.all_cats),
     "Hero Relic - Quarry": RegionInfo("RelicVoid", dead_end=DeadEnd.all_cats),
     "Hero Relic - West Garden": RegionInfo("RelicVoid", dead_end=DeadEnd.all_cats),
@@ -716,17 +716,17 @@ dependent_regions_restricted: Dict[Tuple[str, ...], List[str]] = {
         ["Dark Tomb Entry Point", "Dark Tomb Main", "Dark Tomb Dark Exit"],
     ("Well Boss",):
         ["Dark Tomb Checkpoint", "Well Boss"],
-    ("West Garden", "West Garden Laurels Exit", "West Garden after Boss", "West Garden Hero's Grave"):
-        ["West Garden", "West Garden Laurels Exit", "West Garden after Boss", "West Garden Hero's Grave"],
+    ("West Garden", "West Garden Laurels Exit Region", "West Garden after Boss", "West Garden Hero's Grave Region"):
+        ["West Garden", "West Garden Laurels Exit Region", "West Garden after Boss", "West Garden Hero's Grave Region"],
     ("West Garden Portal", "West Garden Portal Item"): ["West Garden Portal", "West Garden Portal Item"],
     ("Ruined Atoll", "Ruined Atoll Lower Entry Area", "Ruined Atoll Frog Mouth", "Ruined Atoll Portal"):
         ["Ruined Atoll", "Ruined Atoll Lower Entry Area", "Ruined Atoll Frog Mouth", "Ruined Atoll Portal"],
     ("Frog's Domain",):
         ["Frog's Domain", "Frog's Domain Back"],
-    ("Library Exterior Ladder", "Library Exterior Tree"):
-        ["Library Exterior Ladder", "Library Exterior Tree"],
-    ("Library Hall", "Library Hero's Grave"):
-        ["Library Hall", "Library Hero's Grave"],
+    ("Library Exterior Ladder Region", "Library Exterior Tree Region"):
+        ["Library Exterior Ladder Region", "Library Exterior Tree Region"],
+    ("Library Hall", "Library Hero's Grave Region"):
+        ["Library Hall", "Library Hero's Grave Region"],
     ("Library Lab", "Library Lab Lower", "Library Portal"):
         ["Library Lab", "Library Lab Lower", "Library Portal"],
     ("Fortress Courtyard Upper",):
@@ -742,16 +742,16 @@ dependent_regions_restricted: Dict[Tuple[str, ...], List[str]] = {
         ["Fortress East Shortcut Upper", "Fortress East Shortcut Lower"],
     ("Eastern Vault Fortress",):
         ["Eastern Vault Fortress", "Eastern Vault Fortress Gold Door"],
-    ("Fortress Grave Path", "Fortress Grave Path Dusty Entrance", "Fortress Hero's Grave"):
-        ["Fortress Grave Path", "Fortress Grave Path Dusty Entrance", "Fortress Hero's Grave"],
+    ("Fortress Grave Path", "Fortress Grave Path Dusty Entrance Region", "Fortress Hero's Grave Region"):
+        ["Fortress Grave Path", "Fortress Grave Path Dusty Entrance Region", "Fortress Hero's Grave Region"],
     ("Fortress Arena", "Fortress Arena Portal"):
         ["Fortress Arena", "Fortress Arena Portal"],
     ("Lower Mountain", "Lower Mountain Stairs"):
         ["Lower Mountain", "Lower Mountain Stairs"],
     ("Monastery Front",):
-        ["Monastery Front", "Monastery Back", "Monastery Hero's Grave"],
-    ("Monastery Back", "Monastery Hero's Grave"):
-        ["Monastery Back", "Monastery Hero's Grave"],
+        ["Monastery Front", "Monastery Back", "Monastery Hero's Grave Region"],
+    ("Monastery Back", "Monastery Hero's Grave Region"):
+        ["Monastery Back", "Monastery Hero's Grave Region"],
     ("Quarry", "Quarry Portal", "Lower Quarry", "Quarry Entry", "Quarry Back", "Quarry Monastery Entry"):
         ["Quarry", "Quarry Portal", "Lower Quarry", "Quarry Entry", "Quarry Back", "Quarry Monastery Entry",
          "Lower Quarry Zig Door"],
@@ -766,15 +766,15 @@ dependent_regions_restricted: Dict[Tuple[str, ...], List[str]] = {
     ("Rooted Ziggurat Portal", "Rooted Ziggurat Portal Room Exit"):
         ["Rooted Ziggurat Portal", "Rooted Ziggurat Portal Room Exit"],
     ("Swamp", "Swamp to Cathedral Treasure Room"):
-        ["Swamp", "Swamp to Cathedral Treasure Room", "Swamp to Cathedral Main Entrance"],
-    ("Back of Swamp", "Back of Swamp Laurels Area", "Swamp Hero's Grave"):
-        ["Back of Swamp", "Back of Swamp Laurels Area", "Swamp Hero's Grave"],
+        ["Swamp", "Swamp to Cathedral Treasure Room", "Swamp to Cathedral Main Entrance Region"],
+    ("Back of Swamp", "Back of Swamp Laurels Area", "Swamp Hero's Grave Region"):
+        ["Back of Swamp", "Back of Swamp Laurels Area", "Swamp Hero's Grave Region"],
     ("Cathedral Gauntlet Checkpoint",):
         ["Cathedral Gauntlet Checkpoint", "Cathedral Gauntlet Exit", "Cathedral Gauntlet"],
-    ("Far Shore", "Far Shore to Spawn", "Far Shore to East Forest", "Far Shore to Quarry",
-     "Far Shore to Fortress", "Far Shore to Library", "Far Shore to West Garden"):
-        ["Far Shore", "Far Shore to Spawn", "Far Shore to East Forest", "Far Shore to Quarry",
-         "Far Shore to Fortress", "Far Shore to Library", "Far Shore to West Garden"]
+    ("Far Shore", "Far Shore to Spawn Region", "Far Shore to East Forest Region", "Far Shore to Quarry Region",
+     "Far Shore to Fortress Region", "Far Shore to Library Region", "Far Shore to West Garden Region"):
+        ["Far Shore", "Far Shore to Spawn Region", "Far Shore to East Forest Region", "Far Shore to Quarry Region",
+         "Far Shore to Fortress Region", "Far Shore to Library Region", "Far Shore to West Garden Region"]
 }
 
 
@@ -807,18 +807,18 @@ dependent_regions_nmg: Dict[Tuple[str, ...], List[str]] = {
         ["Dark Tomb Entry Point", "Dark Tomb Main", "Dark Tomb Dark Exit"],
     ("Dark Tomb Checkpoint", "Well Boss"):
         ["Dark Tomb Checkpoint", "Well Boss"],
-    ("West Garden", "West Garden Laurels Exit", "West Garden after Boss", "West Garden Hero's Grave",
+    ("West Garden", "West Garden Laurels Exit Region", "West Garden after Boss", "West Garden Hero's Grave Region",
      "West Garden Portal", "West Garden Portal Item"):
-        ["West Garden", "West Garden Laurels Exit", "West Garden after Boss", "West Garden Hero's Grave",
+        ["West Garden", "West Garden Laurels Exit Region", "West Garden after Boss", "West Garden Hero's Grave Region",
          "West Garden Portal", "West Garden Portal Item"],
     ("Ruined Atoll", "Ruined Atoll Lower Entry Area", "Ruined Atoll Frog Mouth", "Ruined Atoll Portal"):
         ["Ruined Atoll", "Ruined Atoll Lower Entry Area", "Ruined Atoll Frog Mouth", "Ruined Atoll Portal"],
     ("Frog's Domain",):
         ["Frog's Domain", "Frog's Domain Back"],
-    ("Library Exterior Ladder", "Library Exterior Tree"):
-        ["Library Exterior Ladder", "Library Exterior Tree"],
-    ("Library Hall", "Library Hero's Grave"):
-        ["Library Hall", "Library Hero's Grave"],
+    ("Library Exterior Ladder Region", "Library Exterior Tree Region"):
+        ["Library Exterior Ladder Region", "Library Exterior Tree Region"],
+    ("Library Hall", "Library Hero's Grave Region"):
+        ["Library Hall", "Library Hero's Grave Region"],
     ("Library Lab", "Library Lab Lower", "Library Portal"):
         ["Library Lab", "Library Lab Lower", "Library Portal"],
     ("Fortress Exterior from East Forest", "Fortress Exterior from Overworld",
@@ -831,17 +831,17 @@ dependent_regions_nmg: Dict[Tuple[str, ...], List[str]] = {
         ["Fortress East Shortcut Upper", "Fortress East Shortcut Lower"],
     ("Eastern Vault Fortress", "Eastern Vault Fortress Gold Door"):
         ["Eastern Vault Fortress", "Eastern Vault Fortress Gold Door"],
-    ("Fortress Grave Path", "Fortress Grave Path Dusty Entrance", "Fortress Hero's Grave"):
-        ["Fortress Grave Path", "Fortress Grave Path Dusty Entrance", "Fortress Hero's Grave"],
+    ("Fortress Grave Path", "Fortress Grave Path Dusty Entrance Region", "Fortress Hero's Grave Region"):
+        ["Fortress Grave Path", "Fortress Grave Path Dusty Entrance Region", "Fortress Hero's Grave Region"],
     ("Fortress Grave Path Upper",):
-        ["Fortress Grave Path Upper", "Fortress Grave Path", "Fortress Grave Path Dusty Entrance",
-         "Fortress Hero's Grave"],
+        ["Fortress Grave Path Upper", "Fortress Grave Path", "Fortress Grave Path Dusty Entrance Region",
+         "Fortress Hero's Grave Region"],
     ("Fortress Arena", "Fortress Arena Portal"):
         ["Fortress Arena", "Fortress Arena Portal"],
     ("Lower Mountain", "Lower Mountain Stairs"):
         ["Lower Mountain", "Lower Mountain Stairs"],
-    ("Monastery Front", "Monastery Back", "Monastery Hero's Grave"):
-        ["Monastery Front", "Monastery Back", "Monastery Hero's Grave"],
+    ("Monastery Front", "Monastery Back", "Monastery Hero's Grave Region"):
+        ["Monastery Front", "Monastery Back", "Monastery Hero's Grave Region"],
     ("Quarry", "Quarry Portal", "Lower Quarry", "Quarry Entry", "Quarry Back", "Quarry Monastery Entry"):
         ["Quarry", "Quarry Portal", "Lower Quarry", "Quarry Entry", "Quarry Back", "Quarry Monastery Entry",
          "Lower Quarry Zig Door"],
@@ -855,17 +855,17 @@ dependent_regions_nmg: Dict[Tuple[str, ...], List[str]] = {
         ["Rooted Ziggurat Lower Front", "Rooted Ziggurat Lower Back", "Rooted Ziggurat Portal Room Entrance"],
     ("Rooted Ziggurat Portal", "Rooted Ziggurat Portal Room Exit"):
         ["Rooted Ziggurat Portal", "Rooted Ziggurat Portal Room Exit"],
-    ("Swamp", "Swamp to Cathedral Treasure Room", "Swamp to Cathedral Main Entrance"):
-        ["Swamp", "Swamp to Cathedral Treasure Room", "Swamp to Cathedral Main Entrance"],
-    ("Back of Swamp", "Back of Swamp Laurels Area", "Swamp Hero's Grave"):
-        ["Back of Swamp", "Back of Swamp Laurels Area", "Swamp Hero's Grave", "Swamp",
-         "Swamp to Cathedral Treasure Room", "Swamp to Cathedral Main Entrance"],
+    ("Swamp", "Swamp to Cathedral Treasure Room", "Swamp to Cathedral Main Entrance Region"):
+        ["Swamp", "Swamp to Cathedral Treasure Room", "Swamp to Cathedral Main Entrance Region"],
+    ("Back of Swamp", "Back of Swamp Laurels Area", "Swamp Hero's Grave Region"):
+        ["Back of Swamp", "Back of Swamp Laurels Area", "Swamp Hero's Grave Region", "Swamp",
+         "Swamp to Cathedral Treasure Room", "Swamp to Cathedral Main Entrance Region"],
     ("Cathedral Gauntlet Checkpoint",):
         ["Cathedral Gauntlet Checkpoint", "Cathedral Gauntlet Exit", "Cathedral Gauntlet"],
-    ("Far Shore", "Far Shore to Spawn", "Far Shore to East Forest", "Far Shore to Quarry",
-     "Far Shore to Fortress", "Far Shore to Library", "Far Shore to West Garden"):
-        ["Far Shore", "Far Shore to Spawn", "Far Shore to East Forest", "Far Shore to Quarry",
-         "Far Shore to Fortress", "Far Shore to Library", "Far Shore to West Garden"]
+    ("Far Shore", "Far Shore to Spawn Region", "Far Shore to East Forest Region", "Far Shore to Quarry Region",
+     "Far Shore to Fortress Region", "Far Shore to Library Region", "Far Shore to West Garden Region"):
+        ["Far Shore", "Far Shore to Spawn Region", "Far Shore to East Forest Region", "Far Shore to Quarry Region",
+         "Far Shore to Fortress Region", "Far Shore to Library Region", "Far Shore to West Garden Region"]
 }
 
 
@@ -901,18 +901,18 @@ dependent_regions_ur: Dict[Tuple[str, ...], List[str]] = {
     ("Dark Tomb Checkpoint", "Well Boss"):
         ["Dark Tomb Checkpoint", "Well Boss"],
     # can ice grapple from portal area to the rest, and vice versa
-    ("West Garden", "West Garden Laurels Exit", "West Garden after Boss", "West Garden Hero's Grave",
+    ("West Garden", "West Garden Laurels Exit Region", "West Garden after Boss", "West Garden Hero's Grave Region",
      "West Garden Portal", "West Garden Portal Item"):
-        ["West Garden", "West Garden Laurels Exit", "West Garden after Boss", "West Garden Hero's Grave",
+        ["West Garden", "West Garden Laurels Exit Region", "West Garden after Boss", "West Garden Hero's Grave Region",
          "West Garden Portal", "West Garden Portal Item"],
     ("Ruined Atoll", "Ruined Atoll Lower Entry Area", "Ruined Atoll Frog Mouth", "Ruined Atoll Portal"):
         ["Ruined Atoll", "Ruined Atoll Lower Entry Area", "Ruined Atoll Frog Mouth", "Ruined Atoll Portal"],
     ("Frog's Domain",):
         ["Frog's Domain", "Frog's Domain Back"],
-    ("Library Exterior Ladder", "Library Exterior Tree"):
-        ["Library Exterior Ladder", "Library Exterior Tree"],
-    ("Library Hall", "Library Hero's Grave"):
-        ["Library Hall", "Library Hero's Grave"],
+    ("Library Exterior Ladder Region", "Library Exterior Tree Region"):
+        ["Library Exterior Ladder Region", "Library Exterior Tree Region"],
+    ("Library Hall", "Library Hero's Grave Region"):
+        ["Library Hall", "Library Hero's Grave Region"],
     ("Library Lab", "Library Lab Lower", "Library Portal"):
         ["Library Lab", "Library Lab Lower", "Library Portal"],
     # can use ice grapple or ladder storage to get from any ladder to upper
@@ -927,18 +927,18 @@ dependent_regions_ur: Dict[Tuple[str, ...], List[str]] = {
         ["Fortress East Shortcut Upper", "Fortress East Shortcut Lower"],
     ("Eastern Vault Fortress", "Eastern Vault Fortress Gold Door"):
         ["Eastern Vault Fortress", "Eastern Vault Fortress Gold Door"],
-    ("Fortress Grave Path", "Fortress Grave Path Dusty Entrance", "Fortress Hero's Grave"):
-        ["Fortress Grave Path", "Fortress Grave Path Dusty Entrance", "Fortress Hero's Grave"],
+    ("Fortress Grave Path", "Fortress Grave Path Dusty Entrance Region", "Fortress Hero's Grave Region"):
+        ["Fortress Grave Path", "Fortress Grave Path Dusty Entrance Region", "Fortress Hero's Grave Region"],
     # can ice grapple down
     ("Fortress Grave Path Upper",):
         ["Fortress Grave Path Upper", "Fortress Grave Path", "Fortress Grave Path Dusty Entrance",
-         "Fortress Hero's Grave"],
+         "Fortress Hero's Grave Region"],
     ("Fortress Arena", "Fortress Arena Portal"):
         ["Fortress Arena", "Fortress Arena Portal"],
     ("Lower Mountain", "Lower Mountain Stairs"):
         ["Lower Mountain", "Lower Mountain Stairs"],
-    ("Monastery Front", "Monastery Back", "Monastery Hero's Grave"):
-        ["Monastery Front", "Monastery Back", "Monastery Hero's Grave"],
+    ("Monastery Front", "Monastery Back", "Monastery Hero's Grave Region"):
+        ["Monastery Front", "Monastery Back", "Monastery Hero's Grave Region"],
     # can use ladder storage at any of the Quarry ladders to get to Monastery Rope
     ("Quarry", "Quarry Portal", "Lower Quarry", "Quarry Entry", "Quarry Back", "Quarry Monastery Entry",
      "Monastery Rope"):
@@ -952,14 +952,14 @@ dependent_regions_ur: Dict[Tuple[str, ...], List[str]] = {
         ["Rooted Ziggurat Lower Front", "Rooted Ziggurat Lower Back", "Rooted Ziggurat Portal Room Entrance"],
     ("Rooted Ziggurat Portal", "Rooted Ziggurat Portal Room Exit"):
         ["Rooted Ziggurat Portal", "Rooted Ziggurat Portal Room Exit"],
-    ("Swamp", "Swamp to Cathedral Treasure Room", "Swamp to Cathedral Main Entrance", "Back of Swamp",
-     "Back of Swamp Laurels Area", "Swamp Hero's Grave"):
-        ["Swamp", "Swamp to Cathedral Treasure Room", "Swamp to Cathedral Main Entrance", "Back of Swamp",
-         "Back of Swamp Laurels Area", "Swamp Hero's Grave"],
+    ("Swamp", "Swamp to Cathedral Treasure Room", "Swamp to Cathedral Main Entrance Region", "Back of Swamp",
+     "Back of Swamp Laurels Area", "Swamp Hero's Grave Region"):
+        ["Swamp", "Swamp to Cathedral Treasure Room", "Swamp to Cathedral Main Entrance Region", "Back of Swamp",
+         "Back of Swamp Laurels Area", "Swamp Hero's Grave Region"],
     ("Cathedral Gauntlet Checkpoint",):
         ["Cathedral Gauntlet Checkpoint", "Cathedral Gauntlet Exit", "Cathedral Gauntlet"],
-    ("Far Shore", "Far Shore to Spawn", "Far Shore to East Forest", "Far Shore to Quarry",
-     "Far Shore to Fortress", "Far Shore to Library", "Far Shore to West Garden"):
-        ["Far Shore", "Far Shore to Spawn", "Far Shore to East Forest", "Far Shore to Quarry",
-         "Far Shore to Fortress", "Far Shore to Library", "Far Shore to West Garden"]
+    ("Far Shore", "Far Shore to Spawn Region", "Far Shore to East Forest Region", "Far Shore to Quarry Region",
+     "Far Shore to Fortress Region", "Far Shore to Library Region Region", "Far Shore to West Garden Region"):
+        ["Far Shore", "Far Shore to Spawn Region", "Far Shore to East Forest Region", "Far Shore to Quarry Region",
+         "Far Shore to Fortress Region", "Far Shore to Library Region", "Far Shore to West Garden Region"]
 }

--- a/worlds/tunic/er_rules.py
+++ b/worlds/tunic/er_rules.py
@@ -237,11 +237,11 @@ def set_er_region_rules(world: "TunicWorld", ability_unlocks: Dict[str, int], re
         rule=lambda state: has_lantern(state, player, options))
 
     # West Garden
-    regions["West Garden Laurels Exit"].connect(
+    regions["West Garden Laurels Exit Region"].connect(
         connecting_region=regions["West Garden"],
         rule=lambda state: state.has(laurels, player))
     regions["West Garden"].connect(
-        connecting_region=regions["West Garden Laurels Exit"],
+        connecting_region=regions["West Garden Laurels Exit Region"],
         rule=lambda state: state.has(laurels, player))
 
     regions["West Garden after Boss"].connect(
@@ -252,9 +252,9 @@ def set_er_region_rules(world: "TunicWorld", ability_unlocks: Dict[str, int], re
         rule=lambda state: state.has(laurels, player) or has_sword(state, player))
 
     regions["West Garden"].connect(
-        connecting_region=regions["West Garden Hero's Grave"],
+        connecting_region=regions["West Garden Hero's Grave Region"],
         rule=lambda state: has_ability(state, player, prayer, options, ability_unlocks))
-    regions["West Garden Hero's Grave"].connect(
+    regions["West Garden Hero's Grave Region"].connect(
         connecting_region=regions["West Garden"])
 
     regions["West Garden Portal"].connect(
@@ -300,18 +300,18 @@ def set_er_region_rules(world: "TunicWorld", ability_unlocks: Dict[str, int], re
         rule=lambda state: state.has(grapple, player))
 
     # Library
-    regions["Library Exterior Tree"].connect(
-        connecting_region=regions["Library Exterior Ladder"],
+    regions["Library Exterior Tree Region"].connect(
+        connecting_region=regions["Library Exterior Ladder Region"],
         rule=lambda state: state.has(grapple, player) or state.has(laurels, player))
-    regions["Library Exterior Ladder"].connect(
-        connecting_region=regions["Library Exterior Tree"],
+    regions["Library Exterior Ladder Region"].connect(
+        connecting_region=regions["Library Exterior Tree Region"],
         rule=lambda state: has_ability(state, player, prayer, options, ability_unlocks)
         and (state.has(grapple, player) or state.has(laurels, player)))
 
     regions["Library Hall"].connect(
-        connecting_region=regions["Library Hero's Grave"],
+        connecting_region=regions["Library Hero's Grave Region"],
         rule=lambda state: has_ability(state, player, prayer, options, ability_unlocks))
-    regions["Library Hero's Grave"].connect(
+    regions["Library Hero's Grave Region"].connect(
         connecting_region=regions["Library Hall"])
 
     regions["Library Lab Lower"].connect(
@@ -387,16 +387,16 @@ def set_er_region_rules(world: "TunicWorld", ability_unlocks: Dict[str, int], re
         rule=lambda state: has_ice_grapple_logic(True, state, player, options, ability_unlocks))
 
     regions["Fortress Grave Path"].connect(
-        connecting_region=regions["Fortress Grave Path Dusty Entrance"],
+        connecting_region=regions["Fortress Grave Path Dusty Entrance Region"],
         rule=lambda state: state.has(laurels, player))
-    regions["Fortress Grave Path Dusty Entrance"].connect(
+    regions["Fortress Grave Path Dusty Entrance Region"].connect(
         connecting_region=regions["Fortress Grave Path"],
         rule=lambda state: state.has(laurels, player))
 
     regions["Fortress Grave Path"].connect(
-        connecting_region=regions["Fortress Hero's Grave"],
+        connecting_region=regions["Fortress Hero's Grave Region"],
         rule=lambda state: has_ability(state, player, prayer, options, ability_unlocks))
-    regions["Fortress Hero's Grave"].connect(
+    regions["Fortress Hero's Grave Region"].connect(
         connecting_region=regions["Fortress Grave Path"])
 
     # nmg: ice grapple from upper grave path to lower
@@ -478,9 +478,9 @@ def set_er_region_rules(world: "TunicWorld", ability_unlocks: Dict[str, int], re
         rule=lambda state: state.has(laurels, player) and options.logic_rules)
 
     regions["Monastery Back"].connect(
-        connecting_region=regions["Monastery Hero's Grave"],
+        connecting_region=regions["Monastery Hero's Grave Region"],
         rule=lambda state: has_ability(state, player, prayer, options, ability_unlocks))
-    regions["Monastery Hero's Grave"].connect(
+    regions["Monastery Hero's Grave Region"].connect(
         connecting_region=regions["Monastery Back"])
 
     # Ziggurat
@@ -507,9 +507,9 @@ def set_er_region_rules(world: "TunicWorld", ability_unlocks: Dict[str, int], re
         rule=lambda state: state.has(laurels, player) or can_ladder_storage(state, player, options))
 
     regions["Rooted Ziggurat Lower Back"].connect(
-        connecting_region=regions["Rooted Ziggurat Portal Room Entrance"],
+        connecting_region=regions["Rooted Ziggurat Portal Room Entrance Region"],
         rule=lambda state: has_ability(state, player, prayer, options, ability_unlocks))
-    regions["Rooted Ziggurat Portal Room Entrance"].connect(
+    regions["Rooted Ziggurat Portal Room Entrance Region"].connect(
         connecting_region=regions["Rooted Ziggurat Lower Back"])
 
     regions["Rooted Ziggurat Portal"].connect(
@@ -523,10 +523,10 @@ def set_er_region_rules(world: "TunicWorld", ability_unlocks: Dict[str, int], re
     # Swamp and Cathedral
     # nmg: ice grapple through cathedral door, can do it both ways
     regions["Swamp"].connect(
-        connecting_region=regions["Swamp to Cathedral Main Entrance"],
+        connecting_region=regions["Swamp to Cathedral Main Entrance Region"],
         rule=lambda state: has_ability(state, player, prayer, options, ability_unlocks)
         or has_ice_grapple_logic(False, state, player, options, ability_unlocks))
-    regions["Swamp to Cathedral Main Entrance"].connect(
+    regions["Swamp to Cathedral Main Entrance Region"].connect(
         connecting_region=regions["Swamp"],
         rule=lambda state: has_ice_grapple_logic(False, state, player, options, ability_unlocks))
 
@@ -550,9 +550,9 @@ def set_er_region_rules(world: "TunicWorld", ability_unlocks: Dict[str, int], re
         and has_ice_grapple_logic(True, state, player, options, ability_unlocks))
 
     regions["Back of Swamp"].connect(
-        connecting_region=regions["Swamp Hero's Grave"],
+        connecting_region=regions["Swamp Hero's Grave Region"],
         rule=lambda state: has_ability(state, player, prayer, options, ability_unlocks))
-    regions["Swamp Hero's Grave"].connect(
+    regions["Swamp Hero's Grave Region"].connect(
         connecting_region=regions["Back of Swamp"])
 
     regions["Cathedral Gauntlet Checkpoint"].connect(
@@ -567,45 +567,41 @@ def set_er_region_rules(world: "TunicWorld", ability_unlocks: Dict[str, int], re
 
     # Far Shore
     regions["Far Shore"].connect(
-        connecting_region=regions["Far Shore to Spawn"],
+        connecting_region=regions["Far Shore to Spawn Region"],
         rule=lambda state: state.has(laurels, player))
-    regions["Far Shore to Spawn"].connect(
+    regions["Far Shore to Spawn Region"].connect(
         connecting_region=regions["Far Shore"],
         rule=lambda state: state.has(laurels, player))
 
     regions["Far Shore"].connect(
-        connecting_region=regions["Far Shore to East Forest"],
+        connecting_region=regions["Far Shore to East Forest Region"],
         rule=lambda state: state.has(laurels, player))
-    regions["Far Shore to East Forest"].connect(
+    regions["Far Shore to East Forest Region"].connect(
         connecting_region=regions["Far Shore"],
         rule=lambda state: state.has(laurels, player))
 
     regions["Far Shore"].connect(
-        connecting_region=regions["Far Shore to West Garden"],
-        name="Far Shore to West Garden",
+        connecting_region=regions["Far Shore to West Garden Region"],
         rule=lambda state: state.has("Activate West Garden Fuse", player))
-    regions["Far Shore to West Garden"].connect(
+    regions["Far Shore to West Garden Region"].connect(
         connecting_region=regions["Far Shore"])
 
     regions["Far Shore"].connect(
-        connecting_region=regions["Far Shore to Quarry"],
-        name="Far Shore to Quarry",
+        connecting_region=regions["Far Shore to Quarry Region"],
         rule=lambda state: state.has("Activate Quarry Fuse", player))
-    regions["Far Shore to Quarry"].connect(
+    regions["Far Shore to Quarry Region"].connect(
         connecting_region=regions["Far Shore"])
 
     regions["Far Shore"].connect(
-        connecting_region=regions["Far Shore to Fortress"],
-        name="Far Shore to Fortress",
+        connecting_region=regions["Far Shore to Fortress Region"],
         rule=lambda state: state.has("Activate Eastern Vault West Fuses", player))
-    regions["Far Shore to Fortress"].connect(
+    regions["Far Shore to Fortress Region"].connect(
         connecting_region=regions["Far Shore"])
 
     regions["Far Shore"].connect(
-        connecting_region=regions["Far Shore to Library"],
-        name="Far Shore to Library",
+        connecting_region=regions["Far Shore to Library Region"],
         rule=lambda state: state.has("Activate Library Fuse", player))
-    regions["Far Shore to Library"].connect(
+    regions["Far Shore to Library Region"].connect(
         connecting_region=regions["Far Shore"])
 
     # Misc

--- a/worlds/tunic/er_rules.py
+++ b/worlds/tunic/er_rules.py
@@ -507,9 +507,9 @@ def set_er_region_rules(world: "TunicWorld", ability_unlocks: Dict[str, int], re
         rule=lambda state: state.has(laurels, player) or can_ladder_storage(state, player, options))
 
     regions["Rooted Ziggurat Lower Back"].connect(
-        connecting_region=regions["Rooted Ziggurat Portal Room Entrance Region"],
+        connecting_region=regions["Rooted Ziggurat Portal Room Entrance"],
         rule=lambda state: has_ability(state, player, prayer, options, ability_unlocks))
-    regions["Rooted Ziggurat Portal Room Entrance Region"].connect(
+    regions["Rooted Ziggurat Portal Room Entrance"].connect(
         connecting_region=regions["Rooted Ziggurat Lower Back"])
 
     regions["Rooted Ziggurat Portal"].connect(

--- a/worlds/tunic/er_rules.py
+++ b/worlds/tunic/er_rules.py
@@ -1,4 +1,4 @@
-from typing import Dict, TYPE_CHECKING
+from typing import Dict, TYPE_CHECKING, List, Tuple
 from worlds.generic.Rules import set_rule, forbid_item
 from .rules import has_ability, has_sword, has_stick, has_ice_grapple_logic, has_lantern, has_mask, can_ladder_storage
 from .er_data import Portal
@@ -631,222 +631,109 @@ def set_er_region_rules(world: "TunicWorld", ability_unlocks: Dict[str, int], re
     # connecting the regions portals are in to other portals you can access via ladder storage
     # using has_stick instead of can_ladder_storage since it's already checking the logic rules
     if options.logic_rules == "unrestricted":
-        def get_paired_region(portal_sd: str) -> str:
+        # returns portal name, connecting region
+        def get_portal_info(portal_sd: str) -> (str, str):
             for portal1, portal2 in portal_pairs.items():
                 if portal1.scene_destination() == portal_sd:
-                    return portal2.region
+                    return portal1.name, portal2.region
                 if portal2.scene_destination() == portal_sd:
-                    return portal1.region
+                    return portal2.name, portal1.region
             raise Exception("no matches found in get_paired_region")
 
-        # convenience helper
-        def get_portal_name(portal_sd: str) -> str:
-            for portal1, portal2 in portal_pairs.items():
-                if portal1.scene_destination() == portal_sd:
-                    return portal1.name
-                if portal2.scene_destination() == portal_sd:
-                    return portal2.name
+        ls_dict: List[Tuple[str, str]] = [
+            # The upper Swamp entrance
+            ("Overworld", "Overworld Redux, Swamp Redux 2_wall"),
+            # Western Furnace entrance, next to the sign that leads to West Garden
+            ("Overworld", "Overworld Redux, Furnace_gyro_west"),
+            # Upper West Garden entry, by the belltower
+            ("Overworld", "Overworld Redux, Archipelagos Redux_upper"),
+            # West Garden entry by the Furnace
+            ("Overworld", "Overworld Redux, Archipelagos Redux_lower"),
+            # West Garden laurels entrance, by the beach
+            ("Overworld", "Overworld Redux, Archipelagos Redux_lowest"),
+            # Well rail, west side. Can ls in town, get extra height by going over the portal pad
+            ("Overworld", "Overworld Redux, Sewer_west_aqueduct"),
+            # Well rail, east side. Need some height from the temple stairs
+            ("Overworld", "Overworld Redux, Furnace_gyro_upper_north"),
 
-        # The upper Swamp entrance
-        regions["Overworld"].connect(
-            regions[get_paired_region("Overworld Redux, Swamp Redux 2_wall")],
-            name=get_portal_name("Overworld Redux, Swamp Redux 2_wall" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
-        # Western Furnace entrance, next to the sign that leads to West Garden
-        regions["Overworld"].connect(
-            regions[get_paired_region("Overworld Redux, Furnace_gyro_west")],
-            name=get_portal_name("Overworld Redux, Furnace_gyro_west" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
-        # Upper West Garden entry, by the belltower
-        regions["Overworld"].connect(
-            regions[get_paired_region("Overworld Redux, Archipelagos Redux_upper")],
-            name=get_portal_name("Overworld Redux, Archipelagos Redux_upper" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
-        # West Garden entry by the Furnace
-        regions["Overworld"].connect(
-            regions[get_paired_region("Overworld Redux, Archipelagos Redux_lower")],
-            name=get_portal_name("Overworld Redux, Archipelagos Redux_lower" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
-        # West Garden laurels entrance, by the beach
-        regions["Overworld"].connect(
-            regions[get_paired_region("Overworld Redux, Archipelagos Redux_lowest")],
-            name=get_portal_name("Overworld Redux, Archipelagos Redux_lowest" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
-        # Well rail, west side. Can ls in town, get extra height by going over the portal pad
-        regions["Overworld"].connect(
-            regions[get_paired_region("Overworld Redux, Sewer_west_aqueduct")],
-            name=get_portal_name("Overworld Redux, Sewer_west_aqueduct" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
-        # Well rail, east side. Need some height from the temple stairs
-        regions["Overworld"].connect(
-            regions[get_paired_region("Overworld Redux, Furnace_gyro_upper_north")],
-            name=get_portal_name("Overworld Redux, Furnace_gyro_upper_north" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
+            # Furnace ladder to the fuse entrance
+            ("Furnace Ladder Area", "Furnace, Overworld Redux_gyro_upper_north"),
+            # Furnace ladder to Dark Tomb
+            ("Furnace Ladder Area", "Furnace, Crypt Redux_"),
+            # Furnace ladder to the West Garden connector
+            ("Furnace Ladder Area", "Furnace, Overworld Redux_gyro_west"),
 
-        # Furnace ladder to the fuse entrance
-        regions["Furnace Ladder Area"].connect(
-            regions[get_paired_region("Furnace, Overworld Redux_gyro_upper_north")],
-            name=get_portal_name("Furnace, Overworld Redux_gyro_upper_north" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
-        # Furnace ladder to Dark Tomb
-        regions["Furnace Ladder Area"].connect(
-            regions[get_paired_region("Furnace, Crypt Redux_")],
-            name=get_portal_name("Furnace, Crypt Redux_" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
-        # Furnace ladder to the West Garden connector
-        regions["Furnace Ladder Area"].connect(
-            regions[get_paired_region("Furnace, Overworld Redux_gyro_west")],
-            name=get_portal_name("Furnace, Overworld Redux_gyro_west" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
+            # West Garden exit after Garden Knight
+            ("West Garden", "Archipelagos Redux, Overworld Redux_upper"),
+            # West Garden laurels exit
+            ("West Garden", "Archipelagos Redux, Overworld Redux_lowest"),
 
-        # West Garden exit after Garden Knight
-        regions["West Garden"].connect(
-            regions[get_paired_region("Archipelagos Redux, Overworld Redux_upper")],
-            name=get_portal_name("Archipelagos Redux, Overworld Redux_upper" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
-        # West Garden laurels exit
-        regions["West Garden"].connect(
-            regions[get_paired_region("Archipelagos Redux, Overworld Redux_lowest")],
-            name=get_portal_name("Archipelagos Redux, Overworld Redux_lowest" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
+            # Frog mouth entrance
+            ("Ruined Atoll", "Atoll Redux, Frog Stairs_mouth"),
 
-        # Frog mouth entrance
-        regions["Ruined Atoll"].connect(
-            regions[get_paired_region("Atoll Redux, Frog Stairs_mouth")],
-            name=get_portal_name("Atoll Redux, Frog Stairs_mouth" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
+            # Entrance by the dancing fox holy cross spot
+            ("East Forest", "East Forest Redux, East Forest Redux Laddercave_upper"),
 
-        # Entrance by the dancing fox holy cross spot
-        regions["East Forest"].connect(
-            regions[get_paired_region("East Forest Redux, East Forest Redux Laddercave_upper")],
-            name=get_portal_name("East Forest Redux, East Forest Redux Laddercave_upper" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
+            # From the west side of guard house 1 to the east side
+            ("Guard House 1 West", "East Forest Redux Laddercave, East Forest Redux_gate"),
+            ("Guard House 1 West", "East Forest Redux Laddercave, Forest Boss Room_"),
 
-        # From the west side of guard house 1 to the east side
-        regions["Guard House 1 West"].connect(
-            regions[get_paired_region("East Forest Redux Laddercave, East Forest Redux_gate")],
-            name=get_portal_name("East Forest Redux Laddercave, East Forest Redux_gate" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
-        regions["Guard House 1 West"].connect(
-            regions[get_paired_region("East Forest Redux Laddercave, Forest Boss Room_")],
-            name=get_portal_name("East Forest Redux Laddercave, Forest Boss Room_" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
+            # Upper exit from the Forest Grave Path, use ls at the ladder by the gate switch
+            ("Forest Grave Path Main", "Sword Access, East Forest Redux_upper"),
 
-        # Upper exit from the Forest Grave Path, use ls at the ladder by the gate switch
-        regions["Forest Grave Path Main"].connect(
-            regions[get_paired_region("Sword Access, East Forest Redux_upper")],
-            name=get_portal_name("Sword Access, East Forest Redux_upper" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
+            # Fortress exterior shop, ls at the ladder by the telescope
+            ("Fortress Exterior from Overworld", "Fortress Courtyard, Shop_"),
+            # Fortress main entry and grave path lower entry, ls at the ladder by the telescope
+            ("Fortress Exterior from Overworld", "Fortress Courtyard, Fortress Main_Big Door"),
+            ("Fortress Exterior from Overworld", "Fortress Courtyard, Fortress Reliquary_Lower"),
+            # Upper exits from the courtyard. Use the ramp in the courtyard, then the blocks north of the first fuse
+            ("Fortress Exterior from Overworld", "Fortress Courtyard, Fortress Reliquary_Upper"),
+            ("Fortress Exterior from Overworld", "Fortress Courtyard, Fortress East_"),
 
-        # Fortress exterior shop, ls at the ladder by the telescope
-        regions["Fortress Exterior from Overworld"].connect(
-            regions[get_paired_region("Fortress Courtyard, Shop_")],
-            name=get_portal_name("Fortress Courtyard, Shop_" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
-        # Fortress main entry and grave path lower entry, ls at the ladder by the telescope
-        regions["Fortress Exterior from Overworld"].connect(
-            regions[get_paired_region("Fortress Courtyard, Fortress Main_Big Door")],
-            name=get_portal_name("Fortress Courtyard, Fortress Main_Big Door" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
-        regions["Fortress Exterior from Overworld"].connect(
-            regions[get_paired_region("Fortress Courtyard, Fortress Reliquary_Lower")],
-            name=get_portal_name("Fortress Courtyard, Fortress Reliquary_Lower" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
-        # Upper exits from the courtyard. Use the ramp in the courtyard, then the blocks north of the first fuse
-        regions["Fortress Exterior from Overworld"].connect(
-            regions[get_paired_region("Fortress Courtyard, Fortress Reliquary_Upper")],
-            name=get_portal_name("Fortress Courtyard, Fortress Reliquary_Upper" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
-        regions["Fortress Exterior from Overworld"].connect(
-            regions[get_paired_region("Fortress Courtyard, Fortress East_")],
-            name=get_portal_name("Fortress Courtyard, Fortress East_" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
+            # same as above, except from the east side of the area
+            ("Fortress Exterior from East Forest", "Fortress Courtyard, Overworld Redux_"),
+            ("Fortress Exterior from East Forest", "Fortress Courtyard, Shop_"),
+            ("Fortress Exterior from East Forest", "Fortress Courtyard, Fortress Main_Big Door"),
+            ("Fortress Exterior from East Forest", "Fortress Courtyard, Fortress Reliquary_Lower"),
+            ("Fortress Exterior from East Forest", "Fortress Courtyard, Fortress Reliquary_Upper"),
+            ("Fortress Exterior from East Forest", "Fortress Courtyard, Fortress East_"),
 
-        # same as above, except from the east side of the area
-        regions["Fortress Exterior from East Forest"].connect(
-            regions[get_paired_region("Fortress Courtyard, Overworld Redux_")],
-            name=get_portal_name("Fortress Courtyard, Overworld Redux_" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
-        regions["Fortress Exterior from East Forest"].connect(
-            regions[get_paired_region("Fortress Courtyard, Shop_")],
-            name=get_portal_name("Fortress Courtyard, Shop_" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
-        regions["Fortress Exterior from East Forest"].connect(
-            regions[get_paired_region("Fortress Courtyard, Fortress Main_Big Door")],
-            name=get_portal_name("Fortress Courtyard, Fortress Main_Big Door" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
-        regions["Fortress Exterior from East Forest"].connect(
-            regions[get_paired_region("Fortress Courtyard, Fortress Reliquary_Lower")],
-            name=get_portal_name("Fortress Courtyard, Fortress Reliquary_Lower" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
-        regions["Fortress Exterior from East Forest"].connect(
-            regions[get_paired_region("Fortress Courtyard, Fortress Reliquary_Upper")],
-            name=get_portal_name("Fortress Courtyard, Fortress Reliquary_Upper" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
-        regions["Fortress Exterior from East Forest"].connect(
-            regions[get_paired_region("Fortress Courtyard, Fortress East_")],
-            name=get_portal_name("Fortress Courtyard, Fortress East_" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
+            # same as above, except from the Beneath the Vault entrance ladder
+            ("Fortress Exterior near cave", "Fortress Courtyard, Overworld Redux_"),
+            ("Fortress Exterior near cave", "Fortress Courtyard, Fortress Main_Big Door"),
+            ("Fortress Exterior near cave", "Fortress Courtyard, Fortress Reliquary_Lower"),
+            ("Fortress Exterior near cave", "Fortress Courtyard, Fortress Reliquary_Upper"),
+            ("Fortress Exterior near cave", "Fortress Courtyard, Fortress East_"),
 
-        # same as above, except from the Beneath the Vault entrance ladder
-        regions["Fortress Exterior near cave"].connect(
-            regions[get_paired_region("Fortress Courtyard, Overworld Redux_")],
-            name=get_portal_name("Fortress Courtyard, Overworld Redux_" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
-        regions["Fortress Exterior near cave"].connect(
-            regions[get_paired_region("Fortress Courtyard, Fortress Main_Big Door")],
-            name=get_portal_name("Fortress Courtyard, Fortress Main_Big Door" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
-        regions["Fortress Exterior near cave"].connect(
-            regions[get_paired_region("Fortress Courtyard, Fortress Reliquary_Lower")],
-            name=get_portal_name("Fortress Courtyard, Fortress Reliquary_Lower" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
-        regions["Fortress Exterior near cave"].connect(
-            regions[get_paired_region("Fortress Courtyard, Fortress Reliquary_Upper")],
-            name=get_portal_name("Fortress Courtyard, Fortress Reliquary_Upper" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
-        regions["Fortress Exterior near cave"].connect(
-            regions[get_paired_region("Fortress Courtyard, Fortress East_")],
-            name=get_portal_name("Fortress Courtyard, Fortress East_" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
+            # ls at the ladder, need to gain a little height to get up the stairs
+            ("Lower Mountain", "Mountain, Mountaintop_"),
 
-        # ls at the ladder, need to gain a little height to get up the stairs
-        regions["Lower Mountain"].connect(
-            regions[get_paired_region("Mountain, Mountaintop_")],
-            name=get_portal_name("Mountain, Mountaintop_" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
+            # Where the rope is behind Monastery. Connecting here since, if you have this region, you don't need a sword
+            ("Quarry Monastery Entry", "Quarry Redux, Monastery_back"),
 
-        # Where the rope is behind Monastery. Connecting here since, if you have this region, you don't need a sword
-        regions["Quarry Monastery Entry"].connect(
-            regions[get_paired_region("Quarry Redux, Monastery_back")],
-            name=get_portal_name("Quarry Redux, Monastery_back" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
-
-        # Swamp to Gauntlet
-        regions["Swamp"].connect(
-            regions[get_paired_region("Swamp Redux 2, Cathedral Arena_")],
-            name=get_portal_name("Swamp Redux 2, Cathedral Arena_" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
-        # Swamp to Overworld upper
-        regions["Swamp"].connect(
-            regions[get_paired_region("Swamp Redux 2, Overworld Redux_wall")],
-            name=get_portal_name("Swamp Redux 2, Overworld Redux_wall" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
-        # Ladder by the hero grave
-        regions["Back of Swamp"].connect(
-            regions[get_paired_region("Swamp Redux 2, Overworld Redux_conduit")],
-            name=get_portal_name("Swamp Redux 2, Overworld Redux_conduit" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
-        regions["Back of Swamp"].connect(
-            regions[get_paired_region("Swamp Redux 2, Shop_")],
-            name=get_portal_name("Swamp Redux 2, Shop_" + " (LS)"),
-            rule=lambda state: has_stick(state, player))
-        # Need to put the cathedral HC code mid-flight
-        regions["Back of Swamp"].connect(
-            regions[get_paired_region("Swamp Redux 2, Cathedral Redux_secret")],
-            name=get_portal_name("Swamp Redux 2, Cathedral Redux_secret" + " (LS)"),
-            rule=lambda state: has_stick(state, player)
-            and has_ability(state, player, holy_cross, options, ability_unlocks))
+            # Swamp to Gauntlet
+            ("Swamp", "Swamp Redux 2, Cathedral Arena_"),
+            # Swamp to Overworld upper
+            ("Swamp", "Swamp Redux 2, Overworld Redux_wall"),
+            # Ladder by the hero grave
+            ("Back of Swamp", "Swamp Redux 2, Overworld Redux_conduit"),
+            ("Back of Swamp", "Swamp Redux 2, Shop_"),
+            # Need to put the cathedral HC code mid-flight
+            ("Back of Swamp", "Swamp Redux 2, Cathedral Redux_secret")
+        ]
+        for region_name, scene_dest in ls_dict:
+            portal_name, paired_region = get_portal_info(scene_dest)
+            if portal_name == "Swamp to Cathedral Secret Legend Room Entrance":
+                regions[region_name].connect(
+                    regions[paired_region],
+                    name=portal_name + " (LS)",
+                    rule=lambda state: has_stick(state, player)
+                    and has_ability(state, player, holy_cross, options, ability_unlocks))
+            else:
+                regions[region_name].connect(
+                    regions[paired_region],
+                    name=portal_name + " (LS)",
+                    rule=lambda state: has_stick(state, player))
 
 
 def set_er_location_rules(world: "TunicWorld", ability_unlocks: Dict[str, int]) -> None:

--- a/worlds/tunic/er_rules.py
+++ b/worlds/tunic/er_rules.py
@@ -640,6 +640,7 @@ def set_er_region_rules(world: "TunicWorld", ability_unlocks: Dict[str, int], re
                     return portal2.name, portal1.region
             raise Exception("no matches found in get_paired_region")
 
+        # List of regions, and the portal you can get to using ladder storage there
         ls_dict: List[Tuple[str, str]] = [
             # The upper Swamp entrance
             ("Overworld", "Overworld Redux, Swamp Redux 2_wall"),
@@ -723,6 +724,7 @@ def set_er_region_rules(world: "TunicWorld", ability_unlocks: Dict[str, int], re
         ]
         for region_name, scene_dest in ls_dict:
             portal_name, paired_region = get_portal_info(scene_dest)
+            # this is the only exception, requiring holy cross as well
             if portal_name == "Swamp to Cathedral Secret Legend Room Entrance":
                 regions[region_name].connect(
                     regions[paired_region],

--- a/worlds/tunic/er_rules.py
+++ b/worlds/tunic/er_rules.py
@@ -639,164 +639,212 @@ def set_er_region_rules(world: "TunicWorld", ability_unlocks: Dict[str, int], re
                     return portal1.region
             raise Exception("no matches found in get_paired_region")
 
+        # convenience helper
+        def get_portal_name(portal_sd: str) -> str:
+            for portal1, portal2 in portal_pairs.items():
+                if portal1.scene_destination() == portal_sd:
+                    return portal1.name
+                if portal2.scene_destination() == portal_sd:
+                    return portal2.name
+
         # The upper Swamp entrance
         regions["Overworld"].connect(
             regions[get_paired_region("Overworld Redux, Swamp Redux 2_wall")],
+            name=get_portal_name("Overworld Redux, Swamp Redux 2_wall" + " (LS)"),
             rule=lambda state: has_stick(state, player))
         # Western Furnace entrance, next to the sign that leads to West Garden
         regions["Overworld"].connect(
             regions[get_paired_region("Overworld Redux, Furnace_gyro_west")],
+            name=get_portal_name("Overworld Redux, Furnace_gyro_west" + " (LS)"),
             rule=lambda state: has_stick(state, player))
         # Upper West Garden entry, by the belltower
         regions["Overworld"].connect(
             regions[get_paired_region("Overworld Redux, Archipelagos Redux_upper")],
+            name=get_portal_name("Overworld Redux, Archipelagos Redux_upper" + " (LS)"),
             rule=lambda state: has_stick(state, player))
         # West Garden entry by the Furnace
         regions["Overworld"].connect(
             regions[get_paired_region("Overworld Redux, Archipelagos Redux_lower")],
+            name=get_portal_name("Overworld Redux, Archipelagos Redux_lower" + " (LS)"),
             rule=lambda state: has_stick(state, player))
         # West Garden laurels entrance, by the beach
         regions["Overworld"].connect(
             regions[get_paired_region("Overworld Redux, Archipelagos Redux_lowest")],
+            name=get_portal_name("Overworld Redux, Archipelagos Redux_lowest" + " (LS)"),
             rule=lambda state: has_stick(state, player))
         # Well rail, west side. Can ls in town, get extra height by going over the portal pad
         regions["Overworld"].connect(
             regions[get_paired_region("Overworld Redux, Sewer_west_aqueduct")],
+            name=get_portal_name("Overworld Redux, Sewer_west_aqueduct" + " (LS)"),
             rule=lambda state: has_stick(state, player))
         # Well rail, east side. Need some height from the temple stairs
         regions["Overworld"].connect(
             regions[get_paired_region("Overworld Redux, Furnace_gyro_upper_north")],
+            name=get_portal_name("Overworld Redux, Furnace_gyro_upper_north" + " (LS)"),
             rule=lambda state: has_stick(state, player))
 
         # Furnace ladder to the fuse entrance
         regions["Furnace Ladder Area"].connect(
             regions[get_paired_region("Furnace, Overworld Redux_gyro_upper_north")],
+            name=get_portal_name("Furnace, Overworld Redux_gyro_upper_north" + " (LS)"),
             rule=lambda state: has_stick(state, player))
         # Furnace ladder to Dark Tomb
         regions["Furnace Ladder Area"].connect(
             regions[get_paired_region("Furnace, Crypt Redux_")],
+            name=get_portal_name("Furnace, Crypt Redux_" + " (LS)"),
             rule=lambda state: has_stick(state, player))
         # Furnace ladder to the West Garden connector
         regions["Furnace Ladder Area"].connect(
             regions[get_paired_region("Furnace, Overworld Redux_gyro_west")],
+            name=get_portal_name("Furnace, Overworld Redux_gyro_west" + " (LS)"),
             rule=lambda state: has_stick(state, player))
 
         # West Garden exit after Garden Knight
         regions["West Garden"].connect(
             regions[get_paired_region("Archipelagos Redux, Overworld Redux_upper")],
+            name=get_portal_name("Archipelagos Redux, Overworld Redux_upper" + " (LS)"),
             rule=lambda state: has_stick(state, player))
         # West Garden laurels exit
         regions["West Garden"].connect(
             regions[get_paired_region("Archipelagos Redux, Overworld Redux_lowest")],
+            name=get_portal_name("Archipelagos Redux, Overworld Redux_lowest" + " (LS)"),
             rule=lambda state: has_stick(state, player))
 
         # Frog mouth entrance
         regions["Ruined Atoll"].connect(
             regions[get_paired_region("Atoll Redux, Frog Stairs_mouth")],
+            name=get_portal_name("Atoll Redux, Frog Stairs_mouth" + " (LS)"),
             rule=lambda state: has_stick(state, player))
 
         # Entrance by the dancing fox holy cross spot
         regions["East Forest"].connect(
             regions[get_paired_region("East Forest Redux, East Forest Redux Laddercave_upper")],
+            name=get_portal_name("East Forest Redux, East Forest Redux Laddercave_upper" + " (LS)"),
             rule=lambda state: has_stick(state, player))
 
         # From the west side of guard house 1 to the east side
         regions["Guard House 1 West"].connect(
             regions[get_paired_region("East Forest Redux Laddercave, East Forest Redux_gate")],
+            name=get_portal_name("East Forest Redux Laddercave, East Forest Redux_gate" + " (LS)"),
             rule=lambda state: has_stick(state, player))
         regions["Guard House 1 West"].connect(
             regions[get_paired_region("East Forest Redux Laddercave, Forest Boss Room_")],
+            name=get_portal_name("East Forest Redux Laddercave, Forest Boss Room_" + " (LS)"),
             rule=lambda state: has_stick(state, player))
 
         # Upper exit from the Forest Grave Path, use ls at the ladder by the gate switch
         regions["Forest Grave Path Main"].connect(
             regions[get_paired_region("Sword Access, East Forest Redux_upper")],
+            name=get_portal_name("Sword Access, East Forest Redux_upper" + " (LS)"),
             rule=lambda state: has_stick(state, player))
 
         # Fortress exterior shop, ls at the ladder by the telescope
         regions["Fortress Exterior from Overworld"].connect(
             regions[get_paired_region("Fortress Courtyard, Shop_")],
+            name=get_portal_name("Fortress Courtyard, Shop_" + " (LS)"),
             rule=lambda state: has_stick(state, player))
         # Fortress main entry and grave path lower entry, ls at the ladder by the telescope
         regions["Fortress Exterior from Overworld"].connect(
             regions[get_paired_region("Fortress Courtyard, Fortress Main_Big Door")],
+            name=get_portal_name("Fortress Courtyard, Fortress Main_Big Door" + " (LS)"),
             rule=lambda state: has_stick(state, player))
         regions["Fortress Exterior from Overworld"].connect(
             regions[get_paired_region("Fortress Courtyard, Fortress Reliquary_Lower")],
+            name=get_portal_name("Fortress Courtyard, Fortress Reliquary_Lower" + " (LS)"),
             rule=lambda state: has_stick(state, player))
         # Upper exits from the courtyard. Use the ramp in the courtyard, then the blocks north of the first fuse
         regions["Fortress Exterior from Overworld"].connect(
             regions[get_paired_region("Fortress Courtyard, Fortress Reliquary_Upper")],
+            name=get_portal_name("Fortress Courtyard, Fortress Reliquary_Upper" + " (LS)"),
             rule=lambda state: has_stick(state, player))
         regions["Fortress Exterior from Overworld"].connect(
             regions[get_paired_region("Fortress Courtyard, Fortress East_")],
+            name=get_portal_name("Fortress Courtyard, Fortress East_" + " (LS)"),
             rule=lambda state: has_stick(state, player))
 
         # same as above, except from the east side of the area
         regions["Fortress Exterior from East Forest"].connect(
             regions[get_paired_region("Fortress Courtyard, Overworld Redux_")],
+            name=get_portal_name("Fortress Courtyard, Overworld Redux_" + " (LS)"),
             rule=lambda state: has_stick(state, player))
         regions["Fortress Exterior from East Forest"].connect(
             regions[get_paired_region("Fortress Courtyard, Shop_")],
+            name=get_portal_name("Fortress Courtyard, Shop_" + " (LS)"),
             rule=lambda state: has_stick(state, player))
         regions["Fortress Exterior from East Forest"].connect(
             regions[get_paired_region("Fortress Courtyard, Fortress Main_Big Door")],
+            name=get_portal_name("Fortress Courtyard, Fortress Main_Big Door" + " (LS)"),
             rule=lambda state: has_stick(state, player))
         regions["Fortress Exterior from East Forest"].connect(
             regions[get_paired_region("Fortress Courtyard, Fortress Reliquary_Lower")],
+            name=get_portal_name("Fortress Courtyard, Fortress Reliquary_Lower" + " (LS)"),
             rule=lambda state: has_stick(state, player))
         regions["Fortress Exterior from East Forest"].connect(
             regions[get_paired_region("Fortress Courtyard, Fortress Reliquary_Upper")],
+            name=get_portal_name("Fortress Courtyard, Fortress Reliquary_Upper" + " (LS)"),
             rule=lambda state: has_stick(state, player))
         regions["Fortress Exterior from East Forest"].connect(
             regions[get_paired_region("Fortress Courtyard, Fortress East_")],
+            name=get_portal_name("Fortress Courtyard, Fortress East_" + " (LS)"),
             rule=lambda state: has_stick(state, player))
 
         # same as above, except from the Beneath the Vault entrance ladder
         regions["Fortress Exterior near cave"].connect(
             regions[get_paired_region("Fortress Courtyard, Overworld Redux_")],
+            name=get_portal_name("Fortress Courtyard, Overworld Redux_" + " (LS)"),
             rule=lambda state: has_stick(state, player))
         regions["Fortress Exterior near cave"].connect(
             regions[get_paired_region("Fortress Courtyard, Fortress Main_Big Door")],
+            name=get_portal_name("Fortress Courtyard, Fortress Main_Big Door" + " (LS)"),
             rule=lambda state: has_stick(state, player))
         regions["Fortress Exterior near cave"].connect(
             regions[get_paired_region("Fortress Courtyard, Fortress Reliquary_Lower")],
+            name=get_portal_name("Fortress Courtyard, Fortress Reliquary_Lower" + " (LS)"),
             rule=lambda state: has_stick(state, player))
         regions["Fortress Exterior near cave"].connect(
             regions[get_paired_region("Fortress Courtyard, Fortress Reliquary_Upper")],
+            name=get_portal_name("Fortress Courtyard, Fortress Reliquary_Upper" + " (LS)"),
             rule=lambda state: has_stick(state, player))
         regions["Fortress Exterior near cave"].connect(
             regions[get_paired_region("Fortress Courtyard, Fortress East_")],
+            name=get_portal_name("Fortress Courtyard, Fortress East_" + " (LS)"),
             rule=lambda state: has_stick(state, player))
 
         # ls at the ladder, need to gain a little height to get up the stairs
         regions["Lower Mountain"].connect(
             regions[get_paired_region("Mountain, Mountaintop_")],
+            name=get_portal_name("Mountain, Mountaintop_" + " (LS)"),
             rule=lambda state: has_stick(state, player))
 
         # Where the rope is behind Monastery. Connecting here since, if you have this region, you don't need a sword
         regions["Quarry Monastery Entry"].connect(
             regions[get_paired_region("Quarry Redux, Monastery_back")],
+            name=get_portal_name("Quarry Redux, Monastery_back" + " (LS)"),
             rule=lambda state: has_stick(state, player))
 
         # Swamp to Gauntlet
         regions["Swamp"].connect(
             regions[get_paired_region("Swamp Redux 2, Cathedral Arena_")],
+            name=get_portal_name("Swamp Redux 2, Cathedral Arena_" + " (LS)"),
             rule=lambda state: has_stick(state, player))
         # Swamp to Overworld upper
         regions["Swamp"].connect(
             regions[get_paired_region("Swamp Redux 2, Overworld Redux_wall")],
+            name=get_portal_name("Swamp Redux 2, Overworld Redux_wall" + " (LS)"),
             rule=lambda state: has_stick(state, player))
         # Ladder by the hero grave
         regions["Back of Swamp"].connect(
             regions[get_paired_region("Swamp Redux 2, Overworld Redux_conduit")],
+            name=get_portal_name("Swamp Redux 2, Overworld Redux_conduit" + " (LS)"),
             rule=lambda state: has_stick(state, player))
         regions["Back of Swamp"].connect(
             regions[get_paired_region("Swamp Redux 2, Shop_")],
+            name=get_portal_name("Swamp Redux 2, Shop_" + " (LS)"),
             rule=lambda state: has_stick(state, player))
         # Need to put the cathedral HC code mid-flight
         regions["Back of Swamp"].connect(
             regions[get_paired_region("Swamp Redux 2, Cathedral Redux_secret")],
+            name=get_portal_name("Swamp Redux 2, Cathedral Redux_secret" + " (LS)"),
             rule=lambda state: has_stick(state, player)
             and has_ability(state, player, holy_cross, options, ability_unlocks))
 

--- a/worlds/tunic/er_scripts.py
+++ b/worlds/tunic/er_scripts.py
@@ -282,10 +282,10 @@ def create_randomized_entrances(portal_pairs: Dict[Portal, Portal], regions: Dic
     for portal1, portal2 in portal_pairs.items():
         region1 = regions[portal1.region]
         region2 = regions[portal2.region]
-        region1.connect(region2, portal1.name)
+        region1.connect(connecting_region=region2, name=portal1.name)
         # prevent the logic from thinking you can get to any shop-connected region from the shop
         if portal2.name != "Shop":
-            region2.connect(region1, portal2.name)
+            region2.connect(connecting_region=region1, name=portal2.name)
 
 
 # loop through the static connections, return regions you can reach from this region

--- a/worlds/tunic/er_scripts.py
+++ b/worlds/tunic/er_scripts.py
@@ -282,10 +282,10 @@ def create_randomized_entrances(portal_pairs: Dict[Portal, Portal], regions: Dic
     for portal1, portal2 in portal_pairs.items():
         region1 = regions[portal1.region]
         region2 = regions[portal2.region]
-        region1.connect(region2, f"{portal1.name}")
+        region1.connect(region2, portal1.name)
         # prevent the logic from thinking you can get to any shop-connected region from the shop
         if portal2.name != "Shop":
-            region2.connect(region1, f"{portal2.name}")
+            region2.connect(region1, portal2.name)
 
 
 # loop through the static connections, return regions you can reach from this region

--- a/worlds/tunic/locations.py
+++ b/worlds/tunic/locations.py
@@ -174,7 +174,7 @@ location_table: Dict[str, TunicLocationData] = {
     "Sealed Temple - Page Pickup": TunicLocationData("Overworld", "Sealed Temple"),
     "Hourglass Cave - Hourglass Chest": TunicLocationData("Overworld", "Hourglass Cave"),
     "Far Shore - Secret Chest": TunicLocationData("Overworld", "Far Shore"),
-    "Far Shore - Page Pickup": TunicLocationData("Overworld", "Far Shore to Spawn"),
+    "Far Shore - Page Pickup": TunicLocationData("Overworld", "Far Shore to Spawn Region"),
     "Coins in the Well - 10 Coins": TunicLocationData("Overworld", "Overworld", "well"),
     "Coins in the Well - 15 Coins": TunicLocationData("Overworld", "Overworld", "well"),
     "Coins in the Well - 3 Coins": TunicLocationData("Overworld", "Overworld", "well"),


### PR DESCRIPTION
## What is this fixing or adding?
From a recommendation by alwaysintreble, uses all state to generate hint paths to locations in ER. All state appears to have short paths to checks most of the time, so it's decently appropriate to use here.

This also just completely removes the old hinting thing we had going on, and good riddance imo.

## How was this tested?
Several gens, hinting everything and looking for anything weird

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/24858499/eeb53aad-69d5-4abe-a5e8-079e9ef0415d)
