### PR TITLE
SoE: Move SNIclient hack to launcher component

### DIFF
--- a/SNIClient.py
+++ b/SNIClient.py
@@ -686,13 +686,12 @@ async def main() -> None:
         args.connect = meta["server"]
         logging.info(f"Wrote rom file to {romfile}")
         if args.diff_file.endswith(".apsoe"):
-            import webbrowser
+            from time import sleep
+            from worlds.soe import launch_soe_client
             async_start(run_game(romfile))
-            await _snes_connect(SNIContext(args.snes, args.connect, args.password), args.snes, False)
-            webbrowser.open(f"http://www.evermizer.com/apclient/#server={meta['server']}")
-            logging.info("Starting Evermizer Client in your Browser...")
-            import time
-            time.sleep(3)
+            launch_soe_client()
+            sleep(3)
+
             sys.exit()
         elif args.diff_file.endswith(".aplttp"):
             from worlds.alttp.Client import get_alttp_settings

--- a/inno_setup.iss
+++ b/inno_setup.iss
@@ -123,8 +123,8 @@ Root: HKCR; Subkey: "{#MyAppName}smz3patch\shell\open\command";  ValueData: """{
 
 Root: HKCR; Subkey: ".apsoe";                                    ValueData: "{#MyAppName}soepatch";        Flags: uninsdeletevalue; ValueType: string;  ValueName: "";
 Root: HKCR; Subkey: "{#MyAppName}soepatch";                      ValueData: "Archipelago Secret of Evermore Patch"; Flags: uninsdeletekey;   ValueType: string;  ValueName: "";
-Root: HKCR; Subkey: "{#MyAppName}soepatch\DefaultIcon";          ValueData: "{app}\ArchipelagoSNIClient.exe,0";                           ValueType: string;  ValueName: "";
-Root: HKCR; Subkey: "{#MyAppName}soepatch\shell\open\command";   ValueData: """{app}\ArchipelagoSNIClient.exe"" ""%1""";                  ValueType: string;  ValueName: "";
+Root: HKCR; Subkey: "{#MyAppName}soepatch\DefaultIcon";          ValueData: "{app}\ArchipelagoLauncher.exe,0";                           ValueType: string;  ValueName: "";
+Root: HKCR; Subkey: "{#MyAppName}soepatch\shell\open\command";   ValueData: """{app}\ArchipelagoLauncher.exe"" ""%1""";                  ValueType: string;  ValueName: "";
 
 Root: HKCR; Subkey: ".apl2ac";                                   ValueData: "{#MyAppName}l2acpatch";        Flags: uninsdeletevalue; ValueType: string;  ValueName: "";
 Root: HKCR; Subkey: "{#MyAppName}l2acpatch";                     ValueData: "Archipelago Lufia II Ancient Cave Patch"; Flags: uninsdeletekey;   ValueType: string;  ValueName: "";

--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -87,7 +87,7 @@ components: List[Component] = [
     Component('Text Client', 'CommonClient', 'ArchipelagoTextClient', func=launch_textclient),
     # SNI
     Component('SNI Client', 'SNIClient',
-              file_identifier=SuffixIdentifier('.apz3', '.apm3', '.apsoe', '.aplttp', '.apsm', '.apsmz3', '.apdkc3',
+              file_identifier=SuffixIdentifier('.apz3', '.apm3', '.aplttp', '.apsm', '.apsmz3', '.apdkc3',
                                                '.apsmw', '.apl2ac')),
     Component('Links Awakening DX Client', 'LinksAwakeningClient',
               file_identifier=SuffixIdentifier('.apladx')),

--- a/worlds/soe/__init__.py
+++ b/worlds/soe/__init__.py
@@ -16,7 +16,7 @@ from worlds.generic.Rules import add_item_rule, set_rule
 from .logic import SoEPlayerLogic
 from .options import Difficulty, EnergyCore, SoEOptions
 from .patch import SoEDeltaPatch, get_base_rom_path
-from worlds.LauncherComponents import Component, Type, components
+from worlds.LauncherComponents import Component, SuffixIdentifier, Type, components
 
 if typing.TYPE_CHECKING:
     from BaseClasses import MultiWorld, CollectionState
@@ -82,7 +82,8 @@ def launch_soe_client(*args: str) -> None:
     open(url)
 
 
-components.append(Component("Evermizer Client", component_type=Type.CLIENT, func=launch_soe_client))
+components.append(Component("Evermizer Client", component_type=Type.CLIENT,
+    func=launch_soe_client, file_identifier=SuffixIdentifier(".apsoe")))
 
 
 _id_base = 64000

--- a/worlds/soe/__init__.py
+++ b/worlds/soe/__init__.py
@@ -1,4 +1,5 @@
 import itertools
+import logging
 import os
 import os.path
 import threading
@@ -15,6 +16,7 @@ from worlds.generic.Rules import add_item_rule, set_rule
 from .logic import SoEPlayerLogic
 from .options import Difficulty, EnergyCore, SoEOptions
 from .patch import SoEDeltaPatch, get_base_rom_path
+from worlds.LauncherComponents import Component, Type, components
 
 if typing.TYPE_CHECKING:
     from BaseClasses import MultiWorld, CollectionState
@@ -57,6 +59,31 @@ Item grouping currently supports
 * Weapons - Matches all weapons but Bazooka, Bone Crusher, Neutron Blade
 * Traps - Matches all traps
 """
+
+
+def launch_soe_client(*args: str) -> None:
+    """Launches the SoE client in browser, patching and launching SNI as needed."""
+    from webbrowser import open
+    from SNIClient import launch_sni
+
+    url = "http://www.evermizer.com/apclient/"
+    launch_sni()
+    for arg in args:
+        if arg.endswith(".apsoe"):
+            from Patch import create_rom_file
+            from Utils import async_start
+            from SNIClient import run_game
+
+            meta, rom_file = create_rom_file(arg)
+            async_start(run_game(rom_file))
+            url += f"#server={meta['server']}"
+
+    logging.info("Starting Evermizer Client in your Browser...")
+    open(url)
+
+
+components.append(Component("Evermizer Client", component_type=Type.CLIENT, func=launch_soe_client))
+
 
 _id_base = 64000
 _id_offset: typing.Dict[int, int] = {


### PR DESCRIPTION
## What is this fixing or adding?
Moves the evermizer behavior of patching, launching sni, then launching the evermizer client in browser out of sniclient into its own launcher component. SNIClient can still handle the file and calls into the new method to support back compatibility. Can be removed at a later date.

## How was this tested?
Clicked the button in the launcher a few times. Ran setup of a frozen build and verified that the patch was able to run both through the launcher and sniclient, and it still patched and connected.

## If this makes graphical changes, please attach screenshots.
