### PR TITLE
LTTP: Open Pyramid and Shop Prog Balancing Bug Fixes

### DIFF
--- a/worlds/alttp/Options.py
+++ b/worlds/alttp/Options.py
@@ -154,9 +154,9 @@ class OpenPyramid(Choice):
 
     def to_bool(self, world: MultiWorld, player: int) -> bool:
         if self.value == self.option_goal:
-            return world.goal[player] in {'crystals', 'ganon_triforce_hunt', 'local_ganon_triforce_hunt', 'ganon_pedestal'}
+            return world.goal[player].current_key in {'crystals', 'ganon_triforce_hunt', 'local_ganon_triforce_hunt', 'ganon_pedestal'}
         elif self.value == self.option_auto:
-            return world.goal[player] in {'crystals', 'ganon_triforce_hunt', 'local_ganon_triforce_hunt', 'ganon_pedestal'} \
+            return world.goal[player].current_key in {'crystals', 'ganon_triforce_hunt', 'local_ganon_triforce_hunt', 'ganon_pedestal'} \
             and (world.entrance_shuffle[player] in {'vanilla', 'dungeons_simple', 'dungeons_full', 'dungeons_crossed'} or not
                  world.shuffle_ganon)
         elif self.value == self.option_open:

--- a/worlds/alttp/Shops.py
+++ b/worlds/alttp/Shops.py
@@ -176,6 +176,9 @@ def push_shop_inventories(multiworld):
                 get_price(multiworld, location.shop.inventory[location.shop_slot], location.player,
                           location.shop_price_type)[1])
 
+    for world in multiworld.get_game_worlds("A Link to the Past"):
+        world.pushed_shop_inventories.set()
+
 
 def create_shops(multiworld, player: int):
 
@@ -451,15 +454,15 @@ def get_price(multiworld, item, player: int, price_type=None):
         if multiworld.randomize_shop_prices[player]:
             adjust = 2 if price < 100 else 5
             price = int((price / adjust) * (0.5 + multiworld.random.random() * 1.5)) * adjust
-        multiworld.random.shuffle(price_types)
+        multiworld.per_slot_randoms[player].shuffle(price_types)
         for p_type in price_types:
             if any(x in item['item'] for x in price_blacklist[p_type]):
                 continue
             return p_type, price_chart[p_type](price, diff)
     else:
         # This is an AP location and the price will be adjusted after an item is shuffled into it
-        p_type = multiworld.random.choice(price_types)
-        return p_type, price_chart[p_type](min(int(multiworld.random.randint(8, 56)
+        p_type = multiworld.per_slot_randoms[player].choice(price_types)
+        return p_type, price_chart[p_type](min(int(multiworld.per_slot_randoms[player].randint(8, 56)
                                            * multiworld.shop_price_modifier[player] / 100) * 5, 9999), diff)
 
 

--- a/worlds/alttp/__init__.py
+++ b/worlds/alttp/__init__.py
@@ -256,6 +256,7 @@ class ALTTPWorld(World):
         self.dungeon_local_item_names = set()
         self.dungeon_specific_item_names = set()
         self.rom_name_available_event = threading.Event()
+        self.pushed_shop_inventories = threading.Event()
         self.has_progressive_bows = False
         self.dungeons = {}
         self.waterfall_fairy_bottle_fill = "Bottle"
@@ -508,8 +509,8 @@ class ALTTPWorld(World):
         fill_dungeons_restrictive(world)
 
     @classmethod
-    def stage_post_fill(cls, world):
-        push_shop_inventories(world)
+    def stage_generate_output(cls, multiworld, output_directory):
+        push_shop_inventories(multiworld)
 
     @property
     def use_enemizer(self) -> bool:
@@ -523,6 +524,9 @@ class ALTTPWorld(World):
     def generate_output(self, output_directory: str):
         multiworld = self.multiworld
         player = self.player
+
+        self.pushed_shop_inventories.wait()
+
         try:
             use_enemizer = self.use_enemizer
 

--- a/worlds/alttp/test/options/TestOpenPyramid.py
+++ b/worlds/alttp/test/options/TestOpenPyramid.py
@@ -23,7 +23,7 @@ class GoalPyramidTest(PyramidTestBase):
     }
 
     def testCrystalsGoalAccess(self):
-        self.multiworld.goal[1] = "crystals"
+        self.multiworld.goal[1].value = 1  # crystals
         self.assertFalse(self.can_reach_entrance("Pyramid Hole"))
         self.collect_by_name(["Hammer", "Progressive Glove", "Moon Pearl"])
         self.assertTrue(self.can_reach_entrance("Pyramid Hole"))


### PR DESCRIPTION
## What is this fixing or adding?
- Fixes a bug with Open Pyramid searching for the class object in a set instead of current key
- Moves `push_shop_inventories` to `stage_generate_output` and uses threading events in `generate_output` to wait for it. This fixes a bug where the shop inventories are pushed based on items in locations before progression balancing is done.

## How was this tested?
- Observing behavior with debugger with and without open pyramid fix.
- Generating games with logged Progression Balancing item swaps, observing items swapped into and out of shops, testing to ensure they are the correct items in-game.