### PR TITLE
Bumper Stickers - logic fixes for "off-by-one" errors

### DIFF
--- a/worlds/bumpstik/Regions.py
+++ b/worlds/bumpstik/Regions.py
@@ -17,21 +17,19 @@ def create_regions(world: MultiWorld, player: int):
         "Level 1": level2_locs + ["Bonus Booster 2"] + [f"Treasure Bumper {i + 9}" for i in range(8)],
         "Level 2": level3_locs + ["Bonus Booster 3"] + [f"Treasure Bumper {i + 17}" for i in range(8)],
         "Level 3": level4_locs + [f"Bonus Booster {i + 4}" for i in range(2)] +
-                                 [f"Treasure Bumper {i + 25}" for i in range(8)],
+                   [f"Treasure Bumper {i + 25}" for i in range(8)],
         "Level 4": level5_locs
     }
 
     entrance_map = {
-        # Give the player some wiggle room on treasure bumpers, by requiring 1 more to
-        # logically access each level than the game actually needs to unlock that level
         "Level 1": lambda state:
-        state.has("Booster Bumper", player, 1) and state.has("Treasure Bumper", player, 9),
+        state.has("Booster Bumper", player, 1) and state.has("Treasure Bumper", player, 8),
         "Level 2": lambda state:
-        state.has("Booster Bumper", player, 2) and state.has("Treasure Bumper", player, 17),
+        state.has("Booster Bumper", player, 2) and state.has("Treasure Bumper", player, 16),
         "Level 3": lambda state:
-        state.has("Booster Bumper", player, 3) and state.has("Treasure Bumper", player, 25),
+        state.has("Booster Bumper", player, 3) and state.has("Treasure Bumper", player, 24),
         "Level 4": lambda state:
-        state.has("Booster Bumper", player, 5) and state.has("Treasure Bumper", player, 33)
+        state.has("Booster Bumper", player, 5) and state.has("Treasure Bumper", player, 32)
     }
 
     for x, region_name in enumerate(region_map):

--- a/worlds/bumpstik/Regions.py
+++ b/worlds/bumpstik/Regions.py
@@ -17,19 +17,21 @@ def create_regions(world: MultiWorld, player: int):
         "Level 1": level2_locs + ["Bonus Booster 2"] + [f"Treasure Bumper {i + 9}" for i in range(8)],
         "Level 2": level3_locs + ["Bonus Booster 3"] + [f"Treasure Bumper {i + 17}" for i in range(8)],
         "Level 3": level4_locs + [f"Bonus Booster {i + 4}" for i in range(2)] +
-                   [f"Treasure Bumper {i + 25}" for i in range(8)],
+                                 [f"Treasure Bumper {i + 25}" for i in range(8)],
         "Level 4": level5_locs
     }
 
     entrance_map = {
+        # Give the player some wiggle room on treasure bumpers, by requiring 1 more to
+        # logically access each level than the game actually needs to unlock that level
         "Level 1": lambda state:
-        state.has("Booster Bumper", player, 1) and state.has("Treasure Bumper", player, 8),
+        state.has("Booster Bumper", player, 1) and state.has("Treasure Bumper", player, 9),
         "Level 2": lambda state:
-        state.has("Booster Bumper", player, 2) and state.has("Treasure Bumper", player, 16),
+        state.has("Booster Bumper", player, 2) and state.has("Treasure Bumper", player, 17),
         "Level 3": lambda state:
-        state.has("Booster Bumper", player, 3) and state.has("Treasure Bumper", player, 24),
+        state.has("Booster Bumper", player, 3) and state.has("Treasure Bumper", player, 25),
         "Level 4": lambda state:
-        state.has("Booster Bumper", player, 5) and state.has("Treasure Bumper", player, 32)
+        state.has("Booster Bumper", player, 5) and state.has("Treasure Bumper", player, 33)
     }
 
     for x, region_name in enumerate(region_map):

--- a/worlds/bumpstik/__init__.py
+++ b/worlds/bumpstik/__init__.py
@@ -116,12 +116,12 @@ class BumpStikWorld(World):
         self.multiworld.itempool += item_pool
 
     def set_rules(self):
