### PR TITLE
Core: don't allow `parent_region` of `Entrance` to be `None`

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -819,13 +819,13 @@ class Entrance:
     hide_path: bool = False
     player: int
     name: str
-    parent_region: Optional[Region]
+    parent_region: Region
     connected_region: Optional[Region] = None
     # LttP specific, TODO: should make a LttPEntrance
     addresses = None
     target = None
 
-    def __init__(self, player: int, name: str = '', parent: Region = None):
+    def __init__(self, player: int, name: str, parent: Region):
         self.name = name
         self.parent_region = parent
         self.player = player

--- a/worlds/oot/Entrance.py
+++ b/worlds/oot/Entrance.py
@@ -3,7 +3,7 @@ from BaseClasses import Entrance
 class OOTEntrance(Entrance): 
     game: str = 'Ocarina of Time'
 
-    def __init__(self, player, world, name='', parent=None): 
+    def __init__(self, player, world, name, parent): 
         super(OOTEntrance, self).__init__(player, name, parent)
         self.multiworld = world
         self.access_rules = []


### PR DESCRIPTION
## What is this fixing or adding?

There are a lot of places where we use `parent_region` without checking to see if it's `None`
so this should be safer.

I went through everthing with both "find all references" to `Entrance.__init__` and a text search for "`Entrance(`"
with special attention to the subclasses of `Entrance` in OoT, LADX, Messenger, and Pokemon RB.
(LADX also has a class named `Entrance` that is not a subclass of this.)

I was not able to find any cases of using the defaults, or of passing `None` for the parent region.

I don't know of any reason we would want to create an `Entrance` without a parent region.

## How was this tested?

just unit tests
