### PR TITLE
Noita: Remove newline from option description so it doesn't look bad on webhost

### DIFF
--- a/worlds/noita/options.py
+++ b/worlds/noita/options.py
@@ -78,8 +78,7 @@ class VictoryCondition(Choice):
 
 
 class ExtraOrbs(Range):
-    """Add extra orbs to your item pool, to prevent you from needing to wait as long
-    for the last orb you need for your victory condition.
+    """Add extra orbs to your item pool, to prevent you from needing to wait as long for the last orb you need for your victory condition.
     Extra orbs received past your victory condition's amount will be received as hearts instead.
     Can be turned on for the Greed Ending goal, but will only really make it harder."""
     display_name = "Extra Orbs"


### PR DESCRIPTION
## What is this fixing or adding?
Remove a newline from the Extra Orbs option description so it doesn't look bad on the webhost.

## How was this tested?
Looking at it.

## If this makes graphical changes, please attach screenshots.
Old:
![image](https://github.com/ArchipelagoMW/Archipelago/assets/24858499/af77e75c-29fe-4afe-b3aa-85d8d960717c)
New:
![image](https://github.com/ArchipelagoMW/Archipelago/assets/24858499/a16a9630-8e21-4d81-962a-30fbdb9023f5)
