### PR TITLE
Core: Additional logging for fill_restrictive during large seeds

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -161,6 +161,7 @@ def fill_restrictive(multiworld: MultiWorld, base_state: CollectionState, locati
             placements.append(spot_to_fill)
             spot_to_fill.event = item_to_place.advancement
             placed += 1
+
             if total < 10000 or placed/total < 0.8:
                 if not placed % 1000:
                     _log_fill_progress(name, placed, total)
@@ -169,6 +170,7 @@ def fill_restrictive(multiworld: MultiWorld, base_state: CollectionState, locati
                     _log_fill_progress(name, placed, total)
             elif not placed % 100:
                 _log_fill_progress(name, placed, total)
+
             if on_place:
                 on_place(spot_to_fill)
 

--- a/Fill.py
+++ b/Fill.py
@@ -161,7 +161,13 @@ def fill_restrictive(multiworld: MultiWorld, base_state: CollectionState, locati
             placements.append(spot_to_fill)
             spot_to_fill.event = item_to_place.advancement
             placed += 1
-            if not placed % 1000:
+            if total < 10000 or placed/total < 0.8:
+                if not placed % 1000:
+                    _log_fill_progress(name, placed, total)
+            elif placed/total > 0.95:
+                if not placed % 10:
+                    _log_fill_progress(name, placed, total)
+            elif not placed % 100:
                 _log_fill_progress(name, placed, total)
             if on_place:
                 on_place(spot_to_fill)


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?

Increase logging frequency when filling progression items for large seeds. This is a naive approach as a first-order approximation.  

This approach:  
- if number of items is fewer than 10k, print every 1k placements  
- if number of items is more than 10k:
  - if fewer than 80% of items placed, print every 1k placements  
  - if between 80-95% of items placed, print every 100 placements  
  - if in last 5% of items placed, print every 10 placements  

## How was this tested?

Generated seeds with 20k+ progression items taking 90+ minutes to generate.

## If this makes graphical changes, please attach screenshots.

<img width="581" alt="Screenshot 2024-03-24 at 22 51 59" src="https://github.com/ArchipelagoMW/Archipelago/assets/4594575/ee28e423-528a-44d2-b09a-9a715b096d8c">