### PR TITLE
SM64ex: Logic and Generation Fixes

### DIFF
--- a/worlds/sm64ex/Regions.py
+++ b/worlds/sm64ex/Regions.py
@@ -220,9 +220,9 @@ def create_regions(world: MultiWorld, options: SM64Options, player: int):
 
     regTTC = create_region("Tick Tock Clock", player, world)
     create_locs(regTTC, "TTC: Stop Time for Red Coins")
-    ttc_lower = create_subregion(regTTC, "TTC: Lower", "TTC: Roll into the Cage", "TTC: Get a Hand", "TTC: 1Up Block Midway Up")
+    ttc_lower = create_subregion(regTTC, "TTC: Lower", "TTC: Roll into the Cage", "TTC: Get a Hand")
     ttc_upper = create_subregion(ttc_lower, "TTC: Upper", "TTC: Timed Jumps on Moving Bars", "TTC: The Pit and the Pendulums")
-    ttc_top = create_subregion(ttc_upper, "TTC: Top", "TTC: Stomp on the Thwomp", "TTC: 1Up Block at the Top")
+    ttc_top = create_subregion(ttc_upper, "TTC: Top", "TTC: 1Up Block Midway Up", "TTC: Stomp on the Thwomp", "TTC: 1Up Block at the Top")
     regTTC.subregions = [ttc_lower, ttc_upper, ttc_top]
     if options.enable_coin_stars:
         create_locs(ttc_top, "TTC: 100 Coins")

--- a/worlds/sm64ex/Regions.py
+++ b/worlds/sm64ex/Regions.py
@@ -165,11 +165,9 @@ def create_regions(world: MultiWorld, options: SM64Options, player: int):
 
     regDDD = create_region("Dire, Dire Docks", player, world)
     create_locs(regDDD, "DDD: Board Bowser's Sub", "DDD: Chests in the Current", "DDD: Through the Jet Stream",
-                        "DDD: The Manta Ray's Reward", "DDD: Collect the Caps...")
-    ddd_moving_poles = create_subregion(regDDD, "DDD: Moving Poles", "DDD: Pole-Jumping for Red Coins")
-    regDDD.subregions = [ddd_moving_poles]
+                        "DDD: The Manta Ray's Reward", "DDD: Collect the Caps...", "DDD: Pole-Jumping for Red Coins")
     if options.enable_coin_stars:
-        create_locs(ddd_moving_poles, "DDD: 100 Coins")
+        create_locs(regDDD, "DDD: 100 Coins")
 
     regCotMC = create_region("Cavern of the Metal Cap", player, world)
     create_default_locs(regCotMC, locCotMC_table)

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -272,7 +272,7 @@ class RuleFactory:
         self.area_randomizer = options.area_rando > 0
         self.capless = not options.strict_cap_requirements
         self.cannonless = not options.strict_cannon_requirements
-        self.moveless = not options.strict_move_requirements or not move_rando_bitvec > 0
+        self.moveless = not options.strict_move_requirements
 
     def assign_rule(self, target_name: str, rule_expr: str):
         target = self.world.get_location(target_name, self.player) if target_name in location_table else self.world.get_entrance(target_name, self.player)

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -208,7 +208,7 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
         rf.assign_rule("HMC: 100 Coins", "GP")
         rf.assign_rule("SSL: 100 Coins", "{SSL: Upper Pyramid} | GP")
         rf.assign_rule("DDD: 100 Coins", "GP")
-        rf.assign_rule("SL: 100 Coins", "VC | MOVELESS")
+        rf.assign_rule("SL: 100 Coins", "VC | CAPLESS")
         rf.assign_rule("WDW: 100 Coins", "GP | {WDW: Downtown}")
         rf.assign_rule("TTC: 100 Coins", "GP")
         rf.assign_rule("THI: 100 Coins", "GP")

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -147,6 +147,7 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     rf.assign_rule("LLL: Upper Volcano", "CL")
     # Shifting Sand Land
     rf.assign_rule("SSL: Upper Pyramid", "CL & TJ/BF/SF/LG | MOVELESS")
