### PR TITLE
WebHost: use redirect for /room form submission

### DIFF
--- a/WebHostLib/misc.py
+++ b/WebHostLib/misc.py
@@ -150,6 +150,7 @@ def host_room(room: UUID):
             if cmd:
                 Command(room=room, commandtext=cmd)
                 commit()
+        return redirect(url_for("host_room", room=room.id))
 
     now = datetime.datetime.utcnow()
     # indicate that the page should reload to get the assigned port


### PR DESCRIPTION
## What is this fixing or adding?
removes
![image](https://github.com/ArchipelagoMW/Archipelago/assets/3189725/21de94d5-605d-434c-9c66-575f14c916c3)
if you enter a command into the bar in  /room,  then go back/forth via browser controls.

## How was this tested?
comparing localhost to archipelago.gg

## If this makes graphical changes, please attach screenshots.
Turns
![image](https://github.com/ArchipelagoMW/Archipelago/assets/3189725/9fdb066a-5352-4191-a9d5-eac4f276f040)
into: