### PR TITLE
The Messenger: update docs formatting and fix outdated info

### DIFF
--- a/worlds/messenger/docs/en_The Messenger.md
+++ b/worlds/messenger/docs/en_The Messenger.md
@@ -55,8 +55,8 @@ quit to title and reload the save. The currently known areas include:
         * After Courage Note collection (Corrupted Future chase)
 * After reaching ninja village a teleport option is added to the menu to reach it quickly
 * Toggle Windmill Shuriken button is added to option menu once the item is received
-* The mod option menu will also have a hint item button, as well as a release and collect button that are all placed when
-the player fulfills the necessary conditions.
+* The mod option menu will also have a hint item button, as well as a release and collect button that are all placed
+when the player fulfills the necessary conditions.
 * After running the game with the mod, a config file (APConfig.toml) will be generated in your game folder that can be
 used to modify certain settings such as text size and color. This can also be used to specify a player name that can't
 be entered in game.
@@ -73,5 +73,5 @@ chest will not work.
 
 ## What do I do if I have a problem?
 
-If you believe something happened that isn't intended, please get the `log.txt` from the folder of your game installation
-and send a bug report either on GitHub or the [Archipelago Discord Server](http://archipelago.gg/discord)
+If you believe something happened that isn't intended, please get the `log.txt` from the folder of your game
+installation and send a bug report either on GitHub or the [Archipelago Discord Server](http://archipelago.gg/discord)

--- a/worlds/messenger/docs/en_The Messenger.md
+++ b/worlds/messenger/docs/en_The Messenger.md
@@ -49,11 +49,10 @@ for it. The groups you can use for The Messenger are:
 ## Other changes
 
 * The player can return to the Tower of Time HQ at any point by selecting the button from the options menu
-    * This can cause issues if used at specific times. Current known:
+    * This can cause issues if used at specific times. If used in any of these known problematic areas, immediately
+quit to title and reload the save. The currently known areas include:
         * During Boss fights
         * After Courage Note collection (Corrupted Future chase)
-            * This is currently an expected action in logic. If you do need to teleport during this chase sequence, it
-is recommended to quit to title and reload the save
 * After reaching ninja village a teleport option is added to the menu to reach it quickly
 * Toggle Windmill Shuriken button is added to option menu once the item is received
 * The mod option menu will also have a hint item button, as well as a release and collect button that are all placed when
@@ -67,7 +66,7 @@ be entered in game.
 * If you receive the Magic Firefly while in Quillshroom Marsh, The De-curse Queen cutscene will not play. You can exit
 to Searing Crags and re-enter to get it to play correctly.
 * Teleporting back to HQ, then returning to the same level you just left through a Portal can cause Ninja to run left
-and enter a different portal than the one entered by the player or other incorrect inputs, causing a soft lock
+and enter a different portal than the one entered by the player or lead to other incorrect inputs, causing a soft lock
 * Text entry menus don't accept controller input
 * In power seal hunt mode, the chest must be opened by entering the shop from a level. Teleporting to HQ and opening the
 chest will not work.

--- a/worlds/messenger/docs/en_The Messenger.md
+++ b/worlds/messenger/docs/en_The Messenger.md
@@ -49,28 +49,28 @@ for it. The groups you can use for The Messenger are:
 ## Other changes
 
 * The player can return to the Tower of Time HQ at any point by selecting the button from the options menu
-  * This can cause issues if used at specific times. Current known:
-    * During Boss fights
-    * After Courage Note collection (Corrupted Future chase)
-      * This is currently an expected action in logic. If you do need to teleport during this chase sequence, it
-        is recommended to quit to title and reload the save
+    * This can cause issues if used at specific times. Current known:
+        * During Boss fights
+        * After Courage Note collection (Corrupted Future chase)
+            * This is currently an expected action in logic. If you do need to teleport during this chase sequence, it
+is recommended to quit to title and reload the save
 * After reaching ninja village a teleport option is added to the menu to reach it quickly
 * Toggle Windmill Shuriken button is added to option menu once the item is received
 * The mod option menu will also have a hint item button, as well as a release and collect button that are all placed when
-  the player fulfills the necessary conditions.
+the player fulfills the necessary conditions.
 * After running the game with the mod, a config file (APConfig.toml) will be generated in your game folder that can be
-  used to modify certain settings such as text size and color. This can also be used to specify a player name that can't
-  be entered in game.
+used to modify certain settings such as text size and color. This can also be used to specify a player name that can't
+be entered in game.
 
 ## Known issues
 * Ruxxtin Coffin cutscene will sometimes not play correctly, but will still reward the item
 * If you receive the Magic Firefly while in Quillshroom Marsh, The De-curse Queen cutscene will not play. You can exit
-  to Searing Crags and re-enter to get it to play correctly.
-* Sometimes upon teleporting back to HQ, Ninja will run left and enter a different portal than the one entered by the
-  player. This may also cause a softlock.
+to Searing Crags and re-enter to get it to play correctly.
+* Teleporting back to HQ, then returning to the same level you just left through a Portal can cause Ninja to run left
+and enter a different portal than the one entered by the player or other incorrect inputs, causing a soft lock
 * Text entry menus don't accept controller input
 * In power seal hunt mode, the chest must be opened by entering the shop from a level. Teleporting to HQ and opening the
-  chest will not work.
+chest will not work.
 
 ## What do I do if I have a problem?
 

--- a/worlds/messenger/docs/setup_en.md
+++ b/worlds/messenger/docs/setup_en.md
@@ -18,7 +18,7 @@ Read changes to the base game on the [Game Info Page](/games/The%20Messenger/inf
 3. Click on "The Messenger"
 4. Follow the prompts
 
-These steps can be followed in the future to launch the game and check for mod updates.
+These steps can also be followed to launch the game and check for mod updates after the initial setup.
 
 ### Manual Installation
 

--- a/worlds/messenger/docs/setup_en.md
+++ b/worlds/messenger/docs/setup_en.md
@@ -18,17 +18,17 @@ Read changes to the base game on the [Game Info Page](/games/The%20Messenger/inf
 3. Click on "The Messenger"
 4. Follow the prompts
 
+These steps can be followed in the future to launch the game and check for mod updates.
+
 ### Manual Installation
 
 1. Download and install Courier Mod Loader using the instructions on the release page
    * [Latest release is currently 0.7.1](https://github.com/Brokemia/Courier/releases)
 2. Download and install the randomizer mod
    1. Download the latest TheMessengerRandomizerAP.zip from
-      [The Messenger Randomizer Mod AP releases page](https://github.com/alwaysintreble/TheMessengerRandomizerModAP/releases)
+[The Messenger Randomizer Mod AP releases page](https://github.com/alwaysintreble/TheMessengerRandomizerModAP/releases)
    2. Extract the zip file to `TheMessenger/Mods/` of your game's install location
-      * You cannot have both the non-AP randomizer and the AP randomizer installed at the same time. The AP randomizer
-        is backwards compatible, so the non-AP mod can be safely removed, and you can still play seeds generated from the
-        non-AP randomizer.
+      * You cannot have both the non-AP randomizer and the AP randomizer installed at the same time
    3. Optionally, Backup your save game
       * On Windows
         1. Press `Windows Key + R` to open run
@@ -46,13 +46,13 @@ Read changes to the base game on the [Game Info Page](/games/The%20Messenger/inf
 3. Enter connection info using the relevant option buttons
    * **The game is limited to alphanumerical characters, `.`, and `-`.**
    * This defaults to `archipelago.gg` and does not need to be manually changed if connecting to a game hosted on the
-     website.
+website.
    * If using a name that cannot be entered in the in game menus, there is a config file (APConfig.toml) in the game
-     directory. When using this, all connection information must be entered in the file. 
+directory. When using this, all connection information must be entered in the file. 
 4. Select the `Connect to Archipelago` button
 5. Navigate to save file selection
 6. Start a new game
-   * If you're already connected, deleting a save will not disconnect you and is completely safe. 
+   * If you're already connected, deleting an existing save will not disconnect you and is completely safe. 
 
 ## Continuing a MultiWorld Game
 

--- a/worlds/messenger/options.py
+++ b/worlds/messenger/options.py
@@ -88,7 +88,7 @@ class ShuffleTransitions(Choice):
 
 
 class Goal(Choice):
-    """Requirement to finish the game."""
+    """Requirement to finish the game. To win power seal hunt you enter the Music Box through the shop chest."""
     display_name = "Goal"
     option_open_music_box = 0
     option_power_seal_hunt = 1

--- a/worlds/messenger/options.py
+++ b/worlds/messenger/options.py
@@ -88,7 +88,7 @@ class ShuffleTransitions(Choice):
 
 
 class Goal(Choice):
-    """Requirement to finish the game. To win power seal hunt you enter the Music Box through the shop chest."""
+    """Requirement to finish the game. To win with the power seal hunt goal, you must enter the Music Box through the shop chest."""
     display_name = "Goal"
     option_open_music_box = 0
     option_power_seal_hunt = 1


### PR DESCRIPTION
## What is this fixing or adding?
Noticed some incorrect information in the docs so this addresses those. The website also doesn't correctly indent 2 space bullet points so swaps to 4 space where needed to render as intended. This still looks pretty bad but it at least gets across the correct intention.

## How was this tested?
👀 

## If this makes graphical changes, please attach screenshots.
