### PR TITLE
Muse Dash: Update songs to 4.2.0. Adds a new trap

### DIFF
--- a/worlds/musedash/MuseDashCollection.py
+++ b/worlds/musedash/MuseDashCollection.py
@@ -36,13 +36,13 @@ class MuseDashCollections:
         "Find this Month's Featured Playlist",
         "PeroPero in the Universe",
         "umpopoff",
-        "P E R O P E R O Brother Dance"
+        "P E R O P E R O Brother Dance",
     ]
     
     REMOVED_SONGS = [
         "CHAOS Glitch",
         "FM 17314 SUGAR RADIO",
-        "Yume Ou Mono Yo Secret"
+        "Yume Ou Mono Yo Secret",
     ]
 
     album_items: Dict[str, AlbumData] = {}

--- a/worlds/musedash/MuseDashCollection.py
+++ b/worlds/musedash/MuseDashCollection.py
@@ -35,7 +35,8 @@ class MuseDashCollections:
         "Rush-Hour",
         "Find this Month's Featured Playlist",
         "PeroPero in the Universe",
-        "umpopoff"
+        "umpopoff",
+        "P E R O P E R O Brother Dance"
     ]
     
     REMOVED_SONGS = [
@@ -57,6 +58,7 @@ class MuseDashCollections:
         "Chromatic Aberration Trap": STARTING_CODE + 5,
         "Background Freeze Trap": STARTING_CODE + 6,
         "Gray Scale Trap": STARTING_CODE + 7,
+        "Focus Line Trap": STARTING_CODE + 10,
     }
 
     sfx_trap_items: Dict[str, int] = {

--- a/worlds/musedash/MuseDashData.txt
+++ b/worlds/musedash/MuseDashData.txt
@@ -518,7 +518,7 @@ Haunted Dance|43-48|MD Plus Project|False|6|9|11|
 Hey Vincent.|43-49|MD Plus Project|True|6|8|10|
 Meteor feat. TEA|43-50|MD Plus Project|True|3|6|9|
 Narcissism Angel|43-51|MD Plus Project|True|1|3|6|
-AlterLuna|43-52|MD Plus Project|True|6|8|11|
+AlterLuna|43-52|MD Plus Project|True|6|8|11|12
 Niki Tousen|43-53|MD Plus Project|True|6|8|10|11
 Rettou Joutou|70-0|Rin Len's Mirrorland|False|4|7|9|
 Telecaster B-Boy|70-1|Rin Len's Mirrorland|False|5|7|10|
@@ -538,3 +538,10 @@ Reality Show|71-2|Valentine Stage|False|5|7|10|
 SIG feat.Tobokegao|71-3|Valentine Stage|True|3|6|8|
 Rose Love|71-4|Valentine Stage|True|2|4|7|
 Euphoria|71-5|Valentine Stage|True|1|3|6|
+P E R O P E R O Brother Dance|72-0|Legends of Muse Warriors|False|0|?|0|
+PA PPA PANIC|72-1|Legends of Muse Warriors|False|4|8|10|
+How To Make Music Game Song!|72-2|Legends of Muse Warriors|False|6|8|10|11
+Re Re|72-3|Legends of Muse Warriors|False|7|9|11|12
+Marmalade Twins|72-4|Legends of Muse Warriors|False|5|8|10|
+DOMINATOR|72-5|Legends of Muse Warriors|False|7|9|11|
+Teshikani TESHiKANi|72-6|Legends of Muse Warriors|False|5|7|9|

--- a/worlds/musedash/test/TestDifficultyRanges.py
+++ b/worlds/musedash/test/TestDifficultyRanges.py
@@ -68,7 +68,7 @@ class DifficultyRanges(MuseDashTestBase):
 
             # umpopoff is a one time weird song. Its currently the only song in the game
             # with non-standard difficulties and also doesn't have 3 or more difficulties.
-            if song_name == 'umpopoff':
+            if song_name == "umpopoff" or song_name == "P E R O P E R O Brother Dance":
                 self.assertTrue(song.easy is None and song.hard is not None and song.master is None,
                                 f"Song '{song_name}' difficulty not set when it should be.")
             else:


### PR DESCRIPTION
## What is this fixing or adding?
Updates the song list to Muse Dash 4.2.0. Also adds a trap using the new VFX that came with the update.

Note: Might conflict a bit with #2809 but will be an easy resolve.

## How was this tested?
Using tests and a test generation.
