### PR TITLE
Pokemon Emerald: Fix incorrect access to Slateport water encounters

### DIFF
--- a/worlds/pokemon_emerald/data/regions/cities.json
+++ b/worlds/pokemon_emerald/data/regions/cities.json
@@ -1269,7 +1269,7 @@
   "REGION_SLATEPORT_CITY/MAIN": {
     "parent_map": "MAP_SLATEPORT_CITY",
     "has_grass": false,
-    "has_water": true,
+    "has_water": false,
     "has_fishing": true,
     "locations": [
       "NPC_GIFT_RECEIVED_POWDER_JAR"
@@ -1279,9 +1279,9 @@
       "EVENT_VISITED_SLATEPORT_CITY"
     ],
     "exits": [
+      "REGION_SLATEPORT_CITY/WATER",
       "REGION_ROUTE109/BEACH",
-      "REGION_ROUTE110/SOUTH",
-      "REGION_ROUTE134/WEST"
+      "REGION_ROUTE110/SOUTH"
     ],
     "warps": [
       "MAP_SLATEPORT_CITY:0/MAP_SLATEPORT_CITY_POKEMON_CENTER_1F:0",
@@ -1295,6 +1295,19 @@
       "MAP_SLATEPORT_CITY:9/MAP_SLATEPORT_CITY_HARBOR:2",
       "MAP_SLATEPORT_CITY:10/MAP_SLATEPORT_CITY_HOUSE:0"
     ]
+  },
+  "REGION_SLATEPORT_CITY/WATER": {
+    "parent_map": "MAP_SLATEPORT_CITY",
+    "has_grass": false,
+    "has_water": true,
+    "has_fishing": true,
+    "locations": [],
+    "events": [],
+    "exits": [
+      "REGION_SLATEPORT_CITY/MAIN",
+      "REGION_ROUTE134/WEST"
+    ],
+    "warps": []
   },
   "REGION_SLATEPORT_CITY_POKEMON_CENTER_2F/MAIN": {
     "parent_map": "MAP_SLATEPORT_CITY_POKEMON_CENTER_2F",

--- a/worlds/pokemon_emerald/data/regions/routes.json
+++ b/worlds/pokemon_emerald/data/regions/routes.json
@@ -3294,7 +3294,7 @@
     "locations": [],
     "events": [],
     "exits": [
-      "REGION_SLATEPORT_CITY/MAIN"
+      "REGION_SLATEPORT_CITY/WATER"
     ],
     "warps": []
   },

--- a/worlds/pokemon_emerald/rules.py
+++ b/worlds/pokemon_emerald/rules.py
@@ -464,7 +464,7 @@ def set_rules(world: "PokemonEmeraldWorld") -> None:
 
     # Slateport City
     set_rule(
-        get_entrance("REGION_SLATEPORT_CITY/MAIN -> REGION_ROUTE134/WEST"),
+        get_entrance("REGION_SLATEPORT_CITY/MAIN -> REGION_SLATEPORT_CITY/WATER"),
         hm_rules["HM03 Surf"]
     )
     set_rule(

--- a/worlds/pokemon_emerald/test/test_accessibility.py
+++ b/worlds/pokemon_emerald/test/test_accessibility.py
@@ -59,6 +59,10 @@ class TestSurf(PokemonEmeraldTestBase):
         self.assertFalse(self.can_reach_entrance("REGION_ROUTE119/UPPER -> REGION_FORTREE_CITY/MAIN"))
         self.assertFalse(self.can_reach_entrance("MAP_FORTREE_CITY:3/MAP_FORTREE_CITY_MART:0"))
 
+        # Slateport Access
+        self.collect_by_name(["HM06 Rock Smash", "Dynamo Badge", "Mach Bike"])
+        self.assertFalse(self.can_reach_region("MAP_SLATEPORT_CITY_WATER_ENCOUNTERS"))
+
     def test_accessible_with_surf_only(self) -> None:
         self.collect_by_name(["HM03 Surf", "Balance Badge"])
         self.assertTrue(self.can_reach_location(location_name_to_label("ITEM_PETALBURG_CITY_ETHER")))
@@ -70,6 +74,7 @@ class TestSurf(PokemonEmeraldTestBase):
         self.assertTrue(self.can_reach_entrance("REGION_ROUTE119/UPPER -> REGION_FORTREE_CITY/MAIN"))
         self.assertTrue(self.can_reach_entrance("MAP_FORTREE_CITY:3/MAP_FORTREE_CITY_MART:0"))
         self.assertTrue(self.can_reach_location(location_name_to_label("BADGE_4")))
+        self.assertTrue(self.can_reach_region("MAP_SLATEPORT_CITY_WATER_ENCOUNTERS"))
 
 
 class TestFreeFly(PokemonEmeraldTestBase):


### PR DESCRIPTION
## What is this fixing or adding?

Slateport has water encounters that may be logical access to dexsanity species which are currently considered reachable without surf. This adds a new region for the water inside the city to seal those encounters behind using Surf.

## How was this tested?

The included new lines in the tests fail without this PR and succeed with it.
