### PR TITLE
HK: Removes Vanilla Items from ItemPool and Uses Grimmchild1 when relevant

### DIFF
--- a/worlds/hk/Items.py
+++ b/worlds/hk/Items.py
@@ -35,6 +35,7 @@ item_name_groups = ({
     "GeoChests": lookup_type_to_names["Geo"],
     "GeoRocks": lookup_type_to_names["Rock"],
     "GrimmkinFlames": lookup_type_to_names["Flame"],
+    "Grimmchild": {"Grimmchild1", "Grimmchild2"},
     "Grubs": lookup_type_to_names["Grub"],
     "JournalEntries": lookup_type_to_names["Journal"],
     "JunkPitChests": lookup_type_to_names["JunkPitChest"],

--- a/worlds/hk/Options.py
+++ b/worlds/hk/Options.py
@@ -406,8 +406,13 @@ class ExtraPlatforms(DefaultOnToggle):
     """Places additional platforms to make traveling throughout Hallownest more convenient."""
 
 
-class SharedItems(Toggle):
-    """Places all Vanilla items as AP Items so they can be shared within one slot. This will inflate hint prices."""
+class AddUnshuffledLocations(Toggle):
+    """Adds non-randomized locations to the location pool, which allows syncing
+    of location state with co-op or automatic collection via collect.
+
+    Note: This will increase the number of location checks required to purchase
+    hints to the total maximum.
+    """
 
 
 class DeathLinkShade(Choice):
@@ -492,7 +497,7 @@ hollow_knight_options: typing.Dict[str, type(Option)] = {
     **{
         option.__name__: option
         for option in (
-            StartLocation, Goal, WhitePalace, ExtraPlatforms, SharedItems, StartingGeo,
+            StartLocation, Goal, WhitePalace, ExtraPlatforms, AddUnshuffledLocations, StartingGeo,
             DeathLink, DeathLinkShade, DeathLinkBreaksFragileCharms,
             MinimumGeoPrice, MaximumGeoPrice,
             MinimumGrubPrice, MaximumGrubPrice,

--- a/worlds/hk/Options.py
+++ b/worlds/hk/Options.py
@@ -406,6 +406,10 @@ class ExtraPlatforms(DefaultOnToggle):
     """Places additional platforms to make traveling throughout Hallownest more convenient."""
 
 
+class SharedItems(Toggle):
+    """Places all Vanilla items as AP Items so they can be shared within one slot. This will inflate hint prices."""
+
+
 class DeathLinkShade(Choice):
     """Sets whether to create a shade when you are killed by a DeathLink and how to handle your existing shade, if any.
 
@@ -488,7 +492,7 @@ hollow_knight_options: typing.Dict[str, type(Option)] = {
     **{
         option.__name__: option
         for option in (
-            StartLocation, Goal, WhitePalace, ExtraPlatforms, StartingGeo,
+            StartLocation, Goal, WhitePalace, ExtraPlatforms, SharedItems, StartingGeo,
             DeathLink, DeathLinkShade, DeathLinkBreaksFragileCharms,
             MinimumGeoPrice, MaximumGeoPrice,
             MinimumGrubPrice, MaximumGrubPrice,

--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -252,21 +252,21 @@ class HKWorld(World):
             if item_name in junk_replace:
                 item_name = self.get_filler_item_name()
 
+            item = self.create_item(item_name) if not vanilla or location_name == "Start" else self.create_event(item_name)
+
             if location_name == "Start":
                 if item_name in randomized_starting_items:
                     if item_name == "Focus":
                         self.create_location("Focus")
                         unfilled_locations += 1
-                    pool.append(self.create_item(item_name))
+                    pool.append(item)
                 else:
-                    self.multiworld.push_precollected(self.create_item(item_name))
+                    self.multiworld.push_precollected(item)
                 return
 
             if vanilla:
-                item = self.create_event(item_name)
                 location = self.create_vanilla_location(location_name, item)
             else:
-                item = self.create_item(item_name)
                 pool.append(item)
                 if location_name in multi_locations:  # Create shop locations later.
                     return

--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -252,7 +252,7 @@ class HKWorld(World):
             if item_name in junk_replace:
                 item_name = self.get_filler_item_name()
 
-            item = self.create_item(item_name) if not vanilla or location_name == "Start" else self.create_event(item_name)
+            item = self.create_item(item_name) if not vanilla or location_name == "Start" or self.multiworld.SharedItems[self.player] else self.create_event(item_name)
 
             if location_name == "Start":
                 if item_name in randomized_starting_items:
@@ -277,7 +277,7 @@ class HKWorld(World):
 
         for option_key, option in hollow_knight_randomize_options.items():
             randomized = getattr(self.multiworld, option_key)[self.player]
-            if randomized or option_key not in logicless_options:
+            if randomized or option_key not in logicless_options or self.multiworld.SharedItems[self.player]:
                 for item_name, location_name in zip(option.items, option.locations):
                     if item_name in junk_replace:
                         item_name = self.get_filler_item_name()
@@ -502,7 +502,7 @@ class HKWorld(World):
 
         region = self.multiworld.get_region("Menu", self.player)
 
-        if vanilla:
+        if vanilla and not self.multiworld.SharedItems[self.player]:
             loc = HKLocation(self.player, name,
                              None, region, costs=costs, vanilla=vanilla,
                              basename=basename)

--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -252,7 +252,7 @@ class HKWorld(World):
             if item_name in junk_replace:
                 item_name = self.get_filler_item_name()
 
-            item = self.create_item(item_name) if not vanilla or location_name == "Start" or self.multiworld.SharedItems[self.player] else self.create_event(item_name)
+            item = self.create_item(item_name) if not vanilla or location_name == "Start" or self.multiworld.AddUnshuffledLocations[self.player] else self.create_event(item_name)
 
             if location_name == "Start":
                 if item_name in randomized_starting_items:
@@ -277,7 +277,7 @@ class HKWorld(World):
 
         for option_key, option in hollow_knight_randomize_options.items():
             randomized = getattr(self.multiworld, option_key)[self.player]
-            if all([not randomized, option_key in logicless_options, not self.multiworld.SharedItems[self.player]]):
+            if all([not randomized, option_key in logicless_options, not self.multiworld.AddUnshuffledLocations[self.player]]):
                 continue
             for item_name, location_name in zip(option.items, option.locations):
                 if item_name in junk_replace:
@@ -503,7 +503,7 @@ class HKWorld(World):
 
         region = self.multiworld.get_region("Menu", self.player)
 
-        if vanilla and not self.multiworld.SharedItems[self.player]:
+        if vanilla and not self.multiworld.AddUnshuffledLocations[self.player]:
             loc = HKLocation(self.player, name,
                              None, region, costs=costs, vanilla=vanilla,
                              basename=basename)

--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -277,30 +277,31 @@ class HKWorld(World):
 
         for option_key, option in hollow_knight_randomize_options.items():
             randomized = getattr(self.multiworld, option_key)[self.player]
-            if randomized or option_key not in logicless_options or self.multiworld.SharedItems[self.player]:
-                for item_name, location_name in zip(option.items, option.locations):
-                    if item_name in junk_replace:
-                        item_name = self.get_filler_item_name()
+            if all([not randomized, option_key in logicless_options, not self.multiworld.SharedItems[self.player]]):
+                continue
+            for item_name, location_name in zip(option.items, option.locations):
+                if item_name in junk_replace:
+                    item_name = self.get_filler_item_name()
 
-                    if (item_name == "Crystal_Heart" and self.multiworld.SplitCrystalHeart[self.player]) or \
-                            (item_name == "Mothwing_Cloak" and self.multiworld.SplitMothwingCloak[self.player]):
-                        _add("Left_" + item_name, location_name, randomized)
-                        _add("Right_" + item_name, "Split_" + location_name, randomized)
-                        continue
-                    if item_name == "Mantis_Claw" and self.multiworld.SplitMantisClaw[self.player]:
-                        _add("Left_" + item_name, "Left_" + location_name, randomized)
-                        _add("Right_" + item_name, "Right_" + location_name, randomized)
-                        continue
-                    if item_name == "Shade_Cloak" and self.multiworld.SplitMothwingCloak[self.player]:
-                        if self.multiworld.random.randint(0, 1):
-                            item_name = "Left_Mothwing_Cloak"
-                        else:
-                            item_name = "Right_Mothwing_Cloak"
-                    if item_name == "Grimmchild2" and self.multiworld.RandomizeGrimmkinFlames[self.player] and self.multiworld.RandomizeCharms[self.player]:
-                        _add("Grimmchild1", location_name, randomized)
-                        continue
+                if (item_name == "Crystal_Heart" and self.multiworld.SplitCrystalHeart[self.player]) or \
+                        (item_name == "Mothwing_Cloak" and self.multiworld.SplitMothwingCloak[self.player]):
+                    _add("Left_" + item_name, location_name, randomized)
+                    _add("Right_" + item_name, "Split_" + location_name, randomized)
+                    continue
+                if item_name == "Mantis_Claw" and self.multiworld.SplitMantisClaw[self.player]:
+                    _add("Left_" + item_name, "Left_" + location_name, randomized)
+                    _add("Right_" + item_name, "Right_" + location_name, randomized)
+                    continue
+                if item_name == "Shade_Cloak" and self.multiworld.SplitMothwingCloak[self.player]:
+                    if self.multiworld.random.randint(0, 1):
+                        item_name = "Left_Mothwing_Cloak"
+                    else:
+                        item_name = "Right_Mothwing_Cloak"
+                if item_name == "Grimmchild2" and self.multiworld.RandomizeGrimmkinFlames[self.player] and self.multiworld.RandomizeCharms[self.player]:
+                    _add("Grimmchild1", location_name, randomized)
+                    continue
 
-                    _add(item_name, location_name, randomized)
+                _add(item_name, location_name, randomized)
 
         if self.multiworld.RandomizeElevatorPass[self.player]:
             randomized = True

--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -296,6 +296,9 @@ class HKWorld(World):
                             item_name = "Left_Mothwing_Cloak"
                         else:
                             item_name = "Right_Mothwing_Cloak"
+                    if item_name == "Grimmchild2" and self.multiworld.RandomizeGrimmkinFlames[self.player] and self.multiworld.RandomizeCharms[self.player]:
+                        _add("Grimmchild1", location_name, randomized)
+                        continue
 
                     _add(item_name, location_name, randomized)
 


### PR DESCRIPTION
## What is this fixing or adding?
All logic-less items when not randomized will not be added to the itempool and should default in-game to their vanilla placements/rewards
All logic-relevant items when not randomized will also not be added to the itempool but will be represented as Events so logic can remain unchanged (for now)

Also adds the Grimmchild1 item to the itempool instead of Grimmchild2 when relevant (when both flames and charms are shuffled), otherwise uses Grimmchild2 as default
* Note: that default is inherited from the Extracted data, so if that changes this fix will likely have to change to match.

## How was this tested?
quickly
tested logicless removal with geo rocks and soul totems off, and with lore on
confirmed the off locations were not present in the spoiler log, were not sent to the server by the game, and did default to vanilla items in-game
confirmed the on locations were present in the spoiler log, did send to the server by the game, and did grant randomized items when checked in-game

only confirmed the Grimmchild updates in spoiler log, but did test that:
with both charm + flames on, Grimmchild1 was shuffled into the multiworld
with only charm on, Grimmchild2 was shuffled into the multiworld
with only flames on, Grimmchild2 was set to its vanilla location (and supposedly an Event to be handled by the game per vanilla rules, but did not confirm)

## If this makes graphical changes, please attach screenshots.
