### PR TITLE
SC2: Fix Kerrigan Primal Form on Half Completion

### DIFF
--- a/worlds/sc2/Client.py
+++ b/worlds/sc2/Client.py
@@ -966,7 +966,7 @@ def kerrigan_primal(ctx: SC2Context, kerrigan_level: int) -> bool:
         return kerrigan_level >= 35
     elif ctx.kerrigan_primal_status == KerriganPrimalStatus.option_half_completion:
         total_missions = len(ctx.mission_id_to_location_ids)
-        completed = len([(mission_id * VICTORY_MODULO + get_location_offset(mission_id)) in ctx.checked_locations
+        completed = sum([(mission_id * VICTORY_MODULO + get_location_offset(mission_id)) in ctx.checked_locations
                          for mission_id in ctx.mission_id_to_location_ids])
         return completed >= (total_missions / 2)
     elif ctx.kerrigan_primal_status == KerriganPrimalStatus.option_item:

--- a/worlds/sc2/Client.py
+++ b/worlds/sc2/Client.py
@@ -966,8 +966,8 @@ def kerrigan_primal(ctx: SC2Context, kerrigan_level: int) -> bool:
         return kerrigan_level >= 35
     elif ctx.kerrigan_primal_status == KerriganPrimalStatus.option_half_completion:
         total_missions = len(ctx.mission_id_to_location_ids)
-        completed = sum([(mission_id * VICTORY_MODULO + get_location_offset(mission_id)) in ctx.checked_locations
-                         for mission_id in ctx.mission_id_to_location_ids])
+        completed = sum((mission_id * VICTORY_MODULO + get_location_offset(mission_id)) in ctx.checked_locations
+                         for mission_id in ctx.mission_id_to_location_ids)
         return completed >= (total_missions / 2)
     elif ctx.kerrigan_primal_status == KerriganPrimalStatus.option_item:
         codes = [item.item for item in ctx.items_received]


### PR DESCRIPTION
## What is this fixing or adding?
Fixes the `half_completion` value for the `kerrigan_primal_status` option incorrectly counting completed missions.

## How was this tested?
Generating a seed with 5 missions and comparing Kerrigan primal status in-game after 2 completed missions and after 3 completed missions.