### PR TITLE
SA2B: Update Setup guide for new Mod Manager

### DIFF
--- a/worlds/sa2b/Options.py
+++ b/worlds/sa2b/Options.py
@@ -227,7 +227,7 @@ class Omosanity(Toggle):
 
 class Animalsanity(Toggle):
     """
-    Determines whether unique counted animals grants checks.
+    Determines whether unique counts of animals grant checks.
     ALL animals must be collected in a single run of a mission to get all checks.
     (421 Locations)
     """

--- a/worlds/sa2b/Options.py
+++ b/worlds/sa2b/Options.py
@@ -227,7 +227,8 @@ class Omosanity(Toggle):
 
 class Animalsanity(Toggle):
     """
-    Determines whether picking up counted small animals grants checks
+    Determines whether unique counted animals grants checks.
+    ALL animals must be collected in a single run of a mission to get all checks.
     (421 Locations)
     """
     display_name = "Animalsanity"

--- a/worlds/sa2b/docs/setup_en.md
+++ b/worlds/sa2b/docs/setup_en.md
@@ -24,15 +24,13 @@
 
 2. Launch the game at least once without mods.
 
-3. Create a `/mods` directory in the folder into which you installed Sonic Adventure 2: Battle.
+3. Install SA Mod Manager as per [its instructions](https://github.com/X-Hax/SA-Mod-Manager/tree/master?tab=readme-ov-file).
 
-4. Install SA Mod Manager as per [its instructions](https://github.com/X-Hax/SA-Mod-Manager/tree/master?tab=readme-ov-file).
+4. Unpack the Archipelago Mod into the `/mods` directory in the folder into which you installed Sonic Adventure 2: Battle, so that `/mods/SA2B_Archipelago` is a valid path.
 
-5. Unpack the Archipelago Mod into this folder, so that `/mods/SA2B_Archipelago` is a valid path.
+5. In the SA2B_Archipelago folder, run the `CopyAPCppDLL.bat` script (a window will very quickly pop up and go away).
 
-6. In the SA2B_Archipelago folder, run the `CopyAPCppDLL.bat` script (a window will very quickly pop up and go away).
-
-7. Launch the `SAModManager.exe` and make sure the SA2B_Archipelago mod is listed and enabled.
+6. Launch the `SAModManager.exe` and make sure the SA2B_Archipelago mod is listed and enabled.
 
 ## Installation Procedures (Linux and Steam Deck)
 
@@ -42,15 +40,13 @@
 
 3. Launch the game at least once without mods.
 
-4. Create a `/mods` directory in the folder into which you installed Sonic Adventure 2: Battle.
+4. Install SA Mod Manager as per [its instructions](https://github.com/X-Hax/SA-Mod-Manager/tree/master?tab=readme-ov-file). To launch it, add ``SAModManager.exe`` as a non-Steam game. In the properties on Steam for SA Mod Manager, set it to use Proton as the compatibility tool.
 
-5. Install SA Mod Manager as per [its instructions](https://github.com/X-Hax/SA-Mod-Manager/tree/master?tab=readme-ov-file). To launch it, add ``SAModManager.exe`` as a non-Steam game. In the properties on Steam for SA Mod Manager, set it to use Proton as the compatibility tool.
+5. Unpack the Archipelago Mod into the `/mods` folder in the Sonic Adventure 2 install folder, so that `/mods/SA2B_Archipelago` is a valid path.
 
-6. Unpack the Archipelago Mod into this folder, so that `/mods/SA2B_Archipelago` is a valid path.
+6. In the SA2B_Archipelago folder, copy the `APCpp.dll` file and paste it in the Sonic Adventure 2 install folder (where `sonic2app.exe` is).
 
-7. In the SA2B_Archipelago folder, copy the `APCpp.dll` file and paste it in the Sonic Adventure 2 install folder (where `sonic2app.exe` is).
-
-8. Launch the `SAModManager.exe` from Steam and make sure the SA2B_Archipelago mod is listed and enabled.
+7. Launch the `SAModManager.exe` from Steam and make sure the SA2B_Archipelago mod is listed and enabled.
 
 Note: Ensure that you launch Sonic Adventure 2 from Steam directly on Linux, rather than launching using the `Save & Play` button in SA Mod Manager.
 

--- a/worlds/sa2b/docs/setup_en.md
+++ b/worlds/sa2b/docs/setup_en.md
@@ -4,8 +4,8 @@
 
 - Sonic Adventure 2: Battle from: [Sonic Adventure 2: Battle Steam Store Page](https://store.steampowered.com/app/213610/Sonic_Adventure_2/)
 	- The Battle DLC is required if you choose to add Chao Karate locations to the randomizer
-- Sonic Adventure 2 Mod Loader from: [Sonic Retro Mod Loader Page](http://info.sonicretro.org/SA2_Mod_Loader)
-- Microsoft Visual C++ 2013 from: [Microsoft Visual C++ 2013 Redistributable Page](https://www.microsoft.com/en-us/download/details.aspx?id=40784)
+- SA Mod Manager from: [SA Mod Manager GitHub Releases Page](https://github.com/X-Hax/SA-Mod-Manager/releases)
+- .NET Desktop Runtime 7.0 from: [.NET Desktop Runtime 7.0 Download Page](https://dotnet.microsoft.com/en-us/download/dotnet/thank-you/runtime-desktop-7.0.9-windows-x64-installer)
 - Archipelago Mod for Sonic Adventure 2: Battle
   from: [Sonic Adventure 2: Battle Archipelago Randomizer Mod Releases Page](https://github.com/PoryGone/SA2B_Archipelago/releases/)
 
@@ -15,6 +15,8 @@
 	- Sonic Adventure 2: Battle Archipelago PopTracker pack from: [SA2B AP Tracker Releases Page](https://github.com/PoryGone/SA2B_AP_Tracker/releases/)
 - Quality of life mods
 	- SA2 Volume Controls from: [SA2 Volume Controls Release Page] (https://gamebanana.com/mods/381193)
+- Sonic Adventure DX from: [Sonic Adventure DX Steam Store Page](https://store.steampowered.com/app/71250/Sonic_Adventure_DX/)
+	- For setting up the `SADX Music` option (See Additional Options for instructions).
 
 ## Installation Procedures (Windows)
 
@@ -22,15 +24,15 @@
 
 2. Launch the game at least once without mods.
 
-3. Install Sonic Adventure 2 Mod Loader as per its instructions.
+3. Create a `/mods` directory in the folder into which you installed Sonic Adventure 2: Battle.
 
-4. The folder you installed the Sonic Adventure 2 Mod Loader into will now have a `/mods` directory.
+4. Install SA Mod Manager as per [its instructions](https://github.com/X-Hax/SA-Mod-Manager/tree/master?tab=readme-ov-file).
 
 5. Unpack the Archipelago Mod into this folder, so that `/mods/SA2B_Archipelago` is a valid path.
 
 6. In the SA2B_Archipelago folder, run the `CopyAPCppDLL.bat` script (a window will very quickly pop up and go away).
 
-7. Launch the `SA2ModManager.exe` and make sure the SA2B_Archipelago mod is listed and enabled.
+7. Launch the `SAModManager.exe` and make sure the SA2B_Archipelago mod is listed and enabled.
 
 ## Installation Procedures (Linux and Steam Deck)
 
@@ -40,21 +42,21 @@
 
 3. Launch the game at least once without mods.
 
-4. Install Sonic Adventure 2 Mod Loader as per its instructions. To launch it, add ``SA2ModManager.exe`` as a non-Steam game. In the properties on Steam for Sonic Adventure 2 Mod Loader, set it to use Proton as the compatibility tool.
+4. Create a `/mods` directory in the folder into which you installed Sonic Adventure 2: Battle.
 
-5. The folder you installed the Sonic Adventure 2 Mod Loader into will now have a `/mods` directory.
+5. Install SA Mod Manager as per [its instructions](https://github.com/X-Hax/SA-Mod-Manager/tree/master?tab=readme-ov-file). To launch it, add ``SAModManager.exe`` as a non-Steam game. In the properties on Steam for SA Mod Manager, set it to use Proton as the compatibility tool.
 
 6. Unpack the Archipelago Mod into this folder, so that `/mods/SA2B_Archipelago` is a valid path.
 
-7. In the SA2B_Archipelago folder, copy the `APCpp.dll` file and paste it in the Sonic Adventure 2 install folder (where `SA2ModManager.exe` is).
+7. In the SA2B_Archipelago folder, copy the `APCpp.dll` file and paste it in the Sonic Adventure 2 install folder (where `sonic2app.exe` is).
 
-8. Launch the `SA2ModManager.exe` from Steam and make sure the SA2B_Archipelago mod is listed and enabled.
+8. Launch the `SAModManager.exe` from Steam and make sure the SA2B_Archipelago mod is listed and enabled.
 
-Note: Ensure that you launch Sonic Adventure 2 from Steam directly on Linux, rather than launching using the `Save & Play` button in Sonic Adventure 2 Mod Loader.
+Note: Ensure that you launch Sonic Adventure 2 from Steam directly on Linux, rather than launching using the `Save & Play` button in SA Mod Manager.
 
 ## Joining a MultiWorld Game
 
-1. Before launching the game, run the `SA2ModManager.exe`, select the SA2B_Archipelago mod, and hit the `Configure...` button.
+1. Before launching the game, run the `SAModManager.exe`, select the SA2B_Archipelago mod, and hit the `Configure Mod` button.
 
 2. For the `Server IP` field under `AP Settings`, enter the address of the server, such as archipelago.gg:38281, your server host should be able to tell you this.
 
@@ -68,7 +70,7 @@ Note: Ensure that you launch Sonic Adventure 2 from Steam directly on Linux, rat
 
 ## Additional Options
 
-Some additional settings related to the Archipelago messages in game can be adjusted in the SA2ModManager if you select `Configure...` on the SA2B_Archipelago mod. This settings will be under a `General Settings` tab.
+Some additional settings related to the Archipelago messages in game can be adjusted in the SAModManager if you select `Configure Mod` on the SA2B_Archipelago mod. This settings will be under a `General Settings` tab.
 	
 - Message Display Count: This is the maximum number of Archipelago messages that can be displayed on screen at any given time.
 - Message Display Duration: This dictates how long Archipelago messages are displayed on screen (in seconds).
@@ -92,9 +94,9 @@ If you wish to use the `SADX Music` option of the Randomizer, you must own a cop
 
 - Game is running too fast (Like Sonic).
 	- Limit framerate using the mod manager:
-		1. Launch `SA2ModManager.exe`.
-		2. Select the `Graphics` tab.
-		3. Check the `Lock framerate` box under the Visuals section.
+		1. Launch `SAModManager.exe`.
+		2. Select the `Game Config` tab, then select the `Patches` subtab.
+		3. Check the `Lock framerate` box under the Patches section.
 		4. Press the `Save` button.
 	- If using an NVidia graphics card:
 		1. Open the NVIDIA Control Panel.
@@ -105,7 +107,7 @@ If you wish to use the `SADX Music` option of the Randomizer, you must own a cop
 		6. Choose the `On` radial option and in the input box next to the slide enter a value of 60 (or 59 if 60 causes the game to crash).
 
 - Controller input is not working.
-	1. Run the Launcher.exe which should be in the same folder as the SA2ModManager.
+	1. Run the Launcher.exe which should be in the same folder as the your Sonic Adventure 2: Battle install.
 	2. Select the `Player` tab and reselect the controller for the player 1 input method.
 	3. Click the `Save settings and launch SONIC ADVENTURE 2` button. (Any mod manager settings will apply even if the game is launched this way rather than through the mod manager)
 	
@@ -125,7 +127,7 @@ If you wish to use the `SADX Music` option of the Randomizer, you must own a cop
 	- If you enabled an `SADX Music` option, then most likely the music data was not copied properly into the mod folder (See Additional Options for instructions).
 	
 - Mission 1 is missing a texture in the stage select UI.
-	- Most likely another mod is conflicting and overwriting the texture pack. It is recommeded to have the SA2B Archipelago mod load last in the mod loader.
+	- Most likely another mod is conflicting and overwriting the texture pack. It is recommeded to have the SA2B Archipelago mod load last in the mod manager.
 
 ## Save File Safeguard (Advanced Option)
 

--- a/worlds/sa2b/docs/setup_en.md
+++ b/worlds/sa2b/docs/setup_en.md
@@ -40,13 +40,23 @@
 
 3. Launch the game at least once without mods.
 
-4. Install SA Mod Manager as per [its instructions](https://github.com/X-Hax/SA-Mod-Manager/tree/master?tab=readme-ov-file). To launch it, add ``SAModManager.exe`` as a non-Steam game. In the properties on Steam for SA Mod Manager, set it to use Proton as the compatibility tool.
+4. Create both a `/mods` directory and a `/SAManager` directory in the folder into which you installed Sonic Adventure 2: Battle.
 
-5. Unpack the Archipelago Mod into the `/mods` folder in the Sonic Adventure 2 install folder, so that `/mods/SA2B_Archipelago` is a valid path.
+5. Install SA Mod Manager as per [its instructions](https://github.com/X-Hax/SA-Mod-Manager/tree/master?tab=readme-ov-file). Specifically, extract SAModManager.exe file to the folder that Sonic Adventure 2: Battle is installed to. To launch it, add ``SAModManager.exe`` as a non-Steam game. In the properties on Steam for SA Mod Manager, set it to use Proton as the compatibility tool.
 
-6. In the SA2B_Archipelago folder, copy the `APCpp.dll` file and paste it in the Sonic Adventure 2 install folder (where `sonic2app.exe` is).
+6. Run SAModManager.exe from Steam once. It should produce an error popup for a missing dependency, close the error.
 
-7. Launch the `SAModManager.exe` from Steam and make sure the SA2B_Archipelago mod is listed and enabled.
+7. Install protontricks, on the Steam Deck this can be done via the Discover store, on other distros instructions vary, [see its github page](https://github.com/Matoking/protontricks).
+
+8. Download the [.NET 7 Desktop Runtime for x64 Windows](https://dotnet.microsoft.com/en-us/download/dotnet/thank-you/runtime-desktop-7.0.17-windows-x64-installer}. If this link does not work, the download can be found on [this page](https://dotnet.microsoft.com/en-us/download/dotnet/7.0).
+
+9. Right click the .NET 7 Desktop Runtime exe, and assuming protontricks was installed correctly, the option to "Open with Protontricks Launcher" should be available. Click that, and in the popup window that opens, select SAModManager.exe. Follow the prompts after this to install the .NET 7 Desktop Runtime for SAModManager. Once it is done, you should be able to successfully launch SAModManager to steam.
+
+6. Unpack the Archipelago Mod into this folder, so that `/mods/SA2B_Archipelago` is a valid path.
+
+7. In the SA2B_Archipelago folder, copy the `APCpp.dll` file and paste it in the Sonic Adventure 2 install folder (where `sonic2app.exe` is).
+
+8. Launch `SAModManager.exe` from Steam and make sure the SA2B_Archipelago mod is listed and enabled.
 
 Note: Ensure that you launch Sonic Adventure 2 from Steam directly on Linux, rather than launching using the `Save & Play` button in SA Mod Manager.
 


### PR DESCRIPTION
## What is this fixing or adding?
SA2 now has a fancy new Mod Manager, and the old one is deprecated. This requires slightly different setup instructions.

Additionally, a single, much-requested option tooltip clarification is included.

## How was this tested?
We read it, and followed it, and it worked.

## If this makes graphical changes, please attach screenshots.
