### PR TITLE
Pokemon Emerald: Bump required client version

### DIFF
--- a/worlds/pokemon_emerald/__init__.py
+++ b/worlds/pokemon_emerald/__init__.py
@@ -87,7 +87,7 @@ class PokemonEmeraldWorld(World):
     location_name_groups = LOCATION_GROUPS
 
     data_version = 2
-    required_client_version = (0, 4, 3)
+    required_client_version = (0, 4, 5)
 
     badge_shuffle_info: Optional[List[Tuple[PokemonEmeraldLocation, PokemonEmeraldItem]]]
     hm_shuffle_info: Optional[List[Tuple[PokemonEmeraldLocation, PokemonEmeraldItem]]]


### PR DESCRIPTION
## What is this fixing or adding?

Increments Emerald's required client version to the current version.

The client already checks compatibility and will tell the user if the client and base patch are mismatched before the client even allows itself to connect, so this isn't strictly necessary, but it's still true that a 0.4.5 client is required.

## How was this tested?

Tried connecting with a client on a commit before the AP version bump, got rejected. Connected successfully with a client on this branch.
