### PR TITLE
WebHost: remove JSON_AS_ASCII

### DIFF
--- a/docs/webhost configuration sample.yaml
+++ b/docs/webhost configuration sample.yaml
@@ -45,9 +45,6 @@
 # TODO
 #CACHE_TYPE: "simple"
 
-# TODO
-#JSON_AS_ASCII: false
-
 # Host Address.  This is the address encoded into the patch that will be used for client auto-connect.
 #HOST_ADDRESS: archipelago.gg
 


### PR DESCRIPTION
## What is this fixing or adding?
Last time I saw this option it came  with a deprecationwarning, so it's either already removed or no longer relevant.

## How was this tested?
Nah

## If this makes graphical changes, please attach screenshots.
