### PR TITLE
Utils: Add a flatten function to Utils.py

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import types
 import typing
 import builtins
 import os
@@ -18,7 +19,7 @@ import warnings
 
 from argparse import Namespace
 from settings import Settings, get_settings
-from typing import BinaryIO, Coroutine, Optional, Set, Dict, Any, Union
+from typing import BinaryIO, Coroutine, Generator, List, Optional, Set, TypeVar, Dict, Any, Union
 from typing_extensions import TypeGuard
 from yaml import load, load_all, dump
 
@@ -773,6 +774,14 @@ def async_start(co: Coroutine[None, None, typing.Any], name: Optional[str] = Non
     task: asyncio.Task[typing.Any] = asyncio.create_task(co, name=name)
     _faf_tasks.add(task)
     task.add_done_callback(_faf_tasks.discard)
+
+
+T = TypeVar("T")
+def flatten(l: List[T] | Generator[T] | T) -> List[T]:
+    if type(l) is list or type(l) is types.GeneratorType:
+        return [ y for x in l for y in flatten(x) ]
+    else:
+        return [ l ]
 
 
 def deprecate(message: str):


### PR DESCRIPTION
## What is this fixing or adding?

This function is useful for #3128 and may be useful for other
multiworlds. SM uses it as well, but only for the varia randomizer
that's pulled in from elsewhere so it doesn't make sense to re-use it
there.

## How was this tested?

This uses essentially the same implementation as the function already
in the SM varia randomizer.