### PR TITLE
Setup: update cx_freeze to latest 6.x and exclude 7.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 # This is a bit jank. We need cx-Freeze to be able to run anything from this script, so install it
 try:
-    requirement = 'cx-Freeze>=6.15.10'
+    requirement = 'cx-Freeze>=6.15.16,<7'
     import pkg_resources
     try:
         pkg_resources.require(requirement)


### PR DESCRIPTION
## What is this fixing or adding?

Disable upgrade to cx_freeze 7.x since that is incompatible for the way we hook into the build process. Also update to latest 6.x while at it.

**Important:** CI release action for Linux will fail if neither this nor #3195 is merged.

## How was this tested?

`python setup.py build_exe bdist_appimage`
