### PR TITLE
Core: Adding remove items from pool as a generic opt-in option

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -12,7 +12,7 @@ from typing import Dict, List, Optional, Set, Tuple, Union
 import worlds
 from BaseClasses import CollectionState, Item, Location, LocationProgressType, MultiWorld, Region
 from Fill import balance_multiworld_progression, distribute_items_restrictive, distribute_planned, flood_items
-from Options import StartInventoryPool, ExcludeItemsPool
+from Options import StartInventoryPool, RemoveItemsPool
 from Utils import __version__, output_path, version_tuple, get_settings
 from settings import get_settings
 from worlds import AutoWorld
@@ -151,7 +151,7 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
         depletion_pool: Dict[int, Dict[str, int]] = {
             player: {
                 **getattr(multiworld.worlds[player].options, "start_inventory_from_pool", StartInventoryPool({})).value,
-                **getattr(multiworld.worlds[player].options, "exclude_items_from_pool", ExcludeItemsPool({})).value
+                **getattr(multiworld.worlds[player].options, "remove_items_from_pool", RemoveItemsPool({})).value
             }
             for player in multiworld.player_ids
         }

--- a/Options.py
+++ b/Options.py
@@ -1000,7 +1000,7 @@ class StartInventoryPool(StartInventory):
     display_name = "Start Inventory from Pool"
 
 
-class ExcludeItemsPool(StartInventory):
+class RemoveItemsPool(ItemDict):
     """Prevent these items to be placed in the world.
     The game decides what the replacement items will be."""
     verify_item_name = True

--- a/Options.py
+++ b/Options.py
@@ -1000,6 +1000,13 @@ class StartInventoryPool(StartInventory):
     display_name = "Start Inventory from Pool"
 
 
+class ExcludeItemsPool(StartInventory):
+    """Prevent these items to be placed in the world.
+    The game decides what the replacement items will be."""
+    verify_item_name = True
+    display_name = "Exclude Items from Pool"
+
+
 class StartHints(ItemSet):
     """Start with these item's locations prefilled into the !hint command."""
     display_name = "Start Hints"


### PR DESCRIPTION
## What is this fixing or adding?
It just adds the option as an opt-in. Since I don't maintain a core game, no game gets it in this PR, unless you want me to.
I'm not sure if it should throw exception if you try to remove things from the item pool if they aren't in it, but it's the behavior of start_inventory_from_pool

## How was this tested?
By removing swords in the item pool of TUNIC. It worked as expected, also throwing exception if I tried to remove too many swords or if the game became unbeatable because of it

## If this makes graphical changes, please attach screenshots.
