### PR TITLE
Super Mario World: Auto Options

### DIFF
--- a/worlds/smw/Options.py
+++ b/worlds/smw/Options.py
@@ -153,14 +153,19 @@ class ExcludeSpecialZone(Toggle):
     display_name = "Exclude Special Zone"
 
 
-class SwapDonutGhostHouseExits(Toggle):
+class SwapDonutGhostHouseExits(Choice):
     """
     If enabled, this option will swap which overworld direction the two exits of the level at the Donut Ghost House
         overworld tile go:
-    False: Normal Exit goes up, Secret Exit goes right.
-    True: Normal Exit goes right, Secret Exit goes up.
+    Off: Normal Exit goes up, Secret Exit goes right.
+    On: Normal Exit goes right, Secret Exit goes up.
+    Auto: On if Level Shuffle is on, and Off if Level Shuffle is on.
     """
     display_name = "Swap Donut GH Exits"
+    option_off = 0
+    option_on = 1
+    option_auto = 2
+    default = 2
 
 
 class DisplayReceivedItemPopups(Choice):
@@ -255,12 +260,17 @@ class Autosave(DefaultOnToggle):
     display_name = "Autosave"
 
 
-class EarlyClimb(Toggle):
+class EarlyClimb(Choice):
     """
     Force Climb to appear early in the seed as a local item.
-    This is particularly useful to prevent BK when Level Shuffle is disabled
+    This is particularly useful to prevent BK when Level Shuffle is disabled.
+    Auto will turn this on if Level Shuffle is off, and off if Level Shuffle is on.
     """
     display_name = "Early Climb"
+    option_off = 0
+    option_on = 1
+    option_auto = 2
+    default = 2
 
 
 class OverworldSpeed(Choice):

--- a/worlds/smw/Rom.py
+++ b/worlds/smw/Rom.py
@@ -3137,8 +3137,9 @@ def patch_rom(world: World, rom, player, active_level_dict):
     
     if world.options.sfx_shuffle != "none":
         generate_shuffled_sfx(rom, world)
-    
-    if world.options.swap_donut_gh_exits:
+
+    if (world.options.swap_donut_gh_exits == "auto"
+        and world.options.level_shuffle) or world.options.swap_donut_gh_exits == "on":
         handle_swap_donut_gh_exits(rom)
 
     handle_mario_palette(rom, world)

--- a/worlds/smw/__init__.py
+++ b/worlds/smw/__init__.py
@@ -89,7 +89,7 @@ class SMWWorld(World):
         return slot_data
 
     def generate_early(self):
-        if self.options.early_climb:
+        if (self.options.early_climb == "auto" and not self.options.level_shuffle) or self.options.early_climb == "on":
             self.multiworld.local_early_items[self.player][ItemName.mario_climb] = 1
 
     def create_regions(self):


### PR DESCRIPTION
## What is this fixing or adding?
- Adds an Auto option to Early Climb, turning it on if Level Shuffle is off.
- Adds an Auto option to Swap Donut GH Exits, turning it on if Level Shuffle is on.

Rationale: These options are especially suited to the corresponding Level Shuffle choices. This will make the lives of people who wish to randomize Level Shuffle easier without needing to use triggers.

## How was this tested?
Generated with a few combinations of options with breakpoints to ensure expected behavior.