### PR TITLE
Generate: only check yaml files in --player_files_path

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -111,7 +111,7 @@ def main(args=None, callback=ERmain):
     player_files = {}
     for file in os.scandir(args.player_files_path):
         fname = file.name
-        ext = os.path.splitext(fname)[1]
+        ext = os.path.splitext(fname)[1].lower()
         if file.is_file() and not fname.startswith(".") and (ext == ".yaml" or ext == ".yml") and \
                 os.path.join(args.player_files_path, fname) not in {args.meta_file_path, args.weights_file_path}:
             path = os.path.join(args.player_files_path, fname)

--- a/Generate.py
+++ b/Generate.py
@@ -111,7 +111,8 @@ def main(args=None, callback=ERmain):
     player_files = {}
     for file in os.scandir(args.player_files_path):
         fname = file.name
-        if file.is_file() and not fname.startswith(".") and \
+        ext = os.path.splitext(fname)[1]
+        if file.is_file() and not fname.startswith(".") and (ext == ".yaml" or ext == ".yml") and \
                 os.path.join(args.player_files_path, fname) not in {args.meta_file_path, args.weights_file_path}:
             path = os.path.join(args.player_files_path, fname)
             try:


### PR DESCRIPTION
## What is this fixing or adding?
CLI ergonomics: ignore non-yaml files in the player files path.

If the user had other files in there (like backup files from certain text editors being named Foo.yaml~, putting a zip file in there and extracting it, or using the same directory for output and player files for multiple seeds), they will be skipped.

## How was this tested?
1. Created a directory with a player yaml file and a zip file.
2. Ran `python3 Generate.py --player_files_path ${path to that directory}`
3. Verified that the output was generated. Relevant output:
```
P1 Weights: HikerNeia.yaml >> Generated by https://archipelago.gg.                                                                                                        
Generating for 1 player, 96269202306990815471 Seed 45914095011566928465 with plando: connections, texts, bosses                      
Archipelago Version 0.4.6  -  Seed: 45914095011566928465  
```

## If this makes graphical changes, please attach screenshots.
No graphical changes.