### PR TITLE
sc2: Fixed missing upgrade from custom tracker

### DIFF
--- a/WebHostLib/templates/tracker__Starcraft2.html
+++ b/WebHostLib/templates/tracker__Starcraft2.html
@@ -106,7 +106,7 @@
                                 <td>{{ sc2_icon('Neosteel Bunker (Bunker)') }}</td>
                                 <td>{{ sc2_icon('Shrike Turret (Bunker)') }}</td>
                                 <td>{{ sc2_icon('Fortified Bunker (Bunker)') }}</td>
-                                <td colspan="3"></td>
+                                <td></td>
                                 <td>{{ sc2_icon('Missile Turret') }}</td>
                                 <td>{{ sc2_icon('Titanium Housing (Missile Turret)') }}</td>
                                 <td>{{ sc2_icon('Hellstorm Batteries (Missile Turret)') }}</td>
@@ -121,12 +121,13 @@
                                 <td>{{ sc2_icon('Planetary Fortress') }}</td>
                                 <td {% if augmented_thrusters_planetary_fortress_level == 1 %}class="tint-terran"{% endif %}>{{ sc2_progressive_icon_with_custom_name('Progressive Augmented Thrusters (Planetary Fortress)', augmented_thrusters_planetary_fortress_url, augmented_thrusters_planetary_fortress_name) }}</td>
                                 <td>{{ sc2_icon('Advanced Targeting (Planetary Fortress)') }}</td>
+                                <td colspan="2"></td>
+                                <td>{{ sc2_icon('Micro-Filtering') }}</td>
+                                <td>{{ sc2_icon('Automated Refinery') }}</td>
                                 <td></td>
                                 <td>{{ sc2_icon('Advanced Construction (SCV)') }}</td>
                                 <td>{{ sc2_icon('Dual-Fusion Welders (SCV)') }}</td>
-                                <td></td>
-                                <td>{{ sc2_icon('Micro-Filtering') }}</td>
-                                <td>{{ sc2_icon('Automated Refinery') }}</td>
+                                <td>{{ sc2_icon('Hostile Environment Adaptation (SCV)') }}</td>
                             </tr>
                             <tr>
                                 <td>{{ sc2_icon('Sensor Tower') }}</td>

--- a/WebHostLib/tracker.py
+++ b/WebHostLib/tracker.py
@@ -1606,6 +1606,7 @@ if "Starcraft 2" in network_data_package["games"]:
             "Hellstorm Batteries (Missile Turret)":        github_icon_base_url + "blizzard/btn-ability-stetmann-corruptormissilebarrage.png",
             "Advanced Construction (SCV)":                 github_icon_base_url + "blizzard/btn-ability-mengsk-trooper-advancedconstruction.png",
             "Dual-Fusion Welders (SCV)":                   github_icon_base_url + "blizzard/btn-upgrade-swann-scvdoublerepair.png",
+            "Hostile Environment Adaptation (SCV)":        github_icon_base_url + "blizzard/btn-upgrade-swann-hellarmor.png",
             "Fire-Suppression System Level 1":             organics_icon_base_url + "Fire-SuppressionSystem.png",
             "Fire-Suppression System Level 2":             github_icon_base_url + "blizzard/btn-upgrade-swann-firesuppressionsystem.png",
 


### PR DESCRIPTION

## What is this fixing or adding?
The SCV Hostile Environment Adaptation upgrade was missing from the custom tracker. Added it in, shuffling some icons around to make room.

## How was this tested?
Started up the webhost, generated a game, checked the tracker with no upgrades and after doing a `/collect`.

## If this makes graphical changes, please attach screenshots.
Old layout:
![image](https://github.com/ArchipelagoMW/Archipelago/assets/31861583/a65668b3-2848-48ba-b739-d37730ac8ed5)

New layout (uncollected):
![image](https://github.com/ArchipelagoMW/Archipelago/assets/31861583/2de9d35e-ee1d-4cd4-b407-5bb0e30f8b71)

New layout (collected):
![image](https://github.com/ArchipelagoMW/Archipelago/assets/31861583/cb97c02d-dbc7-453a-a051-e9d1d8a15d36)
