### PR TITLE
Core, DS3: Gutting the rest of item/location descriptions

### DIFF
--- a/docs/world api.md
+++ b/docs/world api.md
@@ -178,36 +178,6 @@ Classification is one of `LocationProgressType.DEFAULT`, `PRIORITY` or `EXCLUDED
 The Fill algorithm will force progression items to be placed at priority locations, giving a higher chance of them being
 required, and will prevent progression and useful items from being placed at excluded locations.
 
-#### Documenting Locations
-
-Worlds can optionally provide a `location_descriptions` map which contains human-friendly descriptions of locations and
-location groups. These descriptions will show up in location-selection options on the options pages.
-
-```python
-# locations.py
-
-location_descriptions = {
-    "Red Potion #6": "In a secret destructible block under the second stairway",
-    "L2 Spaceship":
-        """
-        The group of all items in the spaceship in Level 2.
-
-        This doesn't include the item on the spaceship door, since it can be accessed without the Spaceship Key.
-        """
-}
-```
-
-```python
-# __init__.py
-
-from worlds.AutoWorld import World
-from .locations import location_descriptions
-
-
-class MyGameWorld(World):
-    location_descriptions = location_descriptions
-```
-
 ### Items
 
 Items are all things that can "drop" for your game. This may be RPG items like weapons, or technologies you normally
@@ -231,36 +201,6 @@ Other classifications include:
   combined with `progression`; see below)
 * `progression_skip_balancing`: the combination of `progression` and `skip_balancing`, i.e., a progression item that
   will not be moved around by progression balancing; used, e.g., for currency or tokens, to not flood early spheres
-
-#### Documenting Items
-
-Worlds can optionally provide an `item_descriptions` map which contains human-friendly descriptions of items and item
-groups. These descriptions will show up in item-selection options on the options pages.
-
-```python
-# items.py
-
-item_descriptions = {
-    "Red Potion": "A standard health potion",
-    "Spaceship Key":
-        """
-        The key to the spaceship in Level 2.
-
-        This is necessary to get to the Star Realm.
-        """
-}
-```
-
-```python
-# __init__.py
-
-from worlds.AutoWorld import World
-from .items import item_descriptions
-
-
-class MyGameWorld(World):
-    item_descriptions = item_descriptions
-```
 
 ### Events
 

--- a/test/general/test_items.py
+++ b/test/general/test_items.py
@@ -64,15 +64,6 @@ class TestBase(unittest.TestCase):
                 for item in multiworld.itempool:
                     self.assertIn(item.name, world_type.item_name_to_id)
 
-    def test_item_descriptions_have_valid_names(self):
-        """Ensure all item descriptions match an item name or item group name"""
-        for game_name, world_type in AutoWorldRegister.world_types.items():
-            valid_names = world_type.item_names.union(world_type.item_name_groups)
-            for name in world_type.item_descriptions:
-                with self.subTest("Name should be valid", game=game_name, item=name):
-                    self.assertIn(name, valid_names,
-                                  "All item descriptions must match defined item names")
-
     def test_itempool_not_modified(self):
         """Test that worlds don't modify the itempool after `create_items`"""
         gen_steps = ("generate_early", "create_regions", "create_items")

--- a/test/general/test_locations.py
+++ b/test/general/test_locations.py
@@ -66,12 +66,3 @@ class TestBase(unittest.TestCase):
                         for location in locations:
                             self.assertIn(location, world_type.location_name_to_id)
                         self.assertNotIn(group_name, world_type.location_name_to_id)
-
-    def test_location_descriptions_have_valid_names(self):
-        """Ensure all location descriptions match a location name or location group name"""
-        for game_name, world_type in AutoWorldRegister.world_types.items():
-            valid_names = world_type.location_names.union(world_type.location_name_groups)
-            for name in world_type.location_descriptions:
-                with self.subTest("Name should be valid", game=game_name, location=name):
-                    self.assertIn(name, valid_names,
-                                  "All location descriptions must match defined location names")

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -55,17 +55,11 @@ class AutoWorldRegister(type):
         dct["item_name_groups"] = {group_name: frozenset(group_set) for group_name, group_set
                                    in dct.get("item_name_groups", {}).items()}
         dct["item_name_groups"]["Everything"] = dct["item_names"]
-        dct["item_descriptions"] = {name: _normalize_description(description) for name, description
-                                    in dct.get("item_descriptions", {}).items()}
-        dct["item_descriptions"]["Everything"] = "All items in the entire game."
         dct["location_names"] = frozenset(dct["location_name_to_id"])
         dct["location_name_groups"] = {group_name: frozenset(group_set) for group_name, group_set
                                        in dct.get("location_name_groups", {}).items()}
         dct["location_name_groups"]["Everywhere"] = dct["location_names"]
         dct["all_item_and_group_names"] = frozenset(dct["item_names"] | set(dct.get("item_name_groups", {})))
-        dct["location_descriptions"] = {name: _normalize_description(description) for name, description
-                                    in dct.get("location_descriptions", {}).items()}
-        dct["location_descriptions"]["Everywhere"] = "All locations in the entire game."
 
         # move away from get_required_client_version function
         if "game" in dct:
@@ -252,22 +246,8 @@ class World(metaclass=AutoWorldRegister):
     item_name_groups: ClassVar[Dict[str, Set[str]]] = {}
     """maps item group names to sets of items. Example: {"Weapons": {"Sword", "Bow"}}"""
 
-    item_descriptions: ClassVar[Dict[str, str]] = {}
-    """An optional map from item names (or item group names) to brief descriptions for users.
-
-    Individual newlines and indentation will be collapsed into spaces before these descriptions are
-    displayed. This may cover only a subset of items.
-    """
-
     location_name_groups: ClassVar[Dict[str, Set[str]]] = {}
     """maps location group names to sets of locations. Example: {"Sewer": {"Sewer Key Drop 1", "Sewer Key Drop 2"}}"""
-
-    location_descriptions: ClassVar[Dict[str, str]] = {}
-    """An optional map from location names (or location group names) to brief descriptions for users.
-
-    Individual newlines and indentation will be collapsed into spaces before these descriptions are
-    displayed. This may cover only a subset of locations.
-    """
 
     data_version: ClassVar[int] = 0
     """
@@ -572,18 +552,3 @@ def data_package_checksum(data: "GamesPackage") -> str:
     assert sorted(data) == list(data), "Data not ordered"
     from NetUtils import encode
     return hashlib.sha1(encode(data).encode()).hexdigest()
-
-
-def _normalize_description(description):
-    """
-    Normalizes a description in item_descriptions or location_descriptions.
-
-    This allows authors to write descritions with nice indentation and line lengths in their world
-    definitions without having it affect the rendered format.
-    """
-    # First, collapse the whitespace around newlines and the ends of the description.
-    description = re.sub(r' *\n *', '\n', description.strip())
-    # Next, condense individual newlines into spaces.
-    description = re.sub(r'(?<!\n)\n(?!\n)', ' ', description)
-    return description
-

--- a/worlds/dark_souls_3/Items.py
+++ b/worlds/dark_souls_3/Items.py
@@ -1271,14 +1271,6 @@ _cut_content_items = [DS3ItemData(row[0], row[1], False, row[2]) for row in [
     ("Dorris Swarm",                        0x40393870, DS3ItemCategory.SKIP),
 ]]
 
-item_descriptions = {
-    "Cinders": """
-      All four Cinders of a Lord.
-
-      Once you have these four, you can fight Soul of Cinder and win the game.
-    """,
-}
-
 _all_items = _vanilla_items + _dlc_items
 
 item_dictionary = {item_data.name: item_data for item_data in _all_items}

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -7,7 +7,7 @@ from Options import Toggle
 from worlds.AutoWorld import World, WebWorld
 from worlds.generic.Rules import set_rule, add_rule, add_item_rule
 
-from .Items import DarkSouls3Item, DS3ItemCategory, item_dictionary, key_item_names, item_descriptions
+from .Items import DarkSouls3Item, DS3ItemCategory, item_dictionary, key_item_names
 from .Locations import DarkSouls3Location, DS3LocationCategory, location_tables, location_dictionary
 from .Options import RandomizeWeaponLevelOption, PoolTypeOption, EarlySmallLothricBanner, dark_souls_options
 
@@ -61,7 +61,6 @@ class DarkSouls3World(World):
             "Cinders of a Lord - Lothric Prince"
         }
     }
-    item_descriptions = item_descriptions
 
 
     def __init__(self, multiworld: MultiWorld, player: int):


### PR DESCRIPTION
## What is this fixing or adding?

https://discord.com/channels/731205301247803413/731214280439103580/1241175981784305784

> And I'll ask again whether or not the remove of item and locations descriptions was intended

https://discord.com/channels/731205301247803413/731214280439103580/1241176207962279976

> Yes, that removal was intended. It never displayed correctly, and in some cases wouldn't have worked at all. I may yet re-add it later.

https://discord.com/channels/731205301247803413/731214280439103580/1241581588974665789

> and  that item/location-descriptions as a feature was  entirely removed, likely  as an accident as it was not listed as a change.

As it was not an accident, all of the related code and documentation should have been gutted as well.

## How was this tested?

Unit tests and generations.
