### PR TITLE
Launcher: make launcher scrollable

### DIFF
--- a/Launcher.py
+++ b/Launcher.py
@@ -161,7 +161,7 @@ def launch(exe, in_terminal=False):
 
 
 def run_gui():
-    from kvui import App, ContainerLayout, GridLayout, Button, Label
+    from kvui import App, ContainerLayout, GridLayout, Button, Label, ScrollBox, Widget
     from kivy.uix.image import AsyncImage
     from kivy.uix.relativelayout import RelativeLayout
 
@@ -185,11 +185,16 @@ def run_gui():
             self.container = ContainerLayout()
             self.grid = GridLayout(cols=2)
             self.container.add_widget(self.grid)
-            self.grid.add_widget(Label(text="General"))
-            self.grid.add_widget(Label(text="Clients"))
-            button_layout = self.grid  # make buttons fill the window
+            self.grid.add_widget(Label(text="General", size_hint_y=None, height=40))
+            self.grid.add_widget(Label(text="Clients", size_hint_y=None, height=40))
+            tool_layout = ScrollBox()
+            tool_layout.layout.orientation = "vertical"
+            self.grid.add_widget(tool_layout)
+            client_layout = ScrollBox()
+            client_layout.layout.orientation = "vertical"
+            self.grid.add_widget(client_layout)
 
-            def build_button(component: Component):
+            def build_button(component: Component) -> Widget:
                 """
                 Builds a button widget for a given component.
 
@@ -200,31 +205,26 @@ def run_gui():
                     None. The button is added to the parent grid layout.
 
                 """
-                button = Button(text=component.display_name)
+                button = Button(text=component.display_name, size_hint_y=None, height=40)
                 button.component = component
                 button.bind(on_release=self.component_action)
                 if component.icon != "icon":
                     image = AsyncImage(source=icon_paths[component.icon],
                                        size=(38, 38), size_hint=(None, 1), pos=(5, 0))
-                    box_layout = RelativeLayout()
+                    box_layout = RelativeLayout(size_hint_y=None, height=40)
                     box_layout.add_widget(button)
                     box_layout.add_widget(image)
-                    button_layout.add_widget(box_layout)
-                else:
-                    button_layout.add_widget(button)
+                    return box_layout
+                return button
 
             for (tool, client) in itertools.zip_longest(itertools.chain(
                     self._tools.items(), self._miscs.items(), self._adjusters.items()), self._clients.items()):
                 # column 1
                 if tool:
-                    build_button(tool[1])
-                else:
-                    button_layout.add_widget(Label())
+                    tool_layout.layout.add_widget(build_button(tool[1]))
                 # column 2
                 if client:
-                    build_button(client[1])
-                else:
-                    button_layout.add_widget(Label())
+                    client_layout.layout.add_widget(build_button(client[1]))
 
             return self.container
 

--- a/kvui.py
+++ b/kvui.py
@@ -38,11 +38,13 @@ from kivy.clock import Clock
 from kivy.factory import Factory
 from kivy.properties import BooleanProperty, ObjectProperty
 from kivy.metrics import dp
+from kivy.effects.scroll import ScrollEffect
 from kivy.uix.widget import Widget
 from kivy.uix.button import Button
 from kivy.uix.gridlayout import GridLayout
 from kivy.uix.layout import Layout
 from kivy.uix.textinput import TextInput
+from kivy.uix.scrollview import ScrollView
 from kivy.uix.recycleview import RecycleView
 from kivy.uix.tabbedpanel import TabbedPanel, TabbedPanelItem
 from kivy.uix.boxlayout import BoxLayout
@@ -116,6 +118,17 @@ class ToolTip(Label):
 
 class ServerToolTip(ToolTip):
     pass
+
+
+class ScrollBox(ScrollView):
+    layout: BoxLayout
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.layout = BoxLayout(size_hint_y=None)
+        self.layout.bind(minimum_height=self.layout.setter("height"))
+        self.add_widget(self.layout)
+        self.effect_cls = ScrollEffect
 
 
 class HovererableLabel(HoverBehavior, Label):


### PR DESCRIPTION
## What is this fixing or adding?
As Archipelago grows and more clients are added, the amount of space given to any given client in the launcher grows ever smaller. This changes the launcher such that the list of tools and clients can be scrolled, and each button is rendered at a straight height of 40.

## How was this tested?
Opening the launcher, confirming the visual changes. Clicked on the OoT Adjuster, Minecraft Client, and Undertale Clients and confirmed the correct program was launched.

## If this makes graphical changes, please attach screenshots.
(I don't have recording software on this machine, so hopefully screenshot will suffice)
![image](https://github.com/ArchipelagoMW/Archipelago/assets/58583688/981760c5-2d60-41a1-b793-06e34946df64)
