### PR TITLE
KDL3: Fix boss access on open world disabled

### DIFF
--- a/worlds/kdl3/Regions.py
+++ b/worlds/kdl3/Regions.py
@@ -110,7 +110,11 @@ def generate_rooms(world: "KDL3World", level_regions: typing.Dict[int, Region]):
             else:
                 world.multiworld.get_location(world.location_id_to_name[world.player_levels[level][stage - 1]],
                                               world.player).parent_region.add_exits([first_rooms[proper_stage].name])
-        level_regions[level].add_exits([first_rooms[0x770200 + level - 1].name])
+        if world.options.open_world:
+            level_regions[level].add_exits([first_rooms[0x770200 + level - 1].name])
+        else:
+            world.multiworld.get_location(world.location_id_to_name[world.player_levels[level][5]], world.player)\
+                .parent_region.add_exits([first_rooms[0x770200 + level - 1].name])
 
 
 def generate_valid_levels(world: "KDL3World", enforce_world: bool, enforce_pattern: bool) -> dict:


### PR DESCRIPTION
## What is this fixing or adding?
With `open_world` disabled, the player must go through all 6 of the prior stages before being able to reach the boss. However, it was currently setup so the boss entrance would be placed on the world itself, rather than connected to the previous level that must be completed. This leads to an impossible seed when combined with `strict_bosses` off when a required item to complete a stage prior to the boss is placed after the boss.

## How was this tested?
Recreated the situation using connections plando, and confirmed spheres were required to pick up the item needed to pass the stage (boss was forced into sphere 2, rather than sphere 1).

## If this makes graphical changes, please attach screenshots.
