### PR TITLE
CI: add mypy to strict type check

### DIFF
--- a/.github/type_check.py
+++ b/.github/type_check.py
@@ -1,15 +1,60 @@
+import json
 from pathlib import Path
 import subprocess
+from typing import Any, Dict, List, Union
 
-config = Path(__file__).parent / "pyright-config.json"
+source_dir = Path(__file__).parent
+config = source_dir / "pyright-config.json"
 
-command = ("pyright", "-p", str(config))
-print(" ".join(command))
 
-try:
-    result = subprocess.run(command)
-except FileNotFoundError as e:
-    print(f"{e} - Is pyright installed?")
-    exit(1)
+def pyright() -> int:
+    """ returns process return code """
+    command = ("pyright", "-p", str(config))
+    print(" ".join(command))
 
-exit(result.returncode)
+    try:
+        pyright_result = subprocess.run(command)
+    except FileNotFoundError as e:
+        print(f"{e} - Is pyright installed?")
+        exit(1)
+    return pyright_result.returncode
+
+
+def mypy() -> int:
+    """ returns process return code """
+    with open(config) as config_file:
+        config_data: Union[Dict[str, Any], Any] = json.load(config_file)
+
+    assert isinstance(config_data, dict)
+    file_list: Union[List[str], None, Any] = config_data.get("include")
+    assert isinstance(file_list, list), f"unknown data in config file: {type(file_list)=}"
+    file_list = [
+        str(source_dir / file_name)
+        for file_name in file_list
+    ]
+    params = [
+        "mypy",
+        "--strict",
+        "--follow-imports=silent",
+        "--no-warn-unused-ignore",
+        "--install-types",
+        "--non-interactive",
+        "typings",
+    ]
+
+    command = params + file_list
+    print(" ".join(params))
+
+    try:
+        mypy_result = subprocess.run(command)
+    except FileNotFoundError as e:
+        print(f"{e} - Is mypy installed?")
+        exit(1)
+    return mypy_result.returncode
+
+
+if __name__ == "__main__":
+    # mypy is first because of its --install-types feature
+    mypy_ret = mypy()
+    pyright_ret = pyright()
+    exit(mypy_ret and pyright_ret)

--- a/.github/workflows/strict-type-check.yml
+++ b/.github/workflows/strict-type-check.yml
@@ -15,7 +15,7 @@ on:
       - "**.pyi"
 
 jobs:
-  pyright:
+  type-check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -26,8 +26,8 @@ jobs:
 
       - name: "Install dependencies"
         run: |
-          python -m pip install --upgrade pip pyright==1.1.358
+          python -m pip install --upgrade pip pyright==1.1.358 mypy==1.9.0
           python ModuleUpdate.py --append "WebHostLib/requirements.txt" --force --yes
 
-      - name: "pyright: strict check on specific files"
+      - name: "type check: strict check on specific files"
         run: python .github/type_check.py


### PR DESCRIPTION
## What is this fixing or adding?

This is an addition to https://github.com/ArchipelagoMW/Archipelago/pull/3121 with some previous discussion here https://github.com/ArchipelagoMW/Archipelago/pull/3107

There are some errors that mypy catches and pyright doesn't, and some errors that pyright catches and mypy doesn't.
So we can catch more problems if we check with both.

The one Python script `.github/type_check.py` will show output from both mypy and pyright.

One of the biggest issues we've found with mypy in AP is this bug: https://github.com/python/mypy/issues/10506
After lots of battling with it in https://github.com/ArchipelagoMW/Archipelago/pull/2173 and https://github.com/ArchipelagoMW/Archipelago/pull/2899, I think we worked around it so it only needs a `# type: ignore` for `default = "random"`
I think that will only happen with a few options in worlds, and this check is opt-in from world maintainers.

## How was this tested?

submitting this PR, because thar's the only way to test github actions