### PR TITLE
Stardew valley: Game version documentation

### DIFF
--- a/worlds/stardew_valley/docs/en_Stardew Valley.md
+++ b/worlds/stardew_valley/docs/en_Stardew Valley.md
@@ -81,22 +81,17 @@ For the locations which do not include a normal reward, Resource Packs and traps
 
 A player can enable some options that will add some items to the pool that are relevant to progression
 - Seasons Randomizer:
-  * All 4 seasons will be items, and one of them will be selected randomly and be added to the player's start inventory. 
-  * At the end of each month, the player can choose the next season, instead of following the vanilla season order. On 
-Seasons Randomizer, they can only choose from the seasons they have received.
+    - All 4 seasons will be items, and one of them will be selected randomly and be added to the player's start inventory. 
+    - At the end of each month, the player can choose the next season, instead of following the vanilla season order. On Seasons Randomizer, they can only choose from the seasons they have received.
 - Cropsanity:
-  * Every single seed in the game starts off locked and cannot be purchased from any merchant. Their unlocks are received 
-  as multiworld items. Growing each seed and harvesting the resulting crop sends a location check
-  * The way merchants sell seeds is considerably changed. Pierre sells fewer seeds at a high price, while Joja sells 
-  unlimited seeds but in huge discount packs, not individually.
+    - Every single seed in the game starts off locked and cannot be purchased from any merchant. Their unlocks are received as multiworld items. Growing each seed and harvesting the resulting crop sends a location check
+    - The way merchants sell seeds is considerably changed. Pierre sells fewer seeds at a high price, while Joja sells unlimited seeds but in huge discount packs, not individually.
 - Museumsanity:
-  * The items that are normally obtained from museum donation milestones are added to the item pool. Some items, like the 
-  magic rock candy, are duplicated for convenience.
-  * The Traveling Merchant now sells artifacts and minerals, with a bias towards undonated ones, to mitigate randomness. 
-  She will sell these items as the player receives "Traveling Merchant Metal Detector" items.
+    - The items that are normally obtained from museum donation milestones are added to the item pool. Some items, like the magic rock candy, are duplicated for convenience.
+    - The Traveling Merchant now sells artifacts and minerals, with a bias towards undonated ones, to mitigate randomness. She will sell these items as the player receives "Traveling Merchant Metal Detector" items.
 - TV Channels
 - Babies
