### PR TITLE
Docs: Mention the "last received item index" paradigm in the network protocol docs

### DIFF
--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -32,7 +32,7 @@ There are also a number of community-supported libraries available that implemen
 
 ## Synchronizing Items
 After a client connects, it will receive all previously collected items for its associated slot in a [ReceivedItems](#ReceivedItems) packet. This will include items the client may have already processed in a previous play session.  
-To ensure the client is able to reject those items if it needs to, each item in the packet will have an associated `index` argument. You will need to find a way to save the "last processed item index" to the player's local savegame, a local file, or something to that effect. Before connecting, you should load that "last processed item index" value and compare against it in your received items handling.
+To ensure the client is able to reject those items if it needs to, each item in the packet has an associated `index` argument. You will need to find a way to save the "last processed item index" to the player's local savegame, a local file, or something to that effect. Before connecting, you should load that "last processed item index" value and compare against it in your received items handling.
 
 When the client receives a [ReceivedItems](#ReceivedItems) packet, if the `index` argument does not match the next index that the client expects then it is expected that the client will re-sync items with the server. This can be accomplished by sending the server a [Sync](#Sync) packet and then a [LocationChecks](#LocationChecks) packet.
 

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -31,7 +31,7 @@ There are also a number of community-supported libraries available that implemen
 | GameMaker: Studio 2.x+        | [see Discord](https://discord.com/channels/731205301247803413/1166418532519653396)                 |                                                                                 |
 
 ## Synchronizing Items
-After a client connects, it will receive all previously collected items for its associated slot in a [ReceivedItems](#ReceivedItems) packet. This will include items the client may already have processed in a previous play session.
+After a client connects, it will receive all previously collected items for its associated slot in a [ReceivedItems](#ReceivedItems) packet. This will include items the client may already have processed in a previous play session.  
 To ensure the client is able to reject those items if it needs to, each item in the packet will have an associated `index` argument. You will need to find a way to save the "last processed item index" to the player's local savegame, a local file, or something to that effect. Before connecting, you should load that "last processed item index" value and compare against it in your received items handling.
 
 When the client receives a [ReceivedItems](#ReceivedItems) packet, if the `index` argument does not match the next index that the client expects then it is expected that the client will re-sync items with the server. This can be accomplished by sending the server a [Sync](#Sync) packet and then a [LocationChecks](#LocationChecks) packet.

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -32,7 +32,7 @@ There are also a number of community-supported libraries available that implemen
 
 ## Synchronizing Items
 After a client connects, it will receive all previously collected items for its associated slot in a [ReceivedItems](#ReceivedItems) packet. This will include items the client may already have processed in a previous play session.
-To make it possible to reject those items if the client shouldn't process them again, each item in the packet will have an associated `index` argument. You will need to find a way to save the "last processed item index" to the player's local savegame, a local file, or something to that effect. Before connecting, you should load that "last processed item index" value and compare against it in your received items handling.
+To ensure the client is able to reject those items if it needs to, each item in the packet will have an associated `index` argument. You will need to find a way to save the "last processed item index" to the player's local savegame, a local file, or something to that effect. Before connecting, you should load that "last processed item index" value and compare against it in your received items handling.
 
 When the client receives a [ReceivedItems](#ReceivedItems) packet, if the `index` argument does not match the next index that the client expects then it is expected that the client will re-sync items with the server. This can be accomplished by sending the server a [Sync](#Sync) packet and then a [LocationChecks](#LocationChecks) packet.
 

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -31,6 +31,9 @@ There are also a number of community-supported libraries available that implemen
 | GameMaker: Studio 2.x+        | [see Discord](https://discord.com/channels/731205301247803413/1166418532519653396)                 |                                                                                 |
 
 ## Synchronizing Items
+After a client connects, it will receive all previously collected items for its associated slot in a [ReceivedItems](#ReceivedItems) packet. This will include items the client may already have processed in a previous play session.
+To make it possible to reject those items if the client shouldn't process them again, each item in the packet will have an associated `index` argument. You will need to find a way to save the "last processed item index" to the player's local savegame, a local file, or something to that effect. Before connecting, you should load that "last processed item index" value and compare against it in your received items handling.
+
 When the client receives a [ReceivedItems](#ReceivedItems) packet, if the `index` argument does not match the next index that the client expects then it is expected that the client will re-sync items with the server. This can be accomplished by sending the server a [Sync](#Sync) packet and then a [LocationChecks](#LocationChecks) packet.
 
 Even if the client detects a desync, it can still accept the items provided in this packet to prevent gameplay interruption.

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -31,7 +31,7 @@ There are also a number of community-supported libraries available that implemen
 | GameMaker: Studio 2.x+        | [see Discord](https://discord.com/channels/731205301247803413/1166418532519653396)                 |                                                                                 |
 
 ## Synchronizing Items
-After a client connects, it will receive all previously collected items for its associated slot in a [ReceivedItems](#ReceivedItems) packet. This will include items the client may already have processed in a previous play session.  
+After a client connects, it will receive all previously collected items for its associated slot in a [ReceivedItems](#ReceivedItems) packet. This will include items the client may have already processed in a previous play session.  
 To ensure the client is able to reject those items if it needs to, each item in the packet will have an associated `index` argument. You will need to find a way to save the "last processed item index" to the player's local savegame, a local file, or something to that effect. Before connecting, you should load that "last processed item index" value and compare against it in your received items handling.
 
 When the client receives a [ReceivedItems](#ReceivedItems) packet, if the `index` argument does not match the next index that the client expects then it is expected that the client will re-sync items with the server. This can be accomplished by sending the server a [Sync](#Sync) packet and then a [LocationChecks](#LocationChecks) packet.


### PR DESCRIPTION
It has happened multiple times recently that people get to the `Sync` portion of the network docs and get completely misled about what they should do to handle asynchronous play / multiple play sessions.

I think that "what you actually have to do" should be more front and center in this section of the doc.

Not a native, this could probably be written better in a multitude of ways.

Proof that this is confusing for people:
https://discord.com/channels/731205301247803413/1214608557077700720/1219457896509865985
https://discord.com/channels/731205301247803413/1214608557077700720/1217287203835871372