### PR TITLE
Zork Grand Inquisitor: Fix Determinism Issues on Fixed Seeds

### DIFF
--- a/worlds/zork_grand_inquisitor/data_funcs.py
+++ b/worlds/zork_grand_inquisitor/data_funcs.py
@@ -1,4 +1,4 @@
-from typing import Dict, Set, Tuple, Union
+from typing import Dict, List, Set, Tuple, Union
 
 from .data.entrance_rule_data import entrance_rule_data
 from .data.item_data import item_data, ZorkGrandInquisitorItemData
@@ -54,15 +54,15 @@ def id_to_locations() -> Dict[int, ZorkGrandInquisitorLocations]:
     }
 
 
-def item_groups() -> Dict[str, Set[str]]:
-    groups: Dict[str, Set[str]] = dict()
+def item_groups() -> Dict[str, List[str]]:
+    groups: Dict[str, List[str]] = dict()
 
     item: ZorkGrandInquisitorItems
     data: ZorkGrandInquisitorItemData
     for item, data in item_data.items():
         if data.tags is not None:
             for tag in data.tags:
-                groups.setdefault(tag.value, set()).add(item.value)
+                groups.setdefault(tag.value, list()).append(item.value)
 
     return {k: v for k, v in groups.items() if len(v)}
 
@@ -92,31 +92,31 @@ def game_id_to_items() -> Dict[int, ZorkGrandInquisitorItems]:
     return mapping
 
 
-def location_groups() -> Dict[str, Set[str]]:
-    groups: Dict[str, Set[str]] = dict()
+def location_groups() -> Dict[str, List[str]]:
+    groups: Dict[str, List[str]] = dict()
 
     tag: ZorkGrandInquisitorTags
     for tag in ZorkGrandInquisitorTags:
-        groups[tag.value] = set()
+        groups[tag.value] = list()
 
     location: ZorkGrandInquisitorLocations
     data: ZorkGrandInquisitorLocationData
     for location, data in location_data.items():
         if data.tags is not None:
             for tag in data.tags:
-                groups[tag.value].add(location.value)
+                groups[tag.value].append(location.value)
 
     return {k: v for k, v in groups.items() if len(v)}
 
 
 def locations_by_region(include_deathsanity: bool = False) -> Dict[
-    ZorkGrandInquisitorRegions, Set[ZorkGrandInquisitorLocations]
+    ZorkGrandInquisitorRegions, List[ZorkGrandInquisitorLocations]
 ]:
-    mapping: Dict[ZorkGrandInquisitorRegions, Set[ZorkGrandInquisitorLocations]] = dict()
+    mapping: Dict[ZorkGrandInquisitorRegions, List[ZorkGrandInquisitorLocations]] = dict()
 
     region: ZorkGrandInquisitorRegions
     for region in ZorkGrandInquisitorRegions:
-        mapping[region] = set()
+        mapping[region] = list()
 
     location: ZorkGrandInquisitorLocations
     data: ZorkGrandInquisitorLocationData
@@ -126,7 +126,7 @@ def locations_by_region(include_deathsanity: bool = False) -> Dict[
         ):
             continue
 
-        mapping[data.region].add(location)
+        mapping[data.region].append(location)
 
     return mapping
 

--- a/worlds/zork_grand_inquisitor/world.py
+++ b/worlds/zork_grand_inquisitor/world.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Set, Tuple
+from typing import Any, Dict, List, Tuple
 
 from BaseClasses import Item, ItemClassification, Location, Region, Tutorial
 
@@ -78,6 +78,7 @@ class ZorkGrandInquisitorWorld(World):
 
     web = ZorkGrandInquisitorWebWorld()
 
+    filler_item_names: List[str] = item_groups()["Filler"]
     item_name_to_item: Dict[str, ZorkGrandInquisitorItems] = item_names_to_item()
 
     def create_regions(self) -> None:
@@ -89,13 +90,13 @@ class ZorkGrandInquisitorWorld(World):
         for region_enum_item in region_data.keys():
             region_mapping[region_enum_item] = Region(region_enum_item.value, self.player, self.multiworld)
 
-        region_locations_mapping: Dict[ZorkGrandInquisitorRegions, Set[ZorkGrandInquisitorLocations]]
+        region_locations_mapping: Dict[ZorkGrandInquisitorRegions, List[ZorkGrandInquisitorLocations]]
         region_locations_mapping = locations_by_region(include_deathsanity=deathsanity)
 
         region_enum_item: ZorkGrandInquisitorRegions
         region: Region
         for region_enum_item, region in region_mapping.items():
-            regions_locations: Set[ZorkGrandInquisitorLocations] = region_locations_mapping[region_enum_item]
+            regions_locations: List[ZorkGrandInquisitorLocations] = region_locations_mapping[region_enum_item]
 
             # Locations
             location_enum_item: ZorkGrandInquisitorLocations
@@ -203,4 +204,4 @@ class ZorkGrandInquisitorWorld(World):
         )
 
     def get_filler_item_name(self) -> str:
-        return self.random.choice(list(self.item_name_groups["Filler"]))
+        return self.random.choice(self.filler_item_names)


### PR DESCRIPTION
Turns out I had 2 separate small issues affecting determinism on fixed seeds:
* An iteration on sets of location enum items
* An inline cast of a set to a list in `get_filler_item_names`

In both cases, I made sure the operations happened on lists instead to make sure the order is deterministic.

**Before**

2 generations with fixed seed `12345` would yield completely different item placement, progression items included

**After**

2 generations with fixed seed `12345` yield identical item placement

World tests are still green after the changes.