### PR TITLE
Docs: Fixing special_range_names example

### DIFF
--- a/docs/options api.md
+++ b/docs/options api.md
@@ -204,7 +204,7 @@ For example:
 ```python
 range_start = 1
 range_end = 99
-special_range_names: {
+special_range_names = {
     "normal": 20,
     "extreme": 99,
     "unlimited": -1,


### PR DESCRIPTION
## What is this fixing or adding?

The example uses `:` when it should use `=`

## How was this tested?

Reading (also actually running into an APWorld using the wrong method and fixing it)