### PR TITLE
Core: Removing item_count

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -718,10 +718,6 @@ class CollectionState():
     def count(self, item: str, player: int) -> int:
         return self.prog_items[player][item]
 
-    def item_count(self, item: str, player: int) -> int:
-        Utils.deprecate("Use count instead.")
-        return self.count(item, player)
-
     def has_from_list(self, items: Iterable[str], player: int, count: int) -> bool:
         """Returns True if the state contains at least `count` items matching any of the item names from a list."""
         found: int = 0


### PR DESCRIPTION
## What is this fixing or adding?

Removing `item_count`

## How was this tested?

Unit tests, looking for things that use it, and one generation with every world except DKC3.

After this, so far as I can tell, the only things that are deprecated and don't have PRs addressing them are ~~`data_version`~~ and `per_slot_randoms`