### PR TITLE
CI: more checks in build and rework compression

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,8 @@ jobs:
         with:
           name: ${{ env.ZIP_NAME }}
           path: dist/${{ env.ZIP_NAME }}
+          compression-level: 0  # .7z is incompressible by zip
+          if-no-files-found: error
           retention-days: 7  # keep for 7 days, should be enough
       - name: Build Setup
         run: |
@@ -74,6 +76,7 @@ jobs:
         with:
           name: ${{ env.SETUP_NAME }}
           path: setups/${{ env.SETUP_NAME }}
+          if-no-files-found: error
           retention-days: 7  # keep for 7 days, should be enough
 
   build-ubuntu2004:
@@ -114,7 +117,7 @@ jobs:
           echo -e "setup.py dist output:\n `ls dist`"
           cd dist && export APPIMAGE_NAME="`ls *.AppImage`" && cd ..
           export TAR_NAME="${APPIMAGE_NAME%.AppImage}.tar.gz"
-          (cd build && DIR_NAME="`ls | grep exe`" && mv "$DIR_NAME" Archipelago && tar -czvf ../dist/$TAR_NAME Archipelago && mv Archipelago "$DIR_NAME")
+          (cd build && DIR_NAME="`ls | grep exe`" && mv "$DIR_NAME" Archipelago && tar -cv Archipelago | gzip -8 > ../dist/$TAR_NAME && mv Archipelago "$DIR_NAME")
           echo "APPIMAGE_NAME=$APPIMAGE_NAME" >> $GITHUB_ENV
           echo "TAR_NAME=$TAR_NAME" >> $GITHUB_ENV
       # - copy code above to release.yml -
@@ -127,10 +130,13 @@ jobs:
         with:
           name: ${{ env.APPIMAGE_NAME }}
           path: dist/${{ env.APPIMAGE_NAME }}
+          if-no-files-found: error
           retention-days: 7
       - name: Store .tar.gz
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.TAR_NAME }}
           path: dist/${{ env.TAR_NAME }}
+          compression-level: 0  # .gz is incompressible by zip
+          if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python setup.py build_exe --yes
+          if ( $? -eq $false ) {
+            Write-Error "setup.py failed!"
+            exit 1
+          }
           $NAME="$(ls build | Select-String -Pattern 'exe')".Split('.',2)[1]
           $ZIP_NAME="Archipelago_$NAME.7z"
           echo "$NAME -> $ZIP_NAME"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
           echo -e "setup.py dist output:\n `ls dist`"
           cd dist && export APPIMAGE_NAME="`ls *.AppImage`" && cd ..
           export TAR_NAME="${APPIMAGE_NAME%.AppImage}.tar.gz"
-          (cd build && DIR_NAME="`ls | grep exe`" && mv "$DIR_NAME" Archipelago && tar -czvf ../dist/$TAR_NAME Archipelago && mv Archipelago "$DIR_NAME")
+          (cd build && DIR_NAME="`ls | grep exe`" && mv "$DIR_NAME" Archipelago && tar -cv Archipelago | gzip -8 > ../dist/$TAR_NAME && mv Archipelago "$DIR_NAME")
           echo "APPIMAGE_NAME=$APPIMAGE_NAME" >> $GITHUB_ENV
           echo "TAR_NAME=$TAR_NAME" >> $GITHUB_ENV
       # - code above copied from build.yml -


### PR DESCRIPTION
## What is this fixing or adding?

* Fail fast for failed setup.py on windows
  * This makes it easier to read errors by not having to scroll up from failed inno setup
* Fail for missing/empty upload
  * This will catch incompatible filename changes that did not update the workflow
* Also reworks compression level setting
  * the  change for .7z makes both the workflow and extraction faster
  * the change for .tar.gz makes the download slightly smaller and faster to unpack at roughly the same workflow runtime

## How was this tested?

Success in CI, failure in https://github.com/black-sliver/Archipelago/actions/runs/8307539482

## If this makes graphical changes, please attach screenshots.

![preview](https://github.com/ArchipelagoMW/Archipelago/assets/59490463/612f3f3f-362e-42d1-be27-98efbc7226c3)