### PR TITLE
CI: Avoid race condition in labeler workflow

### DIFF
--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -18,6 +18,7 @@ jobs:
           sync-labels: true
   peer_review:
     name: 'Apply peer review label'
+    needs: labeler
     if: >-
       (github.event.action == 'opened' || github.event.action == 'reopened' || 
       github.event.action == 'ready_for_review') && !github.event.pull_request.draft
@@ -30,6 +31,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   unblock_draft_prs:
     name: 'Remove waiting-on labels'
+    needs: labeler
     if: github.event.action == 'converted_to_draft' || github.event.action == 'closed'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## What is this fixing or adding?

Fixes a CI race condition in #2904 where the labeler job, by calling the set labels API, may overwrite labels added or removed by the other 2 jobs if timed poorly.

## How was this tested?

Wasn't. I tried to test on my branch and realized that it only runs on main so I gave up

As far as verifying this is the correct fix for the issue, I checked labeler's source code to verify it does what I expected it did (using set labels instead of add/remove) and checked actions' yaml schema to verify this is semantically valid


