### PR TITLE
Core: Make excluded locations and priority locations excluded and remove unreachable code

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -128,7 +128,7 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
         for location_name in multiworld.worlds[player].options.priority_locations.value:
             try:
                 location = multiworld.get_location(location_name, player)
-            except:
+            except KeyError:
                 pass
             else:
                 if location.progress_type != LocationProgressType.EXCLUDED:

--- a/Main.py
+++ b/Main.py
@@ -124,14 +124,19 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
     for player in multiworld.player_ids:
         exclusion_rules(multiworld, player, multiworld.worlds[player].options.exclude_locations.value)
         multiworld.worlds[player].options.priority_locations.value -= multiworld.worlds[player].options.exclude_locations.value
+        world_excluded_locations = set()
         for location_name in multiworld.worlds[player].options.priority_locations.value:
             try:
                 location = multiworld.get_location(location_name, player)
-            except KeyError as e:  # failed to find the given location. Check if it's a legitimate location
-                if location_name not in multiworld.worlds[player].location_name_to_id:
-                    raise Exception(f"Unable to prioritize location {location_name} in player {player}'s world.") from e
+            except:
+                pass
             else:
-                location.progress_type = LocationProgressType.PRIORITY
+                if location.progress_type != LocationProgressType.EXCLUDED:
+                    location.progress_type = LocationProgressType.PRIORITY
+                else:
+                    logger.warning(f"Unable to prioritize location \"{location_name}\" in player {player}'s world because the world excluded it.")
+                    world_excluded_locations.add(location_name)
+        multiworld.worlds[player].options.priority_locations.value -= world_excluded_locations
 
     # Set local and non-local item rules.
     if multiworld.players > 1:

--- a/Main.py
+++ b/Main.py
@@ -129,13 +129,13 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
             try:
                 location = multiworld.get_location(location_name, player)
             except KeyError:
-                pass
+                continue
+
+            if location.progress_type != LocationProgressType.EXCLUDED:
+                location.progress_type = LocationProgressType.PRIORITY
             else:
-                if location.progress_type != LocationProgressType.EXCLUDED:
-                    location.progress_type = LocationProgressType.PRIORITY
-                else:
-                    logger.warning(f"Unable to prioritize location \"{location_name}\" in player {player}'s world because the world excluded it.")
-                    world_excluded_locations.add(location_name)
+                logger.warning(f"Unable to prioritize location \"{location_name}\" in player {player}'s world because the world excluded it.")
+                world_excluded_locations.add(location_name)
         multiworld.worlds[player].options.priority_locations.value -= world_excluded_locations
 
     # Set local and non-local item rules.


### PR DESCRIPTION
## What is this fixing or adding?

If a location's `progress_type` was set to `EXCLUDED` and it was in a user's `priority_locations`, it would end up prioritized. In contrast, if something is in both `exclude_locations` and `priority_locations`, it ends up excluded. This makes it so that dev/world-excluded locations stay excluded and are removed from `priority_locations` (matching the behavior of using both `excluded` and `priority` through user-facing options) and a warning is logged if this overrides a user's `priority_locations` option.

This also simplifies part of an exception that could not be reached because of an earlier [key verification exception](https://github.com/ArchipelagoMW/Archipelago/blob/7058575c9502a4a35bb8e75fae767f2269c576c4/Options.py#L796) with [LocationSet key verfication](https://github.com/ArchipelagoMW/Archipelago/blob/7058575c9502a4a35bb8e75fae767f2269c576c4/Options.py#L1009-L1010).

## How was this tested?

Generations with games that set `progress_type` and viewing spoiler logs.