### PR TITLE
Core: CommonClient: command history and echo

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -497,7 +497,7 @@ class CommonContext:
     def on_ui_command(self, text: str) -> None:
         """Gets called by kivy when the user executes a command starting with `/` or `!`.
         The command processor is still called; this is just intended for command echoing."""
-        self.ui.print_json([{"text": text, "type": "color", "color": "slateblue"}])
+        self.ui.print_json([{"text": text, "type": "color", "color": "orange"}])
 
     def update_permissions(self, permissions: typing.Dict[str, int]):
         for permission_name, permission_flag in permissions.items():

--- a/CommonClient.py
+++ b/CommonClient.py
@@ -493,6 +493,11 @@ class CommonContext:
         """Gets called before sending a Say to the server from the user.
         Returned text is sent, or sending is aborted if None is returned."""
         return text
+    
+    def on_ui_command(self, text: str) -> None:
+        """Gets called by kivy when the user executes a command starting with `/` or `!`.
+        The command processor is still called; this is just intended for command echoing."""
+        self.ui.print_json([{"text": text, "type": "color", "color": "slateblue"}])
 
     def update_permissions(self, permissions: typing.Dict[str, int]):
         for permission_name, permission_flag in permissions.items():

--- a/NetUtils.py
+++ b/NetUtils.py
@@ -198,7 +198,8 @@ class JSONtoTextParser(metaclass=HandlerMeta):
         "slateblue": "6D8BE8",
         "plum": "AF99EF",
         "salmon": "FA8072",
-        "white": "FFFFFF"
+        "white": "FFFFFF",
+        "orange": "FF7700",
     }
 
     def __init__(self, ctx):

--- a/data/client.kv
+++ b/data/client.kv
@@ -13,6 +13,7 @@
     plum: "AF99EF"  # typically progression item
     salmon: "FA8072"  # typically trap item
     white: "FFFFFF"  # not used, if you want to change the generic text color change color in Label
+    orange: "FF7700"  # Used for command echo
 <Label>:
     color: "FFFFFF"
 <TabbedPanel>:

--- a/kvui.py
+++ b/kvui.py
@@ -388,9 +388,9 @@ class CommandPromptTextInput(TextInput):
     MAXIMUM_HISTORY_MESSAGES = 50
 
     def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
         self._command_history_index = -1
         self._command_history: typing.List[str] = []
-        return super().__init__(*args, **kwargs)
     
     def update_history(self, new_entry: str) -> None:
         self._command_history_index = -1

--- a/kvui.py
+++ b/kvui.py
@@ -3,6 +3,7 @@ import logging
 import sys
 import typing
 import re
+from typing import *
 
 if sys.platform == "win32":
     import ctypes
@@ -380,6 +381,51 @@ class ConnectBarTextInput(TextInput):
         return super(ConnectBarTextInput, self).insert_text(s, from_undo=from_undo)
 
 
+def is_command_input(string: str) -> bool:
+    return string and string[0] in "/!"
+
+
+class CommandPromptTextInput(TextInput):
+    MAXIMUM_HISTORY_MESSAGES = 50
+
+    def __init__(self, *args, **kwargs) -> None:
+        self._command_history_index = -1
+        self._command_history: List[str] = []
+        return super().__init__(*args, **kwargs)
+    
+    def update_history(self, new_entry: str) -> None:
+        self._command_history_index = -1
+        if is_command_input(new_entry):
+            self._command_history = [new_entry, *self._command_history[:CommandPromptTextInput.MAXIMUM_HISTORY_MESSAGES-1]]
+
+    def keyboard_on_key_down(self, window, keycode: Tuple[int, str], text: Optional[str], modifiers: List[str]) -> bool:
+        """
+        :param window: The kivy window object
+        :param keycode: A tuple of (keycode, keyname). Keynames are always lowercase
+        :param text: The text printed by this key, not accounting for modifiers, or `None` if no text.
+                     Seems to pretty naively interpret the keycode as unicode, so numlock can return odd characters.
+        :param modifiers: A list of string modifiers, like `ctrl` or `numlock`
+        """
+        if keycode[1] == 'up':
+            self._change_to_history_text_if_available(self._command_history_index + 1)
+            return True
+        if keycode[1] == 'down':
+            self._change_to_history_text_if_available(self._command_history_index - 1)
+            return True
+        return super().keyboard_on_key_down(window, keycode, text, modifiers)
+    
+    def _change_to_history_text_if_available(self, new_index: int) -> None:
+        if new_index < -1:
+            return
+        if new_index >= len(self._command_history):
+            return
+        self._command_history_index = new_index
+        if new_index == -1:
+            self.text = ""
+            return
+        self.text = self._command_history[self._command_history_index]
+
+
 class MessageBox(Popup):
     class MessageBoxLabel(Label):
         def __init__(self, **kwargs):
