### PR TITLE
Doom I/II, Heretic: Removing old option getters

### DIFF
--- a/worlds/doom_1993/__init__.py
+++ b/worlds/doom_1993/__init__.py
@@ -181,7 +181,7 @@ class DOOM1993World(World):
         # platform) Unless the user allows for it.
         if not allow_death_logic:
             for death_logic_location in Locations.death_logic_locations:
-                self.multiworld.exclude_locations[self.player].value.add(death_logic_location)
+                self.options.exclude_locations.value.add(death_logic_location)
     
     def create_item(self, name: str) -> DOOM1993Item:
         item_id: int = self.item_name_to_id[name]

--- a/worlds/doom_ii/__init__.py
+++ b/worlds/doom_ii/__init__.py
@@ -172,7 +172,7 @@ class DOOM2World(World):
         # platform) Unless the user allows for it.
         if not allow_death_logic:
             for death_logic_location in Locations.death_logic_locations:
-                self.multiworld.exclude_locations[self.player].value.add(death_logic_location)
+                self.options.exclude_locations.value.add(death_logic_location)
     
     def create_item(self, name: str) -> DOOM2Item:
         item_id: int = self.item_name_to_id[name]

--- a/worlds/heretic/__init__.py
+++ b/worlds/heretic/__init__.py
@@ -182,7 +182,7 @@ class HereticWorld(World):
         # platform) Unless the user allows for it.
         if not allow_death_logic:
             for death_logic_location in Locations.death_logic_locations:
-                self.multiworld.exclude_locations[self.player].value.add(death_logic_location)
+                self.options.exclude_locations.value.add(death_logic_location)
     
     def create_item(self, name: str) -> HereticItem:
         item_id: int = self.item_name_to_id[name]


### PR DESCRIPTION
## What is this fixing or adding?

Changes from `self.multiworld.exclude_locations[self.player]` to `self.options.exclude_locations`

## How was this tested?

Generations and comparing spoiler logs