### PR TITLE
SNIClient: set SNESState to SNES_DISCONNECTED when disconnected

### DIFF
--- a/SNIClient.py
+++ b/SNIClient.py
@@ -85,6 +85,7 @@ class SNIClientCommandProcessor(ClientCommandProcessor):
         """Close connection to a currently connected snes"""
         self.ctx.snes_reconnect_address = None
         self.ctx.cancel_snes_autoreconnect()
+        self.ctx.snes_state = SNESState.SNES_DISCONNECTED
         if self.ctx.snes_socket and not self.ctx.snes_socket.closed:
             async_start(self.ctx.snes_socket.close())
             return True


### PR DESCRIPTION
## What is this fixing or adding?
When we disconnect from the SNES (intentional or otherwise), we don't actually change our state to reflect this. This means SNIClient cannot reconnect, as `snes_connect` will see our status as SNES_CONNECTED and think we're waiting on the SNES to load a game.

## How was this tested?
Connected to Snes9x-rr using SNI's lua, and then paused the emulator, forcing SNIClient to disconnect. Then, unpaused the emulator and confirmed that SNIClient was capable of reconnecting without any further help.
