### PR TITLE
Pokemon Emerald: Fix missing region for water encounters in Dewford

### DIFF
--- a/worlds/pokemon_emerald/data/regions/cities.json
+++ b/worlds/pokemon_emerald/data/regions/cities.json
@@ -1143,7 +1143,7 @@
   "REGION_DEWFORD_TOWN/MAIN": {
     "parent_map": "MAP_DEWFORD_TOWN",
     "has_grass": false,
-    "has_water": true,
+    "has_water": false,
     "has_fishing": true,
     "locations": [
       "NPC_GIFT_RECEIVED_OLD_ROD"
@@ -1152,6 +1152,7 @@
       "EVENT_VISITED_DEWFORD_TOWN"
     ],
     "exits": [
+      "REGION_DEWFORD_TOWN/WATER",
       "REGION_ROUTE106/EAST",
       "REGION_ROUTE107/MAIN",
       "REGION_ROUTE104_MR_BRINEYS_HOUSE/MAIN",
@@ -1164,6 +1165,16 @@
       "MAP_DEWFORD_TOWN:3/MAP_DEWFORD_TOWN_HOUSE1:0",
       "MAP_DEWFORD_TOWN:4/MAP_DEWFORD_TOWN_HOUSE2:0"
     ]
+  },
+  "REGION_DEWFORD_TOWN/WATER": {
+    "parent_map": "MAP_DEWFORD_TOWN",
+    "has_grass": false,
+    "has_water": true,
+    "has_fishing": true,
+    "locations": [],
+    "events": [],
+    "exits": [],
+    "warps": []
   },
   "REGION_DEWFORD_TOWN_HALL/MAIN": {
     "parent_map": "MAP_DEWFORD_TOWN_HALL",

--- a/worlds/pokemon_emerald/rules.py
+++ b/worlds/pokemon_emerald/rules.py
@@ -427,6 +427,10 @@ def set_rules(world: "PokemonEmeraldWorld") -> None:
             state.can_reach("REGION_ROUTE104_MR_BRINEYS_HOUSE/MAIN -> REGION_DEWFORD_TOWN/MAIN", "Entrance", world.player)
             and state.has("EVENT_TALK_TO_MR_STONE", world.player)
     )
+    set_rule(
+        get_entrance("REGION_DEWFORD_TOWN/MAIN -> REGION_DEWFORD_TOWN/WATER"),
+        hm_rules["HM03 Surf"]
+    )
 
     # Granite Cave
     set_rule(


### PR DESCRIPTION
## What is this fixing or adding?

Dewford Town has water, but needed a separate region for it so it could be locked behind Surf.

## How was this tested?

Generated a game with dexsanity enabled. Testing is limited since I'm doing this on my phone.