### PR TITLE
Speedups: no cinit, no pickling

### DIFF
--- a/_speedups.pyx
+++ b/_speedups.pyx
@@ -48,6 +48,7 @@ cdef struct IndexEntry:
     size_t count
 
 
+@cython.auto_pickle(False)
 cdef class LocationStore:
     """Compact store for locations and their items in a MultiServer"""
     # The original implementation uses Dict[int, Dict[int, Tuple(int, int, int]]
@@ -269,6 +270,7 @@ cdef class LocationStore:
                        entry.location not in checked])
 
 
+@cython.auto_pickle(False)
 @cython.internal  # unsafe. disable direct import
 cdef class PlayerLocationProxy:
     cdef LocationStore _store

--- a/_speedups.pyx
+++ b/_speedups.pyx
@@ -78,18 +78,6 @@ cdef class LocationStore:
         size += sizeof(self._raw_proxies[0]) * self.sender_index_size
         return size
 
-    def __cinit__(self, locations_dict: Dict[int, Dict[int, Sequence[int]]]) -> None:
-        self._mem = None
-        self._keys = None
-        self._items = None
-        self._proxies = None
-        self._len = 0
-        self.entries = NULL
-        self.entry_count = 0
-        self.sender_index = NULL
-        self.sender_index_size = 0
-        self._raw_proxies = NULL
-
     def __init__(self, locations_dict: Dict[int, Dict[int, Sequence[int]]]) -> None:
         self._mem = Pool()
         cdef object key


### PR DESCRIPTION
## What is this fixing or adding?

* **remove unnecessary cinit**
    This was meant for (memory) safety, but [cython docs](https://cython.readthedocs.io/en/latest/src/userguide/special_methods.html#initialisation-methods-cinit-and-init) clearly state that this
    is done automatically. The code generated for cinit with args is what
    triggers a 'possible null deref' in clang's static analyzer, so by removing
    cinit, we can now use static analysis.
* **disable pickling of LocationStore and internal classes**
    This reduces code size and avoids accidentally pickling them.

(Declaring `__cinit__` did disable `__reduce__` for LocationStore (but not for internal classes), so adding this in the same PR.)

## How was this tested?

Unit tests and `scan-build -disable-checker deadcode.DeadStores --status-bugs python setup.py build`