### PR TITLE
Lingo: Started using OptionError

### DIFF
--- a/worlds/lingo/__init__.py
+++ b/worlds/lingo/__init__.py
@@ -4,6 +4,7 @@ Archipelago init file for Lingo
 from logging import warning
 
 from BaseClasses import Item, ItemClassification, Tutorial
+from Options import OptionError
 from worlds.AutoWorld import WebWorld, World
 from .datatypes import Room, RoomEntrance
 from .items import ALL_ITEM_TABLE, ITEMS_BY_GROUP, TRAP_ITEMS, LingoItem
@@ -52,13 +53,14 @@ class LingoWorld(World):
     player_logic: LingoPlayerLogic
 
     def generate_early(self):
-        if not (self.options.shuffle_doors or self.options.shuffle_colors):
+        if not (self.options.shuffle_doors or self.options.shuffle_colors or self.options.shuffle_sunwarps):
             if self.multiworld.players == 1:
                 warning(f"{self.multiworld.get_player_name(self.player)}'s Lingo world doesn't have any progression"
-                        f" items. Please turn on Door Shuffle or Color Shuffle if that doesn't seem right.")
+                        f" items. Please turn on Door Shuffle, Color Shuffle, or Sunwarp Shuffle if that doesn't seem"
+                        f" right.")
             else:
-                raise Exception(f"{self.multiworld.get_player_name(self.player)}'s Lingo world doesn't have any"
-                                f" progression items. Please turn on Door Shuffle or Color Shuffle.")
+                raise OptionError(f"{self.multiworld.get_player_name(self.player)}'s Lingo world doesn't have any"
+                                  f" progression items. Please turn on Door Shuffle, Color Shuffle or Sunwarp Shuffle.")
 
         self.player_logic = LingoPlayerLogic(self)
 
@@ -94,7 +96,7 @@ class LingoWorld(World):
                 total_weight = sum(self.options.trap_weights.values())
 
                 if total_weight == 0:
-                    raise Exception("Sum of trap weights must be at least one.")
+                    raise OptionError("Sum of trap weights must be at least one.")
 
                 trap_counts = {name: int(weight * traps / total_weight)
                                for name, weight in self.options.trap_weights.items()}

--- a/worlds/lingo/player_logic.py
+++ b/worlds/lingo/player_logic.py
@@ -1,6 +1,7 @@
 from enum import Enum
 from typing import Dict, List, NamedTuple, Optional, Set, Tuple, TYPE_CHECKING
 
+from Options import OptionError
 from .datatypes import Door, DoorType, RoomAndDoor, RoomAndPanel
 from .items import ALL_ITEM_TABLE, ItemType
 from .locations import ALL_LOCATION_TABLE, LocationClassification
@@ -149,8 +150,8 @@ class LingoPlayerLogic:
         early_color_hallways = world.options.early_color_hallways
 
         if location_checks == LocationChecks.option_reduced and door_shuffle != ShuffleDoors.option_none:
-            raise Exception("You cannot have reduced location checks when door shuffle is on, because there would not "
-                            "be enough locations for all of the door items.")
+            raise OptionError("You cannot have reduced location checks when door shuffle is on, because there would not"
+                              " be enough locations for all of the door items.")
 
         # Create door items, where needed.
         door_groups: Set[str] = set()
@@ -219,7 +220,7 @@ class LingoPlayerLogic:
             self.event_loc_to_item[self.level_2_location] = "Victory"
 
             if world.options.level_2_requirement == 1:
-                raise Exception("The Level 2 requirement must be at least 2 when LEVEL 2 is the victory condition.")
+                raise OptionError("The Level 2 requirement must be at least 2 when LEVEL 2 is the victory condition.")
         elif victory_condition == VictoryCondition.option_pilgrimage:
             self.victory_condition = "Pilgrim Antechamber - PILGRIM"
             self.add_location("Pilgrim Antechamber", "PILGRIM (Solved)", None,
@@ -248,11 +249,11 @@ class LingoPlayerLogic:
                 self.real_locations.append(location_name)
 
         if world.options.enable_pilgrimage and world.options.sunwarp_access == SunwarpAccess.option_disabled:
-            raise Exception("Sunwarps cannot be disabled when pilgrimage is enabled.")
+            raise OptionError("Sunwarps cannot be disabled when pilgrimage is enabled.")
 
         if world.options.shuffle_sunwarps:
             if world.options.sunwarp_access == SunwarpAccess.option_disabled:
-                raise Exception("Sunwarps cannot be shuffled if they are disabled.")
+                raise OptionError("Sunwarps cannot be shuffled if they are disabled.")
 
             self.sunwarp_mapping = list(range(0, 12))
             world.random.shuffle(self.sunwarp_mapping)


### PR DESCRIPTION
## What is this fixing or adding?
The Lingo world raises exceptions for impossible configurations of options. This converts those exceptions to the newly added OptionError. Exceptions not related to options are still Exceptions.


## How was this tested?
Didn't really need to. Ran pytest though.


## If this makes graphical changes, please attach screenshots.
