### PR TITLE
DKC3: Fix List Out of Range Error on Level Shuffle Hint extension

### DIFF
--- a/worlds/dkc3/Names/LocationName.py
+++ b/worlds/dkc3/Names/LocationName.py
@@ -294,7 +294,7 @@ barnacle_region    = "Barnacle's Island Region"
 blue_region        = "Blue's Beach Hut Region"
 blizzard_region    = "Bizzard's Basecamp Region"
 
-lake_orangatanga_region = "Lake_Orangatanga"
+lake_orangatanga_region = "Lake Orangatanga"
 kremwood_forest_region  = "Kremwood Forest"
 cotton_top_cove_region  = "Cotton-Top Cove"
 mekanos_region          = "Mekanos"

--- a/worlds/dkc3/__init__.py
+++ b/worlds/dkc3/__init__.py
@@ -201,7 +201,12 @@ class DKC3World(World):
             er_hint_data = {}
             for world_index in range(len(world_names)):
                 for level_index in range(5):
-                    level_region = self.multiworld.get_region(self.active_level_list[world_index * 5 + level_index], self.player)
+                    level_id: int = world_index * 5 + level_index
+
+                    if level_id >= len(self.active_level_list):
+                        break
+
+                    level_region = self.multiworld.get_region(self.active_level_list[level_id], self.player)
                     for location in level_region.locations:
                         er_hint_data[location.address] = world_names[world_index]
 


### PR DESCRIPTION
## What is this fixing or adding?
In #2820, I moved hint extension from `modify_multidata`, which was run on a thread, to `extend_hint_information`, which apparently isn't, and now that it's running on the main thread, it can be seen that it actually crashes at the end from an off-by-one error. It doesn't do that anymore.

(Also I noticed a player-facing name had an underscore and no one has ever commented on it)

## How was this tested?
I actually generated with a level shuffle seed, which I apparently failed to do last PR.

## If this makes graphical changes, please attach screenshots.
