### PR TITLE
DOOM 1993: Update to use new Options + logic fixes + Doc fix

### DIFF
--- a/worlds/doom_1993/Options.py
+++ b/worlds/doom_1993/Options.py
@@ -1,6 +1,5 @@
-import typing
-
-from Options import AssembleOptions, Choice, Toggle, DeathLink, DefaultOnToggle, StartInventoryPool
+from Options import PerGameCommonOptions, Choice, Toggle, DeathLink, DefaultOnToggle, StartInventoryPool
+from dataclasses import dataclass
 
 
 class Goal(Choice):
@@ -140,21 +139,22 @@ class Episode4(Toggle):
     display_name = "Episode 4"
 
 
-options: typing.Dict[str, AssembleOptions] = {
-    "start_inventory_from_pool": StartInventoryPool,
-    "goal": Goal,
-    "difficulty": Difficulty,
-    "random_monsters": RandomMonsters,
-    "random_pickups": RandomPickups,
-    "random_music": RandomMusic,
-    "flip_levels": FlipLevels,
-    "allow_death_logic": AllowDeathLogic,
-    "pro": Pro,
-    "start_with_computer_area_maps": StartWithComputerAreaMaps,
-    "death_link": DeathLink,
-    "reset_level_on_death": ResetLevelOnDeath,
-    "episode1": Episode1,
-    "episode2": Episode2,
-    "episode3": Episode3,
-    "episode4": Episode4
-}
+@dataclass
+class DOOM1993Options(PerGameCommonOptions):
+    start_inventory_from_pool: StartInventoryPool
+    goal: Goal
+    difficulty: Difficulty
+    random_monsters: RandomMonsters
+    random_pickups: RandomPickups
+    random_music: RandomMusic
+    flip_levels: FlipLevels
+    allow_death_logic: AllowDeathLogic
+    pro: Pro
+    start_with_computer_area_maps: StartWithComputerAreaMaps
+    death_link: DeathLink
+    reset_level_on_death: ResetLevelOnDeath
+    episode1: Episode1
+    episode2: Episode2
+    episode3: Episode3
+    episode4: Episode4
+

