### PR TITLE
Core - Added classification check to Item Equality

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1148,7 +1148,7 @@ class Item:
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Item):
             return NotImplemented
-        return self.name == other.name and self.player == other.player
+        return self.name == other.name and self.player == other.player and self.classification == other.classification
 
     def __lt__(self, other: object) -> bool:
         if not isinstance(other, Item):


### PR DESCRIPTION
## What is this fixing or adding?
Item equality comparison did not consider classifications. Since the case where the same item exists in many instances, with different classifications, is supported (and even often encouraged), this is a flaw in the system, where equality comparisons can get it wrong sometimes, for example removing or filtering the wrong items from collections

## How was this tested?
Ran all the unit tests, plus my case that had a problem because of this