### PR TITLE
CV64: Fix NPC PermaUps, the ice chunk model staying when bitten by a Villa maze dog, and ItemLinks sometimes giving two items.

### DIFF
--- a/worlds/cv64/aesthetics.py
+++ b/worlds/cv64/aesthetics.py
@@ -449,12 +449,11 @@ def get_location_data(world: "CV64World", active_locations: Iterable[Location]) 
 
         # Figure out the item ID bytes to put in each Location here. Write the item itself if either it's the player's
         # very own, or it belongs to an Item Link that the player is a part of.
-        if loc.item.player == world.player or (loc.item.player in world.multiworld.groups and
-                                               world.player in world.multiworld.groups[loc.item.player]['players']):
+        if loc.item.player == world.player:
             if loc_type not in ["npc", "shop"] and get_item_info(loc.item.name, "pickup actor id") is not None:
                 location_bytes[get_location_info(loc.name, "offset")] = get_item_info(loc.item.name, "pickup actor id")
             else:
-                location_bytes[get_location_info(loc.name, "offset")] = get_item_info(loc.item.name, "code")
+                location_bytes[get_location_info(loc.name, "offset")] = get_item_info(loc.item.name, "code") & 0xFF
         else:
             # Make the item the unused Wooden Stake - our multiworld item.
             location_bytes[get_location_info(loc.name, "offset")] = 0x11

--- a/worlds/cv64/data/patches.py
+++ b/worlds/cv64/data/patches.py
@@ -2863,3 +2863,13 @@ big_tosser = [
     0xAD000814,  # SW    R0, 0x0814 (T0)
     0x03200008   # JR    T9
 ]
+
+dog_bite_ice_trap_fix = [
+    # Sets the freeze timer to 0 when a maze garden dog bites the player to ensure the ice chunk model will break if the
+    # player gets bitten while frozen via Ice Trap.
+    0x3C088039,  # LUI   T0, 0x8039
+    0xA5009E76,  # SH    R0, 0x9E76 (T0)
+    0x3C090F00,  # LUI   T1, 0x0F00
+    0x25291CB8,  # ADDIU T1, T1, 0x1CB8
+    0x01200008   # JR    T1
+]

--- a/worlds/cv64/data/patches.py
+++ b/worlds/cv64/data/patches.py
@@ -197,12 +197,15 @@ deathlink_nitro_edition = [
     0xA168FFFD,  # SB    T0, 0xFFFD (T3)
 ]
 
