### PR TITLE
YGO06: prevent multiple players affecting each others procedure patch

### DIFF
--- a/worlds/yugioh06/__init__.py
+++ b/worlds/yugioh06/__init__.py
@@ -399,12 +399,14 @@ class Yugioh06World(World):
         self.playerName.extend([0] * (0x20 - len(self.playerName)))
         patch = YGO06ProcedurePatch(player=self.player, player_name=self.multiworld.player_name[self.player])
         patch.write_file("base_patch.bsdiff4", pkgutil.get_data(__name__, "patch.bsdiff4"))
+        procedure = [("apply_bsdiff4", ["base_patch.bsdiff4"]), ("apply_tokens", ["token_data.bin"])]
         if self.is_draft_mode:
-            patch.procedure.insert(1, ("apply_bsdiff4", ["draft_patch.bsdiff4"]))
+            procedure.insert(1, ("apply_bsdiff4", ["draft_patch.bsdiff4"]))
             patch.write_file("draft_patch.bsdiff4", pkgutil.get_data(__name__, "patches/draft.bsdiff4"))
         if self.options.ocg_arts:
-            patch.procedure.insert(1, ("apply_bsdiff4", ["ocg_patch.bsdiff4"]))
+            procedure.insert(1, ("apply_bsdiff4", ["ocg_patch.bsdiff4"]))
             patch.write_file("ocg_patch.bsdiff4", pkgutil.get_data(__name__, "patches/ocg.bsdiff4"))
+        patch.procedure = procedure
         write_tokens(self, patch)
 
         # Write Output

--- a/worlds/yugioh06/rom.py
+++ b/worlds/yugioh06/rom.py
@@ -22,8 +22,6 @@ class YGO06ProcedurePatch(APProcedurePatch, APTokenMixin):
     patch_file_ending = ".apygo06"
     result_file_ending = ".gba"
 
-    procedure = [("apply_bsdiff4", ["base_patch.bsdiff4"]), ("apply_tokens", ["token_data.bin"])]
-
     @classmethod
     def get_source_data(cls) -> bytes:
         return get_base_rom_bytes()


### PR DESCRIPTION
## What is this fixing or adding?
When a player has the option "ocg arts" enabled and the another player doesn't, the patch file of the player that has it not enabled ends up being broken. Inside the archipelago.json is a file listed that doesn't exist, that entry needs to be removed for the patch to work again.

This fix prevents the two players affecting each others procedure patch.

## How was this tested?
Generated multiple games that would reproduce the error.
