### PR TITLE
Core: add visibility attribute to Option

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1353,11 +1353,13 @@ class Spoiler:
 
     def to_file(self, filename: str) -> None:
         from worlds import AutoWorld
+        from Options import Visibility
 
         def write_option(option_key: str, option_obj: Options.AssembleOptions) -> None:
             res = getattr(self.multiworld.worlds[player].options, option_key)
-            display_name = getattr(option_obj, "display_name", option_key)
-            outfile.write(f"{display_name + ':':33}{res.current_option_name}\n")
+            if res.visibility & Visibility.spoiler:
+                display_name = getattr(option_obj, "display_name", option_key)
+                outfile.write(f"{display_name + ':':33}{res.current_option_name}\n")
 
         with open(filename, 'w', encoding="utf-8-sig") as outfile:
             outfile.write(

--- a/Options.py
+++ b/Options.py
@@ -7,6 +7,7 @@ import math
 import numbers
 import random
 import typing
+import enum
 from copy import deepcopy
 from dataclasses import dataclass
 
@@ -18,6 +19,15 @@ if typing.TYPE_CHECKING:
     from BaseClasses import PlandoOptions
     from worlds.AutoWorld import World
     import pathlib
+
+
+class Visibility(enum.IntFlag):
+    none = 0b0000
+    template = 0b0001
+    simple_ui = 0b0010  # show option in simple menus, such as player-options
+    complex_ui = 0b0100  # show option in complex menus, such as weighted-options
+    spoiler = 0b1000
+    all = 0b1111
 
 
 class AssembleOptions(abc.ABCMeta):
@@ -102,7 +112,7 @@ T = typing.TypeVar('T')
 class Option(typing.Generic[T], metaclass=AssembleOptions):
     value: T
     default: typing.ClassVar[typing.Any]  # something that __init__ will be able to convert to the correct type
-
+    visibility = Visibility.all
     # convert option_name_long into Name Long as display_name, otherwise name_long is the result.
     # Handled in get_option_name()
     auto_display_name = False
@@ -1170,7 +1180,9 @@ def generate_yaml_templates(target_folder: typing.Union[str, "pathlib.Path"], ge
 
     for game_name, world in AutoWorldRegister.world_types.items():
         if not world.hidden or generate_hidden:
-            all_options: typing.Dict[str, AssembleOptions] = world.options_dataclass.type_hints
+            all_options: typing.Dict[str, AssembleOptions] = {
+                option: option for option_name, option in world.options_dataclass.type_hints.items()
+                if option.visibility & Visibility.template}
 
             with open(local_path("data", "options.yaml")) as f:
                 file_data = f.read()

--- a/Options.py
+++ b/Options.py
@@ -1192,7 +1192,7 @@ def generate_yaml_templates(target_folder: typing.Union[str, "pathlib.Path"], ge
     for game_name, world in AutoWorldRegister.world_types.items():
         if not world.hidden or generate_hidden:
             all_options: typing.Dict[str, AssembleOptions] = {
-                option: option for option_name, option in world.options_dataclass.type_hints.items()
+                option_name: option for option_name, option in world.options_dataclass.type_hints.items()
                 if option.visibility & Visibility.template}
 
             with open(local_path("data", "options.yaml")) as f:

--- a/Options.py
+++ b/Options.py
@@ -113,6 +113,7 @@ class Option(typing.Generic[T], metaclass=AssembleOptions):
     value: T
     default: typing.ClassVar[typing.Any]  # something that __init__ will be able to convert to the correct type
     visibility = Visibility.all
+
     # convert option_name_long into Name Long as display_name, otherwise name_long is the result.
     # Handled in get_option_name()
     auto_display_name = False

--- a/Options.py
+++ b/Options.py
@@ -1194,7 +1194,8 @@ def generate_yaml_templates(target_folder: typing.Union[str, "pathlib.Path"], ge
         if not world.hidden or generate_hidden:
             all_options: typing.Dict[str, AssembleOptions] = {
                 option_name: option for option_name, option in world.options_dataclass.type_hints.items()
-                if option.visibility & Visibility.template}
+                if option.visibility & Visibility.template
+            }
 
             with open(local_path("data", "options.yaml")) as f:
                 file_data = f.read()

--- a/Options.py
+++ b/Options.py
@@ -1125,6 +1125,17 @@ class ItemLinks(OptionList):
             link.setdefault("link_replacement", None)
 
 
+class Removed(FreeText):
+    """This Option has been Removed."""
+    default = ""
+    visibility = Visibility.none
+
+    def __init__(self, value: str):
+        if value:
+            raise Exception("Option removed, please update your options file.")
+        super().__init__(value)
+
+
 @dataclass
 class PerGameCommonOptions(CommonOptions):
     local_items: LocalItems

--- a/worlds/alttp/Options.py
+++ b/worlds/alttp/Options.py
@@ -2,7 +2,7 @@ import typing
 
 from BaseClasses import MultiWorld
 from Options import Choice, Range, Option, Toggle, DefaultOnToggle, DeathLink, StartInventoryPool, PlandoBosses,\
-    FreeText, Visibility
+    FreeText, Removed
 
 
 class GlitchesRequired(Choice):
@@ -721,15 +721,6 @@ class AllowCollect(Toggle):
     Off by default, because it currently crashes on real hardware."""
     display_name = "Allow Collection of checks for other players"
 
-
-class Removed(FreeText):
-    default = ""
-    visibility = Visibility.none
-
-    def __init__(self, value: str):
-        if value:
-            raise Exception("Option removed, please update your options file.")
-        super().__init__(value)
 
 alttp_options: typing.Dict[str, type(Option)] = {
     "start_inventory_from_pool": StartInventoryPool,

--- a/worlds/alttp/Options.py
+++ b/worlds/alttp/Options.py
@@ -2,7 +2,7 @@ import typing
 
 from BaseClasses import MultiWorld
 from Options import Choice, Range, Option, Toggle, DefaultOnToggle, DeathLink, StartInventoryPool, PlandoBosses,\
-    FreeText
+    FreeText, Visibility
 
 
 class GlitchesRequired(Choice):
@@ -722,6 +722,15 @@ class AllowCollect(Toggle):
     display_name = "Allow Collection of checks for other players"
 
 
+class Removed(FreeText):
+    default = ""
+    visibility = Visibility.none
+
+    def __init__(self, value: str):
+        if value:
+            raise Exception("Option removed, please update your options file.")
+        super().__init__(value)
+
 alttp_options: typing.Dict[str, type(Option)] = {
     "start_inventory_from_pool": StartInventoryPool,
     "goal": Goal,
@@ -796,4 +805,9 @@ alttp_options: typing.Dict[str, type(Option)] = {
     "music": Music,
     "reduceflashing": ReduceFlashing,
     "triforcehud": TriforceHud,
+
+    # removed:
+    "goals": Removed,
+    "smallkey_shuffle": Removed,
+    "bigkey_shuffle": Removed,
 }


### PR DESCRIPTION
## What is this fixing or adding?
allows hiding of options in certain contexts. Multiple use cases  have been discussed, this brings legacy alerts for LttP as one such use case with it.

## How was this tested?
I've tested each flag barely, so this could use some more testing.
