### PR TITLE
TUNIC: Add link to AP plando guide to connection plando section of game page

### DIFF
--- a/worlds/tunic/docs/en_TUNIC.md
+++ b/worlds/tunic/docs/en_TUNIC.md
@@ -86,3 +86,5 @@ Notes:
 - There is no limit to the number of Shops hard-coded into place.
 - If you have more than one shop in a scene, you may be wrong warped when exiting a shop.
 - If you have a shop in every scene, and you have an odd number of shops, it will error out.
+
+If you are unsure of what Connection Plando is, please see the [Archipelago Plando Guide](https://archipelago.gg/tutorial/Archipelago/plando/en).

--- a/worlds/tunic/docs/en_TUNIC.md
+++ b/worlds/tunic/docs/en_TUNIC.md
@@ -87,4 +87,4 @@ Notes:
 - If you have more than one shop in a scene, you may be wrong warped when exiting a shop.
 - If you have a shop in every scene, and you have an odd number of shops, it will error out.
 
-If you are unsure of what Connection Plando is, please see the [Archipelago Plando Guide](https://archipelago.gg/tutorial/Archipelago/plando/en).
+See the [Archipelago Plando Guide](https://archipelago.gg/tutorial/Archipelago/plando/en) for more information on Plando and Connection Plando.

--- a/worlds/tunic/docs/en_TUNIC.md
+++ b/worlds/tunic/docs/en_TUNIC.md
@@ -87,4 +87,4 @@ Notes:
 - If you have more than one shop in a scene, you may be wrong warped when exiting a shop.
 - If you have a shop in every scene, and you have an odd number of shops, it will error out.
 
-See the [Archipelago Plando Guide](https://archipelago.gg/tutorial/Archipelago/plando/en) for more information on Plando and Connection Plando.
+See the [Archipelago Plando Guide](../../../tutorial/Archipelago/plando/en) for more information on Plando and Connection Plando.


### PR DESCRIPTION
## What is this fixing or adding?
Adds a link to the AP plando guide to the bottom of the "does this game support connection plando?" section of the Tunic game page.

## How was this tested?
Reading.

## If this makes graphical changes, please attach screenshots.
N/A