### PR TITLE
SC2 Tracker: Use level tinting to let the player know which level he has for Replenishable Magazine

### DIFF
--- a/WebHostLib/templates/tracker__Starcraft2.html
+++ b/WebHostLib/templates/tracker__Starcraft2.html
@@ -180,7 +180,7 @@
                                 <td>{{ sc2_icon('Nano Projector (Medic)') }}</td>
                                 <td colspan="6"></td>
                                 <td>{{ sc2_icon('Vulture') }}</td>
-                                <td>{{ sc2_progressive_icon_with_custom_name('Progressive Replenishable Magazine (Vulture)', replenishable_magazine_vulture_url, replenishable_magazine_vulture_name) }}</td>
+                                <td class="{{ sc2_tint_level(replenishable_magazine_vulture_level) }}">{{ sc2_progressive_icon_with_custom_name('Progressive Replenishable Magazine (Vulture)', replenishable_magazine_vulture_url, replenishable_magazine_vulture_name) }}</td>
                                 <td>{{ sc2_icon('Ion Thrusters (Vulture)') }}</td>
                                 <td>{{ sc2_icon('Auto Launchers (Vulture)') }}</td>
                                 <td>{{ sc2_icon('Auto-Repair (Vulture)') }}</td>


### PR DESCRIPTION
## What is this fixing or adding?
Fixes both levels of `Replenishable Magazine (Vulture) ` having the same icon without any visual distinction in the tracker

## How was this tested?
Ran the webhost and looked at the result (see screenshot)

## If this makes graphical changes, please attach screenshots.
![Snímek obrazovky pořízený 2024-03-18 22-44-21](https://github.com/ArchipelagoMW/Archipelago/assets/3447808/86839c70-6f85-4945-8c16-9f9f05f55cd5)
