### PR TITLE
Stardew Valley: Remove early shipping bin documentation

### DIFF
--- a/worlds/stardew_valley/options.py
+++ b/worlds/stardew_valley/options.py
@@ -268,7 +268,6 @@ class BuildingProgression(Choice):
     Vanilla: You can buy each building normally.
     Progressive: You will receive the buildings and will be able to build the first one of each type for free,
         once it is received. If you want more of the same building, it will cost the vanilla price.
-    Progressive early shipping bin: Same as Progressive, but the shipping bin will be placed early in the multiworld.
     Cheap: Buildings will cost half as much
     Very Cheap: Buildings will cost 1/5th as much
     """


### PR DESCRIPTION
## What is this fixing or adding?
An option that was deprecated in 5.x.x still had a documentation line about it. Now removed

## How was this tested?
It's documentation
