### PR TITLE
HK: add grub hunt goal

### DIFF
--- a/worlds/hk/Options.py
+++ b/worlds/hk/Options.py
@@ -415,7 +415,7 @@ class GrubHuntGoal(NamedRange):
     display_name = "Grub Hunt Goal"
     range_start = 1
     range_end = 46
-    special_range_names = {"all": 0}
+    special_range_names = {"all": -1}
     default = 46
 
 

--- a/worlds/hk/Options.py
+++ b/worlds/hk/Options.py
@@ -409,6 +409,16 @@ class Goal(Choice):
     default = 0
 
 
+class GrubHuntGoal(NamedRange):
+    """The amount of grubs required to finish Grub Hunt.
+    On 'All' any grubs from item links replacements etc. will be counted"""
+    display_name = "Grub Hunt Goal"
+    range_start = 1
+    range_end = 46
+    special_range_names = {"all": 0}
+    default = 46
+
+
 class WhitePalace(Choice):
     """
     Whether or not to include White Palace or not.  Note: Even if excluded, the King Fragment check may still be
@@ -523,7 +533,7 @@ hollow_knight_options: typing.Dict[str, type(Option)] = {
     **{
         option.__name__: option
         for option in (
-            StartLocation, Goal, WhitePalace, ExtraPlatforms, AddUnshuffledLocations, StartingGeo,
+            StartLocation, Goal, GrubHuntGoal, WhitePalace, ExtraPlatforms, AddUnshuffledLocations, StartingGeo,
             DeathLink, DeathLinkShade, DeathLinkBreaksFragileCharms,
             MinimumGeoPrice, MaximumGeoPrice,
             MinimumGrubPrice, MaximumGrubPrice,

--- a/worlds/hk/Options.py
+++ b/worlds/hk/Options.py
@@ -405,6 +405,7 @@ class Goal(Choice):
     option_radiance = 3
     option_godhome = 4
     option_godhome_flower = 5
+    option_grub_hunt = 6
     default = 0
 
 

--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -616,7 +616,7 @@ class HKWorld(World):
                 if state.prog_items[item.player][effect_name] == effect_value:
                     del state.prog_items[item.player][effect_name]
                 else:
-                state.prog_items[item.player][effect_name] -= effect_value
+                    state.prog_items[item.player][effect_name] -= effect_value
 
         return change
 

--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -17,7 +17,7 @@ from .ExtractedData import locations, starts, multi_locations, location_to_regio
     event_names, item_effects, connectors, one_ways, vanilla_shop_costs, vanilla_location_costs
 from .Charms import names as charm_names
 
-from BaseClasses import Region, Location, MultiWorld, Item, LocationProgressType, Tutorial, ItemClassification
+from BaseClasses import Region, Location, MultiWorld, Item, LocationProgressType, Tutorial, ItemClassification, CollectionState
 from worlds.AutoWorld import World, LogicMixin, WebWorld
 
 path_of_pain_locations = {

--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -203,7 +203,7 @@ class HKWorld(World):
 
         # check for any goal that godhome events are relevant to
         all_event_names = event_names.copy()
-        if self.options.Goal in [Goal.option_godhome, Goal.option_godhome_flower]:
+        if self.options.Goal in [Goal.option_godhome, Goal.option_godhome_flower, Goal.option_any]:
             from .GodhomeData import godhome_event_names
             all_event_names.update(set(godhome_event_names))
 
@@ -447,7 +447,7 @@ class HKWorld(World):
             pass  # will set in pre_fill()
         else:
             # Any goal
-            multiworld.completion_condition[player] = lambda state: _hk_can_beat_thk(state, player) or _hk_can_beat_radiance(state, player) or state.count("Defeated_Pantheon_5", player) or state.count("Godhome_Flower_Quest", player)
+            multiworld.completion_condition[player] = lambda state: _hk_can_beat_thk(state, player) or _hk_can_beat_radiance(state, player) or state.count("Defeated_Pantheon_5", player)
 
         set_rules(self)
 

--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -455,7 +455,7 @@ class HKWorld(World):
         grub_hunt_goal = self.options.GrubHuntGoal
         goal = self.options.Goal
         if goal in ["any", "grub_hunt"]:
-            def set_goal(grub_rule: Callable[[CollectionState], bool]):
+            def set_goal(grub_rule: typing.Callable[[CollectionState], bool]):
                 if goal == "grub_hunt":
                     self.multiworld.completion_condition[self.player] = grub_rule
                 else:

--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -444,7 +444,11 @@ class HKWorld(World):
         elif goal == Goal.option_godhome_flower:
             multiworld.completion_condition[player] = lambda state: state.count("Godhome_Flower_Quest", player)
         elif goal == Goal.option_grub_hunt:
-            pass  # will set in pre_fill()
+            if self.options.GrubHuntGoal == "all":
+                pass  # will set in pre_fill()
+            else:
+                self.grub_count = self.options.GrubHuntGoal.value
+                world.completion_condition[player] = lambda state: state.has("Grub", player, self.grub_count)
         else:
             # Any goal
             multiworld.completion_condition[player] = lambda state: _hk_can_beat_thk(state, player) or _hk_can_beat_radiance(state, player)
@@ -452,7 +456,7 @@ class HKWorld(World):
         set_rules(self)
 
     def pre_fill(self):
-        if self.options.Goal == "grub_hunt":
+        if self.options.Goal == "grub_hunt" and self.grub_count == 0:
             from collections import Counter
             relevant_groups = self.multiworld.get_player_groups(self.player)
             grub_player_count = Counter()

--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -447,7 +447,7 @@ class HKWorld(World):
             pass  # will set in stage_pre_fill()
         else:
             # Any goal
-            multiworld.completion_condition[player] = lambda state: _hk_can_beat_thk(state, player) or _hk_can_beat_radiance(state, player) or state.count("Defeated_Pantheon_5", player)
+            multiworld.completion_condition[player] = lambda state: _hk_siblings_ending(state, player) and _hk_can_beat_radiance(state, player) and state.count("Godhome_Flower_Quest", player)
 
         set_rules(self)
 
@@ -466,7 +466,7 @@ class HKWorld(World):
                     multiworld.completion_condition[player] = grub_rule
                 else:
                     old_rule = multiworld.completion_condition[player]
-                    multiworld.completion_condition[player] = lambda state: old_rule(state) or grub_rule(state)
+                    multiworld.completion_condition[player] = lambda state: old_rule(state) and grub_rule(state)
 
             if grub_hunt_goal == grub_hunt_goal.special_range_names["all"]:
                 from collections import Counter

--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -471,7 +471,7 @@ class HKWorld(World):
                 all([state.has("Grub", player, count) for player, count in g.items()])
         else:
             self.grub_count = grub_hunt_goal.value
-            world.completion_condition[player] = lambda state: state.has("Grub", player, self.grub_count)
+            self.multiworld.completion_condition[self.player] = lambda state: state.has("Grub", self.player, self.grub_count)
 
     def fill_slot_data(self):
         slot_data = {}

--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -444,11 +444,7 @@ class HKWorld(World):
         elif goal == Goal.option_godhome_flower:
             multiworld.completion_condition[player] = lambda state: state.count("Godhome_Flower_Quest", player)
         elif goal == Goal.option_grub_hunt:
-            if self.options.GrubHuntGoal == "all":
-                pass  # will set in pre_fill()
-            else:
-                self.grub_count = self.options.GrubHuntGoal.value
-                world.completion_condition[player] = lambda state: state.has("Grub", player, self.grub_count)
+            pass  # will set in pre_fill()
         else:
             # Any goal
             multiworld.completion_condition[player] = lambda state: _hk_can_beat_thk(state, player) or _hk_can_beat_radiance(state, player)
@@ -456,7 +452,8 @@ class HKWorld(World):
         set_rules(self)
 
     def pre_fill(self):
-        if self.options.Goal == "grub_hunt" and self.grub_count == 0:
+        grub_hunt_goal = self.options.GrubHuntGoal
+        if grub_hunt_goal == grub_hunt_goal.special_range_names["all"]:
             from collections import Counter
             relevant_groups = self.multiworld.get_player_groups(self.player)
             grub_player_count = Counter()
@@ -472,6 +469,9 @@ class HKWorld(World):
 
             self.multiworld.completion_condition[self.player] = lambda state, g=grub_player_count: \
                 all([state.has("Grub", player, count) for player, count in g.items()])
+        else:
+            self.grub_count = grub_hunt_goal.value
+            world.completion_condition[player] = lambda state: state.has("Grub", player, self.grub_count)
 
     def fill_slot_data(self):
         slot_data = {}
@@ -510,7 +510,7 @@ class HKWorld(World):
 
         slot_data["notch_costs"] = self.charm_costs
 
-        slot_data["GrubCount"] = self.grub_count
+        slot_data["grub_count"] = self.grub_count
 
         return slot_data
 

--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -448,13 +448,13 @@ class HKWorld(World):
             pass  # will set in stage_pre_fill()
         else:
             # Any goal
-            multiworld.completion_condition[player] = lambda state: _hk_siblings_ending(state, player) and _hk_can_beat_radiance(state, player) and state.count("Godhome_Flower_Quest", player)
+            multiworld.completion_condition[player] = lambda state: _hk_siblings_ending(state, player) and \
+                _hk_can_beat_radiance(state, player) and state.count("Godhome_Flower_Quest", player)
 
         set_rules(self)
 
-    def stage_pre_fill(multiworld: "MultiWorld"):
-        cls = HKWorld
-
+    @classmethod
+    def stage_pre_fill(cls, multiworld: "MultiWorld"):
         def set_goal(player, grub_rule: typing.Callable[[CollectionState], bool]):
             world = multiworld.worlds[player]
 

--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -497,7 +497,7 @@ class HKWorld(World):
 
             for player, grub_player_count in per_player_grubs_per_player.items():
                 if player in all_grub_players:
-                    set_goal(player, lambda state, g=grub_player_count: all([state.has("Grub", owner, count) for owner, count in g.items()]))
+                    set_goal(player, lambda state, g=grub_player_count: all(state.has("Grub", owner, count) for owner, count in g.items()))
 
         for world in worlds:
             if world.player not in all_grub_players:

--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -506,7 +506,7 @@ class HKWorld(World):
 
         slot_data["notch_costs"] = self.charm_costs
 
-        slot_data["grub_count"] = self.grub_count
+        slot_data["GrubCount"] = self.grub_count
 
         return slot_data
 


### PR DESCRIPTION
## What is this fixing or adding?
makes grub hunt goal option that calculates the total available grubs (including item link replacements) and requires all of them to be gathered for goal completion

Note: this is dependent on game mod updates to enable the goal

## How was this tested?
generated with two HK worlds with both item links set to:
```yaml
  item_links:
    - name: Everygrubby
      item_pool:
        - Grub
      replacement_item: Grub
      link_replacement: true
```
and:
```yaml
  item_links:
    - name: Everygrubby
      item_pool:
        - Grub
      replacement_item: Grub
      link_replacement: false
```

and viewed the spoiler log / playthrough for issues

## If this makes graphical changes, please attach screenshots.
