### PR TITLE
Yoshi's Island: add patch suffix

### DIFF
--- a/worlds/yoshisisland/Client.py
+++ b/worlds/yoshisisland/Client.py
@@ -36,6 +36,7 @@ VALID_GAME_STATES = [0x0F, 0x10, 0x2C]
 
 class YoshisIslandSNIClient(SNIClient):
     game = "Yoshi's Island"
+    patch_suffix = ".apyi"
 
     async def deathlink_kill_player(self, ctx: "SNIContext") -> None:
         from SNIClient import DeathState, snes_buffered_write, snes_flush_writes, snes_read


### PR DESCRIPTION
## What is this fixing or adding?
Must've missed it during review, but Yoshi got merged without defining patch suffix, so currently "Open Patch" misses it.

## How was this tested?
Ran the launcher, clicked Open Patch, and confirmed .apyi was present as a selectable option.

## If this makes graphical changes, please attach screenshots.
