### PR TITLE
Pokemon Emerald: Fix typo

### DIFF
--- a/worlds/pokemon_emerald/data.py
+++ b/worlds/pokemon_emerald/data.py
@@ -646,7 +646,7 @@ def _init() -> None:
         ("SPECIES_CHIKORITA", "Chikorita", 152),
         ("SPECIES_BAYLEEF", "Bayleef", 153),
         ("SPECIES_MEGANIUM", "Meganium", 154),
-        ("SPECIES_CYNDAQUIL", "Cindaquil", 155),
+        ("SPECIES_CYNDAQUIL", "Cyndaquil", 155),
         ("SPECIES_QUILAVA", "Quilava", 156),
         ("SPECIES_TYPHLOSION", "Typhlosion", 157),
         ("SPECIES_TOTODILE", "Totodile", 158),

--- a/worlds/pokemon_emerald/data/locations.json
+++ b/worlds/pokemon_emerald/data/locations.json
@@ -2497,7 +2497,7 @@
     "tags": ["Pokedex"]
   },
   "POKEDEX_REWARD_155": {
-    "label": "Pokedex - Cindaquil",
+    "label": "Pokedex - Cyndaquil",
     "tags": ["Pokedex"]
   },
   "POKEDEX_REWARD_156": {


### PR DESCRIPTION
## What is this fixing or adding?

Misspelled a pokemon species label, which is displayed for pokedex entry locations and used as a key for the blacklist options.

## How was this tested?

Generated a game with dexsanity enabled and the correctly-spelled species blacklisted in `wild_encounters`, Ctrl+F "cindaquil" has no more occurrences.
