### PR TITLE
KDL3: fix shuffled animals not actually being random

### DIFF
--- a/worlds/kdl3/__init__.py
+++ b/worlds/kdl3/__init__.py
@@ -206,6 +206,8 @@ class KDL3World(World):
             locations = [self.multiworld.get_location(spawn, self.player) for spawn in spawns]
             items = [self.create_item(animal) for animal in animal_pool]
             allstate = self.multiworld.get_all_state(False)
+            self.random.shuffle(locations)
+            self.random.shuffle(items)
             fill_restrictive(self.multiworld, allstate, locations, items, True, True)
         else:
             animal_friends = animal_friend_spawns.copy()


### PR DESCRIPTION
## What is this fixing or adding?
If you don't manually shuffle the items/locations you pass to `fill_restrictive`, it will provide a relatively deterministic result. Since shuffled animals always has the same animals in the same order, it was affected by this.

## How was this tested?
Generated with and without this change. Without, confirmed it had the animal layout that a previous seed also had. With, confirmed a new layout was generated.

## If this makes graphical changes, please attach screenshots.