+    rf.assign_rule("SSL: Stand Tall on the Four Pillars", "TJ+WC+GP | CANN+WC+GP | TJ/SF/BF & CAPLESS | MOVELESS")
     rf.assign_rule("SSL: Free Flying for 8 Red Coins", "TJ+WC | CANN+WC | TJ/SF/BF & CAPLESS | MOVELESS & CAPLESS")
     # Dire, Dire Docks
     rf.assign_rule("DDD: Moving Poles", "CL & {{Bowser in the Fire Sea Key}} | TJ+DV+LG+WK & MOVELESS")

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -126,7 +126,7 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     rf.assign_rule("WF: Blast Away the Wall", "CANN | CANNLESS & LG")
     # Jolly Roger Bay
     rf.assign_rule("JRB: Upper", "TJ/BF/SF/WK | MOVELESS & LG")
-    rf.assign_rule("JRB: Red Coins on the Ship Afloat", "CL/CANN/TJ/BF/WK")
+    rf.assign_rule("JRB: Red Coins on the Ship Afloat", "CL/CANN/TJ | MOVELESS & BF/WK")
     rf.assign_rule("JRB: Blast to the Stone Pillar", "CANN+CL | CANNLESS & MOVELESS | CANN & MOVELESS")
     rf.assign_rule("JRB: Through the Jet Stream", "MC | CAPLESS")
     # Cool, Cool Mountain

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -174,9 +174,8 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     rf.assign_rule("THI: Make Wiggler Squirm", "GP | MOVELESS & DV")
     # Tick Tock Clock
     rf.assign_rule("TTC: Lower", "LG/TJ/SF/BF/WK")
-    rf.assign_rule("TTC: Upper", "CL | SF+WK")
-    rf.assign_rule("TTC: Top", "CL | SF+WK")
-    rf.assign_rule("TTC: Stomp on the Thwomp", "LG & TJ/SF/BF")
+    rf.assign_rule("TTC: Upper", "CL | MOVELESS & WK")
+    rf.assign_rule("TTC: Top", "TJ+LG | MOVELESS & WK/TJ")
     rf.assign_rule("TTC: Stop Time for Red Coins", "NAR | {TTC: Lower}")
     # Rainbow Ride
     rf.assign_rule("RR: Maze", "WK | LJ & SF/BF/TJ | MOVELESS & LG/TJ")

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -150,7 +150,7 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     rf.assign_rule("SSL: Stand Tall on the Four Pillars", "TJ+WC+GP | CANN+WC+GP | TJ/SF/BF & CAPLESS | MOVELESS")
     rf.assign_rule("SSL: Free Flying for 8 Red Coins", "TJ+WC | CANN+WC | TJ/SF/BF & CAPLESS | MOVELESS & CAPLESS")
     # Dire, Dire Docks
-    rf.assign_rule("DDD: Moving Poles", "CL & {{Bowser in the Fire Sea Key}} | TJ+DV+LG+WK & MOVELESS")
+    rf.assign_rule("DDD: Pole-Jumping for Red Coins", "CL & {{Bowser in the Fire Sea Key}} | TJ+DV+LG+WK & MOVELESS")
     rf.assign_rule("DDD: Through the Jet Stream", "MC | CAPLESS")
     rf.assign_rule("DDD: Collect the Caps...", "VC+MC | CAPLESS & VC")
     # Snowman's Land
@@ -207,7 +207,7 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
         rf.assign_rule("JRB: 100 Coins", "GP & {JRB: Upper}")
         rf.assign_rule("HMC: 100 Coins", "GP")
         rf.assign_rule("SSL: 100 Coins", "{SSL: Upper Pyramid} | GP")
-        rf.assign_rule("DDD: 100 Coins", "GP")
+        rf.assign_rule("DDD: 100 Coins", "GP & {{DDD: Pole-Jumping for Red Coins}}")
         rf.assign_rule("SL: 100 Coins", "VC | CAPLESS")
         rf.assign_rule("WDW: 100 Coins", "GP | {WDW: Downtown}")
         rf.assign_rule("TTC: 100 Coins", "GP")

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -181,8 +181,8 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     # Rainbow Ride
     rf.assign_rule("RR: Maze", "WK | LJ & SF/BF/TJ | MOVELESS & LG/TJ")
     rf.assign_rule("RR: Bob-omb Buddy", "WK | MOVELESS & LG")
