### PR TITLE
WebHost: fix /check creating broken yaml files if files don't end with a newline

### DIFF
--- a/WebHostLib/check.py
+++ b/WebHostLib/check.py
@@ -28,7 +28,7 @@ def check():
                 results, _ = roll_options(options)
                 if len(options) > 1:
                     # offer combined file back
-                    combined_yaml = "---\n".join(f"# original filename: {file_name}\n{file_content.decode('utf-8-sig')}"
+                    combined_yaml = "\n---\n".join(f"# original filename: {file_name}\n{file_content.decode('utf-8-sig')}"
                                                  for file_name, file_content in options.items())
                     combined_yaml = base64.b64encode(combined_yaml.encode("utf-8-sig")).decode()
                 else:


### PR DESCRIPTION
## What is this fixing or adding?
https://discord.com/channels/731205301247803413/1223786643333320767

## How was this tested?
with the zip file from the discord thread

## If this makes graphical changes, please attach screenshots.
