### PR TITLE
The Messenger: fix import that shouldn't be relative

### DIFF
--- a/worlds/messenger/portals.py
+++ b/worlds/messenger/portals.py
@@ -2,8 +2,8 @@ from copy import deepcopy
 from typing import List, TYPE_CHECKING
 
 from BaseClasses import CollectionState, PlandoOptions
+from worlds.generic import PlandoConnection
 from .options import ShufflePortals
-from ..generic import PlandoConnection
 
 if TYPE_CHECKING:
     from . import MessengerWorld


### PR DESCRIPTION
## What is this fixing or adding?
An incorrect import that breaks the 3.8 build

## How was this tested?
Rebuilt and checked that the world loads

## If this makes graphical changes, please attach screenshots.
