### PR TITLE
SNIClient: restore old operands header

### DIFF
--- a/SNIClient.py
+++ b/SNIClient.py
@@ -565,7 +565,7 @@ async def snes_write(ctx: SNIContext, write_list: typing.List[typing.Tuple[int, 
         PutAddress_Request: SNESRequest = {"Opcode": "PutAddress", "Operands": [], 'Space': 'SNES'}
         try:
             for address, data in write_list:
-                PutAddress_Request['Operands'] = [hex(address)[2:], hex(min(len(data), 256))[2:]]
+                PutAddress_Request['Operands'] = [hex(address)[2:], hex(len(data))[2:]]
                 if ctx.snes_socket is not None:
                     await ctx.snes_socket.send(dumps(PutAddress_Request))
                     await ctx.snes_socket.send(data)


### PR DESCRIPTION
## What is this fixing or adding?
removes an overlooked min that now leads to wrong header data in Operands

## How was this tested?
ages ago, since this is now the same line it used to be a long time ago

## If this makes graphical changes, please attach screenshots.
