### PR TITLE
[MMBN3] Fixes incorrect "Game Completion" Flag getting set

### DIFF
--- a/data/lua/connector_mmbn3.lua
+++ b/data/lua/connector_mmbn3.lua
@@ -110,6 +110,11 @@ local IsItemable = function()
 end
 
 local is_game_complete = function()
+    -- If the Cannary Byte is 0xFF, then the save RAM is untrustworthy
+    if memory.read_u8(canary_byte) == 0xFF then
+        return game_complete
+    end
+
     -- If on the title screen don't read RAM, RAM can't be trusted yet
     if IsOnTitle() then return game_complete end
 


### PR DESCRIPTION
## What is this fixing or adding?
Adds in a check preventing the game from reading garbage data as a game completion flag. Addressing a bug report in [Discord](https://discord.com/channels/731205301247803413/1232659654237225030)

Idling on the title screen long enough could write garbage data to the Save ROM when the title screen restarts. This data can sometimes write to the area of the Save that the client uses to check if the game is completed.

## How was this tested?
Ran the attached seed in the discord post with and without Lua fix for 30 minutes. Pre-patch consistently hit the bug within a few minutes, post-patch the bug never occurred.