### PR TITLE
Witness: Fix option description

### DIFF
--- a/worlds/witness/options.py
+++ b/worlds/witness/options.py
@@ -77,7 +77,7 @@ class DoorGroupings(Choice):
     Controls how door items are grouped.
 
     - Off: There will be one key for each door, potentially resulting in upwards of 120 keys being added to the item pool.
-    - Regional: - All doors in the same general region will open at once with a single key, reducing the amount of door items and complexity.
+    - Regional: All doors in the same general region will open at once with a single key, reducing the amount of door items and complexity.
     """
     display_name = "Door Groupings"
     option_off = 0


### PR DESCRIPTION
## What is this fixing or adding?

Changes option description to match actual option value, also fixes an extra `-`

## How was this tested?

👀

## If this makes graphical changes, please attach screenshots.

![Screenshot 2024-05-24 130445](https://github.com/ArchipelagoMW/Archipelago/assets/60412657/6fd83785-5b0c-4dbb-bc01-537906ee2324)
![Screenshot 2024-05-24 130536](https://github.com/ArchipelagoMW/Archipelago/assets/60412657/d815ee20-d6d1-40c4-b3cd-6cc429641607)
