### PR TITLE
Stardew valley: Emergency 1.6 fixes

### DIFF
--- a/worlds/stardew_valley/data/craftable_data.py
+++ b/worlds/stardew_valley/data/craftable_data.py
@@ -222,7 +222,10 @@ iron_lamp_post = shop_recipe(Lighting.iron_lamp_post, Region.carpenter, 1000, {M
 jack_o_lantern = festival_shop_recipe(Lighting.jack_o_lantern, Region.spirit_eve, 2000, {Vegetable.pumpkin: 1, Lighting.torch: 1})
 
 bone_mill = special_order_recipe(Machine.bone_mill, SpecialOrder.fragments_of_the_past, {Fossil.bone_fragment: 10, Material.clay: 3, Material.stone: 20})
+
+# 1.6 went from 4 to 2. Keep highest requirement for now. Update properly later
 charcoal_kiln = skill_recipe(Machine.charcoal_kiln, Skill.foraging, 4, {Material.wood: 20, MetalBar.copper: 2})
+
 crystalarium = skill_recipe(Machine.crystalarium, Skill.mining, 9, {Material.stone: 99, MetalBar.gold: 5, MetalBar.iridium: 2, ArtisanGood.battery_pack: 1})
 furnace = skill_recipe(Machine.furnace, Skill.mining, 1, {Ore.copper: 20, Material.stone: 25})
 geode_crusher = special_order_recipe(Machine.geode_crusher, SpecialOrder.cave_patrol, {MetalBar.gold: 2, Material.stone: 50, Mineral.diamond: 1})
@@ -234,7 +237,11 @@ seed_maker = skill_recipe(Machine.seed_maker, Skill.farming, 9, {Material.wood: 
 slime_egg_press = skill_recipe(Machine.slime_egg_press, Skill.combat, 6, {Material.coal: 25, Mineral.fire_quartz: 1, ArtisanGood.battery_pack: 1})
 slime_incubator = skill_recipe(Machine.slime_incubator, Skill.combat, 8, {MetalBar.iridium: 2, Loot.slime: 100})
 solar_panel = special_order_recipe(Machine.solar_panel, SpecialOrder.island_ingredients, {MetalBar.quartz: 10, MetalBar.iron: 5, MetalBar.gold: 5})
-tapper = skill_recipe(Machine.tapper, Skill.foraging, 3, {Material.wood: 40, MetalBar.copper: 2})
+
+# 1.6 went from 3 to 4. Keep highest requirement for now. Update properly later
+tapper = skill_recipe(Machine.tapper, Skill.foraging, 4, {Material.wood: 40, MetalBar.copper: 2})
+
+# 1.6 went from 8 to 4. Keep highest requirement for now. Update properly later
 worm_bin = skill_recipe(Machine.worm_bin, Skill.fishing, 8, {Material.hardwood: 25, MetalBar.gold: 1, MetalBar.iron: 1, Material.fiber: 50})
 
 tub_o_flowers = festival_shop_recipe(Furniture.tub_o_flowers, Region.flower_dance, 2000, {Material.wood: 15, Seed.tulip: 1, Seed.jazz: 1, Seed.poppy: 1, Seed.spangle: 1})
@@ -260,6 +267,8 @@ mini_jukebox = cutscene_recipe(Craftable.mini_jukebox, Region.saloon, NPC.gus, 5
 mini_obelisk = special_order_recipe(Craftable.mini_obelisk, SpecialOrder.a_curious_substance, {Material.hardwood: 30, Loot.solar_essence: 20, MetalBar.gold: 3})
 farm_computer = special_order_recipe(Craftable.farm_computer, SpecialOrder.aquatic_overpopulation, {Artifact.dwarf_gadget: 1, ArtisanGood.battery_pack: 1, MetalBar.quartz: 10})
 hopper = ap_recipe(Craftable.hopper, {Material.hardwood: 10, MetalBar.iridium: 1, MetalBar.radioactive: 1})
+
+# 1.6 went from 9 to 3. Keep highest requirement for now. Update properly later
 cookout_kit = skill_recipe(Craftable.cookout_kit, Skill.foraging, 9, {Material.wood: 15, Material.fiber: 10, Material.coal: 3})
 
 travel_charm = shop_recipe(ModCraftable.travel_core, Region.adventurer_guild, 250, {Loot.solar_essence: 1, Loot.void_essence: 1}, ModNames.magic)

--- a/worlds/stardew_valley/data/craftable_data.py
+++ b/worlds/stardew_valley/data/craftable_data.py
@@ -143,9 +143,9 @@ basic_fertilizer = skill_recipe(Fertilizer.basic, Skill.farming, 1, {Material.sa
 quality_fertilizer = skill_recipe(Fertilizer.quality, Skill.farming, 9, {Material.sap: 4, Fish.any: 1})
 deluxe_fertilizer = ap_recipe(Fertilizer.deluxe, {MetalBar.iridium: 1, Material.sap: 40})
 
-# 1.6 went changed from clam to moss. Keep both requirements for now. Update properly later
+# 1.6 changed from clam to moss. Keep both requirements for now. Update properly later
 basic_speed_gro = skill_recipe(SpeedGro.basic, Skill.farming, 3, {ArtisanGood.pine_tar: 1, Fish.clam: 1, Material.moss: 5})
-# 1.6 went changed from coral to bone fragments. Keep both requirements for now. Update properly later
+# 1.6 changed from coral to bone fragments. Keep both requirements for now. Update properly later
 deluxe_speed_gro = skill_recipe(SpeedGro.deluxe, Skill.farming, 8, {ArtisanGood.oak_resin: 1, WaterItem.coral: 1, Fossil.bone_fragment: 5})
 hyper_speed_gro = ap_recipe(SpeedGro.hyper, {Ore.radioactive: 1, Fossil.bone_fragment: 3, Loot.solar_essence: 1})
 basic_retaining_soil = skill_recipe(RetainingSoil.basic, Skill.farming, 4, {Material.stone: 2})
@@ -228,7 +228,7 @@ jack_o_lantern = festival_shop_recipe(Lighting.jack_o_lantern, Region.spirit_eve
 
 bone_mill = special_order_recipe(Machine.bone_mill, SpecialOrder.fragments_of_the_past, {Fossil.bone_fragment: 10, Material.clay: 3, Material.stone: 20})
 
-# 1.6 went from 4 to 2. Keep highest requirement for now. Update properly later
+# 1.6 changed from 4 to 2. Keep highest requirement for now. Update properly later
 charcoal_kiln = skill_recipe(Machine.charcoal_kiln, Skill.foraging, 4, {Material.wood: 20, MetalBar.copper: 2})
 
 crystalarium = skill_recipe(Machine.crystalarium, Skill.mining, 9, {Material.stone: 99, MetalBar.gold: 5, MetalBar.iridium: 2, ArtisanGood.battery_pack: 1})
@@ -243,10 +243,10 @@ slime_egg_press = skill_recipe(Machine.slime_egg_press, Skill.combat, 6, {Materi
 slime_incubator = skill_recipe(Machine.slime_incubator, Skill.combat, 8, {MetalBar.iridium: 2, Loot.slime: 100})
 solar_panel = special_order_recipe(Machine.solar_panel, SpecialOrder.island_ingredients, {MetalBar.quartz: 10, MetalBar.iron: 5, MetalBar.gold: 5})
 
-# 1.6 went from 3 to 4. Keep highest requirement for now. Update properly later
+# 1.6 changed from 3 to 4. Keep highest requirement for now. Update properly later
 tapper = skill_recipe(Machine.tapper, Skill.foraging, 4, {Material.wood: 40, MetalBar.copper: 2})
 
-# 1.6 went from 8 to 4. Keep highest requirement for now. Update properly later
+# 1.6 changed from 8 to 4. Keep highest requirement for now. Update properly later
 worm_bin = skill_recipe(Machine.worm_bin, Skill.fishing, 8, {Material.hardwood: 25, MetalBar.gold: 1, MetalBar.iron: 1, Material.fiber: 50})
 
 tub_o_flowers = festival_shop_recipe(Furniture.tub_o_flowers, Region.flower_dance, 2000, {Material.wood: 15, Seed.tulip: 1, Seed.jazz: 1, Seed.poppy: 1, Seed.spangle: 1})
@@ -273,7 +273,7 @@ mini_obelisk = special_order_recipe(Craftable.mini_obelisk, SpecialOrder.a_curio
 farm_computer = special_order_recipe(Craftable.farm_computer, SpecialOrder.aquatic_overpopulation, {Artifact.dwarf_gadget: 1, ArtisanGood.battery_pack: 1, MetalBar.quartz: 10})
 hopper = ap_recipe(Craftable.hopper, {Material.hardwood: 10, MetalBar.iridium: 1, MetalBar.radioactive: 1})
 
-# 1.6 went from 9 to 3. Keep highest requirement for now. Update properly later
+# 1.6 changed from 9 to 3. Keep highest requirement for now. Update properly later
 cookout_kit = skill_recipe(Craftable.cookout_kit, Skill.foraging, 9, {Material.wood: 15, Material.fiber: 10, Material.coal: 3})
 
 travel_charm = shop_recipe(ModCraftable.travel_core, Region.adventurer_guild, 250, {Loot.solar_essence: 1, Loot.void_essence: 1}, ModNames.magic)

--- a/worlds/stardew_valley/data/craftable_data.py
+++ b/worlds/stardew_valley/data/craftable_data.py
@@ -138,10 +138,15 @@ oil_maker = skill_recipe(Machine.oil_maker, Skill.farming, 8, {Loot.slime: 50, M
 preserves_jar = skill_recipe(Machine.preserves_jar, Skill.farming, 4, {Material.wood: 50, Material.stone: 40, Material.coal: 8})
 
 basic_fertilizer = skill_recipe(Fertilizer.basic, Skill.farming, 1, {Material.sap: 2})
-quality_fertilizer = skill_recipe(Fertilizer.quality, Skill.farming, 9, {Material.sap: 2, Fish.any: 1})
+
+# 1.6 doubled the sap requirement
+quality_fertilizer = skill_recipe(Fertilizer.quality, Skill.farming, 9, {Material.sap: 4, Fish.any: 1})
 deluxe_fertilizer = ap_recipe(Fertilizer.deluxe, {MetalBar.iridium: 1, Material.sap: 40})
-basic_speed_gro = skill_recipe(SpeedGro.basic, Skill.farming, 3, {ArtisanGood.pine_tar: 1, Fish.clam: 1})
-deluxe_speed_gro = skill_recipe(SpeedGro.deluxe, Skill.farming, 8, {ArtisanGood.oak_resin: 1, WaterItem.coral: 1})
+
+# 1.6 went changed from clam to moss. Keep both requirements for now. Update properly later
+basic_speed_gro = skill_recipe(SpeedGro.basic, Skill.farming, 3, {ArtisanGood.pine_tar: 1, Fish.clam: 1, Material.moss: 5})
+# 1.6 went changed from coral to bone fragments. Keep both requirements for now. Update properly later
+deluxe_speed_gro = skill_recipe(SpeedGro.deluxe, Skill.farming, 8, {ArtisanGood.oak_resin: 1, WaterItem.coral: 1, Fossil.bone_fragment: 5})
 hyper_speed_gro = ap_recipe(SpeedGro.hyper, {Ore.radioactive: 1, Fossil.bone_fragment: 3, Loot.solar_essence: 1})
 basic_retaining_soil = skill_recipe(RetainingSoil.basic, Skill.farming, 4, {Material.stone: 2})
 quality_retaining_soil = skill_recipe(RetainingSoil.quality, Skill.farming, 7, {Material.stone: 3, Material.clay: 1})

--- a/worlds/stardew_valley/data/recipe_data.py
+++ b/worlds/stardew_valley/data/recipe_data.py
@@ -166,7 +166,7 @@ strange_bun = friendship_recipe(Meal.strange_bun, NPC.shane, 7, {Ingredient.whea
 stuffing = friendship_recipe(Meal.stuffing, NPC.pam, 7, {Meal.bread: 1, Fruit.cranberries: 1, Forageable.hazelnut: 1})
 super_meal = friendship_recipe(Meal.super_meal, NPC.kent, 7, {Vegetable.bok_choy: 1, Fruit.cranberries: 1, Vegetable.artichoke: 1})
 
-# 1.6 went from 2 to 8. Keep highest requirement for now. Update properly later
+# 1.6 changed from 2 to 8. Keep highest requirement for now. Update properly later
 survival_burger = skill_recipe(Meal.survival_burger, Skill.foraging, 8, {Meal.bread: 1, Forageable.cave_carrot: 1, Vegetable.eggplant: 1})
 tom_kha_soup = friendship_recipe(Meal.tom_kha_soup, NPC.sandy, 7, {Forageable.coconut: 1, Fish.shrimp: 1, Forageable.common_mushroom: 1})
 tortilla_ingredients = {Vegetable.corn: 1}

--- a/worlds/stardew_valley/data/recipe_data.py
+++ b/worlds/stardew_valley/data/recipe_data.py
@@ -165,7 +165,9 @@ stir_fry_qos = queen_of_sauce_recipe(Meal.stir_fry, 1, Season.spring, 7, stir_fr
 strange_bun = friendship_recipe(Meal.strange_bun, NPC.shane, 7, {Ingredient.wheat_flour: 1, Fish.periwinkle: 1, ArtisanGood.void_mayonnaise: 1})
 stuffing = friendship_recipe(Meal.stuffing, NPC.pam, 7, {Meal.bread: 1, Fruit.cranberries: 1, Forageable.hazelnut: 1})
 super_meal = friendship_recipe(Meal.super_meal, NPC.kent, 7, {Vegetable.bok_choy: 1, Fruit.cranberries: 1, Vegetable.artichoke: 1})
-survival_burger = skill_recipe(Meal.survival_burger, Skill.foraging, 2, {Meal.bread: 1, Forageable.cave_carrot: 1, Vegetable.eggplant: 1})
+
+# 1.6 went from 2 to 8. Keep highest requirement for now. Update properly later
+survival_burger = skill_recipe(Meal.survival_burger, Skill.foraging, 8, {Meal.bread: 1, Forageable.cave_carrot: 1, Vegetable.eggplant: 1})
 tom_kha_soup = friendship_recipe(Meal.tom_kha_soup, NPC.sandy, 7, {Forageable.coconut: 1, Fish.shrimp: 1, Forageable.common_mushroom: 1})
 tortilla_ingredients = {Vegetable.corn: 1}
 tortilla_qos = queen_of_sauce_recipe(Meal.tortilla, 1, Season.fall, 7, tortilla_ingredients)

--- a/worlds/stardew_valley/logic/building_logic.py
+++ b/worlds/stardew_valley/logic/building_logic.py
@@ -42,7 +42,7 @@ class BuildingLogic(BaseLogic[Union[BuildingLogicMixin, MoneyLogicMixin, RegionL
             Building.well: self.logic.money.can_spend(1000) & self.logic.has(Material.stone),
             Building.shipping_bin: self.logic.money.can_spend(250) & self.logic.has(Material.wood),
             Building.kitchen: self.logic.money.can_spend(10000) & self.logic.has(Material.wood) & self.logic.building.has_house(0),
-            Building.kids_room: self.logic.money.can_spend(50000) & self.logic.has(Material.hardwood) & self.logic.building.has_house(1),
+            Building.kids_room: self.logic.money.can_spend(65000) & self.logic.has(Material.hardwood) & self.logic.building.has_house(1),
             Building.cellar: self.logic.money.can_spend(100000) & self.logic.building.has_house(2),
             # @formatter:on
         })

--- a/worlds/stardew_valley/logic/logic.py
+++ b/worlds/stardew_valley/logic/logic.py
@@ -343,6 +343,7 @@ class StardewLogic(ReceivedLogicMixin, HasLogicMixin, RegionLogicMixin, BuffLogi
             Material.coal: self.mine.can_mine_in_the_mines_floor_41_80() | self.action.can_pan(),
             Material.fiber: True_(),
             Material.hardwood: self.tool.has_tool(Tool.axe, ToolMaterial.copper) & (self.region.can_reach(Region.secret_woods) | self.region.can_reach(Region.island_west)),
+            Material.moss: True_(),
             Material.sap: self.ability.can_chop_trees(),
             Material.stone: self.tool.has_tool(Tool.pickaxe),
             Material.wood: self.tool.has_tool(Tool.axe),

--- a/worlds/stardew_valley/strings/material_names.py
+++ b/worlds/stardew_valley/strings/material_names.py
@@ -1,4 +1,5 @@
 class Material:
+    moss = "Moss"
     coal = "Coal"
     fiber = "Fiber"
     hardwood = "Hardwood"


### PR DESCRIPTION
## What is this fixing or adding?
I went through the entire changelog for the newly release Stardew Valley 1.6, and categorized every single change into 5 categories, based on the work required to make them compatible with the randomizer.

This is the work for the category "Emergency", because the new game introduces actual softlocks in the randomizer due to the logic becoming invalid. It would be very important to get these fixes for the release.

The next PRs will not be as critical and can be mitigated by the mod, or simply ignored by the player as an "incomplete" experience that still works.

## How was this tested?
Unit tests. It's changed requirements based on a textual changelog, and none of the actual code has changed, only specific values in it.
