### PR TITLE
SC2: Remove the deprecated data version attribute in order to avoid cached old item names

### DIFF
--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -42,7 +42,6 @@ class SC2World(World):
 
     game = "Starcraft 2"
     web = Starcraft2WebWorld()
-    data_version = 7
 
     item_name_to_id = {name: data.code for name, data in get_full_item_list().items()}
     location_name_to_id = {location.name: location.code for location in get_locations(None)}

--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -42,7 +42,7 @@ class SC2World(World):
 
     game = "Starcraft 2"
     web = Starcraft2WebWorld()
-    data_version = 6
+    data_version = 7
 
     item_name_to_id = {name: data.code for name, data in get_full_item_list().items()}
     location_name_to_id = {location.name: location.code for location in get_locations(None)}


### PR DESCRIPTION
## What is this fixing or adding?
Remove the deprecated data package version in order to avoid cached old item names

Some ppl got old `+15 Starting Minerals` instead of modern `Additional Starting Minerals` in received item messages as the amount is configurable now.

See: https://discord.com/channels/731205301247803413/980554570075873300/1222598200607903744
## How was this tested?
Bumped the number as the world doc says. However, the world name has changed too and the old apworld could remain on the RC website

## If this makes graphical changes, please attach screenshots.