-        for x in range(1, 33):
-            self.multiworld.get_location(f"Treasure Bumper {x}", self.player).access_rule = \
-                lambda state, n = x: state.has("Treasure Bumper", self.player, n)
-        for x in range(1, 6):
-            self.multiworld.get_location(f"Bonus Booster {x}", self.player).access_rule = \
-                lambda state, n = x: state.has("Booster Bumper", self.player, n)
+        for treasure_count in range(1, 33):
+            self.multiworld.get_location(f"Treasure Bumper {treasure_count}", self.player).access_rule = \
+                lambda state, treasure_held = treasure_count: state.has("Treasure Bumper", self.player, treasure_held)
+        for booster_count in range(1, 6):
+            self.multiworld.get_location(f"Bonus Booster {booster_count}", self.player).access_rule = \
+                lambda state, booster_held = booster_count: state.has("Booster Bumper", self.player, booster_held)
         self.multiworld.get_location("Level 5 - Cleared all Hazards", self.player).access_rule = \
             lambda state: state.has("Hazard Bumper", self.player, 25)
             

--- a/worlds/bumpstik/__init__.py
+++ b/worlds/bumpstik/__init__.py
@@ -116,12 +116,12 @@ class BumpStikWorld(World):
         self.multiworld.itempool += item_pool
 
     def set_rules(self):
-        for x in range(1, 32):
+        for x in range(1, 33):
             self.multiworld.get_location(f"Treasure Bumper {x}", self.player).access_rule = \
-                lambda state, x = x: state.has("Treasure Bumper", self.player, x)
-        for x in range(1, 5):
+                lambda state, n = x: state.has("Treasure Bumper", self.player, n)
+        for x in range(1, 6):
             self.multiworld.get_location(f"Bonus Booster {x}", self.player).access_rule = \
-                lambda state, x = x: state.has("Booster Bumper", self.player, x)
+                lambda state, n = x: state.has("Booster Bumper", self.player, n)
         self.multiworld.get_location("Level 5 - Cleared all Hazards", self.player).access_rule = \
             lambda state: state.has("Hazard Bumper", self.player, 25)
             

--- a/worlds/bumpstik/__init__.py
+++ b/worlds/bumpstik/__init__.py
@@ -117,10 +117,10 @@ class BumpStikWorld(World):
 
     def set_rules(self):
         for x in range(1, 32):
-            self.multiworld.get_location(f"Treasure Bumper {x + 1}", self.player).access_rule = \
+            self.multiworld.get_location(f"Treasure Bumper {x}", self.player).access_rule = \
                 lambda state, x = x: state.has("Treasure Bumper", self.player, x)
         for x in range(1, 5):
-            self.multiworld.get_location(f"Bonus Booster {x + 1}", self.player).access_rule = \
+            self.multiworld.get_location(f"Bonus Booster {x}", self.player).access_rule = \
                 lambda state, x = x: state.has("Booster Bumper", self.player, x)
         self.multiworld.get_location("Level 5 - Cleared all Hazards", self.player).access_rule = \
             lambda state: state.has("Hazard Bumper", self.player, 25)

--- a/worlds/bumpstik/test/TestLogic.py
+++ b/worlds/bumpstik/test/TestLogic.py
@@ -3,38 +3,38 @@ from . import BumpStikTestBase
 
 class TestRuleLogic(BumpStikTestBase):
     def testLogic(self):
-        for x in range(1, 33):
-            if x == 32:
+        for treasure_bumpers_held in range(1, 33):
+            if treasure_bumpers_held == 32:
                 self.assertFalse(self.can_reach_location("Level 5 - Cleared all Hazards"))
 
             self.collect(self.get_item_by_name("Treasure Bumper"))
-            if x % 8 == 0:
-                bb_count = round(x / 8)
+            if treasure_bumpers_held % 8 == 0:
+                bb_count = round(treasure_bumpers_held / 8)
 
                 if bb_count < 4:
-                    self.assertFalse(self.can_reach_location(f"Treasure Bumper {x + 1}"))
+                    self.assertFalse(self.can_reach_location(f"Treasure Bumper {treasure_bumpers_held + 1}"))
                     # Can't reach Treasure Bumper 9 check until level 2 is unlocked, etc.
                     # But we don't have enough Treasure Bumpers to reach this check anyway??
                 elif bb_count == 4:
                     bb_count += 1
                     # Level 4 has two new Bonus Booster checks; need to check both
 