@@ -499,7 +545,7 @@ class GameManager(App):
         info_button = Button(size=(dp(100), dp(30)), text="Command:", size_hint_x=None)
         info_button.bind(on_release=self.command_button_action)
         bottom_layout.add_widget(info_button)
-        self.textinput = TextInput(size_hint_y=None, height=dp(30), multiline=False, write_tab=False)
+        self.textinput = CommandPromptTextInput(size_hint_y=None, height=dp(30), multiline=False, write_tab=False)
         self.textinput.bind(on_text_validate=self.on_message)
         self.textinput.text_validate_unfocus = False
         bottom_layout.add_widget(self.textinput)
@@ -557,14 +603,18 @@ class GameManager(App):
 
         self.ctx.exit_event.set()
 
-    def on_message(self, textinput: TextInput):
+    def on_message(self, textinput: CommandPromptTextInput):
         try:
             input_text = textinput.text.strip()
             textinput.text = ""
+            textinput.update_history(input_text)
 
             if self.ctx.input_requests > 0:
                 self.ctx.input_requests -= 1
                 self.ctx.input_queue.put_nowait(input_text)
+            elif is_command_input(input_text):
+                self.ctx.on_ui_command(input_text)
+                self.commandprocessor(input_text)
             elif input_text:
                 self.commandprocessor(input_text)
 

--- a/kvui.py
+++ b/kvui.py
@@ -3,7 +3,6 @@ import logging
 import sys
 import typing
 import re
-from typing import List, Tuple, Optional
 
 if sys.platform == "win32":
     import ctypes
@@ -390,15 +389,24 @@ class CommandPromptTextInput(TextInput):
 
     def __init__(self, *args, **kwargs) -> None:
         self._command_history_index = -1
-        self._command_history: List[str] = []
+        self._command_history: typing.List[str] = []
         return super().__init__(*args, **kwargs)
     
     def update_history(self, new_entry: str) -> None:
         self._command_history_index = -1
         if is_command_input(new_entry):
-            self._command_history = [new_entry, *self._command_history[:CommandPromptTextInput.MAXIMUM_HISTORY_MESSAGES-1]]
+            self._command_history = [
+                new_entry,
+                *self._command_history[:CommandPromptTextInput.MAXIMUM_HISTORY_MESSAGES-1]
+            ]
 
