### PR TITLE
Docs: remove obsolete yaml generation info

### DIFF
--- a/docs/running from source.md
+++ b/docs/running from source.md
@@ -17,6 +17,8 @@ Then run any of the starting point scripts, like Generate.py, and the included M
 required modules and after pressing enter proceed to install everything automatically.
 After this, you should be able to run the programs.
 
+ * `Launcher.py` gives access to many components, including clients registered in `worlds/LauncherComponents.py`.
+    * The Launcher button "Generate Template Options" will generate default yamls for all worlds.
  * With yaml(s) in the `Players` folder, `Generate.py` will generate the multiworld archive.
  * `MultiServer.py`, with the filename of the generated archive as a command line parameter, will host the multiworld locally.
     * `--log_network` is a command line parameter useful for debugging.

--- a/docs/running from source.md
+++ b/docs/running from source.md
@@ -23,7 +23,6 @@ After this, you should be able to run the programs.
  * `WebHost.py` will host the website on your computer.
     * You can copy `docs/webhost configuration sample.yaml` to `config.yaml`
     to change WebHost options (like the web hosting port number).
-    * As a side effect, `WebHost.py` creates the template yamls for all the games in `WebHostLib/static/generated`.
 
 
 ## Windows


### PR DESCRIPTION
## What is this fixing or adding?

The line about template yamls from WebHost was added when we didn't have the "Generate Template Options" button in the launcher,
so this was one of the best ways to generate the default yamls.

Even though the information is still accurate, I don't think it's useful enough to keep here anymore.

## How was this tested?

on Thursdays
