### PR TITLE
SC2: Local Victory Items option

### DIFF
--- a/worlds/sc2/Locations.py
+++ b/worlds/sc2/Locations.py
@@ -35,6 +35,10 @@ class LocationData(NamedTuple):
     rule: Optional[Callable[[Any], bool]] = Location.access_rule
 
 
+def is_victory_location(location_name):
+    return location_name.endswith((": Victory", ": Defeat"))
+
+
 def get_location_types(world: World, inclusion_type: LocationInclusion) -> Set[LocationType]:
     """
 
@@ -1629,7 +1633,7 @@ def get_locations(world: Optional[World]) -> Tuple[LocationData, ...]:
             location_data = location_data._replace(rule=Location.access_rule)
             location_table[i] = location_data
         # Generating Beat event locations
-        if location_data.name.endswith((": Victory", ": Defeat")):
+        if is_victory_location(location_data.name):
             beat_events.append(
                 location_data._replace(name="Beat " + location_data.name.rsplit(": ", 1)[0], code=None)
             )

--- a/worlds/sc2/Options.py
+++ b/worlds/sc2/Options.py
@@ -764,6 +764,14 @@ class StartingSupplyPerItem(Range):
     default = 5
 
 
+class LocalVictoryItems(Toggle):
+    """
+    Forces mission victory locations to contain items for yourself.
+    This prevents other games running !collect from marking your missions as completed.
+    """
+    display_name = "Local Victory Items"
+
+
 @dataclass
 class Starcraft2Options(PerGameCommonOptions):
     game_difficulty: GameDifficulty
@@ -824,7 +832,7 @@ class Starcraft2Options(PerGameCommonOptions):
     minerals_per_item: MineralsPerItem
     vespene_per_item: VespenePerItem
     starting_supply_per_item: StartingSupplyPerItem
-
+    local_victory_items: LocalVictoryItems
 
 def get_option_value(world: World, name: str) -> Union[int,  FrozenSet]:
     if world is None:

--- a/worlds/sc2/Options.py
+++ b/worlds/sc2/Options.py
@@ -834,6 +834,7 @@ class Starcraft2Options(PerGameCommonOptions):
     starting_supply_per_item: StartingSupplyPerItem
     local_victory_items: LocalVictoryItems
 
+
 def get_option_value(world: World, name: str) -> Union[int,  FrozenSet]:
     if world is None:
         field: Field = [class_field for class_field in fields(Starcraft2Options) if class_field.name == name][0]

--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -404,7 +404,7 @@ def place_local_victory_items(multiworld: MultiWorld, world: World, pool: list):
     victory_locations = [location for location in multiworld.get_unfilled_locations(world.player)
                          if is_victory_location(location.name)]
     for location in victory_locations:
-        add_item_rule(location, lambda state: location.player == world.player)
+        add_item_rule(location, lambda item: location.player == item.player)
     world.random.shuffle(pool)
     fill_restrictive(multiworld, multiworld.state, victory_locations, pool, single_player_placement=True, lock=False,
                      swap=False)

--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -5,6 +5,8 @@ from typing import List, Set, Iterable, Sequence, Dict, Callable, Union
 from math import floor, ceil
 from BaseClasses import Item, MultiWorld, Location, Tutorial, ItemClassification
 from worlds.AutoWorld import WebWorld, World
+from Fill import fill_restrictive
+from worlds.generic.Rules import add_item_rule
 from . import ItemNames
 from .Items import StarcraftItem, filler_items, get_item_table, get_full_item_list, \
     get_basic_units, ItemData, upgrade_included_names, progressive_if_nco, kerrigan_actives, kerrigan_passives, \
@@ -83,6 +85,9 @@ class SC2World(World):
         pool = get_item_pool(self, self.mission_req_table, starter_items, excluded_items, self.location_cache)
 
         fill_item_pool_with_dummy_items(self, self.locked_locations, self.location_cache, pool)
+
+        if self.options.local_victory_items:
+            place_local_victory_items(self.multiworld, self, pool)
 
         self.multiworld.itempool += pool
 
@@ -393,6 +398,16 @@ def fill_item_pool_with_dummy_items(self: SC2World, locked_locations: List[str],
     for _ in range(len(location_cache) - len(locked_locations) - len(pool)):
         item = create_item_with_correct_settings(self.player, self.get_filler_item_name())
         pool.append(item)
+
+
+def place_local_victory_items(multiworld: MultiWorld, world: World, pool: list):
+    victory_locations = [location for location in multiworld.get_unfilled_locations(world.player)
+                         if location.name.endswith((": Victory", ": Defeat"))]
+    for location in victory_locations:
+        add_item_rule(location, lambda state: location.player == world.player)
+    world.random.shuffle(pool)
+    fill_restrictive(multiworld, multiworld.state, victory_locations, pool, single_player_placement=True, lock=False,
+                     swap=False)
 
 
 def create_item_with_correct_settings(player: int, name: str) -> Item:

--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -13,7 +13,7 @@ from .Items import StarcraftItem, filler_items, get_item_table, get_full_item_li
     kerrigan_only_passives, progressive_if_ext, not_balanced_starting_units, spear_of_adun_calldowns, \
     spear_of_adun_castable_passives, nova_equipment
 from .ItemGroups import item_name_groups
-from .Locations import get_locations, LocationType, get_location_types, get_plando_locations
+from .Locations import get_locations, LocationType, get_location_types, get_plando_locations, is_victory_location
 from .Regions import create_regions
 from .Options import get_option_value, LocationInclusion, KerriganLevelItemDistribution, \
     KerriganPresence, KerriganPrimalStatus, RequiredTactics, kerrigan_unit_available, StarterUnit, SpearOfAdunPresence, \
@@ -402,7 +402,7 @@ def fill_item_pool_with_dummy_items(self: SC2World, locked_locations: List[str],
 
 def place_local_victory_items(multiworld: MultiWorld, world: World, pool: list):
     victory_locations = [location for location in multiworld.get_unfilled_locations(world.player)
-                         if location.name.endswith((": Victory", ": Defeat"))]
+                         if is_victory_location(location.name)]
     for location in victory_locations:
         add_item_rule(location, lambda state: location.player == world.player)
     world.random.shuffle(pool)


### PR DESCRIPTION
Wrote this for my own purposes but thought I would offer it upstream.

## What is this fixing or adding?
Adds a Local Victory Items option to SC2. This places local items into Victory locations, which prevents other players' !collects from marking missions as completed when they are not. Items are not locked, but an Item Rule is added to these locations to ensure that if Progression Balancing, etc, swap items out, they do so only with other local items. 

## How was this tested?
Generating a multiworld and ensuring all victory locations contained local items.