### PR TITLE
YGO06: adds the new game yugioh06 to CODEOWNERS, inno_setup and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Currently, the following games are supported:
 * Yoshi's Island
 * Mario & Luigi: Superstar Saga
 * Bomb Rush Cyberfunk
+* Yu-Gi-Oh! Ultimate Masters: World Championship Tournament 2006
 
 For setup and instructions check out our [tutorials page](https://archipelago.gg/tutorial/).
 Downloads can be found at [Releases](https://github.com/ArchipelagoMW/Archipelago/releases), including compiled

--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -203,6 +203,9 @@
 # Yoshi's Island
 /worlds/yoshisisland/ @PinkSwitch
 
+#Yu-Gi-Oh! Ultimate Masters: World Championship Tournament 2006
+/worlds/yugioh06/ @rensen
+
 # Zillion
 /worlds/zillion/ @beauxq
 

--- a/inno_setup.iss
+++ b/inno_setup.iss
@@ -194,6 +194,11 @@ Root: HKCR; Subkey: "{#MyAppName}yipatch";                     ValueData: "Archi
 Root: HKCR; Subkey: "{#MyAppName}yipatch\DefaultIcon";         ValueData: "{app}\ArchipelagoSNIClient.exe,0";                           ValueType: string;  ValueName: "";
 Root: HKCR; Subkey: "{#MyAppName}yipatch\shell\open\command";  ValueData: """{app}\ArchipelagoSNIClient.exe"" ""%1""";                  ValueType: string;  ValueName: "";
 
+Root: HKCR; Subkey: ".apygo06";                                   ValueData: "{#MyAppName}ygo06patch";        Flags: uninsdeletevalue; ValueType: string;  ValueName: "";
+Root: HKCR; Subkey: "{#MyAppName}ygo06patch";                     ValueData: "Archipelago Yu-Gi-Oh 2006 Patch"; Flags: uninsdeletekey;   ValueType: string;  ValueName: "";
+Root: HKCR; Subkey: "{#MyAppName}ygo06patch\DefaultIcon";         ValueData: "{app}\ArchipelagoBizHawkClient.exe,0";                           ValueType: string;  ValueName: "";
+Root: HKCR; Subkey: "{#MyAppName}ygo06patch\shell\open\command";  ValueData: """{app}\ArchipelagoBizHawkClient.exe"" ""%1""";                  ValueType: string;  ValueName: "";
+
 Root: HKCR; Subkey: ".archipelago";                              ValueData: "{#MyAppName}multidata";        Flags: uninsdeletevalue; ValueType: string;  ValueName: "";
 Root: HKCR; Subkey: "{#MyAppName}multidata";                     ValueData: "Archipelago Server Data";      Flags: uninsdeletekey;   ValueType: string;  ValueName: "";
 Root: HKCR; Subkey: "{#MyAppName}multidata\DefaultIcon";         ValueData: "{app}\ArchipelagoServer.exe,0";                         ValueType: string;  ValueName: "";


### PR DESCRIPTION
## What is this fixing or adding?
After the merge of yugio06 there where a few things that where overlocked.
Namely the game needs to be added to CODEOWNERS, inno_setup and readme
