### PR TITLE
Core: clarify error message when reading an `APContainer`

### DIFF
--- a/worlds/Files.py
+++ b/worlds/Files.py
@@ -41,6 +41,13 @@ class AutoPatchRegister(abc.ABCMeta):
 current_patch_version: int = 5
 
 
+class InvalidDataError(Exception):
+    """
+    Since games can override `read_contents` in APContainer,
+    this is to report problems in that process.
+    """
+
+
 class APContainer:
     """A zipfile containing at least archipelago.json"""
     version: int = current_patch_version
@@ -89,7 +96,15 @@ class APContainer:
         with zipfile.ZipFile(zip_file, "r") as zf:
             if file:
                 self.path = zf.filename
-            self.read_contents(zf)
+            try:
+                self.read_contents(zf)
+            except Exception as e:
+                message = ""
+                if len(e.args):
+                    arg0 = e.args[0]
+                    if isinstance(e.args[0], str):
+                        message = f"{arg0} - "
+                raise InvalidDataError(f"{message}This might be the incorrect world version for this file") from e
 
     def read_contents(self, opened_zipfile: zipfile.ZipFile) -> None:
         with opened_zipfile.open("archipelago.json", "r") as f:


### PR DESCRIPTION
## What is this fixing or adding?

Since any game can override `read_contents` in `APContainer` (and might need to),
we could use a more clear error message if something goes wrong with that implementation.

A suggestion was made to do something with the version number that's defined in core.
But if the plan is to move games out of core, or have better support for games outside of core, then we can't use a patch version number in core to keep track of changes in game implementations.

The solution needs to be something that is available to games that have never been in core and never will be in core.

## How was this tested?

I created a patch before this change: https://github.com/ArchipelagoMW/Archipelago/pull/2875
Then tested opening that patch with https://github.com/ArchipelagoMW/Archipelago/pull/2875 with and without these changes.

Before:
```
KeyError: "There is no item named 'gen_data.json' in the archive"
```

After:
```
KeyError: "There is no item named 'gen_data.json' in the archive"

The above exception was the direct cause of the following exception:

...

worlds.Files.InvalidDataError: There is no item named 'gen_data.json' in
the archive - This might be the incorrect world version for this file
```
