### PR TITLE
BizHawkClient: Add error message if patching fails

### DIFF
--- a/worlds/_bizhawk/context.py
+++ b/worlds/_bizhawk/context.py
@@ -235,8 +235,12 @@ async def _run_game(rom: str):
 
 
 async def _patch_and_run_game(patch_file: str):
-    metadata, output_file = Patch.create_rom_file(patch_file)
-    Utils.async_start(_run_game(output_file))
+    try:
+        metadata, output_file = Patch.create_rom_file(patch_file)
+        Utils.async_start(_run_game(output_file))
+    except (FileNotFoundError, ValueError) as exc:
+        logger.info("ERROR: Unable to patch game. It's likely that your ROM is missing or is an incompatible version.")
+        raise exc
 
 
 def launch() -> None:

--- a/worlds/_bizhawk/context.py
+++ b/worlds/_bizhawk/context.py
@@ -238,9 +238,8 @@ async def _patch_and_run_game(patch_file: str):
     try:
         metadata, output_file = Patch.create_rom_file(patch_file)
         Utils.async_start(_run_game(output_file))
-    except (FileNotFoundError, ValueError) as exc:
-        logger.info("ERROR: Unable to patch game. It's likely that your ROM is missing or is an incompatible version.")
-        raise exc
+    except Exception as exc:
+        logger.exception(exc)
 
 
 def launch() -> None:


### PR DESCRIPTION
## What is this fixing or adding?

When a user opens a patch file and is asked to select their vanilla ROM through the settings api, if they close the file selection window or select a file that doesn't validate, the exception isn't visible to the user except through the console/log files. This adds a message to the client UI notifying the user what happened.

It's possible something like this should be closer to CommonClient or Settings, but would probably require quite a bit more UX design. At least compared to catching an error and logging something to the UI.

## How was this tested?

Deleted my Emerald ROM and tried opening a patch file by providing
1. No file
2. An incorrect file
3. A correct file

## If this makes graphical changes, please attach screenshots.

![Capture](https://github.com/ArchipelagoMW/Archipelago/assets/21088150/a6c6d5fa-c489-4cea-8411-d00344f43ae7)