### PR TITLE
Core: Options - Validate keys when loading an OptionSet or OptionList from text

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -885,7 +885,9 @@ class OptionList(Option[typing.List[typing.Any]], VerifyKeys):
 
     @classmethod
     def from_text(cls, text: str):
-        return cls([option.strip() for option in text.split(",")])
+        values = [option.strip() for option in text.split(",")]
+        cls.verify_keys(values)
+        return cls(values)
 
     @classmethod
     def from_any(cls, data: typing.Any):
@@ -911,7 +913,9 @@ class OptionSet(Option[typing.Set[str]], VerifyKeys):
 
     @classmethod
     def from_text(cls, text: str):
-        return cls([option.strip() for option in text.split(",")])
+        values = [option.strip() for option in text.split(",")]
+        cls.verify_keys(values)
+        return cls(values)
 
     @classmethod
     def from_any(cls, data: typing.Any):


### PR DESCRIPTION
## What is this fixing or adding?
Currently, if loading an OptionSet or OptionKey from an iterable, it validates that the keys are all valid, using the valid_keys optional attribute (if set).

![image](https://github.com/ArchipelagoMW/Archipelago/assets/16685738/444c248b-13e6-4469-b63c-54baf0d4324c)

But when loading from_text(), it does not do this validation. This leads to the problem that, depending on how the yaml is formatted (and, presumably, other sources like unit tests could have the same issue), the valid keys can be bypassed entirely

![image](https://github.com/ArchipelagoMW/Archipelago/assets/16685738/b1a5bba9-66f1-47e0-bf87-f9ac5ca11570)

## How was this tested?
Ran the unit tests, made sure nothing was broken.
Ran my own test case (from the original problem that made me discover this), and it now validates my keys properly

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/16685738/8b8385a5-c338-4952-ac33-2ea91ab0d594)
