### PR TITLE
Webhost: Fix a typo on Start Playing page

### DIFF
--- a/WebHostLib/templates/startPlaying.html
+++ b/WebHostLib/templates/startPlaying.html
@@ -18,7 +18,7 @@
                 <br /><br />
 
                 To start playing a game, you'll first need to <a href="/generate">generate a randomized game</a>.
-                You'll need to upload either a config file or a zip file containing one or more config files.
+                You'll need to upload one or more config files (YAMLs) or a zip file containing one or more config files.
                 <br /><br />
 
                 If you have already generated a game and just need to host it, this site can<br />

--- a/WebHostLib/templates/startPlaying.html
+++ b/WebHostLib/templates/startPlaying.html
@@ -18,7 +18,7 @@
                 <br /><br />
 
                 To start playing a game, you'll first need to <a href="/generate">generate a randomized game</a>.
-                You'll need to upload either a config file or a zip file containing one more config files.
+                You'll need to upload either a config file or a zip file containing one or more config files.
                 <br /><br />
 
                 If you have already generated a game and just need to host it, this site can<br />


### PR DESCRIPTION
## What is this fixing or adding?
On the start playing page, it says "You'll need to upload either a config file or a zip file containing one more config files."
Instead of "one more", it should be "one or more".

## How was this tested?
Standardized common core

## If this makes graphical changes, please attach screenshots.
N/A