### PR TITLE
KDL3: Fix invalid animal placements and fill error

### DIFF
--- a/worlds/kdl3/__init__.py
+++ b/worlds/kdl3/__init__.py
@@ -203,11 +203,13 @@ class KDL3World(World):
                 animal_pool.append("Coo Spawn")
             else:
                 animal_pool.append("Kine Spawn")
+            # Weird fill hack, this forces ChuChu to be the last animal friend placed
+            # If Kine is ever the last animal friend placed, he will cause fill errors on closed world
+            animal_pool.sort()
             locations = [self.multiworld.get_location(spawn, self.player) for spawn in spawns]
             items = [self.create_item(animal) for animal in animal_pool]
             allstate = self.multiworld.get_all_state(False)
             self.random.shuffle(locations)
-            self.random.shuffle(items)
             fill_restrictive(self.multiworld, allstate, locations, items, True, True)
         else:
             animal_friends = animal_friend_spawns.copy()

--- a/worlds/kdl3/test/test_locations.py
+++ b/worlds/kdl3/test/test_locations.py
@@ -48,7 +48,6 @@ class TestLocations(KDL3TestBase):
 class TestShiro(KDL3TestBase):
     options = {
         "open_world": False,
-        "strict_bosses": False,
         "plando_connections": [
             [],
             [

--- a/worlds/kdl3/test/test_locations.py
+++ b/worlds/kdl3/test/test_locations.py
@@ -48,6 +48,7 @@ class TestLocations(KDL3TestBase):
 class TestShiro(KDL3TestBase):
     options = {
         "open_world": False,
+        "strict_bosses": False,
         "plando_connections": [
             [],
             [


### PR DESCRIPTION
## What is this fixing or adding?
Addresses two bugs found through tests.
* If "Kine Spawn" is the last item to be placed by our `fill_restrictive` in pre_fill, it could return an invalid placement that would render the world uncompleteable.
* On closed world and strict bosses, placing more than one restrictive stage in world one could cause an impossible layout.

## How was this tested?
Unittests, including running the failing seeds as well as several random seeds.
Also confirmed on test generation of shuffled animals that the animals were still properly shuffled with this change.
