### PR TITLE
SC2: Fix vanilla mission order connection

### DIFF
--- a/worlds/sc2/Regions.py
+++ b/worlds/sc2/Regions.py
@@ -250,7 +250,7 @@ def create_vanilla_regions(
         connect(world, names, "Enemy Intelligence", "Trouble In Paradise",
                 lambda state: state.has("Beat Enemy Intelligence", player))
         connect(world, names, "Trouble In Paradise", "Night Terrors",
-                lambda state: state.has("Beat Evacuation", player))
+                lambda state: state.has("Beat Trouble In Paradise", player))
         connect(world, names, "Night Terrors", "Flashpoint",
                 lambda state: state.has("Beat Night Terrors", player))
         connect(world, names, "Flashpoint", "In the Enemy's Shadow",

--- a/worlds/sc2/Regions.py
+++ b/worlds/sc2/Regions.py
@@ -180,7 +180,7 @@ def create_vanilla_regions(
         connect(world, names, "Menu", "Dark Whispers")
         connect(world, names, "Dark Whispers", "Ghosts in the Fog",
                 lambda state: state.has("Beat Dark Whispers", player))
-        connect(world, names, "Dark Whispers", "Evil Awoken",
+        connect(world, names, "Ghosts in the Fog", "Evil Awoken",
                 lambda state: state.has("Beat Ghosts in the Fog", player))
 
     if SC2Campaign.LOTV in enabled_campaigns:


### PR DESCRIPTION
## What is this fixing or adding?
Fixes vanilla mission order connection in NCO (a copy-paste error)

## How was this tested?
Generated an offending YAML, that failed before

## If this makes graphical changes, please attach screenshots.
No