### PR TITLE
Generate: Trim slot names again after 16 character limitation slice.

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -302,7 +302,9 @@ def handle_name(name: str, player: int, name_counter: Counter):
                                                                  NUMBER=(number if number > 1 else ''),
                                                                  player=player,
                                                                  PLAYER=(player if player > 1 else '')))
-    new_name = new_name.strip()[:16]
+    # Run .strip twice for edge case where after the initial .slice new_name has a leading whitespace.
+    # Could cause issues for some clients that cannot handle the additional whitespace.
+    new_name = new_name.strip()[:16].strip()
     if new_name == "Archipelago":
         raise Exception(f"You cannot name yourself \"{new_name}\"")
     return new_name


### PR DESCRIPTION
## What is this fixing or adding?
There is a unique edge case where if a player has a slot name over 16 characters, but the 16th character is whitespace it will keep the leading whitespace in the slot name, which can cause issues for clients that trim username inputs (including CommonClient). This change trims the username again after the slice to ensure no whitespace remains.

Example:
A user has the slot name of `15CharacterName ThatIsToLong` which gets sliced in code to `15CharacterName ` (16 chars). Because the trim only happens before the slice, MultiServer will expect the final space character to be present, but some clients (like Rogue Legacy for example), will trim user input so there is no way to actually send the request properly.

## How was this tested?
Ran 2 generations before and after the change with the example name above. Was able to connect after the change, but not before (received Incorrect Slot Name error).

## If this makes graphical changes, please attach screenshots.
N/A