### PR TITLE
WebHost: use settings defaults for /api/generate and options -> Single Player Generate

### DIFF
--- a/WebHostLib/options.py
+++ b/WebHostLib/options.py
@@ -11,6 +11,7 @@ import Options
 from Utils import local_path
 from worlds.AutoWorld import AutoWorldRegister
 from . import app, cache
+from .generate import get_meta
 
 
 def create() -> None:
@@ -50,7 +51,7 @@ def render_options_page(template: str, world_name: str, is_complex: bool = False
 
 def generate_game(options: Dict[str, Union[dict, str]]) -> Union[Response, str]:
     from .generate import start_generation
-    return start_generation(options, {"plando_options": ["items", "connections", "texts", "bosses"]})
+    return start_generation(options, get_meta({}))
 
 
 def send_yaml(player_name: str, formatted_options: dict) -> Response:

--- a/settings.py
+++ b/settings.py
@@ -643,17 +643,6 @@ class GeneratorOptions(Group):
         PLAYTHROUGH = 2
         FULL = 3
 
-    class GlitchTriforceRoom(IntEnum):
-        """
-        Glitch to Triforce room from Ganon
-        When disabled, you have to have a weapon that can hurt ganon (master sword or swordless/easy item functionality
-        + hammer) and have completed the goal required for killing ganon to be able to access the triforce room.
-        1 -> Enabled.
-        0 -> Disabled (except in no-logic)
-        """
-        OFF = 0
-        ON = 1
-
     class PlandoOptions(str):
         """
         List of options that can be plando'd. Can be combined, for example "bosses, items"


### PR DESCRIPTION
## What is this fixing or adding?
/api/generate always had its own defaults, which this fixes and single player gen gained its own fresh defaults after the option rework, so this re-fixes it, as we just in 0.4.6 made them follow the same defaults.

## How was this tested?
Tested it against this case: https://github.com/ArchipelagoMW/Archipelago/issues/3378
Got an output that matched my expectation.

## If this makes graphical changes, please attach screenshots.
