### PR TITLE
WebHost: Filter the multitracker summary row using applied search filter

### DIFF
--- a/WebHostLib/static/assets/trackerCommon.js
+++ b/WebHostLib/static/assets/trackerCommon.js
@@ -47,16 +47,31 @@ window.addEventListener('load', () => {
         },
         footerCallback: function(tfoot, data, start, end, display) {
             if (tfoot) {
-                const activityData = this.api().column('lastActivity:name').data().toArray().filter(x => !isNaN(x));
+                const statusColumn = this.api().column('.status', { search: 'applied' });
+                const gamesComplete = statusColumn
+                    .data()
+                    .filter(value => value == "Goal Completed")
+                    .count();
+                const totalGames = statusColumn.data().count();
+                Array.from(tfoot?.children).find(td => td.classList.contains('status')).innerText =
+                    gamesComplete + "/" + totalGames + " Complete";
+
+                const checks = this.api().column('.checks', { search: 'applied' })
+                    .data()
+                    .reduce((acc, fraction) => {
+                        const [checks, locations] = fraction.split("/", 2).map(Number);
+                        return [acc[0] + checks, acc[1] + locations];
+                    }, [0, 0]);
+                Array.from(tfoot?.children).find(td => td.classList.contains('checks')).innerText = checks.join("/");
+                Array.from(tfoot?.children).find(td => td.classList.contains('checks-percent')).innerText =
+                    (checks[1] == 0 ? 0 : checks[0] / checks[1] * 100).toFixed(2);
+
+                const activityData = this.api().column('.last-activity', { search: 'applied' }).data().toArray().filter(x => !isNaN(x))
                 Array.from(tfoot?.children).find(td => td.classList.contains('last-activity')).innerText =
-                  (activityData.length) ? secondsToHours(Math.min(...activityData)) : 'None';
+                    (activityData.length) ? secondsToHours(Math.min(...activityData)) : 'None';
             }
         },
         columnDefs: [
-            {
-                targets: 'last-activity',
-                name: 'lastActivity'
-            },
             {
                 targets: 'hours',
                 render: function (data, type, row) {

--- a/WebHostLib/templates/multitracker.html
+++ b/WebHostLib/templates/multitracker.html
@@ -47,12 +47,12 @@
                             <th>#</th>
                             <th>Name</th>
                             {% if current_tracker == "Generic" %}<th>Game</th>{% endif %}
-                            <th>Status</th>
+                            <th class="status">Status</th>
                             {% block custom_table_headers %}
                             {# Implement this block in game-specific multi-trackers. #}
                             {% endblock %}
-                            <th class="center-column">Checks</th>
-                            <th class="center-column">&percnt;</th>
+                            <th class="center-column checks">Checks</th>
+                            <th class="center-column checks-percent">&percnt;</th>
                             <th class="center-column hours last-activity">Last<br>Activity</th>
                         </tr>
                     </thead>
@@ -114,11 +114,11 @@
                             <tr>
                                 <td colspan="2" style="text-align: right">Total</td>
                                 <td>All Games</td>
-                                <td>{{ completed_worlds[team] }}/{{ players | length }} Complete</td>
-                                <td class="center-column">
+                                <td class="status">{{ completed_worlds[team] }}/{{ players | length }} Complete</td>
+                                <td class="center-column checks">
                                     {{ total_team_locations_complete[team] }}/{{ total_team_locations[team] }}
                                 </td>
-                                <td class="center-column">
+                                <td class="center-column checks-percent">
                                     {%- if total_team_locations[team] == 0 -%}
                                         100
                                     {%- else -%}


### PR DESCRIPTION
## What is this fixing or adding?

The summary row added in #1965 always shows the status of the entire multiworld, regardless of any filter settings applied. This post in #general-suggestions https://discord.com/channels/731205301247803413/1231050777121001482 suggested that if a search filter is applied, the search filter should also apply to the summary. That way it would be easy for a player to easily see the percentage of their own checks they've completed across the multiworld. I agree with that suggestion, so here's an implementation.

Note that with this change the multiTracker.html template doesn't really need to populate the footer at all. And thus we can probably remove a view variables from `render_generic_multiworld_tracker`'s call to `render_template()`. I did not make that part of this PR but am happy to do so if that is desired.

## How was this tested?
I was a bit concerned about performance since this is now calculating it from the data in the table, so I also tested with a 2000-player multi-world (thank you Factorio for being fast to generate). The footerCallback took 4ms-6ms to run with the whole table. After searching for `Player100` which gave me the 12 playes Player100 and Player1000-1009 it took 0.4ms.

I also tested it by just playing around with the search on a copy of the db of a multiworld on my webhost I have in progress, to make sure everything looked right. Also made sure to test empty result as well as ensure things kept working after update was called.

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/2065960/874e8901-2c32-4bf6-b78d-99f8e5ed1735)

![image](https://github.com/ArchipelagoMW/Archipelago/assets/2065960/84344c95-525f-4ecd-97d7-399e1f5c7b9f)

![image](https://github.com/ArchipelagoMW/Archipelago/assets/2065960/810cd363-7a39-419e-914b-c2b4baf68258)

![image](https://github.com/ArchipelagoMW/Archipelago/assets/2065960/451db0c5-4692-4bfd-94e0-78bdffe0a989)