### PR TITLE
Spoiler: Display all precollected items in the Spoiler Log

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1390,13 +1390,13 @@ class Spoiler:
 
             AutoWorld.call_all(self.multiworld, "write_spoiler", outfile)
 
-            precollected_items = [f'{item.name} ({self.multiworld.get_player_name(item.player)})'
+            precollected_items = [f"{item.name} ({self.multiworld.get_player_name(item.player)})"
                                   if self.multiworld.players > 1
                                   else item.name
                                   for item in chain.from_iterable(self.multiworld.precollected_items.values())]
             if precollected_items:
-                outfile.write('\n\nPrecollected Items:\n\n')
-                outfile.write('\n'.join([item for item in precollected_items]))
+                outfile.write("\n\nPrecollected Items:\n\n")
+                outfile.write("\n".join([item for item in precollected_items]))
 
             locations = [(str(location), str(location.item) if location.item is not None else "Nothing")
                          for location in self.multiworld.get_locations() if location.show_in_spoiler]

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1353,6 +1353,7 @@ class Spoiler:
                             get_path(state, multiworld.get_region('Inverted Big Bomb Shop', player))
 
     def to_file(self, filename: str) -> None:
+        from itertools import chain
         from worlds import AutoWorld
 
         def write_option(option_key: str, option_obj: Options.AssembleOptions) -> None:
@@ -1388,6 +1389,14 @@ class Spoiler:
                                                          entry['exit']) for entry in self.entrances.values()]))
 
             AutoWorld.call_all(self.multiworld, "write_spoiler", outfile)
+
+            precollected_items = [f'{item.name} ({self.multiworld.get_player_name(item.player)})'
+                                  if self.multiworld.players > 1
+                                  else item.name
+                                  for item in chain.from_iterable(self.multiworld.precollected_items.values())]
+            if precollected_items:
+                outfile.write('\n\nPrecollected Items:\n\n')
+                outfile.write('\n'.join([item for item in precollected_items]))
 
             locations = [(str(location), str(location.item) if location.item is not None else "Nothing")
                          for location in self.multiworld.get_locations() if location.show_in_spoiler]

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1395,7 +1395,7 @@ class Spoiler:
                                   else item.name
                                   for item in chain.from_iterable(self.multiworld.precollected_items.values())]
             if precollected_items:
-                outfile.write("\n\nPrecollected Items:\n\n")
+                outfile.write("\n\nStarting Items:\n\n")
                 outfile.write("\n".join([item for item in precollected_items]))
 
             locations = [(str(location), str(location.item) if location.item is not None else "Nothing")

--- a/worlds/sa2b/__init__.py
+++ b/worlds/sa2b/__init__.py
@@ -344,11 +344,6 @@ class SA2BWorld(World):
 
         self.multiworld.itempool += itempool
 
-        # VERY TESTING, DON'T PUSH
-        self.multiworld.push_precollected(self.create_item("Five Rings"))
-        self.multiworld.push_precollected(self.create_item("Ten Rings"))
-        self.multiworld.push_precollected(self.create_item("Twenty Rings"))
-
 
 
     def create_item(self, name: str, force_non_progression=False, goal=0) -> Item:

--- a/worlds/sa2b/__init__.py
+++ b/worlds/sa2b/__init__.py
@@ -344,6 +344,11 @@ class SA2BWorld(World):
 
         self.multiworld.itempool += itempool
 
+        # VERY TESTING, DON'T PUSH
+        self.multiworld.push_precollected(self.create_item("Five Rings"))
+        self.multiworld.push_precollected(self.create_item("Ten Rings"))
+        self.multiworld.push_precollected(self.create_item("Twenty Rings"))
+
 
 
     def create_item(self, name: str, force_non_progression=False, goal=0) -> Item:


### PR DESCRIPTION
## What is this fixing or adding?
Previously, items added to a player via `push_precollected` in a World implementation would not appear anywhere in the Spoiler Log, unless they were playthrough-relevant. This adds a section (when relevant) which displays all precollected items for the MultiWorld, whether added through World code or a player's `start_inventory`.

I discovered this shortcoming amidst development of a forthcoming game implementation, wherein under some circumstances, items which are important to gameplay, but irrelevant to logic, can get added to the player's `start_inventory`. I think it will be important for the players to be able to see that information in the spoiler log.

This should behave similarly to the `Locations:` section, in that it will list the player name for the item if there are multiple slots, but only the item name if only one slot is present. If multiple of the same item are added (by either mechanism), then each instance will be listed separately.

## How was this tested?
Several generations with a couple of supported worlds and a specially-modified SA2B world which adds a few filler items via `push_precollected`, as well as YAMLs with items in the `start_inventory`. Multi-slot and Single-slot generations were done, as well as generations without the above, to verify that if no precollected items exist, the section is not created.

World for testing (rename as `.apworld`, GitHub wouldn't let me upload with that extension):
[sa2b.zip](https://github.com/ArchipelagoMW/Archipelago/files/14552296/sa2b.zip)

YAMLs for testing:
[precollected_yamls.zip](https://github.com/ArchipelagoMW/Archipelago/files/14552300/precollected_yamls.zip)


## If this makes graphical changes, please attach screenshots.
Sample spoiler output:
```
...

Precollected Items:

Five Rings (PoryGone_SA2B1)
Ten Rings (PoryGone_SA2B1)
Twenty Rings (PoryGone_SA2B1)
Shield (PoryGone_SA2B)
Shield (PoryGone_SA2B)
Shield (PoryGone_SA2B)
Shield (PoryGone_SA2B)
Shield (PoryGone_SA2B)
Five Rings (PoryGone_SA2B)
Ten Rings (PoryGone_SA2B)
Twenty Rings (PoryGone_SA2B)
Five Rings (Pory's)
Ten Rings (Pory's)
Twenty Rings (Pory's)

Locations:

Lakeside Limbo - Flag (Pory_DKC31): Bonus Coin (Pory_DKC31)
Lakeside Limbo - Bonus 1 (Pory_DKC31): DK Coin (Pory_DKC3)
...
```