### PR TITLE
CustomServer: properly 'inherit' Archipelago from static_server_data

### DIFF
--- a/WebHostLib/customserver.py
+++ b/WebHostLib/customserver.py
@@ -106,9 +106,9 @@ class WebHostContext(Context):
         static_gamespackage = self.gamespackage  # this is shared across all rooms
         static_item_name_groups = self.item_name_groups
         static_location_name_groups = self.location_name_groups
-        self.gamespackage = {"Archipelago": static_gamespackage["Archipelago"]}  # this may be modified by _load
-        self.item_name_groups = {}
-        self.location_name_groups = {}
+        self.gamespackage = {"Archipelago": static_gamespackage.get("Archipelago", {})}  # this may be modified by _load
+        self.item_name_groups = {"Archipelago": static_item_name_groups.get("Archipelago", {})}
+        self.location_name_groups = {"Archipelago": static_location_name_groups.get("Archipelago", {})}
 
         for game in list(multidata.get("datapackage", {})):
             game_data = multidata["datapackage"][game]


### PR DESCRIPTION
This fixes a potential exception during room spin-up.

## What is this fixing or adding?

https://discord.com/channels/731205301247803413/731214280439103580/1242434692234481795

## How was this tested?

Sinning up webhost, connecting to an "unsupported" and a "supported" game and receiving the Datapackage for 'Archipelago' in both cases.
