### PR TITLE
Noita: Add the new bosses to the check pool

### DIFF
--- a/worlds/noita/locations.py
+++ b/worlds/noita/locations.py
@@ -26,7 +26,7 @@ class LocationFlag(IntEnum):
 # Mapping of items in each region.
 # Only the first Hidden Chest and Pedestal are mapped here, the others are created in Regions.
 # ltype key: "chest" = Hidden Chests, "pedestal" = Pedestals, "boss" = Boss, "orb" = Orb.
-# 110000-110649
+# 110000-110671
 location_region_mapping: Dict[str, Dict[str, LocationData]] = {
     "Coal Pits Holy Mountain": {
         "Coal Pits Holy Mountain Shop Item 1":   LocationData(110000),
@@ -90,6 +90,9 @@ location_region_mapping: Dict[str, Dict[str, LocationData]] = {
         "Secret Shop Item 3": LocationData(110044),
         "Secret Shop Item 4": LocationData(110045),
     },
+    "The Sky": {
+        "Kivi": LocationData(110670, LocationFlag.main_world, "boss"),
+    },
     "Floating Island": {
         "Floating Island Orb": LocationData(110658, LocationFlag.main_path, "orb"),
     },
@@ -104,6 +107,7 @@ location_region_mapping: Dict[str, Dict[str, LocationData]] = {
     },
     "Lake": {
         "Syväolento": LocationData(110651, LocationFlag.main_world, "boss"),
+        "Tapion vasalli": LocationData(110669, LocationFlag.main_world, "boss"),
     },
     "Frozen Vault": {
         "Frozen Vault Orb":      LocationData(110660, LocationFlag.main_world, "orb"),
@@ -188,6 +192,7 @@ location_region_mapping: Dict[str, Dict[str, LocationData]] = {
     },
     "Deep Underground": {
         "Limatoukka": LocationData(110647, LocationFlag.main_world, "boss"),
+        "Kolmisilmän sydän": LocationData(110671, LocationFlag.main_world, "boss"),
     },
     "The Laboratory": {
         "Kolmisilmä": LocationData(110646, LocationFlag.main_path, "boss"),

--- a/worlds/noita/locations.py
+++ b/worlds/noita/locations.py
@@ -192,6 +192,8 @@ location_region_mapping: Dict[str, Dict[str, LocationData]] = {
     },
     "Deep Underground": {
         "Limatoukka": LocationData(110647, LocationFlag.main_world, "boss"),
+    },
+    "West Meat Realm": {
         "Kolmisilmän sydän": LocationData(110671, LocationFlag.main_world, "boss"),
     },
     "The Laboratory": {

--- a/worlds/noita/options.py
+++ b/worlds/noita/options.py
@@ -53,7 +53,7 @@ class BossesAsChecks(Choice):
     """Makes bosses count as location checks. The boss only needs to die, you do not need the kill credit.
     The Main Path option includes Gate Guardian, Suomuhauki, and Kolmisilmä.
     The Side Path option includes the Main Path bosses, Sauvojen Tuntija, and Ylialkemisti.
-    The All Bosses option includes all 12 bosses."""
+    The All Bosses option includes all 15 bosses."""
     display_name = "Bosses as Location Checks"
     option_no_bosses = 0
     option_main_path = 1

--- a/worlds/noita/regions.py
+++ b/worlds/noita/regions.py
@@ -113,7 +113,7 @@ noita_connections: Dict[str, List[str]] = {
 
     ###
     "Laboratory Holy Mountain": ["The Laboratory"],
-    "The Laboratory": ["The Work", "Friend Cave", "The Work (Hell)", "Lake"],
+    "The Laboratory": ["The Work", "Friend Cave", "The Work (Hell)", "Lake", "The Sky"],
     ###
 }
 

--- a/worlds/noita/regions.py
+++ b/worlds/noita/regions.py
@@ -72,7 +72,7 @@ def create_all_regions_and_connections(world: "NoitaWorld") -> None:
 # - Snow Chasm is disconnected from the Snowy Wasteland
 # - Pyramid is connected to the Hiisi Base instead of the Desert due to similar difficulty
 # - Frozen Vault is connected to the Vault instead of the Snowy Wasteland due to similar difficulty
-# - Lake is connected to The Laboratory, since the boss is hard without specific set-ups (which means late game)
+# - Lake is connected to The Laboratory, since the bosses are hard without specific set-ups (which means late game)
 # - Snowy Depths connects to Lava Lake orb since you need digging for it, so fairly early is acceptable
 # - Ancient Laboratory is connected to the Coal Pits, so that Ylialkemisti isn't sphere 1
 noita_connections: Dict[str, List[str]] = {
@@ -99,7 +99,7 @@ noita_connections: Dict[str, List[str]] = {
 
     ###
     "Underground Jungle Holy Mountain": ["Underground Jungle"],
-    "Underground Jungle": ["Dragoncave", "Overgrown Cavern", "Vault Holy Mountain", "Lukki Lair", "Snow Chasm"],
+    "Underground Jungle": ["Dragoncave", "Overgrown Cavern", "Vault Holy Mountain", "Lukki Lair", "Snow Chasm", "West Meat Realm"],
 
     ###
     "Vault Holy Mountain": ["The Vault"],


### PR DESCRIPTION
## What is this fixing or adding?
Adds the new Kivi, Tapion vasalli (Deer), and Kolmisilmän sydän (Meatball) to the boss check pool when you have Bosses as Checks set to All Bosses.

## How was this tested?
Tested gen, updated client to send the new checks.

## If this makes graphical changes, please attach screenshots.
terrifying, isn't it?
![Kivi_temple2](https://github.com/ArchipelagoMW/Archipelago/assets/24858499/fac91320-bce7-4586-869d-5dc298690c77)
