### PR TITLE
Hollow Knight: AP Website Tracker

### DIFF
--- a/WebHostLib/static/styles/tracker__HK.css
+++ b/WebHostLib/static/styles/tracker__HK.css
@@ -1,0 +1,260 @@
+@import url('https://fonts.googleapis.com/css2?family=Lexend+Deca:wght@100..900&display=swap');
+
+.tracker-container {
+    width: 600px;
+    box-sizing: border-box;
+    font-family: "Lexend Deca", Arial, Helvetica, sans-serif;
+    border: 2px solid black;
+    border-radius: 4px;
+    resize: both;
+
+    background-color: #000000;
+    color: white;
+}
+
+/* .tracker-container.charms {
+    width: 600px;
+} */
+
+/* .tracker-container ::before {
+    background-image: url('https://cdn.wikimg.net/en/hkwiki/images/9/96/Dialogue_Top.png');
+    background-position: center;
+    background-size: contain;
+    background-repeat: no-repeat;
+    top: 0;
+}
+
+.tracker-container ::before {
+    position: absolute;
+    content: "";
+    height: 2rem;
+    width: calc(100% - 2rem);
+} */
+
+.hidden {
+    display: none !important;
+}
+
+h2 {
+    text-transform: none;
+    cursor: unset;
+    color: #fff677;
+    margin-bottom: 2px;
+    margin-top: 33px;
+    font-size: 44px;
+}
+
+h3 {
+    color: #ffef00;
+    font-weight: bold;
+}
+
+.notRandomized {
+    background-color: #d0d0d0;
+}
+
+.elevatorPass, .Rightslash {
+    transform: rotate(-90deg);
+}
+
+.Leftslash {
+    transform: rotate(90deg);
+}
+
+.Downslash {
+    transform: rotate(0deg);
+}
+
+.Upslash {
+    transform: rotate(180deg);
+}
+
+.fullNail {
+    transform: rotate(225deg);
+}
+
+/* html::before {
+    background-image: url('https://cdn.wikimg.net/en/hkwiki/images/thumb/2/2f/VHpromo6.png/624px-VHpromo6.png?20190823174122');
+    background-size: cover;
+    background-repeat: no-repeat;
+    background-position: center;
+} */
+
+/** Tracker Grid **/
+.grid {
+    background-color: black;
+    display: grid;
+    grid-template-columns: repeat(1fr, 2);
+    grid-template-rows: repeat(1fr, 6);
+    grid-column-gap: 5px;
+    grid-row-gap: 5px;
+    grid-template-areas:
+    'col1 col4'
+    'col8 col4'
+    'col2 col4'
+    'col2 col9'
+    'col3 col5'
+    'col7 col6';
+}
+
+[class^='col'] {
+    min-height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.col-1 { grid-area: col1; }
+.col-2 { grid-area: col2; }
+.col-3 { grid-area: col3; }
+.col-4 { grid-area: col4; }
+.col-5 { grid-area: col5; }
+.col-6 { grid-area: col6; }
+.col-7 { grid-area: col7; }
+.col-8 { grid-area: col8; }
+.col-9 { grid-area: col9; }
+
+.grid::after {
+    content: "";
+    clear: both;
+    display: table;
+}
+
+
+/** Inventory Grid ****************************************************************************************************/
+.inventory-grid {
+    display: grid;
+    grid-template-columns: repeat(8, minmax(0, 1fr));
+    padding: 1rem;
+    gap: 1rem;
+}
+
+.inventory-grid.keys {
+    grid-template-columns: repeat(9, minmax(0, 1fr));
+}
+
+.inventory-grid.charms {
+    grid-template-columns: repeat(10, minmax(0, 1fr));
+}
+
+.inventory-grid.stags {
+    grid-template-columns: repeat(11, minmax(0, 1fr));
+}
+
+.inventory-grid .item {
+    position: relative;
+    display: flex;
+    justify-content: center;
+    height: 48px;
+}
+
+.inventory-grid .dual-item {
+    display: flex;
+    justify-content: center;
+}
+
+.inventory-grid .missing,
+.missing {
+    /* Missing items will be in full grayscale to signify "uncollected". */
+    filter: grayscale(100%) contrast(75%) brightness(75%);
+}
+
+.inventory-grid .item img,
+.inventory-grid .dual-item img {
+    display: flex;
+    align-items: center;
+    text-align: center;
+    font-size: 0.8rem;
+    text-shadow: 0 1px 2px black;
+    font-weight: bold;
+    image-rendering: crisp-edges;
+    background-size: contain;
+    background-repeat: no-repeat;
+}
+
+.inventory-grid .dual-item img {
+    height: 48px;
+    margin: 0 -4px;
+}
+
+.inventory-grid .dual-item img:first-child {
+    align-self: flex-end;
+}
+
+.inventory-grid .item .quantity {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    text-align: right;
+    font-weight: 600;
+    font-size: 1.25rem;
+    line-height: 1.25rem;
+    text-shadow:
+        -1px -1px 0 #000,
+         1px -1px 0 #000,
+        -1px 1px 0 #000,
+         1px 1px 0 #000;
+    user-select: none;
+}
+
+/** Regions List ******************************************************************************************************/
+.regions-list {
+    padding: 1rem;
+}
+
+.regions-list summary {
+    list-style: none;
+    display: flex;
+    gap: 0.5rem;
+    cursor: pointer;
+}
+
+.regions-list summary::before {
+    content: "⯈";
+    width: 1em;
+    flex-shrink: 0;
+}
+
+.regions-list details {
+    font-weight: 300;
+}
+
+.regions-list details[open] > summary::before {
+    content: "⯆";
+}
+
+.regions-list .region {
+    width: 100%;
+    display: grid;
+    grid-template-columns: 20fr 8fr 2fr 2fr;
+    align-items: center;
+    gap: 4px;
+    text-align: center;
+    font-weight: 300;
+    box-sizing: border-box;
+}
+
+.regions-list .region :first-child {
+    text-align: left;
+    font-weight: 500;
+}
+
+.regions-list .region.region-header {
+    margin-left: 24px;
+    width: calc(100% - 24px);
+    padding: 2px;
+}
+
+.regions-list .location-rows {
+    border-top: 1px solid white;
+    display: grid;
+    grid-template-columns: auto 32px;
+    font-weight: 300;
+    padding: 2px 8px;
+    margin-top: 4px;
+    font-size: 0.8rem;
+}
+
+.regions-list .location-rows :nth-child(even) {
+    text-align: right;
+}

--- a/WebHostLib/templates/multitracker__HK.html
+++ b/WebHostLib/templates/multitracker__HK.html
@@ -17,136 +17,136 @@
 
 {# List all tracker-relevant icons. Format: (Name, Image URL) #}
 {% set icons = {
-    "Wayward_Compass":                  "https://cdn.wikimg.net/en/hkwiki/images/thumb/7/7d/Wayward_Compass.png/71px-Wayward_Compass.png",
-    "Gathering_Swarm":                  "https://cdn.wikimg.net/en/hkwiki/images/thumb/8/8a/Gathering_Swarm.png/67px-Gathering_Swarm.png",
-    "Stalwart_Shell":                   "https://cdn.wikimg.net/en/hkwiki/images/thumb/f/f2/Stalwart_Shell.png/72px-Stalwart_Shell.png",
-    "Soul_Catcher":                     "https://cdn.wikimg.net/en/hkwiki/images/thumb/c/ca/Soul_Catcher.png/71px-Soul_Catcher.png",
-    "Shaman_Stone":                     "https://cdn.wikimg.net/en/hkwiki/images/thumb/5/5e/Shaman_Stone.png/72px-Shaman_Stone.png",
-    "Soul_Eater":                       "https://cdn.wikimg.net/en/hkwiki/images/thumb/6/6c/Soul_Eater.png/72px-Soul_Eater.png",
-    "Dashmaster":                       "https://cdn.wikimg.net/en/hkwiki/images/thumb/7/70/Dashmaster.png/71px-Dashmaster.png",
-    "Sprintmaster":                     "https://cdn.wikimg.net/en/hkwiki/images/thumb/e/e9/Sprintmaster.png/72px-Sprintmaster.png",
-    "Grubsong":                         "https://cdn.wikimg.net/en/hkwiki/images/thumb/7/78/Grubsong.png/72px-Grubsong.png",
-    "Grubberfly's_Elegy":               "https://cdn.wikimg.net/en/hkwiki/images/thumb/b/bd/Grubberfly%27s_Elegy.png/68px-Grubberfly%27s_Elegy.png",
-    "Fragile_Heart":                    "https://cdn.wikimg.net/en/hkwiki/images/thumb/1/13/Fragile_Heart.png/72px-Fragile_Heart.png",
-    "Unbreakable_Heart":                "https://cdn.wikimg.net/en/hkwiki/images/thumb/1/15/Unbreakable_Heart.png/69px-Unbreakable_Heart.png",
-    "Fragile_Greed":                    "https://cdn.wikimg.net/en/hkwiki/images/thumb/b/b6/Fragile_Greed.png/69px-Fragile_Greed.png",
-    "Unbreakable_Greed":                "https://cdn.wikimg.net/en/hkwiki/images/thumb/2/2a/Unbreakable_Greed.png/69px-Unbreakable_Greed.png",
-    "Progressive Unbreakable Greed":    "https://cdn.wikimg.net/en/hkwiki/images/thumb/2/2a/Unbreakable_Greed.png/69px-Unbreakable_Greed.png",
-    "Fragile_Strength":                 "https://cdn.wikimg.net/en/hkwiki/images/thumb/7/7b/Fragile_Strength.png/69px-Fragile_Strength.png",
-    "Progressive Fragile Strength":     "https://cdn.wikimg.net/en/hkwiki/images/thumb/7/7b/Fragile_Strength.png/69px-Fragile_Strength.png",
-    "Unbreakable_Strength":             "https://cdn.wikimg.net/en/hkwiki/images/thumb/a/ac/Unbreakable_Strength.png/69px-Unbreakable_Strength.png",
-    "Progressive Unbreakable Strength": "https://cdn.wikimg.net/en/hkwiki/images/thumb/a/ac/Unbreakable_Strength.png/69px-Unbreakable_Strength.png",
-    "Spell_Twister":                    "https://cdn.wikimg.net/en/hkwiki/images/thumb/3/33/Spell_Twister.png/66px-Spell_Twister.png",
-    "Steady_Body":                      "https://cdn.wikimg.net/en/hkwiki/images/thumb/f/f5/Steady_Body.png/69px-Steady_Body.png",
-    "Heavy_Blow":                       "https://cdn.wikimg.net/en/hkwiki/images/thumb/f/f6/Heavy_Blow.png/72px-Heavy_Blow.png",
-    "Quick_Slash":                      "https://cdn.wikimg.net/en/hkwiki/images/thumb/5/5f/Quick_Slash.png/67px-Quick_Slash.png",
-    "Longnail":                         "https://cdn.wikimg.net/en/hkwiki/images/thumb/d/d1/Longnail.png/72px-Longnail.png",
-    "Mark_of_Pride":                    "https://cdn.wikimg.net/en/hkwiki/images/thumb/6/69/Mark_of_Pride.png/71px-Mark_of_Pride.png",
-    "Fury_of_the_Fallen":               "https://cdn.wikimg.net/en/hkwiki/images/thumb/4/4f/Fury_of_the_Fallen.png/71px-Fury_of_the_Fallen.png",
-    "Thorns_of_Agony":                  "https://cdn.wikimg.net/en/hkwiki/images/thumb/8/8f/Thorns_of_Agony.png/72px-Thorns_of_Agony.png",
-    "Baldur_Shell":                     "https://cdn.wikimg.net/en/hkwiki/images/thumb/2/21/Baldur_Shell.png/72px-Baldur_Shell.png",
-    "Flukenest":                        "https://cdn.wikimg.net/en/hkwiki/images/thumb/7/79/Flukenest.png/72px-Flukenest.png",
-    "Defender's_Crest":                 "https://cdn.wikimg.net/en/hkwiki/images/thumb/5/56/Defender%27s_Crest.png/72px-Defender%27s_Crest.png",
-    "Glowing_Womb":                     "https://cdn.wikimg.net/en/hkwiki/images/thumb/c/c6/Glowing_Womb.png/72px-Glowing_Womb.png",
-    "Quick_Focus":                      "https://cdn.wikimg.net/en/hkwiki/images/thumb/6/6a/Quick_Focus.png/69px-Quick_Focus.png",
-    "Deep_Focus":                       "https://cdn.wikimg.net/en/hkwiki/images/thumb/e/ea/Deep_Focus.png/68px-Deep_Focus.png",
-    "Lifeblood_Heart":                  "https://cdn.wikimg.net/en/hkwiki/images/thumb/7/7c/Lifeblood_Heart.png/68px-Lifeblood_Heart.png",
-    "Lifeblood_Core":                   "https://cdn.wikimg.net/en/hkwiki/images/thumb/8/81/Lifeblood_Core.png/70px-Lifeblood_Core.png",
-    "Joni's_Blessing":                  "https://cdn.wikimg.net/en/hkwiki/images/thumb/6/67/Joni%27s_Blessing.png/72px-Joni%27s_Blessing.png",
-    "Hiveblood":                        "https://cdn.wikimg.net/en/hkwiki/images/thumb/e/eb/Hiveblood.png/64px-Hiveblood.png",
-    "Spore_Shroom":                     "https://cdn.wikimg.net/en/hkwiki/images/thumb/7/78/Spore_Shroom.png/72px-Spore_Shroom.png",
-    "Sharp_Shadow":                     "https://cdn.wikimg.net/en/hkwiki/images/thumb/1/13/Sharp_Shadow.png/71px-Sharp_Shadow.png",
-    "Shape_of_Unn":                     "https://cdn.wikimg.net/en/hkwiki/images/thumb/b/b4/Shape_of_Unn.png/69px-Shape_of_Unn.png",
-    "Nailmaster's_Glory":               "https://cdn.wikimg.net/en/hkwiki/images/thumb/0/0f/Nailmaster%27s_Glory.png/68px-Nailmaster%27s_Glory.png",
-    "Weaversong":                       "https://cdn.wikimg.net/en/hkwiki/images/thumb/2/26/Weaversong.png/72px-Weaversong.png",
-    "Dream_Wielder":                    "https://cdn.wikimg.net/en/hkwiki/images/thumb/9/94/Dream_Wielder.png/72px-Dream_Wielder.png",
-    "Dreamshield":                      "https://cdn.wikimg.net/en/hkwiki/images/thumb/4/47/Dreamshield.png/72px-Dreamshield.png",
-    "Grimmchild1":                      "https://cdn.wikimg.net/en/hkwiki/images/6/6a/Grimmchild01.png",
-    "Grimmchild2":                      "https://cdn.wikimg.net/en/hkwiki/images/5/5a/Grimmchild02.png",
-    "Grimmchild3":                      "https://cdn.wikimg.net/en/hkwiki/images/1/18/Grimmchild03.png",
-    "Grimmchild4":                      "https://cdn.wikimg.net/en/hkwiki/images/9/91/Grimmchild.png",
-    "Carefree Melody":                  "https://cdn.wikimg.net/en/hkwiki/images/c/c4/Carefree_Melody.png/70px-Carefree_Melody.png",
-    "Queen_Fragment":                   "https://cdn.wikimg.net/en/hkwiki/images/4/4d/Charm_KingSoul_Left.png",
-    "King_Fragment":                    "https://cdn.wikimg.net/en/hkwiki/images/6/62/Charm_KingSoul_Right.png",
-    "Kingsoul":                         "https://cdn.wikimg.net/en/hkwiki/images/3/34/Kingsoul.png",
-    "Void_Heart":                       "https://cdn.wikimg.net/en/hkwiki/images/b/bb/Void_Heart.png",
-    "Progressive Void_Heart":           "https://cdn.wikimg.net/en/hkwiki/images/b/bb/Void_Heart.png",
+    "Wayward_Compass"                   : "https://cdn.wikimg.net/en/hkwiki/images/thumb/7/7d/Wayward_Compass.png/71px-Wayward_Compass.png",
+    "Gathering_Swarm"                   : "https://cdn.wikimg.net/en/hkwiki/images/thumb/8/8a/Gathering_Swarm.png/67px-Gathering_Swarm.png",
+    "Stalwart_Shell"                    : "https://cdn.wikimg.net/en/hkwiki/images/thumb/f/f2/Stalwart_Shell.png/72px-Stalwart_Shell.png",
+    "Soul_Catcher"                      : "https://cdn.wikimg.net/en/hkwiki/images/thumb/c/ca/Soul_Catcher.png/71px-Soul_Catcher.png",
+    "Shaman_Stone"                      : "https://cdn.wikimg.net/en/hkwiki/images/thumb/5/5e/Shaman_Stone.png/72px-Shaman_Stone.png",
+    "Soul_Eater"                        : "https://cdn.wikimg.net/en/hkwiki/images/thumb/6/6c/Soul_Eater.png/72px-Soul_Eater.png",
+    "Dashmaster"                        : "https://cdn.wikimg.net/en/hkwiki/images/thumb/7/70/Dashmaster.png/71px-Dashmaster.png",
+    "Sprintmaster"                      : "https://cdn.wikimg.net/en/hkwiki/images/thumb/e/e9/Sprintmaster.png/72px-Sprintmaster.png",
+    "Grubsong"                          : "https://cdn.wikimg.net/en/hkwiki/images/thumb/7/78/Grubsong.png/72px-Grubsong.png",
+    "Grubberfly's_Elegy"                : "https://cdn.wikimg.net/en/hkwiki/images/thumb/b/bd/Grubberfly%27s_Elegy.png/68px-Grubberfly%27s_Elegy.png",
+    "Fragile_Heart"                     : "https://cdn.wikimg.net/en/hkwiki/images/thumb/1/13/Fragile_Heart.png/72px-Fragile_Heart.png",
+    "Unbreakable_Heart"                 : "https://cdn.wikimg.net/en/hkwiki/images/thumb/1/15/Unbreakable_Heart.png/69px-Unbreakable_Heart.png",
+    "Fragile_Greed"                     : "https://cdn.wikimg.net/en/hkwiki/images/thumb/b/b6/Fragile_Greed.png/69px-Fragile_Greed.png",
+    "Unbreakable_Greed"                 : "https://cdn.wikimg.net/en/hkwiki/images/thumb/2/2a/Unbreakable_Greed.png/69px-Unbreakable_Greed.png",
+    "Progressive Unbreakable Greed"     : "https://cdn.wikimg.net/en/hkwiki/images/thumb/2/2a/Unbreakable_Greed.png/69px-Unbreakable_Greed.png",
+    "Fragile_Strength"                  : "https://cdn.wikimg.net/en/hkwiki/images/thumb/7/7b/Fragile_Strength.png/69px-Fragile_Strength.png",
+    "Progressive Fragile Strength"      : "https://cdn.wikimg.net/en/hkwiki/images/thumb/7/7b/Fragile_Strength.png/69px-Fragile_Strength.png",
+    "Unbreakable_Strength"              : "https://cdn.wikimg.net/en/hkwiki/images/thumb/a/ac/Unbreakable_Strength.png/69px-Unbreakable_Strength.png",
+    "Progressive Unbreakable Strength"  : "https://cdn.wikimg.net/en/hkwiki/images/thumb/a/ac/Unbreakable_Strength.png/69px-Unbreakable_Strength.png",
+    "Spell_Twister"                     : "https://cdn.wikimg.net/en/hkwiki/images/thumb/3/33/Spell_Twister.png/66px-Spell_Twister.png",
+    "Steady_Body"                       : "https://cdn.wikimg.net/en/hkwiki/images/thumb/f/f5/Steady_Body.png/69px-Steady_Body.png",
+    "Heavy_Blow"                        : "https://cdn.wikimg.net/en/hkwiki/images/thumb/f/f6/Heavy_Blow.png/72px-Heavy_Blow.png",
+    "Quick_Slash"                       : "https://cdn.wikimg.net/en/hkwiki/images/thumb/5/5f/Quick_Slash.png/67px-Quick_Slash.png",
+    "Longnail"                          : "https://cdn.wikimg.net/en/hkwiki/images/thumb/d/d1/Longnail.png/72px-Longnail.png",
+    "Mark_of_Pride"                     : "https://cdn.wikimg.net/en/hkwiki/images/thumb/6/69/Mark_of_Pride.png/71px-Mark_of_Pride.png",
+    "Fury_of_the_Fallen"                : "https://cdn.wikimg.net/en/hkwiki/images/thumb/4/4f/Fury_of_the_Fallen.png/71px-Fury_of_the_Fallen.png",
+    "Thorns_of_Agony"                   : "https://cdn.wikimg.net/en/hkwiki/images/thumb/8/8f/Thorns_of_Agony.png/72px-Thorns_of_Agony.png",
+    "Baldur_Shell"                      : "https://cdn.wikimg.net/en/hkwiki/images/thumb/2/21/Baldur_Shell.png/72px-Baldur_Shell.png",
+    "Flukenest"                         : "https://cdn.wikimg.net/en/hkwiki/images/thumb/7/79/Flukenest.png/72px-Flukenest.png",
+    "Defender's_Crest"                  : "https://cdn.wikimg.net/en/hkwiki/images/thumb/5/56/Defender%27s_Crest.png/72px-Defender%27s_Crest.png",
+    "Glowing_Womb"                      : "https://cdn.wikimg.net/en/hkwiki/images/thumb/c/c6/Glowing_Womb.png/72px-Glowing_Womb.png",
+    "Quick_Focus"                       : "https://cdn.wikimg.net/en/hkwiki/images/thumb/6/6a/Quick_Focus.png/69px-Quick_Focus.png",
+    "Deep_Focus"                        : "https://cdn.wikimg.net/en/hkwiki/images/thumb/e/ea/Deep_Focus.png/68px-Deep_Focus.png",
+    "Lifeblood_Heart"                   : "https://cdn.wikimg.net/en/hkwiki/images/thumb/7/7c/Lifeblood_Heart.png/68px-Lifeblood_Heart.png",
+    "Lifeblood_Core"                    : "https://cdn.wikimg.net/en/hkwiki/images/thumb/8/81/Lifeblood_Core.png/70px-Lifeblood_Core.png",
+    "Joni's_Blessing"                   : "https://cdn.wikimg.net/en/hkwiki/images/thumb/6/67/Joni%27s_Blessing.png/72px-Joni%27s_Blessing.png",
+    "Hiveblood"                         : "https://cdn.wikimg.net/en/hkwiki/images/thumb/e/eb/Hiveblood.png/64px-Hiveblood.png",
+    "Spore_Shroom"                      : "https://cdn.wikimg.net/en/hkwiki/images/thumb/7/78/Spore_Shroom.png/72px-Spore_Shroom.png",
+    "Sharp_Shadow"                      : "https://cdn.wikimg.net/en/hkwiki/images/thumb/1/13/Sharp_Shadow.png/71px-Sharp_Shadow.png",
+    "Shape_of_Unn"                      : "https://cdn.wikimg.net/en/hkwiki/images/thumb/b/b4/Shape_of_Unn.png/69px-Shape_of_Unn.png",
+    "Nailmaster's_Glory"                : "https://cdn.wikimg.net/en/hkwiki/images/thumb/0/0f/Nailmaster%27s_Glory.png/68px-Nailmaster%27s_Glory.png",
+    "Weaversong"                        : "https://cdn.wikimg.net/en/hkwiki/images/thumb/2/26/Weaversong.png/72px-Weaversong.png",
+    "Dream_Wielder"                     : "https://cdn.wikimg.net/en/hkwiki/images/thumb/9/94/Dream_Wielder.png/72px-Dream_Wielder.png",
+    "Dreamshield"                       : "https://cdn.wikimg.net/en/hkwiki/images/thumb/4/47/Dreamshield.png/72px-Dreamshield.png",
+    "Grimmchild1"                       : "https://cdn.wikimg.net/en/hkwiki/images/6/6a/Grimmchild01.png",
+    "Grimmchild2"                       : "https://cdn.wikimg.net/en/hkwiki/images/5/5a/Grimmchild02.png",
+    "Grimmchild3"                       : "https://cdn.wikimg.net/en/hkwiki/images/1/18/Grimmchild03.png",
+    "Grimmchild4"                       : "https://cdn.wikimg.net/en/hkwiki/images/9/91/Grimmchild.png",
+    "Carefree Melody"                   : "https://cdn.wikimg.net/en/hkwiki/images/c/c4/Carefree_Melody.png/70px-Carefree_Melody.png",
+    "Queen_Fragment"                    : "https://cdn.wikimg.net/en/hkwiki/images/4/4d/Charm_KingSoul_Left.png",
+    "King_Fragment"                     : "https://cdn.wikimg.net/en/hkwiki/images/6/62/Charm_KingSoul_Right.png",
+    "Kingsoul"                          : "https://cdn.wikimg.net/en/hkwiki/images/3/34/Kingsoul.png",
+    "Void_Heart"                        : "https://cdn.wikimg.net/en/hkwiki/images/b/bb/Void_Heart.png",
+    "Progressive Void_Heart"            : "https://cdn.wikimg.net/en/hkwiki/images/b/bb/Void_Heart.png",
 
-    "Herrah":                           "https://cdn.wikimg.net/en/hkwiki/images/b/bc/B_Herrah.png",
-    "Lurien":                           "https://cdn.wikimg.net/en/hkwiki/images/c/ce/B_Lurien.png",
-    "Monomon":                          "https://cdn.wikimg.net/en/hkwiki/images/thumb/e/e9/B_Monomon.png/202px-B_Monomon.png",
+    "Herrah"                            : "https://cdn.wikimg.net/en/hkwiki/images/b/bc/B_Herrah.png",
+    "Lurien"                            : "https://cdn.wikimg.net/en/hkwiki/images/c/ce/B_Lurien.png",
+    "Monomon"                           : "https://cdn.wikimg.net/en/hkwiki/images/thumb/e/e9/B_Monomon.png/202px-B_Monomon.png",
 
-    "Focus":                            "https://cdn.wikimg.net/en/hkwiki/images/2/25/Icon_HK_Focus.png",
-    "Vengeful_Spirit":                  "https://cdn.wikimg.net/en/hkwiki/images/a/ab/Icon_HK_Vengeful_Spirit.png",
-    "Shade_Soul":                       "https://cdn.wikimg.net/en/hkwiki/images/e/ef/Icon_HK_Shade_Soul.png",
-    "Progressive Fireball":             "https://cdn.wikimg.net/en/hkwiki/images/e/ef/Icon_HK_Shade_Soul.png",
-    "Desolate_Dive":                    "https://cdn.wikimg.net/en/hkwiki/images/c/c3/Icon_HK_Desolate_Dive.png",
-    "Descending_Dark":                  "https://cdn.wikimg.net/en/hkwiki/images/a/a1/Icon_HK_Descending_Dark.png",
-    "Progressive Dive":                 "https://cdn.wikimg.net/en/hkwiki/images/a/a1/Icon_HK_Descending_Dark.png",
-    "Howling_Wraiths":                  "https://cdn.wikimg.net/en/hkwiki/images/1/16/Icon_HK_Howling_Wraiths.png",
-    "Abyss_Shriek":                     "https://cdn.wikimg.net/en/hkwiki/images/b/bf/Icon_HK_Abyss_Shriek.png",
-    "Progressive Shriek":               "https://cdn.wikimg.net/en/hkwiki/images/b/bf/Icon_HK_Abyss_Shriek.png",
+    "Focus"                             : "https://cdn.wikimg.net/en/hkwiki/images/2/25/Icon_HK_Focus.png",
+    "Vengeful_Spirit"                   : "https://cdn.wikimg.net/en/hkwiki/images/a/ab/Icon_HK_Vengeful_Spirit.png",
+    "Shade_Soul"                        : "https://cdn.wikimg.net/en/hkwiki/images/e/ef/Icon_HK_Shade_Soul.png",
+    "Progressive Fireball"              : "https://cdn.wikimg.net/en/hkwiki/images/e/ef/Icon_HK_Shade_Soul.png",
+    "Desolate_Dive"                     : "https://cdn.wikimg.net/en/hkwiki/images/c/c3/Icon_HK_Desolate_Dive.png",
+    "Descending_Dark"                   : "https://cdn.wikimg.net/en/hkwiki/images/a/a1/Icon_HK_Descending_Dark.png",
+    "Progressive Dive"                  : "https://cdn.wikimg.net/en/hkwiki/images/a/a1/Icon_HK_Descending_Dark.png",
+    "Howling_Wraiths"                   : "https://cdn.wikimg.net/en/hkwiki/images/1/16/Icon_HK_Howling_Wraiths.png",
+    "Abyss_Shriek"                      : "https://cdn.wikimg.net/en/hkwiki/images/b/bf/Icon_HK_Abyss_Shriek.png",
+    "Progressive Shriek"                : "https://cdn.wikimg.net/en/hkwiki/images/b/bf/Icon_HK_Abyss_Shriek.png",
 
-    "Mothwing_Cloak":                   "https://cdn.wikimg.net/en/hkwiki/images/a/a2/Icon_HK_Mothwing_Cloak.png",
-    "Left_Mothwing_Cloak":              "https://cdn.wikimg.net/en/hkwiki/images/a/a2/Icon_HK_Mothwing_Cloak.png",
-    "Right_Mothwing_Cloak":             "https://cdn.wikimg.net/en/hkwiki/images/a/a2/Icon_HK_Mothwing_Cloak.png",
-    "Mantis_Claw":                      "https://cdn.wikimg.net/en/hkwiki/images/b/bf/Icon_HK_Mantis_Claw.png",
-    "Progressive Claw":                 "https://cdn.wikimg.net/en/hkwiki/images/b/bf/Icon_HK_Mantis_Claw.png",
-    "Left_Mantis_Claw":                 "https://cdn.wikimg.net/en/hkwiki/images/b/bf/Icon_HK_Mantis_Claw.png",
-    "Right_Mantis_Claw":                "https://cdn.wikimg.net/en/hkwiki/images/b/bf/Icon_HK_Mantis_Claw.png",
-    "Crystal_Heart":                    "https://cdn.wikimg.net/en/hkwiki/images/e/e8/Icon_HK_Crystal_Heart.png",
-    "Progressive Crystal Heart":        "https://cdn.wikimg.net/en/hkwiki/images/e/e8/Icon_HK_Crystal_Heart.png",
-    "Left_Crystal_Heart":               "https://cdn.wikimg.net/en/hkwiki/images/e/e8/Icon_HK_Crystal_Heart.png",
-    "Right_Crystal_Heart":              "https://cdn.wikimg.net/en/hkwiki/images/e/e8/Icon_HK_Crystal_Heart.png",
-    "Monarch_Wings":                    "https://cdn.wikimg.net/en/hkwiki/images/9/9b/Icon_HK_Monarch_Wings.png",
-    "Isma's_Tear":                      "https://cdn.wikimg.net/en/hkwiki/images/8/8c/Icon_HK_Isma%27s_Tear.png",
-    "Swim":                             "https://cdn.wikimg.net/en/hkwiki/images/thumb/a/a7/Icon_HK_Isma%27s_Tears_Art.png/300px-Icon_HK_Isma%27s_Tears_Art.png",
-    "Shade_Cloak":                      "https://cdn.wikimg.net/en/hkwiki/images/7/75/Icon_HK_Shade_Cloak.png",
-    "Progressive Cloak":                "https://cdn.wikimg.net/en/hkwiki/images/7/75/Icon_HK_Shade_Cloak.png",
-    "Left_Shade_Cloak":                 "https://cdn.wikimg.net/en/hkwiki/images/7/75/Icon_HK_Shade_Cloak.png",
-    "Right_Shade_Cloak":                "https://cdn.wikimg.net/en/hkwiki/images/7/75/Icon_HK_Shade_Cloak.png",
-    "Dream_Nail":                       "https://cdn.wikimg.net/en/hkwiki/images/a/a2/Icon_HK_Dream_Nail.png",
-    "Awoken_Dream_Nail":                "https://cdn.wikimg.net/en/hkwiki/images/b/b0/Icon_HK_Awoken_Dream_Nail.png",
-    "Progressive Dreamnail":            "https://cdn.wikimg.net/en/hkwiki/images/b/b0/Icon_HK_Awoken_Dream_Nail.png",
-    "Dream_Gate":                       "https://cdn.wikimg.net/en/hkwiki/images/3/34/Icon_HK_Dreamgate.png",
-    "World_Sense":                      "https://cdn.wikimg.net/en/hkwiki/images/thumb/d/d7/Icon_HK_World_Sense_Art.png/310px-Icon_HK_World_Sense_Art.png",
+    "Mothwing_Cloak"                    : "https://cdn.wikimg.net/en/hkwiki/images/a/a2/Icon_HK_Mothwing_Cloak.png",
+    "Left_Mothwing_Cloak"               : "https://cdn.wikimg.net/en/hkwiki/images/a/a2/Icon_HK_Mothwing_Cloak.png",
+    "Right_Mothwing_Cloak"              : "https://cdn.wikimg.net/en/hkwiki/images/a/a2/Icon_HK_Mothwing_Cloak.png",
+    "Mantis_Claw"                       : "https://cdn.wikimg.net/en/hkwiki/images/b/bf/Icon_HK_Mantis_Claw.png",
+    "Progressive Claw"                  : "https://cdn.wikimg.net/en/hkwiki/images/b/bf/Icon_HK_Mantis_Claw.png",
+    "Left_Mantis_Claw"                  : "https://cdn.wikimg.net/en/hkwiki/images/b/bf/Icon_HK_Mantis_Claw.png",
+    "Right_Mantis_Claw"                 : "https://cdn.wikimg.net/en/hkwiki/images/b/bf/Icon_HK_Mantis_Claw.png",
+    "Crystal_Heart"                     : "https://cdn.wikimg.net/en/hkwiki/images/e/e8/Icon_HK_Crystal_Heart.png",
+    "Progressive Crystal Heart"         : "https://cdn.wikimg.net/en/hkwiki/images/e/e8/Icon_HK_Crystal_Heart.png",
+    "Left_Crystal_Heart"                : "https://cdn.wikimg.net/en/hkwiki/images/e/e8/Icon_HK_Crystal_Heart.png",
+    "Right_Crystal_Heart"               : "https://cdn.wikimg.net/en/hkwiki/images/e/e8/Icon_HK_Crystal_Heart.png",
+    "Monarch_Wings"                     : "https://cdn.wikimg.net/en/hkwiki/images/9/9b/Icon_HK_Monarch_Wings.png",
+    "Isma's_Tear"                       : "https://cdn.wikimg.net/en/hkwiki/images/8/8c/Icon_HK_Isma%27s_Tear.png",
+    "Swim"                              : "https://cdn.wikimg.net/en/hkwiki/images/thumb/a/a7/Icon_HK_Isma%27s_Tears_Art.png/300px-Icon_HK_Isma%27s_Tears_Art.png",
+    "Shade_Cloak"                       : "https://cdn.wikimg.net/en/hkwiki/images/7/75/Icon_HK_Shade_Cloak.png",
+    "Progressive Cloak"                 : "https://cdn.wikimg.net/en/hkwiki/images/7/75/Icon_HK_Shade_Cloak.png",
+    "Left_Shade_Cloak"                  : "https://cdn.wikimg.net/en/hkwiki/images/7/75/Icon_HK_Shade_Cloak.png",
+    "Right_Shade_Cloak"                 : "https://cdn.wikimg.net/en/hkwiki/images/7/75/Icon_HK_Shade_Cloak.png",
+    "Dream_Nail"                        : "https://cdn.wikimg.net/en/hkwiki/images/a/a2/Icon_HK_Dream_Nail.png",
+    "Awoken_Dream_Nail"                 : "https://cdn.wikimg.net/en/hkwiki/images/b/b0/Icon_HK_Awoken_Dream_Nail.png",
+    "Progressive Dreamnail"             : "https://cdn.wikimg.net/en/hkwiki/images/b/b0/Icon_HK_Awoken_Dream_Nail.png",
+    "Dream_Gate"                        : "https://cdn.wikimg.net/en/hkwiki/images/3/34/Icon_HK_Dreamgate.png",
+    "World_Sense"                       : "https://cdn.wikimg.net/en/hkwiki/images/thumb/d/d7/Icon_HK_World_Sense_Art.png/310px-Icon_HK_World_Sense_Art.png",
     
-    "Cyclone_Slash":                    "https://cdn.wikimg.net/en/hkwiki/images/4/4f/Icon_HK_Cyclone_Slash.png",
-    "Dash_Slash":                       "https://cdn.wikimg.net/en/hkwiki/images/f/fd/Icon_HK_Dash_Slash.png",
-    "Great_Slash":                      "https://cdn.wikimg.net/en/hkwiki/images/4/43/Icon_HK_Great_Slash.png",
+    "Cyclone_Slash"                     : "https://cdn.wikimg.net/en/hkwiki/images/4/4f/Icon_HK_Cyclone_Slash.png",
+    "Dash_Slash"                        : "https://cdn.wikimg.net/en/hkwiki/images/f/fd/Icon_HK_Dash_Slash.png",
+    "Great_Slash"                       : "https://cdn.wikimg.net/en/hkwiki/images/4/43/Icon_HK_Great_Slash.png",
 
-    "Rancid_Egg":                       "https://cdn.wikimg.net/en/hkwiki/images/3/3f/Rancid_Egg.png",
-    "City_Crest":                       "https://cdn.wikimg.net/en/hkwiki/images/f/fb/City_Crest.png",
-    "Elegant_Key":                      "https://cdn.wikimg.net/en/hkwiki/images/7/7f/Elegant_Key.png",
-    "King's_Brand":                     "https://cdn.wikimg.net/en/hkwiki/images/8/8f/Kings_Brand_inventory.png",
-    "Love_Key":                         "https://cdn.wikimg.net/en/hkwiki/images/e/ec/Love_Key.png",
-    "Lumafly_Lantern":                  "https://cdn.wikimg.net/en/hkwiki/images/5/5f/Lumafly_Lantern.png",
-    "Shopkeeper's_Key":                 "https://cdn.wikimg.net/en/hkwiki/images/a/ab/Shopkeeper%27s_Key.png",
-    "Simple_Key":                       "https://cdn.wikimg.net/en/hkwiki/images/f/f3/Simple_Key.png",
-    "Tram_Pass":                        "https://cdn.wikimg.net/en/hkwiki/images/6/69/Tram_Pass.png",
-    "Elevator_Pass":                    "https://cdn.wikimg.net/en/hkwiki/images/6/69/Tram_Pass.png",
+    "Rancid_Egg"                        : "https://cdn.wikimg.net/en/hkwiki/images/3/3f/Rancid_Egg.png",
+    "City_Crest"                        : "https://cdn.wikimg.net/en/hkwiki/images/f/fb/City_Crest.png",
+    "Elegant_Key"                       : "https://cdn.wikimg.net/en/hkwiki/images/7/7f/Elegant_Key.png",
+    "King's_Brand"                      : "https://cdn.wikimg.net/en/hkwiki/images/8/8f/Kings_Brand_inventory.png",
+    "Love_Key"                          : "https://cdn.wikimg.net/en/hkwiki/images/e/ec/Love_Key.png",
+    "Lumafly_Lantern"                   : "https://cdn.wikimg.net/en/hkwiki/images/5/5f/Lumafly_Lantern.png",
+    "Shopkeeper's_Key"                  : "https://cdn.wikimg.net/en/hkwiki/images/a/ab/Shopkeeper%27s_Key.png",
+    "Simple_Key"                        : "https://cdn.wikimg.net/en/hkwiki/images/f/f3/Simple_Key.png",
+    "Tram_Pass"                         : "https://cdn.wikimg.net/en/hkwiki/images/6/69/Tram_Pass.png",
+    "Elevator_Pass"                     : "https://cdn.wikimg.net/en/hkwiki/images/6/69/Tram_Pass.png",
 
-    "Charm_Notch":                      "https://cdn.wikimg.net/en/hkwiki/images/thumb/e/e3/Charm_Notch.png/88px-Charm_Notch.png",
-    "Grimmkin_Flame":                   "https://cdn.wikimg.net/en/hkwiki/images/thumb/8/8f/FlameConsumed.png/100px-FlameConsumed.png",
-    "Grub":                             "https://cdn.wikimg.net/en/hkwiki/images/0/0c/Grub.png",
-    "Pale_Ore":                         "https://cdn.wikimg.net/en/hkwiki/images/e/eb/Pale_Ore.png",
-    "Mask_Shard":                       "https://cdn.wikimg.net/en/hkwiki/images/6/69/Mask_Shard.png",
-    "Vessel_Fragment":                  "https://cdn.wikimg.net/en/hkwiki/images/2/29/Vessel_Fragment.png",
-    "Wanderer's_Journal":               "https://cdn.wikimg.net/en/hkwiki/images/b/b5/Wanderer%27s_Journal.png",
-    "Hallownest_Seal":                  "https://cdn.wikimg.net/en/hkwiki/images/3/38/Hallownest_Seal.png",
-    "King's_Idol":                      "https://cdn.wikimg.net/en/hkwiki/images/d/d2/King%27s_Idol.png",
-    "Arcane_Egg":                       "https://cdn.wikimg.net/en/hkwiki/images/1/18/Arcane_Egg.png",
-    "Essence":                          "https://cdn.wikimg.net/en/hkwiki/images/thumb/0/04/Hidden_Dreams_Icon.png/20px-Hidden_Dreams_Icon.png",
+    "Charm_Notch"                       : "https://cdn.wikimg.net/en/hkwiki/images/thumb/e/e3/Charm_Notch.png/88px-Charm_Notch.png",
+    "Grimmkin_Flame"                    : "https://cdn.wikimg.net/en/hkwiki/images/thumb/8/8f/FlameConsumed.png/100px-FlameConsumed.png",
+    "Grub"                              : "https://cdn.wikimg.net/en/hkwiki/images/0/0c/Grub.png",
+    "Pale_Ore"                          : "https://cdn.wikimg.net/en/hkwiki/images/e/eb/Pale_Ore.png",
+    "Mask_Shard"                        : "https://cdn.wikimg.net/en/hkwiki/images/6/69/Mask_Shard.png",
+    "Vessel_Fragment"                   : "https://cdn.wikimg.net/en/hkwiki/images/2/29/Vessel_Fragment.png",
+    "Wanderer's_Journal"                : "https://cdn.wikimg.net/en/hkwiki/images/b/b5/Wanderer%27s_Journal.png",
+    "Hallownest_Seal"                   : "https://cdn.wikimg.net/en/hkwiki/images/3/38/Hallownest_Seal.png",
+    "King's_Idol"                       : "https://cdn.wikimg.net/en/hkwiki/images/d/d2/King%27s_Idol.png",
+    "Arcane_Egg"                        : "https://cdn.wikimg.net/en/hkwiki/images/1/18/Arcane_Egg.png",
+    "Essence"                           : "https://cdn.wikimg.net/en/hkwiki/images/thumb/0/04/Hidden_Dreams_Icon.png/20px-Hidden_Dreams_Icon.png",
 
-    "Downslash":                        "https://cdn.wikimg.net/en/hkwiki/images/thumb/4/4a/Nail_5_Pure_Nail.png/36px-Nail_5_Pure_Nail.png",
-    "Leftslash":                        "https://cdn.wikimg.net/en/hkwiki/images/thumb/4/4a/Nail_5_Pure_Nail.png/36px-Nail_5_Pure_Nail.png",
-    "Rightslash":                       "https://cdn.wikimg.net/en/hkwiki/images/thumb/4/4a/Nail_5_Pure_Nail.png/36px-Nail_5_Pure_Nail.png",
-    "Upslash":                          "https://cdn.wikimg.net/en/hkwiki/images/thumb/4/4a/Nail_5_Pure_Nail.png/36px-Nail_5_Pure_Nail.png",
-    "Nail":                             "https://cdn.wikimg.net/en/hkwiki/images/thumb/4/4a/Nail_5_Pure_Nail.png/36px-Nail_5_Pure_Nail.png",
+    "Downslash"                         : "https://cdn.wikimg.net/en/hkwiki/images/thumb/4/4a/Nail_5_Pure_Nail.png/36px-Nail_5_Pure_Nail.png",
+    "Leftslash"                         : "https://cdn.wikimg.net/en/hkwiki/images/thumb/4/4a/Nail_5_Pure_Nail.png/36px-Nail_5_Pure_Nail.png",
+    "Rightslash"                        : "https://cdn.wikimg.net/en/hkwiki/images/thumb/4/4a/Nail_5_Pure_Nail.png/36px-Nail_5_Pure_Nail.png",
+    "Upslash"                           : "https://cdn.wikimg.net/en/hkwiki/images/thumb/4/4a/Nail_5_Pure_Nail.png/36px-Nail_5_Pure_Nail.png",
+    "Nail"                              : "https://cdn.wikimg.net/en/hkwiki/images/thumb/4/4a/Nail_5_Pure_Nail.png/36px-Nail_5_Pure_Nail.png",
     
-    "Stag":                             "https://cdn.wikimg.net/en/hkwiki/images/thumb/5/5e/Map_Pin_Stag.png/50px-Map_Pin_Stag.png",
+    "Stag"                              : "https://cdn.wikimg.net/en/hkwiki/images/thumb/5/5e/Map_Pin_Stag.png/50px-Map_Pin_Stag.png",
 
-    "IsCompleted":                      "https://cdn.wikimg.net/en/hkwiki/images/0/06/The_Knight_Front.png"
+    "IsCompleted"                       : "https://cdn.wikimg.net/en/hkwiki/images/0/06/The_Knight_Front.png"
 } %}
 
 {% set multi_items = [
@@ -201,74 +201,74 @@
 
 {# Most have a duplicated 0th entry for when we have none of that item to still load the correct icon/name. #}
 {% set progressive_order = {
-    "Progressive Heart" :           ["Fragile_Heart", "Fragile_Heart", "Unbreakable_Heart"],
-    "Progressive Greed":            ["Fragile_Greed", "Fragile_Greed", "Unbreakable_Greed"],
-    "Progressive Strength":         ["Fragile_Strength", "Fragile_Strength", "Unbreakable_Strength"],
-    "Progressive Grimmchild":       ["Grimmchild1", "Grimmchild1", "Grimmchild2", "Grimmchild3", "Grimmchild4"],
-    "Progressive Void Heart":       ["Kingsoul", "Queen_Fragment", "Kingsoul", "Void_Heart"],
+    "Progressive Heart"             : ["Fragile_Heart", "Fragile_Heart", "Unbreakable_Heart"],
+    "Progressive Greed"             : ["Fragile_Greed", "Fragile_Greed", "Unbreakable_Greed"],
+    "Progressive Strength"          : ["Fragile_Strength", "Fragile_Strength", "Unbreakable_Strength"],
+    "Progressive Grimmchild"        : ["Grimmchild1", "Grimmchild1", "Grimmchild2", "Grimmchild3", "Grimmchild4"],
+    "Progressive Void Heart"        : ["Kingsoul", "Queen_Fragment", "Kingsoul", "Void_Heart"],
 
-    "Progressive Cloak":            ["Mothwing_Cloak", "Mothwing_Cloak", "Shade_Cloak"],
-    "Progressive Left Cloak":       ["Left_Mothwing_Cloak", "Left_Mothwing_Cloak", "Left_Shade_Cloak"],
-    "Progressive Right Cloak":      ["Right_Mothwing_Cloak", "Right_Mothwing_Cloak", "Right_Shade_Cloak"],
-    "Progressive Claw":             ["Mantis_Claw", "Left_Mantis_Claw", "Right_Mantis_Claw", "Mantis_Claw"],
-    "Progressive Crystal Heart":    ["Crystal_Heart", "Left_Crystal_Heart", "Right_Crystal_Heart", "Crystal_Heart"],
+    "Progressive Cloak"             : ["Mothwing_Cloak", "Mothwing_Cloak", "Shade_Cloak"],
+    "Progressive Left Cloak"        : ["Left_Mothwing_Cloak", "Left_Mothwing_Cloak", "Left_Shade_Cloak"],
+    "Progressive Right Cloak"       : ["Right_Mothwing_Cloak", "Right_Mothwing_Cloak", "Right_Shade_Cloak"],
+    "Progressive Claw"              : ["Mantis_Claw", "Left_Mantis_Claw", "Right_Mantis_Claw", "Mantis_Claw"],
+    "Progressive Crystal Heart"     : ["Crystal_Heart", "Left_Crystal_Heart", "Right_Crystal_Heart", "Crystal_Heart"],
 
-    "Progressive Fireball":         ["Vengeful_Spirit", "Vengeful_Spirit", "Shade_Soul"],
-    "Progressive Dive":             ["Desolate_Dive", "Desolate_Dive", "Descending_Dark"],
-    "Progressive Shriek":           ["Howling_Wraiths", "Howling_Wraiths", "Abyss_Shriek"],
+    "Progressive Fireball"          : ["Vengeful_Spirit", "Vengeful_Spirit", "Shade_Soul"],
+    "Progressive Dive"              : ["Desolate_Dive", "Desolate_Dive", "Descending_Dark"],
+    "Progressive Shriek"            : ["Howling_Wraiths", "Howling_Wraiths", "Abyss_Shriek"],
 
-    "Progressive Dreamnail":        ["Dream_Nail", "Dream_Nail", "Awoken_Dream_Nail"]
+    "Progressive Dreamnail"         : ["Dream_Nail", "Dream_Nail", "Awoken_Dream_Nail"]
 } %}
 
 {% set itemToRandomizerOption = {
-    "Nail":                         "RandomizeNail",
+    "Nail"                          : "RandomizeNail",
 
-    "Monomon":                      "RandomizeDreamers",
-    "Herrah":                       "RandomizeDreamers",
-    "Lurien":                       "RandomizeDreamers",
+    "Monomon"                       : "RandomizeDreamers",
+    "Herrah"                        : "RandomizeDreamers",
+    "Lurien"                        : "RandomizeDreamers",
 
-    "Progressive Cloak":            "RandomizeSkills",
-    "Progressive Claw":             "RandomizeSkills",
-    "Progressive Crystal Heart":    "RandomizeSkills",
-    "Monarch_Wings":                "RandomizeSkills",
-    "Isma's_Tear":                  "RandomizeSkills",
-    "Progressive Dreamnail":        "RandomizeSkills",
-    "Dream_Gate":                   "RandomizeSkills",
-    "Cyclone_Slash":                "RandomizeSkills",
-    "Dash_Slash":                   "RandomizeSkills",
-    "Great_Slash":                  "RandomizeSkills",
-    "Progressive Fireball":         "RandomizeSkills",
-    "Progressive Dive":             "RandomizeSkills",
-    "Progressive Shriek":           "RandomizeSkills",
+    "Progressive Cloak"             : "RandomizeSkills",
+    "Progressive Claw"              : "RandomizeSkills",
+    "Progressive Crystal Heart"     : "RandomizeSkills",
+    "Monarch_Wings"                 : "RandomizeSkills",
+    "Isma's_Tear"                   : "RandomizeSkills",
+    "Progressive Dreamnail"         : "RandomizeSkills",
+    "Dream_Gate"                    : "RandomizeSkills",
+    "Cyclone_Slash"                 : "RandomizeSkills",
+    "Dash_Slash"                    : "RandomizeSkills",
+    "Great_Slash"                   : "RandomizeSkills",
+    "Progressive Fireball"          : "RandomizeSkills",
+    "Progressive Dive"              : "RandomizeSkills",
+    "Progressive Shriek"            : "RandomizeSkills",
 
-    "City_Crest":                   "RandomizeKeys",
-    "Elegant_Key":                  "RandomizeKeys",
-    "King's_Brand":                 "RandomizeKeys",
-    "Love_Key":                     "RandomizeKeys",
-    "Lumafly_Lantern":              "RandomizeKeys",
-    "Shopkeeper's_Key":             "RandomizeKeys",
-    "Simple_Key":                   "RandomizeKeys",
-    "Tram_Pass":                    "RandomizeKeys",
+    "City_Crest"                    : "RandomizeKeys",
+    "Elegant_Key"                   : "RandomizeKeys",
+    "King's_Brand"                  : "RandomizeKeys",
+    "Love_Key"                      : "RandomizeKeys",
+    "Lumafly_Lantern"               : "RandomizeKeys",
+    "Shopkeeper's_Key"              : "RandomizeKeys",
+    "Simple_Key"                    : "RandomizeKeys",
+    "Tram_Pass"                     : "RandomizeKeys",
     
-    "Elevator_Pass":                "RandomizeElevatorPass",
+    "Elevator_Pass"                 : "RandomizeElevatorPass",
 
-    "Focus":                        "RandomizeFocus",
+    "Focus"                         : "RandomizeFocus",
 
-    "Swim":                         "RandomizeSwim",
+    "Swim"                          : "RandomizeSwim",
 
-    "Charm_Notch":                  "RandomizeCharmNotches",
+    "Charm_Notch"                   : "RandomizeCharmNotches",
 
-    "Grimmkin_Flame":               "RandomizeGrimmkinFlames",
+    "Grimmkin_Flame"                : "RandomizeGrimmkinFlames",
 
-    "Grub" :                        "RandomizeGrubs",
+    "Grub"                          : "RandomizeGrubs",
 
-    "Rancid_Egg":                   "RandomizeRancidEggs",
+    "Rancid_Egg"                    : "RandomizeRancidEggs",
 
-    "Pale_Ore":                     "RandomizePaleOre",
-    "Mask_Shard":                   "RandomizeMaskShards",
-    "Vessel_Fragment":              "RandomizeVesselFragments",
-    "Essence":                      "RandomizeEssence",
-    "Stag":                         "RandomizeStags"
+    "Pale_Ore"                      : "RandomizePaleOre",
+    "Mask_Shard"                    : "RandomizeMaskShards",
+    "Vessel_Fragment"               : "RandomizeVesselFragments",
+    "Essence"                       : "RandomizeEssence",
+    "Stag"                          : "RandomizeStags"
 } %}
 
 {%- block custom_table_headers %}
@@ -294,6 +294,8 @@
     {%- for item in inventory_order -%}
         {% if item is in itemToRandomizerOption and options[(team, player)][itemToRandomizerOption[item]] == 0 %}
             {%- if inventories[(team, player)][item] -%}
+                {# There are items i.e. Downslash, Focus and Swim you even get send to the tracker although you haven't choosed these as rando options. #}
+                {# Therefore an extra handling. #}
                 <td class="center-column item-acquired">
                     {% if item in multi_items %}
                         {{ inventories[(team, player)][item] }}
@@ -302,9 +304,11 @@
                     {% endif %}
                 </td>
             {%- else -%}
+                {# Items which are not randomized won't send notifications to AP after collecting in game. Dash as a visualization for that. #}
                 <td class="center-column notRandomized">-</td>
             {%- endif -%}
         {%- else -%}
+            {# Item is randomized. #}
             {%- if inventories[(team, player)][item] -%}
                 <td class="center-column item-acquired">
                     {% if item in multi_items %}
@@ -320,6 +324,7 @@
                                     title="{{ non_prog_item }}"
                                 />
 
+                                {# Extra handling for splitted skills. #}
                                 {% if
                                         (item == "Progressive Cloak"         and inventories[(team, player)]["Progressive Left Cloak"] == 1 and inventories[(team, player)][item] == 0) or
                                         (item == "Progressive Claw"          and inventories[(team, player)][item] == 1) or
@@ -342,6 +347,7 @@
                             {{ inventories[(team, player)][item] }}
                         {% endif %}
                     {% elif item == "Nail" and inventories[(team, player)][item] != 15 %}
+                        {# Extra handling for nail: show the directions or ✔️ if all are collected #}
                         {% for nail, data in nails.items() %}
                             {% if nail in inventories[(team, player)] and (inventories[(team, player)][item] or data["bit"]) == inventories[(team, player)][item] %}
                                 <div class="quantity" style="display: block;">{{ data["text"] }}</div>
@@ -352,6 +358,9 @@
                     {% endif %}
                 </td>
             {%- elif item == "Progressive Cloak" -%}
+                {# Extra handling for cloak (if it's still splitted). #}
+                {# Mothwing Cloak or Shade Cloak will be handled in the block above. #}
+                {# Logic rules in Python part. #}
                 <td class="center-column {{ 'item-acquired' if inventories[(team, player)]["Progressive Left Cloak"] or inventories[(team, player)]["Progressive Right Cloak"] }}">
                     {% if inventories[(team, player)]["Progressive Left Cloak"] == 1 or inventories[(team, player)]["Progressive Right Cloak"] == 1 %}
                         {% set non_prog_item = progressive_order["Progressive Cloak"][1] %}
@@ -375,12 +384,14 @@
                     {% endif %}
                 </td>
             {%- else -%}
+                {# Item not collected so far but is randomized and in item pool. #}
                 <td></td>
             {%- endif -%}
         {%- endif -%}
     {% endfor %}
 {% endblock %}
 
+{# visualization for charm notches and charms. #}
 {% block custom_tables %}
 {% for team in total_team_locations %}
     <div class="table-wrapper">

--- a/WebHostLib/templates/multitracker__HK.html
+++ b/WebHostLib/templates/multitracker__HK.html
@@ -1,0 +1,466 @@
+{% extends "multitracker.html" %}
+{% block head %}
+    {{ super() }}
+    <script type="application/ecmascript" src="{{ url_for("static", filename="assets/jquery.scrollsync.js") }}"></script>
+    <script type="application/ecmascript" src="{{ url_for("static", filename="assets/lttpMultiTracker.js") }}"></script>
+    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='styles/tracker__HK.css') }}">
+
+    <style>
+        .quantity {
+            display: inline;
+            font-size: 0.75rem;
+            line-height: 0.75rem;
+            user-select: none;
+        }
+    </style>
+{% endblock %}
+
+{# List all tracker-relevant icons. Format: (Name, Image URL) #}
+{% set icons = {
+    "Wayward_Compass":                  "https://cdn.wikimg.net/en/hkwiki/images/thumb/7/7d/Wayward_Compass.png/71px-Wayward_Compass.png",
+    "Gathering_Swarm":                  "https://cdn.wikimg.net/en/hkwiki/images/thumb/8/8a/Gathering_Swarm.png/67px-Gathering_Swarm.png",
+    "Stalwart_Shell":                   "https://cdn.wikimg.net/en/hkwiki/images/thumb/f/f2/Stalwart_Shell.png/72px-Stalwart_Shell.png",
+    "Soul_Catcher":                     "https://cdn.wikimg.net/en/hkwiki/images/thumb/c/ca/Soul_Catcher.png/71px-Soul_Catcher.png",
+    "Shaman_Stone":                     "https://cdn.wikimg.net/en/hkwiki/images/thumb/5/5e/Shaman_Stone.png/72px-Shaman_Stone.png",
+    "Soul_Eater":                       "https://cdn.wikimg.net/en/hkwiki/images/thumb/6/6c/Soul_Eater.png/72px-Soul_Eater.png",
+    "Dashmaster":                       "https://cdn.wikimg.net/en/hkwiki/images/thumb/7/70/Dashmaster.png/71px-Dashmaster.png",
+    "Sprintmaster":                     "https://cdn.wikimg.net/en/hkwiki/images/thumb/e/e9/Sprintmaster.png/72px-Sprintmaster.png",
+    "Grubsong":                         "https://cdn.wikimg.net/en/hkwiki/images/thumb/7/78/Grubsong.png/72px-Grubsong.png",
+    "Grubberfly's_Elegy":               "https://cdn.wikimg.net/en/hkwiki/images/thumb/b/bd/Grubberfly%27s_Elegy.png/68px-Grubberfly%27s_Elegy.png",
+    "Fragile_Heart":                    "https://cdn.wikimg.net/en/hkwiki/images/thumb/1/13/Fragile_Heart.png/72px-Fragile_Heart.png",
+    "Unbreakable_Heart":                "https://cdn.wikimg.net/en/hkwiki/images/thumb/1/15/Unbreakable_Heart.png/69px-Unbreakable_Heart.png",
+    "Fragile_Greed":                    "https://cdn.wikimg.net/en/hkwiki/images/thumb/b/b6/Fragile_Greed.png/69px-Fragile_Greed.png",
+    "Unbreakable_Greed":                "https://cdn.wikimg.net/en/hkwiki/images/thumb/2/2a/Unbreakable_Greed.png/69px-Unbreakable_Greed.png",
+    "Progressive Unbreakable Greed":    "https://cdn.wikimg.net/en/hkwiki/images/thumb/2/2a/Unbreakable_Greed.png/69px-Unbreakable_Greed.png",
+    "Fragile_Strength":                 "https://cdn.wikimg.net/en/hkwiki/images/thumb/7/7b/Fragile_Strength.png/69px-Fragile_Strength.png",
+    "Progressive Fragile Strength":     "https://cdn.wikimg.net/en/hkwiki/images/thumb/7/7b/Fragile_Strength.png/69px-Fragile_Strength.png",
+    "Unbreakable_Strength":             "https://cdn.wikimg.net/en/hkwiki/images/thumb/a/ac/Unbreakable_Strength.png/69px-Unbreakable_Strength.png",
+    "Progressive Unbreakable Strength": "https://cdn.wikimg.net/en/hkwiki/images/thumb/a/ac/Unbreakable_Strength.png/69px-Unbreakable_Strength.png",
+    "Spell_Twister":                    "https://cdn.wikimg.net/en/hkwiki/images/thumb/3/33/Spell_Twister.png/66px-Spell_Twister.png",
+    "Steady_Body":                      "https://cdn.wikimg.net/en/hkwiki/images/thumb/f/f5/Steady_Body.png/69px-Steady_Body.png",
+    "Heavy_Blow":                       "https://cdn.wikimg.net/en/hkwiki/images/thumb/f/f6/Heavy_Blow.png/72px-Heavy_Blow.png",
+    "Quick_Slash":                      "https://cdn.wikimg.net/en/hkwiki/images/thumb/5/5f/Quick_Slash.png/67px-Quick_Slash.png",
+    "Longnail":                         "https://cdn.wikimg.net/en/hkwiki/images/thumb/d/d1/Longnail.png/72px-Longnail.png",
+    "Mark_of_Pride":                    "https://cdn.wikimg.net/en/hkwiki/images/thumb/6/69/Mark_of_Pride.png/71px-Mark_of_Pride.png",
+    "Fury_of_the_Fallen":               "https://cdn.wikimg.net/en/hkwiki/images/thumb/4/4f/Fury_of_the_Fallen.png/71px-Fury_of_the_Fallen.png",
+    "Thorns_of_Agony":                  "https://cdn.wikimg.net/en/hkwiki/images/thumb/8/8f/Thorns_of_Agony.png/72px-Thorns_of_Agony.png",
+    "Baldur_Shell":                     "https://cdn.wikimg.net/en/hkwiki/images/thumb/2/21/Baldur_Shell.png/72px-Baldur_Shell.png",
+    "Flukenest":                        "https://cdn.wikimg.net/en/hkwiki/images/thumb/7/79/Flukenest.png/72px-Flukenest.png",
+    "Defender's_Crest":                 "https://cdn.wikimg.net/en/hkwiki/images/thumb/5/56/Defender%27s_Crest.png/72px-Defender%27s_Crest.png",
+    "Glowing_Womb":                     "https://cdn.wikimg.net/en/hkwiki/images/thumb/c/c6/Glowing_Womb.png/72px-Glowing_Womb.png",
+    "Quick_Focus":                      "https://cdn.wikimg.net/en/hkwiki/images/thumb/6/6a/Quick_Focus.png/69px-Quick_Focus.png",
+    "Deep_Focus":                       "https://cdn.wikimg.net/en/hkwiki/images/thumb/e/ea/Deep_Focus.png/68px-Deep_Focus.png",
+    "Lifeblood_Heart":                  "https://cdn.wikimg.net/en/hkwiki/images/thumb/7/7c/Lifeblood_Heart.png/68px-Lifeblood_Heart.png",
+    "Lifeblood_Core":                   "https://cdn.wikimg.net/en/hkwiki/images/thumb/8/81/Lifeblood_Core.png/70px-Lifeblood_Core.png",
+    "Joni's_Blessing":                  "https://cdn.wikimg.net/en/hkwiki/images/thumb/6/67/Joni%27s_Blessing.png/72px-Joni%27s_Blessing.png",
+    "Hiveblood":                        "https://cdn.wikimg.net/en/hkwiki/images/thumb/e/eb/Hiveblood.png/64px-Hiveblood.png",
+    "Spore_Shroom":                     "https://cdn.wikimg.net/en/hkwiki/images/thumb/7/78/Spore_Shroom.png/72px-Spore_Shroom.png",
+    "Sharp_Shadow":                     "https://cdn.wikimg.net/en/hkwiki/images/thumb/1/13/Sharp_Shadow.png/71px-Sharp_Shadow.png",
+    "Shape_of_Unn":                     "https://cdn.wikimg.net/en/hkwiki/images/thumb/b/b4/Shape_of_Unn.png/69px-Shape_of_Unn.png",
+    "Nailmaster's_Glory":               "https://cdn.wikimg.net/en/hkwiki/images/thumb/0/0f/Nailmaster%27s_Glory.png/68px-Nailmaster%27s_Glory.png",
+    "Weaversong":                       "https://cdn.wikimg.net/en/hkwiki/images/thumb/2/26/Weaversong.png/72px-Weaversong.png",
+    "Dream_Wielder":                    "https://cdn.wikimg.net/en/hkwiki/images/thumb/9/94/Dream_Wielder.png/72px-Dream_Wielder.png",
+    "Dreamshield":                      "https://cdn.wikimg.net/en/hkwiki/images/thumb/4/47/Dreamshield.png/72px-Dreamshield.png",
+    "Grimmchild1":                      "https://cdn.wikimg.net/en/hkwiki/images/6/6a/Grimmchild01.png",
+    "Grimmchild2":                      "https://cdn.wikimg.net/en/hkwiki/images/5/5a/Grimmchild02.png",
+    "Grimmchild3":                      "https://cdn.wikimg.net/en/hkwiki/images/1/18/Grimmchild03.png",
+    "Grimmchild4":                      "https://cdn.wikimg.net/en/hkwiki/images/9/91/Grimmchild.png",
+    "Carefree Melody":                  "https://cdn.wikimg.net/en/hkwiki/images/c/c4/Carefree_Melody.png/70px-Carefree_Melody.png",
+    "Queen_Fragment":                   "https://cdn.wikimg.net/en/hkwiki/images/4/4d/Charm_KingSoul_Left.png",
+    "King_Fragment":                    "https://cdn.wikimg.net/en/hkwiki/images/6/62/Charm_KingSoul_Right.png",
+    "Kingsoul":                         "https://cdn.wikimg.net/en/hkwiki/images/3/34/Kingsoul.png",
+    "Void_Heart":                       "https://cdn.wikimg.net/en/hkwiki/images/b/bb/Void_Heart.png",
+    "Progressive Void_Heart":           "https://cdn.wikimg.net/en/hkwiki/images/b/bb/Void_Heart.png",
+
+    "Herrah":                           "https://cdn.wikimg.net/en/hkwiki/images/b/bc/B_Herrah.png",
+    "Lurien":                           "https://cdn.wikimg.net/en/hkwiki/images/c/ce/B_Lurien.png",
+    "Monomon":                          "https://cdn.wikimg.net/en/hkwiki/images/thumb/e/e9/B_Monomon.png/202px-B_Monomon.png",
+
+    "Focus":                            "https://cdn.wikimg.net/en/hkwiki/images/2/25/Icon_HK_Focus.png",
+    "Vengeful_Spirit":                  "https://cdn.wikimg.net/en/hkwiki/images/a/ab/Icon_HK_Vengeful_Spirit.png",
+    "Shade_Soul":                       "https://cdn.wikimg.net/en/hkwiki/images/e/ef/Icon_HK_Shade_Soul.png",
+    "Progressive Fireball":             "https://cdn.wikimg.net/en/hkwiki/images/e/ef/Icon_HK_Shade_Soul.png",
+    "Desolate_Dive":                    "https://cdn.wikimg.net/en/hkwiki/images/c/c3/Icon_HK_Desolate_Dive.png",
+    "Descending_Dark":                  "https://cdn.wikimg.net/en/hkwiki/images/a/a1/Icon_HK_Descending_Dark.png",
+    "Progressive Dive":                 "https://cdn.wikimg.net/en/hkwiki/images/a/a1/Icon_HK_Descending_Dark.png",
+    "Howling_Wraiths":                  "https://cdn.wikimg.net/en/hkwiki/images/1/16/Icon_HK_Howling_Wraiths.png",
+    "Abyss_Shriek":                     "https://cdn.wikimg.net/en/hkwiki/images/b/bf/Icon_HK_Abyss_Shriek.png",
+    "Progressive Shriek":               "https://cdn.wikimg.net/en/hkwiki/images/b/bf/Icon_HK_Abyss_Shriek.png",
+
+    "Mothwing_Cloak":                   "https://cdn.wikimg.net/en/hkwiki/images/a/a2/Icon_HK_Mothwing_Cloak.png",
+    "Left_Mothwing_Cloak":              "https://cdn.wikimg.net/en/hkwiki/images/a/a2/Icon_HK_Mothwing_Cloak.png",
+    "Right_Mothwing_Cloak":             "https://cdn.wikimg.net/en/hkwiki/images/a/a2/Icon_HK_Mothwing_Cloak.png",
+    "Mantis_Claw":                      "https://cdn.wikimg.net/en/hkwiki/images/b/bf/Icon_HK_Mantis_Claw.png",
+    "Progressive Claw":                 "https://cdn.wikimg.net/en/hkwiki/images/b/bf/Icon_HK_Mantis_Claw.png",
+    "Left_Mantis_Claw":                 "https://cdn.wikimg.net/en/hkwiki/images/b/bf/Icon_HK_Mantis_Claw.png",
+    "Right_Mantis_Claw":                "https://cdn.wikimg.net/en/hkwiki/images/b/bf/Icon_HK_Mantis_Claw.png",
+    "Crystal_Heart":                    "https://cdn.wikimg.net/en/hkwiki/images/e/e8/Icon_HK_Crystal_Heart.png",
+    "Progressive Crystal Heart":        "https://cdn.wikimg.net/en/hkwiki/images/e/e8/Icon_HK_Crystal_Heart.png",
+    "Left_Crystal_Heart":               "https://cdn.wikimg.net/en/hkwiki/images/e/e8/Icon_HK_Crystal_Heart.png",
+    "Right_Crystal_Heart":              "https://cdn.wikimg.net/en/hkwiki/images/e/e8/Icon_HK_Crystal_Heart.png",
+    "Monarch_Wings":                    "https://cdn.wikimg.net/en/hkwiki/images/9/9b/Icon_HK_Monarch_Wings.png",
+    "Isma's_Tear":                      "https://cdn.wikimg.net/en/hkwiki/images/8/8c/Icon_HK_Isma%27s_Tear.png",
+    "Swim":                             "https://cdn.wikimg.net/en/hkwiki/images/thumb/a/a7/Icon_HK_Isma%27s_Tears_Art.png/300px-Icon_HK_Isma%27s_Tears_Art.png",
+    "Shade_Cloak":                      "https://cdn.wikimg.net/en/hkwiki/images/7/75/Icon_HK_Shade_Cloak.png",
+    "Progressive Cloak":                "https://cdn.wikimg.net/en/hkwiki/images/7/75/Icon_HK_Shade_Cloak.png",
+    "Left_Shade_Cloak":                 "https://cdn.wikimg.net/en/hkwiki/images/7/75/Icon_HK_Shade_Cloak.png",
+    "Right_Shade_Cloak":                "https://cdn.wikimg.net/en/hkwiki/images/7/75/Icon_HK_Shade_Cloak.png",
+    "Dream_Nail":                       "https://cdn.wikimg.net/en/hkwiki/images/a/a2/Icon_HK_Dream_Nail.png",
+    "Awoken_Dream_Nail":                "https://cdn.wikimg.net/en/hkwiki/images/b/b0/Icon_HK_Awoken_Dream_Nail.png",
+    "Progressive Dreamnail":            "https://cdn.wikimg.net/en/hkwiki/images/b/b0/Icon_HK_Awoken_Dream_Nail.png",
+    "Dream_Gate":                       "https://cdn.wikimg.net/en/hkwiki/images/3/34/Icon_HK_Dreamgate.png",
+    "World_Sense":                      "https://cdn.wikimg.net/en/hkwiki/images/thumb/d/d7/Icon_HK_World_Sense_Art.png/310px-Icon_HK_World_Sense_Art.png",
+    
+    "Cyclone_Slash":                    "https://cdn.wikimg.net/en/hkwiki/images/4/4f/Icon_HK_Cyclone_Slash.png",
+    "Dash_Slash":                       "https://cdn.wikimg.net/en/hkwiki/images/f/fd/Icon_HK_Dash_Slash.png",
+    "Great_Slash":                      "https://cdn.wikimg.net/en/hkwiki/images/4/43/Icon_HK_Great_Slash.png",
+
+    "Rancid_Egg":                       "https://cdn.wikimg.net/en/hkwiki/images/3/3f/Rancid_Egg.png",
+    "City_Crest":                       "https://cdn.wikimg.net/en/hkwiki/images/f/fb/City_Crest.png",
+    "Elegant_Key":                      "https://cdn.wikimg.net/en/hkwiki/images/7/7f/Elegant_Key.png",
+    "King's_Brand":                     "https://cdn.wikimg.net/en/hkwiki/images/8/8f/Kings_Brand_inventory.png",
+    "Love_Key":                         "https://cdn.wikimg.net/en/hkwiki/images/e/ec/Love_Key.png",
+    "Lumafly_Lantern":                  "https://cdn.wikimg.net/en/hkwiki/images/5/5f/Lumafly_Lantern.png",
+    "Shopkeeper's_Key":                 "https://cdn.wikimg.net/en/hkwiki/images/a/ab/Shopkeeper%27s_Key.png",
+    "Simple_Key":                       "https://cdn.wikimg.net/en/hkwiki/images/f/f3/Simple_Key.png",
+    "Tram_Pass":                        "https://cdn.wikimg.net/en/hkwiki/images/6/69/Tram_Pass.png",
+    "Elevator_Pass":                    "https://cdn.wikimg.net/en/hkwiki/images/6/69/Tram_Pass.png",
+
+    "Charm_Notch":                      "https://cdn.wikimg.net/en/hkwiki/images/thumb/e/e3/Charm_Notch.png/88px-Charm_Notch.png",
+    "Grimmkin_Flame":                   "https://cdn.wikimg.net/en/hkwiki/images/thumb/8/8f/FlameConsumed.png/100px-FlameConsumed.png",
+    "Grub":                             "https://cdn.wikimg.net/en/hkwiki/images/0/0c/Grub.png",
+    "Pale_Ore":                         "https://cdn.wikimg.net/en/hkwiki/images/e/eb/Pale_Ore.png",
+    "Mask_Shard":                       "https://cdn.wikimg.net/en/hkwiki/images/6/69/Mask_Shard.png",
+    "Vessel_Fragment":                  "https://cdn.wikimg.net/en/hkwiki/images/2/29/Vessel_Fragment.png",
+    "Wanderer's_Journal":               "https://cdn.wikimg.net/en/hkwiki/images/b/b5/Wanderer%27s_Journal.png",
+    "Hallownest_Seal":                  "https://cdn.wikimg.net/en/hkwiki/images/3/38/Hallownest_Seal.png",
+    "King's_Idol":                      "https://cdn.wikimg.net/en/hkwiki/images/d/d2/King%27s_Idol.png",
+    "Arcane_Egg":                       "https://cdn.wikimg.net/en/hkwiki/images/1/18/Arcane_Egg.png",
+    "Essence":                          "https://cdn.wikimg.net/en/hkwiki/images/thumb/0/04/Hidden_Dreams_Icon.png/20px-Hidden_Dreams_Icon.png",
+
+    "Downslash":                        "https://cdn.wikimg.net/en/hkwiki/images/thumb/4/4a/Nail_5_Pure_Nail.png/36px-Nail_5_Pure_Nail.png",
+    "Leftslash":                        "https://cdn.wikimg.net/en/hkwiki/images/thumb/4/4a/Nail_5_Pure_Nail.png/36px-Nail_5_Pure_Nail.png",
+    "Rightslash":                       "https://cdn.wikimg.net/en/hkwiki/images/thumb/4/4a/Nail_5_Pure_Nail.png/36px-Nail_5_Pure_Nail.png",
+    "Upslash":                          "https://cdn.wikimg.net/en/hkwiki/images/thumb/4/4a/Nail_5_Pure_Nail.png/36px-Nail_5_Pure_Nail.png",
+    "Nail":                             "https://cdn.wikimg.net/en/hkwiki/images/thumb/4/4a/Nail_5_Pure_Nail.png/36px-Nail_5_Pure_Nail.png",
+    
+    "Stag":                             "https://cdn.wikimg.net/en/hkwiki/images/thumb/5/5e/Map_Pin_Stag.png/50px-Map_Pin_Stag.png",
+
+    "IsCompleted":                      "https://cdn.wikimg.net/en/hkwiki/images/0/06/The_Knight_Front.png"
+} %}
+
+{% set multi_items = [
+    "Progressive Cloak",
+    "Progressive Claw",
+    "Progressive Crystal Heart",
+    "Progressive Dreamnail",
+    "Progressive Fireball",
+    "Progressive Dive",
+    "Progressive Shriek",
+    "Charm_Notch",
+    "Grimmkin_Flame",
+    "Grub",
+    "Rancid_Egg",
+    "Simple_Key",
+    "Pale_Ore",
+    "Mask_Shard",
+    "Vessel_Fragment",
+    "Essence",
+    "Stag"
+] %}
+
+{% set inventory_order = [
+    "Nail", "Monomon", "Herrah", "Lurien",
+    "Progressive Cloak", "Progressive Claw", "Progressive Crystal Heart",
+    "Monarch_Wings", "Isma's_Tear", "Progressive Dreamnail", "Dream_Gate", "Cyclone_Slash",
+    "Dash_Slash", "Great_Slash", "Progressive Fireball", "Progressive Dive", "Progressive Shriek",
+    "Focus", "Swim", "Grimmkin_Flame", "Grub", "Rancid_Egg",
+    "City_Crest", "Elegant_Key", "King's_Brand", "Love_Key", "Lumafly_Lantern", "Shopkeeper's_Key",
+    "Simple_Key", "Tram_Pass", "Elevator_Pass",
+    "Pale_Ore", "Mask_Shard", "Vessel_Fragment", "Essence", "Stag",
+    "IsCompleted"
+] %}
+
+{% set charms = [
+    "Wayward_Compass", "Gathering_Swarm", "Stalwart_Shell", "Soul_Catcher", "Shaman_Stone",
+    "Soul_Eater", "Dashmaster", "Sprintmaster", "Grubsong", "Grubberfly's_Elegy",
+    "Progressive Heart", "Progressive Greed", "Progressive Strength", "Spell_Twister", "Steady_Body",
+    "Heavy_Blow", "Quick_Slash", "Longnail", "Mark_of_Pride", "Fury_of_the_Fallen",
+    "Thorns_of_Agony", "Baldur_Shell", "Flukenest", "Defender's_Crest", "Glowing_Womb",
+    "Quick_Focus", "Deep_Focus", "Lifeblood_Heart", "Lifeblood_Core", "Joni's_Blessing",
+    "Hiveblood", "Spore_Shroom", "Sharp_Shadow", "Shape_of_Unn", "Nailmaster's_Glory",
+    "Weaversong", "Dream_Wielder", "Dreamshield", "Progressive Grimmchild", "Progressive Void Heart"
+] %}
+
+{%  set nails = {
+        "Downslash"     : { "text" : "Down" , "bit" : 1},
+        "Leftslash"     : { "text" : "Left" , "bit" : 2},
+        "Upslash"       : { "text" : "Up"   , "bit" : 4},
+        "Rightslash"    : { "text" : "Right", "bit" : 8}
+} %}
+
+{# Most have a duplicated 0th entry for when we have none of that item to still load the correct icon/name. #}
+{% set progressive_order = {
+    "Progressive Heart" :           ["Fragile_Heart", "Fragile_Heart", "Unbreakable_Heart"],
+    "Progressive Greed":            ["Fragile_Greed", "Fragile_Greed", "Unbreakable_Greed"],
+    "Progressive Strength":         ["Fragile_Strength", "Fragile_Strength", "Unbreakable_Strength"],
+    "Progressive Grimmchild":       ["Grimmchild1", "Grimmchild1", "Grimmchild2", "Grimmchild3", "Grimmchild4"],
+    "Progressive Void Heart":       ["Kingsoul", "Queen_Fragment", "Kingsoul", "Void_Heart"],
+
+    "Progressive Cloak":            ["Mothwing_Cloak", "Mothwing_Cloak", "Shade_Cloak"],
+    "Progressive Left Cloak":       ["Left_Mothwing_Cloak", "Left_Mothwing_Cloak", "Left_Shade_Cloak"],
+    "Progressive Right Cloak":      ["Right_Mothwing_Cloak", "Right_Mothwing_Cloak", "Right_Shade_Cloak"],
+    "Progressive Claw":             ["Mantis_Claw", "Left_Mantis_Claw", "Right_Mantis_Claw", "Mantis_Claw"],
+    "Progressive Crystal Heart":    ["Crystal_Heart", "Left_Crystal_Heart", "Right_Crystal_Heart", "Crystal_Heart"],
+
+    "Progressive Fireball":         ["Vengeful_Spirit", "Vengeful_Spirit", "Shade_Soul"],
+    "Progressive Dive":             ["Desolate_Dive", "Desolate_Dive", "Descending_Dark"],
+    "Progressive Shriek":           ["Howling_Wraiths", "Howling_Wraiths", "Abyss_Shriek"],
+
+    "Progressive Dreamnail":        ["Dream_Nail", "Dream_Nail", "Awoken_Dream_Nail"]
+} %}
+
+{% set itemToRandomizerOption = {
+    "Nail":                         "RandomizeNail",
+
+    "Monomon":                      "RandomizeDreamers",
+    "Herrah":                       "RandomizeDreamers",
+    "Lurien":                       "RandomizeDreamers",
+
+    "Progressive Cloak":            "RandomizeSkills",
+    "Progressive Claw":             "RandomizeSkills",
+    "Progressive Crystal Heart":    "RandomizeSkills",
+    "Monarch_Wings":                "RandomizeSkills",
+    "Isma's_Tear":                  "RandomizeSkills",
+    "Progressive Dreamnail":        "RandomizeSkills",
+    "Dream_Gate":                   "RandomizeSkills",
+    "Cyclone_Slash":                "RandomizeSkills",
+    "Dash_Slash":                   "RandomizeSkills",
+    "Great_Slash":                  "RandomizeSkills",
+    "Progressive Fireball":         "RandomizeSkills",
+    "Progressive Dive":             "RandomizeSkills",
+    "Progressive Shriek":           "RandomizeSkills",
+
+    "City_Crest":                   "RandomizeKeys",
+    "Elegant_Key":                  "RandomizeKeys",
+    "King's_Brand":                 "RandomizeKeys",
+    "Love_Key":                     "RandomizeKeys",
+    "Lumafly_Lantern":              "RandomizeKeys",
+    "Shopkeeper's_Key":             "RandomizeKeys",
+    "Simple_Key":                   "RandomizeKeys",
+    "Tram_Pass":                    "RandomizeKeys",
+    
+    "Elevator_Pass":                "RandomizeElevatorPass",
+
+    "Focus":                        "RandomizeFocus",
+
+    "Swim":                         "RandomizeSwim",
+
+    "Charm_Notch":                  "RandomizeCharmNotches",
+
+    "Grimmkin_Flame":               "RandomizeGrimmkinFlames",
+
+    "Grub" :                        "RandomizeGrubs",
+
+    "Rancid_Egg":                   "RandomizeRancidEggs",
+
+    "Pale_Ore":                     "RandomizePaleOre",
+    "Mask_Shard":                   "RandomizeMaskShards",
+    "Vessel_Fragment":              "RandomizeVesselFragments",
+    "Essence":                      "RandomizeEssence",
+    "Stag":                         "RandomizeStags"
+} %}
+
+{%- block custom_table_headers %}
+    {#- macro that creates a table header with display name and image -#}
+    {%- macro make_header(name, img_src) %}
+        <th class="center-column">
+            <img height="24" src="{{ img_src }}" title="{{ name }}" alt="{{ name }}" />
+        </th>
+    {% endmacro -%}
+
+    {#- call the macro to build the table header -#}
+    {%- for item in inventory_order %}
+        {%- if item in icons -%}
+            <th class="center-column">
+                <img class="icon-sprite {{ 'elevatorPass' if item == "Elevator_Pass" }} {{ 'fullNail' if item == "Nail" }}" src="{{ icons[item] }}" alt="{{ item | e }}" title="{{ item | e }}" />
+            </th>
+        {%- endif %}
+    {% endfor -%}
+{% endblock %}
+
+{# build each row of custom entries #}
+{% block custom_table_row scoped %}
+    {%- for item in inventory_order -%}
+        {% if item is in itemToRandomizerOption and options[(team, player)][itemToRandomizerOption[item]] == 0 %}
+            {%- if inventories[(team, player)][item] -%}
+                <td class="center-column item-acquired">
+                    {% if item in multi_items %}
+                        {{ inventories[(team, player)][item] }}
+                    {% else %}
+                        ✔️
+                    {% endif %}
+                </td>
+            {%- else -%}
+                <td class="center-column notRandomized">-</td>
+            {%- endif -%}
+        {%- else -%}
+            {%- if inventories[(team, player)][item] -%}
+                <td class="center-column item-acquired">
+                    {% if item in multi_items %}
+                        {% if item in progressive_order %}
+                            {% if progressive_item_max[item] == inventories[(team, player)][item] %}
+                                ✔️
+                            {% else %}
+                                {% set non_prog_item = progressive_order[item][inventories[(team, player)][item]] %}
+                                <img
+                                    height="24"
+                                    src="{{ icons[non_prog_item] }}"
+                                    alt="{{ non_prog_item }}"
+                                    title="{{ non_prog_item }}"
+                                />
+
+                                {% if
+                                        (item == "Progressive Cloak"         and inventories[(team, player)]["Progressive Left Cloak"] == 1 and inventories[(team, player)][item] == 0) or
+                                        (item == "Progressive Claw"          and inventories[(team, player)][item] == 1) or
+                                        (item == "Progressive Crystal Heart" and inventories[(team, player)][item] == 1)
+                                %}
+                                    <div class="quantity">L</div>
+                                {% endif %}
+
+                                {% if
+                                    (
+                                        (item == "Progressive Cloak"         and inventories[(team, player)]["Progressive Right Cloak"] == 1 and inventories[(team, player)][item] == 0) or
+                                        (item == "Progressive Claw"          and inventories[(team, player)][item] == 2) or
+                                        (item == "Progressive Crystal Heart" and inventories[(team, player)][item] == 2)
+                                    )
+                                %}
+                                    <div class="quantity">R</div>
+                                {% endif %}
+                            {% endif %}
+                        {% else %}
+                            {{ inventories[(team, player)][item] }}
+                        {% endif %}
+                    {% elif item == "Nail" and inventories[(team, player)][item] != 15 %}
+                        {% for nail, data in nails.items() %}
+                            {% if nail in inventories[(team, player)] and (inventories[(team, player)][item] or data["bit"]) == inventories[(team, player)][item] %}
+                                <div class="quantity" style="display: block;">{{ data["text"] }}</div>
+                            {% endif %}
+                        {% endfor %}
+                    {% else %}
+                        ✔️
+                    {% endif %}
+                </td>
+            {%- elif item == "Progressive Cloak" -%}
+                <td class="center-column {{ 'item-acquired' if inventories[(team, player)]["Progressive Left Cloak"] or inventories[(team, player)]["Progressive Right Cloak"] }}">
+                    {% if inventories[(team, player)]["Progressive Left Cloak"] == 1 or inventories[(team, player)]["Progressive Right Cloak"] == 1 %}
+                        {% set non_prog_item = progressive_order["Progressive Cloak"][1] %}
+                    {% elif inventories[(team, player)]["Progressive Left Cloak"] == 2 or inventories[(team, player)]["Progressive Right Cloak"] == 2 %}
+                        {% set non_prog_item = progressive_order["Progressive Cloak"][2] %}
+                    {% endif %}
+                    
+                    <img
+                        height="24"
+                        src="{{ icons[non_prog_item] }}"
+                        alt="{{ non_prog_item }}"
+                        title="{{ non_prog_item }}"
+                    />
+
+                    {% if inventories[(team, player)]["Progressive Left Cloak"] >= 1 %}
+                        <div class="quantity">L</div>
+                    {% endif %}
+
+                    {% if inventories[(team, player)]["Progressive Right Cloak"] >= 1 %}
+                        <div class="quantity">R</div>
+                    {% endif %}
+                </td>
+            {%- else -%}
+                <td></td>
+            {%- endif -%}
+        {%- endif -%}
+    {% endfor %}
+{% endblock %}
+
+{% block custom_tables %}
+{% for team in total_team_locations %}
+    <div class="table-wrapper">
+        <table class="table non-unique-item-table">
+            <thead>
+                <tr>
+                    <th>#</th>
+                    <th>Name</th>
+
+                    <th class="center-column">
+                        {% set charmNotch = "Charm_Notch" %}
+                        <img
+                            height="24"
+                            src="{{ icons[charmNotch] }}"
+                            alt="{{ charmNotch }}"
+                            title="{{ charmNotch }}"
+                        />
+                    </th>
+
+                    {% for charm in charms %}
+                        <th class="center-column"></th>
+                    {% endfor %}
+                </tr>
+            </thead>
+
+            <tbody>
+                {% for (player_team, player), inventory in inventories.items() if team == player_team %}
+                    {% if options[(player_team, player)]["RandomizeCharms"] == 1 or options[(player_team, player)]["RandomizeCharmNotches"] == 1 %}
+                        <tr>
+                            <td>
+                                <a href="{{ url_for("get_player_tracker", tracker=room.tracker, tracked_team=team, tracked_player=player) }}">
+                                    {{ player }}
+                                </a>
+                            </td>
+                            <td>{{ player_names_with_alias[(team, player)] | e }}</td>
+
+                            {% if options[(player_team, player)]["RandomizeCharmNotches"] == 1 %}
+                                <td class="center-column {{ 'item-acquired' if inventories[(team, player)]["Charm_Notch"] > 0 }}">
+                                    {{ inventories[(team, player)]["Charm_Notch"] }}
+                                </td>
+                            {% else %}
+                                <td class="center-column notRandomized">
+                                    -
+                                </td>
+                            {% endif %}
+                            
+                            {% if options[(player_team, player)]["RandomizeCharms"] == 1 %}
+                                {% for charm in charms %}
+                                    <td class="center-column {{ 'item-acquired' if charm in inventory }}">
+                                        {% if charm in progressive_order %}
+                                            {% set non_prog_item = progressive_order[charm][inventory[charm]] %}
+                                            <img
+                                                height="24"
+                                                src="{{ icons[non_prog_item] }}"
+                                                alt="{{ non_prog_item }}"
+                                                title="{{ non_prog_item }}"
+                                                class="{{ 'missing' if charm not in inventory }}"
+                                            />
+                                        {% else %}
+                                            <img
+                                                height="24"
+                                                src="{{ icons[charm] }}"
+                                                alt="{{ charm }}"
+                                                title="{{ charm }}"
+                                                class="{{ 'missing' if charm not in inventory }}"
+                                            />
+                                        {% endif %}
+                                    </td>
+                                {% endfor %}
+                            {% else %}
+                                <td colspan="{{ charms|length }}" class="center-column notRandomized">Charms are not randomized</td>
+                                {% for i in range(charms|length-1) %}
+                                    <td style="display: none;"></td>
+                                {% endfor %}
+                            {% endif %}
+                        </tr>
+                    {% endif %}
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+{% endfor %}
+{% endblock %}

--- a/WebHostLib/templates/multitracker__HK.html
+++ b/WebHostLib/templates/multitracker__HK.html
@@ -419,6 +419,7 @@
 
             <tbody>
                 {% for (player_team, player), inventory in inventories.items() if team == player_team %}
+                    {# If a player has neither charms nor charm notches randomized there will not be create a row. #}
                     {% if options[(player_team, player)]["RandomizeCharms"] == 1 or options[(player_team, player)]["RandomizeCharmNotches"] == 1 %}
                         <tr>
                             <td>

--- a/WebHostLib/templates/tracker__HK.html
+++ b/WebHostLib/templates/tracker__HK.html
@@ -1,0 +1,342 @@
+{% set icons = {
+    "Wayward_Compass":                  "https://cdn.wikimg.net/en/hkwiki/images/thumb/7/7d/Wayward_Compass.png/71px-Wayward_Compass.png",
+    "Gathering_Swarm":                  "https://cdn.wikimg.net/en/hkwiki/images/thumb/8/8a/Gathering_Swarm.png/67px-Gathering_Swarm.png",
+    "Stalwart_Shell":                   "https://cdn.wikimg.net/en/hkwiki/images/thumb/f/f2/Stalwart_Shell.png/72px-Stalwart_Shell.png",
+    "Soul_Catcher":                     "https://cdn.wikimg.net/en/hkwiki/images/thumb/c/ca/Soul_Catcher.png/71px-Soul_Catcher.png",
+    "Shaman_Stone":                     "https://cdn.wikimg.net/en/hkwiki/images/thumb/5/5e/Shaman_Stone.png/72px-Shaman_Stone.png",
+    "Soul_Eater":                       "https://cdn.wikimg.net/en/hkwiki/images/thumb/6/6c/Soul_Eater.png/72px-Soul_Eater.png",
+    "Dashmaster":                       "https://cdn.wikimg.net/en/hkwiki/images/thumb/7/70/Dashmaster.png/71px-Dashmaster.png",
+    "Sprintmaster":                     "https://cdn.wikimg.net/en/hkwiki/images/thumb/e/e9/Sprintmaster.png/72px-Sprintmaster.png",
+    "Grubsong":                         "https://cdn.wikimg.net/en/hkwiki/images/thumb/7/78/Grubsong.png/72px-Grubsong.png",
+    "Grubberfly's_Elegy":               "https://cdn.wikimg.net/en/hkwiki/images/thumb/b/bd/Grubberfly%27s_Elegy.png/68px-Grubberfly%27s_Elegy.png",
+    "Fragile_Heart":                    "https://cdn.wikimg.net/en/hkwiki/images/thumb/1/13/Fragile_Heart.png/72px-Fragile_Heart.png",
+    "Unbreakable_Heart":                "https://cdn.wikimg.net/en/hkwiki/images/thumb/1/15/Unbreakable_Heart.png/69px-Unbreakable_Heart.png",
+    "Fragile_Greed":                    "https://cdn.wikimg.net/en/hkwiki/images/thumb/b/b6/Fragile_Greed.png/69px-Fragile_Greed.png",
+    "Unbreakable_Greed":                "https://cdn.wikimg.net/en/hkwiki/images/thumb/2/2a/Unbreakable_Greed.png/69px-Unbreakable_Greed.png",
+    "Progressive Unbreakable Greed":    "https://cdn.wikimg.net/en/hkwiki/images/thumb/2/2a/Unbreakable_Greed.png/69px-Unbreakable_Greed.png",
+    "Fragile_Strength":                 "https://cdn.wikimg.net/en/hkwiki/images/thumb/7/7b/Fragile_Strength.png/69px-Fragile_Strength.png",
+    "Progressive Fragile Strength":     "https://cdn.wikimg.net/en/hkwiki/images/thumb/7/7b/Fragile_Strength.png/69px-Fragile_Strength.png",
+    "Unbreakable_Strength":             "https://cdn.wikimg.net/en/hkwiki/images/thumb/a/ac/Unbreakable_Strength.png/69px-Unbreakable_Strength.png",
+    "Progressive Unbreakable Strength": "https://cdn.wikimg.net/en/hkwiki/images/thumb/a/ac/Unbreakable_Strength.png/69px-Unbreakable_Strength.png",
+    "Spell_Twister":                    "https://cdn.wikimg.net/en/hkwiki/images/thumb/3/33/Spell_Twister.png/66px-Spell_Twister.png",
+    "Steady_Body":                      "https://cdn.wikimg.net/en/hkwiki/images/thumb/f/f5/Steady_Body.png/69px-Steady_Body.png",
+    "Heavy_Blow":                       "https://cdn.wikimg.net/en/hkwiki/images/thumb/f/f6/Heavy_Blow.png/72px-Heavy_Blow.png",
+    "Quick_Slash":                      "https://cdn.wikimg.net/en/hkwiki/images/thumb/5/5f/Quick_Slash.png/67px-Quick_Slash.png",
+    "Longnail":                         "https://cdn.wikimg.net/en/hkwiki/images/thumb/d/d1/Longnail.png/72px-Longnail.png",
+    "Mark_of_Pride":                    "https://cdn.wikimg.net/en/hkwiki/images/thumb/6/69/Mark_of_Pride.png/71px-Mark_of_Pride.png",
+    "Fury_of_the_Fallen":               "https://cdn.wikimg.net/en/hkwiki/images/thumb/4/4f/Fury_of_the_Fallen.png/71px-Fury_of_the_Fallen.png",
+    "Thorns_of_Agony":                  "https://cdn.wikimg.net/en/hkwiki/images/thumb/8/8f/Thorns_of_Agony.png/72px-Thorns_of_Agony.png",
+    "Baldur_Shell":                     "https://cdn.wikimg.net/en/hkwiki/images/thumb/2/21/Baldur_Shell.png/72px-Baldur_Shell.png",
+    "Flukenest":                        "https://cdn.wikimg.net/en/hkwiki/images/thumb/7/79/Flukenest.png/72px-Flukenest.png",
+    "Defender's_Crest":                 "https://cdn.wikimg.net/en/hkwiki/images/thumb/5/56/Defender%27s_Crest.png/72px-Defender%27s_Crest.png",
+    "Glowing_Womb":                     "https://cdn.wikimg.net/en/hkwiki/images/thumb/c/c6/Glowing_Womb.png/72px-Glowing_Womb.png",
+    "Quick_Focus":                      "https://cdn.wikimg.net/en/hkwiki/images/thumb/6/6a/Quick_Focus.png/69px-Quick_Focus.png",
+    "Deep_Focus":                       "https://cdn.wikimg.net/en/hkwiki/images/thumb/e/ea/Deep_Focus.png/68px-Deep_Focus.png",
+    "Lifeblood_Heart":                  "https://cdn.wikimg.net/en/hkwiki/images/thumb/7/7c/Lifeblood_Heart.png/68px-Lifeblood_Heart.png",
+    "Lifeblood_Core":                   "https://cdn.wikimg.net/en/hkwiki/images/thumb/8/81/Lifeblood_Core.png/70px-Lifeblood_Core.png",
+    "Joni's_Blessing":                  "https://cdn.wikimg.net/en/hkwiki/images/thumb/6/67/Joni%27s_Blessing.png/72px-Joni%27s_Blessing.png",
+    "Hiveblood":                        "https://cdn.wikimg.net/en/hkwiki/images/thumb/e/eb/Hiveblood.png/64px-Hiveblood.png",
+    "Spore_Shroom":                     "https://cdn.wikimg.net/en/hkwiki/images/thumb/7/78/Spore_Shroom.png/72px-Spore_Shroom.png",
+    "Sharp_Shadow":                     "https://cdn.wikimg.net/en/hkwiki/images/thumb/1/13/Sharp_Shadow.png/71px-Sharp_Shadow.png",
+    "Shape_of_Unn":                     "https://cdn.wikimg.net/en/hkwiki/images/thumb/b/b4/Shape_of_Unn.png/69px-Shape_of_Unn.png",
+    "Nailmaster's_Glory":               "https://cdn.wikimg.net/en/hkwiki/images/thumb/0/0f/Nailmaster%27s_Glory.png/68px-Nailmaster%27s_Glory.png",
+    "Weaversong":                       "https://cdn.wikimg.net/en/hkwiki/images/thumb/2/26/Weaversong.png/72px-Weaversong.png",
+    "Dream_Wielder":                    "https://cdn.wikimg.net/en/hkwiki/images/thumb/9/94/Dream_Wielder.png/72px-Dream_Wielder.png",
+    "Dreamshield":                      "https://cdn.wikimg.net/en/hkwiki/images/thumb/4/47/Dreamshield.png/72px-Dreamshield.png",
+    "Grimmchild1":                      "https://cdn.wikimg.net/en/hkwiki/images/6/6a/Grimmchild01.png",
+    "Grimmchild2":                      "https://cdn.wikimg.net/en/hkwiki/images/5/5a/Grimmchild02.png",
+    "Grimmchild3":                      "https://cdn.wikimg.net/en/hkwiki/images/1/18/Grimmchild03.png",
+    "Grimmchild4":                      "https://cdn.wikimg.net/en/hkwiki/images/9/91/Grimmchild.png",
+    "Carefree Melody":                  "https://cdn.wikimg.net/en/hkwiki/images/c/c4/Carefree_Melody.png/70px-Carefree_Melody.png",
+    "Queen_Fragment":                   "https://cdn.wikimg.net/en/hkwiki/images/4/4d/Charm_KingSoul_Left.png",
+    "King_Fragment":                    "https://cdn.wikimg.net/en/hkwiki/images/6/62/Charm_KingSoul_Right.png",
+    "Kingsoul":                         "https://cdn.wikimg.net/en/hkwiki/images/3/34/Kingsoul.png",
+    "Void_Heart":                       "https://cdn.wikimg.net/en/hkwiki/images/b/bb/Void_Heart.png",
+    "Progressive Void_Heart":           "https://cdn.wikimg.net/en/hkwiki/images/b/bb/Void_Heart.png",
+
+    "Herrah":                           "https://cdn.wikimg.net/en/hkwiki/images/b/bc/B_Herrah.png",
+    "Lurien":                           "https://cdn.wikimg.net/en/hkwiki/images/c/ce/B_Lurien.png",
+    "Monomon":                          "https://cdn.wikimg.net/en/hkwiki/images/thumb/e/e9/B_Monomon.png/202px-B_Monomon.png",
+
+    "Focus":                            "https://cdn.wikimg.net/en/hkwiki/images/2/25/Icon_HK_Focus.png",
+    "Vengeful_Spirit":                  "https://cdn.wikimg.net/en/hkwiki/images/a/ab/Icon_HK_Vengeful_Spirit.png",
+    "Shade_Soul":                       "https://cdn.wikimg.net/en/hkwiki/images/e/ef/Icon_HK_Shade_Soul.png",
+    "Progressive Fireball":             "https://cdn.wikimg.net/en/hkwiki/images/e/ef/Icon_HK_Shade_Soul.png",
+    "Desolate_Dive":                    "https://cdn.wikimg.net/en/hkwiki/images/c/c3/Icon_HK_Desolate_Dive.png",
+    "Descending_Dark":                  "https://cdn.wikimg.net/en/hkwiki/images/a/a1/Icon_HK_Descending_Dark.png",
+    "Progressive Dive":                 "https://cdn.wikimg.net/en/hkwiki/images/a/a1/Icon_HK_Descending_Dark.png",
+    "Howling_Wraiths":                  "https://cdn.wikimg.net/en/hkwiki/images/1/16/Icon_HK_Howling_Wraiths.png",
+    "Abyss_Shriek":                     "https://cdn.wikimg.net/en/hkwiki/images/b/bf/Icon_HK_Abyss_Shriek.png",
+    "Progressive Shriek":               "https://cdn.wikimg.net/en/hkwiki/images/b/bf/Icon_HK_Abyss_Shriek.png",
+
+    "Mothwing_Cloak":                   "https://cdn.wikimg.net/en/hkwiki/images/a/a2/Icon_HK_Mothwing_Cloak.png",
+    "Left_Mothwing_Cloak":              "https://cdn.wikimg.net/en/hkwiki/images/a/a2/Icon_HK_Mothwing_Cloak.png",
+    "Right_Mothwing_Cloak":             "https://cdn.wikimg.net/en/hkwiki/images/a/a2/Icon_HK_Mothwing_Cloak.png",
+    "Mantis_Claw":                      "https://cdn.wikimg.net/en/hkwiki/images/b/bf/Icon_HK_Mantis_Claw.png",
+    "Progressive Claw":                 "https://cdn.wikimg.net/en/hkwiki/images/b/bf/Icon_HK_Mantis_Claw.png",
+    "Left_Mantis_Claw":                 "https://cdn.wikimg.net/en/hkwiki/images/b/bf/Icon_HK_Mantis_Claw.png",
+    "Right_Mantis_Claw":                "https://cdn.wikimg.net/en/hkwiki/images/b/bf/Icon_HK_Mantis_Claw.png",
+    "Crystal_Heart":                    "https://cdn.wikimg.net/en/hkwiki/images/e/e8/Icon_HK_Crystal_Heart.png",
+    "Progressive Crystal Heart":        "https://cdn.wikimg.net/en/hkwiki/images/e/e8/Icon_HK_Crystal_Heart.png",
+    "Left_Crystal_Heart":               "https://cdn.wikimg.net/en/hkwiki/images/e/e8/Icon_HK_Crystal_Heart.png",
+    "Right_Crystal_Heart":              "https://cdn.wikimg.net/en/hkwiki/images/e/e8/Icon_HK_Crystal_Heart.png",
+    "Monarch_Wings":                    "https://cdn.wikimg.net/en/hkwiki/images/9/9b/Icon_HK_Monarch_Wings.png",
+    "Isma's_Tear":                      "https://cdn.wikimg.net/en/hkwiki/images/8/8c/Icon_HK_Isma%27s_Tear.png",
+    "Swim":                             "https://cdn.wikimg.net/en/hkwiki/images/thumb/a/a7/Icon_HK_Isma%27s_Tears_Art.png/300px-Icon_HK_Isma%27s_Tears_Art.png",
+    "Shade_Cloak":                      "https://cdn.wikimg.net/en/hkwiki/images/7/75/Icon_HK_Shade_Cloak.png",
+    "Progressive Cloak":                "https://cdn.wikimg.net/en/hkwiki/images/7/75/Icon_HK_Shade_Cloak.png",
+    "Left_Shade_Cloak":                 "https://cdn.wikimg.net/en/hkwiki/images/7/75/Icon_HK_Shade_Cloak.png",
+    "Right_Shade_Cloak":                "https://cdn.wikimg.net/en/hkwiki/images/7/75/Icon_HK_Shade_Cloak.png",
+    "Dream_Nail":                       "https://cdn.wikimg.net/en/hkwiki/images/a/a2/Icon_HK_Dream_Nail.png",
+    "Awoken_Dream_Nail":                "https://cdn.wikimg.net/en/hkwiki/images/b/b0/Icon_HK_Awoken_Dream_Nail.png",
+    "Progressive Dreamnail":            "https://cdn.wikimg.net/en/hkwiki/images/b/b0/Icon_HK_Awoken_Dream_Nail.png",
+    "Dream_Gate":                       "https://cdn.wikimg.net/en/hkwiki/images/3/34/Icon_HK_Dreamgate.png",
+    "World_Sense":                      "https://cdn.wikimg.net/en/hkwiki/images/thumb/d/d7/Icon_HK_World_Sense_Art.png/310px-Icon_HK_World_Sense_Art.png",
+    
+    "Cyclone_Slash":                    "https://cdn.wikimg.net/en/hkwiki/images/4/4f/Icon_HK_Cyclone_Slash.png",
+    "Dash_Slash":                       "https://cdn.wikimg.net/en/hkwiki/images/f/fd/Icon_HK_Dash_Slash.png",
+    "Great_Slash":                      "https://cdn.wikimg.net/en/hkwiki/images/4/43/Icon_HK_Great_Slash.png",
+
+    "Rancid_Egg":                       "https://cdn.wikimg.net/en/hkwiki/images/3/3f/Rancid_Egg.png",
+    "City_Crest":                       "https://cdn.wikimg.net/en/hkwiki/images/f/fb/City_Crest.png",
+    "Elegant_Key":                      "https://cdn.wikimg.net/en/hkwiki/images/7/7f/Elegant_Key.png",
+    "King's_Brand":                     "https://cdn.wikimg.net/en/hkwiki/images/8/8f/Kings_Brand_inventory.png",
+    "Love_Key":                         "https://cdn.wikimg.net/en/hkwiki/images/e/ec/Love_Key.png",
+    "Lumafly_Lantern":                  "https://cdn.wikimg.net/en/hkwiki/images/5/5f/Lumafly_Lantern.png",
+    "Shopkeeper's_Key":                 "https://cdn.wikimg.net/en/hkwiki/images/a/ab/Shopkeeper%27s_Key.png",
+    "Simple_Key":                       "https://cdn.wikimg.net/en/hkwiki/images/f/f3/Simple_Key.png",
+    "Tram_Pass":                        "https://cdn.wikimg.net/en/hkwiki/images/6/69/Tram_Pass.png",
+    "Elevator_Pass":                    "https://cdn.wikimg.net/en/hkwiki/images/6/69/Tram_Pass.png",
+
+    "Charm_Notch":                      "https://cdn.wikimg.net/en/hkwiki/images/thumb/e/e3/Charm_Notch.png/88px-Charm_Notch.png",
+    "Grimmkin_Flame":                   "https://cdn.wikimg.net/en/hkwiki/images/thumb/8/8f/FlameConsumed.png/100px-FlameConsumed.png",
+    "Grub":                             "https://cdn.wikimg.net/en/hkwiki/images/0/0c/Grub.png",
+    "Pale_Ore":                         "https://cdn.wikimg.net/en/hkwiki/images/e/eb/Pale_Ore.png",
+    "Mask_Shard":                       "https://cdn.wikimg.net/en/hkwiki/images/6/69/Mask_Shard.png",
+    "Vessel_Fragment":                  "https://cdn.wikimg.net/en/hkwiki/images/2/29/Vessel_Fragment.png",
+    "Wanderer's_Journal":               "https://cdn.wikimg.net/en/hkwiki/images/b/b5/Wanderer%27s_Journal.png",
+    "Hallownest_Seal":                  "https://cdn.wikimg.net/en/hkwiki/images/3/38/Hallownest_Seal.png",
+    "King's_Idol":                      "https://cdn.wikimg.net/en/hkwiki/images/d/d2/King%27s_Idol.png",
+    "Arcane_Egg":                       "https://cdn.wikimg.net/en/hkwiki/images/1/18/Arcane_Egg.png",
+    "Essence":                          "https://cdn.wikimg.net/en/hkwiki/images/thumb/0/04/Hidden_Dreams_Icon.png/20px-Hidden_Dreams_Icon.png",
+
+    "Downslash":                        "https://cdn.wikimg.net/en/hkwiki/images/thumb/4/4a/Nail_5_Pure_Nail.png/36px-Nail_5_Pure_Nail.png",
+    "Leftslash":                        "https://cdn.wikimg.net/en/hkwiki/images/thumb/4/4a/Nail_5_Pure_Nail.png/36px-Nail_5_Pure_Nail.png",
+    "Rightslash":                       "https://cdn.wikimg.net/en/hkwiki/images/thumb/4/4a/Nail_5_Pure_Nail.png/36px-Nail_5_Pure_Nail.png",
+    "Upslash":                          "https://cdn.wikimg.net/en/hkwiki/images/thumb/4/4a/Nail_5_Pure_Nail.png/36px-Nail_5_Pure_Nail.png",
+
+    "Dirtmouth_Stag":                   "https://cdn.wikimg.net/en/hkwiki/images/thumb/5/5e/Map_Pin_Stag.png/50px-Map_Pin_Stag.png",
+    "Crossroads_Stag":                  "https://cdn.wikimg.net/en/hkwiki/images/thumb/5/5e/Map_Pin_Stag.png/50px-Map_Pin_Stag.png",
+    "Greenpath_Stag":                   "https://cdn.wikimg.net/en/hkwiki/images/thumb/5/5e/Map_Pin_Stag.png/50px-Map_Pin_Stag.png",
+    "Queen's_Station_Stag":             "https://cdn.wikimg.net/en/hkwiki/images/thumb/5/5e/Map_Pin_Stag.png/50px-Map_Pin_Stag.png",
+    "Queen's_Gardens_Stag":             "https://cdn.wikimg.net/en/hkwiki/images/thumb/5/5e/Map_Pin_Stag.png/50px-Map_Pin_Stag.png",
+    "City_Storerooms_Stag":             "https://cdn.wikimg.net/en/hkwiki/images/thumb/5/5e/Map_Pin_Stag.png/50px-Map_Pin_Stag.png",
+    "King's_Station_Stag":              "https://cdn.wikimg.net/en/hkwiki/images/thumb/5/5e/Map_Pin_Stag.png/50px-Map_Pin_Stag.png",
+    "Resting_Grounds_Stag":             "https://cdn.wikimg.net/en/hkwiki/images/thumb/5/5e/Map_Pin_Stag.png/50px-Map_Pin_Stag.png",
+    "Distant_Village_Stag":             "https://cdn.wikimg.net/en/hkwiki/images/thumb/5/5e/Map_Pin_Stag.png/50px-Map_Pin_Stag.png",
+    "Hidden_Station_Stag":              "https://cdn.wikimg.net/en/hkwiki/images/thumb/5/5e/Map_Pin_Stag.png/50px-Map_Pin_Stag.png",
+    "Stag_Nest_Stag":                   "https://cdn.wikimg.net/en/hkwiki/images/thumb/5/5e/Map_Pin_Stag.png/50px-Map_Pin_Stag.png"
+} %}
+
+{% set multi_items = [
+    "Charm_Notch",
+    "Grimmkin_Flame",
+    "Grub",
+    "Rancid_Egg",
+    "Simple_Key",
+    "Pale_Ore",
+    "Mask_Shard",
+    "Vessel_Fragment",
+    "Essence",
+    "Wanderer's_Journal",
+    "Hallownest_Seal",
+    "King's_Idol",
+    "Arcane_Egg"
+] %}
+
+{% set inventory_order_charms = [
+    "Wayward_Compass", "Gathering_Swarm", "Stalwart_Shell", "Soul_Catcher", "Shaman_Stone",
+    "Soul_Eater", "Dashmaster", "Sprintmaster", "Grubsong", "Grubberfly's_Elegy",
+    "Progressive Heart", "Progressive Greed", "Progressive Strength", "Spell_Twister", "Steady_Body",
+    "Heavy_Blow", "Quick_Slash", "Longnail", "Mark_of_Pride", "Fury_of_the_Fallen",
+    "Thorns_of_Agony", "Baldur_Shell", "Flukenest", "Defender's_Crest", "Glowing_Womb",
+    "Quick_Focus", "Deep_Focus", "Lifeblood_Heart", "Lifeblood_Core", "Joni's_Blessing",
+    "Hiveblood", "Spore_Shroom", "Sharp_Shadow", "Shape_of_Unn", "Nailmaster's_Glory",
+    "Weaversong", "Dream_Wielder", "Dreamshield", "Progressive Grimmchild", "Progressive Void Heart"
+] %}
+
+{% set inventory_order_skills = [
+    "Progressive Cloak", "Progressive Left Cloak", "Progressive Right Cloak", "Progressive Claw", "Progressive Crystal Heart",
+    "Monarch_Wings", "Progressive Dreamnail", "Dream_Gate", "Cyclone_Slash",
+    "Dash_Slash", "Great_Slash", "Progressive Fireball", "Progressive Dive", "Progressive Shriek", "Isma's_Tear"
+] %}
+
+{# Most have a duplicated 0th entry for when we have none of that item to still load the correct icon/name. #}
+{% set progressive_order = {
+    "Progressive Heart" :           ["Fragile_Heart", "Fragile_Heart", "Unbreakable_Heart"],
+    "Progressive Greed":            ["Fragile_Greed", "Fragile_Greed", "Unbreakable_Greed"],
+    "Progressive Strength":         ["Fragile_Strength", "Fragile_Strength", "Unbreakable_Strength"],
+    "Progressive Grimmchild":       ["Grimmchild1", "Grimmchild2", "Grimmchild3", "Grimmchild4"],
+    "Progressive Void Heart":       ["Kingsoul", "Queen_Fragment", "Kingsoul", "Void_Heart"],
+
+    "Progressive Cloak":            ["Mothwing_Cloak", "Mothwing_Cloak", "Shade_Cloak"],
+    "Progressive Left Cloak":       ["Left_Mothwing_Cloak", "Left_Mothwing_Cloak", "Left_Shade_Cloak"],
+    "Progressive Right Cloak":      ["Right_Mothwing_Cloak", "Right_Mothwing_Cloak", "Right_Shade_Cloak"],
+    "Progressive Claw":             ["Mantis_Claw", "Left_Mantis_Claw", "Right_Mantis_Claw", "Mantis_Claw"],
+    "Progressive Crystal Heart":    ["Crystal_Heart", "Left_Crystal_Heart", "Right_Crystal_Heart", "Crystal_Heart"],
+
+    "Progressive Fireball":         ["Vengeful_Spirit", "Vengeful_Spirit", "Shade_Soul"],
+    "Progressive Dive":             ["Desolate_Dive", "Desolate_Dive", "Descending_Dark"],
+    "Progressive Shriek":           ["Howling_Wraiths", "Howling_Wraiths", "Abyss_Shriek"],
+
+    "Progressive Dreamnail":        ["Dream_Nail", "Dream_Nail", "Awoken_Dream_Nail"]
+} %}
+
+{% set randomizerGroups = {
+    "RandomizeDreamers":            ["Monomon", "Herrah", "Lurien"],
+    "RandomizeDreamers_WorldSense": ["World_Sense"],
+    "RandomizeSkills":              inventory_order_skills,
+    "RandomizeFocus":               ["Focus"],
+    "RandomizeSwim":                ["Swim"],
+    "RandomizeCharms":              inventory_order_charms,
+    "RandomizeKeys":                ["City_Crest", "Elegant_Key", "King's_Brand", "Love_Key", "Lumafly_Lantern", "Shopkeeper's_Key", "Simple_Key", "Tram_Pass"],
+    "RandomizeMaskShards":          ["Mask_Shard"],
+    "RandomizeVesselFragments":     ["Vessel_Fragment"],
+    "RandomizeCharmNotches":        ["Charm_Notch"],
+    "RandomizePaleOre":             ["Pale_Ore"],
+    "RandomizeRancidEggs":          ["Rancid_Egg"],
+    "RandomizeEssence":             ["Essence"],
+    "RandomizeGrubs":               ["Grub"],
+    "RandomizeStags":               stags,
+    "RandomizeGrimmkinFlames":      ["Grimmkin_Flame"],
+    "RandomizeNail":                ["Downslash", "Leftslash", "Upslash", "Rightslash"],
+    "RandomizeElevatorPass":        ["Elevator_Pass"],
+    "RandomizeRelics":              ["Wanderer's_Journal", "Hallownest_Seal", "King's_Idol", "Arcane_Egg"]
+} %}
+
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ player_name }}&apos;s Tracker</title>
+    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='styles/globalStyles.css') }}">
+    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='styles/tracker.css') }}">
+    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='styles/themes/dirt.css') }}">
+    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='styles/themes/base.css') }}">
+    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='styles/tracker__HK.css') }}">
+</head>
+
+<body>
+    <header id="base-header">
+        <div id="base-header-left">
+            <a id="site-title" href="#">{{ player_name }}'s Tracker</a>
+        </div>
+    </header>
+
+    <div id="tracker-navigation">
+        <div class="tracker-navigation-bar">
+            <a class="tracker-navigation-button" href="{{ url_for("get_generic_game_tracker", tracker=room.tracker, tracked_team=team, tracked_player=player) }}"> 🡸 Switch To Generic Tracker </a>
+        </div>
+    </div>
+
+    {% if inventory_order|length == 0 %}
+        <p>There is nothing randomized. So this tracker is empty.</p>
+    {% else %}
+        <div class="grid">
+            {# Show just the items in the grid which are included in the randomization #}
+            {% for (name, value) in inventory_order.items() %}
+                <div class="tracker-container {{value["cssClass"] }} col-{{ loop.index }}" style="margin-bottom: 0.5em;">
+                    {# Inventory Grid #}
+                    <div class="inventory-grid {{value["cssClass"] }}">
+                        {% for option in value["content"] %}
+                            {% for item in randomizerGroups[option] %}
+                                {% if item in progressive_order %}
+                                    {% set non_prog_item = progressive_order[item][inventory[item]] %}
+                                    <div class="item {{ 'hidden' if
+                                                            (item == 'Progressive Cloak' and inventory["ShowCloakSplitted"]) or
+                                                            (item in ('Progressive Left Cloak', 'Progressive Right Cloak') and not inventory["ShowCloakSplitted"])
+                                                    }}">
+                                        <img
+                                            src="{{ icons[non_prog_item] }}"
+                                            alt="{{ non_prog_item }}"
+                                            title="{{ non_prog_item }}"
+                                            class="{{ 'missing' if item not in inventory or inventory[item] == 0 }}"
+                                        />
+        
+                                        {% if
+                                            item == 'Progressive Left Cloak' and options["SplitMothwingCloak"] == 1 or
+                                            item == 'Progressive Claw' and inventory["Left_Mantis_Claw"] == 1 and inventory["Mantis_Claw"] == 0 and options["SplitMantisClaw"] == 1 or
+                                            item == 'Progressive Crystal Heart' and inventory["Left_Crystal_Heart"] and inventory["Crystal_Heart"] == 0 and options["SplitCrystalHeart"] == 1
+                                        %}
+                                            <div class="quantity">L</div>
+                                        {% endif %}
+        
+                                        {% if
+                                            item == 'Progressive Right Cloak' and options["SplitMothwingCloak"] == 1 or
+                                            item == 'Progressive Claw' and inventory["Right_Mantis_Claw"] == 1and inventory["Mantis_Claw"] == 0 and options["SplitMantisClaw"] == 1 or
+                                            item == 'Progressive Crystal Heart' and inventory["Right_Crystal_Heart"] and inventory["Crystal_Heart"] == 0 and options["SplitCrystalHeart"] == 1
+                                        %}
+                                            <div class="quantity">R</div>
+                                        {% endif %}
+                                    </div>
+                                {% else %}
+                                    <div class="item">
+                                        <img
+                                            src="{{ icons[item] }}"
+                                            alt="{{ item }}"
+                                            title="{{ item }}"
+                                            class="{{ 'missing' if item not in inventory or inventory[item] == 0 }} {{ 'elevatorPass' if item == 'Elevator_Pass' }}
+                                                   {{ item if item.endswith('slash') }}"
+                                        />
+        
+                                        {% if item in multi_items %}
+                                            <div class="quantity">{{ inventory[item] }}</div>
+                                        {% endif %}
+
+                                        {% if item in stags %}
+                                            <div class="quantity">{{ stags[item] }}</div>
+                                        {% endif %}
+                                    </div>
+                                {% endif %}
+                            {% endfor %}
+                        {% endfor %}
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+    {% endif %}
+
+    
+
+    <script>
+        const parser = new DOMParser();
+        const interval = 15_000;
+
+        window.addEventListener("load", () => {
+            setInterval(() => updateTracker()
+                .then(() => console.log("Refreshed tracker."))
+                .catch(console.error), interval);
+        });
+
+        async function updateTracker() {
+            const response = await fetch(`${window.location}`);
+            if (!response.ok) {
+                throw new Error(`Failed to fetch tracker update from ${window.location}. Received response: ${response.statusText}`);
+            }
+
+            const fakeDOM = parser.parseFromString(await response.text(), "text/html");
+            document.querySelector(".inventory-grid").innerHTML = fakeDOM.querySelector(".inventory-grid").innerHTML;
+
+            const regionDetailElements = document.querySelectorAll(".region-details");
+            const fakeDetailElements = fakeDOM.querySelectorAll(".region-details");
+
+            for (let i = 0; i < regionDetailElements.length; ++i) {
+                const isOpen = regionDetailElements[i].open;
+                regionDetailElements[i].innerHTML = fakeDetailElements[i].innerHTML;
+                regionDetailElements[i].open = isOpen;
+            }
+        }
+    </script>
+</body>
+</html>

--- a/WebHostLib/templates/tracker__HK.html
+++ b/WebHostLib/templates/tracker__HK.html
@@ -241,6 +241,8 @@
     </div>
 
     {% if inventory_order|length == 0 %}
+        {# Theoretical case: if there are choosen just options which are not included in inventory_order show a short message. #}
+        {# There is no way to avoid this tracker page in that case therefore the notification. #}
         <p>There is nothing randomized. So this tracker is empty.</p>
     {% else %}
         <div class="grid">
@@ -253,6 +255,7 @@
                             {% for item in randomizerGroups[option] %}
                                 {% if item in progressive_order %}
                                     {% set non_prog_item = progressive_order[item][inventory[item]] %}
+                                    {# Show either just cloak or the splitted ones (rules in Python part) #}
                                     <div class="item {{ 'hidden' if
                                                             (item == 'Progressive Cloak' and inventory["ShowCloakSplitted"]) or
                                                             (item in ('Progressive Left Cloak', 'Progressive Right Cloak') and not inventory["ShowCloakSplitted"])
@@ -264,6 +267,7 @@
                                             class="{{ 'missing' if item not in inventory or inventory[item] == 0 }}"
                                         />
         
+                                        {# Show L/R indicator for splitted skill #}
                                         {% if
                                             item == 'Progressive Left Cloak' and options["SplitMothwingCloak"] == 1 or
                                             item == 'Progressive Claw' and inventory["Left_Mantis_Claw"] == 1 and inventory["Mantis_Claw"] == 0 and options["SplitMantisClaw"] == 1 or

--- a/WebHostLib/tracker.py
+++ b/WebHostLib/tracker.py
@@ -2396,3 +2396,271 @@ if "Starcraft 2" in network_data_package["games"]:
         )
 
     _player_trackers["Starcraft 2"] = render_Starcraft2_tracker
+
+if "Hollow Knight" in network_data_package["games"]:
+    # Mapping from non-progressive item to progressive name and max level.
+    non_progressive_items = {
+        "Fragile_Heart":        ("Progressive Heart", 1),
+        "Unbreakable_Heart":    ("Progressive Heart", 2),
+
+        "Fragile_Greed":        ("Progressive Greed", 1),
+        "Unbreakable_Greed":    ("Progressive Greed", 2),
+
+        "Fragile_Strength":     ("Progressive Strength", 1),
+        "Unbreakable_Strength": ("Progressive Strength", 2),
+
+        "Grimmchild1":          ("Progressive Grimmchild", 1),
+        "Grimmchild2":          ("Progressive Grimmchild", 2),
+        "Grimmchild3":          ("Progressive Grimmchild", 3),
+        "Grimmchild4":          ("Progressive Grimmchild", 4),
+
+        "Queen_Fragment":       ("Progressive Void Heart", 1),
+        "Kingsoul":             ("Progressive Void Heart", 2),
+        "Void_Heart":           ("Progressive Void Heart", 3),
+
+        "Mothwing_Cloak":       ("Progressive Cloak", 1),
+        "Shade_Cloak":          ("Progressive Cloak", 2),
+
+        "Left_Mothwing_Cloak":  ("Progressive Left Cloak", 1),
+        "Left_Shade_Cloak":     ("Progressive Left Cloak", 2) ,
+
+        "Right_Mothwing_Cloak": ("Progressive Right Cloak", 1),
+        "Right_Shade_Cloak":    ("Progressive Right Cloak", 2),
+
+        "Left_Mantis_Claw":     ("Progressive Claw", 1),
+        "Right_Mantis_Claw":    ("Progressive Claw", 2),
+        "Mantis_Claw":          ("Progressive Claw", 3),
+
+        "Left_Crystal_Heart":   ("Progressive Crystal Heart", 1),
+        "Right_Crystal_Heart":  ("Progressive Crystal Heart", 2),
+        "Crystal_Heart":        ("Progressive Crystal Heart", 3),
+
+        "Vengeful_Spirit":      ("Progressive Fireball", 1),
+        "Shade_Soul":           ("Progressive Fireball", 2),
+
+        "Desolate_Dive":        ("Progressive Dive", 1),
+        "Descending_Dark":      ("Progressive Dive", 2),
+
+        "Howling_Wraiths":      ("Progressive Shriek", 1),
+        "Abyss_Shriek":         ("Progressive Shriek", 2),
+
+        "Dream_Nail":           ("Progressive Dreamnail", 1),
+        "Awoken_Dream_Nail":    ("Progressive Dreamnail", 2)
+    }
+
+    progressive_item_max = {
+        "Progressive Heart":            2,
+        "Progressive Greed":            2,
+        "Progressive Strength":         2,
+        "Progressive Grimmchild":       4,
+        "Progressive Void Heart":       3,
+        "Progressive Cloak":            2,
+        "Progressive Left Cloak":       2,
+        "Progressive Right Cloak":      2,
+        "Progressive Claw":             3,
+        "Progressive Crystal Heart":    3,
+        "Progressive Fireball":         2,
+        "Progressive Dive":             2,
+        "Progressive Shriek":           2,
+        "Progressive Dreamnail":        2
+    }
+
+    essences = {
+        "Boss_Essence-Elder_Hu":            100,
+        "Boss_Essence-Galien":              200,
+        "Boss_Essence-Gorb":                100,
+        "Boss_Essence-Markoth":             250,
+        "Boss_Essence-Marmu":               150,
+        "Boss_Essence-No_Eyes":             200,
+        "Boss_Essence-Xero":                100,
+        "Boss_Essence-Failed_Champion":     300,
+        "Boss_Essence-Grey_Prince_Zote":    300,
+        "Boss_Essence-Lost_Kin":            400,
+        "Boss_Essence-White_Defender":      300,
+        "Boss_Essence-Soul_Tyrant":         300,
+
+        "Whispering_Root-Ancestral_Mound":  42,
+        "Whispering_Root-City":             28,
+        "Whispering_Root-Crystal_Peak":     21,
+        "Whispering_Root-Deepnest":         45,
+        "Whispering_Root-Crossroads":       29,
+        "Whispering_Root-Leg_Eater":        20,
+        "Whispering_Root-Mantis_Village":   18,
+        "Whispering_Root-Greenpath":        44,
+        "Whispering_Root-Hive":             20,
+        "Whispering_Root-Howling_Cliffs":   46,
+        "Whispering_Root-Kingdoms_Edge":    51,
+        "Whispering_Root-Queens_Gardens":   29,
+        "Whispering_Root-Resting_Grounds":  20,
+        "Whispering_Root-Waterways":        35,
+        "Whispering_Root-Spirits_Glade":    34
+    }
+
+    stags = {
+        "Dirtmouth_Stag":       "DM",
+        "Crossroads_Stag":      "CR",
+        "Greenpath_Stag":       "GP",
+        "Queen's_Station_Stag": "QS",
+        "Queen's_Gardens_Stag": "QG",
+        "City_Storerooms_Stag": "CS",
+        "King's_Station_Stag":  "KS",
+        "Resting_Grounds_Stag": "RG",
+        "Distant_Village_Stag": "DV",
+        "Hidden_Station_Stag":  "HS",
+        "Stag_Nest_Stag":       "SN"
+    }
+
+    def prepare_inventories(team: int, player: int, inventory: Counter[str], tracker_data: TrackerData):
+        if inventory["Left_Mothwing_Cloak"] >= 1 and inventory["Right_Mothwing_Cloak"] >= 1:
+            inventory["Mothwing_Cloak"] = 1
+
+        if inventory["Left_Mothwing_Cloak"] == 2:
+            inventory["Left_Shade_Cloak"] = 1
+
+        if inventory["Right_Mothwing_Cloak"] == 2:
+            inventory["Right_Shade_Cloak"] = 1
+
+        if inventory["Left_Mothwing_Cloak"] + inventory["Right_Mothwing_Cloak"] == 3:
+            inventory["Shade_Cloak"] = 1
+
+        inventory["ShowCloakSplitted"] = not (
+                inventory["Left_Mothwing_Cloak"] == 0 and inventory["Right_Mothwing_Cloak"] == 0 or
+                inventory["Mothwing_Cloak"] == 1 or
+                inventory["Shade_Cloak"] == 1
+            ) or (
+                inventory["Mothwing_Cloak"] == 0 and
+                inventory["Shade_Cloak"] == 0 and
+                inventory["Left_Mothwing_Cloak"] != inventory["Right_Mothwing_Cloak"] and
+                tracker_data.get_slot_data(team, player)["options"]["SplitMothwingCloak"] == 1
+            )
+            
+        if inventory["Left_Mantis_Claw"] == 1 and inventory["Right_Mantis_Claw"] == 1:
+            inventory["Mantis_Claw"] = 1
+
+        if inventory["Left_Crystal_Heart"] == 1 and inventory["Right_Crystal_Heart"] == 1:
+            inventory["Crystal_Heart"] = 1
+
+        for source, essence in essences.items():
+            if source in inventory:
+                inventory["Essence"] += essence
+
+        for stag in stags:
+            if stag in inventory:
+                inventory["Stag"] += 1
+
+        inventory["Nail"] = 1 * inventory["Downslash"] + 2 * inventory["Leftslash"] + 4 * inventory["Upslash"] + 8 * inventory["Rightslash"]
+
+        # add progressive items
+        for item, (prog_item, level) in non_progressive_items.items():
+            if item in inventory:
+                inventory[prog_item] = min(max(inventory[prog_item], level), progressive_item_max[prog_item])
+
+        # Completed item if we meet goal.
+        if tracker_data.get_room_client_statuses()[team, player] == ClientStatus.CLIENT_GOAL:
+            inventory["IsCompleted"] = 1
+
+    def render_HK_multiworld_tracker(tracker_data: TrackerData, enabled_trackers: List[str]):
+        inventories: Dict[Tuple[int, int], Counter[str]] = {
+            (team, player): collections.Counter({
+                tracker_data.item_id_to_name["Hollow Knight"][code]: count
+                for code, count in tracker_data.get_player_inventory_counts(team, player).items()
+            })
+            for team, players in tracker_data.get_all_players().items()
+            for player in players if tracker_data.get_slot_info(team, player).game == "Hollow Knight"
+        }
+
+        # Translate non-progression items to progression items for tracker simplicity.
+        for (team, player), inventory in inventories.items():
+            prepare_inventories(team, player, inventory, tracker_data)
+
+        options: Dict[Tuple[int, int], Dict[str, int]] = {
+            (team, player): {
+                option: value
+                for (option, value) in tracker_data.get_slot_data(team, player)["options"].items()
+            }
+            for team, players in tracker_data.get_all_players().items()
+            for player in players if tracker_data.get_slot_info(team, player).game == "Hollow Knight"
+        }
+
+        for (team, player), randoOptions in options.copy().items():
+            randomizeEssence = 0
+
+            for option, value in randoOptions.items():
+                if(option in ('RandomizeBossEssence', 'RandomizeWhisperingRoots')):
+                    randomizeEssence = randomizeEssence or value
+
+            options[(team, player)]["RandomizeEssence"] = randomizeEssence
+
+        return render_template(
+            "multitracker__HK.html",
+            enabled_trackers=enabled_trackers,
+            current_tracker="Hollow Knight",
+            room=tracker_data.room,
+            all_slots=tracker_data.get_all_slots(),
+            room_players=tracker_data.get_all_players(),
+            locations=tracker_data.get_room_locations(),
+            locations_complete=tracker_data.get_room_locations_complete(),
+            total_team_locations=tracker_data.get_team_locations_total_count(),
+            total_team_locations_complete=tracker_data.get_team_locations_checked_count(),
+            player_names_with_alias=tracker_data.get_room_long_player_names(),
+            completed_worlds=tracker_data.get_team_completed_worlds_count(),
+            games=tracker_data.get_room_games(),
+            states=tracker_data.get_room_client_statuses(),
+            hints=tracker_data.get_team_hints(),
+            activity_timers=tracker_data.get_room_last_activity(),
+            videos=tracker_data.get_room_videos(),
+            item_id_to_name=tracker_data.item_id_to_name,
+            location_id_to_name=tracker_data.location_id_to_name,
+            inventories=inventories,
+            options=options,
+            progressive_item_max=progressive_item_max
+        )
+
+    def render_HK_tracker(tracker_data: TrackerData, team: int, player: int) -> str:
+        options = tracker_data.get_slot_data(team, player)["options"]
+        options["RandomizeDreamers_WorldSense"] = options["RandomizeDreamers"]
+        options["RandomizeEssence"] = options["RandomizeBossEssence"] or options["RandomizeWhisperingRoots"]
+
+        inventory_order_template = {
+            "Dreamers": { "content": ["RandomizeDreamers"] },
+            "Skills":   { "content": ["RandomizeSkills", "RandomizeSwim", "RandomizeFocus"] },
+            "Keys":     { "content": ["RandomizeKeys", "RandomizeElevatorPass"], "cssClass": "keys" },
+            "Charms":   { "content": ["RandomizeCharms"], "cssClass": "charms" },
+            "Counter":  { "content": ["RandomizeEssence", "RandomizeMaskShards", "RandomizeVesselFragments", "RandomizeCharmNotches", "RandomizePaleOre", "RandomizeRancidEggs", "RandomizeGrubs", "RandomizeGrimmkinFlames"] },
+            "Relics":   { "content": ["RandomizeRelics"] },
+            "Misc":     { "content": ["RandomizeDreamers_WorldSense"] },
+            "Nail":     { "content": ["RandomizeNail"] },
+            "Stags":    { "content": ["RandomizeStags"], "cssClass": "stags" }
+        }
+
+        inventory_order = {}
+
+        for (name, value) in inventory_order_template.items():
+            groupToAdd = [item for item in value["content"] if tracker_data.get_slot_data(team, player)["options"][item] == 1]
+            
+            if groupToAdd != []:
+                value["content"] = groupToAdd
+                inventory_order[name] = value
+            
+        inventory = collections.Counter({
+            tracker_data.item_id_to_name["Hollow Knight"][code]: count
+            for code, count in tracker_data.get_player_inventory_counts(team, player).items()
+        })
+        
+        # Translate non-progression items to progression items for tracker simplicity.
+        prepare_inventories(team, player, inventory, tracker_data)
+
+        return render_template(
+            template_name_or_list="tracker__HK.html",
+            room=tracker_data.room,
+            team=team,
+            player=player,
+            inventory=inventory,
+            player_name=tracker_data.get_player_name(team, player),
+            options=options,
+            inventory_order=inventory_order,
+            stags=stags
+        )
+
+    _multiworld_trackers["Hollow Knight"] = render_HK_multiworld_tracker
+    _player_trackers["Hollow Knight"] = render_HK_tracker

--- a/WebHostLib/tracker.py
+++ b/WebHostLib/tracker.py
@@ -2511,6 +2511,11 @@ if "Hollow Knight" in network_data_package["games"]:
     }
 
     def prepare_inventories(team: int, player: int, inventory: Counter[str], tracker_data: TrackerData):
+        # Creating logic for splittet cloak
+        #         Right 0                 1                  2
+        # Left 0  no dash                 right dash        right shade, no left
+        # 1       left dash               left right        shade both
+        # 2       shade left, no right    shade both        -
         if inventory["Left_Mothwing_Cloak"] >= 1 and inventory["Right_Mothwing_Cloak"] >= 1:
             inventory["Mothwing_Cloak"] = 1
 
@@ -2533,13 +2538,17 @@ if "Hollow Knight" in network_data_package["games"]:
                 inventory["Left_Mothwing_Cloak"] != inventory["Right_Mothwing_Cloak"] and
                 tracker_data.get_slot_data(team, player)["options"]["SplitMothwingCloak"] == 1
             )
+        # End cloak logic
             
+        # Handling logic for splittet claw and Crystal Heart
         if inventory["Left_Mantis_Claw"] == 1 and inventory["Right_Mantis_Claw"] == 1:
             inventory["Mantis_Claw"] = 1
 
         if inventory["Left_Crystal_Heart"] == 1 and inventory["Right_Crystal_Heart"] == 1:
             inventory["Crystal_Heart"] = 1
+        # End claw / cdash logic
 
+        # Sum essence and count stags
         for source, essence in essences.items():
             if source in inventory:
                 inventory["Essence"] += essence
@@ -2547,7 +2556,9 @@ if "Hollow Knight" in network_data_package["games"]:
         for stag in stags:
             if stag in inventory:
                 inventory["Stag"] += 1
+        # End essence / stags
 
+        # Naildirections (bit based)
         inventory["Nail"] = 1 * inventory["Downslash"] + 2 * inventory["Leftslash"] + 4 * inventory["Upslash"] + 8 * inventory["Rightslash"]
 
         # add progressive items
@@ -2582,6 +2593,7 @@ if "Hollow Knight" in network_data_package["games"]:
             for player in players if tracker_data.get_slot_info(team, player).game == "Hollow Knight"
         }
 
+        # To handle both options as one on the page
         for (team, player), randoOptions in options.copy().items():
             randomizeEssence = 0
 
@@ -2617,10 +2629,12 @@ if "Hollow Knight" in network_data_package["games"]:
         )
 
     def render_HK_tracker(tracker_data: TrackerData, team: int, player: int) -> str:
+        # Remap rando options for visualization
         options = tracker_data.get_slot_data(team, player)["options"]
         options["RandomizeDreamers_WorldSense"] = options["RandomizeDreamers"]
         options["RandomizeEssence"] = options["RandomizeBossEssence"] or options["RandomizeWhisperingRoots"]
 
+        # Creating the content for the grid placeholders
         inventory_order_template = {
             "Dreamers": { "content": ["RandomizeDreamers"] },
             "Skills":   { "content": ["RandomizeSkills", "RandomizeSwim", "RandomizeFocus"] },

--- a/WebHostLib/tracker.py
+++ b/WebHostLib/tracker.py
@@ -2399,115 +2399,118 @@ if "Starcraft 2" in network_data_package["games"]:
 
 if "Hollow Knight" in network_data_package["games"]:
     # Mapping from non-progressive item to progressive name and max level.
+    non_progressive_charms = {
+        "Fragile_Heart"         : ("Progressive Heart", 1),
+        "Unbreakable_Heart"     : ("Progressive Heart", 2),
+
+        "Fragile_Greed"         : ("Progressive Greed", 1),
+        "Unbreakable_Greed"     : ("Progressive Greed", 2),
+
+        "Fragile_Strength"      : ("Progressive Strength", 1),
+        "Unbreakable_Strength"  : ("Progressive Strength", 2),
+
+        "Grimmchild1"           : ("Progressive Grimmchild", 1),
+        "Grimmchild2"           : ("Progressive Grimmchild", 2),
+        "Grimmchild3"           : ("Progressive Grimmchild", 3),
+        "Grimmchild4"           : ("Progressive Grimmchild", 4),
+
+        "Queen_Fragment"        : ("Progressive Void Heart", 1),
+        "King_Fragment"         : ("Progressive Void Heart", 2),
+        "Kingsoul"              : ("Progressive Void Heart", 3),
+        "Void_Heart"            : ("Progressive Void Heart", 4)
+    }
+
     non_progressive_items = {
-        "Fragile_Heart":        ("Progressive Heart", 1),
-        "Unbreakable_Heart":    ("Progressive Heart", 2),
+        "Mothwing_Cloak"        : ("Progressive Cloak", 1),
+        "Shade_Cloak"           : ("Progressive Cloak", 2),
 
-        "Fragile_Greed":        ("Progressive Greed", 1),
-        "Unbreakable_Greed":    ("Progressive Greed", 2),
+        "Left_Mothwing_Cloak"   : ("Progressive Left Cloak", 1),
+        "Left_Shade_Cloak"      : ("Progressive Left Cloak", 2) ,
 
-        "Fragile_Strength":     ("Progressive Strength", 1),
-        "Unbreakable_Strength": ("Progressive Strength", 2),
+        "Right_Mothwing_Cloak"  : ("Progressive Right Cloak", 1),
+        "Right_Shade_Cloak"     : ("Progressive Right Cloak", 2),
 
-        "Grimmchild1":          ("Progressive Grimmchild", 1),
-        "Grimmchild2":          ("Progressive Grimmchild", 2),
-        "Grimmchild3":          ("Progressive Grimmchild", 3),
-        "Grimmchild4":          ("Progressive Grimmchild", 4),
+        "Left_Mantis_Claw"      : ("Progressive Claw", 1),
+        "Right_Mantis_Claw"     : ("Progressive Claw", 2),
+        "Mantis_Claw"           : ("Progressive Claw", 3),
 
-        "Queen_Fragment":       ("Progressive Void Heart", 1),
-        "Kingsoul":             ("Progressive Void Heart", 2),
-        "Void_Heart":           ("Progressive Void Heart", 3),
+        "Left_Crystal_Heart"    : ("Progressive Crystal Heart", 1),
+        "Right_Crystal_Heart"   : ("Progressive Crystal Heart", 2),
+        "Crystal_Heart"         : ("Progressive Crystal Heart", 3),
 
-        "Mothwing_Cloak":       ("Progressive Cloak", 1),
-        "Shade_Cloak":          ("Progressive Cloak", 2),
+        "Vengeful_Spirit"       : ("Progressive Fireball", 1),
+        "Shade_Soul"            : ("Progressive Fireball", 2),
 
-        "Left_Mothwing_Cloak":  ("Progressive Left Cloak", 1),
-        "Left_Shade_Cloak":     ("Progressive Left Cloak", 2) ,
+        "Desolate_Dive"         : ("Progressive Dive", 1),
+        "Descending_Dark"       : ("Progressive Dive", 2),
 
-        "Right_Mothwing_Cloak": ("Progressive Right Cloak", 1),
-        "Right_Shade_Cloak":    ("Progressive Right Cloak", 2),
+        "Howling_Wraiths"       : ("Progressive Shriek", 1),
+        "Abyss_Shriek"          : ("Progressive Shriek", 2),
 
-        "Left_Mantis_Claw":     ("Progressive Claw", 1),
-        "Right_Mantis_Claw":    ("Progressive Claw", 2),
-        "Mantis_Claw":          ("Progressive Claw", 3),
-
-        "Left_Crystal_Heart":   ("Progressive Crystal Heart", 1),
-        "Right_Crystal_Heart":  ("Progressive Crystal Heart", 2),
-        "Crystal_Heart":        ("Progressive Crystal Heart", 3),
-
-        "Vengeful_Spirit":      ("Progressive Fireball", 1),
-        "Shade_Soul":           ("Progressive Fireball", 2),
-
-        "Desolate_Dive":        ("Progressive Dive", 1),
-        "Descending_Dark":      ("Progressive Dive", 2),
-
-        "Howling_Wraiths":      ("Progressive Shriek", 1),
-        "Abyss_Shriek":         ("Progressive Shriek", 2),
-
-        "Dream_Nail":           ("Progressive Dreamnail", 1),
-        "Awoken_Dream_Nail":    ("Progressive Dreamnail", 2)
+        "Dream_Nail"            : ("Progressive Dreamnail", 1),
+        "Awoken_Dream_Nail"     : ("Progressive Dreamnail", 2)
     }
 
     progressive_item_max = {
-        "Progressive Heart":            2,
-        "Progressive Greed":            2,
-        "Progressive Strength":         2,
-        "Progressive Grimmchild":       4,
-        "Progressive Void Heart":       3,
-        "Progressive Cloak":            2,
-        "Progressive Left Cloak":       2,
-        "Progressive Right Cloak":      2,
-        "Progressive Claw":             3,
-        "Progressive Crystal Heart":    3,
-        "Progressive Fireball":         2,
-        "Progressive Dive":             2,
-        "Progressive Shriek":           2,
-        "Progressive Dreamnail":        2
+        "Progressive Heart"         : 2,
+        "Progressive Greed"         : 2,
+        "Progressive Strength"      : 2,
+        "Progressive Grimmchild"    : 4,
+        "Progressive Void Heart"    : 4,
+        "Progressive Cloak"         : 2,
+        "Progressive Left Cloak"    : 2,
+        "Progressive Right Cloak"   : 2,
+        "Progressive Claw"          : 3,
+        "Progressive Crystal Heart" : 3,
+        "Progressive Fireball"      : 2,
+        "Progressive Dive"          : 2,
+        "Progressive Shriek"        : 2,
+        "Progressive Dreamnail"     : 2
     }
 
     essences = {
-        "Boss_Essence-Elder_Hu":            100,
-        "Boss_Essence-Galien":              200,
-        "Boss_Essence-Gorb":                100,
-        "Boss_Essence-Markoth":             250,
-        "Boss_Essence-Marmu":               150,
-        "Boss_Essence-No_Eyes":             200,
-        "Boss_Essence-Xero":                100,
-        "Boss_Essence-Failed_Champion":     300,
-        "Boss_Essence-Grey_Prince_Zote":    300,
-        "Boss_Essence-Lost_Kin":            400,
-        "Boss_Essence-White_Defender":      300,
-        "Boss_Essence-Soul_Tyrant":         300,
+        "Boss_Essence-Elder_Hu"             : 100,
+        "Boss_Essence-Galien"               : 200,
+        "Boss_Essence-Gorb"                 : 100,
+        "Boss_Essence-Markoth"              : 250,
+        "Boss_Essence-Marmu"                : 150,
+        "Boss_Essence-No_Eyes"              : 200,
+        "Boss_Essence-Xero"                 : 100,
+        "Boss_Essence-Failed_Champion"      : 300,
+        "Boss_Essence-Grey_Prince_Zote"     : 300,
+        "Boss_Essence-Lost_Kin"             : 400,
+        "Boss_Essence-White_Defender"       : 300,
+        "Boss_Essence-Soul_Tyrant"          : 300,
 
-        "Whispering_Root-Ancestral_Mound":  42,
-        "Whispering_Root-City":             28,
-        "Whispering_Root-Crystal_Peak":     21,
-        "Whispering_Root-Deepnest":         45,
-        "Whispering_Root-Crossroads":       29,
-        "Whispering_Root-Leg_Eater":        20,
-        "Whispering_Root-Mantis_Village":   18,
-        "Whispering_Root-Greenpath":        44,
-        "Whispering_Root-Hive":             20,
-        "Whispering_Root-Howling_Cliffs":   46,
-        "Whispering_Root-Kingdoms_Edge":    51,
-        "Whispering_Root-Queens_Gardens":   29,
-        "Whispering_Root-Resting_Grounds":  20,
-        "Whispering_Root-Waterways":        35,
-        "Whispering_Root-Spirits_Glade":    34
+        "Whispering_Root-Ancestral_Mound"   : 42,
+        "Whispering_Root-City"              : 28,
+        "Whispering_Root-Crystal_Peak"      : 21,
+        "Whispering_Root-Deepnest"          : 45,
+        "Whispering_Root-Crossroads"        : 29,
+        "Whispering_Root-Leg_Eater"         : 20,
+        "Whispering_Root-Mantis_Village"    : 18,
+        "Whispering_Root-Greenpath"         : 44,
+        "Whispering_Root-Hive"              : 20,
+        "Whispering_Root-Howling_Cliffs"    : 46,
+        "Whispering_Root-Kingdoms_Edge"     : 51,
+        "Whispering_Root-Queens_Gardens"    : 29,
+        "Whispering_Root-Resting_Grounds"   : 20,
+        "Whispering_Root-Waterways"         : 35,
+        "Whispering_Root-Spirits_Glade"     : 34
     }
 
     stags = {
-        "Dirtmouth_Stag":       "DM",
-        "Crossroads_Stag":      "CR",
-        "Greenpath_Stag":       "GP",
-        "Queen's_Station_Stag": "QS",
-        "Queen's_Gardens_Stag": "QG",
-        "City_Storerooms_Stag": "CS",
-        "King's_Station_Stag":  "KS",
-        "Resting_Grounds_Stag": "RG",
-        "Distant_Village_Stag": "DV",
-        "Hidden_Station_Stag":  "HS",
-        "Stag_Nest_Stag":       "SN"
+        "Dirtmouth_Stag"        : "DM",
+        "Crossroads_Stag"       : "CR",
+        "Greenpath_Stag"        : "GP",
+        "Queen's_Station_Stag"  : "QS",
+        "Queen's_Gardens_Stag"  : "QG",
+        "City_Storerooms_Stag"  : "CS",
+        "King's_Station_Stag"   : "KS",
+        "Resting_Grounds_Stag"  : "RG",
+        "Distant_Village_Stag"  : "DV",
+        "Hidden_Station_Stag"   : "HS",
+        "Stag_Nest_Stag"        : "SN"
     }
 
     def prepare_inventories(team: int, player: int, inventory: Counter[str], tracker_data: TrackerData):
@@ -2565,6 +2568,12 @@ if "Hollow Knight" in network_data_package["games"]:
         for item, (prog_item, level) in non_progressive_items.items():
             if item in inventory:
                 inventory[prog_item] = min(max(inventory[prog_item], level), progressive_item_max[prog_item])
+                
+        # add progressive charms
+        # Charms are progressing in order, not by the one which was actually got.
+        for item, (prog_item, level) in non_progressive_charms.items():
+            if item in inventory:
+                inventory[prog_item] += 1
 
         # Completed item if we meet goal.
         if tracker_data.get_room_client_statuses()[team, player] == ClientStatus.CLIENT_GOAL:


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?
A tracker for Hollow Knight on the AP website.

## How was this tested?
Local game hosting and creating different settings with text client item getting.

## If this makes graphical changes, please attach screenshots.
Multitracker overview over all available HK games.
In the charms section are rows just created for players who have either randomized charms or charm notches.
If a option is not randomized it will be shown with a dash on a grayish background. (there are some exceptions like eggs because they seem to be send to the AP tracker anyway - in that case that are just a few and not all found in the seed)
![HK_Multitracker1](https://github.com/ArchipelagoMW/Archipelago/assets/68022469/8e39c8e7-46d0-4a4f-82f3-070987120985)

Handling of the skills
![HK_Multitracker3](https://github.com/ArchipelagoMW/Archipelago/assets/68022469/2cd9944a-757f-4e03-9a04-44fb766a20e3)
![HK_Multitracker2](https://github.com/ArchipelagoMW/Archipelago/assets/68022469/41ec6e87-a674-4b0d-8faa-e4d8ca1bf250)

Handling of the progressive charms.
![HK_Multitracker4](https://github.com/ArchipelagoMW/Archipelago/assets/68022469/b9d59f20-5404-4937-bc47-3f4b7086f3e0)

View on a single player tracker.
![HK_Tracker1](https://github.com/ArchipelagoMW/Archipelago/assets/68022469/608ded0e-40e3-466a-8def-2bc985ecc010)

The single player tracker just shows icons to options which were randomized. Not randomized stuff will be hidden / not generated for the page tracker.
![HK_Tracker2](https://github.com/ArchipelagoMW/Archipelago/assets/68022469/5f0ed3d5-382d-4165-ac84-fb65a0c1adcd)

In the rare case someone chooses just options which are not handled by the tracker (i.e. Geo Rocks or Lore Tablets) there will just be shown a message. There seems not to be a way to avoid the tracker at all in this case therefore a short notification.
![HK_Tracker3](https://github.com/ArchipelagoMW/Archipelago/assets/68022469/7f35acfb-e86c-48cd-b32c-044b264beb11)
