### PR TITLE
CODEOWNERS: Remove Jarno as world maintainer for BK Sudoku

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -21,9 +21,6 @@
 # ArchipIDLE
 /worlds/archipidle/ @LegendaryLinux
 
-# Sudoku (BK Sudoku)
-/worlds/bk_sudoku/ @Jarno458
-
 # Blasphemous
 /worlds/blasphemous/ @TRPG0
 
@@ -217,6 +214,9 @@
 
 # Final Fantasy (1)
 # /worlds/ff1/
+
+# Sudoku (BK Sudoku)
+# /worlds/bk_sudoku/
 
 
 ## Disabled Unmaintained Worlds


### PR DESCRIPTION
## What is this fixing or adding?
https://discord.com/channels/731205301247803413/1043594049854124152/1245821682992676904
Jarno doesn't want to maintain BK Sudoku anymore, so just PRing this so we don't forget to.