### PR TITLE
MLSS: Remove logger message from validate_rom

### DIFF
--- a/worlds/mlss/Client.py
+++ b/worlds/mlss/Client.py
@@ -48,10 +48,6 @@ class MLSSClient(BizHawkClient):
             rom_name_bytes = await bizhawk.read(ctx.bizhawk_ctx, [(0xA0, 14, "ROM")])
             rom_name = bytes([byte for byte in rom_name_bytes[0] if byte != 0]).decode("UTF-8")
             if not rom_name.startswith("MARIO&LUIGIUA8"):
-                logger.info(
-                    "ERROR: You have opened a game that is not Mario & Luigi Superstar Saga. "
-                    "Please make sure you are opening the correct ROM."
-                )
                 return False
         except UnicodeDecodeError:
             return False


### PR DESCRIPTION
## What is this fixing or adding?
Removes a logger.info() call from validate_rom. This would be called in other games clients if they we're alphabetically past mlss.

## How was this tested?
Loaded a game of Pokemon Emerald and the logger message from mlss didn't pop up.

## If this makes graphical changes, please attach screenshots.
