### PR TITLE
CI: build: create setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,13 @@ on:
       - '.github/workflows/build.yml'
       - 'setup.py'
       - 'requirements.txt'
+      - '*.iss'
   pull_request:
     paths:
       - '.github/workflows/build.yml'
       - 'setup.py'
       - 'requirements.txt'
+      - '*.iss'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,9 +25,9 @@ jobs:
   build-win-py38: # RCs will still be built and signed by hand
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.8'
       - name: Download run-time dependencies
@@ -46,11 +46,28 @@ jobs:
           cd build
           Rename-Item "exe.$NAME" Archipelago
           7z a -mx=9 -mhe=on -ms "../dist/$ZIP_NAME" Archipelago
+          Rename-Item Archipelago "exe.$NAME"  # inno_setup.iss expects the original name
       - name: Store 7z
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.ZIP_NAME }}
           path: dist/${{ env.ZIP_NAME }}
+          retention-days: 7  # keep for 7 days, should be enough
+      - name: Build Setup
+        run: |
+          & "${env:ProgramFiles(x86)}\Inno Setup 6\iscc.exe" inno_setup.iss /DNO_SIGNTOOL
+          if ( $? -eq $false ) {
+            Write-Error "Building setup failed!"
+            exit 1
+          }
+          $contents = Get-ChildItem -Path setups/*.exe -Force -Recurse
+          $SETUP_NAME=$contents[0].Name
+          echo "SETUP_NAME=$SETUP_NAME" >> $Env:GITHUB_ENV
+      - name: Store Setup
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.SETUP_NAME }}
+          path: setups/${{ env.SETUP_NAME }}
           retention-days: 7  # keep for 7 days, should be enough
 
   build-ubuntu2004:

--- a/inno_setup.iss
+++ b/inno_setup.iss
@@ -31,8 +31,11 @@ ArchitecturesAllowed=x64 arm64
 AllowNoIcons=yes
 SetupIconFile={#MyAppIcon}
 UninstallDisplayIcon={app}\{#MyAppExeName}
-; you will likely have to remove the following signtool line when testing/debugging locally. Don't include that change in PRs.
+#ifndef NO_SIGNTOOL
+; You will likely have to remove the SignTool= line when testing/debugging locally or run with iscc.exe /DNO_SIGNTOOL.
+; Don't include that change in PRs.
 SignTool= signtool
+#endif
 LicenseFile= LICENSE
 WizardStyle= modern
 SetupLogging=yes


### PR DESCRIPTION
## What is this fixing or adding?

Build the inno setup as part of our build CI and upload-artifact the result
also add /DNO_SIGNTOOL to inno_setup.iss

This is used to test changes that may break building the setup.

I updated only the actions in the changed job. Updating all (other) actions should be a separate PR imo.

## How was this tested?

CI and trying to run the resulting installer in wine.