### PR TITLE
Subnautica: fix use of _valid_keys where valid_keys should be used.

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -746,7 +746,7 @@ class NamedRange(Range):
 
 class FreezeValidKeys(AssembleOptions):
     def __new__(mcs, name, bases, attrs):
-        assert not "_valid_keys" in attrs, "'_valid_keys' gets set by FreezeValidKeys, define 'valid_keys' instead"
+        assert not "_valid_keys" in attrs, "'_valid_keys' gets set by FreezeValidKeys, define 'valid_keys' instead."
         if "valid_keys" in attrs:
             attrs["_valid_keys"] = frozenset(attrs["valid_keys"])
         return super(FreezeValidKeys, mcs).__new__(mcs, name, bases, attrs)

--- a/Options.py
+++ b/Options.py
@@ -746,6 +746,7 @@ class NamedRange(Range):
 
 class FreezeValidKeys(AssembleOptions):
     def __new__(mcs, name, bases, attrs):
+        assert not "_valid_keys" in attrs, "'_valid_keys' gets set by FreezeValidKeys, define 'valid_keys' instead"
         if "valid_keys" in attrs:
             attrs["_valid_keys"] = frozenset(attrs["valid_keys"])
         return super(FreezeValidKeys, mcs).__new__(mcs, name, bases, attrs)

--- a/worlds/subnautica/options.py
+++ b/worlds/subnautica/options.py
@@ -120,7 +120,7 @@ class FillerItemsDistribution(ItemDict):
     """Random chance weights of various filler resources that can be obtained.
     Available items: """
     __doc__ += ", ".join(f"\"{item_name}\"" for item_name in item_names_by_type[ItemType.resource])
-    _valid_keys = frozenset(item_names_by_type[ItemType.resource])
+    valid_keys = sorted(item_names_by_type[ItemType.resource])
     default = {item_name: 1 for item_name in item_names_by_type[ItemType.resource]}
     display_name = "Filler Items Distribution"
 


### PR DESCRIPTION
## What is this fixing or adding?
uses correct version of valid_keys
adds assert in core  to prevent others from making my mistake

## How was this tested?
includes an assert to test. Also tested against option page listing all items instead of valid keys before.

## If this makes graphical changes, please attach screenshots.
