### PR TITLE
Core: Add functions to check whether an Entrance/Region/Location exists

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -390,6 +390,15 @@ class MultiWorld():
     def get_location(self, location_name: str, player: int) -> Location:
         return self.regions.location_cache[player][location_name]
 
+    def region_exists(self, region_name: str, player: int) -> bool:
+        return region_name in self.regions.region_cache[player]
+
+    def entrance_exists(self, entrance_name: str, player: int) -> bool:
+        return entrance_name in self.regions.entrance_cache[player]
+
+    def location_exists(self, location_name: str, player: int) -> bool:
+        return location_name in self.regions.location_cache[player]
+
     def get_all_state(self, use_cache: bool) -> CollectionState:
         cached = getattr(self, "_all_state", None)
         if use_cache and cached:

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -504,6 +504,15 @@ class World(metaclass=AutoWorldRegister):
     def get_region(self, region_name: str) -> "Region":
         return self.multiworld.get_region(region_name, self.player)
 
+    def region_exists(self, region_name: str) -> bool:
+        return region_name in self.multiworld.regions.region_cache[self.player]
+
+    def entrance_exists(self, entrance_name: str) -> bool:
+        return entrance_name in self.multiworld.regions.entrance_cache[self.player]
+
+    def location_exists(self, location_name: str) -> bool:
+        return location_name in self.multiworld.regions.location_cache[self.player]
+
     @classmethod
     def get_data_package_data(cls) -> "GamesPackage":
         sorted_item_name_groups = {


### PR DESCRIPTION
People are doing goofy shit like

```
if entrance_name in self.multiworld.regions.entrance_cache[self.player]
```
and
```
try:
    self.get_entrance(entrance_name)
except KeyError:
    ...
```

in their world code.
Let's stop that.


## Alternatives

We could just make the `get_[spot]` methods return None if the spot doesn't exist. Maybe we could even add an optional argument called `return_none_if_not_exists=False` for the sake of worlds already relying on the `KeyError` behavior.
(This would make that function significantly slower though)

We could also make alternative methods called `try_get_[spot]`.

I thought this would be the simplest but I'm obviously willing to hear other opinions

## Also:

Are the multiworld versions necessary? I'm not sure whether we should be adding multiworld methods for things at this point, I did it more out of "tradition" than anything