### PR TITLE
CV64: fix import that shouldn't be relative

### DIFF
--- a/worlds/cv64/__init__.py
+++ b/worlds/cv64/__init__.py
@@ -14,7 +14,7 @@ from .stages import get_locations_from_stage, get_normal_stage_exits, vanilla_st
 from .regions import get_region_info
 from .rules import CV64Rules
 from .data import iname, rname, ename
-from ..AutoWorld import WebWorld, World
+from worlds.AutoWorld import WebWorld, World
 from .aesthetics import randomize_lighting, shuffle_sub_weapons, rom_empty_breakables_flags, rom_sub_weapon_flags, \
     randomize_music, get_start_inventory_data, get_location_data, randomize_shop_prices, get_loading_zone_bytes, \
     get_countdown_numbers


### PR DESCRIPTION
## What is this fixing or adding?
Fixed an import in `__init__.py` that caused CV64 to not work on the Python 3.8 build.

## How was this tested?
Ran a generation to make sure it worked. I didn't test the 3.8 build specifically, but it should be the same fix as https://github.com/ArchipelagoMW/Archipelago/pull/3219.
