### PR TITLE
Celeste 64: Add CHANGELOG.md

### DIFF
--- a/worlds/celeste64/CHANGELOG.md
+++ b/worlds/celeste64/CHANGELOG.md
@@ -3,12 +3,12 @@
 
 ## v1.1 - First Stable Release
 
-### Features
+### Features:
 
 - Goal is to collect a certain amount of Strawberries and visit Badeline on her island
 - Locations included:
 	- Strawberries
-- Items included
+- Items included:
 	- Strawberries
 	- Dash Refills
 	- Double Dash Refills


### PR DESCRIPTION
## What is this fixing or adding?
Adds a changelog markdown file to the Celeste 64 World.

## How was this tested?
I read it, and tossed it into a markdown renderer.