--- a/worlds/doom_1993/Rules.py
+++ b/worlds/doom_1993/Rules.py
@@ -239,7 +239,12 @@ def set_episode2_rules(player, world, pro):
 
     # Tower of Babel (E2M8)
     set_rule(world.get_entrance("Hub -> Tower of Babel (E2M8) Main", player), lambda state:
-        state.has("Tower of Babel (E2M8)", player, 1))
+       (state.has("Tower of Babel (E2M8)", player, 1) and
+        state.has("Shotgun", player, 1) and
+        state.has("Chaingun", player, 1)) and
+       (state.has("Rocket launcher", player, 1) or
+        state.has("Plasma gun", player, 1) or
+        state.has("BFG9000", player, 1)))
 
     # Fortress of Mystery (E2M9)
     set_rule(world.get_entrance("Hub -> Fortress of Mystery (E2M9) Main", player), lambda state:

--- a/worlds/doom_1993/__init__.py
+++ b/worlds/doom_1993/__init__.py
@@ -2,9 +2,10 @@ import functools
 import logging
 from typing import Any, Dict, List
 
-from BaseClasses import Entrance, CollectionState, Item, ItemClassification, Location, MultiWorld, Region, Tutorial
+from BaseClasses import Entrance, CollectionState, Item, Location, MultiWorld, Region, Tutorial
 from worlds.AutoWorld import WebWorld, World
-from . import Items, Locations, Maps, Options, Regions, Rules
+from . import Items, Locations, Maps, Regions, Rules
+from .Options import DOOM1993Options
 
 logger = logging.getLogger("DOOM 1993")
 
@@ -37,7 +38,8 @@ class DOOM1993World(World):
     Developed by id Software, and originally released in 1993, DOOM pioneered and popularized the first-person shooter,
     setting a standard for all FPS games.
     """
-    option_definitions = Options.options
+    options_dataclass = DOOM1993Options
+    options: DOOM1993Options
     game = "DOOM 1993"
     web = DOOM1993Web()
     data_version = 3
@@ -89,15 +91,17 @@ class DOOM1993World(World):
 
     def generate_early(self):
         # Cache which episodes are included
-        for i in range(4):
-            self.included_episodes[i] = getattr(self.multiworld, f"episode{i + 1}")[self.player].value
+        self.included_episodes[0] = self.options.episode1.value
+        self.included_episodes[1] = self.options.episode2.value
+        self.included_episodes[2] = self.options.episode3.value
+        self.included_episodes[3] = self.options.episode4.value
 
         # If no episodes selected, select Episode 1
         if self.get_episode_count() == 0:
             self.included_episodes[0] = 1
 
     def create_regions(self):
-        pro = getattr(self.multiworld, "pro")[self.player].value
+        pro = self.options.pro.value
 
         # Main regions
         menu_region = Region("Menu", self.player, self.multiworld)
@@ -148,7 +152,7 @@ class DOOM1993World(World):
 
     def completion_rule(self, state: CollectionState):
         goal_levels = Maps.map_names
-        if getattr(self.multiworld, "goal")[self.player].value:
+        if self.options.goal.value:
             goal_levels = self.boss_level_for_espidoes
 
         for map_name in goal_levels:
@@ -167,8 +171,8 @@ class DOOM1993World(World):
         return True
 
     def set_rules(self):
-        pro = getattr(self.multiworld, "pro")[self.player].value
-        allow_death_logic = getattr(self.multiworld, "allow_death_logic")[self.player].value
+        pro = self.options.pro.value
+        allow_death_logic = self.options.allow_death_logic.value
 
         Rules.set_rules(self, self.included_episodes, pro)
         self.multiworld.completion_condition[self.player] = lambda state: self.completion_rule(state)
@@ -185,7 +189,7 @@ class DOOM1993World(World):
 
     def create_items(self):
         itempool: List[DOOM1993Item] = []
-        start_with_computer_area_maps: bool = getattr(self.multiworld, "start_with_computer_area_maps")[self.player].value
+        start_with_computer_area_maps: bool = self.options.start_with_computer_area_maps.value
 
         # Items
         for item_id, item in Items.item_table.items():
@@ -225,7 +229,7 @@ class DOOM1993World(World):
                 self.multiworld.push_precollected(self.create_item(self.starting_level_for_episode[i]))
         
         # Give Computer area maps if option selected
-        if getattr(self.multiworld, "start_with_computer_area_maps")[self.player].value:
+        if self.options.start_with_computer_area_maps.value:
             for item_id, item_dict in Items.item_table.items():
                 item_episode = item_dict["episode"]
                 if item_episode > 0:
@@ -269,7 +273,7 @@ class DOOM1993World(World):
             itempool.append(self.create_item(item_name))
 
     def fill_slot_data(self) -> Dict[str, Any]:
-        slot_data = {name: getattr(self.multiworld, name)[self.player].value for name in self.option_definitions}
+        slot_data = self.options.as_dict("goal", "difficulty", "random_monsters", "random_pickups", "random_music", "flip_levels", "allow_death_logic", "pro", "start_with_computer_area_maps", "death_link", "reset_level_on_death", "episode1", "episode2", "episode3", "episode4")
 
         # E2M6 and E3M9 each have one way keydoor. You can enter, but required the keycard to get out.
         # We used to force place the keycard behind those doors. Limiting the randomness for those items. A change

--- a/worlds/doom_1993/docs/setup_en.md
+++ b/worlds/doom_1993/docs/setup_en.md
@@ -15,7 +15,7 @@
 1. Download [APDOOM.zip](https://github.com/Daivuk/apdoom/releases) and extract it.
 2. Copy `DOOM.WAD` from your game's installation directory into the newly extracted folder.
    You can find the folder in steam by finding the game in your library,
-   right-clicking it and choosing **Manage -> Browse Local Files**.
+   right-clicking it and choosing **Manage -> Browse Local Files**. The WAD file is in the `/base/` folder.
 
 ## Joining a MultiWorld Game
 


### PR DESCRIPTION
## What is this fixing or adding?

- Changed old Options to use the new @dataclass options
- Added info in doc on which folder to find your WAD file in your steam library
- Fixed logic issue for entry to E2M8:
![image](https://github.com/ArchipelagoMW/Archipelago/assets/2482827/ae7a4d38-ceb5-4186-9ae6-a1fa3f077a74)

## How was this tested?

- Locally. Minor changes. The logic issue was reported and logged months ago

