### PR TITLE
KDL3: Post-PR adjustments

### DIFF
--- a/worlds/kdl3/Client.py
+++ b/worlds/kdl3/Client.py
@@ -97,6 +97,7 @@ def cmd_gift(self: "SNIClientCommandProcessor"):
 
 class KDL3SNIClient(SNIClient):
     game = "Kirby's Dream Land 3"
+    patch_suffix = ".apkdl3"
     levels = None
     consumables = None
     stars = None
@@ -406,7 +407,8 @@ class KDL3SNIClient(SNIClient):
                 ctx.locations_checked.add(new_check_id)
                 location = ctx.location_names[new_check_id]
                 snes_logger.info(
-                    f'New Check: {location} ({len(ctx.locations_checked)}/{len(ctx.missing_locations) + len(ctx.checked_locations)})')
+                    f'New Check: {location} ({len(ctx.locations_checked)}/'
+                    f'{len(ctx.missing_locations) + len(ctx.checked_locations)})')
                 await ctx.send_msgs([{"cmd": 'LocationChecks', "locations": [new_check_id]}])
         except Exception as ex:
             # we crashed, so print log and clean up

--- a/worlds/kdl3/Rules.py
+++ b/worlds/kdl3/Rules.py
@@ -209,7 +209,9 @@ def set_rules(world: "KDL3World") -> None:
                  (can_reach_rick(state, world.player) or can_reach_coo(state, world.player)))
         set_rule(world.multiworld.get_location(LocationName.sand_canyon_5_u3, world.player),
                  lambda state: can_reach_ice(state, world.player) and
-                 (can_reach_rick(state, world.player) or can_reach_coo(state, world.player)))
+                 (can_reach_rick(state, world.player) or can_reach_coo(state, world.player)
+                  or can_reach_chuchu(state, world.player) or can_reach_pitch(state, world.player)
+                  or can_reach_nago(state, world.player)))
         set_rule(world.multiworld.get_location(LocationName.sand_canyon_5_u4, world.player),
                  lambda state: can_reach_ice(state, world.player) and
                  (can_reach_rick(state, world.player) or can_reach_coo(state, world.player)))
@@ -242,7 +244,9 @@ def set_rules(world: "KDL3World") -> None:
         for i in range(12, 18):
             set_rule(world.multiworld.get_location(f"Sand Canyon 5 - Star {i}", world.player),
                      lambda state: can_reach_ice(state, world.player) and
-                     (can_reach_rick(state, world.player) or can_reach_coo(state, world.player)))
+                     (can_reach_rick(state, world.player) or can_reach_coo(state, world.player)
+                      or can_reach_chuchu(state, world.player) or can_reach_pitch(state, world.player)
+                      or can_reach_nago(state, world.player)))
         for i in range(21, 23):
             set_rule(world.multiworld.get_location(f"Sand Canyon 5 - Star {i}", world.player),
                      lambda state: can_reach_chuchu(state, world.player))
