### PR TITLE
CI: Don't auto-remove content based labels on PRs

### DIFF
--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/labeler@v5
         with:
-          sync-labels: true
+          sync-labels: false
   peer_review:
     name: 'Apply peer review label'
     needs: labeler


### PR DESCRIPTION


## What is this fixing or adding?
We've seen a few PRs where the labeling workflow has been overly dogmatic about the correct labels and being a general pain for triage users. For example, it insists that #2509  is not a docs PR and people have had to change the label each time a revision is made. There was some other pr where this issue arose which was related to incorrect/missing globs which I cannot be bothered to find a number.

This change will make it so the labeling workflow does not remove labels if they have been added outside of the normal automation. It will not fix the fact that labels may still be added if they were removed outside of automation.

## How was this tested?
Wasn't, testing this workflow sucks. But the docs indicate that changing the parameter should have the desired behavior 
