### PR TITLE
The Messenger: fix generation failure for no portal shuffle with 3 available portals

### DIFF
--- a/worlds/messenger/__init__.py
+++ b/worlds/messenger/__init__.py
@@ -155,7 +155,8 @@ class MessengerWorld(World):
             self.starting_portals.append("Searing Crags Portal")
             portals_to_strip = [portal for portal in ["Riviere Turquoise Portal", "Sunken Shrine Portal"]
                                 if portal in self.starting_portals]
-            self.starting_portals.remove(self.random.choice(portals_to_strip))
+            if portals_to_strip:
+                self.starting_portals.remove(self.random.choice(portals_to_strip))
 
         self.filler = FILLER.copy()
         if self.options.traps:

--- a/worlds/messenger/test/test_portals.py
+++ b/worlds/messenger/test/test_portals.py
@@ -4,6 +4,10 @@ from ..portals import PORTALS
 
 
 class PortalTestBase(MessengerTestBase):
+    options = {
+        "available_portals": 3,
+    }
+
     def test_portal_reqs(self) -> None:
         """tests the paths to open a portal if only that portal is closed with vanilla connections."""
         # portal and requirements to reach it if it's the only closed portal


### PR DESCRIPTION
## What is this fixing or adding?
I wrote code to guarantee the searing crags portal is always open when portal shuffle is disabled but i never considered that someone would have their starting portals set to 3 when doing that for some reason.

## How was this tested?
Added a test for it that fails without the change.

## If this makes graphical changes, please attach screenshots.
