### PR TITLE
Bumper Stickers and Meritous: Options and world: multiworld fixes

### DIFF
--- a/worlds/bumpstik/Options.py
+++ b/worlds/bumpstik/Options.py
@@ -3,8 +3,10 @@
 # This software is released under the MIT License.
 # https://opensource.org/licenses/MIT
 
+from dataclasses import dataclass
+
 import typing
-from Options import Option, Range
+from Options import Option, Range, PerGameCommonOptions
 
 
 class TaskAdvances(Range):
@@ -68,13 +70,12 @@ class KillerTrapWeight(Range):
     range_end = 100
     default = 0
 
-
-bumpstik_options: typing.Dict[str, type(Option)] = {
-    "task_advances": TaskAdvances,
-    "turners": Turners,
-    "paint_cans": PaintCans,
-    "trap_count": Traps,
-    "rainbow_trap_weight": RainbowTrapWeight,
-    "spinner_trap_weight": SpinnerTrapWeight,
-    "killer_trap_weight": KillerTrapWeight
-}
+@dataclass
+class bumpstikOptions(PerGameCommonOptions):
+    task_advances: TaskAdvances
+    turners: Turners
+    paint_cans: PaintCans
+    trap_count: Traps
+    rainbow_trap_weight: RainbowTrapWeight
+    spinner_trap_weight: SpinnerTrapWeight
+    killer_trap_weight: KillerTrapWeight

--- a/worlds/bumpstik/Options.py
+++ b/worlds/bumpstik/Options.py
@@ -71,7 +71,7 @@ class KillerTrapWeight(Range):
     default = 0
 
 @dataclass
-class bumpstikOptions(PerGameCommonOptions):
+class BumpstikOptions(PerGameCommonOptions):
     task_advances: TaskAdvances
     turners: Turners
     paint_cans: PaintCans

--- a/worlds/bumpstik/Options.py
+++ b/worlds/bumpstik/Options.py
@@ -70,6 +70,7 @@ class KillerTrapWeight(Range):
     range_end = 100
     default = 0
 
+
 @dataclass
 class BumpstikOptions(PerGameCommonOptions):
     task_advances: TaskAdvances

--- a/worlds/bumpstik/Regions.py
+++ b/worlds/bumpstik/Regions.py
@@ -11,7 +11,7 @@ def _generate_entrances(player: int, entrance_list: [str], parent: Region):
     return [Entrance(player, entrance, parent) for entrance in entrance_list]
 
 
