### PR TITLE
The Witness: Don't unnecessarily break people's 0.4.4 yamls

### DIFF
--- a/worlds/witness/options.py
+++ b/worlds/witness/options.py
@@ -23,8 +23,10 @@ class EarlyCaves(Choice):
     If you choose "add_to_pool" and you are already playing a remote Door Shuffle mode, this setting will do nothing."""
     display_name = "Early Caves"
     option_off = 0
+    alias_false = 0
     option_add_to_pool = 1
     option_starting_inventory = 2
+    alias_true = 2
 
 
 class ShuffleSymbols(DefaultOnToggle):
@@ -39,8 +41,10 @@ class ShuffleLasers(Choice):
     be redirected as normal, for both applications of redirection."""
     display_name = "Shuffle Lasers"
     option_off = 0
+    alias_false = 0
     option_local = 1
     option_anywhere = 2
+    alias_true = 2
 
 
 class ShuffleDoors(Choice):

--- a/worlds/witness/options.py
+++ b/worlds/witness/options.py
@@ -27,6 +27,7 @@ class EarlyCaves(Choice):
     option_add_to_pool = 1
     option_starting_inventory = 2
     alias_true = 2
+    alias_on = 2
 
 
 class ShuffleSymbols(DefaultOnToggle):
@@ -45,6 +46,7 @@ class ShuffleLasers(Choice):
     option_local = 1
     option_anywhere = 2
     alias_true = 2
+    alias_on = 2
 
 
 class ShuffleDoors(Choice):


### PR DESCRIPTION
`laser_shuffle` was changed from a `Toggle` to a `Choice`.
The old behavior is preserved, false is "off" and true is "anywhere".

People have been complaining about their 0.4.4 yamls breaking on the beta (idk, it's a thing I guess)

Exempt-Medic has made me aware of this non-that-evil hack that gets around that

Also, did the same for `early_caves` which has the same history, although it's been a version for that one. Idk, doesn't really hurt

Probably will just close this if it doesn't make it into 0.4.5