### PR TITLE
TUNIC: Update option display names

### DIFF
--- a/worlds/tunic/options.py
+++ b/worlds/tunic/options.py
@@ -30,7 +30,7 @@ class AbilityShuffling(Toggle):
     player-facing codes.
     """
     internal_name = "ability_shuffling"
-    display_name = "Ability Shuffling"
+    display_name = "Shuffle Abilities"
 
 
 class LogicRules(Choice):
@@ -115,7 +115,7 @@ class FixedShop(Toggle):
     """Forces the Windmill entrance to lead to a shop, and places only one other shop in the pool.
     Has no effect if Entrance Rando is not enabled."""
     internal_name = "fixed_shop"
-    display_name = "ER Fixed Shop"
+    display_name = "Fewer Shops in Entrance Rando"
 
 
 class LaurelsLocation(Choice):


### PR DESCRIPTION
## What is this fixing or adding?
This PR updates the display name of a few options to match their labels in the game client mod.

## How was this tested?
Running webhost locally and viewing updated option names.

## If this makes graphical changes, please attach screenshots.
