### PR TITLE
Setup: update cx_freeze to 7.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 # This is a bit jank. We need cx-Freeze to be able to run anything from this script, so install it
 try:
-    requirement = 'cx-Freeze>=6.15.10'
+    requirement = 'cx-Freeze>=7.0.0'
     import pkg_resources
     try:
         pkg_resources.require(requirement)
@@ -228,8 +228,8 @@ class BuildCommand(setuptools.command.build.build):
 
 
 # Override cx_Freeze's build_exe command for pre and post build steps
-class BuildExeCommand(cx_Freeze.command.build_exe.BuildEXE):
-    user_options = cx_Freeze.command.build_exe.BuildEXE.user_options + [
+class BuildExeCommand(cx_Freeze.command.build_exe.build_exe):
+    user_options = cx_Freeze.command.build_exe.build_exe.user_options + [
         ('yes', 'y', 'Answer "yes" to all questions.'),
         ('extra-data=', None, 'Additional files to add.'),
     ]


### PR DESCRIPTION
## What is this fixing or adding?

Make setup.py compatible to cx_freeze 7.x and upgrade cx_freeze.

## How was this tested?

`python setup.py build_exe bdist_appimage`

Since this is a major release number change and was only tested very little, I'd strongly prefer to merge this **after** the upcoming release and merge #3194 now instead.