### PR TITLE
BizHawkClient: Add suggestion when no handler is found

### DIFF
--- a/worlds/_bizhawk/context.py
+++ b/worlds/_bizhawk/context.py
@@ -177,7 +177,8 @@ async def _game_watcher(ctx: BizHawkClientContext):
 
                 if ctx.client_handler is None:
                     if not showed_no_handler_message:
-                        logger.info("No handler was found for this game")
+                        logger.info("No handler was found for this game. Double-check that the apworld is installed "
+                                    "correctly and that you loaded the right ROM file.")
                         showed_no_handler_message = True
                     continue
                 else:


### PR DESCRIPTION
## What is this fixing or adding?

Clarifies common reasons a player might be seeing the "no handler was found" message. I've seen occasional confusion from players what they should do when they see it, and almost every time the answer is that they didn't install the apworld in the right place.

## How was this tested?

Wasn't
