### PR TITLE
CustomServer: re-add missing Archipelago to data package

### DIFF
--- a/WebHostLib/customserver.py
+++ b/WebHostLib/customserver.py
@@ -105,7 +105,7 @@ class WebHostContext(Context):
         static_gamespackage = self.gamespackage  # this is shared across all rooms
         static_item_name_groups = self.item_name_groups
         static_location_name_groups = self.location_name_groups
-        self.gamespackage = {}  # this may be modified by _load
+        self.gamespackage = {"Archipelago": static_gamespackage["Archipelago"]}  # this may be modified by _load
         self.item_name_groups = {}
         self.location_name_groups = {}
 


### PR DESCRIPTION
## What is this fixing or adding?

The change to per-room datapackage accidentally removed "Archipelago" is the room was in custom data package mode.
This adds it back in.

See this report https://discord.com/channels/731205301247803413/1043855558303821844/1241808390947344424

## How was this tested?

An assert in `def load`.
