### PR TITLE
TUNIC: Fix minimal Heir access in ladder shuffle

### DIFF
--- a/worlds/tunic/er_rules.py
+++ b/worlds/tunic/er_rules.py
@@ -986,7 +986,7 @@ def set_er_region_rules(world: "TunicWorld", ability_unlocks: Dict[str, int], re
         connecting_region=regions["Spirit Arena Victory"],
         rule=lambda state: (state.has(gold_hexagon, player, world.options.hexagon_goal.value) if
                             world.options.hexagon_quest else
-                            state.has_all({red_hexagon, green_hexagon, blue_hexagon}, player)))
+                            state.has_all({red_hexagon, green_hexagon, blue_hexagon, "Place Questagons"}, player)))
 
     # connecting the regions portals are in to other portals you can access via ladder storage
     # using has_stick instead of can_ladder_storage since it's already checking the logic rules

--- a/worlds/tunic/er_rules.py
+++ b/worlds/tunic/er_rules.py
@@ -986,7 +986,7 @@ def set_er_region_rules(world: "TunicWorld", ability_unlocks: Dict[str, int], re
         connecting_region=regions["Spirit Arena Victory"],
         rule=lambda state: (state.has(gold_hexagon, player, world.options.hexagon_goal.value) if
                             world.options.hexagon_quest else
-                            state.has_all({red_hexagon, green_hexagon, blue_hexagon, "Place Questagons"}, player)))
+                            state.has_all({red_hexagon, green_hexagon, blue_hexagon, "Unseal the Heir"}, player)))
 
     # connecting the regions portals are in to other portals you can access via ladder storage
     # using has_stick instead of can_ladder_storage since it's already checking the logic rules

--- a/worlds/tunic/er_scripts.py
+++ b/worlds/tunic/er_scripts.py
@@ -69,7 +69,8 @@ tunic_events: Dict[str, str] = {
     "Quarry Fuse": "Quarry",
     "Ziggurat Fuse": "Rooted Ziggurat Lower Back",
     "West Garden Fuse": "West Garden",
-    "Library Fuse": "Library Lab"
+    "Library Fuse": "Library Lab",
+    "Place Questagons": "Sealed Temple",
 }
 
 
@@ -77,6 +78,11 @@ def place_event_items(world: "TunicWorld", regions: Dict[str, Region]) -> None:
     for event_name, region_name in tunic_events.items():
         region = regions[region_name]
         location = TunicERLocation(world.player, event_name, None, region)
+        if event_name == "Place Questagons":
+            if world.options.hexagon_quest:
+                continue
+            location.place_locked_item(
+                TunicERItem(event_name, ItemClassification.progression, None, world.player))
         if event_name.endswith("Bell"):
             location.place_locked_item(
                 TunicERItem("Ring " + event_name, ItemClassification.progression, None, world.player))

--- a/worlds/tunic/er_scripts.py
+++ b/worlds/tunic/er_scripts.py
@@ -82,7 +82,7 @@ def place_event_items(world: "TunicWorld", regions: Dict[str, Region]) -> None:
             if world.options.hexagon_quest:
                 continue
             location.place_locked_item(
-                TunicERItem(event_name, ItemClassification.progression, None, world.player))
+                TunicERItem("Unseal the Heir", ItemClassification.progression, None, world.player))
         if event_name.endswith("Bell"):
             location.place_locked_item(
                 TunicERItem("Ring " + event_name, ItemClassification.progression, None, world.player))

--- a/worlds/tunic/er_scripts.py
+++ b/worlds/tunic/er_scripts.py
@@ -83,7 +83,7 @@ def place_event_items(world: "TunicWorld", regions: Dict[str, Region]) -> None:
                 continue
             location.place_locked_item(
                 TunicERItem("Unseal the Heir", ItemClassification.progression, None, world.player))
-        if event_name.endswith("Bell"):
+        elif event_name.endswith("Bell"):
             location.place_locked_item(
                 TunicERItem("Ring " + event_name, ItemClassification.progression, None, world.player))
         else:

--- a/worlds/tunic/rules.py
+++ b/worlds/tunic/rules.py
@@ -129,7 +129,8 @@ def set_region_rules(world: "TunicWorld", ability_unlocks: Dict[str, int]) -> No
     multiworld.get_entrance("Overworld -> Spirit Arena", player).access_rule = \
         lambda state: (state.has(gold_hexagon, player, options.hexagon_goal.value) if options.hexagon_quest.value
                        else state.has_all({red_hexagon, green_hexagon, blue_hexagon}, player)) and \
-        has_ability(state, player, prayer, options, ability_unlocks) and has_sword(state, player)
+        has_ability(state, player, prayer, options, ability_unlocks) and has_sword(state, player) and \
+        state.has_any({lantern, laurels}, player)
 
 
 def set_location_rules(world: "TunicWorld", ability_unlocks: Dict[str, int]) -> None:


### PR DESCRIPTION
## What is this fixing or adding?
When set to minimal with hex quest off and ladder shuffle on, there's a chance of it not giving you access to the place you need to place the 3 hexagons to finish the game.
Now, there's an event there that is required to reach the Spirit Arena.

## How was this tested?
Few test gens.

## If this makes graphical changes, please attach screenshots.
N/A