### PR TITLE
The Messenger: Hotfix item links filler gen

### DIFF
--- a/worlds/messenger/__init__.py
+++ b/worlds/messenger/__init__.py
@@ -153,10 +153,9 @@ class MessengerWorld(World):
         # TODO add a check for transition shuffle when that gets added back in
         if not self.options.shuffle_portals and "Searing Crags Portal" not in self.starting_portals:
             self.starting_portals.append("Searing Crags Portal")
-            if len(self.starting_portals) > 4:
-                portals_to_strip = [portal for portal in ["Riviere Turquoise Portal", "Sunken Shrine Portal"]
-                                    if portal in self.starting_portals]
-                self.starting_portals.remove(self.random.choice(portals_to_strip))
+            portals_to_strip = [portal for portal in ["Riviere Turquoise Portal", "Sunken Shrine Portal"]
+                                if portal in self.starting_portals]
+            self.starting_portals.remove(self.random.choice(portals_to_strip))
 
         self.filler = FILLER.copy()
         if self.options.traps:

--- a/worlds/messenger/__init__.py
+++ b/worlds/messenger/__init__.py
@@ -1,6 +1,5 @@
 import logging
-from datetime import date
-from typing import Any, ClassVar, Dict, List, Optional, TextIO
+from typing import Any, ClassVar, Dict, List, Optional, Set, TextIO
 
 from BaseClasses import CollectionState, Entrance, Item, ItemClassification, MultiWorld, Tutorial
 from Options import Accessibility
@@ -160,7 +159,7 @@ class MessengerWorld(World):
                 self.starting_portals.remove(self.random.choice(portals_to_strip))
 
         self.filler = FILLER.copy()
-        if (not hasattr(self.options, "traps") and date.today() < date(2024, 4, 2)) or self.options.traps:
+        if self.options.traps:
             self.filler.update(TRAPS)
 
         self.plando_portals = []

--- a/worlds/messenger/__init__.py
+++ b/worlds/messenger/__init__.py
@@ -349,6 +349,17 @@ class MessengerWorld(World):
 
         return ItemClassification.filler
 
+    @classmethod
+    def create_group(cls, multiworld: "MultiWorld", new_player_id: int, players: Set[int]) -> World:
+        group = super().create_group(multiworld, new_player_id, players)
+        assert isinstance(group, MessengerWorld)
+        
+        group.filler = FILLER.copy()
+        group.options.traps.value = all(multiworld.worlds[player].options.traps for player in players)
+        if group.options.traps:
+            group.filler.update(TRAPS)
+        return group
+
     def collect(self, state: "CollectionState", item: "Item") -> bool:
         change = super().collect(state, item)
         if change and "Time Shard" in item.name:

--- a/worlds/messenger/connections.py
+++ b/worlds/messenger/connections.py
@@ -567,15 +567,6 @@ CONNECTIONS: Dict[str, Dict[str, List[str]]] = {
             "Elemental Skylands - Earth Generator Shop",
         ],
         "Earth Generator Shop": [
-            "Elemental Skylands - Fire Shmup",
-        ],
-        "Fire Shmup": [
-            "Elemental Skylands - Fire Intro Shop",
-        ],
-        "Fire Intro Shop": [
-            "Elemental Skylands - Fire Generator Shop",
-        ],
-        "Fire Generator Shop": [
             "Elemental Skylands - Water Shmup",
         ],
         "Water Shmup": [
@@ -585,6 +576,15 @@ CONNECTIONS: Dict[str, Dict[str, List[str]]] = {
             "Elemental Skylands - Water Generator Shop",
         ],
         "Water Generator Shop": [
+            "Elemental Skylands - Fire Shmup",
+        ],
+        "Fire Shmup": [
+            "Elemental Skylands - Fire Intro Shop",
+        ],
+        "Fire Intro Shop": [
+            "Elemental Skylands - Fire Generator Shop",
+        ],
+        "Fire Generator Shop": [
             "Elemental Skylands - Right",
         ],
         "Right": [

--- a/worlds/messenger/options.py
+++ b/worlds/messenger/options.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from datetime import date
 from typing import Dict
 
 from schema import And, Optional, Or, Schema
@@ -203,8 +202,6 @@ class MessengerOptions(DeathLinkMixin, PerGameCommonOptions):
     notes_needed: NotesNeeded
     total_seals: AmountSeals
     percent_seals_required: RequiredSeals
+    traps: Traps
     shop_price: ShopPrices
     shop_price_plan: PlannedShopPrices
-
-    if date.today() > date(2024, 4, 1):
-        traps: Traps


### PR DESCRIPTION
## What is this fixing or adding?
Removes the special cased april fools' behavior now that that's over, and fixes item links filler gen crashing due to the new option behavior.

## How was this tested?
Generated some seeds with item links to verify they actually work now.

## If this makes graphical changes, please attach screenshots.
