### PR TITLE
CV64: Include player in APPP constructor

### DIFF
--- a/worlds/cv64/__init__.py
+++ b/worlds/cv64/__init__.py
@@ -270,7 +270,7 @@ class CV64World(World):
         offset_data.update(get_start_inventory_data(self.player, self.options,
                                                     self.multiworld.precollected_items[self.player]))
 
-        patch = CV64ProcedurePatch()
+        patch = CV64ProcedurePatch(player=self.player, player_name=self.multiworld.player_name[self.player])
         write_patch(self, patch, offset_data, shop_name_list, shop_desc_list, shop_colors_list, active_locations)
 
         rom_path = os.path.join(output_directory, f"{self.multiworld.get_out_file_name_base(self.player)}"


### PR DESCRIPTION
## What is this fixing or adding?
"player" is set to Optional, but forgetting to set it will cause WebHost to be unable to find your files.

## How was this tested?
Generated with this change, then hosted on 24242, confirmed the patch file was available.

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/58583688/744e5163-b451-493c-a415-26d183abee5c)
