### PR TITLE
Terraria: migrate to new options API

### DIFF
--- a/worlds/terraria/Options.py
+++ b/worlds/terraria/Options.py
@@ -1,5 +1,5 @@
-from Options import Choice, Option, Toggle, DeathLink
-import typing
+from dataclasses import dataclass
+from Options import Choice, DeathLink, PerGameCommonOptions
 
 
 class Goal(Choice):
@@ -49,9 +49,9 @@ class FillExtraChecksWith(Choice):
     default = 1
 
 
-options: typing.Dict[str, type(Option)] = {  # type: ignore
-    "goal": Goal,
-    "achievements": Achievements,
-    "fill_extra_checks_with": FillExtraChecksWith,
-    "death_link": DeathLink,
-}
+@dataclass
+class TerrariaOptions(PerGameCommonOptions):
+    goal: Goal
+    achievements: Achievements
+    fill_extra_checks_with: FillExtraChecksWith
+    death_link: DeathLink

--- a/worlds/terraria/__init__.py
+++ b/worlds/terraria/__init__.py
@@ -25,7 +25,7 @@ from .Checks import (
     armor_minions,
     accessory_minions,
 )
-from .Options import options
+from .Options import TerrariaOptions
 
 
 class TerrariaWeb(WebWorld):
@@ -49,7 +49,8 @@ class TerrariaWorld(World):
 
     game = "Terraria"
     web = TerrariaWeb()
-    option_definitions = options
+    options_dataclass = TerrariaOptions
+    options: TerrariaOptions
 
     # data_version is used to signal that items, locations or their names
     # changed. Set this to 0 during development so other games' clients do not
@@ -70,7 +71,7 @@ class TerrariaWorld(World):
     goal_locations: Set[str]
 
     def generate_early(self) -> None:
-        goal, goal_locations = goals[self.multiworld.goal[self.player].value]
+        goal, goal_locations = goals[self.options.goal.value]
         ter_goals = {}
         goal_items = set()
         for location in goal_locations:
@@ -79,7 +80,7 @@ class TerrariaWorld(World):
             ter_goals[item] = location
             goal_items.add(item)
 
-        achievements = self.multiworld.achievements[self.player].value
+        achievements = self.options.achievements.value
         location_count = 0
         locations = []
         for rule, flags, _, _ in rules[:goal]:
@@ -89,7 +90,7 @@ class TerrariaWorld(World):
                 or (achievements < 2 and "Grindy" in flags)
                 or (achievements < 3 and "Fishing" in flags)
                 or (
-                    rule == "Zenith" and self.multiworld.goal[self.player].value != 11
+                    rule == "Zenith" and self.options.goal.value != 11
                 )  # Bad hardcoding
             ):
                 continue
@@ -123,7 +124,7 @@ class TerrariaWorld(World):
                 # Event
                 items.append(rule)
 
-        extra_checks = self.multiworld.fill_extra_checks_with[self.player].value
+        extra_checks = self.options.fill_extra_checks_with.value
         ordered_rewards = [
             reward
             for reward in labels["ordered"]
@@ -241,7 +242,7 @@ class TerrariaWorld(World):
             elif condition == "calamity":
                 return sign == self.calamity
             elif condition == "grindy":
-                return sign == (self.multiworld.achievements[self.player].value >= 2)
+                return sign == (self.options.achievements.value >= 2)
             elif condition == "pickaxe":
                 if type(arg) is not int:
                     raise Exception("@pickaxe requires an integer argument")
@@ -340,6 +341,6 @@ class TerrariaWorld(World):
     def fill_slot_data(self) -> Dict[str, object]:
         return {
             "goal": list(self.goal_locations),
-            "achievements": self.multiworld.achievements[self.player].value,
-            "deathlink": bool(self.multiworld.death_link[self.player]),
+            "achievements": self.options.achievements.value,
+            "deathlink": bool(self.options.death_link),
         }


### PR DESCRIPTION
## What is this fixing or adding?

Switches Terraria to the new options API. See #3284.

## How was this tested?

I generated some worlds with different options and checked the spoilers to make sure the options are still being respected. I also played the beginning of a game with the client.