### PR TITLE
Muse Dash: Remove regions for a decent speed gain in generating worlds

### DIFF
--- a/worlds/musedash/__init__.py
+++ b/worlds/musedash/__init__.py
@@ -252,9 +252,7 @@ class MuseDashWorld(World):
 
     def create_regions(self) -> None:
         menu_region = Region("Menu", self.player, self.multiworld)
-        song_select_region = Region("Song Select", self.player, self.multiworld)
-        self.multiworld.regions += [menu_region, song_select_region]
-        menu_region.connect(song_select_region)
+        self.multiworld.regions += [menu_region]
 
         # Make a collection of all songs available for this rando.
         # 1. All starting songs
@@ -271,15 +269,15 @@ class MuseDashWorld(World):
         # Make a region per song/album, then adds 1-2 item locations to them
         for i in range(0, len(all_selected_locations)):
             name = all_selected_locations[i]
-            region = Region(name, self.player, self.multiworld)
-            self.multiworld.regions.append(region)
-            song_select_region.connect(region, name, lambda state, place=name: state.has(place, self.player))
-
             # Muse Dash requires 2 locations per song to be *interesting*. Balanced out by filler.
-            region.add_locations({
-                    name + "-0": self.md_collection.song_locations[name + "-0"],
-                    name + "-1": self.md_collection.song_locations[name + "-1"]
-            }, MuseDashLocation)
+
+            loc1 = MuseDashLocation(self.player,  name + "-0", self.md_collection.song_locations[name + "-0"], menu_region)
+            loc1.access_rule = lambda state, place=name: state.has(place, self.player)
+            menu_region.locations.append(loc1)
+
+            loc2 = MuseDashLocation(self.player,  name + "-1", self.md_collection.song_locations[name + "-1"], menu_region)
+            loc2.access_rule = lambda state, place=name: state.has(place, self.player)
+            menu_region.locations.append(loc2)
 
     def set_rules(self) -> None:
         self.multiworld.completion_condition[self.player] = lambda state: \

--- a/worlds/musedash/__init__.py
+++ b/worlds/musedash/__init__.py
@@ -266,11 +266,9 @@ class MuseDashWorld(World):
         self.random.shuffle(included_song_copy)
         all_selected_locations.extend(included_song_copy)
 
-        # Make a region per song/album, then adds 1-2 item locations to them
+        # Adds 2 item locations per song/album to the menu region.
         for i in range(0, len(all_selected_locations)):
             name = all_selected_locations[i]
-            # Muse Dash requires 2 locations per song to be *interesting*. Balanced out by filler.
-
             loc1 = MuseDashLocation(self.player,  name + "-0", self.md_collection.song_locations[name + "-0"], menu_region)
             loc1.access_rule = lambda state, place=name: state.has(place, self.player)
             menu_region.locations.append(loc1)


### PR DESCRIPTION
## What is this fixing or adding?
Removes the regions for Muse Dash in order to gain a decent amount of performance for larger worlds.

## How was this tested?
Tests and checking the generation log to ensure nothing broke.

Performance testing

![image](https://github.com/ArchipelagoMW/Archipelago/assets/7556376/a0a609b3-edc1-4ee2-b37f-c22416efdcd3)

| Gen | Average Before | Average After |
|--------|--------|--------|
1 x 50 | 0.08304867998 | 0.06629044001 |
10 x 50 | 3.52350716 | 1.65648329  |
1 x 500 | 0.52350967 | 0.31642301  |
10 x 500 | 52.85262655 | 23.17679973  

Tests were not done with set seeds. As the performance difference was consistently large.