### PR TITLE
Lingo: Fix world load on frozen 3.8

### DIFF
--- a/worlds/lingo/options.py
+++ b/worlds/lingo/options.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from schema import And, Schema
 
 from Options import Toggle, Choice, DefaultOnToggle, Range, PerGameCommonOptions, StartInventoryPool, OptionDict
-from worlds.lingo.items import TRAP_ITEMS
+from .items import TRAP_ITEMS
 
 
 class ShuffleDoors(Choice):

--- a/worlds/lingo/static_logic.py
+++ b/worlds/lingo/static_logic.py
@@ -1,6 +1,7 @@
 import os
 import pkgutil
 import pickle
+import sys
 from io import BytesIO
 from typing import Dict, List, Set
 
@@ -77,6 +78,10 @@ def get_progressive_item_id(name: str):
 
 def load_static_data_from_file():
     global PAINTING_ENTRANCES, PAINTING_EXITS
+
+    # This seems to be needed for frozen 3.8.
+    from . import datatypes
+    sys.modules['worlds.lingo.datatypes'] = datatypes
 
     class RenameUnpickler(pickle.Unpickler):
         def find_class(self, module, name):

--- a/worlds/lingo/static_logic.py
+++ b/worlds/lingo/static_logic.py
@@ -1,7 +1,6 @@
 import os
 import pkgutil
 import pickle
-import sys
 from io import BytesIO
 from typing import Dict, List, Set
 
@@ -79,17 +78,16 @@ def get_progressive_item_id(name: str):
 def load_static_data_from_file():
     global PAINTING_ENTRANCES, PAINTING_EXITS
 
-    # This seems to be needed for frozen 3.8.
     from . import datatypes
-    sys.modules['worlds.lingo.datatypes'] = datatypes
+    from Utils import safe_builtins
 
     class RenameUnpickler(pickle.Unpickler):
         def find_class(self, module, name):
-            renamed_module = module
-            if module == "datatypes":
-                renamed_module = "worlds.lingo.datatypes"
-
-            return super(RenameUnpickler, self).find_class(renamed_module, name)
+            if module in ("worlds.lingo.datatypes", "datatypes"):
+                return getattr(datatypes, name)
+            elif module == "builtins" and name in safe_builtins:
+                return getattr(safe_builtins, name)
+            raise pickle.UnpicklingError(f"global '{module}.{name}' is forbidden")
 
     file = pkgutil.get_data(__name__, os.path.join("data", "generated.dat"))
     pickdata = RenameUnpickler(BytesIO(file)).load()

--- a/worlds/lingo/test/TestDatafile.py
+++ b/worlds/lingo/test/TestDatafile.py
@@ -1,8 +1,8 @@
 import os
 import unittest
 
-from worlds.lingo.static_logic import HASHES
-from worlds.lingo.utils.pickle_static_data import hash_file
+from ..static_logic import HASHES
+from ..utils.pickle_static_data import hash_file
 
 
 class TestDatafile(unittest.TestCase):


### PR DESCRIPTION
## What is this fixing or adding?
There was an issue where the Lingo world would not load on a python 3.8 frozen build. This fixes that.

## How was this tested?
Generated on both frozen 3.8 and frozen 3.10. Ran pytest on non-frozen 3.8 and 3.10.