### PR TITLE
Core: Player name property on world class

### DIFF
--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -468,6 +468,10 @@ class World(metaclass=AutoWorldRegister):
     def get_region(self, region_name: str) -> "Region":
         return self.multiworld.get_region(region_name, self.player)
 
+    @property
+    def player_name(self):
+        return self.multiworld.get_player_name(self.player)
+
     @classmethod
     def get_data_package_data(cls) -> "GamesPackage":
         sorted_item_name_groups = {

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -469,7 +469,7 @@ class World(metaclass=AutoWorldRegister):
         return self.multiworld.get_region(region_name, self.player)
 
     @property
-    def player_name(self):
+    def player_name(self) -> str:
         return self.multiworld.get_player_name(self.player)
 
     @classmethod

--- a/worlds/overcooked2/__init__.py
+++ b/worlds/overcooked2/__init__.py
@@ -219,8 +219,6 @@ class Overcooked2World(World):
     # Autoworld Hooks
 
     def generate_early(self):
-        self.player_name = self.multiworld.player_name[self.player]
-
         # 0.0 to 1.0 where 1.0 is World Record
         self.star_threshold_scale = self.options.star_threshold_scale / 100.0
 


### PR DESCRIPTION
`self.multiworld.get_player_name(self.player)` is so stupid lol

Edit: Overcooked was already doing this itself so I needed to make it not do that. @toasterparty 