### PR TITLE
TUNIC: Misc Logic Changes, Additions

### DIFF
--- a/worlds/tunic/er_data.py
+++ b/worlds/tunic/er_data.py
@@ -749,6 +749,8 @@ dependent_regions_restricted: Dict[Tuple[str, ...], List[str]] = {
         ["Forest Belltower Main", "Forest Belltower Lower"],
     ("East Forest", "East Forest Dance Fox Spot", "East Forest Portal"):
         ["East Forest", "East Forest Dance Fox Spot", "East Forest Portal"],
+    ("Guard House 1 East", "Guard House 1 West"):
+        ["Guard House 1 East", "Guard House 1 West"],
     ("Forest Grave Path Main", "Forest Grave Path Upper"):
         ["Forest Grave Path Main", "Forest Grave Path Upper", "Forest Grave Path by Grave", "Forest Hero's Grave"],
     ("Forest Grave Path by Grave", "Forest Hero's Grave"):
@@ -842,6 +844,8 @@ dependent_regions_nmg: Dict[Tuple[str, ...], List[str]] = {
         ["Forest Belltower Main", "Forest Belltower Lower"],
     ("East Forest", "East Forest Dance Fox Spot", "East Forest Portal"):
         ["East Forest", "East Forest Dance Fox Spot", "East Forest Portal"],
+    ("Guard House 1 East", "Guard House 1 West"):
+        ["Guard House 1 East", "Guard House 1 West"],
     ("Forest Grave Path Main", "Forest Grave Path Upper", "Forest Grave Path by Grave", "Forest Hero's Grave"):
         ["Forest Grave Path Main", "Forest Grave Path Upper", "Forest Grave Path by Grave", "Forest Hero's Grave"],
     ("Beneath the Well Front", "Beneath the Well Main", "Beneath the Well Back"):
@@ -934,6 +938,8 @@ dependent_regions_ur: Dict[Tuple[str, ...], List[str]] = {
         ["Forest Belltower Main", "Forest Belltower Lower"],
     ("East Forest", "East Forest Dance Fox Spot", "East Forest Portal"):
         ["East Forest", "East Forest Dance Fox Spot", "East Forest Portal"],
+    ("Guard House 1 East", "Guard House 1 West"):
+        ["Guard House 1 East", "Guard House 1 West"],
     # can use laurels, ice grapple, or ladder storage to traverse
     ("Forest Grave Path Main", "Forest Grave Path Upper", "Forest Grave Path by Grave", "Forest Hero's Grave"):
         ["Forest Grave Path Main", "Forest Grave Path Upper", "Forest Grave Path by Grave", "Forest Hero's Grave"],

--- a/worlds/tunic/er_data.py
+++ b/worlds/tunic/er_data.py
@@ -211,7 +211,7 @@ portal_mapping: List[Portal] = [
            destination="Shop_"),
     Portal(name="Atoll to Far Shore", region="Ruined Atoll Portal",
            destination="Transit_teleporter_atoll"),
-    Portal(name="Atoll Statue Teleporter", region="Ruined Atoll Portal",
+    Portal(name="Atoll Statue Teleporter", region="Ruined Atoll Statue",
            destination="Library Exterior_"),
     Portal(name="Frog Stairs Eye Entrance", region="Ruined Atoll",
            destination="Frog Stairs_eye"),
@@ -600,6 +600,7 @@ tunic_er_regions: Dict[str, RegionInfo] = {
     "Ruined Atoll Lower Entry Area": RegionInfo("Atoll Redux"),
     "Ruined Atoll Frog Mouth": RegionInfo("Atoll Redux"),
     "Ruined Atoll Portal": RegionInfo("Atoll Redux"),
+    "Ruined Atoll Statue": RegionInfo("Atoll Redux"),
     "Frog's Domain Entry": RegionInfo("Frog Stairs"),
     "Frog's Domain": RegionInfo("frog cave main", hint=Hint.region),
     "Frog's Domain Back": RegionInfo("frog cave main", hint=Hint.scene),
@@ -764,8 +765,10 @@ dependent_regions_restricted: Dict[Tuple[str, ...], List[str]] = {
     ("West Garden", "West Garden Laurels Exit", "West Garden after Boss", "West Garden Hero's Grave"):
         ["West Garden", "West Garden Laurels Exit", "West Garden after Boss", "West Garden Hero's Grave"],
     ("West Garden Portal", "West Garden Portal Item"): ["West Garden Portal", "West Garden Portal Item"],
-    ("Ruined Atoll", "Ruined Atoll Lower Entry Area", "Ruined Atoll Frog Mouth", "Ruined Atoll Portal"):
-        ["Ruined Atoll", "Ruined Atoll Lower Entry Area", "Ruined Atoll Frog Mouth", "Ruined Atoll Portal"],
+    ("Ruined Atoll", "Ruined Atoll Lower Entry Area", "Ruined Atoll Frog Mouth", "Ruined Atoll Portal",
+     "Ruined Atoll Statue"):
+        ["Ruined Atoll", "Ruined Atoll Lower Entry Area", "Ruined Atoll Frog Mouth", "Ruined Atoll Portal",
+         "Ruined Atoll Statue"],
     ("Frog's Domain",):
         ["Frog's Domain", "Frog's Domain Back"],
     ("Library Exterior Ladder", "Library Exterior Tree"):
@@ -858,8 +861,10 @@ dependent_regions_nmg: Dict[Tuple[str, ...], List[str]] = {
      "West Garden Portal", "West Garden Portal Item"):
         ["West Garden", "West Garden Laurels Exit", "West Garden after Boss", "West Garden Hero's Grave",
          "West Garden Portal", "West Garden Portal Item"],
-    ("Ruined Atoll", "Ruined Atoll Lower Entry Area", "Ruined Atoll Frog Mouth", "Ruined Atoll Portal"):
-        ["Ruined Atoll", "Ruined Atoll Lower Entry Area", "Ruined Atoll Frog Mouth", "Ruined Atoll Portal"],
+    ("Ruined Atoll", "Ruined Atoll Lower Entry Area", "Ruined Atoll Frog Mouth", "Ruined Atoll Portal",
+     "Ruined Atoll Statue"):
+        ["Ruined Atoll", "Ruined Atoll Lower Entry Area", "Ruined Atoll Frog Mouth", "Ruined Atoll Portal",
+         "Ruined Atoll Statue"],
     ("Frog's Domain",):
         ["Frog's Domain", "Frog's Domain Back"],
     ("Library Exterior Ladder", "Library Exterior Tree"):
@@ -954,8 +959,10 @@ dependent_regions_ur: Dict[Tuple[str, ...], List[str]] = {
      "West Garden Portal", "West Garden Portal Item"):
         ["West Garden", "West Garden Laurels Exit", "West Garden after Boss", "West Garden Hero's Grave",
          "West Garden Portal", "West Garden Portal Item"],
-    ("Ruined Atoll", "Ruined Atoll Lower Entry Area", "Ruined Atoll Frog Mouth", "Ruined Atoll Portal"):
-        ["Ruined Atoll", "Ruined Atoll Lower Entry Area", "Ruined Atoll Frog Mouth", "Ruined Atoll Portal"],
+    ("Ruined Atoll", "Ruined Atoll Lower Entry Area", "Ruined Atoll Frog Mouth", "Ruined Atoll Portal",
+     "Ruined Atoll Statue"):
+        ["Ruined Atoll", "Ruined Atoll Lower Entry Area", "Ruined Atoll Frog Mouth", "Ruined Atoll Portal",
+         "Ruined Atoll Statue"],
     ("Frog's Domain",):
         ["Frog's Domain", "Frog's Domain Back"],
     ("Library Exterior Ladder", "Library Exterior Tree"):

--- a/worlds/tunic/er_rules.py
+++ b/worlds/tunic/er_rules.py
@@ -295,6 +295,12 @@ def set_er_region_rules(world: "TunicWorld", ability_unlocks: Dict[str, int], re
     regions["Ruined Atoll Portal"].connect(
         connecting_region=regions["Ruined Atoll"])
 
+    regions["Ruined Atoll"].connect(
+        connecting_region=regions["Ruined Atoll Statue"],
+        rule=lambda state: has_ability(state, player, prayer, options, ability_unlocks))
+    regions["Ruined Atoll Statue"].connect(
+        connecting_region=regions["Ruined Atoll"])
+
     regions["Frog's Domain"].connect(
         connecting_region=regions["Frog's Domain Back"],
         rule=lambda state: state.has(grapple, player))

--- a/worlds/tunic/er_rules.py
+++ b/worlds/tunic/er_rules.py
@@ -940,10 +940,12 @@ def set_er_location_rules(world: "TunicWorld", ability_unlocks: Dict[str, int]) 
     # Bosses
     set_rule(multiworld.get_location("Fortress Arena - Siege Engine/Vault Key Pickup", player),
              lambda state: has_sword(state, player))
+    # nmg - kill Librarian with a lure, or gun I guess
     set_rule(multiworld.get_location("Librarian - Hexagon Green", player),
-             lambda state: has_sword(state, player))
+             lambda state: has_sword(state, player) or options.logic_rules)
+    # nmg - kill boss scav with orb + firecracker, or similar
     set_rule(multiworld.get_location("Rooted Ziggurat Lower - Hexagon Blue", player),
-             lambda state: has_sword(state, player))
+             lambda state: has_sword(state, player) or (state.has(grapple, player) and options.logic_rules))
 
     # Swamp
     set_rule(multiworld.get_location("Cathedral Gauntlet - Gauntlet Reward", player),

--- a/worlds/tunic/regions.py
+++ b/worlds/tunic/regions.py
@@ -16,7 +16,7 @@ tunic_regions: Dict[str, Set[str]] = {
     "Eastern Vault Fortress": {"Beneath the Vault"},
     "Beneath the Vault": {"Eastern Vault Fortress"},
     "Quarry Back": {"Quarry"},
-    "Quarry": {"Lower Quarry", "Rooted Ziggurat"},
+    "Quarry": {"Lower Quarry"},
     "Lower Quarry": {"Rooted Ziggurat"},
     "Rooted Ziggurat": set(),
     "Swamp": {"Cathedral"},

--- a/worlds/tunic/rules.py
+++ b/worlds/tunic/rules.py
@@ -312,8 +312,9 @@ def set_location_rules(world: "TunicWorld", ability_unlocks: Dict[str, int]) -> 
              lambda state: state.has(laurels, player))
     set_rule(multiworld.get_location("Quarry - [West] Upper Area Bombable Wall", player),
              lambda state: has_mask(state, player, options))
+    # nmg - kill boss scav with orb + firecracker, or similar
     set_rule(multiworld.get_location("Rooted Ziggurat Lower - Hexagon Blue", player),
-             lambda state: has_sword(state, player) or (state.has(orb, player) and options.logic_rules))
+             lambda state: has_sword(state, player) or (state.has(grapple, player) and options.logic_rules))
 
     # Swamp
     set_rule(multiworld.get_location("Cathedral Gauntlet - Gauntlet Reward", player),

--- a/worlds/tunic/rules.py
+++ b/worlds/tunic/rules.py
@@ -131,8 +131,6 @@ def set_region_rules(world: "TunicWorld", ability_unlocks: Dict[str, int]) -> No
         lambda state: has_mask(state, player, options)
     multiworld.get_entrance("Lower Quarry -> Rooted Ziggurat", player).access_rule = \
         lambda state: state.has(grapple, player) and has_ability(state, player, prayer, options, ability_unlocks)
-    multiworld.get_entrance("Quarry -> Rooted Ziggurat", player).access_rule = \
-        lambda state: has_ice_grapple_logic(False, state, player, options, ability_unlocks)
     multiworld.get_entrance("Swamp -> Cathedral", player).access_rule = \
         lambda state: state.has(laurels, player) and has_ability(state, player, prayer, options, ability_unlocks) \
         or has_ice_grapple_logic(False, state, player, options, ability_unlocks)

--- a/worlds/tunic/rules.py
+++ b/worlds/tunic/rules.py
@@ -313,7 +313,7 @@ def set_location_rules(world: "TunicWorld", ability_unlocks: Dict[str, int]) -> 
     set_rule(multiworld.get_location("Quarry - [West] Upper Area Bombable Wall", player),
              lambda state: has_mask(state, player, options))
     set_rule(multiworld.get_location("Rooted Ziggurat Lower - Hexagon Blue", player),
-             lambda state: has_sword(state, player))
+             lambda state: has_sword(state, player) or (state.has(orb, player) and options.logic_rules))
 
     # Swamp
     set_rule(multiworld.get_location("Cathedral Gauntlet - Gauntlet Reward", player),


### PR DESCRIPTION
## What is this fixing or adding?
Adds logic to a couple of quick kills for bosses when using nmg or ur logic.
Also removed ice grappling into zig with ER off due to the soft lock potential caused by saving in zig without prayer.
Also adds a couple of dependent regions that should have been there, which just made the ER pairing more conservative than it needed to be.
Also fixes a minor bug with the Atoll portal and Atoll statue being the same region, implying traversal from the portal region to the statue region without prayer.

## How was this tested?
Generations, looking at the logic, unit tests

## If this makes graphical changes, please attach screenshots.
N/A