### PR TITLE
Launcher: make scrollbar more prominent

### DIFF
--- a/kvui.py
+++ b/kvui.py
@@ -132,7 +132,8 @@ class ScrollBox(ScrollView):
         self.layout.bind(minimum_height=self.layout.setter("height"))
         self.add_widget(self.layout)
         self.effect_cls = ScrollEffect
-
+        self.bar_width = dp(12)
+        self.scroll_type = ["content", "bars"]
 
 class HovererableLabel(HoverBehavior, Label):
     pass

--- a/kvui.py
+++ b/kvui.py
@@ -135,6 +135,7 @@ class ScrollBox(ScrollView):
         self.bar_width = dp(12)
         self.scroll_type = ["content", "bars"]
 
+
 class HovererableLabel(HoverBehavior, Label):
     pass
 


### PR DESCRIPTION
## What is this fixing or adding?
Discussion in ap-core-dev showed that many believed the scrollbar in the Launcher was too subtle. This updates the scrollbar to match CommonClient, as well as allowing scrolling by clicking and holding the bar.

## How was this tested?
I ran Launcher.py and scrolled.

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/58583688/ed81c18e-fb1e-463c-9b61-ae93ac35a18f)
