### PR TITLE
Core: Allow option groups to specify option order

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -1144,22 +1144,28 @@ it.
 def get_option_groups(world: typing.Type[World], visibility_level: Visibility = Visibility.template) -> typing.Dict[
         str, typing.Dict[str, typing.Type[Option[typing.Any]]]]:
     """Generates and returns a dictionary for the option groups of a specified world."""
-    option_groups = {option: option_group.name
-                     for option_group in world.web.option_groups
-                     for option in option_group.options}
+    option_to_name = {option: option_name for option_name, option in world.options_dataclass.type_hints.items()}
+
+    ordered_groups = {group.name: group.options for group in world.web.option_groups}
+
     # add a default option group for uncategorized options to get thrown into
-    ordered_groups = ["Game Options"]
-    [ordered_groups.append(group) for group in option_groups.values() if group not in ordered_groups]
-    grouped_options = {group: {} for group in ordered_groups}
-    for option_name, option in world.options_dataclass.type_hints.items():
-        if visibility_level & option.visibility:
-            grouped_options[option_groups.get(option, "Game Options")][option_name] = option
+    if "Game Options" not in ordered_groups:
+        grouped_options = set(option for group in ordered_groups.values() for option in group)
+        ungrouped_options = [option for option in world.options_dataclass.type_hints.values()
+                             if option not in grouped_options]
+        # if the world doesn't have any ungrouped options, this group will be empty so don't add it
+        if ungrouped_options:
+            ordered_groups = {**{"Game Options": ungrouped_options}, **ordered_groups}
 
-    # if the world doesn't have any ungrouped options, this group will be empty so just remove it
-    if not grouped_options["Game Options"]:
-        del grouped_options["Game Options"]
-
-    return grouped_options
+    return {
+        group: {
+            option_to_name[option]: option
+            for option in group_options
+            if (visibility_level in option.visibility
+                and option in world.options_dataclass.type_hints.values())
+        }
+        for group, group_options in ordered_groups.items()
+    }
 
 
 def generate_yaml_templates(target_folder: typing.Union[str, "pathlib.Path"], generate_hidden: bool = True) -> None:

--- a/Options.py
+++ b/Options.py
@@ -1155,7 +1155,7 @@ def get_option_groups(world: typing.Type[World], visibility_level: Visibility = 
         grouped_options = set(option for group in ordered_groups.values() for option in group)
         ungrouped_options = [option for option in world.options_dataclass.type_hints.values()
                              if option not in grouped_options]
-        # if the world doesn't have any ungrouped options, this group will be empty so don't add it
+        # only add the game options group if we have ungrouped options
         if ungrouped_options:
             ordered_groups = {**{"Game Options": ungrouped_options}, **ordered_groups}
 

--- a/Options.py
+++ b/Options.py
@@ -1153,8 +1153,7 @@ def get_option_groups(world: typing.Type[World], visibility_level: Visibility = 
     # add a default option group for uncategorized options to get thrown into
     if "Game Options" not in ordered_groups:
         grouped_options = set(option for group in ordered_groups.values() for option in group)
-        ungrouped_options = [option for option in world.options_dataclass.type_hints.values()
-                             if option not in grouped_options]
+        ungrouped_options = [option for option in option_to_name if option not in grouped_options]
         # only add the game options group if we have ungrouped options
         if ungrouped_options:
             ordered_groups = {**{"Game Options": ungrouped_options}, **ordered_groups}
@@ -1163,8 +1162,7 @@ def get_option_groups(world: typing.Type[World], visibility_level: Visibility = 
         group: {
             option_to_name[option]: option
             for option in group_options
-            if (visibility_level in option.visibility
-                and option in world.options_dataclass.type_hints.values())
+            if (visibility_level in option.visibility and option in option_to_name)
         }
         for group, group_options in ordered_groups.items()
     }


### PR DESCRIPTION
## What is this fixing or adding?
OptionGroup already requires a list, so we might as well use that ordering for something. This makes it so that option groups will order the options by the group's specification instead of the order defined in the dataclass.

## How was this tested?
with some test groups

## If this makes graphical changes, please attach screenshots.
![Screenshot_234](https://github.com/ArchipelagoMW/Archipelago/assets/13184667/f2e6e523-d228-40a2-bc5e-208adee0fff7)
![Screenshot_235](https://github.com/ArchipelagoMW/Archipelago/assets/13184667/e1c1fd5a-0aaf-4a6c-b623-37fb17716af6)
