### PR TITLE
Generate: remove tag "-"

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -21,7 +21,6 @@ from BaseClasses import seeddigits, get_seed, PlandoOptions
 from Main import main as ERmain
 from settings import get_settings
 from Utils import parse_yamls, version_tuple, __version__, tuplize_version
-from worlds.alttp import Options as LttPOptions
 from worlds.alttp.EntranceRandomizer import parse_arguments
 from worlds.alttp.Text import TextTable
 from worlds.AutoWorld import AutoWorldRegister
@@ -308,13 +307,6 @@ def handle_name(name: str, player: int, name_counter: Counter):
     if new_name == "Archipelago":
         raise Exception(f"You cannot name yourself \"{new_name}\"")
     return new_name
-
-
-def prefer_int(input_data: str) -> Union[str, int]:
-    try:
-        return int(input_data)
-    except:
-        return input_data
 
 
 def roll_percentage(percentage: Union[int, float]) -> bool:

--- a/Generate.py
+++ b/Generate.py
@@ -9,6 +9,7 @@ import urllib.parse
 import urllib.request
 from collections import Counter
 from typing import Any, Dict, Tuple, Union
+from itertools import cycle
 
 import ModuleUpdate
 
@@ -319,7 +320,7 @@ def update_weights(weights: dict, new_weights: dict, update_type: str, name: str
     logging.debug(f'Applying {new_weights}')
     cleaned_weights = {}
     for option in new_weights:
-        option_name = option.lstrip("+")
+        option_name = option.lstrip("+-")
         if option.startswith("+") and option_name in weights:
             cleaned_value = weights[option_name]
             new_value = new_weights[option]
@@ -329,6 +330,20 @@ def update_weights(weights: dict, new_weights: dict, update_type: str, name: str
                 cleaned_value.extend(new_value)
             else:
                 raise Exception(f"Cannot apply merge to non-dict, set, or list type {option_name},"
+                                f" received {type(new_value).__name__}.")
+            cleaned_weights[option_name] = cleaned_value
+        elif option.startswith("-") and option_name in weights:
+            cleaned_value = weights[option_name]
+            new_value = new_weights[option]
+            if isinstance(new_value, set):
+                cleaned_value.difference_update(new_value)
+            elif isinstance(new_value, list):
+                for element in new_value:
+                    cleaned_value.remove(element)
+            elif isinstance(new_value, dict):
+                cleaned_value = dict(Counter(cleaned_value) - Counter(new_value))
+            else:
+                raise Exception(f"Cannot apply remove to non-dict, set, or list type {option_name},"
                                 f" received {type(new_value).__name__}.")
             cleaned_weights[option_name] = cleaned_value
         else:
@@ -460,9 +475,11 @@ def roll_settings(weights: dict, plando_options: PlandoOptions = PlandoOptions.b
     world_type = AutoWorldRegister.world_types[ret.game]
     game_weights = weights[ret.game]
 
-    if any(weight.startswith("+") for weight in game_weights) or \
-       any(weight.startswith("+") for weight in weights):
-        raise Exception(f"Merge tag cannot be used outside of trigger contexts.")
+    for weight in cycle((game_weights, weights)):
+        if weight.startswith("+"):
+            raise Exception(f"Merge tag cannot be used outside of trigger contexts. Found {weight}")
+        if weight.startswith("-"):
+            raise Exception(f"Remove tag cannot be used outside of trigger contexts. Found {weight}")
 
     if "triggers" in game_weights:
         weights = roll_triggers(weights, game_weights["triggers"])


### PR DESCRIPTION
## What is this fixing or adding?
add "-" operation similar to the "+" operation
I expect this to be one of the first  feature requests once "+" exists.

There is an opiniated/questionable function in here though when it comes to dict handling.
{"a": 1} + {"a": 2} -> {"a": 2}
is the current + behaviour, however, - does:
{"a": 1} - {"a": 2} -> {"a": -1}
I considered it out of scope to touch + behaviour to act as a per-key-value + in this PR, but maybe for consistency that should be done?

## How was this tested?
only minimally so far

## If this makes graphical changes, please attach screenshots.
