### PR TITLE
Pokemon Emerald: Change dexsanity to not create locations for blacklisted wilds

### DIFF
--- a/worlds/pokemon_emerald/locations.py
+++ b/worlds/pokemon_emerald/locations.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Dict, Optional, FrozenSet, Iterable
 
 from BaseClasses import Location, Region
 
-from .data import BASE_OFFSET, POKEDEX_OFFSET, data
+from .data import BASE_OFFSET, NATIONAL_ID_TO_SPECIES_ID, POKEDEX_OFFSET, data
 from .items import offset_item_value
 
 if TYPE_CHECKING:
@@ -130,8 +130,14 @@ def create_locations_with_tags(world: "PokemonEmeraldWorld", regions: Dict[str, 
             location_data = data.locations[location_name]
 
             location_id = offset_flag(location_data.flag)
-            if location_data.flag == 0:
-                location_id += POKEDEX_OFFSET + int(location_name[15:])
+            if location_data.flag == 0:  # Dexsanity location
+                national_dex_id = int(location_name[-3:])  # Location names are formatted POKEDEX_REWARD_###
+
+                # Don't create this pokedex location if player can't find it in the wild
+                if NATIONAL_ID_TO_SPECIES_ID[national_dex_id] in world.blacklisted_wilds:
+                    continue
+
+                location_id += POKEDEX_OFFSET + national_dex_id
 
             location = PokemonEmeraldLocation(
                 world.player,

--- a/worlds/pokemon_emerald/pokemon.py
+++ b/worlds/pokemon_emerald/pokemon.py
@@ -242,9 +242,9 @@ def randomize_wild_encounters(world: "PokemonEmeraldWorld") -> None:
         RandomizeWildPokemon.option_match_type,
         RandomizeWildPokemon.option_match_base_stats_and_type,
     }
-    catch_em_all = world.options.dexsanity == Toggle.option_true
 
-    catch_em_all_placed = set()
+    already_placed = set()
+    num_placeable_species = NUM_REAL_SPECIES - len(world.blacklisted_wilds)
 
     priority_species = [data.constants["SPECIES_WAILORD"], data.constants["SPECIES_RELICANTH"]]
 
@@ -290,8 +290,8 @@ def randomize_wild_encounters(world: "PokemonEmeraldWorld") -> None:
 
                             # If dexsanity/catch 'em all mode, blacklist already placed species
                             # until every species has been placed once
-                            if catch_em_all and len(catch_em_all_placed) < NUM_REAL_SPECIES:
-                                blacklists[1].append(catch_em_all_placed)
+                            if world.options.dexsanity and len(already_placed) < num_placeable_species:
+                                blacklists[1].append(already_placed)
 
                             # Blacklist from player options
                             blacklists[2].append(world.blacklisted_wilds)
@@ -329,8 +329,8 @@ def randomize_wild_encounters(world: "PokemonEmeraldWorld") -> None:
                             new_species_id = world.random.choice(candidates).species_id
                         species_old_to_new_map[species_id] = new_species_id
 
-                        if catch_em_all and map_data.name not in POSTGAME_MAPS:
-                            catch_em_all_placed.add(new_species_id)
+                        if world.options.dexsanity and map_data.name not in POSTGAME_MAPS:
+                            already_placed.add(new_species_id)
 
                 # Actually create the new list of slots and encounter table
                 new_slots: List[int] = []

--- a/worlds/pokemon_emerald/rules.py
+++ b/worlds/pokemon_emerald/rules.py
@@ -1527,6 +1527,10 @@ def set_rules(world: "PokemonEmeraldWorld") -> None:
     if world.options.dexsanity:
         for i in range(NUM_REAL_SPECIES):
             species = data.species[NATIONAL_ID_TO_SPECIES_ID[i + 1]]
+
+            if species.species_id in world.blacklisted_wilds:
+                continue
+
             set_rule(
                 get_location(f"Pokedex - {species.label}"),
                 lambda state, species_name=species.name: state.has(f"CATCH_{species_name}", world.player)
@@ -1534,7 +1538,8 @@ def set_rules(world: "PokemonEmeraldWorld") -> None:
 
         # Legendary hunt prevents Latios from being a wild spawn so the roamer
         # can be tracked, and also guarantees that the roamer is a Latios.
-        if world.options.goal == Goal.option_legendary_hunt:
+        if world.options.goal == Goal.option_legendary_hunt and \
+                data.constants["SPECIES_LATIOS"] not in world.blacklisted_wilds:
             set_rule(
                 get_location(f"Pokedex - Latios"),
                 lambda state: state.has("EVENT_ENCOUNTER_LATIOS", world.player)


### PR DESCRIPTION
## What is this fixing or adding?

Current behavior is that dexsanity requires every species to be placed on a wild encounter table so that its dexsanity location is reachable. If the player blacklists a species from wild encounters while dexsanity is enabled, the blacklist must be ignored once to place the species.

This changes the interaction so that the dexsanity location is not created if the user blacklisted the species from wild encounters.

## How was this tested?

Generated with dexsanity on while blacklisting each of
- nothing,
- one species,
- "_Legendaries",
-  "_Legendaries" plus Wailord (with a legendary hunt goal, to make sure Wailord still gets placed)

Total location count dropped as expected, no generation failures. Blacklisted species did not show up anywhere in the wild according to the spoiler log (except for Wailord, which is still required to exist in the wild for legendary hunt).