### PR TITLE
Utils: Fix mistake made with `KeyedDefaultDict` from #1933 that broke tracker functionality.

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -458,8 +458,11 @@ class KeyedDefaultDict(collections.defaultdict):
     """defaultdict variant that uses the missing key as argument to default_factory"""
     default_factory: typing.Callable[[typing.Any], typing.Any]
 
-    def __init__(self, default_factory: typing.Callable[[Any], Any] = None, *args, **kwargs):
-        super().__init__(default_factory, *args, **kwargs)
+    def __init__(self,
+                 default_factory: typing.Callable[[Any], Any] = None,
+                 default: typing.Union[typing.Mapping, typing.Iterable, None] = None,
+                 **kwargs):
+        super().__init__(default_factory, default, **kwargs)
 
     def __missing__(self, key):
         self[key] = value = self.default_factory(key)

--- a/Utils.py
+++ b/Utils.py
@@ -460,10 +460,10 @@ class KeyedDefaultDict(collections.defaultdict):
 
     def __init__(self,
                  default_factory: typing.Callable[[Any], Any] = None,
-                 default: typing.Union[typing.Mapping, typing.Iterable, None] = None,
+                 mapping: typing.Union[typing.Mapping, typing.Iterable, None] = None,
                  **kwargs):
-        if default is not None:
-            super().__init__(default_factory, default, **kwargs)
+        if mapping is not None:
+            super().__init__(default_factory, mapping, **kwargs)
         else:
             super().__init__(default_factory, **kwargs)
 

--- a/Utils.py
+++ b/Utils.py
@@ -458,8 +458,8 @@ class KeyedDefaultDict(collections.defaultdict):
     """defaultdict variant that uses the missing key as argument to default_factory"""
     default_factory: typing.Callable[[typing.Any], typing.Any]
 
-    def __init__(self, default_factory: typing.Callable[[Any], Any] = None, **kwargs):
-        super().__init__(default_factory, **kwargs)
+    def __init__(self, default_factory: typing.Callable[[Any], Any] = None, *args, **kwargs):
+        super().__init__(default_factory, *args, **kwargs)
 
     def __missing__(self, key):
         self[key] = value = self.default_factory(key)

--- a/Utils.py
+++ b/Utils.py
@@ -460,10 +460,10 @@ class KeyedDefaultDict(collections.defaultdict):
 
     def __init__(self,
                  default_factory: typing.Callable[[Any], Any] = None,
-                 mapping: typing.Union[typing.Mapping, typing.Iterable, None] = None,
+                 seq: typing.Union[typing.Mapping, typing.Iterable, None] = None,
                  **kwargs):
-        if mapping is not None:
-            super().__init__(default_factory, mapping, **kwargs)
+        if seq is not None:
+            super().__init__(default_factory, seq, **kwargs)
         else:
             super().__init__(default_factory, **kwargs)
 

--- a/Utils.py
+++ b/Utils.py
@@ -462,7 +462,10 @@ class KeyedDefaultDict(collections.defaultdict):
                  default_factory: typing.Callable[[Any], Any] = None,
                  default: typing.Union[typing.Mapping, typing.Iterable, None] = None,
                  **kwargs):
-        super().__init__(default_factory, default, **kwargs)
+        if default is not None:
+            super().__init__(default_factory, default, **kwargs)
+        else:
+            super().__init__(default_factory, **kwargs)
 
     def __missing__(self, key):
         self[key] = value = self.default_factory(key)


### PR DESCRIPTION
## What is this fixing or adding?
During #1933, I defined a custom `__init__` for `Utils.KeyedDefaultDict` to make PyCharm happy when creating a new dict, but forgot to add a `*args` param, which was only utilized in the tracker code, so I missed in testing. This adds it and fixes the 500 server error that gets displayed on multitracker.

## How was this tested?
Ran WebHost before and after.

## If this makes graphical changes, please attach screenshots.
Before:
![image](https://github.com/ArchipelagoMW/Archipelago/assets/11338376/9f416a07-876f-4746-b82a-e1f3290c4f5f)

After:
![image](https://github.com/ArchipelagoMW/Archipelago/assets/11338376/752ff090-392e-47f8-b1a8-5691ae1e5976)

:P