### PR TITLE
ALTTP: Fix #2290's crashes

### DIFF
--- a/worlds/alttp/ItemPool.py
+++ b/worlds/alttp/ItemPool.py
@@ -508,7 +508,7 @@ def generate_itempool(world):
     multiworld.itempool += items
 
     if multiworld.retro_caves[player]:
-        set_up_take_anys(multiworld, player)  # depends on world.itempool to be set
+        set_up_take_anys(multiworld, world, player)  # depends on world.itempool to be set
 
 
 take_any_locations = {
@@ -528,30 +528,30 @@ take_any_locations_inverted.sort()
 take_any_locations.sort()
 
 
-def set_up_take_anys(world, player):
+def set_up_take_anys(multiworld, world, player):
     # these are references, do not modify these lists in-place
-    if world.mode[player] == 'inverted':
+    if multiworld.mode[player] == 'inverted':
         take_any_locs = take_any_locations_inverted
     else:
         take_any_locs = take_any_locations
 
-    regions = world.random.sample(take_any_locs, 5)
+    regions = multiworld.random.sample(take_any_locs, 5)
 
-    old_man_take_any = LTTPRegion("Old Man Sword Cave", LTTPRegionType.Cave, 'the sword cave', player, world)
-    world.regions.append(old_man_take_any)
+    old_man_take_any = LTTPRegion("Old Man Sword Cave", LTTPRegionType.Cave, 'the sword cave', player, multiworld)
+    multiworld.regions.append(old_man_take_any)
 
     reg = regions.pop()
-    entrance = world.get_region(reg, player).entrances[0]
-    connect_entrance(world, entrance.name, old_man_take_any.name, player)
+    entrance = multiworld.get_region(reg, player).entrances[0]
+    connect_entrance(multiworld, entrance.name, old_man_take_any.name, player)
     entrance.target = 0x58
     old_man_take_any.shop = TakeAny(old_man_take_any, 0x0112, 0xE2, True, True, total_shop_slots)
-    world.shops.append(old_man_take_any.shop)
+    multiworld.shops.append(old_man_take_any.shop)
 
-    swords = [item for item in world.itempool if item.player == player and item.type == 'Sword']
+    swords = [item for item in multiworld.itempool if item.player == player and item.type == 'Sword']
     if swords:
-        sword = world.random.choice(swords)
-        world.itempool.remove(sword)
-        world.itempool.append(item_factory('Rupees (20)', world))
+        sword = multiworld.random.choice(swords)
+        multiworld.itempool.remove(sword)
+        multiworld.itempool.append(item_factory('Rupees (20)', world))
         old_man_take_any.shop.add_inventory(0, sword.name, 0, 0)
         loc_name = "Old Man Sword Cave"
         location = ALttPLocation(player, loc_name, shop_table_by_location[loc_name], parent=old_man_take_any)
@@ -562,16 +562,16 @@ def set_up_take_anys(world, player):
         old_man_take_any.shop.add_inventory(0, 'Rupees (300)', 0, 0)
 
     for num in range(4):
-        take_any = LTTPRegion("Take-Any #{}".format(num+1), LTTPRegionType.Cave, 'a cave of choice', player, world)
-        world.regions.append(take_any)
+        take_any = LTTPRegion("Take-Any #{}".format(num+1), LTTPRegionType.Cave, 'a cave of choice', player, multiworld)
+        multiworld.regions.append(take_any)
 
-        target, room_id = world.random.choice([(0x58, 0x0112), (0x60, 0x010F), (0x46, 0x011F)])
+        target, room_id = multiworld.random.choice([(0x58, 0x0112), (0x60, 0x010F), (0x46, 0x011F)])
         reg = regions.pop()
-        entrance = world.get_region(reg, player).entrances[0]
-        connect_entrance(world, entrance.name, take_any.name, player)
+        entrance = multiworld.get_region(reg, player).entrances[0]
+        connect_entrance(multiworld, entrance.name, take_any.name, player)
         entrance.target = target
         take_any.shop = TakeAny(take_any, room_id, 0xE3, True, True, total_shop_slots + num + 1)
-        world.shops.append(take_any.shop)
+        multiworld.shops.append(take_any.shop)
         take_any.shop.add_inventory(0, 'Blue Potion', 0, 0)
         take_any.shop.add_inventory(1, 'Boss Heart Container', 0, 0)
         location = ALttPLocation(player, take_any.name, shop_table_by_location[take_any.name], parent=take_any)

--- a/worlds/alttp/__init__.py
+++ b/worlds/alttp/__init__.py
@@ -649,7 +649,7 @@ class ALTTPWorld(World):
             if not multiworld.ganonstower_vanilla[player] or \
                     world.options.glitches_required.current_key in {'overworld_glitches', 'hybrid_major_glitches', "no_logic"}:
                 pass
-            elif 'triforce_hunt' in world.options.goal.current_key and ('local' in world.options.goal.current_key or world.players == 1):
+            elif 'triforce_hunt' in world.options.goal.current_key and ('local' in world.options.goal.current_key or multiworld.players == 1):
                 trash_counts[player] = multiworld.random.randint(world.options.crystals_needed_for_gt * 2,
                                                             world.options.crystals_needed_for_gt * 4)
             else:


### PR DESCRIPTION
## What is this fixing or adding?
~~Don't know how that slipped through.~~ Crashes when non-local triforce hunt is generated.
It didn't slip through, it was broken in #2290 along with take-any shops which is now fixed in this @alwaysintreble 

## How was this tested?
Re-generating with the fix.