### PR TITLE
TUNIC: Add option groups, fix option descriptions

### DIFF
--- a/worlds/tunic/__init__.py
+++ b/worlds/tunic/__init__.py
@@ -8,7 +8,7 @@ from .er_rules import set_er_location_rules
 from .regions import tunic_regions
 from .er_scripts import create_er_regions
 from .er_data import portal_mapping
-from .options import TunicOptions, EntranceRando
+from .options import TunicOptions, EntranceRando, tunic_option_groups
 from worlds.AutoWorld import WebWorld, World
 from worlds.generic import PlandoConnection
 from decimal import Decimal, ROUND_HALF_UP
@@ -27,6 +27,7 @@ class TunicWeb(WebWorld):
     ]
     theme = "grassFlowers"
     game = "TUNIC"
+    option_groups = tunic_option_groups
 
 
 class TunicItem(Item):

--- a/worlds/tunic/options.py
+++ b/worlds/tunic/options.py
@@ -32,7 +32,7 @@ class AbilityShuffling(Toggle):
     """
     Locks the usage of Prayer, Holy Cross*, and the Icebolt combo until the relevant pages of the manual have been found.
     If playing Hexagon Quest, abilities are instead randomly unlocked after obtaining 25%, 50%, and 75% of the required Hexagon goal amount.
-    *Certain Holy Cross usages are still allowed, such as the free bomb codes, the seeking spell, and other player-facing codes.
+    * Certain Holy Cross usages are still allowed, such as the free bomb codes, the seeking spell, and other player-facing codes.
     """
     internal_name = "ability_shuffling"
     display_name = "Shuffle Abilities"
@@ -148,8 +148,10 @@ class FixedShop(Toggle):
 
 
 class LaurelsLocation(Choice):
-    """Force the Hero's Laurels to be placed at a location in your world.
-    For if you want to avoid or specify early or late Laurels."""
+    """
+    Force the Hero's Laurels to be placed at a location in your world.
+    For if you want to avoid or specify early or late Laurels.
+    """
     internal_name = "laurels_location"
     display_name = "Laurels Location"
     option_anywhere = 0

