### PR TITLE
TLOZ: Fix markdown issue with game info page

### DIFF
--- a/worlds/tloz/docs/en_The Legend of Zelda.md
+++ b/worlds/tloz/docs/en_The Legend of Zelda.md
@@ -41,7 +41,6 @@ filler and useful items will cost less, and uncategorized items will be in the m
 - Pressing Select will cycle through your inventory.
 - Shop purchases are tracked within sessions, indicated by the item being elevated from its normal position.
 - What slots from a Take Any Cave have been chosen are similarly tracked.
--
 
 ## Local Unique Commands
 


### PR DESCRIPTION
## What is this fixing or adding?
Never thought I'd see the day when a trailing dash would heck something up

## How was this tested?
Ran webhost to verify markdown is correct

## If this makes graphical changes, please attach screenshots.
Before: 
![image](https://github.com/ArchipelagoMW/Archipelago/assets/59876300/f3f3afb5-386f-41f8-af20-3a22ec7ecfb9)
After: 
![image](https://github.com/ArchipelagoMW/Archipelago/assets/59876300/443f113b-1f2a-4c28-9b29-1abb65c337a5)
