### PR TITLE
Core: differentiate between unknown worlds and broken worlds in error message

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -26,6 +26,7 @@ from worlds.alttp.EntranceRandomizer import parse_arguments
 from worlds.alttp.Text import TextTable
 from worlds.AutoWorld import AutoWorldRegister
 from worlds.generic import PlandoConnection
+from worlds import failed_world_loads
 
 
 def mystery_argparse():
@@ -440,7 +441,11 @@ def roll_settings(weights: dict, plando_options: PlandoOptions = PlandoOptions.b
 
     ret.game = get_choice("game", weights)
     if ret.game not in AutoWorldRegister.world_types:
-        picks = Utils.get_fuzzy_results(ret.game, AutoWorldRegister.world_types, limit=1)[0]
+        picks = Utils.get_fuzzy_results(ret.game, list(AutoWorldRegister.world_types) + failed_world_loads, limit=1)[0]
+        if picks[0] in failed_world_loads:
+            raise Exception(f"No functional world found to handle game {ret.game}. "
+                            f"Did you mean '{picks[0]}' ({picks[1]}% sure)? "
+                            f"If so, it appears the world failed to initialize correctly.")
         raise Exception(f"No world found to handle game {ret.game}. Did you mean '{picks[0]}' ({picks[1]}% sure)? "
                         f"Check your spelling or installation of that world.")
 

--- a/worlds/__init__.py
+++ b/worlds/__init__.py
@@ -20,7 +20,11 @@ __all__ = {
     "user_folder",
     "GamesPackage",
     "DataPackage",
+    "failed_world_loads",
 }
+
+
+failed_world_loads: List[str] = []
 
 
 class GamesPackage(TypedDict, total=False):
@@ -87,6 +91,7 @@ class WorldSource:
             file_like.seek(0)
             import logging
             logging.exception(file_like.read())
+            failed_world_loads.append(os.path.basename(self.path).rsplit(".", 1)[0])
             return False
 
 


### PR DESCRIPTION
## What is this fixing or adding?
Makes it a bit clearer what broke, hopefully.

## How was this tested?
By adding carp at the top of factorio's init
[...]NameError: name 'carp' is not defined
[...]Exception: No functional world found to handle game Factorio. Did you mean 'factorio' (100% sure)? If so, it appears the world failed to initialize correctly.[...]

## If this makes graphical changes, please attach screenshots.