-    rf.assign_rule("RR: Swingin' in the Breeze", "LG/TJ/BF/SF")
-    rf.assign_rule("RR: Tricky Triangles!", "LG/TJ/BF/SF")
+    rf.assign_rule("RR: Swingin' in the Breeze", "LG/TJ/BF/SF | MOVELESS")
+    rf.assign_rule("RR: Tricky Triangles!", "LG/TJ/BF/SF | MOVELESS")
     rf.assign_rule("RR: Cruiser", "WK/SF/BF/LG/TJ")
     rf.assign_rule("RR: House", "TJ/SF/BF/LG")
     rf.assign_rule("RR: Somewhere Over the Rainbow", "CANN")
@@ -247,6 +247,7 @@ class RuleFactory:
 
     token_table = {
         "TJ": "Triple Jump",
+        "DJ": "Triple Jump",
         "LJ": "Long Jump",
         "BF": "Backflip",
         "SF": "Side Flip",

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -147,7 +147,7 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     rf.assign_rule("LLL: Upper Volcano", "CL")
     # Shifting Sand Land
     rf.assign_rule("SSL: Upper Pyramid", "CL & TJ/BF/SF/LG | MOVELESS")
-    rf.assign_rule("SSL: Free Flying for 8 Red Coins", "TJ/SF/BF & TJ+WC | TJ/SF/BF & CAPLESS | MOVELESS & CAPLESS")
+    rf.assign_rule("SSL: Free Flying for 8 Red Coins", "TJ+WC | CANN+WC | TJ/SF/BF & CAPLESS | MOVELESS & CAPLESS")
     # Dire, Dire Docks
     rf.assign_rule("DDD: Moving Poles", "CL & {{Bowser in the Fire Sea Key}} | TJ+DV+LG+WK & MOVELESS")
     rf.assign_rule("DDD: Through the Jet Stream", "MC | CAPLESS")

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -119,7 +119,7 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     rf.assign_rule("BoB: Mario Wings to the Sky",  "CANN & WC | CAPLESS & CANN")
     rf.assign_rule("BoB: Behind Chain Chomp's Gate", "GP | MOVELESS")
     # Whomp's Fortress
-    rf.assign_rule("WF: Tower", "{{WF: Chip Off Whomp's Block}}")
+    rf.assign_rule("WF: Tower", "GP")
     rf.assign_rule("WF: Chip Off Whomp's Block", "GP")
     rf.assign_rule("WF: Shoot into the Wild Blue", "WK & TJ/SF | CANN")
     rf.assign_rule("WF: Fall onto the Caged Island", "CL & {WF: Tower} | MOVELESS & TJ | MOVELESS & LJ | MOVELESS & CANN")


### PR DESCRIPTION
## What is this fixing or adding?

- Replaces **entrance** entrance rules that relied on `can_reach` to remove accessibility check errors.  Ignored the legacy entrance dependencies on the Bowser in the Fire Sea entrance (entrance entrance rule depends on a location) as that rule has been around for several versions and has never been reported causing a failure.
- Logic no longer ignores the Strict Move Requirements setting when moves are not randomized.  This was causing hard logic to be unintentionally used on the following checks: - DDD: Pole-Jumping for Red Coins", "WDW: Go to Town for Red Coins", "WDW: Quick Race Through Downtown!", and "WDW: 1Up Block in Downtown"
- A few small changes to move rando logic based on player feedback, making Strict logic easier and non-Strict logic slightly harder.

## How was this tested?

100 generations with everything randomized, and 100 generations with everything randomized except moves.  Went over a few spoiler logs by eye.

(This was originally going to be part of a larger logic polish-up, but I wanted to get these fixes through in time for the big async, as the accessibility check issues could become relevant when generating and the strict move requirements issue could create extremely difficult checks without player consent)