### PR TITLE
Stardew Valley: Added a Great Combat requirement to an entrance that could block its own key

### DIFF
--- a/worlds/stardew_valley/rules.py
+++ b/worlds/stardew_valley/rules.py
@@ -33,6 +33,7 @@ from .strings.entrance_names import dig_to_mines_floor, dig_to_skull_floor, Entr
 from .strings.generic_names import Generic
 from .strings.material_names import Material
 from .strings.metal_names import MetalBar
+from .strings.performance_names import Performance
 from .strings.quest_names import Quest
 from .strings.region_names import Region
 from .strings.season_names import Season
@@ -862,7 +863,7 @@ def set_sve_rules(logic: StardewLogic, multiworld: MultiWorld, player: int, worl
     set_entrance_rule(multiworld, player, SVEEntrance.forest_to_lost_woods, logic.bundle.can_complete_community_center)
     set_entrance_rule(multiworld, player, SVEEntrance.enter_summit, logic.mod.sve.has_iridium_bomb())
     set_entrance_rule(multiworld, player, SVEEntrance.backwoods_to_grove, logic.mod.sve.has_any_rune())
-    set_entrance_rule(multiworld, player, SVEEntrance.badlands_to_cave, logic.has("Aegis Elixir"))
+    set_entrance_rule(multiworld, player, SVEEntrance.badlands_to_cave, logic.has("Aegis Elixir") | logic.combat.can_fight_at_level(Performance.maximum))
     set_entrance_rule(multiworld, player, SVEEntrance.forest_west_to_spring, logic.quest.can_complete_quest(Quest.magic_ink))
     set_entrance_rule(multiworld, player, SVEEntrance.railroad_to_grampleton_station, logic.received(SVEQuestItem.scarlett_job_offer))
     set_entrance_rule(multiworld, player, SVEEntrance.secret_woods_to_west, logic.tool.has_tool(Tool.axe, ToolMaterial.iron))


### PR DESCRIPTION
## What is this fixing or adding?
Recent test failures on main.
One specific door had one specific key that ER could put inside itself.
In practice, that key is not a hard requirement, just a very strong item to survive the transition.
Added a logic alternative of other strong combat abilities instead, so it's possible

## How was this tested?
Ran the failing test seed, then ran all the test seeds, then ran all the tests about 20 times. No more test failures