### PR TITLE
WebHost: add startup option to clean datapackages

### DIFF
--- a/WebHostLib/__init__.py
+++ b/WebHostLib/__init__.py
@@ -38,6 +38,7 @@ app.config["JOB_THRESHOLD"] = 1
 # after what time in seconds should generation be aborted, freeing the queue slot. Can be set to None to disable.
 app.config["JOB_TIME"] = 600
 app.config['SESSION_PERMANENT'] = True
+app.config["CHECK_DATA_PACKAGE_CHECKSUM_ON_STARTUP"] = False
 
 # waitress uses one thread for I/O, these are for processing of views that then get sent
 # archipelago.gg uses gunicorn + nginx; ignoring this option


### PR DESCRIPTION
## What is this fixing or adding?
Allows cleaning datapackage entries that have the wrong checksum. They're deleted entirely, which should be  fine for the server, though  some clients may break. This is a very small may though, as it should only affect clients that relied on a miscontructed apworld.

## How was this tested?
copied the checksum from one row and the data from another row, then watched how only that row disappeared on startup.

## If this makes graphical changes, please attach screenshots.
