### PR TITLE
Lingo: Fix broken good item in panelsanity

### DIFF
--- a/worlds/lingo/player_logic.py
+++ b/worlds/lingo/player_logic.py
@@ -278,7 +278,7 @@ class LingoPlayerLogic:
                                 "iterations. This is very unlikely to happen on its own, and probably indicates some "
                                 "kind of logic error.")
 
-        if door_shuffle != ShuffleDoors.option_none and location_classification != LocationClassification.insanity \
+        if door_shuffle != ShuffleDoors.option_none and location_checks != LocationChecks.option_insanity \
                 and not early_color_hallways and world.multiworld.players > 1:
             # Under the combination of door shuffle, normal location checks, and no early color hallways, sphere 1 is
             # only three checks. In a multiplayer situation, this can be frustrating for the player because they are


### PR DESCRIPTION
## What is this fixing or adding?
There was an issue where the combination of door shuffle, panelsanity, no early color hallways, and being in a multi player world would break generation. This was because of the code that generated an early good item. The code is not supposed to run under panelsanity, but the conditional was not correct. This fixes that.


## How was this tested?
Pytest, and running a test generation under the specific error case from above.


## If this makes graphical changes, please attach screenshots.
