### PR TITLE
LTTP: Missed `per_slot_random` Change

### DIFF
--- a/worlds/alttp/Shops.py
+++ b/worlds/alttp/Shops.py
@@ -453,7 +453,7 @@ def get_price(multiworld, item, player: int, price_type=None):
         price = item["price"]
         if multiworld.randomize_shop_prices[player]:
             adjust = 2 if price < 100 else 5
-            price = int((price / adjust) * (0.5 + multiworld.random.random() * 1.5)) * adjust
+            price = int((price / adjust) * (0.5 + multiworld.per_slot_randoms[player].random() * 1.5)) * adjust
         multiworld.per_slot_randoms[player].shuffle(price_types)
         for p_type in price_types:
             if any(x in item['item'] for x in price_blacklist[p_type]):


### PR DESCRIPTION
## What is this fixing or adding?
#2890 moved `push_shop_inventories` to `stage_generate_output` which necessitated changing some uses of `multiworld.random` to `per_slot_randoms`. One use was missed, causing a crash when `randomize_shop_prices` is on. That is fixed here.

## How was this tested?
Generating with `randomize_shop_prices` on.