### PR TITLE
PKMN R/B: Fixing Key Items Only + Removed Exp. All

### DIFF
--- a/worlds/pokemon_rb/regions.py
+++ b/worlds/pokemon_rb/regions.py
@@ -1560,7 +1560,7 @@ def create_regions(self):
                             <= self.multiworld.trap_percentage[self.player].value and combined_traps != 0):
                         item = self.create_item(self.select_trap())
 
-                if self.multiworld.key_items_only[self.player] and (not location.event) and (not item.advancement):
+                if self.multiworld.key_items_only[self.player] and (not location.event) and (not item.advancement) and location.original_item != "Exp. All":
                     continue
 
                 if item.name in start_inventory and start_inventory[item.name] > 0 and \


### PR DESCRIPTION
## What is this fixing or adding?

When a player has the Exp. All removed and has Key Items Only, the filler replacement item for the Exp. All is never added to the itempool. Previously, a "Nothing" item would be created, now a filler item is made. Worth noting, a filler item was already created when Exp. All was set to Start With, so this is just adding that behavior to the Removed case. The Exp. All is a progression key item, so nothing changes in this if statement when it is randomized.

## How was this tested?

Generations and checking the spoiler log for Nothings and filler