### PR TITLE
The Witness: Fix Mountain Floor 2 Near Row 5 Symbol Requirement

### DIFF
--- a/worlds/witness/data/WitnessLogic.txt
+++ b/worlds/witness/data/WitnessLogic.txt
@@ -1033,7 +1033,7 @@ Mountain Floor 2 (Mountain Floor 2) - Mountain Floor 2 Light Bridge Room Near - 
 158427 - 0x09FD4 (Near Row 2) - 0x09FD3 - Stars & Colored Squares & Stars + Same Colored Symbol
 158428 - 0x09FD6 (Near Row 3) - 0x09FD4 - Stars & Colored Squares & Stars + Same Colored Symbol
 158429 - 0x09FD7 (Near Row 4) - 0x09FD6 - Stars & Colored Squares & Stars + Same Colored Symbol & Shapers
-158430 - 0x09FD8 (Near Row 5) - 0x09FD7 - Colored Squares & Symmetry & Colored Dots
+158430 - 0x09FD8 (Near Row 5) - 0x09FD7 - Symmetry & Colored Dots
 Door - 0x09FFB (Staircase Near) - 0x09FD8
 
 Mountain Floor 2 At Door (Mountain Floor 2) - Mountain Floor 2 Elevator Room - 0x09EDD:


### PR DESCRIPTION
This doesn't actually matter right now because a previous panel in the chain requires Colored Squares anyway, but in the future there might be modes that change the order in which you do panels, and things like that, so yeah

(Found by Exempt-Medic)