### PR TITLE
Core: make open_filename log that it's asking

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -619,6 +619,8 @@ def get_fuzzy_results(input_word: str, wordlist: typing.Sequence[str], limit: ty
 
 def open_filename(title: str, filetypes: typing.Sequence[typing.Tuple[str, typing.Sequence[str]]], suggest: str = "") \
         -> typing.Optional[str]:
+    logging.info(f"Opening file input dialog for {title}.")
+
     def run(*args: str):
         return subprocess.run(args, capture_output=True, text=True).stdout.split("\n", 1)[0] or None
 


### PR DESCRIPTION
## What is this fixing or adding?
I keep seeing people confused why generation stopped or why the client isn't patching, when they didn't see the dialog asking for a file. By logging that it's happening they may have a higher chance to notice.

## How was this tested?
It wasn't, I go to sleep now.

## If this makes graphical changes, please attach screenshots.
