### PR TITLE
Core: Remove extra " character in /forbid_release help message

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1964,7 +1964,7 @@ class ServerCommandProcessor(CommonCommandProcessor):
 
     @mark_raw
     def _cmd_forbid_release(self, player_name: str) -> bool:
-        """"Disallow the specified player from using the !release command."""
+        """Disallow the specified player from using the !release command."""
         player = self.resolve_player(player_name)
         if player:
             team, slot, name = player


### PR DESCRIPTION
## What is this fixing or adding?

This extra quote was pointed out in the Discord: https://discord.com/channels/731205301247803413/731205301818359821/1215882443261870190

Here's a PR to remove it

## How was this tested?

wasn't