### PR TITLE
sc2: Fixing mission levels not counting towards the level 35 threshold

### DIFF
--- a/worlds/sc2/Client.py
+++ b/worlds/sc2/Client.py
@@ -957,13 +957,13 @@ def caclulate_soa_options(ctx: SC2Context) -> int:
 
     return options
 
-def kerrigan_primal(ctx: SC2Context, items: typing.Dict[SC2Race, typing.List[int]]) -> bool:
+def kerrigan_primal(ctx: SC2Context, kerrigan_level: int) -> bool:
     if ctx.kerrigan_primal_status == KerriganPrimalStatus.option_always_zerg:
         return True
     elif ctx.kerrigan_primal_status == KerriganPrimalStatus.option_always_human:
         return False
     elif ctx.kerrigan_primal_status == KerriganPrimalStatus.option_level_35:
-            return items[SC2Race.ZERG][type_flaggroups[SC2Race.ZERG]["Level"]] >= 35
+        return kerrigan_level >= 35
     elif ctx.kerrigan_primal_status == KerriganPrimalStatus.option_half_completion:
         total_missions = len(ctx.mission_id_to_location_ids)
         completed = len([(mission_id * VICTORY_MODULO + get_location_offset(mission_id)) in ctx.checked_locations
@@ -1138,7 +1138,7 @@ class ArchipelagoBot(bot.bot_ai.BotAI):
 
     async def updateZergTech(self, current_items, kerrigan_level):
         zerg_items = current_items[SC2Race.ZERG]
-        kerrigan_primal_by_items = kerrigan_primal(self.ctx, current_items)
+        kerrigan_primal_by_items = kerrigan_primal(self.ctx, kerrigan_level)
         kerrigan_primal_bot_value = 1 if kerrigan_primal_by_items else 0
         await self.chat_send("?GiveZergTech {} {} {} {} {} {} {} {} {} {} {} {}".format(
             kerrigan_level, kerrigan_primal_bot_value, zerg_items[0], zerg_items[1], zerg_items[2],


### PR DESCRIPTION
Fixing mission levels not counting towards the level 35 threshold to unlock primal Kerrigan.

## What is this fixing or adding?
Reported by JarJarThinks in the Discord 2024-04-06:
> Hmm does the lvl 35 Kerrigan Primal status only consider items and not Level from mission completions?

When KerriganPrimalStatus is set to level_35, Kerrigan is supposed to become Primal if her level is 35 or higher. However, the client-side check on her level was calculating based on items, which didn't account for levels that could come from completing missions.

## How was this tested?
I developed this on a branch that let me change the levels per check option dynamically, and have it apply on next mission startup. I completed one mission, set levels per check to 34, and opened a map to ensure Kerrigan was in her Ghost form. Then I exited, updated the option to 35, opened the mission again, and saw Kerrigan was now primal.

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/31861583/d6eb898b-4e2b-4eec-8ff0-1e0ff9385a87)
![image](https://github.com/ArchipelagoMW/Archipelago/assets/31861583/e890bf85-b180-4697-9d19-32eccbe3e8d3)
