### PR TITLE
Webhost: Add a /downloads page hosting the latest release

### DIFF
--- a/WebHostLib/misc.py
+++ b/WebHostLib/misc.py
@@ -9,6 +9,7 @@ from pony.orm import count, commit, db_session
 from worlds.AutoWorld import AutoWorldRegister
 from . import app, cache
 from .models import Seed, Room, Command, UUID, uuid4
+from Utils import __version__
 
 
 def get_world_theme(game_name: str):
@@ -102,6 +103,12 @@ def faq(lang):
 @cache.cached()
 def terms(lang):
     return render_template("glossary.html", lang=lang)
+
+
+@app.route("/downloads")
+@cache.cached()
+def downloads():
+    return render_template("downloads.html", version=__version__)
 
 
 @app.route('/seed/<suuid:seed>')

--- a/WebHostLib/models.py
+++ b/WebHostLib/models.py
@@ -61,3 +61,9 @@ class Generation(db.Entity):
 class GameDataPackage(db.Entity):
     checksum = PrimaryKey(str)
     data = Required(bytes)
+
+
+class ArchipelagoInstaller(db.Entity):
+    id = PrimaryKey(str)
+    name = Required(str)
+    data = Required(bytes)

--- a/WebHostLib/templates/downloads.html
+++ b/WebHostLib/templates/downloads.html
@@ -1,7 +1,7 @@
 {% extends "faq.html" %}
 
 {% block head %}
-{% include "header/grassHeader.html" %}
+{% include "header/oceanHeader.html" %}
 <title>Downloads</title>
 {% endblock %}
 
@@ -17,8 +17,5 @@
     </ul>
     </p>
 </div>
-{% endblock %}
-
-{% block footer %}
 {% include "islandFooter.html" %}
 {% endblock %}

--- a/WebHostLib/templates/downloads.html
+++ b/WebHostLib/templates/downloads.html
@@ -1,21 +1,20 @@
 {% extends "faq.html" %}
 
 {% block head %}
-{% include "header/oceanHeader.html" %}
-<title>Downloads</title>
+    {% include "header/oceanHeader.html" %}
+    <title>Downloads</title>
 {% endblock %}
 
 {% block body %}
-<div id="downloads-wrapper">
-    <p>Latest Release: {{ version }}
-    <ul>
-        <li><a href="https://github.com/ArchipelagoMW/Archipelago/releases/tag/{{ version }}">Github</a></li>
-        <li><a href="{{ url_for("api.get_download", build="windows") }}">Windows Setup</a></li>
-        <li><a href="{{ url_for("api.get_download", build="windows7") }}">Windows 7 Setup</a></li>
-        <li><a href="{{ url_for("api.get_download", build="app") }}">Linux AppImage</a></li>
-        <li><a href="{{ url_for("api.get_download", build="tar") }}">Linux Tarball</a></li>
-    </ul>
-    </p>
-</div>
-{% include "islandFooter.html" %}
+    <div id="downloads-wrapper" style="text-align: center">
+        <h1>Latest Release: {{ version }}</h1>
+        <ul style="display: inline-block; text-align: left">
+            <li><a href="https://github.com/ArchipelagoMW/Archipelago/releases/tag/{{ version }}">Github</a></li>
+            <li><a href="{{ url_for("api.get_download", build="windows") }}">Windows Setup</a></li>
+            <li><a href="{{ url_for("api.get_download", build="windows7") }}">Windows 7 Setup</a></li>
+            <li><a href="{{ url_for("api.get_download", build="app") }}">Linux AppImage</a></li>
+            <li><a href="{{ url_for("api.get_download", build="tar") }}">Linux Tarball</a></li>
+        </ul>
+    </div>
+    {% include "islandFooter.html" %}
 {% endblock %}

--- a/WebHostLib/templates/downloads.html
+++ b/WebHostLib/templates/downloads.html
@@ -1,0 +1,24 @@
+{% extends "faq.html" %}
+
+{% block head %}
+{% include "header/grassHeader.html" %}
+<title>Downloads</title>
+{% endblock %}
+
+{% block body %}
+<div id="downloads-wrapper">
+    <p>Latest Release: {{ version }}
+    <ul>
+        <li><a href="https://github.com/ArchipelagoMW/Archipelago/releases/tag/{{ version }}">Github</a></li>
+        <li><a href="{{ url_for("api.get_download", build="windows") }}">Windows Setup</a></li>
+        <li><a href="{{ url_for("api.get_download", build="windows7") }}">Windows 7 Setup</a></li>
+        <li><a href="{{ url_for("api.get_download", build="app") }}">Linux AppImage</a></li>
+        <li><a href="{{ url_for("api.get_download", build="tar") }}">Linux Tarball</a></li>
+    </ul>
+    </p>
+</div>
+{% endblock %}
+
+{% block footer %}
+{% include "islandFooter.html" %}
+{% endblock %}

--- a/WebHostLib/templates/siteMap.html
+++ b/WebHostLib/templates/siteMap.html
@@ -27,6 +27,7 @@
             <li><a href="/weighted-options">Weighted Options Page</a></li>
             <li><a href="{{url_for('stats')}}">Game Statistics</a></li>
             <li><a href="/glossary/en">Glossary</a></li>
+            <li><a href="/downloads">Download Latest Installer</a></li>
         </ul>
 
         <h2>Tutorials</h2>


### PR DESCRIPTION
## What is this fixing or adding?
Title. There are no links to it currently as I'm unsure where they should be other than possibly the setup guides which is very out of scope for this. Requests the files from github and saves them to the db on first request for any of the files. There's likely a better way to do the data storage on startup but I couldn't get it to work easily, and this works well enough. Adds an api endpoint for each specific file, and a page with links to those endpoints.

## How was this tested?
Ran webhost and clicked all the buttons.

## If this makes graphical changes, please attach screenshots.
