### PR TITLE
CI: update actions

### DIFF
--- a/.github/workflows/analyze-modified-files.yml
+++ b/.github/workflows/analyze-modified-files.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Determine modified files (pull_request)"
         if: github.event_name == 'pull_request'
@@ -50,7 +50,7 @@ jobs:
         run: |
           echo "diff=." >> $GITHUB_ENV
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         if: env.diff != ''
         with:
           python-version: 3.8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,14 +76,14 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       # - copy code below to release.yml -
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install base dependencies
         run: |
           sudo apt update
           sudo apt -y install build-essential p7zip xz-utils wget libglib2.0-0
           sudo apt -y install python3-gi libgirepository1.0-dev  # should pull dependencies for gi installation below
       - name: Get a recent python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
       - name: Install build-time dependencies
@@ -119,13 +119,13 @@ jobs:
           source venv/bin/activate
           python setup.py build_exe --yes
       - name: Store AppImage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.APPIMAGE_NAME }}
           path: dist/${{ env.APPIMAGE_NAME }}
           retention-days: 7
       - name: Store .tar.gz
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.TAR_NAME }}
           path: dist/${{ env.TAR_NAME }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV  # tag x.y.z will become "Archipelago x.y.z"
       - name: Create Release
-        uses: softprops/action-gh-release@b7e450da2a4b4cb4bfbae528f788167786cfcedf
+        uses: softprops/action-gh-release@975c1b265e11dd76618af1c374e7981f9a6ff44a
         with:
           draft: true  # don't publish right away, especially since windows build is added by hand
           prerelease: false
@@ -35,14 +35,14 @@ jobs:
       - name: Set env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       # - code below copied from build.yml -
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install base dependencies
         run: |
           sudo apt update
           sudo apt -y install build-essential p7zip xz-utils wget libglib2.0-0
           sudo apt -y install python3-gi libgirepository1.0-dev  # should pull dependencies for gi installation below
       - name: Get a recent python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
       - name: Install build-time dependencies
@@ -74,7 +74,7 @@ jobs:
           echo "TAR_NAME=$TAR_NAME" >> $GITHUB_ENV
       # - code above copied from build.yml -
       - name: Add to Release
-        uses: softprops/action-gh-release@b7e450da2a4b4cb4bfbae528f788167786cfcedf
+        uses: softprops/action-gh-release@975c1b265e11dd76618af1c374e7981f9a6ff44a
         with:
           draft: true  # see above
           prerelease: false

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -46,9 +46,9 @@ jobs:
             os: macos-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python.version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python.version }}
     - name: Install dependencies


### PR DESCRIPTION
## What is this fixing or adding?

* Update checkout, upload-artifact and setup-python to latest.
* Update softprops/action-gh-release to the sha of the latest commit before 2.0. I did not (find the time to) review 2.x.

## How was this tested?

CI. Also we already use most of this in the current build-win-py38 job in build.yml. The action-gh-release commit is the one I updated PopTracker to recently, so this was tested as well.