### PR TITLE
Yoshi's World: Fixed minor logic inconsistincy in Rules.py

### DIFF
--- a/worlds/yoshisisland/Rules.py
+++ b/worlds/yoshisisland/Rules.py
@@ -329,6 +329,7 @@ def set_normal_rules(world: "YoshisIslandWorld") -> None:
 
     set_rule(world.multiworld.get_location("GO! GO! MARIO!!: Red Coins", player), lambda state: state.has("Super Star", player))
     set_rule(world.multiworld.get_location("GO! GO! MARIO!!: Flowers", player), lambda state: state.has("Super Star", player))
+    set_rule(world.multiworld.get_location("GO! GO! MARIO!!: Stars", player), lambda state: logic.has_midring(state) or state.has("Tulip", player))
     set_rule(world.multiworld.get_location("GO! GO! MARIO!!: Level Clear", player), lambda state: state.has("Super Star", player))
 
     set_rule(world.multiworld.get_location("The Cave Of The Lakitus: Red Coins", player), lambda state: state.has_all({"Large Spring Ball", "! Switch", "Egg Launcher"}, player))

--- a/worlds/yoshisisland/Rules.py
+++ b/worlds/yoshisisland/Rules.py
@@ -329,7 +329,6 @@ def set_normal_rules(world: "YoshisIslandWorld") -> None:
 
     set_rule(world.multiworld.get_location("GO! GO! MARIO!!: Red Coins", player), lambda state: state.has("Super Star", player))
     set_rule(world.multiworld.get_location("GO! GO! MARIO!!: Flowers", player), lambda state: state.has("Super Star", player))
-    set_rule(world.multiworld.get_location("GO! GO! MARIO!!: Stars", player), lambda state: state.has("Super Star", player))
     set_rule(world.multiworld.get_location("GO! GO! MARIO!!: Level Clear", player), lambda state: state.has("Super Star", player))
 
     set_rule(world.multiworld.get_location("The Cave Of The Lakitus: Red Coins", player), lambda state: state.has_all({"Large Spring Ball", "! Switch", "Egg Launcher"}, player))


### PR DESCRIPTION
As of easy logic for this goal is
   ```logic.has_midring(state) or (state.has("Tulip", player) and logic.cansee_clouds(state))```
normal logic shouldn't need any collectable as `logic.cansee_clouds(state)` allways evaluates to `true` in normal logic and therefore the hole equation is `true`. Normal logic shouldn't need more collectables than easy logic.