### PR TITLE
WebHost: move atexit saving to end of room hosting function

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -508,7 +508,7 @@ class Context:
                 self.logger.exception(e)
             self._start_async_saving()
 
-    def _start_async_saving(self):
+    def _start_async_saving(self, atexit_save: bool = True):
         if not self.auto_saver_thread:
             def save_regularly():
                 # time.time() is platform dependent, so using the expensive datetime method instead
@@ -532,8 +532,9 @@ class Context:
             self.auto_saver_thread = threading.Thread(target=save_regularly, daemon=True)
             self.auto_saver_thread.start()
 
-            import atexit
-            atexit.register(self._save, True)  # make sure we save on exit too
+            if atexit_save:
+                import atexit
+                atexit.register(self._save, True)  # make sure we save on exit too
 
     def get_save(self) -> dict:
         self.recheck_hints()

--- a/WebHostLib/customserver.py
+++ b/WebHostLib/customserver.py
@@ -142,7 +142,7 @@ class WebHostContext(Context):
             savegame_data = Room.get(id=self.room_id).multisave
             if savegame_data:
                 self.set_save(restricted_loads(Room.get(id=self.room_id).multisave))
-            self._start_async_saving()
+            self._start_async_saving(atexit_save=False)
         threading.Thread(target=self.listen_to_db_commands, daemon=True).start()
 
     @db_session
@@ -278,6 +278,7 @@ def run_server_process(name: str, ponyconfig: dict, static_server_data: dict,
                 raise
             finally:
                 try:
+                    ctx._save()
                     with (db_session):
                         # ensure the Room does not spin up again on its own, minute of safety buffer
                         room = Room.get(id=room_id)


### PR DESCRIPTION
## What is this fixing or adding?
If a webhost is running long enough for rooms to go to sleep, they would still have an atexit handler registered that would save that old version of the room at exit, rolling back data if you got unlucky if that is the last save to DB made.

## How was this tested?
Quickly locally and currently on prod.

## If this makes graphical changes, please attach screenshots.