-nitro_fall_killer = [
-    # Custom code to force the instant fall death if at a high enough falling speed after getting killed by the Nitro
-    # explosion, since the game doesn't run the checks for the fall death after getting hit by said explosion and could
-    # result in a softlock when getting blown into an abyss.
+launch_fall_killer = [
+    # Custom code to force the instant fall death if at a high enough falling speed after getting killed by something
+    # that launches you (whether it be the Nitro explosion or a Big Toss hit). The game doesn't normally run the check
+    # that would trigger the fall death after you get killed by some other means, which could result in a softlock
+    # when a killing blow launches you into an abyss.
     0x3C0C8035,  # LUI   T4, 0x8035
     0x918807E2,  # LBU   T0, 0x07E2 (T4)
+    0x24090008,  # ADDIU T1, R0, 0x0008
+    0x11090002,  # BEQ   T0, T1, [forward 0x02]
     0x2409000C,  # ADDIU T1, R0, 0x000C
     0x15090006,  # BNE   T0, T1, [forward 0x06]
     0x3C098035,  # LUI   T1, 0x8035

--- a/worlds/cv64/docs/obscure_checks.md
+++ b/worlds/cv64/docs/obscure_checks.md
@@ -27,7 +27,7 @@ in vanilla, contains 5 checks in rando.
 #### Bat archway rock
 After the broken bridge containing the invisible pathway to the Special1 in vanilla, this rock is off to the side in front
 of the gate frame with a swarm of bats that come at you, before the Werewolf's territory. Contains 4 checks. If you are new
-to speedrunning the vanilla game and haven't yet learned the RNG manip strats, this is a guranteed spot to find a PowerUp at.
+to speedrunning the vanilla game and haven't yet learned the RNG manip strats, this is a guaranteed spot to find a PowerUp at.
 
 
 

--- a/worlds/cv64/options.py
+++ b/worlds/cv64/options.py
@@ -74,7 +74,8 @@ class HardItemPool(Toggle):
 
 
 class Special1sPerWarp(Range):
-    """Sets how many Special1 jewels are needed per warp menu option unlock."""
+    """Sets how many Special1 jewels are needed per warp menu option unlock.
+    This will decrease until the number x 7 is less than or equal to the Total Specail1s if it isn't already."""
     range_start = 1
     range_end = 10
     default = 1
@@ -82,8 +83,7 @@ class Special1sPerWarp(Range):
 
 
 class TotalSpecial1s(Range):
-    """Sets how many Speical1 jewels are in the pool in total.
-    If this is set to be less than Special1s Per Warp x 7, it will decrease by 1 until it isn't."""
+    """Sets how many Speical1 jewels are in the pool in total."""
     range_start = 7
     range_end = 70
     default = 7

--- a/worlds/cv64/rom.py
+++ b/worlds/cv64/rom.py
@@ -786,6 +786,10 @@ def patch_rom(world: "CV64World", rom: LocalRom, offset_data: Dict[int, int], sh
                                 0x00000000])  # NOP
     rom.write_int32s(0xBFE4C0, patches.freeze_verifier)
 
+    # Fix for the ice chunk model staying when getting bitten by the maze garden dogs
+    rom.write_int32(0xA2DC48, 0x803FE8E0)  # J 0x803FE808
+    rom.write_int32s(0xBFE8E0, patches.dog_bite_ice_trap_fix)
+
     # Initial Countdown numbers
     rom.write_int32(0xAD6A8, 0x080FF60A)  # J	0x803FD828
     rom.write_int32s(0xBFD828, patches.new_game_extras)

--- a/worlds/cv64/rom.py
+++ b/worlds/cv64/rom.py
@@ -23,7 +23,6 @@ if TYPE_CHECKING:
     from . import CV64World
 
 CV64US10HASH = "1cc5cf3b4d29d8c3ade957648b529dc1"
-ROM_PLAYER_LIMIT = 65535
 
 warp_map_offsets = [0xADF67, 0xADF77, 0xADF87, 0xADF97, 0xADFA7, 0xADFBB, 0xADFCB, 0xADFDF]
 
@@ -396,8 +395,8 @@ def patch_rom(world: "CV64World", rom: LocalRom, offset_data: Dict[int, int], sh
     # DeathLink counter decrementer code
     rom.write_int32(0x1C340, 0x080FF8F0)  # J 0x803FE3C0
     rom.write_int32s(0xBFE3C0, patches.deathlink_counter_decrementer)
-    rom.write_int32(0x25B6C, 0x0080FF052)  # J 0x803FC148
-    rom.write_int32s(0xBFC148, patches.nitro_fall_killer)
+    rom.write_int32(0x25B6C, 0x080FFA5E)  # J 0x803FE978
+    rom.write_int32s(0xBFE978, patches.launch_fall_killer)
 
     # Death flag un-setter on "Beginning of stage" state overwrite code
     rom.write_int32(0x1C2B0, 0x080FF047)  # J 0x803FC11C

--- a/worlds/cv64/rom.py
+++ b/worlds/cv64/rom.py
@@ -786,8 +786,8 @@ def patch_rom(world: "CV64World", rom: LocalRom, offset_data: Dict[int, int], sh
     rom.write_int32s(0xBFE4C0, patches.freeze_verifier)
 
     # Fix for the ice chunk model staying when getting bitten by the maze garden dogs
-    rom.write_int32(0xA2DC48, 0x803FE8E0)  # J 0x803FE808
-    rom.write_int32s(0xBFE8E0, patches.dog_bite_ice_trap_fix)
+    rom.write_int32(0xA2DC48, 0x803FE9C0)
+    rom.write_int32s(0xBFE9C0, patches.dog_bite_ice_trap_fix)
 
     # Initial Countdown numbers
     rom.write_int32(0xAD6A8, 0x080FF60A)  # J	0x803FD828


### PR DESCRIPTION
## What is this fixing or adding?
Several things:
-Fixes PermaUps randomized onto NPCs being impossible to get due to the game crashing when talking to said NPCs that have them. Due to the PermaUp's AP item code being weird (I made it 0x10C instead of 0x0C so AP would distinguish it) its item ID was being written wrong specifically for them; only the lower byte 0x0C should have been written.
-Fixes the ice chunk model staying when getting bitten by one of the Villa maze dogs while being frozen via an Ice Trap. A little extra assembly is being injected specifically to set the freeze timer to 0 when the bite happens so the ice model will break like it should.
-Fixes ItemLinked items effectively giving you two items instead of one if you are part of the ItemLink group by writing an AP item for them in these instances instead of the actual item. I thought, for some reason, that the server would not give you ItemLinked items found in your own world if you were in that ItemLink group but it turns out I was very, very wrong about that!

ADDENDUM:
-Fixes a softlock that could happen if you get Big Tossed into an abyss by a hit that kills you. This was a problem with the Nitro explosion as well, so I extended the code I made to catch the problem there to check for both the "blown up by nitro" (0xC) and "launched" (0x8) player state values.
-Moves the part of the option description in Total Specail1s that explained the behavior of decrementing Special1s Per Warp to the Special1s Per Warp description and reworded it to be (hopefully) less confusing as to which option is being decreased.
-Fixed a small type in obscure_checks.md that someone noted somewhere on the initial Yoshi's Island PR as well.
-Removes the unused ROM_PLAYER_LIMIT variable from rom.py; another thing that was also noted on the Yoshi PR.

## How was this tested?
Plando'd PermaUps on NPC locations to make sure they work, gave myself Ice Traps in the maze chase to make sure the dog bites would break the ice model (and played the whole section to make sure nothing else broke), sent an ItemLinked item to a group I was in, let one of Renon's fireballs Big Toss me off the platform he's fought on while simultaneously getting killed by it, and of course; reading!
