### PR TITLE
Core: Fix Template Yaml Generation breaking with newlines

### DIFF
--- a/data/options.yaml
+++ b/data/options.yaml
@@ -53,8 +53,8 @@ requires:
     {%- if option.__doc__ %}
     # {{ option.__doc__
         | trim
-        | replace('\n\n', '\n    \n')
-        | replace('\n    ', '\n# ')
+        | replace('\n    ', '\n')
+        | replace('\n', '\n# ')
         | indent(4, first=False)
       }}
     {%- endif -%}


### PR DESCRIPTION
This docstring:

![image](https://github.com/ArchipelagoMW/Archipelago/assets/57900059/13aa16b4-776e-465b-803d-d3bf512df631)

Results in this yaml:

![image](https://github.com/ArchipelagoMW/Archipelago/assets/57900059/f6abfe0b-966a-4650-83d2-71900edfbe10)

Which is an invalid yaml, and also crashes a bunch of things.
This change fixes that.

Since trailing whitespace is now displayed on the options pages, I would really like to have the option of having "normal linebreaks" by underindenting my options docstrings.
Basically, right now, this is not possible:

![image](https://github.com/ArchipelagoMW/Archipelago/assets/57900059/5daeda11-d1e7-4d0d-9b5c-f700413cc0b2)

Tested:
Looked at some yamls, they look fine.
Also, the file generation unit test passes.

There might have been something I didn't consider tho.