### PR TITLE
Pokemon Emerald: Update changelog

### DIFF
--- a/worlds/pokemon_emerald/CHANGELOG.md
+++ b/worlds/pokemon_emerald/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 2.2.0
+
+### Features
+
+- When you blacklist species from wild encounters and turn on dexsanity, blacklisted species are not added as locations
+and won't show up in the wild. Previously they would be forced to show up exactly once.
+- Added support for some new autotracking events.
+
+### Fixes
+
+- The Lilycove Wailmer now logically block you from the east. Actual game behavior is still unchanged for now.
+- Water encounters in Slateport now correctly require Surf.
+- Updated the tracker link in the setup guide.
+
 # 2.1.1
 
 ### Features
@@ -12,10 +26,11 @@ _Separately released, branching from 2.0.0. Included procedure patch migration, 
 
 ### Fixes
 
-- Changed "Ho-oh" to "Ho-Oh" in options
+- Changed "Ho-oh" to "Ho-Oh" in options.
 - Temporary fix to alleviate problems with sometimes not receiving certain items just after connecting if `remote_items`
 is `true`.
-- Temporarily disable a possible location for Marine Cave to spawn, as its causes an overflow
+- Temporarily disable a possible location for Marine Cave to spawn, as its causes an overflow.
+- Water encounters in Dewford now correctly require Surf.
 
 # 2.0.0
 

--- a/worlds/pokemon_emerald/CHANGELOG.md
+++ b/worlds/pokemon_emerald/CHANGELOG.md
@@ -29,7 +29,7 @@ _Separately released, branching from 2.0.0. Included procedure patch migration, 
 - Changed "Ho-oh" to "Ho-Oh" in options.
 - Temporary fix to alleviate problems with sometimes not receiving certain items just after connecting if `remote_items`
 is `true`.
-- Temporarily disable a possible location for Marine Cave to spawn, as its causes an overflow.
+- Temporarily disable a possible location for Marine Cave to spawn, as it causes an overflow.
 - Water encounters in Dewford now correctly require Surf.
 
 # 2.0.0


### PR DESCRIPTION
## What is this fixing or adding?

Updates Emerald's changelog for all merged PRs since 0.4.6 (and one that got missed that was released in 0.4.6).

Emerald 2.1.0 and 2.1.1 were released separately from the main AP release. AP 0.4.6 contained Emerald 2.0.1.

## How was this tested?

Reading
