### PR TITLE
Pokemon Emerald: Fix opponents learning excluded and non-randomized TMs

### DIFF
--- a/worlds/pokemon_emerald/__init__.py
+++ b/worlds/pokemon_emerald/__init__.py
@@ -568,14 +568,6 @@ class PokemonEmeraldWorld(World):
         self.modified_misc_pokemon = copy.deepcopy(emerald_data.misc_pokemon)
         self.modified_starters = copy.deepcopy(emerald_data.starters)
 
-        randomize_abilities(self)
-        randomize_learnsets(self)
-        randomize_tm_hm_compatibility(self)
-        randomize_legendary_encounters(self)
-        randomize_misc_pokemon(self)
-        randomize_opponent_parties(self)
-        randomize_starters(self)
-
         # Modify catch rate
         min_catch_rate = min(self.options.min_catch_rate.value, 255)
         for species in self.modified_species.values():
@@ -589,6 +581,14 @@ class PokemonEmeraldWorld(World):
                 new_move = get_random_move(self.random, new_moves | self.blacklisted_moves)
                 new_moves.add(new_move)
                 self.modified_tmhm_moves[i] = new_move
+
+        randomize_abilities(self)
+        randomize_learnsets(self)
+        randomize_tm_hm_compatibility(self)
+        randomize_legendary_encounters(self)
+        randomize_misc_pokemon(self)
+        randomize_opponent_parties(self)
+        randomize_starters(self)
 
         create_patch(self, output_directory)
 

--- a/worlds/pokemon_emerald/opponents.py
+++ b/worlds/pokemon_emerald/opponents.py
@@ -80,7 +80,7 @@ def randomize_opponent_parties(world: "PokemonEmeraldWorld") -> None:
                 per_species_tmhm_moves[new_species.species_id] = sorted({
                     world.modified_tmhm_moves[i]
                     for i, is_compatible in enumerate(int_to_bool_array(new_species.tm_hm_compatibility))
-                    if is_compatible
+                    if is_compatible and world.modified_tmhm_moves[i] not in world.blacklisted_moves
                 })
 
             # TMs and HMs compatible with the species


### PR DESCRIPTION
## What is this fixing or adding?

After reordering the randomization in `generate_output` for organization, the randomization of TMs was inadvertently moved to after TMs are used to create opponent movesets. So opponents currently use moves based on the TMs in the vanilla game, rather than in the player's randomized game.

Opponents could also learn blacklisted moves through vanilla TMs, so they are now filtered when selecting opponent movesets.

## How was this tested?

Generated a few times with random TMs and blacklisted moves.