### PR TITLE
WebHost: Restore the old size of the collapsible element arrows

### DIFF
--- a/WebHostLib/static/styles/markdown.css
+++ b/WebHostLib/static/styles/markdown.css
@@ -43,6 +43,20 @@
     margin-bottom: 0.5rem;
     text-transform: lowercase;
     text-shadow: 1px 1px 2px #000000;
+    display: flex;
+    align-items: center;
+}
+
+.markdown details summary.h2::before{
+    content: "▶";
+    font-size: 20px;
+    display: inline-block;
+    vertical-align: middle;
+    padding-right: 9px;
+}
+
+.markdown details[open] summary.h2::before{
+    content: "▼";
 }
 
 .markdown h3, .markdown details summary.h3{


### PR DESCRIPTION
## What is this fixing or adding?
With the new WebHost options overhauls, the arrows for some collapsible elements in both the Supported Games page and Game Options page were replaced with the details element's markers, which were gigantic compared to the old arrows. I couldn't be sure if this was intentional, but I assumed it was not. I wrote some additional code here to revert these back to the style that was previously seen on the WebHost. I believe the smaller original size to be far superior to the new oversized arrows, but obviously this is just my opinion and this PR can just be closed if the bigger arrows were intentional.

## If this makes graphical changes, please attach screenshots.
The current (too big) size:
![Supported Games - Google Chrome 5_27_2024 10_24_15 PM](https://github.com/ArchipelagoMW/Archipelago/assets/66492208/40d82089-6bc7-4a4e-bd2e-837046541095)

After this PR (and original) size:
![Supported Games - Google Chrome 5_27_2024 10_23_53 PM](https://github.com/ArchipelagoMW/Archipelago/assets/66492208/47644e6e-3d59-4327-91a9-537dd6fad382)
