### PR TITLE
Core: fix item_name_groups unfolding in item links

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -1113,6 +1113,7 @@ class ItemLinks(OptionList):
                 raise Exception(f"item_link {link['name']} has {intersection} "
                                 f"items in both its local_items and non_local_items pool.")
             link.setdefault("link_replacement", None)
+            link["item_pool"] = list(pool)
 
 
 @dataclass

--- a/test/general/test_options.py
+++ b/test/general/test_options.py
@@ -24,18 +24,18 @@ class TestOptions(unittest.TestCase):
     def test_item_links_name_groups(self):
         """Tests that item links successfully unfold item_name_groups"""
         item_link_groups = [
-            {
+            [{
                 "name": "ItemLinkGroup",
                 "item_pool": ["Everything"],
                 "link_replacement": False,
                 "replacement_item": None,
-            },
-            {
+            }],
+            [{
                 "name": "ItemLinkGroup",
                 "item_pool": ["Hammer", "Bow"],
                 "link_replacement": False,
                 "replacement_item": None,
-            }
+            }]
         ]
         # we really need some sort of test world but generic doesn't have enough items for this
         world = AutoWorldRegister.world_types["A Link to the Past"]

--- a/test/general/test_options.py
+++ b/test/general/test_options.py
@@ -1,4 +1,7 @@
 import unittest
+
+from BaseClasses import PlandoOptions
+from Options import ItemLinks
 from worlds.AutoWorld import AutoWorldRegister
 
 
@@ -17,3 +20,30 @@ class TestOptions(unittest.TestCase):
             with self.subTest(game=gamename):
                 self.assertFalse(hasattr(world_type, "options"),
                                  f"Unexpected assignment to {world_type.__name__}.options!")
+
+    def test_item_links_name_groups(self):
+        """Tests that item links successfully unfold item_name_groups"""
+        item_link_groups = [
+            {
+                "name": "ItemLinkGroup",
+                "item_pool": ["Everything"],
+                "link_replacement": False,
+                "replacement_item": None,
+            },
+            {
+                "name": "ItemLinkGroup",
+                "item_pool": ["Hammer", "Bow"],
+                "link_replacement": False,
+                "replacement_item": None,
+            }
+        ]
+        # we really need some sort of test world but generic doesn't have enough items for this
+        world = AutoWorldRegister.world_types["A Link to the Past"]
+        plando_options = PlandoOptions.from_option_string("bosses")
+        item_links = [ItemLinks.from_any(item_link_groups[0]), ItemLinks.from_any(item_link_groups[1])]
+        for link in item_links:
+            link.verify(world, "tester", plando_options)
+            self.assertIn("Hammer", link.value[0]["item_pool"])
+            self.assertIn("Bow", link.value[0]["item_pool"])
+        
+        # TODO test that the group created using these options has the items


### PR DESCRIPTION
## What is this fixing or adding?

Item Links properly unfold item_name_groups but the unfolded names don't get assigned back to the link

## How was this tested?
Debugged and added a unit test

## If this makes graphical changes, please attach screenshots.
