### PR TITLE
LADX: fix local and non-local instrument placement

### DIFF
--- a/worlds/ladx/__init__.py
+++ b/worlds/ladx/__init__.py
@@ -184,19 +184,21 @@ class LinksAwakeningWorld(World):
         self.pre_fill_items = []
         # For any and different world, set item rule instead
         
-        for option in ["maps", "compasses", "small_keys", "nightmare_keys", "stone_beaks", "instruments"]:
-            option = "shuffle_" + option
+        for dungeon_item_type in ["maps", "compasses", "small_keys", "nightmare_keys", "stone_beaks", "instruments"]:
+            option = "shuffle_" + dungeon_item_type
             option = self.player_options[option]
 
             dungeon_item_types[option.ladxr_item] = option.value
 
+            num_items = 9 if dungeon_item_type == "instruments" else 10
+
             if option.value == DungeonItemShuffle.option_own_world:
                 self.multiworld.local_items[self.player].value |= {
-                    ladxr_item_to_la_item_name[f"{option.ladxr_item}{i}"] for i in range(1, 10)
+                    ladxr_item_to_la_item_name[f"{option.ladxr_item}{i}"] for i in range(1, num_items)
                 }
             elif option.value == DungeonItemShuffle.option_different_world:
                 self.multiworld.non_local_items[self.player].value |= {
-                    ladxr_item_to_la_item_name[f"{option.ladxr_item}{i}"] for i in range(1, 10)
+                    ladxr_item_to_la_item_name[f"{option.ladxr_item}{i}"] for i in range(1, num_items)
                 }
         # option_original_dungeon = 0
         # option_own_dungeons = 1

--- a/worlds/ladx/__init__.py
+++ b/worlds/ladx/__init__.py
@@ -190,15 +190,16 @@ class LinksAwakeningWorld(World):
 
             dungeon_item_types[option.ladxr_item] = option.value
 
-            num_items = 9 if dungeon_item_type == "instruments" else 10
+            # The color dungeon does not contain an instrument
+            num_items = 8 if dungeon_item_type == "instruments" else 9
 
             if option.value == DungeonItemShuffle.option_own_world:
                 self.multiworld.local_items[self.player].value |= {
-                    ladxr_item_to_la_item_name[f"{option.ladxr_item}{i}"] for i in range(1, num_items)
+                    ladxr_item_to_la_item_name[f"{option.ladxr_item}{i}"] for i in range(1, num_items + 1)
                 }
             elif option.value == DungeonItemShuffle.option_different_world:
                 self.multiworld.non_local_items[self.player].value |= {
-                    ladxr_item_to_la_item_name[f"{option.ladxr_item}{i}"] for i in range(1, num_items)
+                    ladxr_item_to_la_item_name[f"{option.ladxr_item}{i}"] for i in range(1, num_items + 1)
                 }
         # option_original_dungeon = 0
         # option_own_dungeons = 1


### PR DESCRIPTION
## What is this fixing or adding?

This fixes failure to generate when `instrument_shuffle` is set to `own_world` or `different_world`.
Before https://github.com/ArchipelagoMW/Archipelago/pull/2804 got merged, instruments were not a shuffleable dungeon item and the code assumed there is a dungeon item of each kind for each dungeon. However, there is no instrument in D0, so this assumption does not hold anymore.
This PR adds instruments as exception to the rule.

Original bug report:
https://discord.com/channels/731205301247803413/1219301554654548109

## How was this tested?
I verified that the world generates with both settings and checked the spoiler log to verify that the instruments are placed accordingly.

## If this makes graphical changes, please attach screenshots.
n/a