### PR TITLE
SC2 Tracker: Fix grouped items pointing at wrong item IDs

### DIFF
--- a/WebHostLib/tracker.py
+++ b/WebHostLib/tracker.py
@@ -2333,12 +2333,12 @@ if "Starcraft 2" in network_data_package["games"]:
             "Progressive Zerg Armor Upgrade":           106 + SC2HOTS_ITEM_ID_OFFSET,
             "Progressive Zerg Ground Upgrade":          107 + SC2HOTS_ITEM_ID_OFFSET,
             "Progressive Zerg Flyer Upgrade":           108 + SC2HOTS_ITEM_ID_OFFSET,
-            "Progressive Zerg Weapon/Armor Upgrade":    109 + SC2WOL_ITEM_ID_OFFSET,
-            "Progressive Protoss Weapon Upgrade":       105 + SC2HOTS_ITEM_ID_OFFSET,
-            "Progressive Protoss Armor Upgrade":        106 + SC2HOTS_ITEM_ID_OFFSET,
-            "Progressive Protoss Ground Upgrade":       107 + SC2HOTS_ITEM_ID_OFFSET,
-            "Progressive Protoss Air Upgrade":          108 + SC2HOTS_ITEM_ID_OFFSET,
-            "Progressive Protoss Weapon/Armor Upgrade": 109 + SC2WOL_ITEM_ID_OFFSET,
+            "Progressive Zerg Weapon/Armor Upgrade":    109 + SC2HOTS_ITEM_ID_OFFSET,
+            "Progressive Protoss Weapon Upgrade":       105 + SC2LOTV_ITEM_ID_OFFSET,
+            "Progressive Protoss Armor Upgrade":        106 + SC2LOTV_ITEM_ID_OFFSET,
+            "Progressive Protoss Ground Upgrade":       107 + SC2LOTV_ITEM_ID_OFFSET,
+            "Progressive Protoss Air Upgrade":          108 + SC2LOTV_ITEM_ID_OFFSET,
+            "Progressive Protoss Weapon/Armor Upgrade": 109 + SC2LOTV_ITEM_ID_OFFSET,
         }
         grouped_item_replacements = {
             "Progressive Terran Weapon Upgrade":   ["Progressive Terran Infantry Weapon",


### PR DESCRIPTION
## What is this fixing or adding?
This fixes some wrong item IDs that caused some SC2 options to not show certain received items on the tracker.

## How was this tested?
Running the webhost locally and comparing the tracker on a /collect-ed world.

## If this makes graphical changes, please attach screenshots.
![firefox_fmO2heGmtq](https://github.com/ArchipelagoMW/Archipelago/assets/30208051/5235825a-8f10-44cd-8ba0-9517662d0a4a)
This is from a world with the option `generic_upgrade_items: bundle_all`. Previously the center and right columns were blank.
