### PR TITLE
DLC Quest: AP World Status fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,6 @@ non_apworlds: set = {
     "Archipelago",
     "ChecksFinder",
     "Clique",
-    "DLCQuest",
     "Final Fantasy",
     "Lufia II Ancient Cave",
     "Meritous",


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?
DLC Quest is working in AP World status but I didn't know where to do it

## How was this tested?
https://discord.com/channels/731205301247803413/1214398728706854933/1214422249235419147

## If this makes graphical changes, please attach screenshots.
