### PR TITLE
worlds/generic: Changing deprecated option getter

### DIFF
--- a/worlds/generic/Rules.py
+++ b/worlds/generic/Rules.py
@@ -41,12 +41,12 @@ def locality_rules(world: MultiWorld):
             forbid_data[sender][receiver].update(items)
 
         for receiving_player in world.player_ids:
-            local_items: typing.Set[str] = world.local_items[receiving_player].value
+            local_items: typing.Set[str] = world.worlds[receiving_player].options.local_items.value
             if local_items:
                 for sending_player in world.player_ids:
                     if receiving_player != sending_player:
                         forbid(sending_player, receiving_player, local_items)
-            non_local_items: typing.Set[str] = world.non_local_items[receiving_player].value
+            non_local_items: typing.Set[str] = world.worlds[receiving_player].options.non_local_items.value
             if non_local_items:
                 forbid(receiving_player, receiving_player, non_local_items)
 


### PR DESCRIPTION
## What is this fixing or adding?

Changes the `local_items` and `non_local_items` option getters in `world/generic/Rules.py` to use the new options system.

## How was this tested?

Generations and reading.

## Additional Note

I opened this PR because of printed warning messages when generating games. I am aware that this change is also covered in [PR 2626](https://github.com/ArchipelagoMW/Archipelago/pull/2626), but that PR touches numerous other files, is a draft, fails tests, and has merge conflicts. I figured getting the changes into core as soon as possible was desirable and so I have opened this PR.