### PR TITLE
Webhost: Fix Counter typing on Python 3.8

### DIFF
--- a/WebHostLib/tracker.py
+++ b/WebHostLib/tracker.py
@@ -422,7 +422,7 @@ from worlds import network_data_package
 
 if "Factorio" in network_data_package["games"]:
     def render_Factorio_multiworld_tracker(tracker_data: TrackerData, enabled_trackers: List[str]):
-        inventories: Dict[TeamPlayer, collections.Counter[str]] = {
+        inventories: Dict[TeamPlayer, Counter[str]] = {
             (team, player): collections.Counter({
                 tracker_data.item_id_to_name["Factorio"][item_id]: count
                 for item_id, count in tracker_data.get_player_inventory_counts(team, player).items()

--- a/test/benchmark/locations.py
+++ b/test/benchmark/locations.py
@@ -28,7 +28,7 @@ def run_locations_benchmark():
                 return "\n".join(f"  {time:.4f} in {name}" for name, time in counter.most_common(top))
         else:
             @staticmethod
-            def format_times_from_counter(counter: collections.Counter, top: int = 5) -> str:
+            def format_times_from_counter(counter: Counter, top: int = 5) -> str:
                 return "\n".join(f"  {time:.4f} in {name}" for name, time in counter.most_common(top))
 
         def location_test(self, test_location: Location, state: CollectionState, state_name: str) -> float:

--- a/test/benchmark/locations.py
+++ b/test/benchmark/locations.py
@@ -7,6 +7,7 @@ def run_locations_benchmark():
     import sys
 
     from time_it import TimeIt
+    from typing import Counter
 
     from Utils import init_logging
     from BaseClasses import MultiWorld, CollectionState, Location
@@ -23,7 +24,7 @@ def run_locations_benchmark():
 
         if sys.version_info >= (3, 9):
             @staticmethod
-            def format_times_from_counter(counter: collections.Counter[str], top: int = 5) -> str:
+            def format_times_from_counter(counter: Counter[str], top: int = 5) -> str:
                 return "\n".join(f"  {time:.4f} in {name}" for name, time in counter.most_common(top))
         else:
             @staticmethod
@@ -42,7 +43,7 @@ def run_locations_benchmark():
 
         def main(self):
             for game in sorted(AutoWorld.AutoWorldRegister.world_types):
-                summary_data: typing.Dict[str, collections.Counter[str]] = {
+                summary_data: typing.Dict[str, Counter[str]] = {
                     "empty_state": collections.Counter(),
                     "all_state": collections.Counter(),
                 }


### PR DESCRIPTION
~~Unit tests are failing right now because you can't do `collections.Counter[str]` in Python 3.8.~~
Nvm, they're not failing. Idk if this is necessary then