### PR TITLE
CV64: Change all mentions of "settings" to "options" and fix a broken link

### DIFF
--- a/worlds/cv64/__init__.py
+++ b/worlds/cv64/__init__.py
@@ -48,9 +48,9 @@ class CV64Web(WebWorld):
 
 class CV64World(World):
     """
-    Castlevania for the Nintendo 64 is the first 3D game in the franchise. As either whip-wielding Belmont descendant
-    Reinhardt Schneider or powerful sorceress Carrie Fernandez, brave many terrifying traps and foes as you make your
-    way to Dracula's chamber and stop his rule of terror!
+    Castlevania for the Nintendo 64 is the first 3D game in the Castlevania franchise. As either whip-wielding Belmont
+    descendant Reinhardt Schneider or powerful sorceress Carrie Fernandez, brave many terrifying traps and foes as you
+    make your way to Dracula's chamber and stop his rule of terror!
     """
     game = "Castlevania 64"
     item_name_groups = {

--- a/worlds/cv64/docs/en_Castlevania 64.md
+++ b/worlds/cv64/docs/en_Castlevania 64.md
@@ -1,8 +1,8 @@
 # Castlevania 64
 
-## Where is the settings page?
+## Where is the options page?
 
-The [player settings page for this game](../player-settings) contains all the options you need to configure and export a
+The [player options page for this game](../player-options) contains all the options you need to configure and export a
 config file.
 
 ## What does randomization do to this game?
@@ -116,7 +116,7 @@ Enabling Carrie Logic will also expect the following:
 
 - Orb-sniping dogs through the front gates in Villa
 
-Library Skip is **NOT** logically expected on any setting. The basement hallway crack will always logically expect two Nitros
+Library Skip is **NOT** logically expected with any option. The basement arena crack will always logically expect two Nitros
 and two Mandragoras even with Hard Logic on due to the possibility of wasting a pair on the upper wall, after managing
 to skip past it. And plus, the RNG manip may not even be possible after picking up all the items in the Nitro room.
 

--- a/worlds/cv64/docs/en_Castlevania 64.md
+++ b/worlds/cv64/docs/en_Castlevania 64.md
@@ -116,7 +116,7 @@ Enabling Carrie Logic will also expect the following:
 
 - Orb-sniping dogs through the front gates in Villa
 
-Library Skip is **NOT** logically expected with any option. The basement arena crack will always logically expect two Nitros
+Library Skip is **NOT** logically expected by any options. The basement arena crack will always logically expect two Nitros
 and two Mandragoras even with Hard Logic on due to the possibility of wasting a pair on the upper wall, after managing
 to skip past it. And plus, the RNG manip may not even be possible after picking up all the items in the Nitro room.
 

--- a/worlds/cv64/docs/setup_en.md
+++ b/worlds/cv64/docs/setup_en.md
@@ -28,8 +28,8 @@ the White Jewels.
 
 ## Generating and Patching a Game
 
-1. Create your settings file (YAML). You can make one on the
-[Castlevania 64 settings page](../../../games/Castlevania 64/player-settings).
+1. Create your options file (YAML). You can make one on the
+[Castlevania 64 options page](../../../games/Castlevania%2064/player-options).
 2. Follow the general Archipelago instructions for [generating a game](../../Archipelago/setup/en#generating-a-game).
 This will generate an output file for you. Your patch file will have the `.apcv64` file extension.
 3. Open `ArchipelagoLauncher.exe`

--- a/worlds/cv64/options.py
+++ b/worlds/cv64/options.py
@@ -337,13 +337,13 @@ class BigToss(Toggle):
     """Makes every non-immobilizing damage source launch you as if you got hit by Behemoth's charge.
     Press A while tossed to cancel the launch momentum and avoid being thrown off ledges.
     Hold Z to have all incoming damage be treated as it normally would.
-    Any tricks that might be possible with it are NOT considered in logic with any option."""
+    Any tricks that might be possible with it are NOT considered in logic by any options."""
     display_name = "Big Toss"
 
 
 class PantherDash(Choice):
     """Hold C-right at any time to sprint way faster. Any tricks that might be
-    possible with it are NOT considered in logic with any option and any boss
+    possible with it are NOT considered in logic by any options and any boss
     fights with boss health meters, if started, are expected to be finished
     before leaving their arenas if Dracula's Condition is bosses. Jumpless will
     prevent jumping while moving at the increased speed to ensure logic cannot be broken with it."""

--- a/worlds/cv64/options.py
+++ b/worlds/cv64/options.py
@@ -337,13 +337,13 @@ class BigToss(Toggle):
     """Makes every non-immobilizing damage source launch you as if you got hit by Behemoth's charge.
     Press A while tossed to cancel the launch momentum and avoid being thrown off ledges.
     Hold Z to have all incoming damage be treated as it normally would.
-    Any tricks that might be possible with it are NOT considered in logic on any setting."""
+    Any tricks that might be possible with it are NOT considered in logic with any option."""
     display_name = "Big Toss"
 
 
 class PantherDash(Choice):
     """Hold C-right at any time to sprint way faster. Any tricks that might be
-    possible with it are NOT considered in logic on any setting and any boss
+    possible with it are NOT considered in logic with any option and any boss
     fights with boss health meters, if started, are expected to be finished
     before leaving their arenas if Dracula's Condition is bosses. Jumpless will
     prevent jumping while moving at the increased speed to ensure logic cannot be broken with it."""


### PR DESCRIPTION
## What is this fixing or adding?
At @ReverM's request, changes all the mentions of player "settings" that I could find to player "options". Also fixes a link to the options page that is currently broken on the English setup page and changes a couple of wording oddities I happened to notice.

## How was this tested?
Ran the webhost and made sure all the links were working.
