### PR TITLE
[The Legend of Zelda] Add Arrow Shuffle

### DIFF
--- a/worlds/tloz/ItemPool.py
+++ b/worlds/tloz/ItemPool.py
@@ -1,6 +1,6 @@
 from BaseClasses import ItemClassification
 from .Locations import level_locations, all_level_locations, standard_level_locations, shop_locations
-from .Options import TriforceLocations, StartingPosition
+from .Options import TriforceLocations, StartingPosition, ArrowLocation
 
 # Swords are in starting_weapons
 overworld_items = {
@@ -87,7 +87,13 @@ def get_pool_core(world):
     minor_items = dict(minor_dungeon_items)
 
     # Guaranteed Shop Items
-    reserved_store_slots = random.sample(shop_locations[0:9], 4)
+    guaranteed_shop_items = ["Small Key", "Bomb", "Water of Life (Red)", "Arrow"]
+#    print("DEBUG: list is ", guaranteed_shop_items, "and len is ", len(guaranteed_shop_items))
+    if (world.options.ArrowLocation == ArrowLocation.option_anywhere) and ("Arrow" in guaranteed_shop_items):
+        guaranteed_shop_items.remove("Arrow")
+#    print("DEBUG: new list is ", guaranteed_shop_items, "and len is ", len(guaranteed_shop_items))
+    reserved_store_slots = random.sample(shop_locations[0:9], len(guaranteed_shop_items))
+#    print("DEBUG: Slots reserved: ", len(reserved_store_slots))
     for location, item in zip(reserved_store_slots, guaranteed_shop_items):
         placed_items[location] = item
 

--- a/worlds/tloz/ItemPool.py
+++ b/worlds/tloz/ItemPool.py
@@ -87,14 +87,13 @@ def get_pool_core(world):
     minor_items = dict(minor_dungeon_items)
 
     # Guaranteed Shop Items
-    guaranteed_shop_items = ["Small Key", "Bomb", "Water of Life (Red)", "Arrow"]
-#    print("DEBUG: list is ", guaranteed_shop_items, "and len is ", len(guaranteed_shop_items))
-    if (world.options.ArrowLocation == ArrowLocation.option_anywhere) and ("Arrow" in guaranteed_shop_items):
-        guaranteed_shop_items.remove("Arrow")
-#    print("DEBUG: new list is ", guaranteed_shop_items, "and len is ", len(guaranteed_shop_items))
-    reserved_store_slots = random.sample(shop_locations[0:9], len(guaranteed_shop_items))
-#    print("DEBUG: Slots reserved: ", len(reserved_store_slots))
-    for location, item in zip(reserved_store_slots, guaranteed_shop_items):
+    arrow = "Arrow"
+    copy_shop_items = guaranteed_shop_items.copy()
+    if (world.options.ArrowLocation == ArrowLocation.option_anywhere) and (arrow in copy_shop_items):
+        copy_shop_items.remove(arrow)
+        pool.append(arrow)
+    reserved_store_slots = random.sample(shop_locations[0:9], len(copy_shop_items))
+    for location, item in zip(reserved_store_slots, copy_shop_items):
         placed_items[location] = item
 
     # Starting Weapon

--- a/worlds/tloz/Options.py
+++ b/worlds/tloz/Options.py
@@ -33,8 +33,17 @@ class StartingPosition(Choice):
     option_dangerous = 2
     option_very_dangerous = 3
 
+class ArrowLocation(Choice):
+    """Bow requires you to also find an Arrow in order to use it.
+    Shop means that Arrow is guaranteed to appear in one of the shops in your world.
+    Anywhere shuffles Arrow into the pool to be placed in any game in the multiworld."""
+    display_name = "Arrow Location"
+    option_shop = 0
+    option_anywhere = 1
+
 @dataclass
 class TlozOptions(PerGameCommonOptions):
     ExpandedPool: ExpandedPool
     TriforceLocations: TriforceLocations
     StartingPosition: StartingPosition
+    ArrowLocation: ArrowLocation


### PR DESCRIPTION
## What is this fixing or adding?
This adds the ability to shuffle the Arrow item into the item pool. This ability is controlled by the "Arrow Location" YAML option that has now been added.

## How was this tested?
After confirming functionality, I generated YAMLs for 20 games on each setting (other settings set to random). In the 5 of these 20 that I checked the spoiler log, Arrows placed correctly.

I did not attempt to host or connect to a game with these features, but I feel that this is not something that will be impacted by this change. 

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/3732379/46e8df17-f1f0-4934-9905-5c3cf2d918ab)

