### PR TITLE
MultiServer: Fix `/alias <name>` not removing aliases.

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1905,7 +1905,7 @@ class ServerCommandProcessor(CommonCommandProcessor):
     @mark_raw
     def _cmd_alias(self, player_name_then_alias_name):
         """Set a player's alias, by listing their base name and then their intended alias."""
-        player_name, alias_name = player_name_then_alias_name.split(" ", 1)
+        player_name, _, alias_name = player_name_then_alias_name.partition(" ")
         player_name, usable, response = get_intended_text(player_name, self.ctx.player_names.values())
         if usable:
             for (team, slot), name in self.ctx.player_names.items():


### PR DESCRIPTION
## What is this fixing or adding?
As reported in: https://discord.com/channels/731205301247803413/1231278945199067157

Current implementation of server-side `/alias` did not allow removing an alias due to an unpacking logic bug. This change fixes that. 

## How was this tested?
Ran MultiServer.py and tested changes.

## If this makes graphical changes, please attach screenshots.
Before:
![image](https://github.com/ArchipelagoMW/Archipelago/assets/11338376/3cf1b3b4-d960-4c85-8f86-10ba9afeac21)

After:
![image](https://github.com/ArchipelagoMW/Archipelago/assets/11338376/0827a43a-b874-4129-bf8a-c118f4373b8a)
