### PR TITLE
LTTP: Thieves Town KDS Key Fix

### DIFF
--- a/worlds/alttp/Rules.py
+++ b/worlds/alttp/Rules.py
@@ -401,7 +401,7 @@ def global_rules(world, player):
 
     set_rule(world.get_location('Thieves\' Town - Big Chest', player),
              lambda state: ((state._lttp_has_key('Small Key (Thieves Town)', player, 3)) or (location_item_name(state, 'Thieves\' Town - Big Chest', player) == ("Small Key (Thieves Town)", player)) and state._lttp_has_key('Small Key (Thieves Town)', player, 2)) and state.has('Hammer', player))
-    if world.accessibility[player] != 'locations':
+    if world.accessibility[player] != 'locations' and not world.key_drop_shuffle[player]:
         set_always_allow(world.get_location('Thieves\' Town - Big Chest', player), lambda state, item: item.name == 'Small Key (Thieves Town)' and item.player == player)
 
     set_rule(world.get_location('Thieves\' Town - Attic', player), lambda state: state._lttp_has_key('Small Key (Thieves Town)', player, 3))


### PR DESCRIPTION
## What is this fixing or adding?
Only allow locking a Thieves' Town key in the Big Chest if KDS is off (when only one key is placed randomly). I may work on a more elegant solution that works with KDS in the future, but this quick fix should do for now.

## How was this tested?
Just generated an LTTP game and made sure it doesn't crash or anything