-  * Only if Friendsanity is enabled
+    - Only if Friendsanity is enabled
 
 There are a few extra vanilla items, which are added to the pool for convenience, but do not have a matching location. These include
 - [Wizard Buildings](https://stardewvalleywiki.com/Wizard%27s_Tower#Buildings)
@@ -135,32 +130,32 @@ for these mods, the specifics will vary from mod to mod
 List of supported mods:
 
 - General
-  * [Stardew Valley Expanded](https://www.nexusmods.com/stardewvalley/mods/3753)
-  * [DeepWoods](https://www.nexusmods.com/stardewvalley/mods/2571)
-  * [Skull Cavern Elevator](https://www.nexusmods.com/stardewvalley/mods/963)
-  * [Bigger Backpack](https://www.nexusmods.com/stardewvalley/mods/1845)
-  * [Tractor Mod](https://www.nexusmods.com/stardewvalley/mods/1401)
-  * [Distant Lands - Witch Swamp Overhaul](https://www.nexusmods.com/stardewvalley/mods/18109)
+    - [Stardew Valley Expanded](https://www.nexusmods.com/stardewvalley/mods/3753)
+    - [DeepWoods](https://www.nexusmods.com/stardewvalley/mods/2571)
+    - [Skull Cavern Elevator](https://www.nexusmods.com/stardewvalley/mods/963)
+    - [Bigger Backpack](https://www.nexusmods.com/stardewvalley/mods/1845)
+    - [Tractor Mod](https://www.nexusmods.com/stardewvalley/mods/1401)
+    - [Distant Lands - Witch Swamp Overhaul](https://www.nexusmods.com/stardewvalley/mods/18109)
 - Skills
-  * [Magic](https://www.nexusmods.com/stardewvalley/mods/2007)
-  * [Luck Skill](https://www.nexusmods.com/stardewvalley/mods/521)
-  * [Socializing Skill](https://www.nexusmods.com/stardewvalley/mods/14142)
-  * [Archaeology](https://www.nexusmods.com/stardewvalley/mods/15793)
-  * [Cooking Skill](https://www.nexusmods.com/stardewvalley/mods/522)
-  * [Binning Skill](https://www.nexusmods.com/stardewvalley/mods/14073)
+    - [Magic](https://www.nexusmods.com/stardewvalley/mods/2007)
+    - [Luck Skill](https://www.nexusmods.com/stardewvalley/mods/521)
+    - [Socializing Skill](https://www.nexusmods.com/stardewvalley/mods/14142)
+    - [Archaeology](https://www.nexusmods.com/stardewvalley/mods/15793)
+    - [Cooking Skill](https://www.nexusmods.com/stardewvalley/mods/522)
+    - [Binning Skill](https://www.nexusmods.com/stardewvalley/mods/14073)
 - NPCs
-  * [Ayeisha - The Postal Worker (Custom NPC)](https://www.nexusmods.com/stardewvalley/mods/6427)
-  * [Mister Ginger (cat npc)](https://www.nexusmods.com/stardewvalley/mods/5295)
-  * [Juna - Roommate NPC](https://www.nexusmods.com/stardewvalley/mods/8606)
-  * [Professor Jasper Thomas](https://www.nexusmods.com/stardewvalley/mods/5599)
-  * [Alec Revisited](https://www.nexusmods.com/stardewvalley/mods/10697)
-  * [Custom NPC - Yoba](https://www.nexusmods.com/stardewvalley/mods/14871)
-  * [Custom NPC Eugene](https://www.nexusmods.com/stardewvalley/mods/9222)
-  * ['Prophet' Wellwick](https://www.nexusmods.com/stardewvalley/mods/6462)
-  * [Shiko - New Custom NPC](https://www.nexusmods.com/stardewvalley/mods/3732)
-  * [Delores - Custom NPC](https://www.nexusmods.com/stardewvalley/mods/5510)
-  * [Custom NPC - Riley](https://www.nexusmods.com/stardewvalley/mods/5811)
-  * [Alecto the Witch](https://www.nexusmods.com/stardewvalley/mods/10671)
+    - [Ayeisha - The Postal Worker (Custom NPC)](https://www.nexusmods.com/stardewvalley/mods/6427)
+    - [Mister Ginger (cat npc)](https://www.nexusmods.com/stardewvalley/mods/5295)
+    - [Juna - Roommate NPC](https://www.nexusmods.com/stardewvalley/mods/8606)
+    - [Professor Jasper Thomas](https://www.nexusmods.com/stardewvalley/mods/5599)
+    - [Alec Revisited](https://www.nexusmods.com/stardewvalley/mods/10697)
+    - [Custom NPC - Yoba](https://www.nexusmods.com/stardewvalley/mods/14871)
+    - [Custom NPC Eugene](https://www.nexusmods.com/stardewvalley/mods/9222)
+    - ['Prophet' Wellwick](https://www.nexusmods.com/stardewvalley/mods/6462)
+    - [Shiko - New Custom NPC](https://www.nexusmods.com/stardewvalley/mods/3732)
+    - [Delores - Custom NPC](https://www.nexusmods.com/stardewvalley/mods/5510)
+    - [Custom NPC - Riley](https://www.nexusmods.com/stardewvalley/mods/5811)
+    - [Alecto the Witch](https://www.nexusmods.com/stardewvalley/mods/10671)
   
 Some of these mods might need a patch mod to tie the randomizer with the mod. These can be found 
 [here](https://github.com/Witchybun/SDV-Randomizer-Content-Patcher/releases)

--- a/worlds/stardew_valley/docs/setup_en.md
+++ b/worlds/stardew_valley/docs/setup_en.md
@@ -20,7 +20,7 @@
     * The more unsupported mods you have, and the bigger they are, the more likely things are to break.
 
 ## Notes About Game Versions
-The randomizer is built for a specific version of Stardew Valley. When a new version gets released, we will try our best to support it as fast as possible, but we can't make promises.
+The randomizer is built for a specific version of Stardew Valley. When a new version gets released, we will try our best to support it as fast as possible, but we can't make any promises.
 
 You may need to downgrade your game in order to play Archipelago when Stardew Valley itself has had a recent update.
 

--- a/worlds/stardew_valley/docs/setup_en.md
+++ b/worlds/stardew_valley/docs/setup_en.md
@@ -20,7 +20,7 @@
     * The more unsupported mods you have, and the bigger they are, the more likely things are to break.
 
 ## Notes About Game Versions
-The randomizer is built for a specific version of Stardew Valley. When a new version gets released, we will try our best to support it as fast as possible, but can't make promises.
+The randomizer is built for a specific version of Stardew Valley. When a new version gets released, we will try our best to support it as fast as possible, but we can't make promises.
 
 You may need to downgrade your game in order to play Archipelago when Stardew Valley itself has had a recent update.
 

--- a/worlds/stardew_valley/docs/setup_en.md
+++ b/worlds/stardew_valley/docs/setup_en.md
@@ -3,7 +3,11 @@
 ## Required Software
 
 - Stardew Valley on PC (Recommended: [Steam version](https://store.steampowered.com/app/413150/Stardew_Valley/))
-- SMAPI ([Mod loader for Stardew Valley](https://smapi.io/))
+    - You need version 1.5.6. It is available in a public beta branch on Steam ![image](https://i.imgur.com/uKAUmF0.png).
+    - If your Stardew is not on Steam, you are responsible for finding a way to downgrade it.
+    - This measure is temporary. We are working hard to bring the mod to Stardew 1.6 as soon as possible.
+- SMAPI 3.x.x ([Mod loader for Stardew Valley](https://www.nexusmods.com/stardewvalley/mods/2400?tab=files))
+    - Same as Stardew Valley itself, SMAPI needs a slightly older version to be compatible with Stardew Valley 1.5.6 ![image](https://i.imgur.com/kzgObHy.png)
 - [StardewArchipelago Mod Release 5.x.x](https://github.com/agilbert1412/StardewArchipelago/releases)
     - It is important to use a mod release of version 5.x.x to play seeds that have been generated here. Later releases 
   can only be used with later releases of the world generator, that are not hosted on archipelago.gg yet.
@@ -18,13 +22,6 @@
     * It is **not** recommended to further mod Stardew Valley with unsupported mods, although it is possible to do so. 
   Mod interactions can be unpredictable, and no support will be offered for related bugs.
     * The more unsupported mods you have, and the bigger they are, the more likely things are to break.
-
-## Notes About Game Versions
-The randomizer is built for a specific version of Stardew Valley. When a new version gets released, we will try our best to support it as fast as possible, but we can't make any promises.
-
-You may need to downgrade your game in order to play Archipelago when Stardew Valley itself has had a recent update.
-
-The SMAPI mod will tell you what version is currently supported. If you are having trouble, feel free to join the Archipelago Discord to ask for assistance.
 
 ## Configuring your YAML file
 

--- a/worlds/stardew_valley/docs/setup_en.md
+++ b/worlds/stardew_valley/docs/setup_en.md
@@ -19,6 +19,13 @@
   Mod interactions can be unpredictable, and no support will be offered for related bugs.
     * The more unsupported mods you have, and the bigger they are, the more likely things are to break.
 
+## Notes About Game Versions
+The randomizer is built for a specific version of Stardew Valley. When a new version gets released, we will try our best to support it as fast as possible, but can't make promises.
+
+You may need to downgrade your game in order to play Archipelago when Stardew Valley itself has had a recent update.
+
+The SMAPI mod will tell you what version is currently supported.
+
 ## Configuring your YAML file
 
 ### What is a YAML file and why do I need one?
@@ -37,8 +44,7 @@ You can customize your options by visiting the [Stardew Valley Player Options Pa
 - Install [SMAPI](https://smapi.io/) by following the instructions on their website
 - Download and extract the [StardewArchipelago](https://github.com/agilbert1412/StardewArchipelago/releases) mod into 
 your Stardew Valley "Mods" folder
-- *OPTIONAL*: If you want to launch your game through Steam, add the following to your Stardew Valley launch options:
-    - "[PATH TO STARDEW VALLEY]\Stardew Valley\StardewModdingAPI.exe" %command%
+- *OPTIONAL*: If you want to launch your game through Steam, add the following to your Stardew Valley launch options: `"[PATH TO STARDEW VALLEY]\Stardew Valley\StardewModdingAPI.exe" %command%`
 - Otherwise just launch "StardewModdingAPI.exe" in your installation folder directly
 - Stardew Valley should launch itself alongside a console which allows you to read mod information and interact with some of them.
 

--- a/worlds/stardew_valley/docs/setup_en.md
+++ b/worlds/stardew_valley/docs/setup_en.md
@@ -24,7 +24,7 @@ The randomizer is built for a specific version of Stardew Valley. When a new ver
 
 You may need to downgrade your game in order to play Archipelago when Stardew Valley itself has had a recent update.
 
-The SMAPI mod will tell you what version is currently supported.
+The SMAPI mod will tell you what version is currently supported. If you are having trouble, feel free to join the Archipelago Discord to ask for assistance.
 
 ## Configuring your YAML file
 

--- a/worlds/stardew_valley/docs/setup_en.md
+++ b/worlds/stardew_valley/docs/setup_en.md
@@ -38,7 +38,7 @@ You can customize your options by visiting the [Stardew Valley Player Options Pa
 
 ### Installing the mod
 
-- Install [SMAPI](https://smapi.io/) by following the instructions on their website
+- Install [SMAPI version 3.x.x](https://www.nexusmods.com/stardewvalley/mods/2400?tab=files) by following the instructions on the mod page
 - Download and extract the [StardewArchipelago](https://github.com/agilbert1412/StardewArchipelago/releases) mod into 
 your Stardew Valley "Mods" folder
 - *OPTIONAL*: If you want to launch your game through Steam, add the following to your Stardew Valley launch options: `"[PATH TO STARDEW VALLEY]\Stardew Valley\StardewModdingAPI.exe" %command%`

--- a/worlds/stardew_valley/options.py
+++ b/worlds/stardew_valley/options.py
@@ -197,7 +197,7 @@ class Cropsanity(Choice):
     """Formerly named "Seed Shuffle"
     Pierre now sells a random amount of seasonal seeds and Joja sells them without season requirements, but only in huge packs.
     Disabled: All the seeds are unlocked from the start, there are no location checks for growing and harvesting crops
-    Shuffled: Seeds are unlocked as archipelago items, for each seed there is a location check for growing and harvesting that crop
+    Enabled: Seeds are unlocked as archipelago items, for each seed there is a location check for growing and harvesting that crop
     """
     internal_name = "cropsanity"
     display_name = "Cropsanity"


### PR DESCRIPTION
## What is this fixing or adding?
With the 1.6 release of the game on Steam soon, the game needs to be downgraded on Steam to work for Archipelago. It will  be a huge source of tech support requests if not specified, so I added documentation about downgrading to the correct version, for 5.x.x
When 6.x.x releases, and downgrading is no longer required, this section will be removed
I also fixed the indent on some existing documentation in the game page

## How was this tested?
It's documentation

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/16685738/1ea00bc5-db3b-472e-9b2e-1e00e5fd49f3)

![image](https://github.com/ArchipelagoMW/Archipelago/assets/16685738/4b7297b8-ed0f-4300-9005-30a49dae9295)
