### PR TITLE
Landstalker: Fixed rare generation issues

### DIFF
--- a/worlds/landstalker/Hints.py
+++ b/worlds/landstalker/Hints.py
@@ -30,6 +30,9 @@ def generate_lithograph_hint(world: "LandstalkerWorld"):
     jewel_items = world.jewel_items
 
     for item in jewel_items:
+        if item.location is None:
+            continue
+
         # Jewel hints are composed of 4 'words' shuffled randomly:
         # - the name of the player whose world contains said jewel (if not ours)
         # - the color of the jewel (if relevant)
@@ -61,7 +64,7 @@ def generate_random_hints(world: "LandstalkerWorld"):
     excluded_items = ["Life Stock", "EkeEke"]
 
     progression_items = [item for item in multiworld.itempool if item.advancement and
-                         item.name not in excluded_items]
+                         item.name not in excluded_items and item.location is not None]
 
     local_own_progression_items = [item for item in progression_items if item.player == this_player
                                    and item.location.player == this_player]

--- a/worlds/landstalker/Regions.py
+++ b/worlds/landstalker/Regions.py
@@ -37,7 +37,7 @@ def create_regions(world: "LandstalkerWorld"):
     for code, region_data in WORLD_NODES_JSON.items():
         random_hint_name = None
         if "hints" in region_data:
-            random_hint_name = multiworld.random.choice(region_data["hints"])
+            random_hint_name = world.random.choice(region_data["hints"])
         region = LandstalkerRegion(code, region_data["name"], player, multiworld, random_hint_name)
         regions_table[code] = region
         multiworld.regions.append(region)

--- a/worlds/landstalker/Rules.py
+++ b/worlds/landstalker/Rules.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 
 def _landstalker_has_visited_regions(state: CollectionState, player: int, regions):
-    return all([state.can_reach(region, None, player) for region in regions])
+    return all([state.has("event_visited_" + region.code, player) for region in regions])
 
 
 def _landstalker_has_health(state: CollectionState, player: int, health):

--- a/worlds/landstalker/Rules.py
+++ b/worlds/landstalker/Rules.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 
 def _landstalker_has_visited_regions(state: CollectionState, player: int, regions):
-    return all([state.has("event_visited_" + region.code, player) for region in regions])
+    return all(state.has("event_visited_" + region.code, player) for region in regions)
 
 
 def _landstalker_has_health(state: CollectionState, player: int, health):

--- a/worlds/landstalker/__init__.py
+++ b/worlds/landstalker/__init__.py
@@ -204,6 +204,9 @@ class LandstalkerWorld(World):
             for location in self.multiworld.get_locations(self.player):
                 if location.parent_region.name in excluded_regions:
                     location.progress_type = LocationProgressType.EXCLUDED
+                # We need to make that event non-progression since it would crash generation in reach_kazalt goal
+                if location.item is not None and location.item.name == "event_visited_king_nole_labyrinth_raft_entrance":
+                    location.item.classification = ItemClassification.filler
 
     def get_starting_health(self):
         spawn_id = self.options.spawn_region.current_key


### PR DESCRIPTION
## What is this fixing or adding?

This fixes generation bugs reported in the following Discord threads:
https://discord.com/channels/731205301247803413/1199949415373344798
https://discord.com/channels/731205301247803413/1225442951447187456

These issues were caused by three different causes:
- World hint system referencing location for progression items whereas in some cases, progression items appear to have no location on generation end (that's weird, but at least Landstalker won't try to hint them anymore)
- World was using `can_reach` in an unreliable way, those were replaced by events
- There was one case of `multiworld.random` being used instead of `world.random`. This was not reported but I preferred to fix it.

## How was this tested?

This was tested by generating hundreds of seeds with various option combinations each.
Not a single one caused a generation issue.
Logic was manually analyzed for a few seeds to ensure can_reach replacement events are well tested, and playthrough made perfect sense while using events.