### PR TITLE
WebHost: Fix clicking arrow no longer toggling collapsing on Supported Games page

### DIFF
--- a/WebHostLib/static/assets/supportedGames.js
+++ b/WebHostLib/static/assets/supportedGames.js
@@ -1,7 +1,5 @@
 window.addEventListener('load', () => {
-  // Add toggle listener to all elements with .collapse-toggle
-  const toggleButtons = document.querySelectorAll('.collapse-toggle');
-  toggleButtons.forEach((e) => e.addEventListener('click', toggleCollapse));
+  const allDetails = document.querySelectorAll('details');
 
   // Handle game filter input
   const gameSearch = document.getElementById('game-search');
@@ -9,24 +7,21 @@ window.addEventListener('load', () => {
   gameSearch.addEventListener('input', (evt) => {
     if (!evt.target.value.trim()) {
       // If input is empty, display all collapsed games
-      return toggleButtons.forEach((header) => {
-        header.style.display = null;
-        header.firstElementChild.innerText = '▶';
-        header.nextElementSibling.classList.add('collapsed');
+      return allDetails.forEach((detail) => {
+        detail.style.display = null;
+        detail.open = false;
       });
     }
 
     // Loop over all the games
-    toggleButtons.forEach((header) => {
+    allDetails.forEach((details) => {
       // If the game name includes the search string, display the game. If not, hide it
-      if (header.getAttribute('data-game').toLowerCase().includes(evt.target.value.toLowerCase())) {
-        header.style.display = null;
-        header.firstElementChild.innerText = '▼';
-        header.nextElementSibling.classList.remove('collapsed');
+      if (details.getAttribute('data-game').toLowerCase().includes(evt.target.value.toLowerCase())) {
+        details.style.display = null;
+        details.open = true;
       } else {
-        header.style.display = 'none';
-        header.firstElementChild.innerText = '▶';
-        header.nextElementSibling.classList.add('collapsed');
+        details.style.display = 'none';
+        details.open = false;
       }
     });
   });
@@ -35,31 +30,14 @@ window.addEventListener('load', () => {
   document.getElementById('collapse-all').addEventListener('click', collapseAll);
 });
 
-const toggleCollapse = (evt) => {
-  const header = evt.target.closest('.collapse-toggle')
-  const gameArrow = header.firstElementChild;
-  const gameInfo = header.nextElementSibling;
-  if (gameInfo.classList.contains('collapsed')) {
-    gameArrow.innerText = '▼';
-    gameInfo.classList.remove('collapsed');
-  } else {
-    gameArrow.innerText = '▶';
-    gameInfo.classList.add('collapsed');
-  }
-};
-
 const expandAll = () => {
-  document.querySelectorAll('.collapse-toggle').forEach((header) => {
-    if (header.style.display === 'none') { return; }
-    header.firstElementChild.innerText = '▼';
-    header.nextElementSibling.classList.remove('collapsed');
+  document.querySelectorAll('details').forEach((details) => {
+    details.open = true;
   });
 };
 
 const collapseAll = () => {
-  document.querySelectorAll('.collapse-toggle').forEach((header) => {
-    if (header.style.display === 'none') { return; }
-    header.firstElementChild.innerText = '▶';
-    header.nextElementSibling.classList.add('collapsed');
+  document.querySelectorAll('details').forEach((details) => {
+    details.open = false;
   });
 };

--- a/WebHostLib/static/assets/supportedGames.js
+++ b/WebHostLib/static/assets/supportedGames.js
@@ -36,8 +36,9 @@ window.addEventListener('load', () => {
 });
 
 const toggleCollapse = (evt) => {
-  const gameArrow = evt.target.firstElementChild;
-  const gameInfo = evt.target.nextElementSibling;
+  const header = evt.target.closest('.collapse-toggle')
+  const gameArrow = header.firstElementChild;
+  const gameInfo = header.nextElementSibling;
   if (gameInfo.classList.contains('collapsed')) {
     gameArrow.innerText = '▼';
     gameInfo.classList.remove('collapsed');

--- a/WebHostLib/static/styles/supportedGames.css
+++ b/WebHostLib/static/styles/supportedGames.css
@@ -13,25 +13,15 @@
     cursor: unset;
 }
 
-#games h2{
+#games summary{
     color: #93dcff;
     margin-bottom: 2px;
-}
-
-#games .collapse-toggle{
+    margin-top: 20px;
     cursor: pointer;
 }
 
-#games h2 .collapse-arrow{
-    font-size: 20px;
-    display: inline-block; /* make vertical-align work */
-    padding-bottom: 9px;
-    vertical-align: middle;
-    padding-right: 8px;
-}
-
-#games p.collapsed{
-    display: none;
+#games summary > *{
+    display: inline;
 }
 
 #games a{

--- a/WebHostLib/templates/supportedGames.html
+++ b/WebHostLib/templates/supportedGames.html
@@ -7,21 +7,9 @@
     <script type="application/ecmascript" src="{{ url_for('static', filename="assets/supportedGames.js") }}"></script>
     <noscript>
     <style>
-        /* always un-collapse all and hide arrow and search bar */
+        /* always hide search bar */
         .js-only{
           display: none;
-        }
-
-        #games p.collapsed{
-          display: block;
-        }
-
-        #games h2 .collapse-arrow{
-          display: none;
-        }
-
-        #games .collapse-toggle{
-          cursor: unset;
         }
     </style>
     </noscript>
@@ -41,28 +29,30 @@
         </div>
         {% for game_name in worlds | title_sorted %}
         {% set world = worlds[game_name] %}
-        <h2 class="collapse-toggle" data-game="{{ game_name }}">
-            <span class="collapse-arrow">▶</span>{{ game_name }}
-        </h2>
-        <p class="collapsed">
-            {{ world.__doc__ | default("No description provided.", true) }}<br />
-            <a href="{{ url_for("game_info", game=game_name, lang="en") }}">Game Page</a>
-            {% if world.web.tutorials %}
-            <span class="link-spacer">|</span>
-            <a href="{{ url_for("tutorial_landing") }}#{{ game_name }}">Setup Guides</a>
-            {% endif %}
-            {% if world.web.options_page is string %}
-            <span class="link-spacer">|</span>
-            <a href="{{ world.web.options_page }}">Options Page</a>
-            {% elif world.web.options_page %}
-            <span class="link-spacer">|</span>
-            <a href="{{ url_for("player_options", game=game_name) }}">Options Page</a>
-            {% endif %}
-            {% if world.web.bug_report_page %}
-            <span class="link-spacer">|</span>
-            <a href="{{ world.web.bug_report_page }}">Report a Bug</a>
-            {% endif %}
-        </p>
+          <details data-game="{{ game_name }}">
+                <summary>
+                    <h2>{{ game_name }}</h2>
+                </summary>
+                <p>
+                    {{ world.__doc__ | default("No description provided.", true) }}<br />
+                    <a href="{{ url_for("game_info", game=game_name, lang="en") }}">Game Page</a>
+                    {% if world.web.tutorials %}
+                    <span class="link-spacer">|</span>
+                    <a href="{{ url_for("tutorial_landing") }}#{{ game_name }}">Setup Guides</a>
+                    {% endif %}
+                    {% if world.web.options_page is string %}
+                    <span class="link-spacer">|</span>
+                    <a href="{{ world.web.options_page }}">Options Page</a>
+                    {% elif world.web.options_page %}
+                    <span class="link-spacer">|</span>
+                    <a href="{{ url_for("player_options", game=game_name) }}">Options Page</a>
+                    {% endif %}
+                    {% if world.web.bug_report_page %}
+                    <span class="link-spacer">|</span>
+                    <a href="{{ world.web.bug_report_page }}">Report a Bug</a>
+                    {% endif %}
+                </p>
+        </details>
         {% endfor %}
     </div>
 {% endblock %}


### PR DESCRIPTION
## What is this fixing or adding?

Clicking the arrow on the Supported Games page doesn't toggle the collapsible section and the handler crashes.

This gets the `h2` element from which `gameArrow` and `gameInfo` are meant to be found before actually looking for them.

If this behavior was working in the past and something broke it, it was likely #2266.

## How was this tested?

Ran the page with JS enabled and disabled. Clicked a bunch of times on the arrow and game title.
