### PR TITLE
CommonClient: fix hint tab overlapping

### DIFF
--- a/kvui.py
+++ b/kvui.py
@@ -703,6 +703,13 @@ class HintLog(RecycleView):
     def hint_sorter(element: dict) -> str:
         return ""
 
+    def fix_heights(self):
+        """Workaround fix for divergent texture and layout heights"""
+        for element in self.children[0].children:
+            max_height = max(child.texture_size[1] for child in element.children)
+            if element.height != max_height:
+                element.height = max_height
+
 
 class E(ExceptionHandler):
     logger = logging.getLogger("Client")

--- a/kvui.py
+++ b/kvui.py
@@ -707,8 +707,7 @@ class HintLog(RecycleView):
         """Workaround fix for divergent texture and layout heights"""
         for element in self.children[0].children:
             max_height = max(child.texture_size[1] for child in element.children)
-            if element.height != max_height:
-                element.height = max_height
+            element.height = max_height
 
 
 class E(ExceptionHandler):


### PR DESCRIPTION
## What is this fixing or adding?
![image](https://github.com/ArchipelagoMW/Archipelago/assets/58583688/2ff26d64-9577-42dd-a009-e78e37a30af0)

Turns out the issue was solved before for the text tabs, just needed to implement `fix_heights` for HintLog.

## How was this tested?
Manually, by hinting out an entire slot's items and scrolling through the hint tab to confirm the issue no longer occurred.
