### PR TITLE
Pokemon Emerald: Fix client crash if 0.4.6 client connects to 0.4.5 seed

### DIFF
--- a/worlds/pokemon_emerald/__init__.py
+++ b/worlds/pokemon_emerald/__init__.py
@@ -87,7 +87,7 @@ class PokemonEmeraldWorld(World):
     location_name_groups = LOCATION_GROUPS
 
     data_version = 2
-    required_client_version = (0, 4, 5)
+    required_client_version = (0, 4, 6)
 
     badge_shuffle_info: Optional[List[Tuple[PokemonEmeraldLocation, PokemonEmeraldItem]]]
     hm_shuffle_info: Optional[List[Tuple[PokemonEmeraldLocation, PokemonEmeraldItem]]]

--- a/worlds/pokemon_emerald/client.py
+++ b/worlds/pokemon_emerald/client.py
@@ -87,7 +87,8 @@ KEY_LOCATION_FLAGS = [
 ]
 KEY_LOCATION_FLAG_MAP = {data.locations[location_name].flag: location_name for location_name in KEY_LOCATION_FLAGS}
 
-LEGENDARY_NAMES = {
+# .lower() keys for backward compatibility between 0.4.5 and 0.4.6
+LEGENDARY_NAMES = {k.lower(): v for k, v in {
     "Groudon": "GROUDON",
     "Kyogre": "KYOGRE",
     "Rayquaza": "RAYQUAZA",
@@ -100,7 +101,7 @@ LEGENDARY_NAMES = {
     "Deoxys": "DEOXYS",
     "Ho-Oh": "HO_OH",
     "Lugia": "LUGIA",
-}
+}.items()}
 
 DEFEATED_LEGENDARY_FLAG_MAP = {data.constants[f"FLAG_DEFEATED_{name}"]: name for name in LEGENDARY_NAMES.values()}
 CAUGHT_LEGENDARY_FLAG_MAP = {data.constants[f"FLAG_CAUGHT_{name}"]: name for name in LEGENDARY_NAMES.values()}
@@ -311,7 +312,7 @@ class PokemonEmeraldClient(BizHawkClient):
 
                 num_caught = 0
                 for legendary, is_caught in caught_legendaries.items():
-                    if is_caught and legendary in [LEGENDARY_NAMES[name] for name in ctx.slot_data["allowed_legendary_hunt_encounters"]]:
+                    if is_caught and legendary in [LEGENDARY_NAMES[name.lower()] for name in ctx.slot_data["allowed_legendary_hunt_encounters"]]:
                         num_caught += 1
 
                 if num_caught >= ctx.slot_data["legendary_hunt_count"]:


### PR DESCRIPTION
## What is this fixing or adding?

A client on `main` connecting to a seed generated on 0.4.5 will encounter an exception if the player is playing legendary hunt, catches Ho-Oh, and Ho-Oh is a valid legendary hunt encounter.

This is the only thing needed to make the client backwards compatible.

Also bumps the required client version to avoid the crash in the other direction, where a game is generated on main/0.4.6 and a player attempts to connect with a 0.4.5 client.

## How was this tested?

Generated on 0.4.5, set the Ho-Oh flag, and ran on `main` and this branch. `main` hit an exception, this branch fixed it.
