### PR TITLE
Core: prevent "Could not find identify Component responsible for None" from being logged.

### DIFF
--- a/Launcher.py
+++ b/Launcher.py
@@ -259,7 +259,7 @@ def main(args: Optional[Union[argparse.Namespace, dict]] = None):
     elif not args:
         args = {}
 
-    if "Patch|Game|Component" in args:
+    if args.get("Patch|Game|Component", None) is not None:
         file, component = identify(args["Patch|Game|Component"])
         if file:
             args['file'] = file


### PR DESCRIPTION
## What is this fixing or adding?
Should fix the message appearing in places like https://discord.com/channels/731205301247803413/1214608557077700720/1233912447933481006

## How was this tested?
Made adventure into an apworld and somehow that triggers it.

