### PR TITLE
Terraria: Add logic for Witch Doctor selling Bewitching Table

### DIFF
--- a/worlds/terraria/Rules.dsv
+++ b/worlds/terraria/Rules.dsv
@@ -207,7 +207,7 @@ Clothier;                           Npc;                                        
 Dungeon;                            ;                                           Skeletron;
 Dungeon Heist;                      Achievement;                                Dungeon;
 Bone;                               ;                                           Dungeon | (@calamity & #Skeletron);
-Bewitching Table;                   Minions(1);                                 Dungeon;
+Bewitching Table;                   Minions(1);                                 Dungeon | (Witch Doctor & Wizard);
 Mechanic;                           ;                                           Dungeon;
 Wire;                               ;                                           Mechanic;
 Decryption Computer;                Calamity;                                   Mysterious Circuitry & Dubious Plating & Wire;


### PR DESCRIPTION
## What is this fixing or adding?

The Witch Doctor can sell Bewitching Tables if the Wizard is present, which I hadn't accounted for in the rules. So I added it.

## How was this tested?

I generated a world and it looks fine