### PR TITLE
OOT: Add keys item_name_group

### DIFF
--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -166,15 +166,6 @@ class OOTWorld(World):
             "Sell Big Poe", "Bottle with Red Potion", "Bottle with Green Potion",
             "Bottle with Blue Potion", "Bottle with Fairy", "Bottle with Fish",
             "Bottle with Blue Fire", "Bottle with Bugs", "Bottle with Poe"},
-        "keys": {"Small Key (Bottom of the Well)", "Small Key (Fire Temple)", "Small Key (Forest Temple)",
-                 "Small Key (Ganons Castle)", "Small Key (Gerudo Training Ground)", "Small Key (Shadow Temple)",
-                 "Small Key (Spirit Temple)", "Small Key (Thieves Hideout)", "Small Key (Water Temple)",
-                 "Small Key Ring (Bottom of the Well)", "Small Key Ring (Fire Temple)",
-                 "Small Key Ring (Forest Temple)", "Small Key Ring (Ganons Castle)",
-                 "Small Key Ring (Gerudo Training Ground)", "Small Key Ring (Shadow Temple)",
-                 "Small Key Ring (Spirit Temple)", "Small Key Ring (Thieves Hideout)", "Small Key Ring (Water Temple)",
-                 "Boss Key (Fire Temple)", "Boss Key (Forest Temple)", "Boss Key (Ganons Castle)",
-                 "Boss Key (Shadow Temple)", "Boss Key (Spirit Temple)", "Boss Key (Water Temple)"},
 
         # hint groups
         "Bottles": {"Bottle", "Bottle with Milk", "Rutos Letter",
@@ -184,6 +175,15 @@ class OOTWorld(World):
         "Adult Trade Item": {"Pocket Egg", "Pocket Cucco", "Cojiro", "Odd Mushroom",
             "Odd Potion", "Poachers Saw", "Broken Sword", "Prescription",
             "Eyeball Frog", "Eyedrops", "Claim Check"},
+        "Keys": {"Small Key (Bottom of the Well)", "Small Key (Fire Temple)", "Small Key (Forest Temple)",
+                 "Small Key (Ganons Castle)", "Small Key (Gerudo Training Ground)", "Small Key (Shadow Temple)",
+                 "Small Key (Spirit Temple)", "Small Key (Thieves Hideout)", "Small Key (Water Temple)",
+                 "Small Key Ring (Bottom of the Well)", "Small Key Ring (Fire Temple)",
+                 "Small Key Ring (Forest Temple)", "Small Key Ring (Ganons Castle)",
+                 "Small Key Ring (Gerudo Training Ground)", "Small Key Ring (Shadow Temple)",
+                 "Small Key Ring (Spirit Temple)", "Small Key Ring (Thieves Hideout)", "Small Key Ring (Water Temple)",
+                 "Boss Key (Fire Temple)", "Boss Key (Forest Temple)", "Boss Key (Ganons Castle)",
+                 "Boss Key (Shadow Temple)", "Boss Key (Spirit Temple)", "Boss Key (Water Temple)"},
     }
 
     location_name_groups = build_location_name_groups()

--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -169,11 +169,12 @@ class OOTWorld(World):
         "keys": {"Small Key (Bottom of the Well)", "Small Key (Fire Temple)", "Small Key (Forest Temple)",
                  "Small Key (Ganons Castle)", "Small Key (Gerudo Training Ground)", "Small Key (Shadow Temple)",
                  "Small Key (Spirit Temple)", "Small Key (Thieves Hideout)", "Small Key (Water Temple)",
-                 "Small Key Ring (Bottom of the Well)", "Small Key Ring (Fire Temple)", "Small Key Ring (Forest Temple)",
-                 "Small Key Ring (Ganons Castle)", "Small Key Ring (Gerudo Training Ground)",
-                 "Small Key Ring (Shadow Temple)", "Small Key Ring (Spirit Temple)", "Small Key Ring (Thieves Hideout)",
-                 "Small Key Ring (Water Temple)", "Boss Key (Fire Temple)", "Boss Key (Forest Temple)",
-                 "Boss Key (Ganons Castle)", "Boss Key (Shadow Temple)", "Boss Key (Spirit Temple)", "Boss Key (Water Temple)"},
+                 "Small Key Ring (Bottom of the Well)", "Small Key Ring (Fire Temple)",
+                 "Small Key Ring (Forest Temple)", "Small Key Ring (Ganons Castle)",
+                 "Small Key Ring (Gerudo Training Ground)", "Small Key Ring (Shadow Temple)",
+                 "Small Key Ring (Spirit Temple)", "Small Key Ring (Thieves Hideout)", "Small Key Ring (Water Temple)",
+                 "Boss Key (Fire Temple)", "Boss Key (Forest Temple)", "Boss Key (Ganons Castle)",
+                 "Boss Key (Shadow Temple)", "Boss Key (Spirit Temple)", "Boss Key (Water Temple)"},
 
         # hint groups
         "Bottles": {"Bottle", "Bottle with Milk", "Rutos Letter",

--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -166,6 +166,14 @@ class OOTWorld(World):
             "Sell Big Poe", "Bottle with Red Potion", "Bottle with Green Potion",
             "Bottle with Blue Potion", "Bottle with Fairy", "Bottle with Fish",
             "Bottle with Blue Fire", "Bottle with Bugs", "Bottle with Poe"},
+        "keys": {"Small Key (Bottom of the Well)", "Small Key (Fire Temple)", "Small Key (Forest Temple)",
+                 "Small Key (Ganons Castle)", "Small Key (Gerudo Training Ground)", "Small Key (Shadow Temple)",
+                 "Small Key (Spirit Temple)", "Small Key (Thieves Hideout)", "Small Key (Water Temple)",
+                 "Small Key Ring (Bottom of the Well)", "Small Key Ring (Fire Temple)", "Small Key Ring (Forest Temple)",
+                 "Small Key Ring (Ganons Castle)", "Small Key Ring (Gerudo Training Ground)",
+                 "Small Key Ring (Shadow Temple)", "Small Key Ring (Spirit Temple)", "Small Key Ring (Thieves Hideout)",
+                 "Small Key Ring (Water Temple)", "Boss Key (Fire Temple)", "Boss Key (Forest Temple)",
+                 "Boss Key (Ganons Castle)", "Boss Key (Shadow Temple)", "Boss Key (Spirit Temple)", "Boss Key (Water Temple)"},
 
         # hint groups
         "Bottles": {"Bottle", "Bottle with Milk", "Rutos Letter",


### PR DESCRIPTION
## What is this fixing or adding?
Adds an item_name_group for keys.
There was discussion on which settings for OoT slow down gen, in the context of the big async. One of them was small key shuffle being set to one of the options that makes the small keys in your own world. Since there's potential of this option being meta'd off, I figure there should be a convenient way to make the keys local if you want them to be that is separate from the option.

## How was this tested?
Ran gen, did /item_groups

## If this makes graphical changes, please attach screenshots.
N/A