### PR TITLE
Update options pages macros to respect valid_keys for item and location options

### DIFF
--- a/WebHostLib/templates/playerOptions/macros.html
+++ b/WebHostLib/templates/playerOptions/macros.html
@@ -114,7 +114,7 @@
 {% macro ItemDict(option_name, option, world) %}
     {{ OptionTitle(option_name, option) }}
     <div class="option-container">
-        {% for item_name in world.item_names|sort %}
+        {% for item_name in (option.valid_keys|sort if (option.valid_keys|length > 0) else world.item_names|sort) %}
             <div class="option-entry">
                 <label for="{{ option_name }}-{{ item_name }}-qty">{{ item_name }}</label>
                 <input type="number" id="{{ option_name }}-{{ item_name }}-qty" name="{{ option_name }}||{{ item_name }}||qty" value="{{ option.default[item_name]|default("0") }}" data-option-name="{{ option_name }}" data-item-name="{{ item_name }}" />
@@ -149,7 +149,7 @@
         {% if world.location_name_groups.keys()|length > 1 %}
             <div class="option-divider">&nbsp;</div>
         {% endif %}
-        {% for location_name in world.location_names|sort %}
+        {% for location_name in (option.valid_keys|sort if (option.valid_keys|length > 0) else world.location_names|sort) %}
             <div class="option-entry">
                 <input type="checkbox" id="{{ option_name }}-{{ location_name }}" name="{{ option_name }}" value="{{ location_name }}" {{ "checked" if location_name in option.default }} />
                 <label for="{{ option_name }}-{{ location_name }}">{{ location_name }}</label>
@@ -172,7 +172,7 @@
         {% if world.item_name_groups.keys()|length > 1 %}
             <div class="option-divider">&nbsp;</div>
         {% endif %}
-        {% for item_name in world.item_names|sort %}
+        {% for item_name in (option.valid_keys|sort if (option.valid_keys|length > 0) else world.item_names|sort) %}
             <div class="option-entry">
                 <input type="checkbox" id="{{ option_name }}-{{ item_name }}" name="{{ option_name }}" value="{{ item_name }}" {{ "checked" if item_name in option.default }} />
                 <label for="{{ option_name }}-{{ item_name }}">{{ item_name }}</label>

--- a/WebHostLib/templates/weightedOptions/macros.html
+++ b/WebHostLib/templates/weightedOptions/macros.html
@@ -105,7 +105,7 @@
 
 {% macro ItemDict(option_name, option, world) %}
     <div class="dict-container">
-        {% for item_name in world.item_names|sort %}
+        {% for item_name in (option.valid_keys|sort if (option.valid_keys|length > 0) else world.item_names|sort) %}
             <div class="dict-entry">
                 <label for="{{ option_name }}-{{ item_name }}-qty">{{ item_name }}</label>
                 <input
@@ -150,7 +150,7 @@
         {% if world.location_name_groups.keys()|length > 1 %}
             <div class="divider">&nbsp;</div>
         {% endif %}
-        {% for location_name in world.location_names|sort %}
+        {% for location_name in (option.valid_keys|sort if (option.valid_keys|length > 0) else world.location_names|sort) %}
             <div class="set-entry">
                 <input type="checkbox" id="{{ option_name }}-{{ location_name }}" name="{{ option_name }}||{{ location_name }}" value="1" {{ "checked" if location_name in option.default }} />
                 <label for="{{ option_name }}-{{ location_name }}">{{ location_name }}</label>
@@ -172,7 +172,7 @@
         {% if world.item_name_groups.keys()|length > 1 %}
             <div class="set-divider">&nbsp;</div>
         {% endif %}
-        {% for item_name in world.item_names|sort %}
+        {% for item_name in (option.valid_keys|sort if (option.valid_keys|length > 0) else world.item_names|sort) %}
             <div class="set-entry">
                 <input type="checkbox" id="{{ option_name }}-{{ item_name }}" name="{{ option_name }}||{{ item_name }}" value="1" {{ "checked" if item_name in option.default }} />
                 <label for="{{ option_name }}-{{ item_name }}">{{ item_name }}</label>


### PR DESCRIPTION
## What is this fixing or adding?
This causes both options pages to use the list of `valid_keys` instead of `world.location_names` or `world.item_names` if `valid_keys` is not empty.

## How was this tested?
Ran it locally and confirmed the correct lists were displayed.
