### PR TITLE
Customserver: only save on exit if it's in a good state.

### DIFF
--- a/WebHostLib/customserver.py
+++ b/WebHostLib/customserver.py
@@ -270,7 +270,8 @@ def run_server_process(name: str, ponyconfig: dict, static_server_data: dict,
                 await ctx.shutdown_task
 
             except (KeyboardInterrupt, SystemExit):
-                ctx._save()
+                if ctx.saving:
+                    ctx._save()
             except Exception as e:
                 with db_session:
                     room = Room.get(id=room_id)
@@ -278,7 +279,8 @@ def run_server_process(name: str, ponyconfig: dict, static_server_data: dict,
                 logger.exception(e)
                 raise
             else:
-                ctx._save()
+                if ctx.saving:
+                    ctx._save()
             finally:
                 try:
                     with (db_session):

--- a/WebHostLib/customserver.py
+++ b/WebHostLib/customserver.py
@@ -270,15 +270,17 @@ def run_server_process(name: str, ponyconfig: dict, static_server_data: dict,
                 await ctx.shutdown_task
 
             except (KeyboardInterrupt, SystemExit):
-                pass
-            except Exception:
+                ctx._save()
+            except Exception as e:
                 with db_session:
                     room = Room.get(id=room_id)
                     room.last_port = -1
+                logger.exception(e)
                 raise
+            else:
+                ctx._save()
             finally:
                 try:
-                    ctx._save()
                     with (db_session):
                         # ensure the Room does not spin up again on its own, minute of safety buffer
                         room = Room.get(id=room_id)


### PR DESCRIPTION
## What is this fixing or adding?
ctx._save() on finally may force a save of empty data if data was never loaded  successfully.

## How was this tested?
~~locally by adding a raise() into load.~~
On prod.

## If this makes graphical changes, please attach screenshots.
