### PR TITLE
Core: fix incorrect ordering on the always_allow static method

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1032,7 +1032,7 @@ class Location:
     locked: bool = False
     show_in_spoiler: bool = True
     progress_type: LocationProgressType = LocationProgressType.DEFAULT
-    always_allow = staticmethod(lambda item, state: False)
+    always_allow = staticmethod(lambda state, item: False)
     access_rule: Callable[[CollectionState], bool] = staticmethod(lambda state: True)
     item_rule = staticmethod(lambda item: True)
     item: Optional[Item] = None


### PR DESCRIPTION
## What is this fixing or adding?
always_allow is called with (state, item) but the default static method has it as (item, state). since it always returns False it's "fine" but it threw me off when working with some code hitting that path.

## How was this tested?
:eyes:

## If this makes graphical changes, please attach screenshots.
