### PR TITLE
WebHost: properly stop worker threads

### DIFF
--- a/WebHost.py
+++ b/WebHost.py
@@ -140,6 +140,9 @@ if __name__ == "__main__":
             serve(app, port=app.config["PORT"], threads=app.config["WAITRESS_THREADS"])
     else:
         from time import sleep
-        while True:
-            sleep(1)  # wait for process to be killed
+        try:
+            while True:
+                sleep(1)  # wait for process to be killed
+        except (SystemExit, KeyboardInterrupt):
+            pass
     stop()  # stop worker threads

--- a/WebHost.py
+++ b/WebHost.py
@@ -117,7 +117,7 @@ if __name__ == "__main__":
     logging.basicConfig(format='[%(asctime)s] %(message)s', level=logging.INFO)
 
     from WebHostLib.lttpsprites import update_sprites_lttp
-    from WebHostLib.autolauncher import autohost, autogen
+    from WebHostLib.autolauncher import autohost, autogen, stop
     from WebHostLib.options import create as create_options_files
 
     try:
@@ -138,3 +138,8 @@ if __name__ == "__main__":
         else:
             from waitress import serve
             serve(app, port=app.config["PORT"], threads=app.config["WAITRESS_THREADS"])
+    else:
+        from time import sleep
+        while True:
+            sleep(1)  # wait for process to be killed
+    stop()  # stop worker threads

--- a/WebHostLib/autolauncher.py
+++ b/WebHostLib/autolauncher.py
@@ -83,9 +83,7 @@ def autohost(config: dict):
                     hosters.append(hoster)
                     hoster.start()
 
-                while 1:
-                    if stop_event.wait(0.1):
-                        break
+                while not stop_event.wait(0.1):
                     with db_session:
                         rooms = select(
                             room for room in Room if
@@ -124,9 +122,7 @@ def autogen(config: dict):
                             commit()
                         select(generation for generation in Generation if generation.state == STATE_ERROR).delete()
 
-                    while 1:
-                        if stop_event.wait(0.1):
-                            break
+                    while not stop_event.wait(0.1):
                         with db_session:
                             # for update locks the database row(s) during transaction, preventing writes from elsewhere
                             to_start = select(

--- a/WebHostLib/autolauncher.py
+++ b/WebHostLib/autolauncher.py
@@ -3,15 +3,25 @@ from __future__ import annotations
 import json
 import logging
 import multiprocessing
-import time
 import typing
-from uuid import UUID
 from datetime import timedelta, datetime
+from threading import Event, Thread
+from uuid import UUID
 
 from pony.orm import db_session, select, commit
 
 from Utils import restricted_loads
 from .locker import Locker, AlreadyRunningException
+
+_stop_event = Event()
+
+
+def stop():
+    """Stops previously launched threads"""
+    global _stop_event
+    stop_event = _stop_event
+    _stop_event = Event()  # new event for new threads
+    stop_event.set()
 
 
 def handle_generation_success(seed_id):
@@ -63,6 +73,7 @@ def cleanup():
 
 def autohost(config: dict):
     def keep_running():
+        stop_event = _stop_event
         try:
             with Locker("autohost"):
                 cleanup()
@@ -73,7 +84,8 @@ def autohost(config: dict):
                     hoster.start()
 
                 while 1:
-                    time.sleep(0.1)
+                    if stop_event.wait(0.1):
+                        break
                     with db_session:
                         rooms = select(
                             room for room in Room if
@@ -86,12 +98,12 @@ def autohost(config: dict):
         except AlreadyRunningException:
             logging.info("Autohost reports as already running, not starting another.")
 
-    import threading
-    threading.Thread(target=keep_running, name="AP_Autohost").start()
+    Thread(target=keep_running, name="AP_Autohost").start()
 
 
 def autogen(config: dict):
     def keep_running():
+        stop_event = _stop_event
         try:
             with Locker("autogen"):
 
@@ -113,7 +125,8 @@ def autogen(config: dict):
                         select(generation for generation in Generation if generation.state == STATE_ERROR).delete()
 
                     while 1:
-                        time.sleep(0.1)
+                        if stop_event.wait(0.1):
+                            break
                         with db_session:
                             # for update locks the database row(s) during transaction, preventing writes from elsewhere
                             to_start = select(
@@ -124,8 +137,7 @@ def autogen(config: dict):
         except AlreadyRunningException:
             logging.info("Autogen reports as already running, not starting another.")
 
-    import threading
-    threading.Thread(target=keep_running, name="AP_Autogen").start()
+    Thread(target=keep_running, name="AP_Autogen").start()
 
 
 multiworlds: typing.Dict[type(Room.id), MultiworldInstance] = {}


### PR DESCRIPTION
## What is this fixing or adding?

In the current code
* with SELFHOST:
  * killing the main thread will hang waiting for the worker threads to stop.
  * this has the side effect of multiprocessing workers to receive Ctrl+C, die and respawn because the pool never stops
  * pressing Ctrl+C again will stop waiting for the worker threads and just terminate
* without SELFHOST: 
  * similar to above, but we immediately enter the state where we wait for the threads to stop, so only one Ctrl+C is required to actually terminate the process

After this change:
* with SELHOST:
  * we gracefully stop the worker threads once waitress finishes
  * the application terminates cleanly (with just 1x Ctrl+C)
* without SELHOST:
  * similar to above, but we spin the main thread ourself until SIGINT is received

## How was this tested?

Only with waitress locally and with SELFHOST: false locally.