### PR TITLE
Adventure: Remove runtime changes to location templates to fix determinism issues

### DIFF
--- a/worlds/adventure/Locations.py
+++ b/worlds/adventure/Locations.py
@@ -19,9 +19,9 @@ class WorldPosition:
 
     def get_position(self, random):
         if self.room_x is None or self.room_y is None:
-            return random.choice(standard_positions)
+            return self.room_id, random.choice(standard_positions)
         else:
-            return self.room_x, self.room_y
+            return self.room_id, (self.room_x, self.room_y)
 
 
 class LocationData:
@@ -46,24 +46,26 @@ class LocationData:
         self.needs_bat_logic: int = needs_bat_logic
         self.local_item: int = None
 
-    def get_position(self, random):
+    def get_random_position(self, random):
+        x: int = None
+        y: int = None
         if self.world_positions is None or len(self.world_positions) == 0:
             if self.room_id is None:
                 return None
-            self.room_x, self.room_y = random.choice(standard_positions)
-        if self.room_id is None:
+            x, y = random.choice(standard_positions)
+            return self.room_id, x, y
+        else:
             selected_pos = random.choice(self.world_positions)
-            self.room_id = selected_pos.room_id
-            self.room_x, self.room_y = selected_pos.get_position(random)
-        return self.room_x, self.room_y
+            room_id, (x, y) = selected_pos.get_position(random)
+            return self.get_random_room_id(random), x, y
 
-    def get_room_id(self, random):
+    def get_random_room_id(self, random):
         if self.world_positions is None or len(self.world_positions) == 0:
-            return None
+            if self.room_id is None:
+                return None
         if self.room_id is None:
             selected_pos = random.choice(self.world_positions)
-            self.room_id = selected_pos.room_id
-            self.room_x, self.room_y = selected_pos.get_position(random)
+            return selected_pos.room_id
         return self.room_id
 
 
@@ -97,7 +99,7 @@ def get_random_room_in_regions(regions: [str], random) -> int:
     possible_rooms = {}
     for locname in location_table:
         if location_table[locname].region in regions:
-            room = location_table[locname].get_room_id(random)
+            room = location_table[locname].get_random_room_id(random)
             if room is not None:
                 possible_rooms[room] = location_table[locname].room_id
     return random.choice(list(possible_rooms.keys()))

--- a/worlds/adventure/Regions.py
+++ b/worlds/adventure/Regions.py
@@ -25,8 +25,6 @@ def connect(world: MultiWorld, player: int, source: str, target: str, rule: call
 
 
 def create_regions(multiworld: MultiWorld, player: int, dragon_rooms: []) -> None:
-    for name, locdata in location_table.items():
-        locdata.get_position(multiworld.random)
 
     menu = Region("Menu", player, multiworld)
 

--- a/worlds/adventure/__init__.py
+++ b/worlds/adventure/__init__.py
@@ -371,8 +371,9 @@ class AdventureWorld(World):
                 if location.item.player == self.player and \
                         location.item.name == "nothing":
                     location_data = location_table[location.name]
+                    room_id = location_data.get_random_room_id(self.random)
                     auto_collect_locations.append(AdventureAutoCollectLocation(location_data.short_location_id,
-                                                                               location_data.room_id))
+                                                                               room_id))
                 # standard Adventure items, which are placed in the rom
                 elif location.item.player == self.player and \
                         location.item.name != "nothing" and \
@@ -383,14 +384,18 @@ class AdventureWorld(World):
                     item_ram_address = item_ram_addresses[item_table[location.item.name].table_index]
                     item_position_data_start = item_position_table + item_ram_address - items_ram_start
                     location_data = location_table[location.name]
-                    room_x, room_y = location_data.get_position(self.multiworld.per_slot_randoms[self.player])
+                    (room_id, room_x, room_y) = \
+                        location_data.get_random_position(self.random)
                     if location_data.needs_bat_logic and bat_logic == 0x0:
                         copied_location = copy.copy(location_data)
                         copied_location.local_item = item_ram_address
+                        copied_location.room_id = room_id
+                        copied_location.room_x = room_x
+                        copied_location.room_y = room_y
                         bat_no_touch_locs.append(copied_location)
                     del unplaced_local_items[location.item.name]
 
-                    rom_deltas[item_position_data_start] = location_data.room_id
+                    rom_deltas[item_position_data_start] = room_id
                     rom_deltas[item_position_data_start + 1] = room_x
                     rom_deltas[item_position_data_start + 2] = room_y
                     local_item_to_location[item_table_offset] = self.location_name_to_id[location.name] \
@@ -398,14 +403,20 @@ class AdventureWorld(World):
                 # items from other worlds, and non-standard Adventure items handled by script, like difficulty switches
                 elif location.item.code is not None:
                     if location.item.code != nothing_item_id:
-                        location_data = location_table[location.name]
+                        location_data = copy.copy(location_table[location.name])
+                        (room_id, room_x, room_y) = \
+                            location_data.get_random_position(self.random)
+                        location_data.room_id = room_id
+                        location_data.room_x = room_x
+                        location_data.room_y = room_y
                         foreign_item_locations.append(location_data)
                         if location_data.needs_bat_logic and bat_logic == 0x0:
                             bat_no_touch_locs.append(location_data)
                     else:
                         location_data = location_table[location.name]
+                        room_id = location_data.get_random_room_id(self.random)
                         auto_collect_locations.append(AdventureAutoCollectLocation(location_data.short_location_id,
-                                                                                   location_data.room_id))
+                                                                                   room_id))
             # Adventure items that are in another world get put in an invalid room until needed
             for unplaced_item_name, unplaced_item in unplaced_local_items.items():
                 item_position_data_start = get_item_position_data_start(unplaced_item.table_index)


### PR DESCRIPTION
## What is this fixing or adding?
Does not assign room id or room_x, room_y to the fixed location table entries (except room_id in some cases when it only can have a single possible value).

## How was this tested?
Ran determinism test from https://github.com/ArchipelagoMW/Archipelago/pull/2977, all other tests, generated a couple 2600 world multiworlds, generated a few 1 and 4 world Adventure multiworlds and played one of them..

## If this makes graphical changes, please attach screenshots.
N/A