### PR TITLE
Tests: allow for completely hidden options to not have docstrings

### DIFF
--- a/test/general/test_options.py
+++ b/test/general/test_options.py
@@ -1,7 +1,7 @@
 import unittest
 
 from BaseClasses import PlandoOptions
-from Options import ItemLinks
+from Options import ItemLinks, Visibility
 from worlds.AutoWorld import AutoWorldRegister
 
 
@@ -11,6 +11,8 @@ class TestOptions(unittest.TestCase):
         for gamename, world_type in AutoWorldRegister.world_types.items():
             if not world_type.hidden:
                 for option_key, option in world_type.options_dataclass.type_hints.items():
+                    if option.visibility in {Visibility.none, Visibility.spoiler}:
+                        continue
                     with self.subTest(game=gamename, option=option_key):
                         self.assertTrue(option.__doc__)
 


### PR DESCRIPTION
## What is this fixing or adding?
We have hidden options now, but unit tests still assert that they have docstrings even though said strings can never be user visible in certain cases, so this allows that.

## How was this tested?
Removed a docstring from one of my options and ran the test with all the different visibility flags.

## If this makes graphical changes, please attach screenshots.
