### PR TITLE
Core: String comparison with FreeText class (fixes ALTTP bug)

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -180,6 +180,14 @@ class FreeText(Option[str]):
     def get_option_name(cls, value: str) -> str:
         return value
 
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return other.value == self.value
+        elif isinstance(other, str):
+            return other == self.value
+        else:
+            raise TypeError(f"Can't compare {self.__class__.__name__} with {other.__class__.__name__}")
+
 
 class NumericOption(Option[int], numbers.Integral, abc.ABC):
     default = 0


### PR DESCRIPTION
## What is this fixing or adding?
Allows comparing a FreeText class with a string, testing it against the class value. I have created bugs twice now by attempting to do this. This change will fix a bug with ALTTP Entrance Shuffle Seed set to "random" being treated as a seed group with that name.

## How was this tested?
Generating ALTTP with debug breakpoint and observing correct identification of the ER Seed "random" value and it not creating a seed group.