### PR TITLE
BizHawkClient: Fix error logging in python 3.8

### DIFF
--- a/worlds/_bizhawk/context.py
+++ b/worlds/_bizhawk/context.py
@@ -7,7 +7,6 @@ checking or launching the client, otherwise it will probably cause circular impo
 import asyncio
 import enum
 import subprocess
-import traceback
 from typing import Any, Dict, Optional
 
 from CommonClient import CommonContext, ClientCommandProcessor, get_base_parser, server_loop, logger, gui_enabled
@@ -260,7 +259,7 @@ def launch() -> None:
         try:
             await watcher_task
         except Exception as e:
-            logger.error("".join(traceback.format_exception(e)))
+            logger.exception(e)
 
         await ctx.exit_event.wait()
         await ctx.shutdown()


### PR DESCRIPTION
## What is this fixing or adding?

The current method for displaying uncaught exceptions to the user is overly complex and not compatible with Python 3.8. This just switches it to what it probably should have been in the first place.

## How was this tested?

Raised an error in `_game_watcher` using Python 3.8. On the current version, you'll eventually see
```
TypeError: format_exception() missing 2 required positional arguments: 'value' and 'tb'
```

With the changes, you still show the actual exception to the user, but don't get the extra exceptions like the one above.

Also did a sanity test in 3.11.2, new code showed the expected result.