### PR TITLE
Pokemon Emerald: Fix wonder trade race condition

### DIFF
--- a/worlds/pokemon_emerald/client.py
+++ b/worlds/pokemon_emerald/client.py
@@ -664,8 +664,10 @@ class PokemonEmeraldClient(BizHawkClient):
                 "cmd": "SetNotify",
                 "keys": [f"pokemon_wonder_trades_{ctx.team}"],
             }, {
-                "cmd": "Get",
-                "keys": [f"pokemon_wonder_trades_{ctx.team}"],
+                "cmd": "Set",
+                "key": f"pokemon_wonder_trades_{ctx.team}",
+                "default": {"_lock": 0},
+                "operations": [{"operation": "default", "value": None}]  # value is ignored
             }]))
         elif cmd == "SetReply":
             if args.get("key", "") == f"pokemon_wonder_trades_{ctx.team}":


### PR DESCRIPTION
## What is this fixing or adding?

https://discord.com/channels/731205301247803413/1218987814352584785

If the first player to modify the wonder trade key manages to finish another loop of their client's game watcher before receiving the response from their first `Set`, their local `ctx.stored_data` will still have the original `None` in it, since nothing has set it to its default value yet.

This defaults the key on connect instead of using `Get`, so the first client to connect will initialize the value and it will always be a dict.

## How was this tested?

Connected a fresh client to a fresh server while logging the changes to `ctx.stored_data`, saw that it always contained at least the default value.