### PR TITLE
Pokemon Emerald: Change Ho-Oh capitalization

### DIFF
--- a/worlds/pokemon_emerald/client.py
+++ b/worlds/pokemon_emerald/client.py
@@ -98,7 +98,7 @@ LEGENDARY_NAMES = {
     "Registeel": "REGISTEEL",
     "Mew": "MEW",
     "Deoxys": "DEOXYS",
-    "Ho-oh": "HO_OH",
+    "Ho-Oh": "HO_OH",
     "Lugia": "LUGIA",
 }
 

--- a/worlds/pokemon_emerald/data.py
+++ b/worlds/pokemon_emerald/data.py
@@ -741,7 +741,7 @@ def _init() -> None:
         ("SPECIES_PUPITAR", "Pupitar", 247),
         ("SPECIES_TYRANITAR", "Tyranitar", 248),
         ("SPECIES_LUGIA", "Lugia", 249),
-        ("SPECIES_HO_OH", "Ho-oh", 250),
+        ("SPECIES_HO_OH", "Ho-Oh", 250),
         ("SPECIES_CELEBI", "Celebi", 251),
         ("SPECIES_TREECKO", "Treecko", 252),
         ("SPECIES_GROVYLE", "Grovyle", 253),

--- a/worlds/pokemon_emerald/data/locations.json
+++ b/worlds/pokemon_emerald/data/locations.json
@@ -2877,7 +2877,7 @@
     "tags": ["Pokedex"]
   },
   "POKEDEX_REWARD_250": {
-    "label": "Pokedex - Ho-oh",
+    "label": "Pokedex - Ho-Oh",
     "tags": ["Pokedex"]
   },
   "POKEDEX_REWARD_251": {

--- a/worlds/pokemon_emerald/options.py
+++ b/worlds/pokemon_emerald/options.py
@@ -246,7 +246,7 @@ class AllowedLegendaryHuntEncounters(OptionSet):
     "Regirock"
     "Registeel"
     "Regice"
-    "Ho-oh"
+    "Ho-Oh"
     "Lugia"
     "Deoxys"
     "Mew"
@@ -261,7 +261,7 @@ class AllowedLegendaryHuntEncounters(OptionSet):
         "Regirock",
         "Registeel",
         "Regice",
-        "Ho-oh",
+        "Ho-Oh",
         "Lugia",
         "Deoxys",
         "Mew",

--- a/worlds/pokemon_emerald/rules.py
+++ b/worlds/pokemon_emerald/rules.py
@@ -56,7 +56,7 @@ def set_rules(world: "PokemonEmeraldWorld") -> None:
             "Registeel": "REGISTEEL",
             "Mew": "MEW",
             "Deoxys": "DEOXYS",
-            "Ho-oh": "HO_OH",
+            "Ho-Oh": "HO_OH",
             "Lugia": "LUGIA",
         }.items()
         if name in world.options.allowed_legendary_hunt_encounters.value


### PR DESCRIPTION
## What is this fixing or adding?

Changes the capitalization of Ho-oh to Ho-Oh, which is consistent with the way it's capitalized in newer generations.

Screencap from ORAS:
![Capture](https://github.com/ArchipelagoMW/Archipelago/assets/21088150/752f6bf2-73e7-4540-96d3-df360740475d)

## How was this tested?

Generated using "Ho-Oh" in `allowed_legendary_hunt_encounters` and `wild_encounter_blacklist`. Searched for every instance of `ho.?oh` in the code and changed any with the wrong capitalization.
