### PR TITLE
BizHawkClient: Minor linting/style

### DIFF
--- a/worlds/_bizhawk/__init__.py
+++ b/worlds/_bizhawk/__init__.py
@@ -103,7 +103,7 @@ async def connect(ctx: BizHawkContext) -> bool:
             return True
         except (TimeoutError, ConnectionRefusedError):
             continue
-    
+
     # No ports worked
     ctx.streams = None
     ctx.connection_status = ConnectionStatus.NOT_CONNECTED

--- a/worlds/_bizhawk/client.py
+++ b/worlds/_bizhawk/client.py
@@ -2,7 +2,6 @@
 A module containing the BizHawkClient base class and metaclass
 """
 
-
 from __future__ import annotations
 
 import abc
@@ -12,13 +11,12 @@ from worlds.LauncherComponents import Component, SuffixIdentifier, Type, compone
 
 if TYPE_CHECKING:
     from .context import BizHawkClientContext
-else:
-    BizHawkClientContext = object
 
 
 def launch_client(*args) -> None:
     from .context import launch
     launch_subprocess(launch, name="BizHawkClient")
+
 
 component = Component("BizHawk Client", "BizHawkClient", component_type=Type.CLIENT, func=launch_client,
                       file_identifier=SuffixIdentifier())
@@ -56,7 +54,7 @@ class AutoBizHawkClientRegister(abc.ABCMeta):
         return new_class
 
     @staticmethod
-    async def get_handler(ctx: BizHawkClientContext, system: str) -> Optional[BizHawkClient]:
+    async def get_handler(ctx: "BizHawkClientContext", system: str) -> Optional[BizHawkClient]:
         for systems, handlers in AutoBizHawkClientRegister.game_handlers.items():
             if system in systems:
                 for handler in handlers.values():
@@ -77,7 +75,7 @@ class BizHawkClient(abc.ABC, metaclass=AutoBizHawkClientRegister):
     """The file extension(s) this client is meant to open and patch (e.g. ".apz3")"""
 
     @abc.abstractmethod
-    async def validate_rom(self, ctx: BizHawkClientContext) -> bool:
+    async def validate_rom(self, ctx: "BizHawkClientContext") -> bool:
         """Should return whether the currently loaded ROM should be handled by this client. You might read the game name
         from the ROM header, for example. This function will only be asked to validate ROMs from the system set by the
         client class, so you do not need to check the system yourself.
@@ -86,18 +84,18 @@ class BizHawkClient(abc.ABC, metaclass=AutoBizHawkClientRegister):
         as necessary (such as setting `ctx.game = self.game`, modifying `ctx.items_handling`, etc...)."""
         ...
 
-    async def set_auth(self, ctx: BizHawkClientContext) -> None:
+    async def set_auth(self, ctx: "BizHawkClientContext") -> None:
         """Should set ctx.auth in anticipation of sending a `Connected` packet. You may override this if you store slot
         name in your patched ROM. If ctx.auth is not set after calling, the player will be prompted to enter their
         username."""
         pass
 
     @abc.abstractmethod
-    async def game_watcher(self, ctx: BizHawkClientContext) -> None:
+    async def game_watcher(self, ctx: "BizHawkClientContext") -> None:
         """Runs on a loop with the approximate interval `ctx.watcher_timeout`. The currently loaded ROM is guaranteed
         to have passed your validator when this function is called, and the emulator is very likely to be connected."""
         ...
 
-    def on_package(self, ctx: BizHawkClientContext, cmd: str, args: dict) -> None:
+    def on_package(self, ctx: "BizHawkClientContext", cmd: str, args: dict) -> None:
         """For handling packages from the server. Called from `BizHawkClientContext.on_package`."""
         pass

--- a/worlds/_bizhawk/context.py
+++ b/worlds/_bizhawk/context.py
@@ -3,7 +3,6 @@ A module containing context and functions relevant to running the client. This m
 checking or launching the client, otherwise it will probably cause circular import issues.
 """
 
-
 import asyncio
 import enum
 import subprocess
@@ -77,7 +76,7 @@ class BizHawkClientContext(CommonContext):
         if self.client_handler is not None:
             self.client_handler.on_package(self, cmd, args)
 
-    async def server_auth(self, password_requested: bool = False):
+    async def server_auth(self, password_requested: bool=False):
         self.password_requested = password_requested
 
         if self.bizhawk_ctx.connection_status != ConnectionStatus.CONNECTED:
@@ -103,7 +102,7 @@ class BizHawkClientContext(CommonContext):
         await self.send_connect()
         self.auth_status = AuthStatus.PENDING
 
-    async def disconnect(self, allow_autoreconnect: bool = False):
+    async def disconnect(self, allow_autoreconnect: bool=False):
         self.auth_status = AuthStatus.NOT_AUTHENTICATED
         await super().disconnect(allow_autoreconnect)
 
@@ -148,7 +147,8 @@ async def _game_watcher(ctx: BizHawkClientContext):
                 script_version = await get_script_version(ctx.bizhawk_ctx)
 
                 if script_version != EXPECTED_SCRIPT_VERSION:
-                    logger.info(f"Connector script is incompatible. Expected version {EXPECTED_SCRIPT_VERSION} but got {script_version}. Disconnecting.")
+                    logger.info(f"Connector script is incompatible. Expected version {EXPECTED_SCRIPT_VERSION} but "
+                                f"got {script_version}. Disconnecting.")
                     disconnect(ctx.bizhawk_ctx)
                     continue
 


### PR DESCRIPTION
## What is this fixing or adding?

Tiny linting/style so boring that they might never change except via this PR.

## How was this tested?

Also ran pep8 and ignored a couple line length violations :stuck_out_tongue:. Those can be addressed when we drop 3.8 and 3.9 and can adjust the type hints.

Ran the Emerald client with these changes while testing other things (python 3.11).
