### PR TITLE
LttP: fix percentage Triforce Pieces and missed cleanup from #3160

### DIFF
--- a/worlds/alttp/ItemPool.py
+++ b/worlds/alttp/ItemPool.py
@@ -686,7 +686,7 @@ def get_pool_core(world, player: int):
         else:  # available
             triforce_pieces = world.triforce_pieces_available[player].value
 
-        triforce_pieces = min(90, max(triforce_pieces, world.triforce_pieces_required[player].value))
+        triforce_pieces = int(min(90, max(triforce_pieces, world.triforce_pieces_required[player].value)))
 
         pieces_in_core = min(extraitems, triforce_pieces)
         additional_pieces_to_place = triforce_pieces - pieces_in_core

--- a/worlds/alttp/ItemPool.py
+++ b/worlds/alttp/ItemPool.py
@@ -682,11 +682,11 @@ def get_pool_core(world, player: int):
             triforce_pieces = world.triforce_pieces_available[player].value + world.triforce_pieces_extra[player].value
         elif world.triforce_pieces_mode[player].value == TriforcePiecesMode.option_percentage:
             percentage = float(world.triforce_pieces_percentage[player].value) / 100
-            triforce_pieces = round(world.triforce_pieces_required[player].value * percentage, 0)
+            triforce_pieces = int(round(world.triforce_pieces_required[player].value * percentage, 0))
         else:  # available
             triforce_pieces = world.triforce_pieces_available[player].value
 
-        triforce_pieces = int(min(90, max(triforce_pieces, world.triforce_pieces_required[player].value)))
+        triforce_pieces = min(90, max(triforce_pieces, world.triforce_pieces_required[player].value))
 
         pieces_in_core = min(extraitems, triforce_pieces)
         additional_pieces_to_place = triforce_pieces - pieces_in_core

--- a/worlds/alttp/__init__.py
+++ b/worlds/alttp/__init__.py
@@ -484,8 +484,8 @@ class ALTTPWorld(World):
                     if state.has('Silver Bow', item.player):
                         return
                     elif state.has('Bow', item.player) and (self.difficulty_requirements.progressive_bow_limit >= 2
-                                                            or self.glitches_required == 'no_glitches'
-                                                            or self.swordless):  # modes where silver bow is always required for ganon
+                                                            or self.multiworld.glitches_required[self.player] == 'no_glitches'
+                                                            or self.multiworld.swordless[self.player]):  # modes where silver bow is always required for ganon
                         return 'Silver Bow'
                     elif self.difficulty_requirements.progressive_bow_limit >= 1:
                         return 'Bow'


### PR DESCRIPTION
## What is this fixing or adding?
Changes a use of `self.swordless` and `self.glitches_required` to `self.multiworld.swordless[self.player]` and `self.multiworld.glitches_required[self.player]` respectively.

Round returns the datatype that was passed in, so we cast the resulting float to an int when on percentage Triforce Pieces.

## How was this tested?
Generated using the offending yaml.

## If this makes graphical changes, please attach screenshots.
