### PR TITLE
Core: Improve join/leave messages, add "HintGame" tag

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -804,10 +804,18 @@ async def on_client_joined(ctx: Context, client: Client):
     if ctx.client_game_state[client.team, client.slot] == ClientStatus.CLIENT_UNKNOWN:
         update_client_status(ctx, client, ClientStatus.CLIENT_CONNECTED)
     version_str = '.'.join(str(x) for x in client.version)
-    verb = "tracking" if "Tracker" in client.tags else "playing"
+    
+    verbs = {"Tracker": "tracking", "TextOnly": "viewing"}
+    for tag, verb in verbs.items():
+        if tag in client.tags:
+            final_verb = verb
+            break
+    else:
+        final_verb = "playing"
+    
     ctx.broadcast_text_all(
         f"{ctx.get_aliased_name(client.team, client.slot)} (Team #{client.team + 1}) "
-        f"{verb} {ctx.games[client.slot]} has joined. "
+        f"{final_verb} {ctx.games[client.slot]} has joined. "
         f"Client({version_str}), {client.tags}.",
         {"type": "Join", "team": client.team, "slot": client.slot, "tags": client.tags})
     ctx.notify_client(client, "Now that you are connected, "
@@ -822,8 +830,20 @@ async def on_client_left(ctx: Context, client: Client):
     if len(ctx.clients[client.team][client.slot]) < 1:
         update_client_status(ctx, client, ClientStatus.CLIENT_UNKNOWN)
         ctx.client_connection_timers[client.team, client.slot] = datetime.datetime.now(datetime.timezone.utc)
+    
+    version_str = '.'.join(str(x) for x in client.version)
+    
+    verbs = {"Tracker": "stopped tracking", "TextOnly": "stopped viewing"}
+    for tag, verb in verbs.items():
+        if tag in client.tags:
+            final_verb = verb
+            break
+    else:
+        final_verb = "left"
+    
     ctx.broadcast_text_all(
-        "%s (Team #%d) has left the game" % (ctx.get_aliased_name(client.team, client.slot), client.team + 1),
+        f"{ctx.get_aliased_name(client.team, client.slot)} (Team #{client.team + 1}) has {final_verb} the game. "
+        f"Client({version_str}), {client.tags}.",
         {"type": "Part", "team": client.team, "slot": client.slot})
 
 

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -805,7 +805,7 @@ async def on_client_joined(ctx: Context, client: Client):
         update_client_status(ctx, client, ClientStatus.CLIENT_CONNECTED)
     version_str = '.'.join(str(x) for x in client.version)
     
-    verbs = {"Tracker": "tracking", "TextOnly": "viewing"}
+    verbs = {"HintGame": "hinting", "Tracker": "tracking", "TextOnly": "viewing"}
     for tag, verb in verbs.items():
         if tag in client.tags:
             final_verb = verb
@@ -833,7 +833,7 @@ async def on_client_left(ctx: Context, client: Client):
     
     version_str = '.'.join(str(x) for x in client.version)
     
-    verbs = {"Tracker": "stopped tracking", "TextOnly": "stopped viewing"}
+    verbs = {"HintGame": "stopped hinting", "Tracker": "stopped tracking", "TextOnly": "stopped viewing"}
     for tag, verb in verbs.items():
         if tag in client.tags:
             final_verb = verb
@@ -1629,7 +1629,14 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
         else:
             team, slot = ctx.connect_names[args['name']]
             game = ctx.games[slot]
-            ignore_game = ("TextOnly" in args["tags"] or "Tracker" in args["tags"]) and not args.get("game")
+            
+            ignore_game = False
+            if not args.get("game"):
+                for tag in args["tags"]:
+                    if tag in {"HintGame", "TextOnly", "Tracker"}:
+                        ignore_game = True
+                        break
+            
             if not ignore_game and args['game'] != game:
                 errors.add('InvalidGame')
             minver = min_client_version if ignore_game else ctx.minimum_client_versions[slot]

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1632,12 +1632,7 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
             team, slot = ctx.connect_names[args['name']]
             game = ctx.games[slot]
 
-            ignore_game = False
-            if not args.get("game"):
-                for tag in args["tags"]:
-                    if tag in _non_game_messages:
-                        ignore_game = True
-                        break
+            ignore_game = not args.get("game") and any(tag in _non_game_messages for tag in args["tags"])
 
             if not ignore_game and args['game'] != game:
                 errors.add('InvalidGame')

--- a/worlds/tunic/__init__.py
+++ b/worlds/tunic/__init__.py
@@ -73,9 +73,6 @@ class TunicWorld(World):
                 self.options.hexagon_quest.value = passthrough["hexagon_quest"]
                 self.options.entrance_rando.value = passthrough["entrance_rando"]
 
-        if self.options.start_with_sword and "Sword" not in self.options.start_inventory:
-            self.options.start_inventory.value["Sword"] = 1
-
     def create_item(self, name: str) -> TunicItem:
         item_data = item_table[name]
         return TunicItem(name, item_data.classification, self.item_name_to_id[name], self.player)
@@ -93,6 +90,9 @@ class TunicWorld(World):
         for money_fool in fool_tiers[self.options.fool_traps]:
             items_to_create["Fool Trap"] += items_to_create[money_fool]
             items_to_create[money_fool] = 0
+
+        if self.options.start_with_sword:
+            self.multiworld.push_precollected(self.create_item("Sword"))
 
         if sword_progression:
             items_to_create["Stick"] = 0


### PR DESCRIPTION
## What is this fixing or adding?
- Adds the `HintGame` tag, for projects like BKSudoku/APSudoku/HintMachine (this tag, like `TextOnly`/`Tracker`, allows `ignore_game`)
- Adds new verbs to join messages:
  - `hinting` for `HintGame`
  - (unchanged) `tracking` for `Tracker`
  - `viewing` for `TextOnly`
  - Default (unchanged) `playing`
- Adds verbs to leave messages (which were previously completely lacking)
  - `stopped hinting` for `HintGame`
  - `stopped tracking` for `Tracker`
  - `stopped viewing` for `TextOnly`
  - Default (unchanged) `left` 
- Adds client version/tags info to leave messages (same as it was previously on join messages)

Where multiple tags that have associated verbs are on the same client, it picks the first applicable verb, in tag order `HintGame`, `Tracker`, `TextOnly`, default.

## How was this tested?
Connected and disconnected with various tags, using `CommonClient` for `TextOnly`, and my own `APSudoku` project with various sets/combinations of tags.

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/35015090/06575c99-1932-4f88-9ece-60f6abc5153e)
![image](https://github.com/ArchipelagoMW/Archipelago/assets/35015090/63f52829-954c-4b42-a54d-a7ad2900f99c)
![image](https://github.com/ArchipelagoMW/Archipelago/assets/35015090/fc0c00d9-8318-43ec-82ce-6f9979b260c6)
