### PR TITLE
World: remove ClassVar typing from topology_present

### DIFF
--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -206,8 +206,8 @@ class World(metaclass=AutoWorldRegister):
 
     game: ClassVar[str]
     """name the game"""
-    topology_present: ClassVar[bool] = False
-    """indicate if world type has any meaningful layout/pathing"""
+    topology_present: bool = False
+    """indicate if this world has any meaningful layout/pathing"""
 
     all_item_and_group_names: ClassVar[FrozenSet[str]] = frozenset()
     """gets automatically populated with all item and item group names"""


### PR DESCRIPTION
## What is this fixing or adding?
Can take it or leave it, but I believe the ClassVar typing is incorrect here. Some worlds already change this attribute per world, and when core checks this attribute it checks it per player, not per world type.

## How was this tested?
Wasn't, just a typing change.

## If this makes graphical changes, please attach screenshots.
