### PR TITLE
SC2: Don't Filter Excluded Victory Locations

### DIFF
--- a/worlds/sc2/Locations.py
+++ b/worlds/sc2/Locations.py
@@ -1620,7 +1620,7 @@ def get_locations(world: Optional[World]) -> Tuple[LocationData, ...]:
         plando_locations = get_plando_locations(world)
         exclude_locations = get_option_value(world, "exclude_locations")
         location_table = [location for location in location_table
-                          if (LocationType is LocationType.VICTORY or location.name not in exclude_locations)
+                          if (location.type is LocationType.VICTORY or location.name not in exclude_locations)
                           and location.type not in excluded_location_types
                           or location.name in plando_locations]
     for i, location_data in enumerate(location_table):


### PR DESCRIPTION
## What is this fixing or adding?
In testing #3017 I put a victory location into `exclude_locations` to make sure it worked. I found the location was not created. Evidently SC2 filters out excluded locations, and attempts to prevent victory locations from being filtered out, but fails due to a bug. I didn't check what happens if a game is played under this condition but since victory locations determine whether a mission is considered beaten, I can't imagine it goes well.

## How was this tested?
Generating with an excluded victory location and observing in the spoiler log that the location is still created.