### PR TITLE
lufia2ac: prevent 0 byte reads

### DIFF
--- a/worlds/lufia2ac/Client.py
+++ b/worlds/lufia2ac/Client.py
@@ -118,10 +118,11 @@ class L2ACSNIClient(SNIClient):
             snes_buffered_write(ctx, L2AC_TX_ADDR + 8, total_blue_chests_checked.to_bytes(2, "little"))
             location_ids: List[int] = [locations_start_id + i for i in range(total_blue_chests_checked)]
 
-            loc_data: Optional[bytes] = await snes_read(ctx, L2AC_TX_ADDR + 32, snes_other_locations_checked * 2)
-            if loc_data is not None:
-                location_ids.extend(locations_start_id + int.from_bytes(loc_data[2 * i:2 * i + 2], "little")
-                                    for i in range(snes_other_locations_checked))
+            if snes_other_locations_checked:
+                loc_data: Optional[bytes] = await snes_read(ctx, L2AC_TX_ADDR + 32, snes_other_locations_checked * 2)
+                if loc_data is not None:
+                    location_ids.extend(locations_start_id + int.from_bytes(loc_data[2 * i:2 * i + 2], "little")
+                                        for i in range(snes_other_locations_checked))
 
             if new_location_ids := [loc_id for loc_id in location_ids if loc_id not in ctx.locations_checked]:
                 await ctx.send_msgs([{"cmd": "LocationChecks", "locations": new_location_ids}])


### PR DESCRIPTION
## What is this fixing or adding?

One of the SRAM reads in the client is implemented using a variable size; that size can be 0.
This doesn't seem to be a problem for luabridge-base emulator connections, which simply return a 0 byte result in that case.
But when such a read command with size 0 is sent to snes9x-nwa it causes an error and a disconnect.
We can avoid this entirely by performing the read only if the size is greater than 0.

## How was this tested?

https://discord.com/channels/731205301247803413/1229626698216116265/1229936513299779584
