### PR TITLE
Core: Add has_list and count_list and improve (?) count_group

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -767,8 +767,8 @@ class CollectionState():
         Utils.deprecate("Use count instead.")
         return self.count(item, player)
 
-    def has_from_list(self, items: Iterable[str], player: int, count: int = 1) -> bool:
-        """Returns True if the cumulative count of items from a list present in state exceeds the specified number."""
+    def has_from_list(self, items: Iterable[str], player: int, count: int) -> bool:
+        """Returns True if the state contains at least `count` items matching any of the item names from a list."""
         found: int = 0
         player_prog_items = self.prog_items[player]
         for item_name in items:

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -767,6 +767,18 @@ class CollectionState():
         Utils.deprecate("Use count instead.")
         return self.count(item, player)
 
+    def has_list(self, items: Iterable[str], player: int, count: int = 1) -> bool:
+        found: int = 0
+        player_prog_items = self.prog_items[player]
+        for item_name in items:
+            found += player_prog_items[item_name]
+            if found >= count:
+                return True
+        return False
+
+    def count_list(self, items: Iterable[str], player: int) -> int:
+        return sum(self.prog_items[player][item_name] for item_name in items)
+
     # item name group related
     def has_group(self, item_name_group: str, player: int, count: int = 1) -> bool:
         found: int = 0
@@ -778,11 +790,11 @@ class CollectionState():
         return False
 
     def count_group(self, item_name_group: str, player: int) -> int:
-        found: int = 0
         player_prog_items = self.prog_items[player]
-        for item_name in self.multiworld.worlds[player].item_name_groups[item_name_group]:
-            found += player_prog_items[item_name]
-        return found
+        return sum(
+            player_prog_items[item_name]
+            for item_name in self.multiworld.worlds[player].item_name_groups[item_name_group]
+        )
 
     # Item related
     def collect(self, item: Item, event: bool = False, location: Optional[Location] = None) -> bool:

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -783,6 +783,9 @@ class CollectionState():
 
     # item name group related
     def has_group(self, item_name_group: str, player: int, count: int = 1) -> bool:
+        """
+        Returns True if the cumulative count of items from an item group present in state exceeds the specified number.
+        """
         found: int = 0
         player_prog_items = self.prog_items[player]
         for item_name in self.multiworld.worlds[player].item_name_groups[item_name_group]:
@@ -792,6 +795,7 @@ class CollectionState():
         return False
 
     def count_group(self, item_name_group: str, player: int) -> int:
+        """Returns the cumulative count of items from an item group present in state."""
         player_prog_items = self.prog_items[player]
         return sum(
             player_prog_items[item_name]

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1261,7 +1261,7 @@ class Spoiler:
         # reducing each range of influence to the bare minimum required inside it
         restore_later = {}
         for num, sphere in reversed(tuple(enumerate(collection_spheres))):
-            to_delete = set()has_
+            to_delete = set()
             for location in sphere:
                 # we remove the item at location and check if game is still beatable
                 logging.debug('Checking if %s (Player %d) is required to beat the game.', location.item.name,

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -768,6 +768,7 @@ class CollectionState():
         return self.count(item, player)
 
     def has_list(self, items: Iterable[str], player: int, count: int = 1) -> bool:
+        """Returns True if the cumulative count of items from a list present in state exceeds the specified number."""
         found: int = 0
         player_prog_items = self.prog_items[player]
         for item_name in items:
@@ -777,6 +778,7 @@ class CollectionState():
         return False
 
     def count_list(self, items: Iterable[str], player: int) -> int:
+        """Returns the cumulative count of items from a list present in state."""
         return sum(self.prog_items[player][item_name] for item_name in items)
 
     # item name group related
@@ -1255,7 +1257,7 @@ class Spoiler:
         # reducing each range of influence to the bare minimum required inside it
         restore_later = {}
         for num, sphere in reversed(tuple(enumerate(collection_spheres))):
-            to_delete = set()
+            to_delete = set()has_
             for location in sphere:
                 # we remove the item at location and check if game is still beatable
                 logging.debug('Checking if %s (Player %d) is required to beat the game.', location.item.name,

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -783,9 +783,7 @@ class CollectionState():
 
     # item name group related
     def has_group(self, item_name_group: str, player: int, count: int = 1) -> bool:
-        """
-        Returns True if the cumulative count of items from an item group present in state exceeds the specified number.
-        """
+        """Returns True if the state contains at least `count` items present in a specified item group."""
         found: int = 0
         player_prog_items = self.prog_items[player]
         for item_name in self.multiworld.worlds[player].item_name_groups[item_name_group]:

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -767,7 +767,7 @@ class CollectionState():
         Utils.deprecate("Use count instead.")
         return self.count(item, player)
 
-    def has_list(self, items: Iterable[str], player: int, count: int = 1) -> bool:
+    def has_from_list(self, items: Iterable[str], player: int, count: int = 1) -> bool:
         """Returns True if the cumulative count of items from a list present in state exceeds the specified number."""
         found: int = 0
         player_prog_items = self.prog_items[player]
@@ -777,7 +777,7 @@ class CollectionState():
                 return True
         return False
 
-    def count_list(self, items: Iterable[str], player: int) -> int:
+    def count_from_list(self, items: Iterable[str], player: int) -> int:
         """Returns the cumulative count of items from a list present in state."""
         return sum(self.prog_items[player][item_name] for item_name in items)
 


### PR DESCRIPTION
## What was done

### has_list and count_list
`has_group` and `count_group` currently exist to be able to check for a specific overall quantity of a list of items.
However, these need item groups to be defined, and also the user has no way of telling this function **which items from a group actually exist**. Those functions will just blindly try all items from the item group.

So, I decided to add two new functions called `has_list` and `count_list`, that are completely analogous to `has_group` and `count_group`, except you can specify the list of items you care about. This way, you 1. don't need an item group to be defined for the items and 2. can prepare the item list yourself, first sorting out any items that don't exist because of e.g. the options the player chose.

### count_group refactor

This function uses a for loop for a sum despite not having any sort of early exit / lazy eval (like e.g. `has_group` does). This should probably just be a `return sum(...)` expression.

## Motivation

[An new world dev](https://discord.com/channels/731205301247803413/1214608557077700720/1216166637884014662) asked for it and [me](https://discord.com/channels/731205301247803413/1214608557077700720/1216167608324198521) and [Treble](https://discord.com/channels/731205301247803413/1214608557077700720/1216167583057973399) agreed that the current implementation is not really [das Gelbe vom Ei](https://en.wiktionary.org/wiki/das_Gelbe_vom_Ei), at least if it's going to be the only option for this.

## Considerations

Some of these decisions might have been made because of how frozen builds are optimised. I'm not sure how to judge or test that. If the `count_group` refactor actually makes the frozen build slower bc of some weird optimisation thing, I am happy to revert it and take it out of the scope of this PR.