### PR TITLE
Setup: pin cx_freeze to 7.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 # This is a bit jank. We need cx-Freeze to be able to run anything from this script, so install it
 try:
-    requirement = 'cx-Freeze>=7.0.0'
+    requirement = 'cx-Freeze==7.0.0'
     import pkg_resources
     try:
         pkg_resources.require(requirement)


### PR DESCRIPTION
## What is this fixing or adding?

7.1.0 is broken on Linux when using pygobject, which we use as optional dependency for kivy.
Already reported upstream. 

## How was this tested?

The last round of builds was done with 7.0.0 and they worked.
