### PR TITLE
Core: typing: return type of `fill_slot_data` to `Mapping`

### DIFF
--- a/docs/world api.md
+++ b/docs/world api.md
@@ -738,14 +738,14 @@ def generate_output(self, output_directory: str) -> None:
 
 If the game client needs to know information about the generated seed, a preferred method of transferring the data
 is through the slot data. This is filled with the `fill_slot_data` method of your world by returning
-a `Dict[str, Any]`, but, to not waste resources, should be limited to data that is absolutely necessary. Slot data is
+a `Mapping[str, Any]`, but, to not waste resources, should be limited to data that is absolutely necessary. Slot data is
 sent to your client once it has successfully [connected](network%20protocol.md#connected).
 If you need to know information about locations in your world, instead of propagating the slot data, it is preferable
 to use [LocationScouts](network%20protocol.md#locationscouts), since that data already exists on the server. The most
 common usage of slot data is sending option results that the client needs to be aware of.
 
 ```python
-def fill_slot_data(self) -> Dict[str, Any]:
+def fill_slot_data(self) -> Mapping[str, Any]:
     # In order for our game client to handle the generated seed correctly we need to know what the user selected
     # for their difficulty and final boss HP.
     # A dictionary returned from this method gets set as the slot_data and will be sent to the client after connecting.

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -7,8 +7,8 @@ import re
 import sys
 import time
 from dataclasses import make_dataclass
-from typing import Any, Callable, ClassVar, Dict, Set, Tuple, FrozenSet, List, Optional, TYPE_CHECKING, TextIO, Type, \
-    Union
+from typing import (Any, Callable, ClassVar, Dict, FrozenSet, List, Mapping,
+                    Optional, Set, TextIO, Tuple, TYPE_CHECKING, Type, Union)
 
 from Options import PerGameCommonOptions
 from BaseClasses import CollectionState
@@ -365,7 +365,7 @@ class World(metaclass=AutoWorldRegister):
         If you need any last-second randomization, use self.random instead."""
         pass
 
-    def fill_slot_data(self) -> Dict[str, Any]:  # json of WebHostLib.models.Slot
+    def fill_slot_data(self) -> Mapping[str, Any]:  # json of WebHostLib.models.Slot
         """Fill in the `slot_data` field in the `Connected` network package.
         This is a way the generator can give custom data to the client.
         The client will receive this as JSON in the `Connected` response.


### PR DESCRIPTION
## What is this fixing or adding?

type checker be like:

"Wait a minute! If you give this mutable dict to those sussy sketchbags, they might mutate it and invalidate your more specific typing!"

Note that this doesn't mean the return value needs to be immutable. It just means the caller won't mutate it (which matches current `Main.py` implementation).

I've seen some talk of introducing ownership to the type system.

https://discuss.python.org/t/we-may-need-better-specification-for-existing-and-future-refinement-types-in-the-type-system/43955/5

Then maybe I could say: "Do whatever you want with it, because I'm giving up ownership." But that doesn't exist in the type system currently.

## How was this tested?

type checking and unit tests