### PR TITLE
Settings: add NESRomPath

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -496,6 +496,22 @@ class SNESRomPath(UserFilePath):
                 raise ValueError(f"File hash does not match for {path}")
 
 
+class NESRomPath(UserFilePath):
+    # Special UserFilePath that ignores a non-optional variable header when validating
+
+    @classmethod
+    def validate(cls, path: str) -> None:
+        with open(path, "rb", buffering=0) as f:
+            if f.read(4) == b"NES\x1A":
+                f.seek(16)
+            else:
+                f.seek(0)
+            try:
+                cls._validate_stream_hashes(f)
+            except ValueError:
+                raise ValueError(f"File hash does not match for {path}")
+
+
 # World-independent setting groups
 
 class GeneralOptions(Group):

--- a/settings.py
+++ b/settings.py
@@ -497,7 +497,8 @@ class SNESRomPath(UserFilePath):
 
 
 class NESRomPath(UserFilePath):
-    # Special UserFilePath that ignores a non-optional variable header when validating
+    """Special UserFilePath that ignores a non-optional variable header when validating. Using this will require
+    validating that the rom has a header when loading the rom, and adding one should it be missing."""
 
     @classmethod
     def validate(cls, path: str) -> None:


### PR DESCRIPTION
## What is this fixing or adding?
Adds a new variant of UserFilePath called NESRomPath. Normally, when dumping straight from the cartridge, NES roms are unheadered. A header is then attached to the start of the file to signify information about the cartridge it came from (such as mapper). This header is then used to signal to emulators about how they should run this rom.

Over the course of time, the actual header for each game has become different, despite the underlying rom being identical. The most notable of these changes is the move from iNES to NES 2.0 headers, which while fully back-compatible, guarantee a difference in hashes due to an additional flag being set.

As such, we should ignore these headers when checking the validity of a NES rom. It should be noted that doing this means you need to ensure the resulting rom has a header, either by replacing all headers with one predefined header, or by simply adding one should it not exist.

## How was this tested?
Moved The Legend of Zelda to use NESRomPath (not as a part of this PR), and adjusted the hash accordingly. Confirmed that the code could correctly ignore the header and confirm the rom as valid, with both iNES and NES 2.0 headers.
