### PR TITLE
Terraria: make Broken Hero Sword require post mech bosses

### DIFF
--- a/worlds/terraria/Rules.dsv
+++ b/worlds/terraria/Rules.dsv
@@ -385,7 +385,7 @@ Armored Digger;                     Calamity | Location | Item;                 
 Temple Raider;                      Achievement;                                #Plantera;
 Lihzahrd Temple;                    ;                                           #Plantera | (Plantera & Actuator) | @pickaxe(210) | (@calamity & Hardmode Anvil & Soul of Light & Soul of Night);
 Solar Eclipse;                      ;                                           Lihzahrd Temple & Wall of Flesh;
-Broken Hero Sword;                  ;                                           (Solar Eclipse & Plantera) | (@calamity & #Calamitas Clone);
+Broken Hero Sword;                  ;                                           (Solar Eclipse & Plantera & @mech_boss(3)) | (@calamity & #Calamitas Clone);
 Terra Blade;                        ;                                           Hardmode Anvil & True Night's Edge & True Excalibur & Broken Hero Sword & (~@calamity | Living Shard);
 Sword of the Hero;                  Achievement;                                Terra Blade;
 Kill the Sun;                       Achievement;                                Solar Eclipse;


### PR DESCRIPTION
## What is this fixing or adding?

Mothron only drops Broken Hero Sword if you have all post mech boss flags, which I hadn't accounted for. So I updated the logic to fix this.

## How was this tested?

I generated a world and it looks fine