### PR TITLE
Stardew Valley: Fix potential soft lock with vanilla tools and entrance randomizer + Performance improvement for vanilla tool/skills

### DIFF
--- a/worlds/stardew_valley/logic/ability_logic.py
+++ b/worlds/stardew_valley/logic/ability_logic.py
@@ -33,7 +33,7 @@ class AbilityLogic(BaseLogic[Union[AbilityLogicMixin, RegionLogicMixin, Received
 
     def can_fish_perfectly(self) -> StardewRule:
         skill_rule = self.logic.skill.has_level(Skill.fishing, 10)
-        return skill_rule & self.logic.tool.has_fishing_rod(3)
+        return skill_rule & self.logic.tool.has_fishing_rod(4)
 
     def can_chop_trees(self) -> StardewRule:
         return self.logic.tool.has_tool(Tool.axe) & self.logic.region.can_reach(Region.forest)

--- a/worlds/stardew_valley/logic/ability_logic.py
+++ b/worlds/stardew_valley/logic/ability_logic.py
@@ -33,7 +33,7 @@ class AbilityLogic(BaseLogic[Union[AbilityLogicMixin, RegionLogicMixin, Received
 
     def can_fish_perfectly(self) -> StardewRule:
         skill_rule = self.logic.skill.has_level(Skill.fishing, 10)
-        return skill_rule & self.logic.tool.has_fishing_rod(4)
+        return skill_rule & self.logic.tool.has_fishing_rod(3)
 
     def can_chop_trees(self) -> StardewRule:
         return self.logic.tool.has_tool(Tool.axe) & self.logic.region.can_reach(Region.forest)

--- a/worlds/stardew_valley/logic/fishing_logic.py
+++ b/worlds/stardew_valley/logic/fishing_logic.py
@@ -30,11 +30,11 @@ class FishingLogic(BaseLogic[Union[FishingLogicMixin, ReceivedLogicMixin, Region
 
     def has_max_fishing(self) -> StardewRule:
         skill_rule = self.logic.skill.has_level(Skill.fishing, 10)
-        return self.logic.tool.has_fishing_rod(3) & skill_rule
+        return self.logic.tool.has_fishing_rod(4) & skill_rule
 
     def can_fish_chests(self) -> StardewRule:
         skill_rule = self.logic.skill.has_level(Skill.fishing, 6)
-        return self.logic.tool.has_fishing_rod(3) & skill_rule
+        return self.logic.tool.has_fishing_rod(4) & skill_rule
 
     def can_fish_at(self, region: str) -> StardewRule:
         return self.logic.skill.can_fish() & self.logic.region.can_reach(region)
@@ -66,7 +66,7 @@ class FishingLogic(BaseLogic[Union[FishingLogicMixin, ReceivedLogicMixin, Region
     def can_catch_quality_fish(self, fish_quality: str) -> StardewRule:
         if fish_quality == FishQuality.basic:
             return True_()
-        rod_rule = self.logic.tool.has_fishing_rod(1)
+        rod_rule = self.logic.tool.has_fishing_rod(2)
         if fish_quality == FishQuality.silver:
             return rod_rule
         if fish_quality == FishQuality.gold:

--- a/worlds/stardew_valley/logic/fishing_logic.py
+++ b/worlds/stardew_valley/logic/fishing_logic.py
@@ -30,11 +30,11 @@ class FishingLogic(BaseLogic[Union[FishingLogicMixin, ReceivedLogicMixin, Region
 
     def has_max_fishing(self) -> StardewRule:
         skill_rule = self.logic.skill.has_level(Skill.fishing, 10)
-        return self.logic.tool.has_fishing_rod(4) & skill_rule
+        return self.logic.tool.has_fishing_rod(3) & skill_rule
 
     def can_fish_chests(self) -> StardewRule:
         skill_rule = self.logic.skill.has_level(Skill.fishing, 6)
-        return self.logic.tool.has_fishing_rod(4) & skill_rule
+        return self.logic.tool.has_fishing_rod(3) & skill_rule
 
     def can_fish_at(self, region: str) -> StardewRule:
         return self.logic.skill.can_fish() & self.logic.region.can_reach(region)
@@ -66,14 +66,15 @@ class FishingLogic(BaseLogic[Union[FishingLogicMixin, ReceivedLogicMixin, Region
     def can_catch_quality_fish(self, fish_quality: str) -> StardewRule:
         if fish_quality == FishQuality.basic:
             return True_()
-        rod_rule = self.logic.tool.has_fishing_rod(2)
+        rod_rule = self.logic.tool.has_fishing_rod(1)
         if fish_quality == FishQuality.silver:
             return rod_rule
         if fish_quality == FishQuality.gold:
             return rod_rule & self.logic.skill.has_level(Skill.fishing, 4)
         if fish_quality == FishQuality.iridium:
             return rod_rule & self.logic.skill.has_level(Skill.fishing, 10)
-        return False_()
+
+        raise ValueError(f"Quality {fish_quality} is unknown.")
 
     def can_catch_every_fish(self) -> StardewRule:
         rules = [self.has_max_fishing()]

--- a/worlds/stardew_valley/logic/skill_logic.py
+++ b/worlds/stardew_valley/logic/skill_logic.py
@@ -51,7 +51,7 @@ CombatLogicMixin, CropLogicMixin, MagicLogicMixin]]):
             previous_level_rule = True_()
 
         if skill == Skill.fishing:
-            xp_rule = self.logic.tool.has_fishing_rod(min(tool_level, 3))
+            xp_rule = self.logic.tool.has_fishing_rod(max(tool_level, 1))
         elif skill == Skill.farming:
             xp_rule = self.logic.tool.has_tool(Tool.hoe, tool_material) & self.logic.tool.can_water(tool_level)
         elif skill == Skill.foraging:
@@ -152,7 +152,7 @@ CombatLogicMixin, CropLogicMixin, MagicLogicMixin]]):
         skill_rule = self.logic.skill.has_level(Skill.fishing, skill_required)
         region_rule = self.logic.region.can_reach_any(regions)
         # Training rod only works with fish < 50. Fiberglass does not help you to catch higher difficulty fish, so it's skipped in logic.
-        number_fishing_rod_required = 0 if difficulty < 50 else (1 if difficulty < 80 else 3)
+        number_fishing_rod_required = 1 if difficulty < 50 else (2 if difficulty < 80 else 4)
         return self.logic.tool.has_fishing_rod(number_fishing_rod_required) & skill_rule & region_rule
 
     @cache_self1

--- a/worlds/stardew_valley/logic/skill_logic.py
+++ b/worlds/stardew_valley/logic/skill_logic.py
@@ -51,7 +51,7 @@ CombatLogicMixin, CropLogicMixin, MagicLogicMixin]]):
             previous_level_rule = True_()
 
         if skill == Skill.fishing:
-            xp_rule = self.logic.tool.has_fishing_rod(max(tool_level, 3))
+            xp_rule = self.logic.tool.has_fishing_rod(min(tool_level, 3))
         elif skill == Skill.farming:
             xp_rule = self.logic.tool.has_tool(Tool.hoe, tool_material) & self.logic.tool.can_water(tool_level)
         elif skill == Skill.foraging:
@@ -151,7 +151,8 @@ CombatLogicMixin, CropLogicMixin, MagicLogicMixin]]):
 
         skill_rule = self.logic.skill.has_level(Skill.fishing, skill_required)
         region_rule = self.logic.region.can_reach_any(regions)
-        number_fishing_rod_required = 1 if difficulty < 50 else (2 if difficulty < 80 else 4)
+        # Training rod only works with fish < 50. Fiberglass does not help you to catch higher difficulty fish, so it's skipped in logic.
+        number_fishing_rod_required = 0 if difficulty < 50 else (1 if difficulty < 80 else 3)
         return self.logic.tool.has_fishing_rod(number_fishing_rod_required) & skill_rule & region_rule
 
     @cache_self1

--- a/worlds/stardew_valley/logic/skill_logic.py
+++ b/worlds/stardew_valley/logic/skill_logic.py
@@ -44,10 +44,14 @@ CombatLogicMixin, CropLogicMixin, MagicLogicMixin]]):
         tool_material = ToolMaterial.tiers[tool_level]
         months = max(1, level - 1)
         months_rule = self.logic.time.has_lived_months(months)
-        previous_level_rule = self.logic.skill.has_level(skill, level - 1)
+
+        if self.options.skill_progression != options.SkillProgression.option_vanilla:
+            previous_level_rule = self.logic.skill.has_level(skill, level - 1)
+        else:
+            previous_level_rule = True_()
 
         if skill == Skill.fishing:
-            xp_rule = self.logic.tool.has_tool(Tool.fishing_rod, ToolMaterial.tiers[max(tool_level, 3)])
+            xp_rule = self.logic.tool.has_fishing_rod(max(tool_level, 3))
         elif skill == Skill.farming:
             xp_rule = self.logic.tool.has_tool(Tool.hoe, tool_material) & self.logic.tool.can_water(tool_level)
         elif skill == Skill.foraging:
@@ -137,11 +141,14 @@ CombatLogicMixin, CropLogicMixin, MagicLogicMixin]]):
     def can_fish(self, regions: Union[str, Tuple[str, ...]] = None, difficulty: int = 0) -> StardewRule:
         if isinstance(regions, str):
             regions = regions,