-def create_regions(world: MultiWorld, player: int):
+def create_regions(multiworld: MultiWorld, player: int):
     region_map = {
         "Menu": level1_locs + ["Bonus Booster 1"] + [f"Treasure Bumper {i + 1}" for i in range(8)],
         "Level 1": level2_locs + ["Bonus Booster 2"] + [f"Treasure Bumper {i + 9}" for i in range(8)],
@@ -34,7 +34,7 @@ def create_regions(world: MultiWorld, player: int):
 
     for x, region_name in enumerate(region_map):
         region_list = region_map[region_name]
-        region = Region(region_name, player, world)
+        region = Region(region_name, player, multiworld)
         for location_name in region_list:
             region.locations += [BumpStikLocation(
                 player, location_name, location_table[location_name], region)]
@@ -42,9 +42,9 @@ def create_regions(world: MultiWorld, player: int):
             region.exits += _generate_entrances(player,
                                                 [f"To Level {x + 1}"], region)
 
-        world.regions += [region]
+        multiworld.regions += [region]
 
     for entrance in entrance_map:
-        connection = world.get_entrance(f"To {entrance}", player)
+        connection = multiworld.get_entrance(f"To {entrance}", player)
         connection.access_rule = entrance_map[entrance]
-        connection.connect(world.get_region(entrance, player))
+        connection.connect(multiworld.get_region(entrance, player))

--- a/worlds/bumpstik/__init__.py
+++ b/worlds/bumpstik/__init__.py
@@ -43,7 +43,7 @@ class BumpStikWorld(World):
 
     required_client_version = (0, 3, 8)
 
-    options = BumpstikOptions
+    options: BumpstikOptions
     options_dataclass = BumpstikOptions
 
     def __init__(self, world: MultiWorld, player: int):

--- a/worlds/bumpstik/__init__.py
+++ b/worlds/bumpstik/__init__.py
@@ -43,7 +43,7 @@ class BumpStikWorld(World):
 
     required_client_version = (0, 3, 8)
 
-    options_dataclass = bumpstikOptions
+    options_dataclass = BumpstikOptions
 
     def __init__(self, world: MultiWorld, player: int):
         super(BumpStikWorld, self).__init__(world, player)

--- a/worlds/bumpstik/__init__.py
+++ b/worlds/bumpstik/__init__.py
@@ -43,6 +43,7 @@ class BumpStikWorld(World):
 
     required_client_version = (0, 3, 8)
 
+    options = BumpstikOptions
     options_dataclass = BumpstikOptions
 
     def __init__(self, world: MultiWorld, player: int):

--- a/worlds/bumpstik/__init__.py
+++ b/worlds/bumpstik/__init__.py
@@ -46,8 +46,8 @@ class BumpStikWorld(World):
     options: BumpstikOptions
     options_dataclass = BumpstikOptions
 
-    def __init__(self, world: MultiWorld, player: int):
-        super(BumpStikWorld, self).__init__(world, player)
+    def __init__(self, multiworld: MultiWorld, player: int):
+        super(BumpStikWorld, self).__init__(multiworld, player)
         self.task_advances = TaskAdvances.default
         self.turners = Turners.default
         self.paint_cans = PaintCans.default

--- a/worlds/bumpstik/__init__.py
+++ b/worlds/bumpstik/__init__.py
@@ -43,7 +43,7 @@ class BumpStikWorld(World):
 
     required_client_version = (0, 3, 8)
 
-    option_definitions = bumpstik_options
+    options_dataclass = bumpstikOptions
 
     def __init__(self, world: MultiWorld, player: int):
         super(BumpStikWorld, self).__init__(world, player)
@@ -86,13 +86,13 @@ class BumpStikWorld(World):
         return "Nothing"
 
     def generate_early(self):
-        self.task_advances = self.multiworld.task_advances[self.player].value
-        self.turners = self.multiworld.turners[self.player].value
-        self.paint_cans = self.multiworld.paint_cans[self.player].value
-        self.traps = self.multiworld.trap_count[self.player].value
-        self.rainbow_trap_weight = self.multiworld.rainbow_trap_weight[self.player].value
-        self.spinner_trap_weight = self.multiworld.spinner_trap_weight[self.player].value
-        self.killer_trap_weight = self.multiworld.killer_trap_weight[self.player].value
+        self.task_advances = self.options.task_advances.value
+        self.turners = self.options.turners.value
+        self.paint_cans = self.options.paint_cans.value
+        self.traps = self.options.trap_count.value
+        self.rainbow_trap_weight = self.options.rainbow_trap_weight.value
+        self.spinner_trap_weight = self.options.spinner_trap_weight.value
+        self.killer_trap_weight = self.options.killer_trap_weight.value
 
     def create_regions(self):
         create_regions(self.multiworld, self.player)

--- a/worlds/meritous/Options.py
+++ b/worlds/meritous/Options.py
@@ -3,8 +3,10 @@
 # This software is released under the MIT License.
 # https://opensource.org/licenses/MIT
 
+from dataclasses import dataclass
+
 import typing
-from Options import Option, DeathLink, Toggle, DefaultOnToggle, Choice
+from Options import Option, DeathLink, Toggle, DefaultOnToggle, Choice, PerGameCommonOptions
 
 
 cost_scales = {
@@ -51,10 +53,10 @@ class ItemCacheCost(Choice):
     default = 0
 
 
-meritous_options: typing.Dict[str, type(Option)] = {
-    "goal": Goal,
-    "include_psi_keys": IncludePSIKeys,
-    "include_evolution_traps": IncludeEvolutionTraps,
-    "item_cache_cost": ItemCacheCost,
-    "death_link": DeathLink
-}
+@dataclass
+class MeritousOptions(PerGameCommonOptions):
+    goal: Goal
+    include_psi_keys: IncludePSIKeys
+    include_evolution_traps: IncludeEvolutionTraps
+    item_cache_cost: ItemCacheCost
+    death_link: DeathLink

--- a/worlds/meritous/Regions.py
+++ b/worlds/meritous/Regions.py
@@ -13,7 +13,7 @@ def _generate_entrances(player: int, entrance_list: [str], parent: Region):
     return [Entrance(player, entrance, parent) for entrance in entrance_list]
 
 
-def create_regions(world: MultiWorld, player: int):
+def create_regions(multiworld: MultiWorld, player: int):
     regions = ["First", "Second", "Third", "Last"]
     bosses = ["Meridian", "Ataraxia", "Merodach"]
 
@@ -23,7 +23,7 @@ def create_regions(world: MultiWorld, player: int):
         if x == 0:
             insidename = "Menu"
 
-        region = Region(insidename, player, world)
+        region = Region(insidename, player, multiworld)
         for store in ["Alpha Cache", "Beta Cache", "Gamma Cache", "Reward Chest"]:
             for y in range(1, 7):
                 loc_name = f"{store} {(x * 6) + y}"
@@ -42,26 +42,26 @@ def create_regions(world: MultiWorld, player: int):
                                                          "Back to the entrance with the Knife"],
                                                 region)
 
