### PR TITLE
Core: Getting rid of forfeit_mode

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -586,7 +586,7 @@ class Context:
             self.location_check_points = savedata["game_options"]["location_check_points"]
             self.server_password = savedata["game_options"]["server_password"]
             self.password = savedata["game_options"]["password"]
-            self.release_mode = savedata["game_options"].get("release_mode", savedata["game_options"].get("forfeit_mode", "goal"))
+            self.release_mode = savedata["game_options"]["release_mode"]
             self.remaining_mode = savedata["game_options"]["remaining_mode"]
             self.collect_mode = savedata["game_options"]["collect_mode"]
             self.item_cheat = savedata["game_options"]["item_cheat"]
@@ -631,8 +631,6 @@ class Context:
 
     def _set_options(self, server_options: dict):
         for key, value in server_options.items():
-            if key == "forfeit_mode":
-                key = "release_mode"
             data_type = self.simple_options.get(key, None)
             if data_type is not None:
                 if value not in {False, True, None}:  # some can be boolean OR text, such as password


### PR DESCRIPTION
## What is this fixing or adding?
Getting rid of the two remaining uses for `forfeit_mode`. Partly because it's outdated, partly because I ran into an error where my `host.yaml` still had `forfeit_mode` which was overriding my `release_mode` setting.

## How was this tested?
Generations and running webhost locally.
