### PR TITLE
The Messenger: fix items accessibility reachability bug due to new rules

### DIFF
--- a/worlds/messenger/rules.py
+++ b/worlds/messenger/rules.py
@@ -523,7 +523,7 @@ class MessengerOOBRules(MessengerRules):
 
 def set_self_locking_items(world: "MessengerWorld", player: int) -> None:
     # locations where these placements are always valid
-    allow_self_locking_items(world.get_location("Searing Crags - Key of Strength"), "Power Thistle")
+    allow_self_locking_items(world.get_location("Searing Crags - Key of Strength").parent_region, "Power Thistle")
     allow_self_locking_items(world.get_location("Sunken Shrine - Key of Love"), "Sun Crest", "Moon Crest")
-    allow_self_locking_items(world.get_location("Corrupted Future - Key of Courage"), "Demon King Crown")
+    allow_self_locking_items(world.get_location("Corrupted Future - Key of Courage").parent_region, "Demon King Crown")
     allow_self_locking_items(world.get_location("Elemental Skylands Seal - Water"), "Currents Master")

--- a/worlds/messenger/test/test_access.py
+++ b/worlds/messenger/test/test_access.py
@@ -1,3 +1,5 @@
+import typing
+
 from . import MessengerTestBase
 from ..constants import NOTES, PHOBEKINS
 
@@ -208,5 +210,8 @@ class ItemsAccessTest(MessengerTestBase):
             for item_name in location_lock_pairs[loc]:
                 item = self.get_item_by_name(item_name)
                 with self.subTest("Fulfills Accessibility", location=loc, item=item_name):
-                    self.assertTrue(self.multiworld.get_location(loc, self.player).can_fill(self.multiworld.state, item,
-                                                                                            True))
+                    location = self.multiworld.get_location(loc, self.player)
+                    self.assertTrue(location.can_fill(self.multiworld.state, item, True))
+                    location.item = item
+                    self.multiworld.state.update_reachable_regions(self.player)
+                    self.assertTrue(self.can_reach_location(loc))


### PR DESCRIPTION
## What is this fixing or adding?
The new rules setup adds the access of these two locations to the entrance of the region they're contained in instead of directly to the location.

## How was this tested?
Added tests to check the new behavior. The location that can have two different items locked on it already has its region reachable in the initial setup so the extra sweeps don't hurt.
