### PR TITLE
CV64: A couple of very small docs corrections.

### DIFF
--- a/worlds/cv64/docs/en_Castlevania 64.md
+++ b/worlds/cv64/docs/en_Castlevania 64.md
@@ -91,7 +91,7 @@ either filler, useful, or a trap.
 
 When you pick up someone else's item, you will not receive anything and the item textbox will show up to announce what you
 found and who it was for. The color of the text will tell you its classification:
-- <font color="moccasin">Light brown-ish</font>: Common
+- <font color="moccasin">Light brown-ish</font>: Filler
 - <font color="white">White</font>/<font color="yellow">Yellow</font>: Useful
 - <font color="yellow">Yellow</font>/<font color="lime">Green</font>: Progression
 - <font color="yellow">Yellow</font>/<font color="red">Red</font>: Trap

--- a/worlds/cv64/options.py
+++ b/worlds/cv64/options.py
@@ -144,8 +144,9 @@ class HardLogic(Toggle):
 
 
 class MultiHitBreakables(Toggle):
-    """Adds the items that drop from the objects that break in three hits to the pool. There are 17 of these throughout
-    the game, adding up to 74 checks in total with all stages.
+    """Adds the items that drop from the objects that break in three hits to the pool. There are 18 of these throughout
+    the game, adding up to 79 or 80 checks (depending on sub-weapons
+    being shuffled anywhere or not) in total with all stages.
     The game will be modified to
     remember exactly which of their items you've picked up instead of simply whether they were broken or not."""
     display_name = "Multi-hit Breakables"


### PR DESCRIPTION
## What is this fixing or adding?
Two things:
1. Under the "what does another world's item look like in CV64" in en_Castlevania 64.md, changed the "common" by "Light brown-ish" to its proper classification name of "filler". Thanks to Snolid Ice for pointing this out.
2. Corrected the number of multi hit breakables in the game under the MultiHitBreakables options description from 17 to 18 (and subsequently the number of checks it adds to 79/80). I had this at 17 before discovering an additional one in Tower of Execution but never thought about that since. Whoops! Thanks to Mauwhir for catching this one.

If anyone finds any other inaccurate info to add, please speak up before this merges! I don't want to do a third one of these (assuming there'll even be time for that before the release).

## How was this tested?
Ran it in my vision to make sure there are no memetic kill agents that would fatally crash my brain. I wouldn't be alive to submit this PR if that weren't the case!