### PR TITLE
TUNIC: Add option presets

### DIFF
--- a/worlds/tunic/__init__.py
+++ b/worlds/tunic/__init__.py
@@ -8,7 +8,7 @@ from .er_rules import set_er_location_rules
 from .regions import tunic_regions
 from .er_scripts import create_er_regions
 from .er_data import portal_mapping
-from .options import TunicOptions, EntranceRando, tunic_option_groups
+from .options import TunicOptions, EntranceRando, tunic_option_groups, tunic_option_presets
 from worlds.AutoWorld import WebWorld, World
 from worlds.generic import PlandoConnection
 from decimal import Decimal, ROUND_HALF_UP
@@ -28,6 +28,7 @@ class TunicWeb(WebWorld):
     theme = "grassFlowers"
     game = "TUNIC"
     option_groups = tunic_option_groups
+    option_presets = tunic_option_presets
 
 
 class TunicItem(Item):

--- a/worlds/tunic/__init__.py
+++ b/worlds/tunic/__init__.py
@@ -28,7 +28,7 @@ class TunicWeb(WebWorld):
     theme = "grassFlowers"
     game = "TUNIC"
     option_groups = tunic_option_groups
-    option_presets = tunic_option_presets
+    options_presets = tunic_option_presets
 
 
 class TunicItem(Item):

--- a/worlds/tunic/options.py
+++ b/worlds/tunic/options.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-
+from typing import Dict, Any
 from Options import (DefaultOnToggle, Toggle, StartInventoryPool, Choice, Range, TextChoice, PerGameCommonOptions,
                      OptionGroup)
 
@@ -199,3 +199,24 @@ tunic_option_groups = [
         Maskless,
     ])
 ]
+
+tunic_option_presets: Dict[str, Dict[str, Any]] = {
+    "Sync": {
+        "ability_shuffling": True,
+    },
+    "Async": {
+        "progression_balancing": 0,
+        "ability_shuffling": True,
+        "shuffle_ladders": True,
+        "laurels_location": "10_fairies",
+    },
+    "Glace Mode": {
+        "accessibility": "minimal",
+        "ability_shuffling": True,
+        "entrance_rando": True,
+        "fool_traps": "onslaught",
+        "logic_rules": "unrestricted",
+        "maskless": True,
+        "lanternless": True,
+    },
+}

--- a/worlds/tunic/options.py
+++ b/worlds/tunic/options.py
@@ -213,7 +213,7 @@ tunic_option_presets: Dict[str, Dict[str, Any]] = {
     "Glace Mode": {
         "accessibility": "minimal",
         "ability_shuffling": True,
-        "entrance_rando": True,
+        "entrance_rando": "yes",
         "fool_traps": "onslaught",
         "logic_rules": "unrestricted",
         "maskless": True,


### PR DESCRIPTION
## What is this fixing or adding?
Adds a few option presets for TUNIC. The first two to give a little recommendation for someone unsure what to bring to a sync or async. The third to punish the curious.

## How was this tested?
Ran webhost, made sure the presets worked as intended. Ran tests.

## If this makes graphical changes, please attach screenshots.
N/A