### PR TITLE
TUNIC: Fix for incorrect Zig 3 ER rule

### DIFF
--- a/worlds/tunic/er_rules.py
+++ b/worlds/tunic/er_rules.py
@@ -504,7 +504,8 @@ def set_er_region_rules(world: "TunicWorld", ability_unlocks: Dict[str, int], re
     # unrestricted: use ladder storage to get to the front, get hit by one of the many enemies
     regions["Rooted Ziggurat Lower Back"].connect(
         connecting_region=regions["Rooted Ziggurat Lower Front"],
-        rule=lambda state: state.has(laurels, player) or can_ladder_storage(state, player, options))
+        rule=lambda state: (state.has(laurels, player) and has_ability(state, player, prayer, options, ability_unlocks)
+                            and has_sword(state, player)) or can_ladder_storage(state, player, options))
 
     regions["Rooted Ziggurat Lower Back"].connect(
         connecting_region=regions["Rooted Ziggurat Portal Room Entrance"],

--- a/worlds/tunic/er_rules.py
+++ b/worlds/tunic/er_rules.py
@@ -502,9 +502,12 @@ def set_er_region_rules(world: "TunicWorld", ability_unlocks: Dict[str, int], re
         rule=lambda state: state.has(laurels, player)
         or (has_sword(state, player) and has_ability(state, player, prayer, options, ability_unlocks)))
     # unrestricted: use ladder storage to get to the front, get hit by one of the many enemies
+    # nmg: can ice grapple on the voidlings to the double admin fight, still need to pray at the fuse
     regions["Rooted Ziggurat Lower Back"].connect(
         connecting_region=regions["Rooted Ziggurat Lower Front"],
-        rule=lambda state: (state.has(laurels, player) and has_ability(state, player, prayer, options, ability_unlocks)
+        rule=lambda state: ((state.has(laurels, player) or
+                            has_ice_grapple_logic(True, state, player, options, ability_unlocks)) and
+                            has_ability(state, player, prayer, options, ability_unlocks)
                             and has_sword(state, player)) or can_ladder_storage(state, player, options))
 
     regions["Rooted Ziggurat Lower Back"].connect(


### PR DESCRIPTION
## What is this fixing or adding?
I thought you could dash across the bridge before the double admin fight when doing lower Zig backwards. I was wrong.
Adds the requirement of having Prayer and Sword to the Laurels requirement for doing Lower Zig backwards in ER.

## How was this tested?
Ran gen a few times, mostly.

## If this makes graphical changes, please attach screenshots.
N/A