### PR TITLE
Stardew Valley: Improve default options performances by grouping rules before counting them

### DIFF
--- a/worlds/stardew_valley/logic/building_logic.py
+++ b/worlds/stardew_valley/logic/building_logic.py
@@ -15,6 +15,8 @@ from ..strings.fish_names import WaterItem
 from ..strings.material_names import Material
 from ..strings.metal_names import MetalBar
 
+has_group = "building"
+
 
 class BuildingLogicMixin(BaseLogicMixin):
     def __init__(self, *args, **kwargs):
@@ -60,7 +62,7 @@ class BuildingLogic(BaseLogic[Union[BuildingLogicMixin, MoneyLogicMixin, RegionL
 
         carpenter_rule = self.logic.received(Event.can_construct_buildings)
         if not self.options.building_progression & BuildingProgression.option_progressive:
-            return Has(building, self.registry.building_rules) & carpenter_rule
+            return Has(building, self.registry.building_rules, has_group) & carpenter_rule
 
         count = 1
         if building in [Building.coop, Building.barn, Building.shed]:
@@ -86,10 +88,10 @@ class BuildingLogic(BaseLogic[Union[BuildingLogicMixin, MoneyLogicMixin, RegionL
             return carpenter_rule & self.logic.received(f"Progressive House", upgrade_level)
 
         if upgrade_level == 1:
-            return carpenter_rule & Has(Building.kitchen, self.registry.building_rules)
+            return carpenter_rule & Has(Building.kitchen, self.registry.building_rules, has_group)
 
         if upgrade_level == 2:
-            return carpenter_rule & Has(Building.kids_room, self.registry.building_rules)
+            return carpenter_rule & Has(Building.kids_room, self.registry.building_rules, has_group)
 
         # if upgrade_level == 3:
-        return carpenter_rule & Has(Building.cellar, self.registry.building_rules)
+        return carpenter_rule & Has(Building.cellar, self.registry.building_rules, has_group)

--- a/worlds/stardew_valley/logic/has_logic.py
+++ b/worlds/stardew_valley/logic/has_logic.py
@@ -1,5 +1,5 @@
 from .base_logic import BaseLogic
-from ..stardew_rule import StardewRule, And, Or, Has, Count
+from ..stardew_rule import StardewRule, And, Or, Has, Count, true_
 
 
 class HasLogicMixin(BaseLogic[None]):
@@ -24,6 +24,16 @@ class HasLogicMixin(BaseLogic[None]):
     def count(count: int, *rules: StardewRule) -> StardewRule:
         assert rules, "Can't create a Count conditions without rules"
         assert len(rules) >= count, "Count need at least as many rules as the count"
+        assert count > 0, "Count can't be negative"
+
+        count -= sum(r is true_ for r in rules)
+        rules = list(r for r in rules if r is not true_)
+
+        if count <= 0:
+            return true_
+
+        if len(rules) == 1:
+            return rules[0]
 
         if count == 1:
             return Or(*rules)
@@ -31,4 +41,4 @@ class HasLogicMixin(BaseLogic[None]):
         if count == len(rules):
             return And(*rules)
 
-        return Count(list(rules), count)
+        return Count(rules, count)

--- a/worlds/stardew_valley/logic/quest_logic.py
+++ b/worlds/stardew_valley/logic/quest_logic.py
@@ -110,7 +110,7 @@ FishingLogicMixin, CookingLogicMixin, CombatLogicMixin, SeasonLogicMixin, SkillL
         self.registry.quest_rules.update(new_rules)
 
     def can_complete_quest(self, quest: str) -> StardewRule:
-        return Has(quest, self.registry.quest_rules)
+        return Has(quest, self.registry.quest_rules, "quest")
 
     def has_club_card(self) -> StardewRule:
         if self.options.quest_locations < 0:

--- a/worlds/stardew_valley/logic/region_logic.py
+++ b/worlds/stardew_valley/logic/region_logic.py
@@ -42,6 +42,9 @@ class RegionLogic(BaseLogic[Union[RegionLogicMixin, HasLogicMixin]]):
 
     @cache_self1
     def can_reach_any(self, region_names: Tuple[str, ...]) -> StardewRule:
+        if any(r in always_regions_by_setting[self.options.entrance_randomization] for r in region_names):
+            return true_
+
         return Or(*(self.logic.region.can_reach(spot) for spot in region_names))
 
     @cache_self1

--- a/worlds/stardew_valley/logic/special_order_logic.py
+++ b/worlds/stardew_valley/logic/special_order_logic.py
@@ -35,7 +35,6 @@ from ..strings.monster_names import Monster
 from ..strings.region_names import Region
 from ..strings.season_names import Season
 from ..strings.special_order_names import SpecialOrder
-from ..strings.tool_names import Tool
 from ..strings.villager_names import NPC
 
 
@@ -105,7 +104,7 @@ AbilityLogicMixin, SpecialOrderLogicMixin, MonsterLogicMixin]]):
         self.registry.special_order_rules.update(new_rules)
 
     def can_complete_special_order(self, special_order: str) -> StardewRule:
-        return Has(special_order, self.registry.special_order_rules)
+        return Has(special_order, self.registry.special_order_rules, "special order")
 
     def has_island_transport(self) -> StardewRule:
         return self.logic.received(Transportation.island_obelisk) | self.logic.received(Transportation.boat_repair)

--- a/worlds/stardew_valley/stardew_rule/base.py
+++ b/worlds/stardew_valley/stardew_rule/base.py
@@ -435,13 +435,13 @@ class Has(BaseStardewRule):
 
     def __str__(self):
         if self.item not in self.other_rules:
-            return f"Has {self.item} {self.group} -> {MISSING_ITEM}"
-        return f"Has {self.item} {self.group}"
+            return f"Has {self.item} ({self.group}) -> {MISSING_ITEM}"
+        return f"Has {self.item} ({self.group})"
 
     def __repr__(self):
         if self.item not in self.other_rules:
-            return f"Has {self.item} {self.group} -> {MISSING_ITEM}"
-        return f"Has {self.item} {self.group} -> {repr(self.other_rules[self.item])}"
+            return f"Has {self.item} ({self.group}) -> {MISSING_ITEM}"
+        return f"Has {self.item} ({self.group}) -> {repr(self.other_rules[self.item])}"
 
 
 class RepeatableChain(Iterable, Sized):

--- a/worlds/stardew_valley/stardew_rule/base.py
+++ b/worlds/stardew_valley/stardew_rule/base.py
@@ -374,7 +374,7 @@ class Count(BaseStardewRule):
 
     def __call__(self, state: CollectionState) -> bool:
         c = 0
-        t = self.counter.total()
+        t = sum(self.counter.values())
 
         for i in range(self.rules_count):
             original_rule = self.rules[i]

--- a/worlds/stardew_valley/stardew_rule/base.py
+++ b/worlds/stardew_valley/stardew_rule/base.py
@@ -393,6 +393,8 @@ class Count(BaseStardewRule):
 
     def call_evaluate_while_simplifying_cached(self, rule: StardewRule, state: CollectionState) -> bool:
         try:
+            # A mapping table with the original rule is used here because two rules could resolve to the same rule.
+            #  This would require to change the counter to merge both rules, and quickly become complicated.
             return self.rule_mapping[rule].evaluate_while_simplifying(state)
         except KeyError:
             self.rule_mapping[rule], value = rule.evaluate_while_simplifying(state)

--- a/worlds/stardew_valley/stardew_rule/base.py
+++ b/worlds/stardew_valley/stardew_rule/base.py
@@ -417,7 +417,7 @@ class Count(BaseStardewRule):
         return f"Received {self.count} {repr(self.rules)}"
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class Has(BaseStardewRule):
     item: str
     # For sure there is a better way than just passing all the rules everytime

--- a/worlds/stardew_valley/stardew_rule/base.py
+++ b/worlds/stardew_valley/stardew_rule/base.py
@@ -367,19 +367,17 @@ class Count(BaseStardewRule):
     def __init__(self, rules: List[StardewRule], count: int):
         self.count = count
         self.counter = Counter(rules)
+        self.total = sum(self.counter.values())
         self.rules = sorted(self.counter.keys(), key=lambda x: self.counter[x], reverse=True)
         self.rule_mapping = {}
 
-        assert self.counter.total() == len(rules)
-
     def __call__(self, state: CollectionState) -> bool:
         c = 0
-        t = sum(self.counter.values())
+        t = self.total
 
-        for i in range(self.rules_count):
-            original_rule = self.rules[i]
-            evaluation_value = self.call_evaluate_while_simplifying_cached(original_rule, state)
-            rule_value = self.counter[original_rule]
+        for rule in self.rules:
+            evaluation_value = self.call_evaluate_while_simplifying_cached(rule, state)
+            rule_value = self.counter[rule]
 
             if evaluation_value:
                 c += rule_value

--- a/worlds/stardew_valley/stardew_rule/state.py
+++ b/worlds/stardew_valley/stardew_rule/state.py
@@ -47,7 +47,7 @@ class TotalReceived(BaseStardewRule):
         return f"Received {self.count} {self.items}"
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class Received(CombinableStardewRule):
     item: str
     player: int
@@ -80,7 +80,7 @@ class Received(CombinableStardewRule):
         return self.count
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class Reach(BaseStardewRule):
     spot: str
     resolution_hint: str
@@ -101,7 +101,7 @@ class Reach(BaseStardewRule):
         return 1
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class HasProgressionPercent(CombinableStardewRule):
     player: int
     percent: int

--- a/worlds/stardew_valley/stardew_rule/state.py
+++ b/worlds/stardew_valley/stardew_rule/state.py
@@ -47,7 +47,7 @@ class TotalReceived(BaseStardewRule):
         return f"Received {self.count} {self.items}"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class Received(CombinableStardewRule):
     item: str
     player: int
@@ -80,7 +80,7 @@ class Received(CombinableStardewRule):
         return self.count
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class Reach(BaseStardewRule):
     spot: str
     resolution_hint: str
@@ -101,7 +101,7 @@ class Reach(BaseStardewRule):
         return 1
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class HasProgressionPercent(CombinableStardewRule):
     player: int
     percent: int

--- a/worlds/stardew_valley/test/TestRules.py
+++ b/worlds/stardew_valley/test/TestRules.py
@@ -5,7 +5,7 @@ from .. import options, HasProgressionPercent
 from ..data.craftable_data import all_crafting_recipes_by_name
 from ..locations import locations_by_tag, LocationTags, location_table
 from ..options import ToolProgression, BuildingProgression, ExcludeGingerIsland, Chefsanity, Craftsanity, Shipsanity, SeasonRandomization, Friendsanity, \
-    FriendsanityHeartSize, BundleRandomization, SkillProgression
+    FriendsanityHeartSize, BundleRandomization, SkillProgression, Museumsanity
 from ..strings.entrance_names import Entrance
 from ..strings.region_names import Region
 
@@ -90,6 +90,18 @@ class TestProgressiveToolsLogic(SVTestBase):
         self.remove(green_house)
         self.assert_rule_false(rule, self.multiworld.state)
         self.remove(friday)
+
+
+class TestMuseumMilestones(SVTestBase):
+    options = {
+        Museumsanity.internal_name: Museumsanity.option_milestones
+    }
+
+    def test_50_milestone(self):
+        self.multiworld.state.prog_items = {1: Counter()}
+
+        milestone_rule = self.world.logic.museum.can_find_museum_items(50)
+        self.assert_rule_false(milestone_rule, self.multiworld.state)
 
 
 class TestBundlesLogic(SVTestBase):

--- a/worlds/stardew_valley/test/TestStardewRule.py
+++ b/worlds/stardew_valley/test/TestStardewRule.py
@@ -1,7 +1,8 @@
 import unittest
 from unittest.mock import MagicMock, Mock
 
-from ..stardew_rule import Received, And, Or, HasProgressionPercent, false_, true_
+from .. import StardewRule
+from ..stardew_rule import Received, And, Or, HasProgressionPercent, false_, true_, Count
 
 
 class TestSimplification(unittest.TestCase):
@@ -242,3 +243,56 @@ class TestEvaluateWhileSimplifyingDoubleCalls(unittest.TestCase):
         self.assertTrue(called_once)
         self.assertTrue(internal_call_result)
         self.assertTrue(actual_result)
+
+
+class TestCount(unittest.TestCase):
+
+    def test_duplicate_rule_count_double(self):
+        expected_result = True
+        collection_state = MagicMock()
+        simplified_rule = MagicMock()
+        other_rule = MagicMock(spec=StardewRule)
+        other_rule.evaluate_while_simplifying = Mock(return_value=(simplified_rule, expected_result))
+        rule = Count([other_rule, other_rule, other_rule], 2)
+
+        actual_result = rule(collection_state)
+
+        other_rule.evaluate_while_simplifying.assert_called_once_with(collection_state)
+        self.assertEqual(expected_result, actual_result)
+
+    def test_simplified_rule_is_reused(self):
+        expected_result = True
+        collection_state = MagicMock()
+        simplified_rule = MagicMock(return_value=expected_result)
+        other_rule = MagicMock(spec=StardewRule)
+        other_rule.evaluate_while_simplifying = Mock(return_value=(simplified_rule, expected_result))
+        rule = Count([other_rule, other_rule, other_rule], 2)
+
+        actual_result = rule(collection_state)
+
+        other_rule.evaluate_while_simplifying.assert_called_once_with(collection_state)
+        self.assertEqual(expected_result, actual_result)
+
+        other_rule.evaluate_while_simplifying.reset_mock()
+
+        actual_result = rule(collection_state)
+
+        other_rule.evaluate_while_simplifying.assert_not_called()
+        simplified_rule.assert_not_called()
+        self.assertEqual(expected_result, actual_result)
+
+    def test_break_if_not_enough_rule_to_complete(self):
+        expected_result = False
+        collection_state = MagicMock()
+        simplified_rule = MagicMock()
+        never_called_rule = MagicMock()
+        other_rule = MagicMock(spec=StardewRule)
+        other_rule.evaluate_while_simplifying = Mock(return_value=(simplified_rule, expected_result))
+        rule = Count([other_rule, other_rule, other_rule, never_called_rule], 2)
+
+        actual_result = rule(collection_state)
+
+        other_rule.evaluate_while_simplifying.assert_called_once_with(collection_state)
+        never_called_rule.assert_not_called()
+        never_called_rule.evaluate_while_simplifying.assert_not_called()
+        self.assertEqual(expected_result, actual_result)

--- a/worlds/stardew_valley/test/TestStardewRule.py
+++ b/worlds/stardew_valley/test/TestStardewRule.py
@@ -250,8 +250,8 @@ class TestCount(unittest.TestCase):
     def test_duplicate_rule_count_double(self):
         expected_result = True
         collection_state = MagicMock()
-        simplified_rule = MagicMock()
-        other_rule = MagicMock(spec=StardewRule)
+        simplified_rule = Mock()
+        other_rule = Mock(spec=StardewRule)
         other_rule.evaluate_while_simplifying = Mock(return_value=(simplified_rule, expected_result))
         rule = Count([other_rule, other_rule, other_rule], 2)
 
@@ -261,10 +261,10 @@ class TestCount(unittest.TestCase):
         self.assertEqual(expected_result, actual_result)
 
     def test_simplified_rule_is_reused(self):
-        expected_result = True
+        expected_result = False
         collection_state = MagicMock()
-        simplified_rule = MagicMock(return_value=expected_result)
-        other_rule = MagicMock(spec=StardewRule)
+        simplified_rule = Mock(return_value=expected_result)
+        other_rule = Mock(spec=StardewRule)
         other_rule.evaluate_while_simplifying = Mock(return_value=(simplified_rule, expected_result))
         rule = Count([other_rule, other_rule, other_rule], 2)
 
@@ -278,15 +278,15 @@ class TestCount(unittest.TestCase):
         actual_result = rule(collection_state)
 
         other_rule.evaluate_while_simplifying.assert_not_called()
-        simplified_rule.assert_not_called()
+        simplified_rule.assert_called()
         self.assertEqual(expected_result, actual_result)
 
     def test_break_if_not_enough_rule_to_complete(self):
         expected_result = False
         collection_state = MagicMock()
-        simplified_rule = MagicMock()
-        never_called_rule = MagicMock()
-        other_rule = MagicMock(spec=StardewRule)
+        simplified_rule = Mock()
+        never_called_rule = Mock()
+        other_rule = Mock(spec=StardewRule)
         other_rule.evaluate_while_simplifying = Mock(return_value=(simplified_rule, expected_result))
         rule = Count([other_rule, other_rule, other_rule, never_called_rule], 2)
 
@@ -296,3 +296,8 @@ class TestCount(unittest.TestCase):
         never_called_rule.assert_not_called()
         never_called_rule.evaluate_while_simplifying.assert_not_called()
         self.assertEqual(expected_result, actual_result)
+
+    def test_evaluate_without_shortcircuit_when_rules_are_all_different(self):
+        rule = Count([Mock(), Mock(), Mock(), Mock()], 2)
+
+        self.assertEqual(rule.evaluate, rule.evaluate_without_shortcircuit)

--- a/worlds/stardew_valley/test/stability/TestStability.py
+++ b/worlds/stardew_valley/test/stability/TestStability.py
@@ -29,7 +29,6 @@ class TestGenerationIsStable(SVTestCase):
         output_a = subprocess.check_output([sys.executable, '-m', 'worlds.stardew_valley.test.stability.StabilityOutputScript', '--seed', str(seed)])
         output_b = subprocess.check_output([sys.executable, '-m', 'worlds.stardew_valley.test.stability.StabilityOutputScript', '--seed', str(seed)])
 
-        #
         result_a = json.loads(output_a[:-BYTES_TO_REMOVE])
         result_b = json.loads(output_b[:-BYTES_TO_REMOVE])
 

--- a/worlds/stardew_valley/test/stability/TestStability.py
+++ b/worlds/stardew_valley/test/stability/TestStability.py
@@ -6,6 +6,9 @@ import sys
 from BaseClasses import get_seed
 from .. import SVTestCase
 
+# There seems to be 4 bytes that appear at random at the end of the output, breaking the json... I don't know where they came from.
+BYTES_TO_REMOVE = 4
+
 # <function Location.<lambda> at 0x102ca98a0>
 lambda_regex = re.compile(r"^<function Location\.<lambda> at (.*)>$")
 # Python 3.10.2\r\n
@@ -26,8 +29,9 @@ class TestGenerationIsStable(SVTestCase):
         output_a = subprocess.check_output([sys.executable, '-m', 'worlds.stardew_valley.test.stability.StabilityOutputScript', '--seed', str(seed)])
         output_b = subprocess.check_output([sys.executable, '-m', 'worlds.stardew_valley.test.stability.StabilityOutputScript', '--seed', str(seed)])
 
-        result_a = json.loads(output_a[:-4])
-        result_b = json.loads(output_b[:-4])
+        #
+        result_a = json.loads(output_a[:-BYTES_TO_REMOVE])
+        result_b = json.loads(output_b[:-BYTES_TO_REMOVE])
 
         for i, ((room_a, bundles_a), (room_b, bundles_b)) in enumerate(zip(result_a["bundles"].items(), result_b["bundles"].items())):
             self.assertEqual(room_a, room_b, f"Bundle rooms at index {i} is different between both executions. Seed={seed}")

--- a/worlds/stardew_valley/test/stability/TestStability.py
+++ b/worlds/stardew_valley/test/stability/TestStability.py
@@ -26,8 +26,8 @@ class TestGenerationIsStable(SVTestCase):
         output_a = subprocess.check_output([sys.executable, '-m', 'worlds.stardew_valley.test.stability.StabilityOutputScript', '--seed', str(seed)])
         output_b = subprocess.check_output([sys.executable, '-m', 'worlds.stardew_valley.test.stability.StabilityOutputScript', '--seed', str(seed)])
 
-        result_a = json.loads(output_a)
-        result_b = json.loads(output_b)
+        result_a = json.loads(output_a[:-4])
+        result_b = json.loads(output_b[:-4])
 
         for i, ((room_a, bundles_a), (room_b, bundles_b)) in enumerate(zip(result_a["bundles"].items(), result_b["bundles"].items())):
             self.assertEqual(room_a, room_b, f"Bundle rooms at index {i} is different between both executions. Seed={seed}")


### PR DESCRIPTION
## What is this fixing or adding?
This improves performances when filling Stardew Valley seed. The biggest gain is when playing with Museumsanity set to milestones (default), which improves performances by ~10%. 

![image](https://github.com/ArchipelagoMW/Archipelago/assets/16137441/c720dd0e-fb03-45bb-9bee-c1d7fba7b79e)

This works because a lot of artifacts have the same condition. Some rules only need to be evaluated once, but count toward multiple artifacts. 

## How was this tested?
Ran our performance tests, filling ~80 seeds with multiple settings. 


## If this makes graphical changes, please attach screenshots.
N/A