### PR TITLE
Zillion: add OptionGroup

### DIFF
--- a/worlds/zillion/__init__.py
+++ b/worlds/zillion/__init__.py
@@ -14,7 +14,7 @@ from BaseClasses import ItemClassification, LocationProgressType, \
 from .gen_data import GenData
 from .logic import cs_to_zz_locs
 from .region import ZillionLocation, ZillionRegion
-from .options import ZillionOptions, validate
+from .options import ZillionOptions, validate, z_option_groups
 from .id_maps import ZillionSlotInfo, get_slot_info, item_name_to_id as _item_name_to_id, \
     loc_name_to_id as _loc_name_to_id, make_id_to_others, \
     zz_reg_name_to_reg_name, base_id
@@ -61,6 +61,8 @@ class ZillionWebWorld(WebWorld):
         "setup/en",
         ["beauxq"]
     )]
+
+    option_groups = z_option_groups
 
 
 class ZillionWorld(World):

--- a/worlds/zillion/options.py
+++ b/worlds/zillion/options.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import ClassVar, Dict, Tuple
 from typing_extensions import TypeGuard  # remove when Python >= 3.10
 
-from Options import DefaultOnToggle, NamedRange, PerGameCommonOptions, Range, Toggle, Choice
+from Options import Choice, DefaultOnToggle, NamedRange, OptionGroup, PerGameCommonOptions, Range, Toggle
 
 from zilliandomizer.options import (
     Options as ZzOptions, char_to_gun, char_to_jump, ID,
@@ -277,6 +277,14 @@ class ZillionOptions(PerGameCommonOptions):
     skill: ZillionSkill
     starting_cards: ZillionStartingCards
     room_gen: ZillionRoomGen
+
+
+z_option_groups = [
+    OptionGroup("item counts", [
+        ZillionIDCardCount, ZillionBreadCount, ZillionOpaOpaCount, ZillionZillionCount,
+        ZillionFloppyDiskCount, ZillionScopeCount, ZillionRedIDCardCount
+    ])
+]
 
 
 def convert_item_counts(ic: "Counter[str]") -> ZzItemCounts:


### PR DESCRIPTION
## What is this fixing or adding?

adds an "item counts" option group for Zillion

## How was this tested?

run web host and see options page
generate yaml from launcher and see option group

## If this makes graphical changes, please attach screenshots.

![zillion-option-group](https://github.com/ArchipelagoMW/Archipelago/assets/6052147/48bbcd11-4485-4d02-910b-84a79b7d8065)
