### PR TITLE
Pokemon RB: Add an item group for each HM to improve hinting

### DIFF
--- a/worlds/pokemon_rb/items.py
+++ b/worlds/pokemon_rb/items.py
@@ -212,7 +212,13 @@ item_table.update(
 )
 
 
-item_groups = {}
+item_groups = {
+    "HM01": {"HM01 Cut"},
+    "HM02": {"HM02 Fly"},
+    "HM03": {"HM03 Surf"},
+    "HM04": {"HM04 Strength"},
+    "HM05": {"HM05 Flash"},
+}
 for item, data in item_table.items():
     for group in data.groups:
         item_groups[group] = item_groups.get(group, []) + [item]

--- a/worlds/pokemon_rb/items.py
+++ b/worlds/pokemon_rb/items.py
@@ -119,11 +119,11 @@ item_table = {
     "Card Key 11F": ItemData(109, ItemClassification.progression, ["Unique", "Key Items", "Card Keys"]),
     "Progressive Card Key": ItemData(110, ItemClassification.progression, ["Unique", "Key Items", "Card Keys"]),
     "Sleep Trap": ItemData(111, ItemClassification.trap, ["Traps"]),
-    "HM01 Cut": ItemData(196, ItemClassification.progression, ["Unique", "HMs", "Key Items"]),
-    "HM02 Fly": ItemData(197, ItemClassification.progression, ["Unique", "HMs", "Key Items"]),
-    "HM03 Surf": ItemData(198, ItemClassification.progression, ["Unique", "HMs", "Key Items"]),
-    "HM04 Strength": ItemData(199, ItemClassification.progression, ["Unique", "HMs", "Key Items"]),
-    "HM05 Flash": ItemData(200, ItemClassification.progression, ["Unique", "HMs", "Key Items"]),
+    "HM01 Cut": ItemData(196, ItemClassification.progression, ["Unique", "HMs", "HM01", "Key Items"]),
+    "HM02 Fly": ItemData(197, ItemClassification.progression, ["Unique", "HMs", "HM02", "Key Items"]),
+    "HM03 Surf": ItemData(198, ItemClassification.progression, ["Unique", "HMs", "HM03", "Key Items"]),
+    "HM04 Strength": ItemData(199, ItemClassification.progression, ["Unique", "HMs", "HM04", "Key Items"]),
+    "HM05 Flash": ItemData(200, ItemClassification.progression, ["Unique", "HMs", "HM05", "Key Items"]),
     "TM01 Mega Punch": ItemData(201, ItemClassification.useful, ["Unique", "TMs"]),
     "TM02 Razor Wind": ItemData(202, ItemClassification.filler, ["Unique", "TMs"]),
     "TM03 Swords Dance": ItemData(203, ItemClassification.useful, ["Unique", "TMs"]),
@@ -212,13 +212,7 @@ item_table.update(
 )
 
 
-item_groups = {
-    "HM01": {"HM01 Cut"},
-    "HM02": {"HM02 Fly"},
-    "HM03": {"HM03 Surf"},
-    "HM04": {"HM04 Strength"},
-    "HM05": {"HM05 Flash"},
-}
+item_groups = {}
 for item, data in item_table.items():
     for group in data.groups:
         item_groups[group] = item_groups.get(group, []) + [item]


### PR DESCRIPTION
## What is this fixing or adding?

HMs are suffixed with the name of the move, e.g. "HM02 Fly". If TM move are randomized, they do not have the move name, e.g. "TM02".

If someone hints for an HM using the just the number, the fuzzy matching sees "TM02" as closer than "HM02 Fly", and in fact sees it as close enough to not ask the user to confirm, leading them to waste hint points on non-progression item that they didn't intend.

Emerald already [does this](https://github.com/ArchipelagoMW/Archipelago/blob/main/worlds/pokemon_emerald/items.py#L62) for this reason, adding the same for RB.

## How was this tested?

Hinted for an HM via `!hint HM02` before and after this change.

## If this makes graphical changes, please attach screenshots.

Before:
![image](https://github.com/ArchipelagoMW/Archipelago/assets/2065960/2086d04d-ffcf-4a05-9ee0-8bd31f0dc6c5)

After:
![image](https://github.com/ArchipelagoMW/Archipelago/assets/2065960/187b9f8c-6434-43ac-90eb-fc9bbbec8b04)

