### PR TITLE
Docs: Add detail on customizing the forced groups

### DIFF
--- a/docs/options api.md
+++ b/docs/options api.md
@@ -86,17 +86,27 @@ class ExampleWorld(World):
 ```
 
 ### Option Groups
-Options may be categorized into groups for display on the WebHost. Option groups are displayed alphabetically on the
-player-options and weighted-options pages. Options without a group name are categorized into a generic "Game Options"
-group.
+Options may be categorized into groups for display on the WebHost. Option groups are displayed in the order as specified
+by your world on the player-options and weighted-options pages.
+
+Options without a group name are categorized into a generic "Game Options" group, which is always the first group. If
+every option for your world is in a group, this group will be removed. There is also an "Items & Locations Options"
+group, which is automatically created using certain specified`item_and_loc_options`. These specified options cannot be
+removed from this group.
+
+Both the "Game Options" and "Item & Location Options" groups can be overridden by creating your own groups with
+those names, and specify specific options to add to them. The "Item & Location Options" group can also be moved to a
+different position in the group ordering, but "Game Options" will always be first, regardless of where it is in your
+list.
 
 ```python
 from worlds.AutoWorld import WebWorld
 from Options import OptionGroup
+from . import Options
 
 class MyWorldWeb(WebWorld):
     option_groups = [
-        OptionGroup('Color Options', [
+        OptionGroup("Color Options", [
             Options.ColorblindMode,
             Options.FlashReduction,
             Options.UIColors,

--- a/docs/options api.md
+++ b/docs/options api.md
@@ -86,7 +86,7 @@ class ExampleWorld(World):
 ```
 
 ### Option Groups
-Options may be categorized into groups for display on the WebHost. Option groups are displayed in the order as specified
+Options may be categorized into groups for display on the WebHost. Option groups are displayed in the order specified
 by your world on the player-options and weighted-options pages. In the generated template files, there will be a comment
 with the group name at the beginning of each group of options. The `start_collapsed` Boolean only affects how the groups
 appear on the WebHost, with the grouping being collapsed when this is `True`.

--- a/docs/options api.md
+++ b/docs/options api.md
@@ -87,7 +87,9 @@ class ExampleWorld(World):
 
 ### Option Groups
 Options may be categorized into groups for display on the WebHost. Option groups are displayed in the order as specified
-by your world on the player-options and weighted-options pages.
+by your world on the player-options and weighted-options pages. In the generated template files, there will be a comment
+with the group name at the beginning of each group of options. The `start_collapsed` only affects how the groups appear
+on the WebHost, with the grouping being collapsed when this is `True`.
 
 Options without a group name are categorized into a generic "Game Options" group, which is always the first group. If
 every option for your world is in a group, this group will be removed. There is also an "Items & Locations Options"
@@ -95,9 +97,9 @@ group, which is automatically created using certain specified`item_and_loc_optio
 removed from this group.
 
 Both the "Game Options" and "Item & Location Options" groups can be overridden by creating your own groups with
-those names, and specify specific options to add to them. The "Item & Location Options" group can also be moved to a
-different position in the group ordering, but "Game Options" will always be first, regardless of where it is in your
-list.
+those names, and specify specific options to add to them, as well as change the visibility. The "Item & Location
+Options" group can also be moved to a different position in the group ordering, but "Game Options" will always be first,
+regardless of where it is in your list.
 
 ```python
 from worlds.AutoWorld import WebWorld

--- a/docs/options api.md
+++ b/docs/options api.md
@@ -92,8 +92,8 @@ with the group name at the beginning of each group of options. The `start_collap
 on the WebHost, with the grouping being collapsed when this is `True`.
 
 Options without a group name are categorized into a generic "Game Options" group, which is always the first group. If
-every option for your world is in a group, this group will be removed. There is also an "Items & Locations Options"
-group, which is automatically created using certain specified`item_and_loc_options`. These specified options cannot be
+every option for your world is in a group, this group will be removed. There is also an "Items & Location Options"
+group, which is automatically created using certain specified `item_and_loc_options`. These specified options cannot be
 removed from this group.
 
 Both the "Game Options" and "Item & Location Options" groups can be overridden by creating your own groups with

--- a/docs/options api.md
+++ b/docs/options api.md
@@ -97,7 +97,7 @@ group, which is automatically created using certain specified `item_and_loc_opti
 removed from this group.
 
 Both the "Game Options" and "Item & Location Options" groups can be overridden by creating your own groups with
-those names, allowing specifying options to add to them, as well as change whether they start collapsed. The "Item &
+those names, letting you add options to them and change whether they start collapsed. The "Item &
 Location Options" group can also be moved to a different position in the group ordering, but "Game Options" will always
 be first, regardless of where it is in your list.
 

--- a/docs/options api.md
+++ b/docs/options api.md
@@ -88,8 +88,8 @@ class ExampleWorld(World):
 ### Option Groups
 Options may be categorized into groups for display on the WebHost. Option groups are displayed in the order as specified
 by your world on the player-options and weighted-options pages. In the generated template files, there will be a comment
-with the group name at the beginning of each group of options. The `start_collapsed` only affects how the groups appear
-on the WebHost, with the grouping being collapsed when this is `True`.
+with the group name at the beginning of each group of options. The `start_collapsed` Boolean only affects how the groups
+appear on the WebHost, with the grouping being collapsed when this is `True`.
 
 Options without a group name are categorized into a generic "Game Options" group, which is always the first group. If
 every option for your world is in a group, this group will be removed. There is also an "Items & Location Options"
@@ -97,9 +97,9 @@ group, which is automatically created using certain specified `item_and_loc_opti
 removed from this group.
 
 Both the "Game Options" and "Item & Location Options" groups can be overridden by creating your own groups with
-those names, and specify specific options to add to them, as well as change the visibility. The "Item & Location
-Options" group can also be moved to a different position in the group ordering, but "Game Options" will always be first,
-regardless of where it is in your list.
+those names, allowing specifying options to add to them, as well as change whether they start collapsed. The "Item &
+Location Options" group can also be moved to a different position in the group ordering, but "Game Options" will always
+be first, regardless of where it is in your list.
 
 ```python
 from worlds.AutoWorld import WebWorld


### PR DESCRIPTION
## What is this fixing or adding?
Fixes an incorrect assertion on the ordering of option groups and adds detail on the two auto generated groups as well as how you can customize them.

## How was this tested?
:eye: