### PR TITLE
Core: change start inventory from pool to warn when nothing to remove

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -199,8 +199,12 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
             for player, remaining_items in depletion_pool.items():
                 remaining_items = {name: count for name, count in remaining_items.items() if count}
                 if remaining_items:
-                    raise Exception(f"{multiworld.get_player_name(player)}"
+                    logger.warning(f"{multiworld.get_player_name(player)}"
                                     f" is trying to remove items from their pool that don't exist: {remaining_items}")
+                    # find all filler we generated for the current player and remove until it matches 
+                    removables = [item for item in new_items if item.player == player]
+                    for _ in range(len(remaining_items)):
+                        new_items.remove(removables.pop())
         assert len(multiworld.itempool) == len(new_items), "Item Pool amounts should not change."
         multiworld.itempool[:] = new_items
 

--- a/Main.py
+++ b/Main.py
@@ -171,6 +171,7 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
     # Because some worlds don't actually create items during create_items this has to be as late as possible.
     if any(getattr(multiworld.worlds[player].options, "start_inventory_from_pool", None) for player in multiworld.player_ids):
         new_items: List[Item] = []
+        old_items: List[Item] = []
         depletion_pool: Dict[int, Dict[str, int]] = {
             player: getattr(multiworld.worlds[player].options,
                             "start_inventory_from_pool",
@@ -189,10 +190,10 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
                 depletion_pool[item.player][item.name] -= 1
                 # quick abort if we have found all items
                 if not target:
-                    new_items.extend(multiworld.itempool[i+1:])
+                    old_items.extend(multiworld.itempool[i+1:])
                     break
             else:
-                new_items.append(item)
+                old_items.append(item)
 
         # leftovers?
         if target:
@@ -205,8 +206,8 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
                     removables = [item for item in new_items if item.player == player]
                     for _ in range(sum(remaining_items.values())):
                         new_items.remove(removables.pop())
-        assert len(multiworld.itempool) == len(new_items), "Item Pool amounts should not change."
-        multiworld.itempool[:] = new_items
+        assert len(multiworld.itempool) == len(new_items + old_items), "Item Pool amounts should not change."
+        multiworld.itempool[:] = new_items + old_items
 
     # temporary home for item links, should be moved out of Main
     for group_id, group in multiworld.groups.items():

--- a/Main.py
+++ b/Main.py
@@ -203,7 +203,7 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
                                     f" is trying to remove items from their pool that don't exist: {remaining_items}")
                     # find all filler we generated for the current player and remove until it matches 
                     removables = [item for item in new_items if item.player == player]
-                    for _ in range(len(remaining_items)):
+                    for _ in range(sum(remaining_items.values())):
                         new_items.remove(removables.pop())
         assert len(multiworld.itempool) == len(new_items), "Item Pool amounts should not change."
         multiworld.itempool[:] = new_items


### PR DESCRIPTION
## What is this fixing or adding?
makes start inventory from pool warn and fixes the itempool to match when it can not find a matching item to remove

## How was this tested?
lightly,
Generate a Lingo game with:
```
  start_inventory_from_pool:
    # Start with these items and don't place them in the world.
    # The game decides what the replacement items will be.
    {"Black": 2}
```
see screenshots

and with `{"Black": 3}` once i noticed my math was off

and with `{"Black": 500}` once it was noticed that a previous iteration was popping from the entire itempool not just the new filler

## If this makes graphical changes, please attach screenshots.
previous error
![image](https://github.com/ArchipelagoMW/Archipelago/assets/4809984/f6e30be9-1187-453e-9ae9-918d3dae3cd7)

new warning
![image](https://github.com/ArchipelagoMW/Archipelago/assets/4809984/691f8be6-54d7-4469-beee-6d427c889f48)
