### PR TITLE
Options: Preserve the exact default value of custom options

### DIFF
--- a/WebHostLib/options.py
+++ b/WebHostLib/options.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import numbers
 import os
 import typing
 
@@ -9,6 +10,15 @@ from worlds.AutoWorld import AutoWorldRegister
 
 handled_in_js = {"start_inventory", "local_items", "non_local_items", "start_hints", "start_location_hints",
                  "exclude_locations", "priority_locations"}
+
+
+def _is_json_safe(value: typing.Any) -> bool:
+    """Returns whether the value can be serialized to JSON."""
+    try:
+        json.dumps(value)
+        return True
+    except TypeError:
+        return False
 
 
 def create():
@@ -113,12 +123,14 @@ def create():
 
             elif issubclass(option, Options.VerifyKeys) and not issubclass(option, Options.OptionDict):
                 if option.valid_keys:
+                    default = option.default if hasattr(option, "default") else []
+                    if not _is_json_safe(default): default = list(default)
                     game_options[option_name] = {
                         "type": "custom-list",
                         "displayName": option.display_name if hasattr(option, "display_name") else option_name,
                         "description": get_html_doc(option),
                         "options": list(option.valid_keys),
-                        "defaultValue": list(option.default) if hasattr(option, "default") else []
+                        "defaultValue": default
                     }
 
             else:


### PR DESCRIPTION
## What is this fixing or adding?

Converting this to a list breaks options whose default values are
something else, like a dict. For example, #3128 adds an option that's
a nested YAML document that needs to default to `{}`. This ensures
that the declared default value is preserved as long as it's
JSON-compatible.

## How was this tested?

I manually verified that this preserves the existing behavior for
non-list iterable defaults, such as Overcooked! 2's `include_dlcs`
option.

## If this makes graphical changes, please attach screenshots.