### PR TITLE
Lingo: Expand sphere 1 under restrictive conditions

### DIFF
--- a/worlds/lingo/locations.py
+++ b/worlds/lingo/locations.py
@@ -10,6 +10,7 @@ class LocationClassification(Flag):
     normal = auto()
     reduced = auto()
     insanity = auto()
+    small_sphere_one = auto()
 
 
 class LocationData(NamedTuple):
@@ -46,6 +47,9 @@ def load_location_data():
 
                 if not panel.exclude_reduce:
                     classification |= LocationClassification.reduced
+
+            if room_name == "Starting Room":
+                classification |= LocationClassification.small_sphere_one
 
             ALL_LOCATION_TABLE[location_name] = \
                 LocationData(get_panel_location_id(room_name, panel_name), room_name,

--- a/worlds/lingo/player_logic.py
+++ b/worlds/lingo/player_logic.py
@@ -236,9 +236,12 @@ class LingoPlayerLogic:
         elif location_checks == LocationChecks.option_insanity:
             location_classification = LocationClassification.insanity
 
+        if door_shuffle != ShuffleDoors.option_none and not early_color_hallways:
+            location_classification |= LocationClassification.small_sphere_one
+
         for location_name, location_data in ALL_LOCATION_TABLE.items():
             if location_name != self.victory_condition:
-                if location_classification not in location_data.classification:
+                if not (location_classification & location_data.classification):
                     continue
 
                 self.add_location(location_data.room, location_name, location_data.code, location_data.panels, world)


### PR DESCRIPTION
## What is this fixing or adding?
When door shuffle is on and early color hallways is off, sphere 1 is only three checks. This has proven to be difficult for the fill algorithm sometimes. This PR adds four more checks to the starting room under these conditions to make things less likely to fail.

Client branch: https://code.fourisland.com/lingo-archipelago/log/?h=tinysphere
Tracker branch: https://code.fourisland.com/lingo-ap-tracker/log/?h=tinysphere


## How was this tested?
Test gens using both the updated client and tracker.


## If this makes graphical changes, please attach screenshots.
