### PR TITLE
CV64: Fix items with weird characters landing on Renon's shop crashing

### DIFF
--- a/worlds/cv64/text.py
+++ b/worlds/cv64/text.py
@@ -31,7 +31,7 @@ def cv64_string_to_bytearray(cv64text: str, a_advance: bool = False, append_end:
             if char in cv64_char_dict:
                 text_bytes.extend([0x00, cv64_char_dict[char][0]])
             else:
-                text_bytes.extend([0x00, 0x41])
+                text_bytes.extend([0x00, 0x21])
 
     if a_advance:
         text_bytes.extend([0xA3, 0x00])
@@ -45,7 +45,10 @@ def cv64_text_truncate(cv64text: str, textbox_len_limit: int) -> str:
     line_len = 0
 
     for i in range(len(cv64text)):
-        line_len += cv64_char_dict[cv64text[i]][1]
+        if cv64text[i] in cv64_char_dict:
+            line_len += cv64_char_dict[cv64text[i]][1]
+        else:
+            line_len += 5
 
         if line_len > textbox_len_limit:
             return cv64text[0x00:i]


### PR DESCRIPTION
## What is this fixing or adding?
Fixes an oversight with the `cv64_text_truncate` function wherein for some reason I completely and utterly forgot to check to see if the character we're taking the length of is in `cv64_char_dict` to begin with. This is problematic for the item names in Renon's shop specifically as they are the only thing that currently use this.

Also changed the replacement character from an `_` to a `?` because I thought it looked better.

## How was this tested?
Plando'd MegaMan Battle Network 3's "AlphaArmΩ V" onto a Renon shop slot and made sure it generated properly.

## If this makes graphical changes, please attach screenshots.
![Screenshot 2024-05-15 094708](https://github.com/ArchipelagoMW/Archipelago/assets/74896918/ba4066d8-1a85-4875-bfb5-19d6b29e337e)
