### PR TITLE
[TLOZ]: Dark Rooms and Level 8 Logic Fixes

### DIFF
--- a/worlds/tloz/Rules.py
+++ b/worlds/tloz/Rules.py
@@ -49,7 +49,7 @@ def set_rules(tloz_world: "TLoZWorld"):
         for location in level.locations:
             add_rule(world.get_location(location.name, player),
                      lambda state: state.has_group("candles", player)
-                                   or (state.has("Magical Rod", player) and state.has("Book", player)))
+                                   or (state.has("Magical Rod", player) and state.has("Book of Magic", player)))
 
     # Everything from 5 on up has gaps
     for level in tloz_world.levels[5:]:
@@ -83,6 +83,11 @@ def set_rules(tloz_world: "TLoZWorld"):
     for location in gleeok_locations:
         add_rule(world.get_location(location, player),
                  lambda state: state.has_group("swords", player) or state.has("Magical Rod", player))
+
+    # Candle access for Level 8
+    for location in tloz_world.levels[8].locations:
+        add_rule(world.get_location(location.name, player),
+            lambda state: state.has_group("candles", player))
 
     add_rule(world.get_location("Level 8 Item (Magical Key)", player),
              lambda state: state.has("Bow", player) and state.has_group("arrows", player))


### PR DESCRIPTION
## What is this fixing or adding?
Properly name the Book to Book of Magic in Rules.py so you can actually possibly be expected to use Magical Rod plus Book of Magic to get through dark rooms. No wonder we tend to see candles so early oops.

Also adding a rule that you need candles for access to Level 8 so you aren't required to time a Rod+Book shot against a moblin to burn the bush. Might make this a logic trick or something later.

## How was this tested?
Test gens with a yaml that plandos candles in places that forced Rod + Book in early enough places to get proper dark room access, and other test gens that plandos the candles in Level 8 to see that it makes the game unbeatable

## If this makes graphical changes, please attach screenshots.
