### PR TITLE
TUNIC: Fix plando connections, seed groups, and UT support

### DIFF
--- a/worlds/tunic/__init__.py
+++ b/worlds/tunic/__init__.py
@@ -8,7 +8,7 @@ from .er_rules import set_er_location_rules
 from .regions import tunic_regions
 from .er_scripts import create_er_regions
 from .er_data import portal_mapping
-from .options import TunicOptions, EntranceRando, tunic_option_groups, tunic_option_presets
+from .options import TunicOptions, EntranceRando, tunic_option_groups, tunic_option_presets, TunicPlandoConnections
 from worlds.AutoWorld import WebWorld, World
 from Options import PlandoConnection
 from decimal import Decimal, ROUND_HALF_UP
@@ -43,7 +43,7 @@ class SeedGroup(TypedDict):
     logic_rules: int  # logic rules value
     laurels_at_10_fairies: bool  # laurels location value
     fixed_shop: bool  # fixed shop value
-    plando: List[PlandoConnection]  # consolidated list of plando connections for the seed group
+    plando: TunicPlandoConnections  # consolidated of plando connections for the seed group
 
 
 class TunicWorld(World):
@@ -128,6 +128,7 @@ class TunicWorld(World):
             if multiworld.plando_connections[tunic.player]:
                 # loop through the connections in the player's yaml
                 for cxn in multiworld.plando_connections[tunic.player]:
+                    print(type(cls.seed_groups[group]["plando"]))
                     new_cxn = True
                     for group_cxn in cls.seed_groups[group]["plando"]:
                         # if neither entrance nor exit match anything in the group, add to group

--- a/worlds/tunic/__init__.py
+++ b/worlds/tunic/__init__.py
@@ -128,7 +128,6 @@ class TunicWorld(World):
             if multiworld.plando_connections[tunic.player]:
                 # loop through the connections in the player's yaml
                 for cxn in multiworld.plando_connections[tunic.player]:
-                    print(type(cls.seed_groups[group]["plando"]))
                     new_cxn = True
                     for group_cxn in cls.seed_groups[group]["plando"]:
                         # if neither entrance nor exit match anything in the group, add to group

--- a/worlds/tunic/__init__.py
+++ b/worlds/tunic/__init__.py
@@ -96,13 +96,15 @@ class TunicWorld(World):
                 self.options.hexagon_quest.value = passthrough["hexagon_quest"]
                 self.options.entrance_rando.value = passthrough["entrance_rando"]
                 self.options.shuffle_ladders.value = passthrough["shuffle_ladders"]
+                self.options.fixed_shop.value = self.options.fixed_shop.option_false
+                self.options.laurels_location.value = self.options.laurels_location.option_anywhere
 
     @classmethod
     def stage_generate_early(cls, multiworld: MultiWorld) -> None:
         tunic_worlds: Tuple[TunicWorld] = multiworld.get_game_worlds("TUNIC")
         for tunic in tunic_worlds:
             # if it's one of the options, then it isn't a custom seed group
-            if tunic.options.entrance_rando.value in EntranceRando.options:
+            if tunic.options.entrance_rando.value in EntranceRando.options.values():
                 continue
             group = tunic.options.entrance_rando.value
             # if this is the first world in the group, set the rules equal to its rules
@@ -147,7 +149,7 @@ class TunicWorld(World):
                                             f"{tunic.multiworld.get_player_name(tunic.player)}'s plando "
                                             f"connection {cxn.entrance} <-> {cxn.exit}")
                     if new_cxn:
-                        cls.seed_groups[group]["plando"].append(cxn)
+                        cls.seed_groups[group]["plando"].value.append(cxn)
 
     def create_item(self, name: str) -> TunicItem:
         item_data = item_table[name]

--- a/worlds/tunic/er_scripts.py
+++ b/worlds/tunic/er_scripts.py
@@ -140,7 +140,7 @@ def pair_portals(world: "TunicWorld") -> Dict[Portal, Portal]:
     waterfall_plando = False
 
     # if it's not one of the EntranceRando options, it's a custom seed
-    if world.options.entrance_rando.value not in EntranceRando.options:
+    if world.options.entrance_rando.value not in EntranceRando.options.values():
         seed_group = world.seed_groups[world.options.entrance_rando.value]
         logic_rules = seed_group["logic_rules"]
         fixed_shop = seed_group["fixed_shop"]
@@ -161,6 +161,11 @@ def pair_portals(world: "TunicWorld") -> Dict[Portal, Portal]:
             if portal.region == "Zig Skip Exit":
                 portal_map.remove(portal)
                 break
+
+    # If using Universal Tracker, restore portal_map. Could be cleaner, but it does not matter for UT even a little bit
+    if hasattr(world.multiworld, "re_gen_passthrough"):
+        if "TUNIC" in world.multiworld.re_gen_passthrough:
+            portal_map = portal_mapping.copy()
 
     # create separate lists for dead ends and non-dead ends
     for portal in portal_map:
