### PR TITLE
Lingo: Fix Basement access with THE MASTER

### DIFF
--- a/worlds/lingo/player_logic.py
+++ b/worlds/lingo/player_logic.py
@@ -17,19 +17,23 @@ class AccessRequirements:
     rooms: Set[str]
     doors: Set[RoomAndDoor]
     colors: Set[str]
+    the_master: bool
 
     def __init__(self):
         self.rooms = set()
         self.doors = set()
         self.colors = set()
+        self.the_master = False
 
     def merge(self, other: "AccessRequirements"):
         self.rooms |= other.rooms
         self.doors |= other.doors
         self.colors |= other.colors
+        self.the_master |= other.the_master
 
     def __str__(self):
-        return f"AccessRequirements(rooms={self.rooms}, doors={self.doors}, colors={self.colors})"
+        return f"AccessRequirements(rooms={self.rooms}, doors={self.doors}, colors={self.colors})," \
+               f" the_master={self.the_master}"
 
 
 class PlayerLocation(NamedTuple):
@@ -443,6 +447,9 @@ class LingoPlayerLogic:
                                                                     req_panel.panel, world)
                 access_reqs.merge(sub_access_reqs)
 
+            if panel == "THE MASTER":
+                access_reqs.the_master = True
+
             self.panel_reqs[room][panel] = access_reqs
 
         return self.panel_reqs[room][panel]
@@ -482,15 +489,17 @@ class LingoPlayerLogic:
             unhindered_panels_by_color: dict[Optional[str], int] = {}
 
             for panel_name, panel_data in room_data.items():
-                # We won't count non-counting panels. THE MASTER has special access rules and is handled separately.
-                if panel_data.non_counting or panel_name == "THE MASTER":
+                # We won't count non-counting panels.
+                if panel_data.non_counting:
                     continue
 
                 # We won't coalesce any panels that have requirements beyond colors. To simplify things for now, we will
-                # only coalesce single-color panels. Chains/stacks/combo puzzles will be separate.
+                # only coalesce single-color panels. Chains/stacks/combo puzzles will be separate. THE MASTER has
+                # special access rules and is handled separately.
                 if len(panel_data.required_panels) > 0 or len(panel_data.required_doors) > 0\
                         or len(panel_data.required_rooms) > 0\
-                        or (world.options.shuffle_colors and len(panel_data.colors) > 1):
+                        or (world.options.shuffle_colors and len(panel_data.colors) > 1)\
+                        or panel_name == "THE MASTER":
                     self.counting_panel_reqs.setdefault(room_name, []).append(
                         (self.calculate_panel_requirements(room_name, panel_name, world), 1))
                 else:

--- a/worlds/lingo/regions.py
+++ b/worlds/lingo/regions.py
@@ -49,8 +49,15 @@ def connect_entrance(regions: Dict[str, Region], source_region: Region, target_r
     if door is not None:
         effective_room = target_region.name if door.room is None else door.room
         if door.door not in world.player_logic.item_by_door.get(effective_room, {}):
-            for region in world.player_logic.calculate_door_requirements(effective_room, door.door, world).rooms:
+            access_reqs = world.player_logic.calculate_door_requirements(effective_room, door.door, world)
+            for region in access_reqs.rooms:
                 world.multiworld.register_indirect_condition(regions[region], connection)
+
+            # This pretty much only applies to Orange Tower Sixth Floor -> Orange Tower Basement.
+            if access_reqs.the_master:
+                for mastery_req in world.player_logic.mastery_reqs:
+                    for region in mastery_req.rooms:
+                        world.multiworld.register_indirect_condition(regions[region], connection)
     
     if not pilgrimage and world.options.enable_pilgrimage and is_acceptable_pilgrimage_entrance(entrance_type, world)\
             and source_region.name != "Menu":

--- a/worlds/lingo/rules.py
+++ b/worlds/lingo/rules.py
@@ -42,12 +42,6 @@ def lingo_can_use_level_2_location(state: CollectionState, world: "LingoWorld"):
                 counted_panels += panel_count
         if counted_panels >= world.options.level_2_requirement.value - 1:
             return True
-    # THE MASTER has to be handled separately, because it has special access rules.
-    if state.can_reach("Orange Tower Seventh Floor", "Region", world.player)\
-            and lingo_can_use_mastery_location(state, world):
-        counted_panels += 1
-    if counted_panels >= world.options.level_2_requirement.value - 1:
-        return True
     return False
 
 
@@ -64,6 +58,9 @@ def _lingo_can_satisfy_requirements(state: CollectionState, access: AccessRequir
         for color in access.colors:
             if not state.has(color.capitalize(), world.player):
                 return False
+
+    if access.the_master and not lingo_can_use_mastery_location(state, world):
+        return False
 
     return True
 

--- a/worlds/lingo/test/TestMastery.py
+++ b/worlds/lingo/test/TestMastery.py
@@ -37,3 +37,20 @@ class TestMasteryWhenVictoryIsTheMaster(LingoTestBase):
 
         self.collect_by_name(["Green", "Gray", "Brown", "Yellow"])
         self.assertTrue(self.can_reach_location("Orange Tower Seventh Floor - Mastery Achievements"))
+
+
+class TestMasteryBlocksDependents(LingoTestBase):
+    options = {
+        "mastery_achievements": "24",
+        "shuffle_colors": "true",
+        "location_checks": "insanity"
+    }
+
+    def test_requirement(self):
+        self.collect_all_but("Gray")
+        self.assertFalse(self.can_reach_location("Orange Tower Basement - THE LIBRARY"))
+        self.assertFalse(self.can_reach_location("Orange Tower Seventh Floor - MASTERY"))
+
+        self.collect_by_name("Gray")
+        self.assertTrue(self.can_reach_location("Orange Tower Basement - THE LIBRARY"))
+        self.assertTrue(self.can_reach_location("Orange Tower Seventh Floor - MASTERY"))


### PR DESCRIPTION
## What is this fixing or adding?
On vanilla doors (and the upcoming panels mode door shuffle), the Orange Tower Basement is not accessible without solving THE MASTER (unless painting shuffle is on, in which there's a small chance it could be accessed without it). THE MASTER has special access requirements that are handled both for the location itself, and for counting the solve as part of the LEVEL 2 panel hunt. The special rules are not, however, passed on to other access checks that may depend on that panel, which affects all MASTERY panels, as well as the entrance to the Orange Tower Basement.

This change adds a flag to the AccessRequirements struct that allows THE MASTER's special rules to be inherited by other entrances or locations that may need it. The LEVEL 2 check was retrofitted to use this instead. Indirect conditions are also registered for the one entrance that uses this.


## How was this tested?
New unit test, and several test generations on different options.


## If this makes graphical changes, please attach screenshots.
