### PR TITLE
Core: Silently fix invalid yaml option for Toggles

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -384,7 +384,8 @@ class Toggle(NumericOption):
     default = 0
 
     def __init__(self, value: int):
-        assert value == 0 or value == 1, "value of Toggle can only be 0 or 1"
+        # if user puts in an invalid value, make it valid
+        value = int(bool(value))
         self.value = value
 
     @classmethod


### PR DESCRIPTION
## What is this fixing or adding?
When the user puts in an invalid option for a Toggle, it fails at the end of gen with a very unhelpful
```
Traceback (most recent call last):
  File "__startup__.py", line 124, in run
  File "console.py", line 16, in run
  File "Generate.py", line 549, in <module>
  File "Generate.py", line 240, in main
  File "Main.py", line 442, in main
  File "BaseClasses.py", line 1377, in to_file
  File "BaseClasses.py", line 1360, in write_option
  File "Options.py", line 137, in current_option_name
  File "Options.py", line 397, in get_option_name
IndexError: list index out of range
```

Now, it'll just convert it to something valid.

Ref discussion: https://discord.com/channels/731205301247803413/1224562534753898647

Previous PR: https://github.com/ArchipelagoMW/Archipelago/pull/3098

Easy way to reproduce the error:
Grab a Clique yaml, set the Hard Mode option to 4

## How was this tested?
Tested by picking a yaml, setting a Toggle setting to something greater than 1, then seeing it not error out.

## If this makes graphical changes, please attach screenshots.
N/A