### PR TITLE
Zillion: apworld-compatible package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,6 @@ non_apworlds: set = {
     "Super Mario 64",
     "VVVVVV",
     "Wargroove",
-    "Zillion",
 }
 
 # LogicMixin is broken before 3.10 import revamp

--- a/typings/kivy/graphics/texture.pyi
+++ b/typings/kivy/graphics/texture.pyi
@@ -10,4 +10,4 @@ class FillType_Drawable:
 
 
 class Texture:
-    pass
+    size: FillType_Vec

--- a/worlds/zillion/__init__.py
+++ b/worlds/zillion/__init__.py
@@ -25,7 +25,7 @@ from zilliandomizer.logic_components.items import RESCUE, items as zz_items, Ite
 from zilliandomizer.logic_components.locations import Location as ZzLocation, Req
 from zilliandomizer.options import Chars
 
-from ..AutoWorld import World, WebWorld
+from worlds.AutoWorld import World, WebWorld
 
 
 class ZillionSettings(settings.Group):

--- a/worlds/zillion/client.py
+++ b/worlds/zillion/client.py
@@ -1,5 +1,7 @@
 import asyncio
 import base64
+import io
+import pkgutil
 import platform
 from typing import Any, ClassVar, Coroutine, Dict, List, Optional, Protocol, Tuple, cast
 
@@ -17,7 +19,7 @@ from zilliandomizer.options import Chars
 from zilliandomizer.patch import RescueInfo
 
 from .id_maps import loc_name_to_id, make_id_to_others
-from .config import base_id, zillion_map
+from .config import base_id
 
 
 class ZillionCommandProcessor(ClientCommandProcessor):
@@ -138,7 +140,9 @@ class ZillionContext(CommonContext):
         from kvui import GameManager
         from kivy.core.text import Label as CoreLabel
         from kivy.graphics import Ellipse, Color, Rectangle
+        from kivy.graphics.texture import Texture
         from kivy.uix.layout import Layout
+        from kivy.uix.image import CoreImage
         from kivy.uix.widget import Widget
 
         class ZillionManager(GameManager):
@@ -150,11 +154,20 @@ class ZillionContext(CommonContext):
             class MapPanel(Widget):
                 MAP_WIDTH: ClassVar[int] = 281
 
-                _number_textures: List[Any] = []
+                map_background: CoreImage
+                _number_textures: List[Texture] = []
                 rooms: List[List[int]] = []
 
                 def __init__(self, **kwargs: Any) -> None:
                     super().__init__(**kwargs)
+
+                    FILE_NAME = "empty-zillion-map-row-col-labels-281.png"
+                    image_file_data = pkgutil.get_data(__name__, FILE_NAME)
+                    if not image_file_data:
+                        raise FileNotFoundError(f"{__name__=} {FILE_NAME=}")
+                    data = io.BytesIO(image_file_data)
+                    self.map_background = CoreImage(data, ext="png")
+                    assert self.map_background.texture.size[0] == ZillionManager.MapPanel.MAP_WIDTH
 
                     self.rooms = [[0 for _ in range(8)] for _ in range(16)]
 
@@ -176,10 +189,9 @@ class ZillionContext(CommonContext):
 
                     with self.canvas:
                         Color(1, 1, 1, 1)
-                        Rectangle(source=zillion_map,
+                        Rectangle(texture=self.map_background.texture,
                                   pos=self.pos,
-                                  size=(ZillionManager.MapPanel.MAP_WIDTH,
-                                        int(ZillionManager.MapPanel.MAP_WIDTH * 1.456)))  # aspect ratio of that image
+                                  size=self.map_background.texture.size)
                         for y in range(16):
                             for x in range(8):
                                 num = self.rooms[15 - y][x]
@@ -194,7 +206,7 @@ class ZillionContext(CommonContext):
 
             def build(self) -> Layout:
                 container = super().build()
-                self.map_widget = ZillionManager.MapPanel(size_hint_x=None, width=0)
+                self.map_widget = ZillionManager.MapPanel(size_hint_x=None, width=ZillionManager.MapPanel.MAP_WIDTH)
                 self.main_area_container.add_widget(self.map_widget)
                 return container
 

--- a/worlds/zillion/config.py
+++ b/worlds/zillion/config.py
@@ -1,4 +1,1 @@
-import os
-
 base_id = 8675309
-zillion_map = os.path.join(os.path.dirname(__file__), "empty-zillion-map-row-col-labels-281.png")


### PR DESCRIPTION
## What is this fixing or adding?

changed some package data access to use `pkgutil`
so that it can be accessed from an apworld

I think that makes it work as an internal apworld.
("internal" = `zillion/requirements.txt` is installed in the frozen build, and `ZillionClient.py` is built)

## How was this tested?

- zipped up the `zillion` folder
- renamed it `.apworld`
- removed the original `zillion` folder
- generated 1-player Zillion game
- played through the game connected to `MultiServer`, toggling map tracker off and on and watching it for accuracy

I did not test the whole Windows frozen build.
(I don't know how to build it and don't use Windows.)
But I'm confident any problem with that would be found in release candidate phase.
edit: Thank you remyjette for testing the Windows frozen build.