+
         if regions is None or len(regions) == 0:
             regions = fishing_regions
+
         skill_required = min(10, max(0, int((difficulty / 10) - 1)))
         if difficulty <= 40:
             skill_required = 0
+
         skill_rule = self.logic.skill.has_level(Skill.fishing, skill_required)
         region_rule = self.logic.region.can_reach_any(regions)
         number_fishing_rod_required = 1 if difficulty < 50 else (2 if difficulty < 80 else 4)

--- a/worlds/stardew_valley/logic/tool_logic.py
+++ b/worlds/stardew_valley/logic/tool_logic.py
@@ -12,7 +12,6 @@ from ..options import ToolProgression
 from ..stardew_rule import StardewRule, True_, False_
 from ..strings.ap_names.skill_level_names import ModSkillLevel
 from ..strings.region_names import Region
-from ..strings.skill_names import ModSkill
 from ..strings.spells import MagicSpell
 from ..strings.tool_names import ToolMaterial, Tool
 
@@ -40,13 +39,16 @@ class ToolLogicMixin(BaseLogicMixin):
 class ToolLogic(BaseLogic[Union[ToolLogicMixin, HasLogicMixin, ReceivedLogicMixin, RegionLogicMixin, SeasonLogicMixin, MoneyLogicMixin, MagicLogicMixin]]):
     # Should be cached
     def has_tool(self, tool: str, material: str = ToolMaterial.basic) -> StardewRule:
