### PR TITLE
KDL3: fix invalid inno_setup components and deathlink messages

### DIFF
--- a/inno_setup.iss
+++ b/inno_setup.iss
@@ -131,10 +131,10 @@ Root: HKCR; Subkey: "{#MyAppName}l2acpatch";                     ValueData: "Arc
 Root: HKCR; Subkey: "{#MyAppName}l2acpatch\DefaultIcon";         ValueData: "{app}\ArchipelagoSNIClient.exe,0";                           ValueType: string;  ValueName: "";
 Root: HKCR; Subkey: "{#MyAppName}l2acpatch\shell\open\command";  ValueData: """{app}\ArchipelagoSNIClient.exe"" ""%1""";                  ValueType: string;  ValueName: "";
 
-Root: HKCR; Subkey: ".apkdl3";                                   ValueData: "{#MyAppName}kdl3patch";        Flags: uninsdeletevalue; ValueType: string;  ValueName: ""; Components: client/sni
-Root: HKCR; Subkey: "{#MyAppName}kdl3patch";                     ValueData: "Archipelago Kirby's Dream Land 3 Patch"; Flags: uninsdeletekey;   ValueType: string;  ValueName: ""; Components: client/sni
-Root: HKCR; Subkey: "{#MyAppName}kdl3patch\DefaultIcon";         ValueData: "{app}\ArchipelagoSNIClient.exe,0";                           ValueType: string;  ValueName: ""; Components: client/sni
-Root: HKCR; Subkey: "{#MyAppName}kdl3patch\shell\open\command";  ValueData: """{app}\ArchipelagoSNIClient.exe"" ""%1""";                  ValueType: string;  ValueName: ""; Components: client/sni
+Root: HKCR; Subkey: ".apkdl3";                                   ValueData: "{#MyAppName}kdl3patch";        Flags: uninsdeletevalue; ValueType: string;  ValueName: "";
+Root: HKCR; Subkey: "{#MyAppName}kdl3patch";                     ValueData: "Archipelago Kirby's Dream Land 3 Patch"; Flags: uninsdeletekey;   ValueType: string;  ValueName: "";
+Root: HKCR; Subkey: "{#MyAppName}kdl3patch\DefaultIcon";         ValueData: "{app}\ArchipelagoSNIClient.exe,0";                           ValueType: string;  ValueName: "";
+Root: HKCR; Subkey: "{#MyAppName}kdl3patch\shell\open\command";  ValueData: """{app}\ArchipelagoSNIClient.exe"" ""%1""";                  ValueType: string;  ValueName: "";
 
 Root: HKCR; Subkey: ".apmc";                                     ValueData: "{#MyAppName}mcdata";         Flags: uninsdeletevalue; ValueType: string;  ValueName: "";
 Root: HKCR; Subkey: "{#MyAppName}mcdata";                        ValueData: "Archipelago Minecraft Data"; Flags: uninsdeletekey;   ValueType: string;  ValueName: "";

--- a/worlds/kdl3/Client.py
+++ b/worlds/kdl3/Client.py
@@ -310,9 +310,12 @@ class KDL3SNIClient(SNIClient):
                 return  # null, title screen, opening, save select, true and false endings
             game_state = await snes_read(ctx, KDL3_GAME_STATE, 1)
             current_hp = await snes_read(ctx, KDL3_KIRBY_HP, 1)
+            current_world = struct.unpack("H", await snes_read(ctx, KDL3_CURRENT_WORLD, 2))[0]
+            current_level = struct.unpack("H", await snes_read(ctx, KDL3_CURRENT_LEVEL, 2))[0]
             if "DeathLink" in ctx.tags and game_state[0] == 0x00 and ctx.last_death_link + 1 < time.time():
                 currently_dead = current_hp[0] == 0x00
-                await ctx.handle_deathlink_state(currently_dead)
+                message = deathlink_messages[self.levels[current_world][current_level - 1]]
+                await ctx.handle_deathlink_state(currently_dead, f"{ctx.player_names[ctx.slot]}{message}")
 
             recv_count = await snes_read(ctx, KDL3_RECV_COUNT, 2)
             recv_amount = unpack("H", recv_count)[0]

--- a/worlds/kdl3/Client.py
+++ b/worlds/kdl3/Client.py
@@ -309,10 +309,10 @@ class KDL3SNIClient(SNIClient):
             if current_bgm[0] in (0x00, 0x21, 0x22, 0x23, 0x25, 0x2A, 0x2B):
                 return  # null, title screen, opening, save select, true and false endings
             game_state = await snes_read(ctx, KDL3_GAME_STATE, 1)
-            current_hp = await snes_read(ctx, KDL3_KIRBY_HP, 1)
-            current_world = struct.unpack("H", await snes_read(ctx, KDL3_CURRENT_WORLD, 2))[0]
-            current_level = struct.unpack("H", await snes_read(ctx, KDL3_CURRENT_LEVEL, 2))[0]
             if "DeathLink" in ctx.tags and game_state[0] == 0x00 and ctx.last_death_link + 1 < time.time():
+                current_hp = await snes_read(ctx, KDL3_KIRBY_HP, 1)
+                current_world = struct.unpack("H", await snes_read(ctx, KDL3_CURRENT_WORLD, 2))[0]
+                current_level = struct.unpack("H", await snes_read(ctx, KDL3_CURRENT_LEVEL, 2))[0]
                 currently_dead = current_hp[0] == 0x00
                 message = deathlink_messages[self.levels[current_world][current_level - 1]]
                 await ctx.handle_deathlink_state(currently_dead, f"{ctx.player_names[ctx.slot]}{message}")


### PR DESCRIPTION
## What is this fixing or adding?
Managed to forget removing `Components: client/sni` from when the installer changes were merged, and I didn't test it since then. 

## How was this tested?
Built the installer, it would fail before this change was made.