### PR TITLE
Pokemon Emerald: Fix inconsistent location name

### DIFF
--- a/worlds/pokemon_emerald/data/locations.json
+++ b/worlds/pokemon_emerald/data/locations.json
@@ -1784,7 +1784,7 @@
     "tags": ["BerryTree"]
   },
   "BERRY_TREE_65": {
-    "label": "Route 123 - Berry Master Berry Tree 9",
+    "label": "Route 123 - Berry Tree Berry Master 9",
     "tags": ["BerryTree"]
   },
   "BERRY_TREE_66": {


### PR DESCRIPTION
## What is this fixing or adding?

All the other location names are of the format `Berry Tree Berry Master #`. This one got them mixed up.

## How was this tested?

Generated with berry tree locations enabled. Inside the Emerald apworld, these user-facing location names are never used as keys or referenced directly (except location groups, I suppose). So this wouldn't affect logic or anything anyway.