+        if tool == Tool.fishing_rod:
+            return self.logic.tool.has_fishing_rod(tool_materials[material])
+
         if material == ToolMaterial.basic or tool == Tool.scythe:
             return True_()
 
         if self.options.tool_progression & ToolProgression.option_progressive:
             return self.logic.received(f"Progressive {tool}", tool_materials[material])
 
-        return self.logic.has(f"{material} Bar") & self.logic.money.can_spend(tool_upgrade_prices[material])
+        return self.logic.has(f"{material} Bar") & self.logic.money.can_spend_at(Region.blacksmith, tool_upgrade_prices[material])
 
     def can_use_tool_at(self, tool: str, material: str, region: str) -> StardewRule:
         return self.has_tool(tool, material) & self.logic.region.can_reach(region)

--- a/worlds/stardew_valley/logic/tool_logic.py
+++ b/worlds/stardew_valley/logic/tool_logic.py
@@ -16,8 +16,8 @@ from ..strings.spells import MagicSpell
 from ..strings.tool_names import ToolMaterial, Tool
 
 fishing_rod_prices = {
-    2: 1800,  # Fibreglass
-    3: 7500,  # Iridium
+    3: 1800,
+    4: 7500,
 }
 
 tool_materials = {
@@ -59,12 +59,12 @@ class ToolLogic(BaseLogic[Union[ToolLogicMixin, HasLogicMixin, ReceivedLogicMixi
 
     @cache_self1
     def has_fishing_rod(self, level: int) -> StardewRule:
-        assert 0 <= level <= 3, "Fishing rod 0 is Training, 1 is Bamboo, 2 is Fiberglass and 3 is Iridium."
+        assert 1 <= level <= 4, "Fishing rod 0 isn't real, it can't hurt you. Training is 1, Bamboo is 2, Fiberglass is 3 and Iridium is 4."
 
         if self.options.tool_progression & ToolProgression.option_progressive:
             return self.logic.received(f"Progressive {Tool.fishing_rod}", level)
 
-        if level <= 1:
+        if level <= 2:
             # We assume you always have access to the Bamboo pole, because mod side there is a builtin way to get it back.
             return self.logic.region.can_reach(Region.beach)
 

--- a/worlds/stardew_valley/logic/tool_logic.py
+++ b/worlds/stardew_valley/logic/tool_logic.py
@@ -39,8 +39,7 @@ class ToolLogicMixin(BaseLogicMixin):
 class ToolLogic(BaseLogic[Union[ToolLogicMixin, HasLogicMixin, ReceivedLogicMixin, RegionLogicMixin, SeasonLogicMixin, MoneyLogicMixin, MagicLogicMixin]]):
     # Should be cached
     def has_tool(self, tool: str, material: str = ToolMaterial.basic) -> StardewRule:
-        if tool == Tool.fishing_rod:
-            return self.logic.tool.has_fishing_rod(tool_materials[material])
+        assert tool != Tool.fishing_rod, "Use `has_fishing_rod` instead of `has_tool`."
 
         if material == ToolMaterial.basic or tool == Tool.scythe:
             return True_()

--- a/worlds/stardew_valley/logic/tool_logic.py
+++ b/worlds/stardew_valley/logic/tool_logic.py
@@ -15,6 +15,11 @@ from ..strings.region_names import Region
 from ..strings.spells import MagicSpell
 from ..strings.tool_names import ToolMaterial, Tool
 
+fishing_rod_prices = {
+    2: 1800,  # Fibreglass
+    3: 7500,  # Iridium
+}
+
 tool_materials = {
     ToolMaterial.copper: 1,
     ToolMaterial.iron: 2,
@@ -54,14 +59,16 @@ class ToolLogic(BaseLogic[Union[ToolLogicMixin, HasLogicMixin, ReceivedLogicMixi
 
     @cache_self1
     def has_fishing_rod(self, level: int) -> StardewRule:
+        assert 0 <= level <= 3, "Fishing rod 0 is Training, 1 is Bamboo, 2 is Fiberglass and 3 is Iridium."
+
         if self.options.tool_progression & ToolProgression.option_progressive:
             return self.logic.received(f"Progressive {Tool.fishing_rod}", level)
 
         if level <= 1:
+            # We assume you always have access to the Bamboo pole, because mod side there is a builtin way to get it back.
             return self.logic.region.can_reach(Region.beach)
-        prices = {2: 500, 3: 1800, 4: 7500}
-        level = min(level, 4)
-        return self.logic.money.can_spend_at(Region.fish_shop, prices[level])
+
+        return self.logic.money.can_spend_at(Region.fish_shop, fishing_rod_prices[level])
 
     # Should be cached
     def can_forage(self, season: Union[str, Iterable[str]], region: str = Region.forest, need_hoe: bool = False) -> StardewRule:

--- a/worlds/stardew_valley/test/TestRules.py
+++ b/worlds/stardew_valley/test/TestRules.py
@@ -626,12 +626,12 @@ class TestToolVanillaRequiresBlacksmith(SVTestBase):
         place_region_at_entrance(self.multiworld, self.player, Region.fish_shop, Entrance.enter_bathhouse_entrance)
         collect_all_except(self.multiworld, railroad_item)
 
-        for fishing_rod_level in [2, 3]:
+        for fishing_rod_level in [3, 4]:
             self.assert_rule_false(self.world.logic.tool.has_fishing_rod(fishing_rod_level), self.multiworld.state)
 
         self.multiworld.state.collect(self.world.create_item(railroad_item), event=False)
 
-        for fishing_rod_level in [2, 3]:
+        for fishing_rod_level in [3, 4]:
             self.assert_rule_true(self.world.logic.tool.has_fishing_rod(fishing_rod_level), self.multiworld.state)
 
 

--- a/worlds/stardew_valley/test/TestRules.py
+++ b/worlds/stardew_valley/test/TestRules.py
@@ -8,6 +8,7 @@ from ..options import ToolProgression, BuildingProgression, ExcludeGingerIsland,
     FriendsanityHeartSize, BundleRandomization, SkillProgression
 from ..strings.entrance_names import Entrance
 from ..strings.region_names import Region
+from ..strings.tool_names import Tool, ToolMaterial
 
 
 class TestProgressiveToolsLogic(SVTestBase):
@@ -594,6 +595,38 @@ def swap_museum_and_bathhouse(multiworld, player):
     bathhouse_entrance = multiworld.get_entrance(Entrance.enter_bathhouse_entrance, player)
     museum_entrance.connect(bathhouse_region)
     bathhouse_entrance.connect(museum_region)
+
+
+class TestToolVanillaRequiresBlacksmith(SVTestBase):
+    options = {
+        options.EntranceRandomization: options.EntranceRandomization.option_buildings,
+        options.ToolProgression: options.ToolProgression.option_vanilla,
+    }
+
+    def test_cannot_make_get_any_tool_without_blacksmith_access(self):
+        railroad_item = "Railroad Boulder Removed"
+        swap_blacksmith_and_bathhouse(self.multiworld, self.player)
+        collect_all_except(self.multiworld, railroad_item)
+
+        for tool in [Tool.pickaxe, Tool.axe, Tool.hoe, Tool.trash_can, Tool.watering_can]:
+            for material in [ToolMaterial.copper, ToolMaterial.iron, ToolMaterial.gold, ToolMaterial.iridium]:
+                self.assert_rule_false(self.world.logic.tool.has_tool(tool, material), self.multiworld.state)
+
+        self.multiworld.state.collect(self.world.create_item(railroad_item), event=False)
+
+        for tool in [Tool.pickaxe, Tool.axe, Tool.hoe, Tool.trash_can, Tool.watering_can]:
+            for material in [ToolMaterial.copper, ToolMaterial.iron, ToolMaterial.gold, ToolMaterial.iridium]:
+                self.assert_rule_true(self.world.logic.tool.has_tool(tool, material), self.multiworld.state)
+
+
+def swap_blacksmith_and_bathhouse(multiworld, player):
+    blacksmith_region = multiworld.get_region(Region.blacksmith, player)
+    bathhouse_entrance = multiworld.get_entrance(Entrance.enter_bathhouse_entrance, player)
+
+    blacksmith_entrance = blacksmith_region.entrances[0]
+    bathhouse_region = bathhouse_entrance.connected_region
+    blacksmith_entrance.connect(bathhouse_region)
+    bathhouse_entrance.connect(blacksmith_region)
 
 
 def collect_all_except(multiworld, item_to_not_collect: str):


### PR DESCRIPTION
## What is this fixing or adding?
While looking for performance improvement, I found this potential soft locking bug where Clint's Blacksmith is not required for tool upgrade. For instance, you could a setting where Clint is as the bathhouse, which requires the "Railroad Boulder Removed" item. However, this item is randomized in a foraging bundle which requires the Copper Axe to access. You could still get it with a chair skip, but it's out of logic. There are for sure other locations that are really locked being having an upgraded tool, but it's late, and it's the first example I came with.

Anyway, there is also a significant performance improvement (around 20%) when running the vanilla skill progression, which come from not requiring the previous skill level. In that setting, all those require a tool, which ended up adding a lot of metal bars in the rule, when only one is needed.

Fish no longer require metal bars, that was a bug as well, since at least 4.x.x.

## How was this tested?
Unit tests. 

Also see the old rule for fishing an Octopus (we see all bugs above)
<details><summary>Octopus Before</summary>
<p>

Yes, Gold Bar is there 8 times.
```
  Has Octopus (item) -> True
    (Received Can Ship Items & Received Can Shop At Pierre's & HasProgressionPercent 14 & Received Summer & Has Gold Bar (item) & Has Gold Bar (item) & Has Gold Bar (item) & Has Gold Bar (item) & Has Gold Bar (item) & Has Gold Bar (item) & Has Gold Bar (item) & Has Gold Bar (item)) -> True
      Received Can Ship Items -> True
      Received Can Shop At Pierre's -> True
      HasProgressionPercent 14 -> True
      Received Summer -> True
      Has Gold Bar (item) -> True
          [...]
      Has Gold Bar (item) -> True
          [...]
      Has Gold Bar (item) -> True
          [...]
      Has Gold Bar (item) -> True
          [...]
      Has Gold Bar (item) -> True
          [...]
      Has Gold Bar (item) -> True
          [...]
      Has Gold Bar (item) -> True
          [...]
      Has Gold Bar (item) -> True
          [...]
```

</p>
</details> 


<details><summary>Octopus After</summary>
<p>

No more Gold Bar 🎉 
```
  Has Octopus (item) -> True
    (Received Can Ship Items & Received Can Shop At Pierre's & HasProgressionPercent 14 & Received Summer & Has Gold Bar (item) & Has Gold Bar (item) & Has Gold Bar (item) & Has Gold Bar (item) & Has Gold Bar (item) & Has Gold Bar (item) & Has Gold Bar (item) & Has Gold Bar (item)) -> True
      Received Can Ship Items -> True
      Received Can Shop At Pierre's -> True
      HasProgressionPercent 14 -> True
      Received Summer -> True
```

</p>
</details> 

Lastly, see the performance difference when running vanilla skill + tool : 
![image](https://github.com/ArchipelagoMW/Archipelago/assets/16137441/2a5ea902-e9f8-4efb-bad3-7dcf96788412)

## If this makes graphical changes, please attach screenshots.
N/A