### PR TITLE
Docs: Update advanced yaml guide wording for priority locations

### DIFF
--- a/docs/options api.md
+++ b/docs/options api.md
@@ -155,10 +155,12 @@ Gives the player starting hints for where the items defined here are.
 Gives the player starting hints for the items on locations defined here.
 
 ### ExcludeLocations
-Marks locations given here as `LocationProgressType.Excluded` so that neither progression nor useful items can be placed on them.
+Marks locations given here as `LocationProgressType.Excluded` so that neither progression nor useful items can be
+placed on them.
 
 ### PriorityLocations
-Marks locations given here as `LocationProgressType.Priority` forcing progression items on them.
+Marks locations given here as `LocationProgressType.Priority` forcing progression items on them if any are available in
+the pool.
 
 ### ItemLinks
 Allows users to share their item pool with other players. Currently item links are per game. A link of one game between

--- a/docs/options api.md
+++ b/docs/options api.md
@@ -155,7 +155,7 @@ Gives the player starting hints for where the items defined here are.
 Gives the player starting hints for the items on locations defined here.
 
 ### ExcludeLocations
-Marks locations given here as `LocationProgressType.Excluded` so that progression items can't be placed on them.
+Marks locations given here as `LocationProgressType.Excluded` so that neither progression nor useful items can be placed on them.
 
 ### PriorityLocations
 Marks locations given here as `LocationProgressType.Priority` forcing progression items on them.

--- a/worlds/generic/docs/advanced_settings_en.md
+++ b/worlds/generic/docs/advanced_settings_en.md
@@ -132,10 +132,10 @@ guide: [Archipelago Plando Guide](/tutorial/Archipelago/plando/en)
   the location without using any hint points.
 * `start_location_hints` is the same as `start_hints` but for locations, allowing you to hint for the item contained
   there without using any hint points.
-* `exclude_locations` lets you define any locations that you don't want to do and during generation will force a filler
-  or trap item which isn't necessary for progression to go in these locations.
-* `priority_locations` lets you define any locations that you want to do and during generation will force a progression
-  item to go in these locations.
+* `exclude_locations` lets you define any locations that you don't want to do and forces a filler or trap item which
+  isn't necessary for progression into these locations.
+* `priority_locations` lets you define any locations that you want to do and forces a progression item into these
+  locations.
 * `item_links` allows players to link their items into a group with the same item link name and game. The items declared
   in `item_pool` get combined and when an item is found for the group, all players in the group receive it. Item links
   can also have local and non local items, forcing the items to either be placed within the worlds of the group or in

--- a/worlds/generic/docs/advanced_settings_en.md
+++ b/worlds/generic/docs/advanced_settings_en.md
@@ -134,7 +134,8 @@ guide: [Archipelago Plando Guide](/tutorial/Archipelago/plando/en)
   there without using any hint points.
 * `exclude_locations` lets you define any locations that you don't want to do and during generation will force a "junk"
   item which isn't necessary for progression to go in these locations.
-* `priority_locations` is the inverse of `exclude_locations`, forcing a progression item in the defined locations.
+* `priority_locations` lets you define any locations that you want to do and during generation will force a progression
+*  item to go in these locations.
 * `item_links` allows players to link their items into a group with the same item link name and game. The items declared
   in `item_pool` get combined and when an item is found for the group, all players in the group receive it. Item links
   can also have local and non local items, forcing the items to either be placed within the worlds of the group or in

--- a/worlds/generic/docs/advanced_settings_en.md
+++ b/worlds/generic/docs/advanced_settings_en.md
@@ -132,8 +132,8 @@ guide: [Archipelago Plando Guide](/tutorial/Archipelago/plando/en)
   the location without using any hint points.
 * `start_location_hints` is the same as `start_hints` but for locations, allowing you to hint for the item contained
   there without using any hint points.
-* `exclude_locations` lets you define any locations that you don't want to do and during generation will force a "junk"
-  item which isn't necessary for progression to go in these locations.
+* `exclude_locations` lets you define any locations that you don't want to do and during generation will force a filler
+* or trap item which isn't necessary for progression to go in these locations.
 * `priority_locations` lets you define any locations that you want to do and during generation will force a progression
 *  item to go in these locations.
 * `item_links` allows players to link their items into a group with the same item link name and game. The items declared

--- a/worlds/generic/docs/advanced_settings_en.md
+++ b/worlds/generic/docs/advanced_settings_en.md
@@ -133,9 +133,9 @@ guide: [Archipelago Plando Guide](/tutorial/Archipelago/plando/en)
 * `start_location_hints` is the same as `start_hints` but for locations, allowing you to hint for the item contained
   there without using any hint points.
 * `exclude_locations` lets you define any locations that you don't want to do and during generation will force a filler
-* or trap item which isn't necessary for progression to go in these locations.
+  or trap item which isn't necessary for progression to go in these locations.
 * `priority_locations` lets you define any locations that you want to do and during generation will force a progression
-*  item to go in these locations.
+  item to go in these locations.
 * `item_links` allows players to link their items into a group with the same item link name and game. The items declared
   in `item_pool` get combined and when an item is found for the group, all players in the group receive it. Item links
   can also have local and non local items, forcing the items to either be placed within the worlds of the group or in


### PR DESCRIPTION
## What is this fixing or adding?
Currently, it says that priority_locations is the inverse of exclude_locations. This is not true, since neither exclude_locations nor priority_locations allow useful items.
I'm not a huge fan of the wording, I'm mostly just mirroring the exclude_locations text.

## How was this tested?
Reading

## If this makes graphical changes, please attach screenshots.
N/A