### PR TITLE
TUNIC: Fix link to player options page in setup guide

### DIFF
--- a/worlds/tunic/docs/setup_en.md
+++ b/worlds/tunic/docs/setup_en.md
@@ -54,7 +54,7 @@ Launch the game, and if everything was installed correctly you should see `Rando
 
 ### Configure Your YAML File
 
-Visit the [TUNIC options page](/games/Tunic/player-options) to generate a YAML with your selected options.
+Visit the [TUNIC options page](/games/TUNIC/player-options) to generate a YAML with your selected options.
 
 ### Configure Your Mod Settings
 Launch the game, and using the menu on the Title Screen select `Archipelago` under `Randomizer Mode`. 


### PR DESCRIPTION
## What is this fixing or adding?
These are case sensitive, and this one got missed in the Tunic -> TUNIC change earlier on.

## How was this tested?
Clicking the link.

## If this makes graphical changes, please attach screenshots.
N/A