### PR TITLE
ALTTP: Fix NotImplemented error when using non-`none` values for `timer`.

### DIFF
--- a/worlds/alttp/ItemPool.py
+++ b/worlds/alttp/ItemPool.py
@@ -234,8 +234,8 @@ def generate_itempool(world):
         raise NotImplementedError(f"Goal {multiworld.goal[player]} for player {player}")
     if multiworld.mode[player] not in ('open', 'standard', 'inverted'):
         raise NotImplementedError(f"Mode {multiworld.mode[player]} for player {player}")
-    if multiworld.timer[player] not in {False, 'display', 'timed', 'timed_ohko', 'ohko', 'timed_countdown'}:
-        raise NotImplementedError(f"Timer {multiworld.mode[player]} for player {player}")
+    if multiworld.timer[player] not in (False, 'display', 'timed', 'timed_ohko', 'ohko', 'timed_countdown'):
+        raise NotImplementedError(f"Timer {multiworld.timer[player]} for player {player}")
 
     if multiworld.timer[player] in ['ohko', 'timed_ohko']:
         multiworld.can_take_damage[player] = False


### PR DESCRIPTION
Also show `timer` value not `mode` value when raising a NotImplemented exception. I'm assuming this was a copy/paste gone wrong.

![image](https://github.com/ArchipelagoMW/Archipelago/assets/11338376/6cf32a7a-e94a-4b22-b848-9f155efc826b)

## How was this tested?
Ran generations with other timer values before and after this change and generation continues instead of fails after this fix.

## If this makes graphical changes, please attach screenshots.
N/A