### PR TITLE
LttP: allow Triforce Piece as start inventory item

### DIFF
--- a/worlds/alttp/Rom.py
+++ b/worlds/alttp/Rom.py
@@ -1269,7 +1269,8 @@ def patch_rom(world: MultiWorld, rom: LocalRom, player: int, enemized: bool):
         rom.write_int32(0x18020C, 0)  # starting time (in frames, sint32)
 
     # set up goals for treasure hunt
-    rom.write_int16(0x180163, local_world.treasure_hunt_required)
+    rom.write_int16(0x180163, max(0, local_world.treasure_hunt_required -
+                    sum(1 for item in world.precollected_items[player] if item.name == "Triforce Piece")))
     rom.write_bytes(0x180165, [0x0E, 0x28])  #  Triforce Piece Sprite
     rom.write_byte(0x180194, 1)  # Must turn in triforced pieces (instant win not enabled)
 
@@ -1372,7 +1373,7 @@ def patch_rom(world: MultiWorld, rom: LocalRom, player: int, enemized: bool):
                          'Golden Sword', 'Tempered Sword', 'Master Sword', 'Fighter Sword', 'Progressive Sword',
                          'Mirror Shield', 'Red Shield', 'Blue Shield', 'Progressive Shield',
                          'Red Mail', 'Blue Mail', 'Progressive Mail',
-                         'Magic Upgrade (1/4)', 'Magic Upgrade (1/2)'}:
+                         'Magic Upgrade (1/4)', 'Magic Upgrade (1/2)', 'Triforce Piece'}:
             continue
 
         set_table = {'Book of Mudora': (0x34E, 1), 'Hammer': (0x34B, 1), 'Bug Catching Net': (0x34D, 1),
@@ -2475,6 +2476,9 @@ def write_strings(rom, world, player):
     tt['sahasrahla_quest_have_master_sword'] = Sahasrahla2_texts[local_random.randint(0, len(Sahasrahla2_texts) - 1)]
     tt['blind_by_the_light'] = Blind_texts[local_random.randint(0, len(Blind_texts) - 1)]
 
+    triforce_pieces_required = max(0, w.treasure_hunt_required -
+                                   sum(1 for item in world.precollected_items[player] if item.name == "Triforce Piece"))
+
     if world.goal[player] in ['triforce_hunt', 'local_triforce_hunt']:
         tt['ganon_fall_in_alt'] = 'Why are you even here?\n You can\'t even hurt me! Get the Triforce Pieces.'
         tt['ganon_phase_3_alt'] = 'Seriously? Go Away, I will not Die.'
@@ -2482,16 +2486,16 @@ def write_strings(rom, world, player):
             tt['sign_ganon'] = 'Go find the Triforce pieces with your friends... Ganon is invincible!'
         else:
             tt['sign_ganon'] = 'Go find the Triforce pieces... Ganon is invincible!'
-        if w.treasure_hunt_required > 1:
+        if triforce_pieces_required > 1:
             tt['murahdahla'] = "Hello @. I\nam Murahdahla, brother of\nSahasrahla and Aginah. Behold the power of\n" \
                                "invisibility.\n\n\n\n… … …\n\nWait! you can see me? I knew I should have\n" \
                                "hidden in  a hollow tree. If you bring\n%d Triforce pieces out of %d, I can reassemble it." % \
-                               (w.treasure_hunt_required, w.treasure_hunt_total)
+                               (triforce_pieces_required, w.treasure_hunt_total)
         else:
             tt['murahdahla'] = "Hello @. I\nam Murahdahla, brother of\nSahasrahla and Aginah. Behold the power of\n" \
                                "invisibility.\n\n\n\n… … …\n\nWait! you can see me? I knew I should have\n" \
                                "hidden in  a hollow tree. If you bring\n%d Triforce piece out of %d, I can reassemble it." % \
-                               (w.treasure_hunt_required, w.treasure_hunt_total)
+                               (triforce_pieces_required, w.treasure_hunt_total)
     elif world.goal[player] in ['pedestal']:
         tt['ganon_fall_in_alt'] = 'Why are you even here?\n You can\'t even hurt me! Your goal is at the pedestal.'
         tt['ganon_phase_3_alt'] = 'Seriously? Go Away, I will not Die.'
@@ -2500,20 +2504,20 @@ def write_strings(rom, world, player):
         tt['ganon_fall_in'] = Ganon1_texts[local_random.randint(0, len(Ganon1_texts) - 1)]
         tt['ganon_fall_in_alt'] = 'You cannot defeat me until you finish your goal!'
         tt['ganon_phase_3_alt'] = 'Got wax in\nyour ears?\nI can not die!'
-        if w.treasure_hunt_required > 1:
+        if triforce_pieces_required > 1:
             if world.goal[player] == 'ganon_triforce_hunt' and world.players > 1:
                 tt['sign_ganon'] = 'You need to find %d Triforce pieces out of %d with your friends to defeat Ganon.' % \
-                                   (w.treasure_hunt_required, w.treasure_hunt_total)
+                                   (triforce_pieces_required, w.treasure_hunt_total)
             elif world.goal[player] in ['ganon_triforce_hunt', 'local_ganon_triforce_hunt']:
                 tt['sign_ganon'] = 'You need to find %d Triforce pieces out of %d to defeat Ganon.' % \
-                                   (w.treasure_hunt_required, w.treasure_hunt_total)
+                                   (triforce_pieces_required, w.treasure_hunt_total)
         else:
             if world.goal[player] == 'ganon_triforce_hunt' and world.players > 1:
                 tt['sign_ganon'] = 'You need to find %d Triforce piece out of %d with your friends to defeat Ganon.' % \
-                                   (w.treasure_hunt_required, w.treasure_hunt_total)
+                                   (triforce_pieces_required, w.treasure_hunt_total)
             elif world.goal[player] in ['ganon_triforce_hunt', 'local_ganon_triforce_hunt']:
                 tt['sign_ganon'] = 'You need to find %d Triforce piece out of %d to defeat Ganon.' % \
-                                   (w.treasure_hunt_required, w.treasure_hunt_total)
+                                   (triforce_pieces_required, w.treasure_hunt_total)
 
     tt['kakariko_tavern_fisherman'] = TavernMan_texts[local_random.randint(0, len(TavernMan_texts) - 1)]
 


### PR DESCRIPTION
## What is this fixing or adding?
When Triforce Pieces are in start inventory instead of crashing the triforce pieces required counter is decreased.

## How was this tested?
Only that a yaml with
```yaml
  start_inventory:
    # Start with these items.
    {"Triforce Piece": 10}
```
no longer crashes gen.