-                for y in range(self.count("Booster Bumper"), bb_count + 1):
-                    if y > 0:
-                        self.assertTrue(self.can_reach_location(f"Bonus Booster {y}"),
-                                    f"Bonus Booster {y} check not reachable with {self.count('Booster Bumper')} Booster Bumpers")
-                    if y < 5:
-                        self.assertFalse(self.can_reach_location(f"Bonus Booster {y + 1}"),
-                                         f"Bonus Booster {y + 1} check reachable with {self.count('Treasure Bumper')} Treasure Bumpers and {self.count('Booster Bumper')} Booster Bumpers")
-                    if y < bb_count:
+                for booster_bumpers_held in range(self.count("Booster Bumper"), bb_count + 1):
+                    if booster_bumpers_held > 0:
+                        self.assertTrue(self.can_reach_location(f"Bonus Booster {booster_bumpers_held}"),
+                                    f"Bonus Booster {booster_bumpers_held} check not reachable with {self.count('Booster Bumper')} Booster Bumpers")
+                    if booster_bumpers_held < 5:
+                        self.assertFalse(self.can_reach_location(f"Bonus Booster {booster_bumpers_held + 1}"),
+                                         f"Bonus Booster {booster_bumpers_held + 1} check reachable with {self.count('Treasure Bumper')} Treasure Bumpers and {self.count('Booster Bumper')} Booster Bumpers")
+                    if booster_bumpers_held < bb_count:
                         self.collect(self.get_item_by_name("Booster Bumper"))
 
-            self.assertTrue(self.can_reach_location(f"Treasure Bumper {x}"),
-                            f"Treasure Bumper {x} check not reachable with {self.count('Treasure Bumper')} Treasure Bumpers")
+            self.assertTrue(self.can_reach_location(f"Treasure Bumper {treasure_bumpers_held}"),
+                            f"Treasure Bumper {treasure_bumpers_held} check not reachable with {self.count('Treasure Bumper')} Treasure Bumpers")
 
-            if x < 32:
-                self.assertFalse(self.can_reach_location(f"Treasure Bumper {x + 1}"))
-            elif x == 32:
+            if treasure_bumpers_held < 32:
+                self.assertFalse(self.can_reach_location(f"Treasure Bumper {treasure_bumpers_held + 1}"))
+            elif treasure_bumpers_held == 32:
                 self.assertTrue(self.can_reach_location("Level 5 - 50,000+ Total Points"))
                 self.assertFalse(self.can_reach_location("Level 5 - Cleared all Hazards"))
                 self.collect(self.get_items_by_name("Hazard Bumper"))

--- a/worlds/bumpstik/test/TestLogic.py
+++ b/worlds/bumpstik/test/TestLogic.py
@@ -3,8 +3,8 @@ from . import BumpStikTestBase
 
 class TestRuleLogic(BumpStikTestBase):
     def testLogic(self):
-        for x in range(1, 34):
-            if x == 33:
+        for x in range(1, 33):
+            if x == 32:
                 self.assertFalse(self.can_reach_location("Level 5 - Cleared all Hazards"))
 
             self.collect(self.get_item_by_name("Treasure Bumper"))
@@ -29,15 +29,12 @@ class TestRuleLogic(BumpStikTestBase):
                     if y < bb_count:
                         self.collect(self.get_item_by_name("Booster Bumper"))
 
+            self.assertTrue(self.can_reach_location(f"Treasure Bumper {x}"),
+                            f"Treasure Bumper {x} check not reachable with {self.count('Treasure Bumper')} Treasure Bumpers")
+
             if x < 32:
                 self.assertFalse(self.can_reach_location(f"Treasure Bumper {x + 1}"))
             elif x == 32:
-                self.assertFalse(self.can_reach_location("Level 5 - 50,000+ Total Points"))
-
-            if x < 33:
-                self.assertTrue(self.can_reach_location(f"Treasure Bumper {x}"),
-                                f"Treasure Bumper {x} check not reachable with {self.count('Treasure Bumper')} Treasure Bumpers")
-            elif x == 33:
                 self.assertTrue(self.can_reach_location("Level 5 - 50,000+ Total Points"))
                 self.assertFalse(self.can_reach_location("Level 5 - Cleared all Hazards"))
                 self.collect(self.get_items_by_name("Hazard Bumper"))

--- a/worlds/bumpstik/test/TestLogic.py
+++ b/worlds/bumpstik/test/TestLogic.py
@@ -3,8 +3,8 @@ from . import BumpStikTestBase
 
 class TestRuleLogic(BumpStikTestBase):
     def testLogic(self):
-        for x in range(1, 33):
-            if x == 32:
+        for x in range(1, 34):
+            if x == 33:
                 self.assertFalse(self.can_reach_location("Level 5 - Cleared all Hazards"))
 
             self.collect(self.get_item_by_name("Treasure Bumper"))
@@ -13,26 +13,31 @@ class TestRuleLogic(BumpStikTestBase):
 
                 if bb_count < 4:
                     self.assertFalse(self.can_reach_location(f"Treasure Bumper {x + 1}"))
