### PR TITLE
Core: Options - Distinguish between empty set and None, so that an option can have zero valid keys

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -783,13 +783,13 @@ class SpecialRange(NamedRange):
 
 class FreezeValidKeys(AssembleOptions):
     def __new__(mcs, name, bases, attrs):
-        if "valid_keys" in attrs:
+        if "valid_keys" in attrs and attrs["valid_keys"] is not None:
             attrs["_valid_keys"] = frozenset(attrs["valid_keys"])
         return super(FreezeValidKeys, mcs).__new__(mcs, name, bases, attrs)
 
 
 class VerifyKeys(metaclass=FreezeValidKeys):
-    valid_keys: typing.Iterable = []
+    valid_keys: typing.Iterable = None
     _valid_keys: frozenset  # gets created by AssembleOptions from valid_keys
     valid_keys_casefold: bool = False
     convert_name_groups: bool = False

--- a/Options.py
+++ b/Options.py
@@ -799,7 +799,7 @@ class VerifyKeys(metaclass=FreezeValidKeys):
 
     @classmethod
     def verify_keys(cls, data: typing.Iterable[str]) -> None:
-        if cls.valid_keys:
+        if cls.valid_keys is not None:
             data = set(data)
             dataset = set(word.casefold() for word in data) if cls.valid_keys_casefold else set(data)
             extra = dataset - cls._valid_keys

--- a/WebHostLib/options.py
+++ b/WebHostLib/options.py
@@ -112,7 +112,7 @@ def create():
                 }
 
             elif issubclass(option, Options.VerifyKeys) and not issubclass(option, Options.OptionDict):
-                if option.valid_keys:
+                if option.valid_keys is not None:
                     game_options[option_name] = {
                         "type": "custom-list",
                         "displayName": option.display_name if hasattr(option, "display_name") else option_name,

--- a/worlds/stardew_valley/options.py
+++ b/worlds/stardew_valley/options.py
@@ -683,13 +683,7 @@ class Mods(OptionSet):
     internal_name = "mods"
     display_name = "Mods"
     valid_keys = {
-        ModNames.deepwoods, ModNames.tractor, ModNames.big_backpack,
-        ModNames.luck_skill, ModNames.magic, ModNames.socializing_skill, ModNames.archaeology,
-        ModNames.cooking_skill, ModNames.binning_skill, ModNames.juna,
-        ModNames.jasper, ModNames.alec, ModNames.yoba, ModNames.eugene,
-        ModNames.wellwick, ModNames.ginger, ModNames.shiko, ModNames.delores,
-        ModNames.ayeisha, ModNames.riley, ModNames.skull_cavern_elevator, ModNames.sve, ModNames.distant_lands,
-        ModNames.alecto, ModNames.lacey, ModNames.boarding_house
+
     }
 
 

--- a/worlds/stardew_valley/options.py
+++ b/worlds/stardew_valley/options.py
@@ -683,7 +683,13 @@ class Mods(OptionSet):
     internal_name = "mods"
     display_name = "Mods"
     valid_keys = {
-
+        ModNames.deepwoods, ModNames.tractor, ModNames.big_backpack,
+        ModNames.luck_skill, ModNames.magic, ModNames.socializing_skill, ModNames.archaeology,
+        ModNames.cooking_skill, ModNames.binning_skill, ModNames.juna,
+        ModNames.jasper, ModNames.alec, ModNames.yoba, ModNames.eugene,
+        ModNames.wellwick, ModNames.ginger, ModNames.shiko, ModNames.delores,
+        ModNames.ayeisha, ModNames.riley, ModNames.skull_cavern_elevator, ModNames.sve, ModNames.distant_lands,
+        ModNames.alecto, ModNames.lacey, ModNames.boarding_house
     }
 
 


### PR DESCRIPTION
## What is this fixing or adding?
Currently, using the valid_keys attribute on OptionSet or OptionList, a developer can configure an option to only accept some values. If this is omitted, any value is accepted.
But if the field is set on purpose, yet left empty, it is treated the same as if it was not set at all, which is "accept everything", but my intent is "accept nothing". In the current state of things, it is impossible to create an OptionSet that accepts nothing.

I understand that this use case is very niche, but I have ran into a development state where I would have benefitted greatly from that, so I figured I'd be the change I want to see in the world.

## How was this tested?
Ran the whole unit test suite.
Tested yamls with OptionSets, with verify keys omitted, or with verify keys set to empty, both behave as expected.
I also ran the webhost locally to see what happens with the weighted settings page in both cases, and it seemed fine to me. It also generated valid yamls.