### PR TITLE
The Messenger: Fix precollected notes not being removed from the itempool

### DIFF
--- a/worlds/messenger/__init__.py
+++ b/worlds/messenger/__init__.py
@@ -146,8 +146,9 @@ class MessengerWorld(World):
         self.starting_portals = [f"{portal} Portal"
                                  for portal in starting_portals[:3] +
                                  self.random.sample(starting_portals[3:], k=self.options.available_portals - 3)]
+
         # super complicated method for adding searing crags to starting portals if it wasn't chosen
-        # need to add a check for transition shuffle when that gets added back in
+        # TODO add a check for transition shuffle when that gets added back in
         if not self.options.shuffle_portals and "Searing Crags Portal" not in self.starting_portals:
             self.starting_portals.append("Searing Crags Portal")
             if len(self.starting_portals) > 4:
@@ -182,12 +183,13 @@ class MessengerWorld(World):
     def create_items(self) -> None:
         # create items that are always in the item pool
         main_movement_items = ["Rope Dart", "Wingsuit"]
+        precollected_names = [item.name for item in self.multiworld.precollected_items[self.player]]
         itempool: List[MessengerItem] = [
             self.create_item(item)
             for item in self.item_name_to_id
             if "Time Shard" not in item and item not in {
                 "Power Seal", *NOTES, *FIGURINES, *main_movement_items,
-                *{collected_item.name for collected_item in self.multiworld.precollected_items[self.player]},
+                *precollected_names,
             }
         ]
 
@@ -199,7 +201,7 @@ class MessengerWorld(World):
         if self.options.goal == Goal.option_open_music_box:
             # make a list of all notes except those in the player's defined starting inventory, and adjust the
             # amount we need to put in the itempool and precollect based on that
-            notes = [note for note in NOTES if note not in self.multiworld.precollected_items[self.player]]
+            notes = [note for note in NOTES if note not in precollected_names]
             self.random.shuffle(notes)
             precollected_notes_amount = NotesNeeded.range_end - \
                                         self.options.notes_needed - \

--- a/worlds/messenger/constants.py
+++ b/worlds/messenger/constants.py
@@ -48,6 +48,11 @@ FILLER = {
     "Time Shard (500)": 5,
 }
 
+TRAPS = {
+    "Teleport Trap": 5,
+    "Prophecy Trap": 10,
+}
+
 # item_name_to_id needs to be deterministic and match upstream
 ALL_ITEMS = [
     *NOTES,
@@ -71,6 +76,8 @@ ALL_ITEMS = [
     *SHOP_ITEMS,
     *FIGURINES,
     "Money Wrench",
+    "Teleport Trap",
+    "Prophecy Trap",
 ]
 
 # locations

--- a/worlds/messenger/options.py
+++ b/worlds/messenger/options.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from datetime import date
 from typing import Dict
 
 from schema import And, Optional, Or, Schema
@@ -123,6 +124,11 @@ class RequiredSeals(Range):
     default = range_end
 
 
+class Traps(Toggle):
+    """Whether traps should be included in the itempool."""
+    display_name = "Include Traps"
+
+
 class ShopPrices(Range):
     """Percentage modifier for shuffled item prices in shops"""
     display_name = "Shop Prices Modifier"
@@ -199,3 +205,6 @@ class MessengerOptions(DeathLinkMixin, PerGameCommonOptions):
     percent_seals_required: RequiredSeals
     shop_price: ShopPrices
     shop_price_plan: PlannedShopPrices
+
+    if date.today() > date(2024, 4, 1):
+        traps: Traps


### PR DESCRIPTION
## What is this fixing or adding?

it was comparing items to names which we don't really have a proper override for; we probably should get that at some point. either way this fixes the comparison, and bumps the required client version due to some client side bug fixes.

## How was this tested?
simple change but still generated and debugged a few times to verify they were being properly removed.