+                    # Can't reach Treasure Bumper 9 check until level 2 is unlocked, etc.
+                    # But we don't have enough Treasure Bumpers to reach this check anyway??
                 elif bb_count == 4:
                     bb_count += 1
+                    # Level 4 has two new Bonus Booster checks; need to check both
 
-                for y in range(self.count("Booster Bumper"), bb_count):
-                    self.assertTrue(self.can_reach_location(f"Bonus Booster {y + 1}"),
-                                    f"BB {y + 1} check not reachable with {self.count('Booster Bumper')} BBs")
-                    if y < 4:
-                        self.assertFalse(self.can_reach_location(f"Bonus Booster {y + 2}"),
-                                         f"BB {y + 2} check reachable with {self.count('Treasure Bumper')} TBs")
-                    self.collect(self.get_item_by_name("Booster Bumper"))
-
-            if x < 31:
-                self.assertFalse(self.can_reach_location(f"Treasure Bumper {x + 2}"))
-            elif x == 31:
-                self.assertFalse(self.can_reach_location("Level 5 - 50,000+ Total Points"))
+                for y in range(self.count("Booster Bumper"), bb_count + 1):
+                    if y > 0:
+                        self.assertTrue(self.can_reach_location(f"Bonus Booster {y}"),
+                                    f"Bonus Booster {y} check not reachable with {self.count('Booster Bumper')} Booster Bumpers")
+                    if y < 5:
+                        self.assertFalse(self.can_reach_location(f"Bonus Booster {y + 1}"),
+                                         f"Bonus Booster {y + 1} check reachable with {self.count('Treasure Bumper')} Treasure Bumpers and {self.count('Booster Bumper')} Booster Bumpers")
+                    if y < bb_count:
+                        self.collect(self.get_item_by_name("Booster Bumper"))
 
             if x < 32:
-                self.assertTrue(self.can_reach_location(f"Treasure Bumper {x + 1}"),
-                                f"TB {x + 1} check not reachable with {self.count('Treasure Bumper')} TBs")
+                self.assertFalse(self.can_reach_location(f"Treasure Bumper {x + 1}"))
             elif x == 32:
+                self.assertFalse(self.can_reach_location("Level 5 - 50,000+ Total Points"))
+
+            if x < 33:
+                self.assertTrue(self.can_reach_location(f"Treasure Bumper {x}"),
+                                f"Treasure Bumper {x} check not reachable with {self.count('Treasure Bumper')} Treasure Bumpers")
+            elif x == 33:
                 self.assertTrue(self.can_reach_location("Level 5 - 50,000+ Total Points"))
                 self.assertFalse(self.can_reach_location("Level 5 - Cleared all Hazards"))
                 self.collect(self.get_items_by_name("Hazard Bumper"))


### PR DESCRIPTION
## What is this fixing or adding?
There were a number of errors in the generation and test logic for Bumper Stickers, logically requiring one less Treasure/Booster Bumper for each Treasure Bumper/Bonus Booster check (respectively) than the actual game requires. In addition, no restrictions were being placed on the "Treasure Bumper 32" and "Bonus Booster 5" checks, due to improper use of a "range" function. This corrects these errors.

To clarify: The following checks had these logical requirements.
Treasure Bumper 1: No requirements (should be 1 Treasure Bumper)
Treasure Bumper 2: 1 Treasure Bumper (should be 2)
Treasure Bumper 3: 2 Treasure Bumpers (should be 3)
...
Treasure Bumper 31: 30 Treasure Bumpers (should be 31)
Treasure Bumper 32: No requirements (should be 32 Treasure Bumpers

Bonus Booster 1: No requirements (should be 1 Booster Bumper)
Bonus Booster 2: 1 Booster Bumper (should be 2)
Bonus Booster 3: 2 Booster Bumpers (should be 3)
Bonus Booster 4: 3 Booster Bumpers (should be 4)
Bonus Booster 5: No requirements (should be 5 Booster Bumpers)

## How was this tested?
A number of games were generated, attempting to plando Treasure and Booster Bumpers into locations that should/should not render the game unwinnable, accounting for the fact that 33 total Treasure Bumpers exist in the item pool (the last one is just to give the player/generator a little "wiggle room"). The generator worked on the cases where it was supposed to work, and failed on the cases where it was supposed to fail. The updated Bumper Sticker unit test was also run, and completed successfully.

Regards to TheT113 for getting this fix started.
