### PR TITLE
Webhost: Disallow empty option groups

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -1155,6 +1155,10 @@ def get_option_groups(world: typing.Type[World], visibility_level: Visibility = 
         if visibility_level & option.visibility:
             grouped_options[option_groups.get(option, "Game Options")][option_name] = option
 
+    # if the world doesn't have any ungrouped options, this group will be empty so just remove it
+    if not grouped_options["Game Options"]:
+        del grouped_options["Game Options"]
+
     return grouped_options
 
 

--- a/Options.py
+++ b/Options.py
@@ -1132,7 +1132,16 @@ class OptionGroup(typing.NamedTuple):
     """Options to be in the defined group."""
 
 
-def generate_yaml_templates(target_folder: typing.Union[str, "pathlib.Path"], generate_hidden: bool = True):
+item_and_loc_options = [LocalItems, NonLocalItems, StartInventory, StartInventoryPool, StartHints,
+                        StartLocationHints, ExcludeLocations, PriorityLocations, ItemLinks]
+"""
+Options that are always populated in "Item & Location Options" Option Group. Cannot be moved to another group.
+If desired, a custom "Item & Location Options" Option Group can be defined, but only for adding additional options to
+it.
+"""
+
+
+def generate_yaml_templates(target_folder: typing.Union[str, "pathlib.Path"], generate_hidden: bool = True) -> None:
     import os
 
     import yaml

--- a/Options.py
+++ b/Options.py
@@ -1142,7 +1142,7 @@ it.
 
 
 def get_option_groups(world: typing.Type[World], visibility_level: Visibility = Visibility.template) -> typing.Dict[
-    str, typing.Dict[str, typing.Type[Option[typing.Any]]]]:
+        str, typing.Dict[str, typing.Type[Option[typing.Any]]]]:
     """Generates and returns a dictionary for the option groups of a specified world."""
     option_groups = {option: option_group.name
                      for option_group in world.web.option_groups

--- a/WebHostLib/options.py
+++ b/WebHostLib/options.py
@@ -27,26 +27,16 @@ def get_world_theme(game_name: str) -> str:
 
 
 def render_options_page(template: str, world_name: str, is_complex: bool = False) -> Union[Response, str]:
-    visibility_flag = Options.Visibility.complex_ui if is_complex else Options.Visibility.simple_ui
     world = AutoWorldRegister.world_types[world_name]
     if world.hidden or world.web.options_page is False:
         return redirect("games")
-
-    option_groups = {option: option_group.name
-                     for option_group in world.web.option_groups
-                     for option in option_group.options}
-    ordered_groups = ["Game Options", *[group.name for group in world.web.option_groups]]
-    grouped_options = {group: {} for group in ordered_groups}
-    for option_name, option in world.options_dataclass.type_hints.items():
-        # Exclude settings from options pages if their visibility is disabled
-        if visibility_flag in option.visibility:
-            grouped_options[option_groups.get(option, "Game Options")][option_name] = option
+    visibility_flag = Options.Visibility.complex_ui if is_complex else Options.Visibility.simple_ui
 
     return render_template(
         template,
         world_name=world_name,
         world=world,
-        option_groups=grouped_options,
+        option_groups=Options.get_option_groups(world, visibility_level=visibility_flag),
         issubclass=issubclass,
         Options=Options,
         theme=get_world_theme(world_name),

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -11,10 +11,7 @@ from dataclasses import make_dataclass
 from typing import (Any, Callable, ClassVar, Dict, FrozenSet, List, Mapping,
                     Optional, Set, TextIO, Tuple, TYPE_CHECKING, Type, Union)
 
-from Options import (
-    ExcludeLocations, ItemLinks, LocalItems, NonLocalItems, OptionGroup, PerGameCommonOptions,
-    PriorityLocations, StartHints, StartInventory, StartInventoryPool, StartLocationHints
-)
+from Options import item_and_loc_options, OptionGroup, PerGameCommonOptions
 from BaseClasses import CollectionState
 
 if TYPE_CHECKING:
@@ -125,8 +122,6 @@ class WebWorldRegister(type):
         # don't allow an option to appear in multiple groups, allow "Item & Location Options" to appear anywhere by the
         # dev, putting it at the end if they don't define options in it
         option_groups: List[OptionGroup] = dct.get("option_groups", [])
-        item_and_loc_options = [LocalItems, NonLocalItems, StartInventory, StartInventoryPool, StartHints,
-                                StartLocationHints, ExcludeLocations, PriorityLocations, ItemLinks]
         seen_options = []
         item_group_in_list = False
         for group in option_groups:

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -126,6 +126,7 @@ class WebWorldRegister(type):
         item_group_in_list = False
         for group in option_groups:
             assert group.name != "Game Options", "Game Options is a pre-determined group and can not be defined."
+            assert group.options, "A custom defined Option Group must contain at least one Option."
             if group.name == "Item & Location Options":
                 group.options.extend(item_and_loc_options)
                 item_group_in_list = True


### PR DESCRIPTION
## What is this fixing or adding?
prevents worlds from defining an option group with no options in it, fixes options always being printed to the template when they shouldn't be, removes the default "Game Options" option group if it's empty.

## How was this tested?

![Screenshot_231](https://github.com/ArchipelagoMW/Archipelago/assets/13184667/86d6f17c-35f5-43b5-b99d-1c66cbfb87db)
