### PR TITLE
WebHost: allow deleting Rooms and Seeds, as well as their associated data

### DIFF
--- a/WebHostLib/templates/userContent.html
+++ b/WebHostLib/templates/userContent.html
@@ -25,6 +25,7 @@
                             <th class="center">Players</th>
                             <th>Created (UTC)</th>
                             <th>Last Activity (UTC)</th>
+                            <th>Mark for deletion</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -35,6 +36,7 @@
                                 <td>{{ room.seed.slots|length }}</td>
                                 <td>{{ room.creation_time.strftime("%Y-%m-%d %H:%M") }}</td>
                                 <td>{{ room.last_activity.strftime("%Y-%m-%d %H:%M") }}</td>
+                                <td><a href="{{ url_for("disown_room", room=room.id) }}">Delete next maintenance.</td>
                             </tr>
                         {% endfor %}
                     </tbody>
@@ -51,6 +53,7 @@
                             <th>Seed</th>
                             <th class="center">Players</th>
                             <th>Created (UTC)</th>
+                            <th>Mark for deletion</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -60,6 +63,7 @@
                                 <td>{% if seed.multidata %}{{ seed.slots|length }}{% else %}1{% endif %}
                                 </td>
                                 <td>{{ seed.creation_time.strftime("%Y-%m-%d %H:%M") }}</td>
+                                <td><a href="{{ url_for("disown_seed", seed=seed.id) }}">Delete next maintenance.</td>
                             </tr>
                         {% endfor %}
                     </tbody>

--- a/WebHostLib/upload.py
+++ b/WebHostLib/upload.py
@@ -7,7 +7,7 @@ import zipfile
 import zlib
 
 from io import BytesIO
-from flask import request, flash, redirect, url_for, session, render_template
+from flask import request, flash, redirect, url_for, session, render_template, abort
 from markupsafe import Markup
 from pony.orm import commit, flush, select, rollback
 from pony.orm.core import TransactionIntegrityError
@@ -219,3 +219,29 @@ def user_content():
     rooms = select(room for room in Room if room.owner == session["_id"])
     seeds = select(seed for seed in Seed if seed.owner == session["_id"])
     return render_template("userContent.html", rooms=rooms, seeds=seeds)
+
+
+@app.route("/disown_seed/<suuid:seed>", methods=["GET"])
+def disown_seed(seed):
+    seed = Seed.get(id=seed)
+    if not seed:
+        return abort(404)
+    if seed.owner !=  session["_id"]:
+        return abort(403)
+    
+    seed.owner = 0
+
+    return redirect(url_for("user_content"))
+
+
+@app.route("/disown_room/<suuid:room>", methods=["GET"])
+def disown_room(room):
+    room = Room.get(id=room)
+    if not room:
+        return abort(404)
+    if room.owner != session["_id"]:
+        return abort(403)
+
+    room.owner = 0
+
+    return redirect(url_for("user_content"))


### PR DESCRIPTION
## What is this fixing or adding?
delete button

## How was this tested?
a bit, which is how I found out:
```
>>> bool(uuid.UUID(int=0))
True
```
and why the logging statement exists

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/3189725/1e7628e5-c181-4f4a-bccd-ed4e8aadf8b7)

##  Additional

This instantly hides the entry, but continues running it if it's still in use.  Unlike some other platforms  we do actually eventually delete the entry though.