### PR TITLE
Docs: Making option description more readable and accurate

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -910,8 +910,10 @@ class Accessibility(Choice):
 
 
 class ProgressionBalancing(NamedRange):
-    """A system that can move progression earlier, to try and prevent the player from getting stuck and bored early.
-    A lower setting means more getting stuck. A higher setting means less getting stuck."""
+    """
+    A system that can move progression earlier, to try and prevent the player from getting stuck and bored early.
+    A lower setting means more getting stuck. A higher setting means less getting stuck.
+    """
     default = 50
     range_start = 0
     range_end = 99
@@ -984,7 +986,7 @@ class LocalItems(ItemSet):
 
 class NonLocalItems(ItemSet):
     """Forces these items to be outside their native world."""
-    display_name = "Not Local Items"
+    display_name = "Non-local Items"
 
 
 class StartInventory(ItemDict):


### PR DESCRIPTION
## What is this fixing or adding?

The tooltip for `ProgressionBalancing` had awkward spacing and did not match the format used in any of the recently-PR'ed option docstring changes for worlds, so this changes that. Also removes the only instance of "not local".

## How was this tested?

Reading, WebHost.

## If this makes graphical changes, please attach screenshots.

![Screenshot 2024-06-01 003504](https://github.com/ArchipelagoMW/Archipelago/assets/60412657/6a61f1e2-f402-46cb-b1a7-ce9b492ac631)
->
![Screenshot 2024-06-01 003600](https://github.com/ArchipelagoMW/Archipelago/assets/60412657/ddfc70e2-db32-47bf-9b55-7eedcf79469f)

![Screenshot 2024-06-01 003939](https://github.com/ArchipelagoMW/Archipelago/assets/60412657/63b96547-35c7-47ce-8cb6-ab37e5fa210e)
->
![Screenshot 2024-06-01 004030](https://github.com/ArchipelagoMW/Archipelago/assets/60412657/057bcd35-2d50-41cd-b8de-e0b16ec75c6d)
