### PR TITLE
SC2: Fix HERC upgrades

### DIFF
--- a/WebHostLib/templates/tracker__Starcraft2.html
+++ b/WebHostLib/templates/tracker__Starcraft2.html
@@ -294,7 +294,8 @@
                                 <td>{{ sc2_icon('HERC') }}</td>
                                 <td>{{ sc2_icon('Juggernaut Plating (HERC)') }}</td>
                                 <td>{{ sc2_icon('Kinetic Foam (HERC)') }}</td>
-                                <td colspan="5"></td>
+                                <td>{{ sc2_icon('Resource Efficiency (HERC)') }}</td>
+                                <td colspan="4"></td>
                                 <td>{{ sc2_icon('Widow Mine') }}</td>
                                 <td>{{ sc2_icon('Drilling Claws (Widow Mine)') }}</td>
                                 <td>{{ sc2_icon('Concealment (Widow Mine)') }}</td>

--- a/WebHostLib/tracker.py
+++ b/WebHostLib/tracker.py
@@ -1674,6 +1674,7 @@ if "Starcraft 2" in network_data_package["games"]:
             "Resource Efficiency (Spectre)":               github_icon_base_url + "blizzard/btn-ability-hornerhan-salvagebonus.png",
             "Juggernaut Plating (HERC)":                   organics_icon_base_url + "JuggernautPlating.png",
             "Kinetic Foam (HERC)":                         organics_icon_base_url + "KineticFoam.png",
+            "Resource Efficiency (HERC)":                  github_icon_base_url + "blizzard/btn-ability-hornerhan-salvagebonus.png",
 
             "Hellion":                                     "https://static.wikia.nocookie.net/starcraft/images/5/56/Hellion_SC2_Icon1.jpg",
             "Vulture":                                     github_icon_base_url + "blizzard/btn-unit-terran-vulture.png",

--- a/worlds/sc2/Items.py
+++ b/worlds/sc2/Items.py
@@ -661,11 +661,11 @@ item_table = {
                  description=RESOURCE_EFFICIENCY_DESCRIPTION_TEMPLATE.format("HERC")),
     ItemNames.HERC_JUGGERNAUT_PLATING:
         ItemData(285 + SC2WOL_ITEM_ID_OFFSET, "Armory 6", 16, SC2Race.TERRAN,
-                 parent_item=ItemNames.WARHOUND, origin={"ext"},
+                 parent_item=ItemNames.HERC, origin={"ext"},
                  description="Increases HERC armor by 2."),
     ItemNames.HERC_KINETIC_FOAM:
         ItemData(286 + SC2WOL_ITEM_ID_OFFSET, "Armory 6", 17, SC2Race.TERRAN,
-                 parent_item=ItemNames.WARHOUND, origin={"ext"},
+                 parent_item=ItemNames.HERC, origin={"ext"},
                  description="Increases HERC life by 50."),
 
     ItemNames.HELLION_TWIN_LINKED_FLAMETHROWER:


### PR DESCRIPTION
## What is this fixing or adding?
Fixes HERC upgrades being attached to Warhound.
Fixes `Resource Efficiency (HERC)` missing in the tracker

## How was this tested?
Checked the tracker that the missing item is rendered

## If this makes graphical changes, please attach screenshots.
[
![Snímek obrazovky pořízený 2024-03-27 22-54-44](https://github.com/ArchipelagoMW/Archipelago/assets/3447808/7ddc68b7-fcc0-4060-a5ac-c0444de45bda)
](url)