@@ -267,32 +271,32 @@ def set_rules(world: "KDL3World") -> None:
     # Kirby cannot eat enemies fully submerged in water. Vast majority of cases, the enemy can be brought to the surface
     # and eaten by inhaling while falling on top of them
     set_rule(world.multiworld.get_location(EnemyAbilities.Ripple_Field_2_E3, world.player),
-             lambda state: can_reach_kine(state, world.player))
+             lambda state: can_reach_kine(state, world.player) or can_reach_chuchu(state, world.player))
     set_rule(world.multiworld.get_location(EnemyAbilities.Ripple_Field_3_E6, world.player),
-             lambda state: can_reach_kine(state, world.player))
+             lambda state: can_reach_kine(state, world.player) or can_reach_chuchu(state, world.player))
     # Ripple Field 4 E5, E7, and E8 are doable, but too strict to leave in logic
     set_rule(world.multiworld.get_location(EnemyAbilities.Ripple_Field_4_E5, world.player),
-             lambda state: can_reach_kine(state, world.player))
+             lambda state: can_reach_kine(state, world.player) or can_reach_chuchu(state, world.player))
     set_rule(world.multiworld.get_location(EnemyAbilities.Ripple_Field_4_E7, world.player),
-             lambda state: can_reach_kine(state, world.player))
+             lambda state: can_reach_kine(state, world.player) or can_reach_chuchu(state, world.player))
     set_rule(world.multiworld.get_location(EnemyAbilities.Ripple_Field_4_E8, world.player),
-             lambda state: can_reach_kine(state, world.player))
+             lambda state: can_reach_kine(state, world.player) or can_reach_chuchu(state, world.player))
     set_rule(world.multiworld.get_location(EnemyAbilities.Ripple_Field_5_E1, world.player),
-             lambda state: can_reach_kine(state, world.player))
+             lambda state: can_reach_kine(state, world.player) or can_reach_chuchu(state, world.player))
     set_rule(world.multiworld.get_location(EnemyAbilities.Ripple_Field_5_E2, world.player),
-             lambda state: can_reach_kine(state, world.player))
+             lambda state: can_reach_kine(state, world.player) or can_reach_chuchu(state, world.player))
     set_rule(world.multiworld.get_location(EnemyAbilities.Ripple_Field_5_E3, world.player),
-             lambda state: can_reach_kine(state, world.player))
+             lambda state: can_reach_kine(state, world.player) or can_reach_chuchu(state, world.player))
     set_rule(world.multiworld.get_location(EnemyAbilities.Ripple_Field_5_E4, world.player),
-             lambda state: can_reach_kine(state, world.player))
+             lambda state: can_reach_kine(state, world.player) or can_reach_chuchu(state, world.player))
     set_rule(world.multiworld.get_location(EnemyAbilities.Sand_Canyon_4_E7, world.player),
-             lambda state: can_reach_kine(state, world.player))
+             lambda state: can_reach_kine(state, world.player) or can_reach_chuchu(state, world.player))
     set_rule(world.multiworld.get_location(EnemyAbilities.Sand_Canyon_4_E8, world.player),
-             lambda state: can_reach_kine(state, world.player))
+             lambda state: can_reach_kine(state, world.player) or can_reach_chuchu(state, world.player))
     set_rule(world.multiworld.get_location(EnemyAbilities.Sand_Canyon_4_E9, world.player),
-             lambda state: can_reach_kine(state, world.player))
+             lambda state: can_reach_kine(state, world.player) or can_reach_chuchu(state, world.player))
     set_rule(world.multiworld.get_location(EnemyAbilities.Sand_Canyon_4_E10, world.player),
-             lambda state: can_reach_kine(state, world.player))
+             lambda state: can_reach_kine(state, world.player) or can_reach_chuchu(state, world.player))
 
     for boss_flag, purification, i in zip(["Level 1 Boss - Purified", "Level 2 Boss - Purified",
                                            "Level 3 Boss - Purified", "Level 4 Boss - Purified",

--- a/worlds/kdl3/Rules.py
+++ b/worlds/kdl3/Rules.py
@@ -206,7 +206,9 @@ def set_rules(world: "KDL3World") -> None:
                  lambda state: can_reach_needle(state, world.player))
         set_rule(world.multiworld.get_location(LocationName.sand_canyon_5_u2, world.player),
                  lambda state: can_reach_ice(state, world.player) and
-                 (can_reach_rick(state, world.player) or can_reach_coo(state, world.player)))
+                 (can_reach_rick(state, world.player) or can_reach_coo(state, world.player)
+                  or can_reach_chuchu(state, world.player) or can_reach_pitch(state, world.player)
+                  or can_reach_nago(state, world.player)))
         set_rule(world.multiworld.get_location(LocationName.sand_canyon_5_u3, world.player),
                  lambda state: can_reach_ice(state, world.player) and
                  (can_reach_rick(state, world.player) or can_reach_coo(state, world.player)
@@ -214,7 +216,9 @@ def set_rules(world: "KDL3World") -> None:
                   or can_reach_nago(state, world.player)))
         set_rule(world.multiworld.get_location(LocationName.sand_canyon_5_u4, world.player),
                  lambda state: can_reach_ice(state, world.player) and
-                 (can_reach_rick(state, world.player) or can_reach_coo(state, world.player)))
+                 (can_reach_rick(state, world.player) or can_reach_coo(state, world.player)
+                  or can_reach_chuchu(state, world.player) or can_reach_pitch(state, world.player)
+                  or can_reach_nago(state, world.player)))
         set_rule(world.multiworld.get_location(LocationName.cloudy_park_6_u1, world.player),
                  lambda state: can_reach_cutter(state, world.player))
 


### PR DESCRIPTION
## What is this fixing or adding?
#2870 got merged, but didn't actually include KDL3 with its changes. This adds the needed patch_suffix required for patching.

Two logic rules were also adjusted. I learned that ChuChu can also eat enemies while underwater, not just Kine. Every animal except for Kine is capable of breaking the Ice blocks in 3-5, Coo and Rick were just the ones I had known prior.

## How was this tested?
Ran unit tests, opened the launcher to confirm ".apkdl3" can be patched via Open Patch.
