### PR TITLE
Muse Dash: Add Muse Dash 4.1.0 songs

### DIFF
--- a/worlds/musedash/MuseDashCollection.py
+++ b/worlds/musedash/MuseDashCollection.py
@@ -37,6 +37,12 @@ class MuseDashCollections:
         "PeroPero in the Universe",
         "umpopoff"
     ]
+    
+    REMOVED_SONGS = [
+        "CHAOS Glitch",
+        "FM 17314 SUGAR RADIO",
+        "Yume Ou Mono Yo Secret"
+    ]
 
     album_items: Dict[str, AlbumData] = {}
     album_locations: Dict[str, int] = {}
@@ -129,6 +135,9 @@ class MuseDashCollections:
 
         for songKey, songData in self.song_items.items():
             if not self.song_matches_dlc_filter(songData, dlc_songs):
+                continue
+                
+            if songKey in self.REMOVED_SONGS:
                 continue
 
             if streamer_mode_active and not songData.streamer_mode:

--- a/worlds/musedash/MuseDashData.txt
+++ b/worlds/musedash/MuseDashData.txt
@@ -530,3 +530,11 @@ Bitter Choco Decoration|70-6|Rin Len's Mirrorland|False|3|6|9|
 Dance Robot Dance|70-7|Rin Len's Mirrorland|False|4|7|10|
 Sweet Devil|70-8|Rin Len's Mirrorland|False|5|7|9|
 Someday'z Coming|70-9|Rin Len's Mirrorland|False|5|7|9|
+Yume Ou Mono Yo Secret|0-53|Default Music|True|6|8|10|
+Yume Ou Mono Yo|0-54|Default Music|True|1|4|0|
+Sweet Dream VIVINOS|71-0|Valentine Stage|False|1|4|7|
+Ruler Of My Heart VIVINOS|71-1|Valentine Stage|False|2|4|6|
+Reality Show|71-2|Valentine Stage|False|5|7|10|
+SIG feat.Tobokegao|71-3|Valentine Stage|True|3|6|8|
+Rose Love|71-4|Valentine Stage|True|2|4|7|
+Euphoria|71-5|Valentine Stage|True|1|3|6|

--- a/worlds/musedash/test/TestCollection.py
+++ b/worlds/musedash/test/TestCollection.py
@@ -3,11 +3,6 @@ from ..MuseDashCollection import MuseDashCollections
 
 
 class CollectionsTest(unittest.TestCase):
-    REMOVED_SONGS = [
-        "CHAOS Glitch",
-        "FM 17314 SUGAR RADIO",
-    ]
-
     def test_all_names_are_ascii(self) -> None:
         bad_names = list()
         collection = MuseDashCollections()
@@ -58,5 +53,5 @@ class CollectionsTest(unittest.TestCase):
         collection = MuseDashCollections()
         songs = collection.get_songs_with_settings({x for x in collection.DLC}, False, 0, 12)
 
-        for song_name in self.REMOVED_SONGS:
+        for song_name in collection.REMOVED_SONGS:
             self.assertNotIn(song_name, songs, f"Song '{song_name}' wasn't removed correctly.")


### PR DESCRIPTION
## What is this fixing or adding?
Adds 4.1.0 songs. (Valentine Stage)

- Also adjusted exclusions to now be explicit rather than implicit due to a new song having normal value difficulties but being hidden.

## How was this tested?
Several test generations + Tests.
