### PR TITLE
CI: add static analysis for native code / cython

### DIFF
--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -12,6 +12,7 @@ on:
       - '**.hpp'
       - '**.pyx'
       - 'setup.py'
+      - 'requirements.txt'
       - '.github/workflows/scan-build.yml'
   pull_request:
     paths:
@@ -24,6 +25,7 @@ on:
       - '**.hpp'
       - '**.pyx'
       - 'setup.py'
+      - 'requirements.txt'
       - '.github/workflows/scan-build.yml'
 
 jobs:

--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -1,0 +1,63 @@
+name: Native Code Static Analysis
+
+on:
+  push:
+    paths:
+      - '**.c'
+      - '**.cc'
+      - '**.cpp'
+      - '**.cxx'
+      - '**.h'
+      - '**.hh'
+      - '**.hpp'
+      - '**.pyx'
+      - 'setup.py'
+      - '.github/workflows/scan-build.yml'
+  pull_request:
+    paths:
+      - '**.c'
+      - '**.cc'
+      - '**.cpp'
+      - '**.cxx'
+      - '**.h'
+      - '**.hh'
+      - '**.hpp'
+      - '**.pyx'
+      - 'setup.py'
+      - '.github/workflows/scan-build.yml'
+
+jobs:
+  scan-build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+    - name: Install newer Clang
+      run: |
+        wget https://apt.llvm.org/llvm.sh
+        chmod +x ./llvm.sh
+        sudo ./llvm.sh 17
+    - name: Install scan-build command
+      run: |
+        sudo apt install clang-tools-17
+    - name: Get a recent python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+    - name: Install dependencies
+      run: |
+        python -m venv venv
+        source venv/bin/activate
+        python -m pip install --upgrade pip -r requirements.txt
+    - name: scan-build
+      run: |
+        source venv/bin/activate
+        scan-build-17 --status-bugs -o scan-build-reports -disable-checker deadcode.DeadStores python setup.py build -y
+    - name: Store report
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: scan-build-reports
+        path: scan-build-reports


### PR DESCRIPTION
## What is this fixing or adding?

Runs static analysis of native code using clang's scan-build when a native code file or setup.py changes.
When it finds a problem (warning), the action fails and it uploads a report.

## How was this tested?

CI here and at https://github.com/black-sliver/scan-build-cython-test