### PR TITLE
Core: Fix weights file data not being reused

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -415,7 +415,6 @@ def handle_option(ret: argparse.Namespace, game_weights: dict, option_key: str, 
                 player_option = option.from_any(game_weights[option_key])
             else:
                 player_option = option.from_any(get_choice(option_key, game_weights))
-            del game_weights[option_key]
         else:
             player_option = option.from_any(option.default)  # call the from_any here to support default "random"
         setattr(ret, option_key, player_option)
@@ -429,9 +428,9 @@ def roll_settings(weights: dict, plando_options: PlandoOptions = PlandoOptions.b
     if "linked_options" in weights:
         weights = roll_linked_options(weights)
 
-    valid_trigger_names = set()
+    valid_keys = set()
     if "triggers" in weights:
-        weights = roll_triggers(weights, weights["triggers"], valid_trigger_names)
+        weights = roll_triggers(weights, weights["triggers"], valid_keys)
 
     requirements = weights.get("requires", {})
     if requirements:
@@ -471,7 +470,7 @@ def roll_settings(weights: dict, plando_options: PlandoOptions = PlandoOptions.b
         raise Exception(f"Merge tag cannot be used outside of trigger contexts.")
 
     if "triggers" in game_weights:
-        weights = roll_triggers(weights, game_weights["triggers"], valid_trigger_names)
+        weights = roll_triggers(weights, game_weights["triggers"], valid_keys)
         game_weights = weights[ret.game]
 
     ret.name = get_choice('name', weights)
@@ -480,8 +479,9 @@ def roll_settings(weights: dict, plando_options: PlandoOptions = PlandoOptions.b
 
     for option_key, option in world_type.options_dataclass.type_hints.items():
         handle_option(ret, game_weights, option_key, option, plando_options)
+        valid_keys.add(option_key)
     for option_key in game_weights:
-        if option_key in {"triggers", *valid_trigger_names}:
+        if option_key in {"triggers", *valid_keys}:
             continue
         logging.warning(f"{option_key} is not a valid option name for {ret.game} and is not present in triggers.")
     if PlandoOptions.items in plando_options:


### PR DESCRIPTION
## What is this fixing or adding?
#3380
i forgot about weighted files when i added that delete line apparently. this reverses that checking by just adding the actual valid options to the set instead of deleting weights that we decide are valid.

## How was this tested?
generated with 1 custom and a weights file confirming that invalid options still print and custom options from the weights all worked.
