### PR TITLE
SNIClient: Let clients based on SNIClient monitor packages via on_package method

### DIFF
--- a/SNIClient.py
+++ b/SNIClient.py
@@ -242,6 +242,9 @@ class SNIContext(CommonContext):
                 # Once the games handled by SNIClient gets made to be remote items,
                 # this will no longer be needed.
                 async_start(self.send_msgs([{"cmd": "LocationScouts", "locations": list(new_locations)}]))
+                
+        if self.client_handler is not None:
+            self.client_handler.on_package(self, cmd, args)
 
     def run_gui(self) -> None:
         from kvui import GameManager

--- a/worlds/AutoSNIClient.py
+++ b/worlds/AutoSNIClient.py
@@ -83,3 +83,7 @@ class SNIClient(abc.ABC, metaclass=AutoSNIClientRegister):
     async def deathlink_kill_player(self, ctx: SNIContext) -> None:
         """ override this with implementation to kill player """
         pass
+
+    async def on_package(self, ctx: SNIContext, cmd: str, args: dict) -> None:
+        """ override this with code to handle packages from the server """
+        pass

--- a/worlds/AutoSNIClient.py
+++ b/worlds/AutoSNIClient.py
@@ -84,6 +84,6 @@ class SNIClient(abc.ABC, metaclass=AutoSNIClientRegister):
         """ override this with implementation to kill player """
         pass
 
-    async def on_package(self, ctx: SNIContext, cmd: str, args: dict) -> None:
+    def on_package(self, ctx: SNIContext, cmd: str, args: dict) -> None:
         """ override this with code to handle packages from the server """
         pass

--- a/worlds/AutoSNIClient.py
+++ b/worlds/AutoSNIClient.py
@@ -84,6 +84,6 @@ class SNIClient(abc.ABC, metaclass=AutoSNIClientRegister):
         """ override this with implementation to kill player """
         pass
 
-    def on_package(self, ctx: SNIContext, cmd: str, args: dict) -> None:
+    def on_package(self, ctx: SNIContext, cmd: str, args: Dict[str, Any]) -> None:
         """ override this with code to handle packages from the server """
         pass


### PR DESCRIPTION
## What is this fixing or adding?
Adds the ability for worlds using SNIClient to monitor/handle packages via the `on_package` method in their client code.

## How was this tested?
Edited my (WIP) MMX3 world to listen to `Connected`, `SetReply` and `Retrieved` packages with `EnergyLink` as their keys (if applicable) to monitor EnergyLink updates and modify a label accordingly, label got updated so it worked fine. The image below shows the label being up to date with the latest deposit which can be seen on the client lines.

Also tested SMW and ALTTP if their clients broke with my changes and they didn't. Worked fine.

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/17969056/65c45a4c-100a-41a4-a523-c32b48c7f3ac)
