### PR TITLE
Core: organize files on ingest via alpha, not ascii

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -120,7 +120,7 @@ def main(args=None, callback=ERmain):
                 raise ValueError(f"File {fname} is invalid. Please fix your yaml.") from e
 
     # sort dict for consistent results across platforms:
-    weights_cache = {key: value for key, value in sorted(weights_cache.items(), key=lambda k: k[0].lower())}
+    weights_cache = {key: value for key, value in sorted(weights_cache.items(), key=lambda k: k[0].casefold())}
     for filename, yaml_data in weights_cache.items():
         if filename not in {args.meta_file_path, args.weights_file_path}:
             for yaml in yaml_data:

--- a/Generate.py
+++ b/Generate.py
@@ -120,7 +120,7 @@ def main(args=None, callback=ERmain):
                 raise ValueError(f"File {fname} is invalid. Please fix your yaml.") from e
 
     # sort dict for consistent results across platforms:
-    weights_cache = {key: value for key, value in sorted(weights_cache.items())}
+    weights_cache = {key: value for key, value in sorted(weights_cache.items(), key=lambda k: k[0].lower())}
     for filename, yaml_data in weights_cache.items():
         if filename not in {args.meta_file_path, args.weights_file_path}:
             for yaml in yaml_data:


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?

Use alphabetic rather than asciibetic sorting when ingesting files for generation (upper and lower case letters will be interspersed rather than upper case before lower case. This doesn't fully order names. It's unclear if that would make things easier or harder (having all seeds together from a single file may make them easier to find).

## How was this tested?

Generated many seeds.

## If this makes graphical changes, please attach screenshots.

<img width="607" alt="Screenshot 2024-03-24 at 23 04 57" src="https://github.com/ArchipelagoMW/Archipelago/assets/4594575/d44460da-2321-46f3-8774-fa186302988e">

