### PR TITLE
CODEOWNERS: Remove @jtoyoda as world maintainer for Final Fantasy

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -6,10 +6,6 @@
 #
 # All usernames must be GitHub usernames (and are case sensitive).
 
-###################
-## Active Worlds ##
-###################
-
 # Adventure
 /worlds/adventure/ @JusticePS
 
@@ -66,9 +62,6 @@
 
 # Factorio
 /worlds/factorio/ @Berserker66
-
-# Final Fantasy
-/worlds/ff1/ @jtoyoda
 
 # Final Fantasy Mystic Quest
 /worlds/ffmq/ @Alchav @wildham0
@@ -215,9 +208,22 @@
 # Zork Grand Inquisitor
 /worlds/zork_grand_inquisitor/ @nbrochu
 
-##################################
-## Disabled Unmaintained Worlds ##
-##################################
+
+## Active Unmaintained Worlds
+
+# The following worlds in this repo are currently unmaintained, but currently still work in core. If any update breaks
+# compatibility, these worlds may be moved to `worlds_disabled`. If you are interested in stepping up as maintainer for
+# any of these worlds, please review `/docs/world maintainer.md` documentation.
+
+# Final Fantasy (1)
+# /worlds/ff1/
+
+
+## Disabled Unmaintained Worlds
+
+# The following worlds in this repo are currently unmaintained and disabled as they do not work in core. If you are
+# interested in stepping up as maintainer for any of these worlds, please review `/docs/world maintainer.md`
+# documentation.
 
 # Ori and the Blind Forest
-# /worlds_disabled/oribf/ <Unmaintained>
+# /worlds_disabled/oribf/


### PR DESCRIPTION
## What is this fixing or adding?
Removing as world maintainer based on this comment: https://github.com/ArchipelagoMW/Archipelago/pull/3284#issuecomment-2110461370

Keeping `ff1` world in `worlds` as world still works, but may move to `worlds_disabled` if world compatibility breaks with no new maintainer to take on the role.

## How was this tested?
N/A

## If this makes graphical changes, please attach screenshots.
N/A