### PR TITLE
Core: Hard Deprecate old options API

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -268,7 +268,7 @@ class MultiWorld():
                               AutoWorld.AutoWorldRegister.world_types[self.game[player]].options_dataclass.type_hints}
         for option_key in all_keys:
             option = Utils.DeprecateDict(f"Getting options from multiworld is now deprecated. "
-                                         f"Please use `self.options.{option_key}` instead.")
+                                         f"Please use `self.options.{option_key}` instead.", True)
             option.update(getattr(args, option_key, {}))
             setattr(self, option_key, option)
 

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -12,6 +12,7 @@ from typing import (Any, Callable, ClassVar, Dict, FrozenSet, List, Mapping,
 
 from Options import PerGameCommonOptions
 from BaseClasses import CollectionState
+from Utils import deprecate
 
 if TYPE_CHECKING:
     import random
@@ -78,9 +79,8 @@ class AutoWorldRegister(type):
         # TODO - remove this once all worlds use options dataclasses
         if "options_dataclass" not in dct and "option_definitions" in dct:
             # TODO - switch to deprecate after a version
-            if __debug__:
-                logging.warning(f"{name} Assigned options through option_definitions which is now deprecated. "
-                                "Please use options_dataclass instead.")
+            deprecate(f"{name} Assigned options through option_definitions which is now deprecated. "
+                      "Please use options_dataclass instead.")
             dct["options_dataclass"] = make_dataclass(f"{name}Options", dct["option_definitions"].items(),
                                                       bases=(PerGameCommonOptions,))
 


### PR DESCRIPTION
## What is this fixing or adding?
Title. old options API will still work on a frozen build (with warnings), but not on source.

## How was this tested?
wasn't yet

## If this makes graphical changes, please attach screenshots.
