### PR TITLE
BizHawkClient: Reset `ctx.finished_game` if ROM hash changes

### DIFF
--- a/worlds/_bizhawk/context.py
+++ b/worlds/_bizhawk/context.py
@@ -168,6 +168,7 @@ async def _game_watcher(ctx: BizHawkClientContext):
                 ctx.auth = None
                 ctx.username = None
                 ctx.client_handler = None
+                ctx.finished_game = False
                 await ctx.disconnect(False)
             ctx.rom_hash = rom_hash
 


### PR DESCRIPTION
## What is this fixing or adding?

If a client handler sets `finished_game` on the context and then the client is disconnected and reconnected to a new slot or server, it automatically sends the game complete update.

This resets it to `False` any time the ROM hash changes with the expectation that a game handler will be able to re-detect being in a finished state.

## How was this tested?

Wasn't
