### PR TITLE
WebHost: update trackers only if they're visible.

### DIFF
--- a/WebHostLib/static/assets/trackerCommon.js
+++ b/WebHostLib/static/assets/trackerCommon.js
@@ -27,7 +27,7 @@ const adjustTableHeight = () => {
  * @returns {string}
  */
 const secondsToHours = (seconds) => {
-    let hours   = Math.floor(seconds / 3600);
+    let hours = Math.floor(seconds / 3600);
     let minutes = Math.floor((seconds - (hours * 3600)) / 60).toString().padStart(2, '0');
     return `${hours}:${minutes}`;
 };
@@ -38,18 +38,18 @@ window.addEventListener('load', () => {
         info: false,
         dom: "t",
         stateSave: true,
-        stateSaveCallback: function(settings, data) {
+        stateSaveCallback: function (settings, data) {
             delete data.search;
             localStorage.setItem(`DataTables_${settings.sInstance}_/tracker`, JSON.stringify(data));
         },
-        stateLoadCallback: function(settings) {
+        stateLoadCallback: function (settings) {
             return JSON.parse(localStorage.getItem(`DataTables_${settings.sInstance}_/tracker`));
         },
-        footerCallback: function(tfoot, data, start, end, display) {
+        footerCallback: function (tfoot, data, start, end, display) {
             if (tfoot) {
                 const activityData = this.api().column('lastActivity:name').data().toArray().filter(x => !isNaN(x));
                 Array.from(tfoot?.children).find(td => td.classList.contains('last-activity')).innerText =
-                  (activityData.length) ? secondsToHours(Math.min(...activityData)) : 'None';
+                    (activityData.length) ? secondsToHours(Math.min(...activityData)) : 'None';
             }
         },
         columnDefs: [
@@ -126,45 +126,60 @@ window.addEventListener('load', () => {
     const tracker = document.getElementById('tracker-wrapper').getAttribute('data-tracker');
     const target_second = document.getElementById('tracker-wrapper').getAttribute('data-second') + 3;
 
-    function getSleepTimeSeconds(){
+    function getSleepTimeSeconds() {
         // -40 % 60 is -40, which is absolutely wrong and should burn
         var sleepSeconds = (((target_second - new Date().getSeconds()) % 60) + 60) % 60;
         return sleepSeconds || 60;
     }
 
+    let update_on_view = false;
     const update = () => {
-        const target = $("<div></div>");
-        console.log("Updating Tracker...");
-        target.load(location.href, function (response, status) {
-            if (status === "success") {
-                target.find(".table").each(function (i, new_table) {
-                    const new_trs = $(new_table).find("tbody>tr");
-                    const footer_tr = $(new_table).find("tfoot>tr");
-                    const old_table = tables.eq(i);
-                    const topscroll = $(old_table.settings()[0].nScrollBody).scrollTop();
-                    const leftscroll = $(old_table.settings()[0].nScrollBody).scrollLeft();
-                    old_table.clear();
-                    if (footer_tr.length) {
-                        $(old_table.table).find("tfoot").html(footer_tr);
-                    }
-                    old_table.rows.add(new_trs);
-                    old_table.draw();
-                    $(old_table.settings()[0].nScrollBody).scrollTop(topscroll);
-                    $(old_table.settings()[0].nScrollBody).scrollLeft(leftscroll);
-                });
-                $("#multi-stream-link").replaceWith(target.find("#multi-stream-link"));
-            } else {
-                console.log("Failed to connect to Server, in order to update Table Data.");
-                console.log(response);
-            }
-        })
-        setTimeout(update, getSleepTimeSeconds()*1000);
+        if (document.hidden) {
+            console.log("Document reporting as not visible, not updating Tracker...");
+            update_on_view = true;
+        } else {
+            update_on_view = false;
+            const target = $("<div></div>");
+            console.log("Updating Tracker...");
+            target.load(location.href, function (response, status) {
+                if (status === "success") {
+                    target.find(".table").each(function (i, new_table) {
+                        const new_trs = $(new_table).find("tbody>tr");
+                        const footer_tr = $(new_table).find("tfoot>tr");
+                        const old_table = tables.eq(i);
+                        const topscroll = $(old_table.settings()[0].nScrollBody).scrollTop();
+                        const leftscroll = $(old_table.settings()[0].nScrollBody).scrollLeft();
+                        old_table.clear();
+                        if (footer_tr.length) {
+                            $(old_table.table).find("tfoot").html(footer_tr);
+                        }
+                        old_table.rows.add(new_trs);
+                        old_table.draw();
+                        $(old_table.settings()[0].nScrollBody).scrollTop(topscroll);
+                        $(old_table.settings()[0].nScrollBody).scrollLeft(leftscroll);
+                    });
+                    $("#multi-stream-link").replaceWith(target.find("#multi-stream-link"));
+                } else {
+                    console.log("Failed to connect to Server, in order to update Table Data.");
+                    console.log(response);
+                }
+            })
+        }
+        updater = setTimeout(update, getSleepTimeSeconds() * 1000);
     }
-    setTimeout(update, getSleepTimeSeconds()*1000);
+    let updater = setTimeout(update, getSleepTimeSeconds() * 1000);
 
     window.addEventListener('resize', () => {
         adjustTableHeight();
         tables.draw();
+    });
+
+    window.addEventListener('visibilitychange', () => {
+        if (!document.hidden && update_on_view) {
+            console.log("Page became visible, tracker should be refreshed.");
+            clearTimeout(updater);
+            update();
+        }
     });
 
     adjustTableHeight();

--- a/WebHostLib/static/assets/trackerCommon.js
+++ b/WebHostLib/static/assets/trackerCommon.js
@@ -123,8 +123,8 @@ window.addEventListener('load', () => {
             event.preventDefault();
         }
     });
-    const tracker = document.getElementById('tracker-wrapper').getAttribute('data-tracker');
-    const target_second = document.getElementById('tracker-wrapper').getAttribute('data-second') + 3;
+    const target_second = parseInt(document.getElementById('tracker-wrapper').getAttribute('data-second')) + 3;
+    console.log("Target second of refresh: " + target_second);
 
     function getSleepTimeSeconds() {
         // -40 % 60 is -40, which is absolutely wrong and should burn

--- a/WebHostLib/templates/multitracker.html
+++ b/WebHostLib/templates/multitracker.html
@@ -10,7 +10,7 @@
     {% include "header/dirtHeader.html" %}
     {% include "multitrackerNavigation.html" %}
 
-    <div id="tracker-wrapper" data-tracker="{{ room.tracker | suuid }}">
+    <div id="tracker-wrapper" data-tracker="{{ room.tracker | suuid }}" data-second="{{ saving_second }}">
         <div id="tracker-header-bar">
             <input placeholder="Search" id="search" />
 

--- a/WebHostLib/tracker.py
+++ b/WebHostLib/tracker.py
@@ -411,6 +411,7 @@ def render_generic_multiworld_tracker(tracker_data: TrackerData, enabled_tracker
         videos=tracker_data.get_room_videos(),
         item_id_to_name=tracker_data.item_id_to_name,
         location_id_to_name=tracker_data.location_id_to_name,
+        saving_second=tracker_data.get_room_saving_second(),
     )
 
 

--- a/WebHostLib/tracker.py
+++ b/WebHostLib/tracker.py
@@ -300,8 +300,10 @@ def _process_if_request_valid(incoming_request, room: Optional[Room]) -> Optiona
     if_modified = incoming_request.headers.get("If-Modified-Since", None)
     if if_modified:
         if_modified = parsedate_to_datetime(if_modified)
-        if if_modified < room.last_activity:
+        # if_modified has less precision than last_activity, so we add an extra second to avoid misses due to precision
+        if if_modified + datetime.timedelta(seconds=1) > room.last_activity:
             return make_response("",  304)
+
 
 @app.route("/tracker/<suuid:tracker>/<int:tracked_team>/<int:tracked_player>")
 def get_player_tracker(tracker: UUID, tracked_team: int, tracked_player: int, generic: bool = False) -> Response:

--- a/WebHostLib/tracker.py
+++ b/WebHostLib/tracker.py
@@ -300,8 +300,8 @@ def _process_if_request_valid(incoming_request, room: Optional[Room]) -> Optiona
     if_modified = incoming_request.headers.get("If-Modified-Since", None)
     if if_modified:
         if_modified = parsedate_to_datetime(if_modified)
-        # if_modified has less precision than last_activity, so we add an extra second to avoid misses due to precision
-        if if_modified + datetime.timedelta(seconds=1) > room.last_activity:
+        # if_modified has less precision than last_activity, so we bring them to same precision
+        if if_modified >= room.last_activity.replace(microsecond=0):
             return make_response("",  304)
 
 

--- a/WebHostLib/tracker.py
+++ b/WebHostLib/tracker.py
@@ -335,7 +335,8 @@ def get_timeout_and_player_tracker(room: Room, tracked_team: int, tracked_player
     else:
         tracker = render_generic_tracker(tracker_data, tracked_team, tracked_player)
 
-    return (tracker_data.get_room_saving_second() - datetime.datetime.now().second) % 60 or 60, room.last_activity, tracker
+    return ((tracker_data.get_room_saving_second() - datetime.datetime.now().second)
+            % TRACKER_CACHE_TIMEOUT_IN_SECONDS or TRACKER_CACHE_TIMEOUT_IN_SECONDS, room.last_activity, tracker)
 
 
 @app.route("/generic_tracker/<suuid:tracker>/<int:tracked_team>/<int:tracked_player>")
@@ -374,7 +375,8 @@ def get_timeout_and_multiworld_tracker(room: Room, game: str)\
     else:
         tracker = render_generic_multiworld_tracker(tracker_data, enabled_trackers)
 
-    return (tracker_data.get_room_saving_second() - datetime.datetime.now().second) % 60 or 60, room.last_activity, tracker
+    return ((tracker_data.get_room_saving_second() - datetime.datetime.now().second)
+            % TRACKER_CACHE_TIMEOUT_IN_SECONDS or TRACKER_CACHE_TIMEOUT_IN_SECONDS, room.last_activity, tracker)
 
 
 def get_enabled_multiworld_trackers(room: Room) -> Dict[str, Callable]:

--- a/WebHostLib/tracker.py
+++ b/WebHostLib/tracker.py
@@ -325,7 +325,7 @@ def get_player_tracker(tracker: UUID, tracked_team: int, tracked_player: int, ge
 
 
 def get_timeout_and_player_tracker(room: Room, tracked_team: int, tracked_player: int, generic: bool)\
-        -> Tuple[int, datetime, str]:
+        -> Tuple[int, datetime.datetime, str]:
     tracker_data = TrackerData(room)
 
     # Load and render the game-specific player tracker, or fallback to generic tracker if none exists.
@@ -366,7 +366,7 @@ def get_multiworld_tracker(tracker: UUID, game: str) -> Response:
 
 
 def get_timeout_and_multiworld_tracker(room: Room, game: str)\
-        -> Tuple[int, datetime, str]:
+        -> Tuple[int, datetime.datetime, str]:
     tracker_data = TrackerData(room)
     enabled_trackers = list(get_enabled_multiworld_trackers(room).keys())
     if game in _multiworld_trackers:


### PR DESCRIPTION
## What is this fixing or adding?
checks if the tracker is visible before updating  it.
If the tracker becomes visible after a missed update it instantly updates

## How was this tested?
![image](https://github.com/ArchipelagoMW/Archipelago/assets/3189725/7f593d53-6cb8-44dc-aed0-a106cbe92fed)
with logging.

## If this makes graphical changes, please attach screenshots.
