### PR TITLE
Pokemon Emerald: Exclude Norman Trainer Location During Norman Goal

### DIFF
--- a/worlds/pokemon_emerald/__init__.py
+++ b/worlds/pokemon_emerald/__init__.py
@@ -300,6 +300,7 @@ class PokemonEmeraldWorld(World):
 
             # Locations which are directly unlocked by defeating Norman.
             exclude_locations([
+                "Petalburg Gym - Leader Norman",
                 "Petalburg Gym - Balance Badge",
                 "Petalburg Gym - TM42 from Norman",
                 "Petalburg City - HM03 from Wally's Uncle",


### PR DESCRIPTION
## What is this fixing or adding?

Locations which are always only accessible after a player completes their goal should be excluded. With the addition of trainersanity, I missed adding Norman's trainer reward to this list.

## How was this tested?

Generated a game with `norman` goal and trainersanity turned on. No issues; spoiler showed a filler item on the location.
