### PR TITLE
Option groups dedent

### DIFF
--- a/WebHostLib/options.py
+++ b/WebHostLib/options.py
@@ -81,9 +81,18 @@ def send_yaml(player_name: str, formatted_options: dict):
     return response
 
 
+def ap_dedent(text: str) -> str:
+    text = text.strip("\n")
+    if text.startswith("  "):
+        return dedent(text)
+    lines = text.split("\n")
+    not_first = dedent("\n".join(lines[1:]))
+    return f"{lines[0]}\n{not_first}"
+
+
 @app.template_filter("dedent")
-def filter_dedent(text: str):
-    return dedent(text)
+def filter_dedent(text: str) -> str:
+    return ap_dedent(text)
 
 
 @app.route("/weighted-options")

--- a/WebHostLib/options.py
+++ b/WebHostLib/options.py
@@ -82,6 +82,10 @@ def send_yaml(player_name: str, formatted_options: dict):
 
 
 def ap_dedent(text: str) -> str:
+    """
+    handles 2 different styles of multiline doc strings,
+    opening triple-quote either isolated or not isolated
+    """
     text = text.strip("\n")
     if text.startswith("  "):
         return dedent(text)

--- a/WebHostLib/options.py
+++ b/WebHostLib/options.py
@@ -90,6 +90,8 @@ def ap_dedent(text: str) -> str:
     if text.startswith("  "):
         return dedent(text)
     lines = text.split("\n")
+    if len(lines) < 2:
+        return text
     not_first = dedent("\n".join(lines[1:]))
     return f"{lines[0]}\n{not_first}"
 


### PR DESCRIPTION
(This is a PR to a PR, but the target branch happens to also be in the main repo.)

## What is this fixing or adding?

There are 26 supported worlds that use this style that works well with dedent.
```python
"""
doc text here
2nd line
"""
```
But there are 12 supported worlds that use another style that doesn't work well with dedent.
```python
"""doc text here
2nd line
"""
```

(If those numbers don't add up to the total number of supported worlds... 🤷 Maybe the rest don't have any multiline doc strings in options?? ...or something??)

Here's a solution that works well for both of these 2 different styles

## How was this tested?

ran web host and looked at `Option` tooltips for both styles
