### PR TITLE
WebHost: Prevent committing data packages with invalid checksums to database and prevent 500 error from invalid `zip` files.

### DIFF
--- a/WebHostLib/upload.py
+++ b/WebHostLib/upload.py
@@ -63,12 +63,13 @@ def process_multidata(compressed_multidata, files={}):
                 game_data = games_package_schema.validate(game_data)
                 game_data = {key: value for key, value in sorted(game_data.items())}
                 game_data["checksum"] = data_package_checksum(game_data)
-                game_data_package = GameDataPackage(checksum=game_data["checksum"],
-                                                    data=pickle.dumps(game_data))
                 if original_checksum != game_data["checksum"]:
                     raise Exception(f"Original checksum {original_checksum} != "
                                     f"calculated checksum {game_data['checksum']} "
                                     f"for game {game}.")
+
+                game_data_package = GameDataPackage(checksum=game_data["checksum"],
+                                                    data=pickle.dumps(game_data))
                 decompressed_multidata["datapackage"][game] = {
                     "version": game_data.get("version", 0),
                     "checksum": game_data["checksum"],
@@ -192,6 +193,8 @@ def uploads():
                             res = upload_zip_to_db(zfile)
                         except VersionException:
                             flash(f"Could not load multidata. Wrong Version detected.")
+                        except Exception as e:
+                            flash(f"Could not load multidata. File may be corrupted or incompatible. ({e})")
                         else:
                             if res is str:
                                 return res


### PR DESCRIPTION
## What is this fixing or adding?

This is a two-fold PR just because both fixes were trivial.

1. Prevent committing data packages with invalid checksums to database.

	If a game with a data package checksum that does not match the re-calculated checksum is uploaded, an error would flash on the screen with the specific error, but the data package would still be uploaded to the database. Then the next time a user uploads the same game data package, it will return a 500 error instead as PONY would throw an exception.

	The fix was to compare the checksums first, then create a `GameDataPackage` entity as doing it before would still commit to DB even without running `commit`.

2. Prevent 500 error from invalid `zip` files.

	Similar to the above, if a `.zip` file containing the `.archipelago` file with the invalid  data package checksums was uploaded, it would return a 500 error regardless. This was because there was no base `Exception` catch. We just add the base Exception catch and flash the same error message as above.

Error discovered in this tech support thread: https://discord.com/channels/731205301247803413/1232485200542433423

Adding `affects: release/blocker` as without this change, DB will still be polluted with bad checksum data. 

~~Ideally the whole `GameDataPackage` table in the DB should also be run through for invalid data packages with mismatched checksums to remove existing bad entries, but that's a @Berserker66 request since I don't have access to the server. :P~~ Edit: Actually impossible to check because `upload.py` overrides the checksum from the uploaded file in both column and data package. So unless the rest of the data package is invalid, it probably can't be detected (but may be fine anyway?).

## How was this tested?
Ran WebHost and uploaded generations with invalid data packages and valid data packages.

- The valid ones would work and still write new data packages to DB.
- The invalid ones would not work, but shows a nicer error message at least.

## If this makes graphical changes, please attach screenshots.
~~No pictures of my database for you. Just trust me bro.~~

![image](https://github.com/ArchipelagoMW/Archipelago/assets/11338376/061e92b6-f87a-4a11-90a5-2346586a2fe7)
