### PR TITLE
The Witness: Don't unnecessarily break people's 0.4.4 yamls

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -767,6 +767,18 @@ class CollectionState():
         Utils.deprecate("Use count instead.")
         return self.count(item, player)
 
+    def has_list(self, items: Iterable[str], player: int, count: int = 1) -> bool:
+        found: int = 0
+        player_prog_items = self.prog_items[player]
+        for item_name in items:
+            found += player_prog_items[item_name]
+            if found >= count:
+                return True
+        return False
+
+    def count_list(self, items: Iterable[str], player: int) -> int:
+        return sum(self.prog_items[player][item_name] for item_name in items)
+
     # item name group related
     def has_group(self, item_name_group: str, player: int, count: int = 1) -> bool:
         found: int = 0
@@ -778,11 +790,11 @@ class CollectionState():
         return False
 
     def count_group(self, item_name_group: str, player: int) -> int:
-        found: int = 0
         player_prog_items = self.prog_items[player]
-        for item_name in self.multiworld.worlds[player].item_name_groups[item_name_group]:
-            found += player_prog_items[item_name]
-        return found
+        return sum(
+            player_prog_items[item_name]
+            for item_name in self.multiworld.worlds[player].item_name_groups[item_name_group]
+        )
 
     # Item related
     def collect(self, item: Item, event: bool = False, location: Optional[Location] = None) -> bool:

--- a/worlds/witness/options.py
+++ b/worlds/witness/options.py
@@ -39,8 +39,10 @@ class ShuffleLasers(Choice):
     be redirected as normal, for both applications of redirection."""
     display_name = "Shuffle Lasers"
     option_off = 0
+    alias_false = 0
     option_local = 1
     option_anywhere = 2
+    alias_true = 2
 
 
 class ShuffleDoors(Choice):

--- a/worlds/witness/options.py
+++ b/worlds/witness/options.py
@@ -23,8 +23,10 @@ class EarlyCaves(Choice):
     If you choose "add_to_pool" and you are already playing a remote Door Shuffle mode, this setting will do nothing."""
     display_name = "Early Caves"
     option_off = 0
+    alias_false = 0
     option_add_to_pool = 1
     option_starting_inventory = 2
+    alias_true = 2
 
 
 class ShuffleSymbols(DefaultOnToggle):


### PR DESCRIPTION
`laser_shuffle` was changed from a `Toggle` to a `Choice`.
The old behavior is preserved, false is "off" and true is "anywhere".

People have been complaining about their 0.4.4 yamls breaking on the beta (idk, it's a thing I guess)

Exempt-Medic has made me aware of a non-that-evil hack that gets around that