### PR TITLE
Zillion: Docs: add information to skill option documentation

### DIFF
--- a/worlds/zillion/options.py
+++ b/worlds/zillion/options.py
@@ -222,7 +222,14 @@ class ZillionEarlyScope(Toggle):
 
 
 class ZillionSkill(Range):
-    """ the difficulty level of the game """
+    """
+    the difficulty level of the game
+
+    higher skill:
+    - can require more precise platforming movement
+    - lowers your defense
+    - gives you less time to escape at the end
+    """
     range_start = 0
     range_end = 5
     default = 2


### PR DESCRIPTION
## What is this fixing or adding?

This is a common question that comes up in the Zillion discord channel.

"What does the skill option do?"

## How was this tested?

run WebHost.py, open zillion options page to see how it looks there
