### PR TITLE
Overcooked 2: Make single player games not assign priority locations

### DIFF
--- a/worlds/overcooked2/__init__.py
+++ b/worlds/overcooked2/__init__.py
@@ -221,6 +221,10 @@ class Overcooked2World(World):
     def generate_early(self):
         self.player_name = self.multiworld.player_name[self.player]
 
+        # if single player, this setting doesn't matter, and disabling it removes test failures
+        if self.multiworld.players == 1:
+            self.options.location_balancing.value = LocationBalancingMode.disabled
+
         # 0.0 to 1.0 where 1.0 is World Record
         self.star_threshold_scale = self.options.star_threshold_scale / 100.0
 


### PR DESCRIPTION
## What is this fixing or adding?
Sets the location balancing option to disabled in single player games.
My assumption is that the random oc2 unit test failures were caused by a mix of location balancing and level shuffle, causing swap to fail due to only having a few successful layouts and swap not being able to figure out what they are.
Since this option does nothing to benefit the player in a single player game, might as well disable it.

## How was this tested?
It was not yet, I will be testing it tonight.

## If this makes graphical changes, please attach screenshots.
N/A