--- a/worlds/tunic/options.py
+++ b/worlds/tunic/options.py
@@ -6,7 +6,7 @@ from Options import (DefaultOnToggle, Toggle, StartInventoryPool, Choice, Range,
 
 class SwordProgression(DefaultOnToggle):
     """
-    Adds four sword upgrades to the item pool that will progressively grant stronger melee weapons, including two new swords with increased range.
+    Adds four sword upgrades to the item pool that will progressively grant stronger melee weapons, including two new swords with increased range and attack power.
     """
     internal_name = "sword_progression"
     display_name = "Sword Progression"

--- a/worlds/tunic/options.py
+++ b/worlds/tunic/options.py
@@ -1,28 +1,36 @@
 from dataclasses import dataclass
 
-from Options import DefaultOnToggle, Toggle, StartInventoryPool, Choice, Range, TextChoice, PerGameCommonOptions
+from Options import (DefaultOnToggle, Toggle, StartInventoryPool, Choice, Range, TextChoice, PerGameCommonOptions,
+                     OptionGroup)
 
 
 class SwordProgression(DefaultOnToggle):
-    """Adds four sword upgrades to the item pool that will progressively grant stronger melee weapons, including two new swords with increased range and attack power."""
+    """
+    Adds four sword upgrades to the item pool that will progressively grant stronger melee weapons, including two new swords with increased range.
+    """
     internal_name = "sword_progression"
     display_name = "Sword Progression"
 
 
 class StartWithSword(Toggle):
-    """Start with a sword in the player's inventory. Does not count towards Sword Progression."""
+    """
+    Start with a sword in the player's inventory. Does not count towards Sword Progression.
+    """
     internal_name = "start_with_sword"
     display_name = "Start With Sword"
 
 
 class KeysBehindBosses(Toggle):
-    """Places the three hexagon keys behind their respective boss fight in your world."""
+    """
+    Places the three hexagon keys behind their respective boss fight in your world.
+    """
     internal_name = "keys_behind_bosses"
     display_name = "Keys Behind Bosses"
 
 
 class AbilityShuffling(Toggle):
-    """Locks the usage of Prayer, Holy Cross*, and the Icebolt combo until the relevant pages of the manual have been found.
+    """
+    Locks the usage of Prayer, Holy Cross*, and the Icebolt combo until the relevant pages of the manual have been found.
     If playing Hexagon Quest, abilities are instead randomly unlocked after obtaining 25%, 50%, and 75% of the required Hexagon goal amount.
     *Certain Holy Cross usages are still allowed, such as the free bomb codes, the seeking spell, and other player-facing codes.
     """
@@ -37,9 +45,9 @@ class LogicRules(Choice):
     No Major Glitches: Sneaky Laurels zips, ice grapples through doors, shooting the west bell, and boss quick kills are included in logic.
     * Ice grappling through the Ziggurat door is not in logic since you will get stuck in there without Prayer.
     Unrestricted: Logic in No Major Glitches, as well as ladder storage to get to certain places early.
-    *Torch is given to the player at the start of the game due to the high softlock potential with various tricks. Using the torch is not required in logic.
-    *Using Ladder Storage to get to individual chests is not in logic to avoid tedium.
-    *Getting knocked out of the air by enemies during Ladder Storage to reach places is not in logic, except for in Rooted Ziggurat Lower. This is so you're not punished for playing with enemy rando on.
+    * Torch is given to the player at the start of the game due to the high softlock potential with various tricks. Using the torch is not required in logic.
+    * Using Ladder Storage to get to individual chests is not in logic to avoid tedium.
+    * Getting knocked out of the air by enemies during Ladder Storage to reach places is not in logic, except for in Rooted Ziggurat Lower. This is so you're not punished for playing with enemy rando on.
     """
     internal_name = "logic_rules"
     display_name = "Logic Rules"
@@ -52,21 +60,27 @@ class LogicRules(Choice):
 
 
 class Lanternless(Toggle):
-    """Choose whether you require the Lantern for dark areas.
-    When enabled, the Lantern is marked as Useful instead of Progression."""
+    """
+    Choose whether you require the Lantern for dark areas.
+    When enabled, the Lantern is marked as Useful instead of Progression.
+    """
     internal_name = "lanternless"
     display_name = "Lanternless"
 
 
 class Maskless(Toggle):
-    """Choose whether you require the Scavenger's Mask for Lower Quarry.
-    When enabled, the Scavenger's Mask is marked as Useful instead of Progression."""
+    """
+    Choose whether you require the Scavenger's Mask for Lower Quarry.
+    When enabled, the Scavenger's Mask is marked as Useful instead of Progression.
+    """
     internal_name = "maskless"
     display_name = "Maskless"
 
 
 class FoolTraps(Choice):
-    """Replaces low-to-medium value money rewards in the item pool with fool traps, which cause random negative effects to the player."""
+    """
+    Replaces low-to-medium value money rewards in the item pool with fool traps, which cause random negative effects to the player.
+    """
     internal_name = "fool_traps"
     display_name = "Fool Traps"
     option_off = 0
@@ -77,13 +91,17 @@ class FoolTraps(Choice):
 
 
 class HexagonQuest(Toggle):
-    """An alternate goal that shuffles Gold "Questagon" items into the item pool and allows the game to be completed after collecting the required number of them."""
+    """
+    An alternate goal that shuffles Gold "Questagon" items into the item pool and allows the game to be completed after collecting the required number of them.
+    """
     internal_name = "hexagon_quest"
     display_name = "Hexagon Quest"
 
 
 class HexagonGoal(Range):
-    """How many Gold Questagons are required to complete the game on Hexagon Quest."""
+    """
+    How many Gold Questagons are required to complete the game on Hexagon Quest.
+    """
     internal_name = "hexagon_goal"
     display_name = "Gold Hexagons Required"
     range_start = 15
@@ -92,7 +110,9 @@ class HexagonGoal(Range):
 
 
 class ExtraHexagonPercentage(Range):
-    """How many extra Gold Questagons are shuffled into the item pool, taken as a percentage of the goal amount."""
+    """
+    How many extra Gold Questagons are shuffled into the item pool, taken as a percentage of the goal amount.
+    """
     internal_name = "extra_hexagon_percentage"
     display_name = "Percentage of Extra Gold Hexagons"
     range_start = 0
@@ -118,9 +138,11 @@ class EntranceRando(TextChoice):
 
 
 class FixedShop(Toggle):
-    """Forces the Windmill entrance to lead to a shop, and removes the remaining shops from the pool.
+    """
+    Forces the Windmill entrance to lead to a shop, and removes the remaining shops from the pool.
     Adds another entrance in Rooted Ziggurat Lower to keep an even number of entrances.
-    Has no effect if Entrance Rando is not enabled."""
+    Has no effect if Entrance Rando is not enabled.
+    """
     internal_name = "fixed_shop"
     display_name = "Fewer Shops in Entrance Rando"
 
@@ -138,9 +160,12 @@ class LaurelsLocation(Choice):
 
 
 class ShuffleLadders(Toggle):
-    """Turns several ladders in the game into items that must be found before they can be climbed on.
+    """
+    Turns several ladders in the game into items that must be found before they can be climbed on.
     Adds more layers of progression to the game by blocking access to many areas early on.
-    "Ladders were a mistake." —Andrew Shouldice"""
+    "Ladders were a mistake."
+    —Andrew Shouldice
+    """
     internal_name = "shuffle_ladders"
     display_name = "Shuffle Ladders"
 
@@ -163,3 +188,12 @@ class TunicOptions(PerGameCommonOptions):
     lanternless: Lanternless
     maskless: Maskless
     laurels_location: LaurelsLocation
+
+
+tunic_option_groups = [
+    OptionGroup("Logic Options", [
+        LogicRules,
+        Lanternless,
+        Maskless,
+    ])
+]


### PR DESCRIPTION
## What is this fixing or adding?
Adds an option group to section off the logic options (since those are more "advanced" options that we want to section off).
Also changes the descriptions to not look weird with the new webhost update.

## How was this tested?
Ran webhost

## If this makes graphical changes, please attach screenshots.
N/A