### PR TITLE
Subnautica: Option to ignore prawn for logical depth

### DIFF
--- a/worlds/subnautica/__init__.py
+++ b/worlds/subnautica/__init__.py
@@ -160,6 +160,7 @@ class SubnauticaWorld(World):
         slot_data: Dict[str, Any] = {
             "goal": self.options.goal.current_key,
             "swim_rule": self.options.swim_rule.current_key,
+            "ignore_prawn_depth": self.options.ignore_prawn_depth.value,
             "vanilla_tech": vanilla_tech,
             "creatures_to_scan": self.creatures_to_scan,
             "death_link": self.options.death_link.value,

--- a/worlds/subnautica/options.py
+++ b/worlds/subnautica/options.py
@@ -41,6 +41,12 @@ class FreeSamples(Toggle):
     display_name = "Free Samples"
 
 
+class IgnorePrawnDepth(Toggle):
+    """Whether to include the prawn suit when determining logical depth.
+    Makes it less likely to do Prawn suit Lost River runs."""
+    display_name = "Ignore Prawn Depth"
+
+
 class Goal(Choice):
     """Goal to complete.
     Launch: Leave the planet.
@@ -107,6 +113,7 @@ option_definitions = {
     "swim_rule": SwimRule,
     "early_seaglide": EarlySeaglide,
     "free_samples": FreeSamples,
+    "ignore_prawn_depth": IgnorePrawnDepth,
     "goal": Goal,
     "creature_scans": CreatureScans,
     "creature_scan_logic": AggressiveScanLogic,

--- a/worlds/subnautica/rules.py
+++ b/worlds/subnautica/rules.py
@@ -214,11 +214,15 @@ def get_prawn_max_depth(state: "CollectionState", player):
 
 
 def get_max_depth(state: "CollectionState", player: int):
-    return get_max_swim_depth(state, player) + max(
+    max_depth: int = get_max_swim_depth(state, player) + max(
         get_seamoth_max_depth(state, player),
-        get_cyclops_max_depth(state, player),
-        get_prawn_max_depth(state, player)
+        get_cyclops_max_depth(state, player)
     )
+
+    if not state.multiworld.ignore_prawn_depth[player]:
+        return max(max_depth, get_prawn_max_depth(state, player))
+
+    return max_depth
 
 
 def is_radiated(x: float, y: float, z: float) -> bool:


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?

Based on conversations in discord channel, adding an option to allow ignoring the prawn suits depth when calculating logical depth. This is intended to avoid Prawn Suit Lost River runs.

## How was this tested?

Genned many games.

## If this makes graphical changes, please attach screenshots.
