### PR TITLE
LTTP: Thieves' Town Big Chest fix

### DIFF
--- a/worlds/alttp/Rules.py
+++ b/worlds/alttp/Rules.py
@@ -397,9 +397,9 @@ def global_rules(world, player):
         set_rule(world.get_entrance('Blind Fight', player), lambda state: state._lttp_has_key('Small Key (Thieves Town)', player, 3) and can_use_bombs(state, player))
 
     set_rule(world.get_location('Thieves\' Town - Big Chest', player),
-             lambda state: (state._lttp_has_key('Small Key (Thieves Town)', player, 3)) and state.has('Hammer', player))
+             lambda state: ((state._lttp_has_key('Small Key (Thieves Town)', player, 3)) or (location_item_name(state, 'Thieves\' Town - Big Chest', player) == ("Small Key (Thieves Town)", player)) and state._lttp_has_key('Small Key (Thieves Town)', player, 2)) and state.has('Hammer', player))
     if world.accessibility[player] != 'locations':
-        allow_self_locking_items(world.get_location('Thieves\' Town - Big Chest', player), 'Small Key (Thieves Town)')
+        set_always_allow(world.get_location('Thieves\' Town - Big Chest', player), lambda state, item: item.name == 'Small Key (Thieves Town)' and item.player == player)
 
     set_rule(world.get_location('Thieves\' Town - Attic', player), lambda state: state._lttp_has_key('Small Key (Thieves Town)', player, 3))
     set_rule(world.get_location('Thieves\' Town - Spike Switch Pot Key', player),


### PR DESCRIPTION
## What is this fixing or adding?
Changes the "self locking" rules on the Thieves' Town Big Chest so that it always logically requires Hammer.

## How was this tested?
Generated two games with a Small Key (Thieves Town) plando'd onto the Big Chest, one with Hammer plando'd in the attic and one without. The former failed and the latter succeeded.