### PR TITLE
ALttP: Re-mark light/dark world regions after applying plando connections

### DIFF
--- a/worlds/alttp/EntranceShuffle.py
+++ b/worlds/alttp/EntranceShuffle.py
@@ -3,6 +3,8 @@ from collections import defaultdict
 
 from .OverworldGlitchRules import overworld_glitch_connections
 from .UnderworldGlitchRules import underworld_glitch_connections
+from .Regions import mark_light_world_regions
+from .InvertedRegions import mark_dark_world_regions
 
 
 def link_entrances(world, player):
@@ -1827,6 +1829,10 @@ def plando_connect(world, player: int):
                 func(world, connection.entrance, connection.exit, player)
             except Exception as e:
                 raise Exception(f"Could not connect using {connection}") from e
+        if world.mode[player] != 'inverted':
+            mark_light_world_regions(world, player)
+        else:
+            mark_dark_world_regions(world, player)
 
 
 LW_Dungeon_Entrances = ['Desert Palace Entrance (South)',


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?

What locations end up as early locations following plando connection changes

## How was this tested?

Set the world to inverted.  Plando'd Moon Pearl into "Secret Passage".  Plando connected the Hyrule Castle secret entrance dropdown to one of the skull woods holes.

Without this fix, the game is declared unbeatable by the generator even though the moon pearl is definitely in logic.

## If this makes graphical changes, please attach screenshots.
