### PR TITLE
The Messenger: Fix various portal shuffle issues

### DIFF
--- a/worlds/messenger/portals.py
+++ b/worlds/messenger/portals.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from typing import List, TYPE_CHECKING
 
 from BaseClasses import CollectionState, PlandoOptions
@@ -239,11 +240,12 @@ def shuffle_portals(world: "MessengerWorld") -> None:
             world.plando_portals.append(connection.entrance)
 
     shuffle_type = world.options.shuffle_portals
-    shop_points = SHOP_POINTS.copy()
+    shop_points = deepcopy(SHOP_POINTS)
     for portal in PORTALS:
         shop_points[portal].append(f"{portal} Portal")
     if shuffle_type > ShufflePortals.option_shops:
-        shop_points.update(CHECKPOINTS)
+        for area, points in CHECKPOINTS.items():
+            shop_points[area] += points
     out_to_parent = {checkpoint: parent for parent, checkpoints in shop_points.items() for checkpoint in checkpoints}
     available_portals = [val for zone in shop_points.values() for val in zone]
 

--- a/worlds/messenger/portals.py
+++ b/worlds/messenger/portals.py
@@ -226,9 +226,9 @@ def shuffle_portals(world: "MessengerWorld") -> None:
         world.spoiler_portal_mapping[in_portal] = exit_string
         connect_portal(world, in_portal, exit_string)
 
-        available_portals.remove(warp)
         if shuffle_type < ShufflePortals.option_anywhere:
             available_portals = [port for port in available_portals if port not in shop_points[parent]]
+            world.random.shuffle(available_portals)
 
     def handle_planned_portals(plando_connections: List[PlandoConnection]) -> None:
         """checks the provided plando connections for portals and connects them"""
@@ -248,6 +248,7 @@ def shuffle_portals(world: "MessengerWorld") -> None:
             shop_points[area] += points
     out_to_parent = {checkpoint: parent for parent, checkpoints in shop_points.items() for checkpoint in checkpoints}
     available_portals = [val for zone in shop_points.values() for val in zone]
+    world.random.shuffle(available_portals)
 
     plando = world.multiworld.plando_connections[world.player]
     if plando and world.multiworld.plando_options & PlandoOptions.connections:
@@ -257,7 +258,7 @@ def shuffle_portals(world: "MessengerWorld") -> None:
     for portal in PORTALS:
         if portal in world.plando_portals:
             continue
-        warp_point = world.random.choice(available_portals)
+        warp_point = available_portals.pop()
         create_mapping(portal, warp_point)
 
 

--- a/worlds/messenger/portals.py
+++ b/worlds/messenger/portals.py
@@ -250,8 +250,7 @@ def shuffle_portals(world: "MessengerWorld") -> None:
     plando = world.multiworld.plando_connections[world.player]
     if plando and world.multiworld.plando_options & PlandoOptions.connections:
         handle_planned_portals(plando)
-        world.multiworld.plando_connections[world.player] = [connection for connection in plando
-                                                             if connection.entrance not in PORTALS]
+
     for portal in PORTALS:
         if portal in world.plando_portals:
             continue

