### PR TITLE
Fill: Improve clarity of remaining_fill messages

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -208,7 +208,8 @@ def fill_restrictive(multiworld: MultiWorld, base_state: CollectionState, locati
 
 def remaining_fill(multiworld: MultiWorld,
                    locations: typing.List[Location],
-                   itempool: typing.List[Item]) -> None:
+                   itempool: typing.List[Item],
+                   name: str = "Remaining") -> None:
     unplaced_items: typing.List[Item] = []
     placements: typing.List[Location] = []
     swapped_items: typing.Counter[typing.Tuple[int, str]] = Counter()
@@ -265,10 +266,10 @@ def remaining_fill(multiworld: MultiWorld,
         placements.append(spot_to_fill)
         placed += 1
         if not placed % 1000:
-            _log_fill_progress("Remaining", placed, total)
+            _log_fill_progress(name, placed, total)
 
     if total > 1000:
-        _log_fill_progress("Remaining", placed, total)
+        _log_fill_progress(name, placed, total)
 
     if unplaced_items and locations:
         # There are leftover unplaceable items and locations that won't accept them
@@ -466,7 +467,7 @@ def distribute_items_restrictive(multiworld: MultiWorld) -> None:
 
     inaccessible_location_rules(multiworld, multiworld.state, defaultlocations)
 
-    remaining_fill(multiworld, excludedlocations, filleritempool)
+    remaining_fill(multiworld, excludedlocations, filleritempool, name="Remaining Excluded")
     if excludedlocations:
         raise FillError(
             f"Not enough filler items for excluded locations. There are {len(excludedlocations)} more locations than items")

--- a/Fill.py
+++ b/Fill.py
@@ -467,7 +467,7 @@ def distribute_items_restrictive(multiworld: MultiWorld) -> None:
 
     inaccessible_location_rules(multiworld, multiworld.state, defaultlocations)
 
-    remaining_fill(multiworld, excludedlocations, filleritempool, name="Remaining Excluded")
+    remaining_fill(multiworld, excludedlocations, filleritempool, "Remaining Excluded")
     if excludedlocations:
         raise FillError(
             f"Not enough filler items for excluded locations. There are {len(excludedlocations)} more locations than items")


### PR DESCRIPTION
## What is this fixing or adding?

When generating a multiworld with 1000+ excluded locations and 1000+ `remaining_fill` locations afterwards, the printed messages are confusing and unclear. This adds a parameter like the one in `fill_restrictive` to improve the message's clarity.

## How was this tested?

Generations and reading.

## If this makes graphical changes, please attach screenshots.
Before:
![BEFORE](https://github.com/ArchipelagoMW/Archipelago/assets/60412657/86d66b50-4410-4284-a35a-01d8dd5c46af)

After:
![AFTER](https://github.com/ArchipelagoMW/Archipelago/assets/60412657/216ff67c-d5bf-41de-a356-e39dac753e2e)