-        world.regions += [region]
+        multiworld.regions += [region]
 
     for x, boss in enumerate(bosses):
-        boss_region = Region(boss, player, world)
+        boss_region = Region(boss, player, multiworld)
         boss_region.locations += [
             MeritousLocation(player, boss, location_table[boss], boss_region),
             MeritousLocation(player, f"{boss} Defeat", None, boss_region)
         ]
         boss_region.exits = _generate_entrances(player, [f"To {regions[x + 1]} Quarter"], boss_region)
-        world.regions.append(boss_region)
+        multiworld.regions.append(boss_region)
 
-    region_final_boss = Region("Final Boss", player, world)
+    region_final_boss = Region("Final Boss", player, multiworld)
     region_final_boss.locations += [MeritousLocation(
         player, "Wervyn Anixil", None, region_final_boss)]
-    world.regions.append(region_final_boss)
+    multiworld.regions.append(region_final_boss)
 
-    region_tfb = Region("True Final Boss", player, world)
+    region_tfb = Region("True Final Boss", player, multiworld)
     region_tfb.locations += [MeritousLocation(
         player, "Wervyn Anixil?", None, region_tfb)]
-    world.regions.append(region_tfb)
+    multiworld.regions.append(region_tfb)
 
     entrance_map = {
         "To Meridian": {
@@ -103,6 +103,6 @@ def create_regions(world: MultiWorld, player: int):
 
     for entrance in entrance_map:
         connection_data = entrance_map[entrance]
-        connection = world.get_entrance(entrance, player)
+        connection = multiworld.get_entrance(entrance, player)
         connection.access_rule = connection_data["rule"]
-        connection.connect(world.get_region(connection_data["to"], player))
+        connection.connect(multiworld.get_region(connection_data["to"], player))

--- a/worlds/meritous/__init__.py
+++ b/worlds/meritous/__init__.py
@@ -7,7 +7,7 @@ from BaseClasses import Item, MultiWorld, Tutorial
 from Fill import fill_restrictive
 from .Items import item_table, item_groups, MeritousItem
 from .Locations import location_table, MeritousLocation
-from .Options import meritous_options, cost_scales
+from .Options import MeritousOptions, cost_scales
 from .Regions import create_regions
 from .Rules import set_rules
 from ..AutoWorld import World, WebWorld
@@ -49,10 +49,11 @@ class MeritousWorld(World):
     # NOTE: Remember to change this before this game goes live
     required_client_version = (0, 2, 4)
 
-    option_definitions = meritous_options
+    options = MeritousOptions
+    options_dataclass = MeritousOptions
 
-    def __init__(self, world: MultiWorld, player: int):
-        super(MeritousWorld, self).__init__(world, player)
+    def __init__(self, multiworld: MultiWorld, player: int):
+        super(MeritousWorld, self).__init__(multiworld, player)
         self.goal = 0
         self.include_evolution_traps = False
         self.include_psi_keys = False
@@ -97,11 +98,11 @@ class MeritousWorld(World):
             return "Crystals x2000"
 
     def generate_early(self):
-        self.goal = self.multiworld.goal[self.player].value
-        self.include_evolution_traps = self.multiworld.include_evolution_traps[self.player].value
-        self.include_psi_keys = self.multiworld.include_psi_keys[self.player].value
-        self.item_cache_cost = self.multiworld.item_cache_cost[self.player].value
-        self.death_link = self.multiworld.death_link[self.player].value
+        self.goal = self.options.goal.value
+        self.include_evolution_traps = self.options.include_evolution_traps.value
+        self.include_psi_keys = self.options.include_psi_keys.value
+        self.item_cache_cost = self.options.item_cache_cost.value
+        self.death_link = self.options.death_link.value
 
     def create_regions(self):
         create_regions(self.multiworld, self.player)

--- a/worlds/meritous/__init__.py
+++ b/worlds/meritous/__init__.py
@@ -49,7 +49,7 @@ class MeritousWorld(World):
     # NOTE: Remember to change this before this game goes live
     required_client_version = (0, 2, 4)
 
-    options = MeritousOptions
+    options: MeritousOptions
     options_dataclass = MeritousOptions
 
     def __init__(self, multiworld: MultiWorld, player: int):


### PR DESCRIPTION
## What is this fixing or adding?

Affects both Bumper Stickers and Meritous. Specifically changes them to use the options dataclass, removes deprecated option getters, and removes `world: multiworld`

## How was this tested?

Generations, connecting to one multiworld with both games, and the unit tests