### PR TITLE
Use world.web.options_presets directly

### DIFF
--- a/WebHostLib/options.py
+++ b/WebHostLib/options.py
@@ -79,10 +79,6 @@ def test_ordered(obj):
 @cache.cached()
 def option_presets(game: str) -> Response:
     world = AutoWorldRegister.world_types[game]
-    presets = {}
-
-    if world.web.options_presets:
-        presets = presets | world.web.options_presets
 
     class SetEncoder(json.JSONEncoder):
         def default(self, obj):
@@ -91,7 +87,7 @@ def option_presets(game: str) -> Response:
                 return list(obj)
             return json.JSONEncoder.default(self, obj)
 
-    json_data = json.dumps(presets, cls=SetEncoder)
+    json_data = json.dumps(world.web.options_presets, cls=SetEncoder)
     response = Response(json_data)
     response.headers["Content-Type"] = "application/json"
     return response


### PR DESCRIPTION
## What is this fixing or adding?
This prevents a crash on Python 3.8 by removing a bitwise or comparison between two dicts

## How was this tested?
Tested locally by running WebHost
