### PR TITLE
Fix options pages sometimes displaying blank values in form fields

### DIFF
--- a/WebHostLib/options.py
+++ b/WebHostLib/options.py
@@ -80,6 +80,34 @@ def test_ordered(obj):
 def option_presets(game: str) -> Response:
     world = AutoWorldRegister.world_types[game]
 
+    presets = {}
+    for preset_name, preset in world.web.options_presets.items():
+        presets[preset_name] = {}
+        for preset_option_name, preset_option in preset.items():
+            if preset_option == "random":
+                presets[preset_name][preset_option_name] = preset_option
+                continue
+
+            option = world.options_dataclass.type_hints[preset_option_name].from_any(preset_option)
+            if isinstance(option, Options.NamedRange) and isinstance(preset_option, str):
+                assert preset_option in option.special_range_names, \
+                    f"Invalid preset value '{preset_option}' for '{preset_option_name}' in '{preset_name}'. " \
+                    f"Expected {option.special_range_names.keys()} or {option.range_start}-{option.range_end}."
+
+                presets[preset_name][preset_option_name] = option.value
+            elif isinstance(option, Options.Range):
+                presets[preset_name][preset_option_name] = option.value
+            elif isinstance(preset_option, str):
+                # Ensure the option value is valid for Choice and Toggle options
+                assert option.name_lookup[option.value] == preset_option, \
+                    f"Invalid option value '{preset_option}' for '{preset_option_name}' in preset '{preset_name}'. " \
+                    f"Values must not be resolved to a different option via option.from_text (or an alias)."
+                # Use the name of the option
+                presets[preset_name][preset_option_name] = option.current_key
+            else:
+                # Use the name of the option
+                presets[preset_name][preset_option_name] = option.current_key
+
     class SetEncoder(json.JSONEncoder):
         def default(self, obj):
             from collections.abc import Set
@@ -87,7 +115,7 @@ def option_presets(game: str) -> Response:
                 return list(obj)
             return json.JSONEncoder.default(self, obj)
 
-    json_data = json.dumps(world.web.options_presets, cls=SetEncoder)
+    json_data = json.dumps(presets, cls=SetEncoder)
     response = Response(json_data)
     response.headers["Content-Type"] = "application/json"
     return response


### PR DESCRIPTION
## What is this fixing or adding?
This fixes a bug causing values on the options pages to sometimes display as blank fields if a preset was chosen which was defined in a particular way

## How was this tested?
Tested locally by running WebHost

## If this makes graphical changes, please attach screenshots.
### Before:
![image](https://github.com/ArchipelagoMW/Archipelago/assets/6321333/c13104bb-0345-469b-bc13-b0d30086f589)

### After:
![image](https://github.com/ArchipelagoMW/Archipelago/assets/6321333/7da2f60a-9362-4e0b-aebc-c1191833703c)
