### PR TITLE
CommonClient: Port Casting Bug

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -643,7 +643,10 @@ async def server_loop(ctx: CommonContext, address: typing.Optional[str] = None) 
         ctx.username = server_url.username
     if server_url.password:
         ctx.password = server_url.password
-    port = server_url.port or 38281
+    try:
+        port = server_url.port or 38281
+    except ValueError as e:
+        logger.info("Given Port could not be converted into an Integer")
 
     def reconnect_hint() -> str:
         return ", type /connect to reconnect" if ctx.server_address else ""

--- a/CommonClient.py
+++ b/CommonClient.py
@@ -649,7 +649,7 @@ async def server_loop(ctx: CommonContext, address: typing.Optional[str] = None) 
 
     logger.info(f'Connecting to Archipelago server at {address}')
     try:
-        port = server_url.port or 38281
+        port = server_url.port or 38281  # raises ValueError if invalid
         socket = await websockets.connect(address, port=port, ping_timeout=None, ping_interval=None,
                                           ssl=get_ssl_context() if address.startswith("wss://") else None)
         if ctx.ui is not None:

--- a/CommonClient.py
+++ b/CommonClient.py
@@ -643,16 +643,13 @@ async def server_loop(ctx: CommonContext, address: typing.Optional[str] = None) 
         ctx.username = server_url.username
     if server_url.password:
         ctx.password = server_url.password
-    try:
-        port = server_url.port or 38281
-    except ValueError as e:
-        logger.info("Given Port could not be converted into an Integer")
 
     def reconnect_hint() -> str:
         return ", type /connect to reconnect" if ctx.server_address else ""
 
     logger.info(f'Connecting to Archipelago server at {address}')
     try:
+        port = server_url.port or 38281
         socket = await websockets.connect(address, port=port, ping_timeout=None, ping_interval=None,
                                           ssl=get_ssl_context() if address.startswith("wss://") else None)
         if ctx.ui is not None:


### PR DESCRIPTION
## What is this fixing or adding?
when a port is used to connect in CommonClient that cannot be cast to an int urllib.parse() throws an exception that is uncaught and puts the client into an invalid state where the port can never be updated to be valid without closing the application.
This adds a try/catch for that does not set the port when not a valid int, which causes downstream code to error and handle the disconnect gracefully. 
I think a prettier solution would be much better, since this adds a lot more error messages that hide the actual issue, but at least this allows you to retry a connection.

## How was this tested?
using ports with spaces (i.e. "123 ") full text ports (i.e. "asdf") and valid ports (i.e. "123") and making sure an error was thrown when the port was invalid, and a connection was attempted when the port was valid. And then confirming that the port could be changed and a new connection attempted

Note: testing on py 3.8 seems to automatically trim the whitespace (and thus not throw the Exception) but this still handles a full text port.

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/4809984/338cdf90-8e74-4752-bec0-a3e3eaab28bf)
![image](https://github.com/ArchipelagoMW/Archipelago/assets/4809984/40016eba-c4ec-4e69-a926-3102e7127c84)