--- a/worlds/messenger/portals.py
+++ b/worlds/messenger/portals.py
@@ -207,9 +207,8 @@ REGION_ORDER = [
 
 def shuffle_portals(world: "MessengerWorld") -> None:
     """shuffles the output of the portals from the main hub"""
-    def create_mapping(in_portal: str, warp: str) -> None:
+    def create_mapping(in_portal: str, warp: str) -> str:
         """assigns the chosen output to the input"""
-        nonlocal available_portals
         parent = out_to_parent[warp]
         exit_string = f"{parent.strip(' ')} - "
 
@@ -226,9 +225,7 @@ def shuffle_portals(world: "MessengerWorld") -> None:
         world.spoiler_portal_mapping[in_portal] = exit_string
         connect_portal(world, in_portal, exit_string)
 
-        if shuffle_type < ShufflePortals.option_anywhere:
-            available_portals = [port for port in available_portals if port not in shop_points[parent]]
-            world.random.shuffle(available_portals)
+        return parent
 
     def handle_planned_portals(plando_connections: List[PlandoConnection]) -> None:
         """checks the provided plando connections for portals and connects them"""
@@ -259,7 +256,10 @@ def shuffle_portals(world: "MessengerWorld") -> None:
         if portal in world.plando_portals:
             continue
         warp_point = available_portals.pop()
-        create_mapping(portal, warp_point)
+        parent = create_mapping(portal, warp_point)
+        if shuffle_type < ShufflePortals.option_anywhere:
+            available_portals = [port for port in available_portals if port not in shop_points[parent]]
+            world.random.shuffle(available_portals)
 
 
 def connect_portal(world: "MessengerWorld", portal: str, out_region: str) -> None:

--- a/worlds/messenger/portals.py
+++ b/worlds/messenger/portals.py
@@ -213,12 +213,12 @@ def shuffle_portals(world: "MessengerWorld") -> None:
         if "Portal" in warp:
             exit_string += "Portal"
             world.portal_mapping.append(int(f"{REGION_ORDER.index(parent)}00"))
-        elif warp_point in SHOP_POINTS[parent]:
-            exit_string += f"{warp_point} Shop"
-            world.portal_mapping.append(int(f"{REGION_ORDER.index(parent)}1{SHOP_POINTS[parent].index(warp_point)}"))
+        elif warp in SHOP_POINTS[parent]:
+            exit_string += f"{warp} Shop"
+            world.portal_mapping.append(int(f"{REGION_ORDER.index(parent)}1{SHOP_POINTS[parent].index(warp)}"))
         else:
-            exit_string += f"{warp_point} Checkpoint"
-            world.portal_mapping.append(int(f"{REGION_ORDER.index(parent)}2{CHECKPOINTS[parent].index(warp_point)}"))
+            exit_string += f"{warp} Checkpoint"
+            world.portal_mapping.append(int(f"{REGION_ORDER.index(parent)}2{CHECKPOINTS[parent].index(warp)}"))
 
         world.spoiler_portal_mapping[in_portal] = exit_string
         connect_portal(world, in_portal, exit_string)

--- a/worlds/messenger/portals.py
+++ b/worlds/messenger/portals.py
@@ -205,7 +205,9 @@ REGION_ORDER = [
 
 
 def shuffle_portals(world: "MessengerWorld") -> None:
+    """shuffles the output of the portals from the main hub"""
     def create_mapping(in_portal: str, warp: str) -> None:
+        """assigns the chosen output to the input"""
         nonlocal available_portals
         parent = out_to_parent[warp]
         exit_string = f"{parent.strip(' ')} - "
@@ -228,6 +230,7 @@ def shuffle_portals(world: "MessengerWorld") -> None:
             available_portals = [port for port in available_portals if port not in shop_points[parent]]
 
     def handle_planned_portals(plando_connections: List[PlandoConnection]) -> None:
+        """checks the provided plando connections for portals and connects them"""
         for connection in plando_connections:
             if connection.entrance not in PORTALS:
                 continue

--- a/worlds/messenger/portals.py
+++ b/worlds/messenger/portals.py
@@ -250,6 +250,8 @@ def shuffle_portals(world: "MessengerWorld") -> None:
         world.multiworld.plando_connections[world.player] = [connection for connection in plando
                                                              if connection.entrance not in PORTALS]
     for portal in PORTALS:
+        if portal in world.plando_portals:
+            continue
         warp_point = world.random.choice(available_portals)
         create_mapping(portal, warp_point)
 

--- a/worlds/messenger/portals.py
+++ b/worlds/messenger/portals.py
@@ -18,24 +18,6 @@ PORTALS = [
 ]
 
 
-REGION_ORDER = [
-    "Autumn Hills",
-    "Forlorn Temple",
-    "Catacombs",
-    "Bamboo Creek",
-    "Howling Grotto",
-    "Quillshroom Marsh",
-    "Searing Crags",
-    "Glacial Peak",
-    "Tower of Time",
-    "Cloud Ruins",
-    "Underworld",
-    "Riviere Turquoise",
-    "Elemental Skylands",
-    "Sunken Shrine",
-]
-
-
 SHOP_POINTS = {
     "Autumn Hills": [
         "Climbing Claws",
@@ -202,6 +184,24 @@ CHECKPOINTS = {
         "Moon Crest",
     ]
 }
+
+
+REGION_ORDER = [
+    "Autumn Hills",
+    "Forlorn Temple",
+    "Catacombs",
+    "Bamboo Creek",
+    "Howling Grotto",
+    "Quillshroom Marsh",
+    "Searing Crags",
+    "Glacial Peak",
+    "Tower of Time",
+    "Cloud Ruins",
+    "Underworld",
+    "Riviere Turquoise",
+    "Elemental Skylands",
+    "Sunken Shrine",
+]
 
 
 def shuffle_portals(world: "MessengerWorld") -> None:


### PR DESCRIPTION
## What is this fixing or adding?
Fixes plando portals being assigned and then immediately overwritten. Fixes the pool of portal outputs not matching what the option description actually says - checkpoints and anywhere *only* had checkpoints when they were supposed to have everything. Fixes a scoping issue that could cause plando to crash.

## How was this tested?
Was moving portal plando to the options API introduced with #2904 and wrote a unit test to test everything worked correctly. unit test is not currently included here or there as we don't have an API to assign settings for tests.

## If this makes graphical changes, please attach screenshots.