@@ -193,7 +198,7 @@ def pair_portals(world: "TunicWorld") -> Dict[Portal, Portal]:
     connected_regions.add(start_region)
     connected_regions = update_reachable_regions(connected_regions, traversal_reqs, has_laurels, logic_rules)
 
-    if world.options.entrance_rando.value in EntranceRando.options:
+    if world.options.entrance_rando.value in EntranceRando.options.values():
         plando_connections = world.options.plando_connections.value
     else:
         plando_connections = world.seed_groups[world.options.entrance_rando.value]["plando"]
@@ -255,7 +260,7 @@ def pair_portals(world: "TunicWorld") -> Dict[Portal, Portal]:
             else:
                 # if not both, they're both dead ends
                 if not portal2:
-                    if world.options.entrance_rando.value not in EntranceRando.options:
+                    if world.options.entrance_rando.value not in EntranceRando.options.values():
                         raise Exception(f"Tunic ER seed group {world.options.entrance_rando.value} paired a dead "
                                         "end to a dead end in their plando connections.")
                     else:
@@ -302,21 +307,21 @@ def pair_portals(world: "TunicWorld") -> Dict[Portal, Portal]:
                 traversal_reqs.setdefault(portal1.region, dict())[portal2.region] = []
                 traversal_reqs.setdefault(portal2.region, dict())[portal1.region] = []
 
-            if portal1.region == "Zig Skip Exit" or portal2.region == "Zig Skip Exit":
-                if portal1_dead_end or portal2_dead_end or \
-                        portal1.region == "Secret Gathering Place" or portal2.region == "Secret Gathering Place":
-                    if world.options.entrance_rando.value not in EntranceRando.options:
-                        raise Exception(f"Tunic ER seed group {world.options.entrance_rando.value} paired a dead "
-                                        "end to a dead end in their plando connections.")
-                    else:
-                        raise Exception(f"{player_name} paired a dead end to a dead end in their "
-                                        "plando connections.")
+            if (portal1.region == "Zig Skip Exit" and (portal2_dead_end or portal2.region == "Secret Gathering Place")
+                    or portal2.region == "Zig Skip Exit" and (portal1_dead_end or portal1.region == "Secret Gathering Place")):
+                if world.options.entrance_rando.value not in EntranceRando.options.values():
+                    raise Exception(f"Tunic ER seed group {world.options.entrance_rando.value} paired a dead "
+                                    "end to a dead end in their plando connections.")
+                else:
+                    raise Exception(f"{player_name} paired a dead end to a dead end in their "
+                                    "plando connections.")
 
-            if portal1.region == "Secret Gathering Place" or portal2.region == "Secret Gathering Place":
+            if (portal1.region == "Secret Gathering Place" and (portal2_dead_end or portal2.region == "Zig Skip Exit")
+                    or portal2.region == "Secret Gathering Place" and (portal1_dead_end or portal1.region == "Zig Skip Exit")):
                 # need to make sure you didn't pair this to a dead end or zig skip
                 if portal1_dead_end or portal2_dead_end or \
                         portal1.region == "Zig Skip Exit" or portal2.region == "Zig Skip Exit":
-                    if world.options.entrance_rando.value not in EntranceRando.options:
+                    if world.options.entrance_rando.value not in EntranceRando.options.values():
                         raise Exception(f"Tunic ER seed group {world.options.entrance_rando.value} paired a dead "
                                         "end to a dead end in their plando connections.")
                     else:

--- a/worlds/tunic/options.py
+++ b/worlds/tunic/options.py
@@ -173,7 +173,7 @@ class ShuffleLadders(Toggle):
     display_name = "Shuffle Ladders"
     
     
-class TUNICPlandoConnections(PlandoConnections):
+class TunicPlandoConnections(PlandoConnections):
     entrances = {*(portal.name for portal in portal_mapping), "Shop", "Shop Portal"}
     exits = {*(portal.name for portal in portal_mapping), "Shop", "Shop Portal"}
 
@@ -198,7 +198,7 @@ class TunicOptions(PerGameCommonOptions):
     lanternless: Lanternless
     maskless: Maskless
     laurels_location: LaurelsLocation
-    plando_connections: TUNICPlandoConnections
+    plando_connections: TunicPlandoConnections
       
 
 tunic_option_groups = [


### PR DESCRIPTION
## What is this fixing or adding?
Fixes plando connection + seed groups support. For appending things in the new plando connections system, I need to add `.value`.

Fixes seed groups. For getting whether a custom string is used, I now need to compare to `EntranceRando.options.values()` instead of just `EntranceRando.options` like before.

Fixes a Universal Tracker support issue. If fixed shop is off in the yaml, it removes the Zig Skip Exit portal from the portal map. So if the slot has fixed shop on, and the yaml doesn't, it would mismatch. Since this option does not get loaded into slot data (since it is unnecessary for trackers), I had to write a quick thing to fix that up.

## How was this tested?
Many test gens with weird yamls. Lots of triggers, plando connections, etc.

## If this makes graphical changes, please attach screenshots.
N/A