### PR TITLE
MultiServer: add datastore list command to MultiServer

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2163,6 +2163,16 @@ class ServerCommandProcessor(CommonCommandProcessor):
             self.ctx.broadcast_all([{"cmd": "RoomUpdate", option_name: getattr(self.ctx, option_name)}])
         return True
 
+    def _cmd_datastore(self):
+        """Debug Tool: list writable datastorage keys and approximate the size of their values with pickle."""
+        total: int = 0
+        texts = []
+        for key, value in self.ctx.stored_data.items():
+            texts.append(f"Key: {key} | Size: {len(pickle.dumps(value))}")
+        texts.insert(0, f"Found {len(self.ctx.stored_data)} keys, "
+                        f"approximately totaling {Utils.format_SI_prefix(total, power=1024)}B")
+        self.output("\n".join(texts))
+
 
 async def console(ctx: Context):
     import sys

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2168,7 +2168,9 @@ class ServerCommandProcessor(CommonCommandProcessor):
         total: int = 0
         texts = []
         for key, value in self.ctx.stored_data.items():
-            texts.append(f"Key: {key} | Size: {len(pickle.dumps(value))}")
+            size = len(pickle.dumps(value))
+            total += size
+            texts.append(f"Key: {key} | Size: {size}")
         texts.insert(0, f"Found {len(self.ctx.stored_data)} keys, "
                         f"approximately totaling {Utils.format_SI_prefix(total, power=1024)}B")
         self.output("\n".join(texts))

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2170,7 +2170,7 @@ class ServerCommandProcessor(CommonCommandProcessor):
         for key, value in self.ctx.stored_data.items():
             size = len(pickle.dumps(value))
             total += size
-            texts.append(f"Key: {key} | Size: {size}")
+            texts.append(f"Key: {key} | Size: {size}B")
         texts.insert(0, f"Found {len(self.ctx.stored_data)} keys, "
                         f"approximately totaling {Utils.format_SI_prefix(total, power=1024)}B")
         self.output("\n".join(texts))


### PR DESCRIPTION
## What is this fixing or adding?
/datastore

## How was this tested?
only a little, turns out among my 3 games I use a single datastore key, so I don't have much known data to test with.

## If this makes graphical changes, please attach screenshots.
