### PR TITLE
The Witness: Fix world bleed issue creating impossible seeds in Multiworld

### DIFF
--- a/worlds/witness/player_logic.py
+++ b/worlds/witness/player_logic.py
@@ -652,8 +652,8 @@ class WitnessPlayerLogic:
         elif self.DIFFICULTY == "none":
             self.REFERENCE_LOGIC = StaticWitnessLogic.vanilla
 
-        self.CONNECTIONS_BY_REGION_NAME = copy.copy(self.REFERENCE_LOGIC.STATIC_CONNECTIONS_BY_REGION_NAME)
-        self.DEPENDENT_REQUIREMENTS_BY_HEX = copy.copy(self.REFERENCE_LOGIC.STATIC_DEPENDENT_REQUIREMENTS_BY_HEX)
+        self.CONNECTIONS_BY_REGION_NAME = copy.deepcopy(self.REFERENCE_LOGIC.STATIC_CONNECTIONS_BY_REGION_NAME)
+        self.DEPENDENT_REQUIREMENTS_BY_HEX = copy.deepcopy(self.REFERENCE_LOGIC.STATIC_DEPENDENT_REQUIREMENTS_BY_HEX)
         self.REQUIREMENTS_BY_HEX = dict()
 
         # Determining which panels need to be events is a difficult process.


### PR DESCRIPTION
Pretty self explanatory if you look at the file diff

What I tested:
In a Multiworld, any seed following a seed with `elevators_come_to_you: true` would act as if that setting was enabled even when it wasn't. I confirmed that with this change, that no longer happens.