### PR TITLE
SC2: Fix so End Game gets proper priority for final mission

### DIFF
--- a/worlds/sc2/MissionTables.py
+++ b/worlds/sc2/MissionTables.py
@@ -50,7 +50,7 @@ class SC2Campaign(Enum):
     PROLOGUE = 4, "Whispers of Oblivion (Legacy of the Void: Prologue)", SC2CampaignGoalPriority.MINI_CAMPAIGN, SC2Race.PROTOSS
     LOTV = 5, "Legacy of the Void", SC2CampaignGoalPriority.VERY_HARD, SC2Race.PROTOSS
     EPILOGUE = 6, "Into the Void (Legacy of the Void: Epilogue)", SC2CampaignGoalPriority.EPILOGUE, SC2Race.ANY
-    NCO = 7, "Nova Covert Ops", SC2CampaignGoalPriority.HARD, SC2Race.TERRAN
+    NCO = 7, "Nova Covert Ops", SC2CampaignGoalPriority.VERY_HARD, SC2Race.TERRAN
 
 
 class SC2Mission(Enum):
@@ -650,7 +650,7 @@ campaign_final_mission_locations: Dict[SC2Campaign, SC2CampaignGoal] = {
     SC2Campaign.PROLOGUE: SC2CampaignGoal(SC2Mission.EVIL_AWOKEN, "Evil Awoken: Victory"),
     SC2Campaign.LOTV: SC2CampaignGoal(SC2Mission.SALVATION, "Salvation: Victory"),
     SC2Campaign.EPILOGUE: None,
-    SC2Campaign.NCO: None,
+    SC2Campaign.NCO: SC2CampaignGoal(SC2Mission.END_GAME, "End Game: Victory"),
 }
 
 campaign_alt_final_mission_locations: Dict[SC2Campaign, Dict[SC2Mission, str]] = {

--- a/worlds/sc2/MissionTables.py
+++ b/worlds/sc2/MissionTables.py
@@ -683,7 +683,6 @@ campaign_alt_final_mission_locations: Dict[SC2Campaign, Dict[SC2Mission, str]] =
         SC2Mission.THE_ESSENCE_OF_ETERNITY: "The Essence of Eternity: Victory",
     },
     SC2Campaign.NCO: {
-        SC2Mission.END_GAME: "End Game: Victory",
         SC2Mission.FLASHPOINT: "Flashpoint: Victory",
         SC2Mission.DARK_SKIES: "Dark Skies: Victory",
         SC2Mission.NIGHT_TERRORS: "Night Terrors: Victory",


### PR DESCRIPTION
## What is this fixing or adding?
Start of discord conversation related to this: https://discord.com/channels/731205301247803413/980554570075873300/1230675826467668059
TL;DR: End Game seems to have been bumped up from a Hard mission to a Very Hard mission near the end of dev for the big SC2 update. However, this change wasn't reflected in a few areas. Because of this, currently End Game cannot be considered a final mission, or has a very low chance to be considered one. The test case that brought this up was a mixed WoL/NCO grid with All In excluded would not set End Game as the final mission. It would end up picking one of the other hard missions from either WoL or NCO instead. I am not sure what other ramifications this might cause, but at least for the test case that brought this about, the contents of this PR bring about the desired result

## How was this tested?
Several test gens with a yaml with the following options:
  mission_order: grid
  enable_wol_missions: 'true'
  (all other campaigns: false)
  enable_nco_missions: 'true'
  shuffle_campaigns: 'true'
  excluded_missions: [All-In]
## If this makes graphical changes, please attach screenshots.
N/A