### PR TITLE
The Witness: Bump required client version

### DIFF
--- a/worlds/witness/__init__.py
+++ b/worlds/witness/__init__.py
@@ -56,7 +56,7 @@ class WitnessWorld(World):
     item_name_groups = StaticWitnessItems.item_groups
     location_name_groups = StaticWitnessLocations.AREA_LOCATION_GROUPS
 
-    required_client_version = (0, 4, 4)
+    required_client_version = (0, 4, 5)
 
     def __init__(self, multiworld: "MultiWorld", player: int):
         super().__init__(multiworld, player)


### PR DESCRIPTION
Bump required client version from 0.4.4 to 0.4.5.

The [client](https://github.com/NewSoupVi/The-Witness-Randomizer-for-Archipelago/releases/tag/v5.0.0p14) now connects with version 0.4.5.