### PR TITLE
Stardew Valley: Fix extended family legendary fishes being locations with fishsanity set to exclude legendary

### DIFF
--- a/worlds/stardew_valley/locations.py
+++ b/worlds/stardew_valley/locations.py
@@ -6,7 +6,7 @@ from typing import Optional, Dict, Protocol, List, FrozenSet, Iterable
 
 from . import data
 from .bundles.bundle_room import BundleRoom
-from .data.fish_data import legendary_fish, special_fish, get_fish_for_mods
+from .data.fish_data import special_fish, get_fish_for_mods
 from .data.museum_data import all_museum_items
 from .data.villagers_data import get_villagers_for_mods
 from .mods.mod_data import ModNames
@@ -206,7 +206,8 @@ def extend_fishsanity_locations(randomized_locations: List[LocationData], option
     if fishsanity == Fishsanity.option_none:
         return
     elif fishsanity == Fishsanity.option_legendaries:
-        randomized_locations.extend(location_table[f"{prefix}{legendary.name}"] for legendary in legendary_fish)
+        fish_locations = [location_table[f"{prefix}{fish.name}"] for fish in active_fish if fish.legendary]
+        randomized_locations.extend(filter_disabled_locations(options, fish_locations))
     elif fishsanity == Fishsanity.option_special:
         randomized_locations.extend(location_table[f"{prefix}{special.name}"] for special in special_fish)
     elif fishsanity == Fishsanity.option_randomized:

--- a/worlds/stardew_valley/locations.py
+++ b/worlds/stardew_valley/locations.py
@@ -216,7 +216,7 @@ def extend_fishsanity_locations(randomized_locations: List[LocationData], option
         fish_locations = [location_table[f"{prefix}{fish.name}"] for fish in active_fish]
         randomized_locations.extend(filter_disabled_locations(options, fish_locations))
     elif fishsanity == Fishsanity.option_exclude_legendaries:
-        fish_locations = [location_table[f"{prefix}{fish.name}"] for fish in active_fish if fish not in legendary_fish]
+        fish_locations = [location_table[f"{prefix}{fish.name}"] for fish in active_fish if not fish.legendary]
         randomized_locations.extend(filter_disabled_locations(options, fish_locations))
     elif fishsanity == Fishsanity.option_exclude_hard_fish:
         fish_locations = [location_table[f"{prefix}{fish.name}"] for fish in active_fish if fish.difficulty < 80]

--- a/worlds/stardew_valley/options.py
+++ b/worlds/stardew_valley/options.py
@@ -356,7 +356,7 @@ class QuestLocations(NamedRange):
 class Fishsanity(Choice):
     """Locations for catching a fish the first time?
     None: There are no locations for catching fish
-    Legendaries: Each of the 5 legendary fish are checks
+    Legendaries: Each of the 5 legendary fish are checks, plus the extended family if qi board is turned on
     Special: A curated selection of strong fish are checks
     Randomized: A random selection of fish are checks
     All: Every single fish in the game is a location that contains an item. Pairs well with the Master Angler Goal


### PR DESCRIPTION
## What is this fixing or adding?
Right now, if you use the Fishsanity setting `exclude_legendaries`, only the basic legendary fishes will be excluded. Extended family fish are still locations when the special orders are set to `board_qi`, they should not. (Because they have the same difficulty as their original copy, player won't want to catch them if they don't want to catch basic one).

This bug was already there in 4.x.x btw, it's not a 5.x.x thing.

## How was this tested?
Locations before the change (from spoiler). 

<details><summary>See that "Ms. Angler", "Son of Crimsonfish", "Glacierfish Jr.", "Legend II" and "Radioactive Carp" are there</summary>
<p>

```
Fishsanity: Albacore: Stardrop
Fishsanity: Anchovy: Ancient Seeds Recipe
Fishsanity: Blue Discus: Farm Computer
Fishsanity: Bream: Progressive Mine Elevator
Fishsanity: Bullhead: Progressive Club
Fishsanity: Carp: Ancient Seeds
Fishsanity: Catfish: Magic Rock Candy
Fishsanity: Chub: 20 Qi Gems
Fishsanity: Dorado: Fishing Level
Fishsanity: Eel: Livin' Off The Land
Fishsanity: Flounder: Movement Speed Bonus
Fishsanity: Ghostfish: Fishing Level
Fishsanity: Halibut: Time Flies Trap
Fishsanity: Herring: Monsters Trap
Fishsanity: Ice Pip: Progressive House
Fishsanity: Largemouth Bass: Random Teleport Trap
Fishsanity: Lava Eel: Combat Level
Fishsanity: Lingcod: Skull Key
Fishsanity: Lionfish: Lupini: Clouds
Fishsanity: Midnight Carp: Progressive Mine Elevator
Fishsanity: Octopus: Fairy Dust Recipe
Fishsanity: Perch: Tomato Seeds
Fishsanity: Pike: Progressive Club
Fishsanity: Pufferfish: Progressive Mine Elevator
Fishsanity: Rainbow Trout: Golden Egg
Fishsanity: Red Mullet: Magic Rock Candy
Fishsanity: Red Snapper: Ancient Seeds
Fishsanity: Salmon: Taxes Trap
Fishsanity: Sandfish: Junimo Kart: Extra Life
Fishsanity: Sardine: Progressive Footwear
Fishsanity: Scorpion Carp: Iridium Sprinkler
Fishsanity: Sea Cucumber: Mining Level
Fishsanity: Shad: Solar Panel Recipe
Fishsanity: Slimejack: Starfruit Seeds
Fishsanity: Smallmouth Bass: Progressive Trash Can
Fishsanity: Squid: Progressive Club
Fishsanity: Stingray: Progressive Shed
Fishsanity: Stonefish: Well
Fishsanity: Sturgeon: 10 Qi Gems
Fishsanity: Sunfish: Debris Trap
Fishsanity: Super Cucumber: Progressive Barn
Fishsanity: Tiger Trout: Resource Pack: 20 Quality Fertilizer
Fishsanity: Tilapia: Resource Pack: 75 Copper Ore
Fishsanity: Tuna: Progressive Mine Elevator
Fishsanity: Void Salmon: Farming Level
Fishsanity: Walleye: Enricher
Fishsanity: Woodskip: Radish Seeds
Fishsanity: Blobfish: Resource Pack: 10 Tree Fertilizer
Fishsanity: Midnight Squid: Peach Sapling
Fishsanity: Spook Fish: Apricot Sapling
Fishsanity: Ms. Angler: Beet Seeds
Fishsanity: Son of Crimsonfish: Progressive Backpack
Fishsanity: Glacierfish Jr.: Hopper
Fishsanity: Legend II: Recycling Machine
Fishsanity: Radioactive Carp: Pearl
Fishsanity: Clam: Traveling Merchant: Tuesday
Fishsanity: Cockle: Resource Pack: 10000 Money
Fishsanity: Crab: Lupini: 'Tropical Fish #173'
Fishsanity: Crayfish: Magic Rock Candy
Fishsanity: Lobster: The Queen of Sauce
Fishsanity: Mussel: Auto-Grabber
Fishsanity: Oyster: Stardrop
Fishsanity: Periwinkle: Fishing Level
Fishsanity: Shrimp: Cactus Seeds
Fishsanity: Snail: Jinxed Trap
```

</p>
</details> 



<details><summary>And now they're not</summary>
<p>

```
Fishsanity: Albacore: Bok Choy Seeds
Fishsanity: Anchovy: JotPK: Progressive Boots
Fishsanity: Blue Discus: Cask
Fishsanity: Bream: Combat Level
Fishsanity: Bullhead: Earth Obelisk
Fishsanity: Carp: 40 Qi Gems
Fishsanity: Catfish: Fishing Level
Fishsanity: Chub: Traveling Merchant Metal Detector
Fishsanity: Dorado: Progressive Movie Theater
Fishsanity: Eel: Slime Hutch
Fishsanity: Flounder: Mining Level
Fishsanity: Ghostfish: Starport Decal
Fishsanity: Halibut: Progressive Mine Elevator
Fishsanity: Herring: Traveling Merchant Discount
Fishsanity: Ice Pip: Traveling Merchant: Wednesday
Fishsanity: Largemouth Bass: Fairy Dust
Fishsanity: Lava Eel: Traveling Merchant: Sunday
Fishsanity: Lingcod: Progressive Footwear
Fishsanity: Lionfish: Solar Panel
Fishsanity: Midnight Carp: Island West Turtle
Fishsanity: Octopus: Magic Rock Candy
Fishsanity: Perch: Progressive Sword
Fishsanity: Pike: 40 Qi Gems
Fishsanity: Pufferfish: Progressive Club
Fishsanity: Rainbow Trout: Garden Pot
Fishsanity: Red Mullet: Tapper
Fishsanity: Red Snapper: Resource Pack: 50 Wood
Fishsanity: Salmon: Traveling Merchant: Friday
Fishsanity: Sandfish: Farming Level
Fishsanity: Sardine: Fishing Level
Fishsanity: Scorpion Carp: Island Trader
Fishsanity: Sea Cucumber: Progressive Mine Elevator
Fishsanity: Shad: Bridge Repair
Fishsanity: Slimejack: Fish Pond
Fishsanity: Smallmouth Bass: Progressive Mine Elevator
Fishsanity: Squid: Ancient Seeds
Fishsanity: Stingray: Pumpkin Seeds
Fishsanity: Stonefish: Fortune Teller
Fishsanity: Sturgeon: Meow Trap
Fishsanity: Sunfish: Progressive Mine Elevator
Fishsanity: Super Cucumber: Progressive House
Fishsanity: Tiger Trout: Monsters Trap
Fishsanity: Tilapia: Pressure Nozzle
Fishsanity: Tuna: Mining Level
Fishsanity: Void Salmon: Bone Mill Recipe
Fishsanity: Walleye: 20 Qi Gems
Fishsanity: Woodskip: Wheat Seeds
Fishsanity: Blobfish: Mushroom Boxes
Fishsanity: Midnight Squid: JotPK: Progressive Gun
Fishsanity: Spook Fish: Stone Chest Recipe
Fishsanity: Clam: Progressive Trash Can
Fishsanity: Cockle: Kale Seeds
Fishsanity: Crab: Rhubarb Seeds
Fishsanity: Crayfish: Golden Walnut
Fishsanity: Lobster: Magnet Ring
Fishsanity: Mussel: Fiber Seeds Recipe
Fishsanity: Oyster: Jinxed Trap
Fishsanity: Periwinkle: Mining Level
Fishsanity: Shrimp: Ancient Seeds
Fishsanity: Snail: Corn Seeds
```

</p>
</details> 

Note that I also added unit test for that, but in the 6.x.x branch. I don't want to back port them because they rely on heavy refactoring. 

## If this makes graphical changes, please attach screenshots.
N/A