-    def keyboard_on_key_down(self, window, keycode: Tuple[int, str], text: Optional[str], modifiers: List[str]) -> bool:
+    def keyboard_on_key_down(
+        self,
+        window,
+        keycode: typing.Tuple[int, str],
+        text: typing.Optional[str],
+        modifiers: typing.List[str]
+    ) -> bool:
         """
         :param window: The kivy window object
         :param keycode: A tuple of (keycode, keyname). Keynames are always lowercase

--- a/kvui.py
+++ b/kvui.py
@@ -381,14 +381,14 @@ class ConnectBarTextInput(TextInput):
 
 
 def is_command_input(string: str) -> bool:
-    return string and string[0] in "/!"
+    return len(string) > 0 and string[0] in "/!"
 
 
 class CommandPromptTextInput(TextInput):
     MAXIMUM_HISTORY_MESSAGES = 50
 
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
         self._command_history_index = -1
         self._command_history: typing.List[str] = []
     
@@ -469,7 +469,7 @@ class GameManager(App):
         self.commandprocessor = ctx.command_processor(ctx)
         self.icon = r"data/icon.png"
         self.json_to_kivy_parser = KivyJSONtoTextParser(ctx)
-        self.log_panels = {}
+        self.log_panels: typing.Dict[str, Widget] = {}
 
         # keep track of last used command to autofill on click
         self.last_autofillable_command = "hint"

--- a/kvui.py
+++ b/kvui.py
@@ -3,7 +3,7 @@ import logging
 import sys
 import typing
 import re
-from typing import *
+from typing import List, Tuple, Optional
 
 if sys.platform == "win32":
     import ctypes

--- a/kvui.py
+++ b/kvui.py
@@ -3,6 +3,7 @@ import logging
 import sys
 import typing
 import re
+from collections import deque
 
 if sys.platform == "win32":
     import ctypes
@@ -390,15 +391,12 @@ class CommandPromptTextInput(TextInput):
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
         self._command_history_index = -1
-        self._command_history: typing.List[str] = []
+        self._command_history: typing.Deque[str] = deque(maxlen=CommandPromptTextInput.MAXIMUM_HISTORY_MESSAGES)
     
     def update_history(self, new_entry: str) -> None:
         self._command_history_index = -1
         if is_command_input(new_entry):
-            self._command_history = [
-                new_entry,
-                *self._command_history[:CommandPromptTextInput.MAXIMUM_HISTORY_MESSAGES-1]
-            ]
+            self._command_history.appendleft(new_entry)
 
     def keyboard_on_key_down(
         self,

--- a/worlds/sc2/Client.py
+++ b/worlds/sc2/Client.py
@@ -122,7 +122,6 @@ class ColouredMessage:
 
 class StarcraftClientProcessor(ClientCommandProcessor):
     ctx: SC2Context
-    echo_commands = True
 
     def formatted_print(self, text: str) -> None:
         """Prints with kivy formatting to the GUI, and also prints to command-line and to all logs"""


### PR DESCRIPTION
## What is this fixing or adding?
Client command history
* When executing a command (ie enter a message starting with `/` or `!`) in the common client, the command gets saved to a history buffer.
* Pressing "up" fills in the text input with the previous command, up to a maximum of 50 commands
* Pressing "down" returns to newer commands
* Pressing "down" from the last executed command returns to the empty command (ie clears the text prompt)
* Pressing "down" when on the empty command doesn't clear history (ie this will only clear your text if you've already been scrolling through history)
* Executing a new command adds to the history and resets the history index to the empty command

Client command echo
* Executing a command (ie enter a message starting with `/` or `!`) in the common client will echo the command back to you
* The printout is handled by `.on_ui_command()` on CommonClient, so game-specific clients can override this behaviour
* I chose to colour these commands for some extra visual clarity, introduced orange to the base colours to represent commands.

Note commands entered in the GUI client don't appear echoed in the command-line client and vice versa.

## How was this tested?
I opened the Starcraft 2 client with these changes and tested manually -- entering various commands, going through history, verifying echo manually. GUI tests unfortunately aren't really unit-testable most of the time `:/`

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/31861583/7057acb7-d60f-42f6-ae0b-0b39ba545dde)
![image](https://github.com/ArchipelagoMW/Archipelago/assets/31861583/ff555261-3a16-4fd6-930b-9a711d9916c7)

![ap_client_history_2](https://github.com/ArchipelagoMW/Archipelago/assets/31861583/09e9e24c-b479-4f7a-be28-8d2d4d0a73fe)

