### PR TITLE
Subnautica: ability to remove vehicles either from logic or entirely

### DIFF
--- a/worlds/subnautica/__init__.py
+++ b/worlds/subnautica/__init__.py
@@ -10,7 +10,11 @@ from . import items
 from . import locations
 from . import creatures
 from . import options
-from .items import item_table, group_items, items_by_type, ItemType
+from .items import (
+    item_table, group_items, items_by_type, ItemType,
+    base_item_table, non_vehicle_depth_table,
+    seamoth_table, prawn_table, cyclops_table,
+)
 from .rules import set_rules
 
 logger = logging.getLogger("Subnautica")
@@ -102,6 +106,14 @@ class SubnauticaWorld(World):
     # refer to rules.py
     set_rules = set_rules
 
+    def get_theoretical_swim_depth(self):
+        depth: int = self.options.swim_rule.base_depth
+
+        if self.options.swim_rule.consider_items:
+            return depth + 350
+
+        return depth
+
     def create_items(self):
         # Generate item pool
         pool: List[SubnauticaItem] = []
@@ -109,17 +121,58 @@ class SubnauticaWorld(World):
 
         grouped = set(itertools.chain.from_iterable(group_items.values()))
 
-        for item_id, item in item_table.items():
+        for item_id, item in base_item_table.items():
             if item_id in grouped:
                 extras += item.count
             else:
-                for i in range(item.count):
+                for _ in range(item.count):
                     subnautica_item = self.create_item(item.name)
                     if item.name == "Neptune Launch Platform":
                         self.get_location("Aurora - Captain Data Terminal").place_locked_item(
                             subnautica_item)
+                    elif item.name == "Cyclops Shield Generator":
+                        if self.options.include_cyclops.value == 2 \
+                                and self.options.goal.get_event_name() != "Neptune Launch":
+                            extras += 1
+                        else:
+                            pool.append(subnautica_item)
                     else:
                         pool.append(subnautica_item)
+
+        for item_id, item in seamoth_table.items():
+            if self.options.include_seamoth.value < 2:
+                for _ in range(item.count):
+                    pool.append(self.create_item(item.name))
+            else:
+                extras += item.count
+
+        for item_id, item in prawn_table.items():
+            if self.options.include_prawn.value < 2:
+                for _ in range(item.count):
+                    pool.append(self.create_item(item.name))
+            else:
+                extras += item.count
+
+        for item_id, item in cyclops_table.items():
+            if self.options.include_cyclops.value < 2:
+                for _ in range(item.count):
+                    pool.append(self.create_item(item.name))
+            else:
+                extras += item.count
+
+        # If we can't make the necessary depth by traditional (vehicle) means, use the alternates
+        # Shift the items to progression as part of that change
+        seamoth_can_make_it: bool = False
+        if self.options.include_seamoth.value == 0 and self.get_theoretical_swim_depth() + 900 > 1443:
+            seamoth_can_make_it = True
+
+        for item_id, item in non_vehicle_depth_table.items():
+            for _ in range(item.count):
+                if seamoth_can_make_it is False and self.options.include_prawn.value > 0 and \
+                        self.options.include_cyclops.value > 0:
+                    pool.append(self.create_shifted_item(item.name, ItemClassification.progression))
+                else:
+                    pool.append(self.create_item(item.name))
 
         group_amount: int = 2
         assert len(group_items) * group_amount <= extras
@@ -129,20 +182,37 @@ class SubnauticaWorld(World):
                 pool.append(self.create_item(name))
             extras -= group_amount
 
-        for item_name in self.random.sample(
-                # list of high-count important fragments as priority filler
-                [
-                    "Cyclops Engine Fragment",
-                    "Cyclops Hull Fragment",
-                    "Cyclops Bridge Fragment",
-                    "Seamoth Fragment",
-                    "Prawn Suit Fragment",
-                    "Mobile Vehicle Bay Fragment",
-                    "Modification Station Fragment",
-                    "Moonpool Fragment",
-                    "Laser Cutter Fragment",
-                ],
-                k=min(extras, 9)):
+        # list of high-count important fragments as priority filler
+        num = 2
+        priority_filler: List[str] = [
+            "Modification Station Fragment",
+            "Laser Cutter Fragment",
+        ]
+
+        # There are edge cases where we don't need these; don't make extra priority filler if we don't need them
+        # We're wasting a single item here with moonpool fragments for the Cyclops... meh
+        if self.options.include_seamoth.value < 2 or \
+                self.options.include_prawn.value < 2 or \
+                self.options.include_cyclops.value < 2 or \
+                self.options.goal.get_event_name() == "Neptune Launch":
+            num += 2
+            priority_filler.append("Mobile Vehicle Bay Fragment")
+            priority_filler.append("Moonpool Fragment")
+
+        # Vehicle priority filler
+        if self.options.include_seamoth.value < 2:
+            priority_filler.append("Seamoth Fragment")
+            num += 1
+        if self.options.include_prawn.value < 2:
+            priority_filler.append("Prawn Suit Fragment")
+            num += 1
+        if self.options.include_cyclops.value < 2:
+            priority_filler.append("Cyclops Engine Fragment")
+            priority_filler.append("Cyclops Hull Fragment")
+            priority_filler.append("Cyclops Bridge Fragment")
+            num += 3
+
+        for item_name in self.random.sample(priority_filler, k=min(extras, num)):
             item = self.create_item(item_name)
             pool.append(item)
             extras -= 1
@@ -165,6 +235,9 @@ class SubnauticaWorld(World):
             "creatures_to_scan": self.creatures_to_scan,
             "death_link": self.options.death_link.value,
             "free_samples": self.options.free_samples.value,
+            "include_seamoth": self.options.include_seamoth.value,
+            "include_prawn": self.options.include_prawn.value,
+            "include_cyclops": self.options.include_cyclops.value,
         }
 
         return slot_data
@@ -175,6 +248,10 @@ class SubnauticaWorld(World):
         return SubnauticaItem(name,
                               item_table[item_id].classification,
                               item_id, player=self.player)
+
+    def create_shifted_item(self, name: str, cls) -> SubnauticaItem:
+        item_id: int = self.item_name_to_id[name]
+        return SubnauticaItem(name, cls, item_id, player=self.player)
 
     def get_filler_item_name(self) -> str:
         item_names, cum_item_weights = self.options.filler_items_distribution.weights_pair

--- a/worlds/subnautica/items.py
+++ b/worlds/subnautica/items.py
@@ -23,62 +23,54 @@ def make_resource_bundle_data(display_name: str, internal_name: str = "") -> Ite
     return ItemData(IC.filler, 0, display_name, internal_name, ItemType.resource)
 
 
-item_table: Dict[int, ItemData] = {
-    35000: ItemData(IC.useful, 1, "Compass", "Compass"),
+progression_table = {
     35001: ItemData(IC.progression, 1, "Lightweight High Capacity Tank", "PlasteelTank"),
     35002: ItemData(IC.progression, 1, "Vehicle Upgrade Console", "BaseUpgradeConsole"),
     35003: ItemData(IC.progression, 1, "Ultra Glide Fins", "UltraGlideFins"),
-    35004: ItemData(IC.useful, 1, "Cyclops Sonar Upgrade", "CyclopsSonarModule"),
-    35005: ItemData(IC.useful, 1, "Reinforced Dive Suit", "ReinforcedDiveSuit"),
-    35006: ItemData(IC.useful, 1, "Cyclops Thermal Reactor Module", "CyclopsThermalReactorModule"),
-    35007: ItemData(IC.filler, 1, "Water Filtration Suit", "WaterFiltrationSuit"),
     35008: ItemData(IC.progression, 1, "Alien Containment", "BaseWaterPark"),
-    35009: ItemData(IC.useful, 1, "Creature Decoy", "CyclopsDecoy"),
-    35010: ItemData(IC.useful, 1, "Cyclops Fire Suppression System", "CyclopsFireSuppressionModule"),
-    35011: ItemData(IC.useful, 1, "Swim Charge Fins", "SwimChargeFins"),
-    35012: ItemData(IC.useful, 1, "Repulsion Cannon", "RepulsionCannon"),
-    35013: ItemData(IC.useful, 1, "Cyclops Decoy Tube Upgrade", "CyclopsDecoyModule"),
     35014: ItemData(IC.progression, 1, "Cyclops Shield Generator", "CyclopsShieldModule"),
-    35015: ItemData(IC.progression, 1, "Cyclops Depth Module MK1", "CyclopsHullModule1"),
-    35016: ItemData(IC.useful, 1, "Cyclops Docking Bay Repair Module", "CyclopsSeamothRepairModule"),
-    35017: ItemData(IC.useful, 2, "Battery Charger fragment", "BatteryChargerFragment"),
-    35018: ItemData(IC.filler, 2, "Beacon Fragment", "BeaconFragment"),
-    35019: ItemData(IC.useful, 2, "Bioreactor Fragment", "BaseBioReactorFragment"),
-    35020: ItemData(IC.progression, 4, "Cyclops Bridge Fragment", "CyclopsBridgeFragment"),
-    35021: ItemData(IC.progression, 4, "Cyclops Engine Fragment", "CyclopsEngineFragment"),
-    35022: ItemData(IC.progression, 4, "Cyclops Hull Fragment", "CyclopsHullFragment"),
-    35023: ItemData(IC.filler, 2, "Grav Trap Fragment", "GravSphereFragment"),
     35024: ItemData(IC.progression, 3, "Laser Cutter Fragment", "LaserCutterFragment"),
-    35025: ItemData(IC.filler, 2, "Light Stick Fragment", "TechlightFragment"),
     35026: ItemData(IC.progression, 5, "Mobile Vehicle Bay Fragment", "ConstructorFragment"),
     35027: ItemData(IC.progression, 3, "Modification Station Fragment", "WorkbenchFragment"),
     35028: ItemData(IC.progression, 2, "Moonpool Fragment", "MoonpoolFragment"),
-    35029: ItemData(IC.useful, 3, "Nuclear Reactor Fragment", "BaseNuclearReactorFragment"),
-    35030: ItemData(IC.useful, 2, "Power Cell Charger Fragment", "PowerCellChargerFragment"),
-    35031: ItemData(IC.filler, 1, "Power Transmitter Fragment", "PowerTransmitterFragment"),
-    35032: ItemData(IC.progression, 6, "Prawn Suit Fragment", "ExosuitFragment"),
-    35033: ItemData(IC.useful, 2, "Prawn Suit Drill Arm Fragment", "ExosuitDrillArmFragment"),
-    35034: ItemData(IC.useful, 2, "Prawn Suit Grappling Arm Fragment", "ExosuitGrapplingArmFragment"),
-    35035: ItemData(IC.useful, 2, "Prawn Suit Propulsion Cannon Fragment", "ExosuitPropulsionArmFragment"),
-    35036: ItemData(IC.useful, 2, "Prawn Suit Torpedo Arm Fragment", "ExosuitTorpedoArmFragment"),
-    35037: ItemData(IC.useful, 3, "Scanner Room Fragment", "BaseMapRoomFragment"),
-    35038: ItemData(IC.progression, 5, "Seamoth Fragment", "SeamothFragment"),
     35039: ItemData(IC.progression, 2, "Stasis Rifle Fragment", "StasisRifleFragment"),
-    35040: ItemData(IC.useful, 2, "Thermal Plant Fragment", "ThermalPlantFragment"),
     35041: ItemData(IC.progression, 4, "Seaglide Fragment", "SeaglideFragment"),
     35042: ItemData(IC.progression, 1, "Radiation Suit", "RadiationSuit"),
     35043: ItemData(IC.progression, 2, "Propulsion Cannon Fragment", "PropulsionCannonFragment"),
     35044: ItemData(IC.progression_skip_balancing, 1, "Neptune Launch Platform", "RocketBase"),
     35045: ItemData(IC.progression, 1, "Ion Power Cell", "PrecursorIonPowerCell"),
-    35046: ItemData(IC.filler, 2, "Exterior Growbed", "FarmingTray"),
+    35053: ItemData(IC.progression, 1, "Multipurpose Room", "BaseRoom"),
+    35075: ItemData(IC.progression, 1, "Ion Battery", "PrecursorIonBattery"),
+    35076: ItemData(IC.progression_skip_balancing, 1, "Neptune Gantry", "RocketBaseLadder"),
+    35077: ItemData(IC.progression_skip_balancing, 1, "Neptune Boosters", "RocketStage1"),
+    35078: ItemData(IC.progression_skip_balancing, 1, "Neptune Fuel Reserve", "RocketStage2"),
+    35079: ItemData(IC.progression_skip_balancing, 1, "Neptune Cockpit", "RocketStage3"),
+    35081: ItemData(IC.progression, 1, "Ultra High Capacity Tank", "HighCapacityTank"),
+    35082: ItemData(IC.progression, 1, "Large Room", "BaseLargeRoom"),
+}
+
+useful_table = {
+    35000: ItemData(IC.useful, 1, "Compass", "Compass"),
+    35005: ItemData(IC.useful, 1, "Reinforced Dive Suit", "ReinforcedDiveSuit"),
+    35011: ItemData(IC.useful, 1, "Swim Charge Fins", "SwimChargeFins"),
+    35012: ItemData(IC.useful, 1, "Repulsion Cannon", "RepulsionCannon"),
+    35017: ItemData(IC.useful, 2, "Battery Charger fragment", "BatteryChargerFragment"),
+    35030: ItemData(IC.useful, 2, "Power Cell Charger Fragment", "PowerCellChargerFragment"),
+    35037: ItemData(IC.useful, 3, "Scanner Room Fragment", "BaseMapRoomFragment"),
+    35054: ItemData(IC.useful, 1, "Bulkhead", "BaseBulkhead"),
+}
+
+junk_table = {
+    35007: ItemData(IC.filler, 1, "Water Filtration Suit", "WaterFiltrationSuit"),
+    35018: ItemData(IC.filler, 2, "Beacon Fragment", "BeaconFragment"),
+    35023: ItemData(IC.filler, 2, "Grav Trap Fragment", "GravSphereFragment"),
+    35025: ItemData(IC.filler, 2, "Light Stick Fragment", "TechlightFragment"),
     35047: ItemData(IC.filler, 1, "Picture Frame", "PictureFrameFragment"),
     35048: ItemData(IC.filler, 1, "Bench", "Bench"),
     35049: ItemData(IC.filler, 1, "Basic Plant Pot", "PlanterPotFragment"),
     35050: ItemData(IC.filler, 1, "Interior Growbed", "PlanterBoxFragment"),
     35051: ItemData(IC.filler, 1, "Plant Shelf", "PlanterShelfFragment"),
     35052: ItemData(IC.filler, 1, "Observatory", "BaseObservatory"),
-    35053: ItemData(IC.progression, 1, "Multipurpose Room", "BaseRoom"),
-    35054: ItemData(IC.useful, 1, "Bulkhead", "BaseBulkhead"),
     35055: ItemData(IC.filler, 1, "Spotlight", "Spotlight"),
     35056: ItemData(IC.filler, 1, "Desk", "StarshipDesk"),
     35057: ItemData(IC.filler, 1, "Swivel Chair", "StarshipChair"),
@@ -99,14 +91,8 @@ item_table: Dict[int, ItemData] = {
     35072: ItemData(IC.filler, 1, "Chic Plant Pot", "PlanterPot3"),
     35073: ItemData(IC.filler, 1, "Nuclear Waste Disposal", "LabTrashcan"),
     35074: ItemData(IC.filler, 1, "Wall Planter", "BasePlanter"),
-    35075: ItemData(IC.progression, 1, "Ion Battery", "PrecursorIonBattery"),
-    35076: ItemData(IC.progression_skip_balancing, 1, "Neptune Gantry", "RocketBaseLadder"),
-    35077: ItemData(IC.progression_skip_balancing, 1, "Neptune Boosters", "RocketStage1"),
-    35078: ItemData(IC.progression_skip_balancing, 1, "Neptune Fuel Reserve", "RocketStage2"),
-    35079: ItemData(IC.progression_skip_balancing, 1, "Neptune Cockpit", "RocketStage3"),
     35080: ItemData(IC.filler, 1, "Water Filtration Machine", "BaseFiltrationMachine"),
-    35081: ItemData(IC.progression, 1, "Ultra High Capacity Tank", "HighCapacityTank"),
-    35082: ItemData(IC.progression, 1, "Large Room", "BaseLargeRoom"),
+
     # awarded with their rooms, keeping that as-is as they"re cosmetic
     35083: ItemData(IC.filler, 0, "Large Room Glass Dome", "BaseLargeGlassDome"),
     35084: ItemData(IC.filler, 0, "Multipurpose Room Glass Dome", "BaseGlassDome"),
@@ -141,6 +127,55 @@ item_table: Dict[int, ItemData] = {
     35213: make_resource_bundle_data("Reactor Rod", "ReactorRod"),
 }
 
+non_vehicle_depth_table = {
+    35019: ItemData(IC.useful, 2, "Bioreactor Fragment", "BaseBioReactorFragment"),
+    35029: ItemData(IC.useful, 3, "Nuclear Reactor Fragment", "BaseNuclearReactorFragment"),
+    35031: ItemData(IC.useful, 1, "Power Transmitter Fragment", "PowerTransmitterFragment"),
+    35040: ItemData(IC.useful, 2, "Thermal Plant Fragment", "ThermalPlantFragment"),
+    35046: ItemData(IC.useful, 2, "Exterior Growbed", "FarmingTray"),
+}
+
+seamoth_table = {
+    35038: ItemData(IC.progression, 5, "Seamoth Fragment", "SeamothFragment"),
+}
+
+prawn_table = {
+    35032: ItemData(IC.progression, 6, "Prawn Suit Fragment", "ExosuitFragment"),
+    35033: ItemData(IC.useful, 2, "Prawn Suit Drill Arm Fragment", "ExosuitDrillArmFragment"),
+    35034: ItemData(IC.useful, 2, "Prawn Suit Grappling Arm Fragment", "ExosuitGrapplingArmFragment"),
+    35035: ItemData(IC.useful, 2, "Prawn Suit Propulsion Cannon Fragment", "ExosuitPropulsionArmFragment"),
+    35036: ItemData(IC.useful, 2, "Prawn Suit Torpedo Arm Fragment", "ExosuitTorpedoArmFragment"),
+}
+
+cyclops_table = {
+    35004: ItemData(IC.useful, 1, "Cyclops Sonar Upgrade", "CyclopsSonarModule"),
+    35006: ItemData(IC.useful, 1, "Cyclops Thermal Reactor Module", "CyclopsThermalReactorModule"),
+    35009: ItemData(IC.useful, 1, "Creature Decoy", "CyclopsDecoy"),
+    35010: ItemData(IC.useful, 1, "Cyclops Fire Suppression System", "CyclopsFireSuppressionModule"),
+    35013: ItemData(IC.useful, 1, "Cyclops Decoy Tube Upgrade", "CyclopsDecoyModule"),
+    35015: ItemData(IC.progression, 1, "Cyclops Depth Module MK1", "CyclopsHullModule1"),
+    35016: ItemData(IC.useful, 1, "Cyclops Docking Bay Repair Module", "CyclopsSeamothRepairModule"),
+    35020: ItemData(IC.progression, 4, "Cyclops Bridge Fragment", "CyclopsBridgeFragment"),
+    35021: ItemData(IC.progression, 4, "Cyclops Engine Fragment", "CyclopsEngineFragment"),
+    35022: ItemData(IC.progression, 4, "Cyclops Hull Fragment", "CyclopsHullFragment"),
+}
+
+base_item_table: Dict[int, ItemData] = {
+    **progression_table,
+    **useful_table,
+    **junk_table,
+}
+
+item_table: Dict[int, ItemData] = {
+    **progression_table,
+    **useful_table,
+    **junk_table,
+    **non_vehicle_depth_table,
+    **seamoth_table,
+    **prawn_table,
+    **cyclops_table
+}
+
 
 items_by_type: Dict[ItemType, List[int]] = {item_type: [] for item_type in ItemType}
 for item_id, item_data in item_table.items():
@@ -152,6 +187,7 @@ item_names_by_type: Dict[ItemType, List[str]] = {
 group_items: Dict[int, Set[int]] = {
     35100: {35025, 35047, 35048, 35056, 35057, 35058, 35059, 35060, 35061, 35062, 35063, 35064, 35065, 35067, 35068,
             35069, 35070, 35073, 35074},
+    # Removing 35050 from here will allow the Interior Growbed to spawn (but takes an extra item)
     35101: {35049, 35050, 35051, 35071, 35072, 35074},
     35102: set(items_by_type[ItemType.resource]),
 }

--- a/worlds/subnautica/options.py
+++ b/worlds/subnautica/options.py
@@ -48,6 +48,42 @@ class EarlySeaglide(DefaultOnToggle):
     display_name = "Early Seaglide"
 
 
+class IncludeSeamoth(Choice):
+    """Whether to include the Seamoth or not.
+    Include: Include the Seamoth both logically and really.
+    Exclude from Logic: Include the Seamoth, but don't count it towards depth or distance calculations.
+    Exclude: Do not include any Seamoth fragments. The Seamoth will be unobtainable in game."""
+    display_name = "Seamoth"
+    option_include = 0
+    option_exclude_logically = 1
+    option_exclude = 2
+
+
+class IncludePrawnSuit(Choice):
+    """Whether to include the Prawn Suit or not.
+    Include: Include the Prawn Suit both logically and really.
+    Exclude from Logic: Include the Prawn Suit, but don't count it towards depth or distance calculations.
+    Exclude: Do not include any Prawn Suit fragments. The Prawn Suit will be unobtainable in game."""
+    display_name = "Prawn Suit"
+    option_include = 0
+    option_exclude_logically = 1
+    option_exclude = 2
+
+
+class IncludeCyclops(Choice):
+    """Whether to include the Cyclops or not.
+    Include: Include the Cyclops both logically and really.
+    Exclude from Logic: Include the Cyclops, but don't count it towards depth or distance calculations.
+    Exclude: Do not include any Cyclops fragments. The Cyclops will be unobtainable in game.
+
+    If the Cyclops is excluded and the goal is Launch, the Shield Generator will be
+    available at the Moonpool Fabricator (A.K.A. Vehicle Upgrade Console)."""
+    display_name = "Cyclops"
+    option_include = 0
+    option_exclude_logically = 1
+    option_exclude = 2
+
+
 class FreeSamples(Toggle):
     """Get free items with your blueprints.
     Items that can go into your inventory are awarded when you unlock their blueprint through Archipelago."""
@@ -133,6 +169,9 @@ class FillerItemsDistribution(ItemDict):
 @dataclass
 class SubnauticaOptions(PerGameCommonOptions):
     swim_rule: SwimRule
+    include_seamoth: IncludeSeamoth
+    include_prawn: IncludePrawnSuit
+    include_cyclops: IncludeCyclops
     early_seaglide: EarlySeaglide
     free_samples: FreeSamples
     goal: Goal

--- a/worlds/subnautica/rules.py
+++ b/worlds/subnautica/rules.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Dict, Callable, Optional
 from worlds.generic.Rules import set_rule, add_rule
 from .locations import location_table, LocationDict
 from .creatures import all_creatures, aggressive, suffix, hatchable, containment
-from .options import AggressiveScanLogic, SwimRule
+from .options import AggressiveScanLogic, SubnauticaOptions
 import math
 
 if TYPE_CHECKING:
@@ -13,6 +13,10 @@ if TYPE_CHECKING:
 
 def has_seaglide(state: "CollectionState", player: int) -> bool:
     return state.has("Seaglide Fragment", player, 2)
+
+
+def has_exterior_growbed(state: "CollectionState", player: int) -> bool:
+    return state.has("Exterior Growbed", player, 1)
 
 
 def has_modification_station(state: "CollectionState", player: int) -> bool:
@@ -32,7 +36,9 @@ def has_vehicle_upgrade_console(state: "CollectionState", player: int) -> bool:
            has_moonpool(state, player)
 
 
-def has_seamoth(state: "CollectionState", player: int) -> bool:
+def has_seamoth(state: "CollectionState", player: int, options: SubnauticaOptions) -> bool:
+    if options.include_seamoth > 0:
+        return False
     return state.has("Seamoth Fragment", player, 3) and \
            has_mobile_vehicle_bay(state, player)
 
@@ -63,7 +69,21 @@ def has_cyclops_hull(state: "CollectionState", player: int) -> bool:
     return state.has("Cyclops Hull Fragment", player, 3)
 
 
-def has_cyclops(state: "CollectionState", player: int) -> bool:
+def has_nuclear_reactor(state: "CollectionState", player: int) -> bool:
+    return state.has("Nuclear Reactor Fragment", player, 3) and has_utility_room(state, player)
+
+
+def has_bioreactor(state: "CollectionState", player: int) -> bool:
+    return state.has("Bioreactor Fragment", player, 2) and has_utility_room(state, player)
+
+
+def has_thermal_plant(state: "CollectionState", player: int) -> bool:
+    return state.has("Thermal Plant Fragment", player, 2) and state.has("Power Transmitter Fragment", player, 1)
+
+
+def has_cyclops(state: "CollectionState", player: int, options: SubnauticaOptions, shield_check: bool = False) -> bool:
+    if options.include_cyclops > 0 and not shield_check:
+        return False
     return has_cyclops_bridge(state, player) and \
            has_cyclops_engine(state, player) and \
            has_cyclops_hull(state, player) and \
@@ -85,7 +105,9 @@ def has_cyclops_depth_module_mk3(state: "CollectionState", player: int) -> bool:
            has_modification_station(state, player)
 
 
-def has_prawn(state: "CollectionState", player: int) -> bool:
+def has_prawn(state: "CollectionState", player: int, options: SubnauticaOptions) -> bool:
+    if options.include_prawn > 0:
+        return False
     return state.has("Prawn Suit Fragment", player, 4) and \
            has_mobile_vehicle_bay(state, player)
 
@@ -125,9 +147,16 @@ def has_propulsion_cannon(state: "CollectionState", player: int) -> bool:
     return state.has("Propulsion Cannon Fragment", player, 2)
 
 
-def has_cyclops_shield(state: "CollectionState", player: int) -> bool:
-    return has_cyclops(state, player) and \
-           state.has("Cyclops Shield Generator", player)
+def has_cyclops_shield(state: "CollectionState", player: int, options: SubnauticaOptions) -> bool:
+    # Cyclops in game
+    if options.include_cyclops < 2:
+        return has_cyclops(state, player, options, True) and \
+            state.has("Cyclops Shield Generator", player)
+
+    # Cyclops not in game
+    return has_moonpool(state, player) and \
+        has_vehicle_upgrade_console(state, player) and \
+        state.has("Cyclops Shield Generator", player)
 
 
 def has_ultra_high_capacity_tank(state: "CollectionState", player: int) -> bool:
@@ -141,83 +170,135 @@ def has_lightweight_high_capacity_tank(state: "CollectionState", player: int) ->
 def has_ultra_glide_fins(state: "CollectionState", player: int) -> bool:
     return has_modification_station(state, player) and state.has("Ultra Glide Fins", player)
 
+
+def get_max_swim_depth(state: "CollectionState", player: int, options: SubnauticaOptions, \
+        theoretical: bool = False) -> int:
+    depth: int = options.swim_rule.base_depth
+
+    additional_depth: int = 0
+    if options.swim_rule.consider_items:
+        if theoretical:
+            additional_depth = 350
+        else:
+            additional_depth = get_additional_item_depth(state, player, options)
+
+    return depth + additional_depth
+
+
 # Swim depth rules:
 # Rebreather, high capacity tank and fins are available from the start.
 # All tests for those were done without inventory for light weight.
 # Fins and ultra Fins are better than charge fins, so we ignore charge fins.
 
 # swim speeds: https://subnautica.fandom.com/wiki/Swimming_Speed
+def get_additional_item_depth(state: "CollectionState", player: int, options: SubnauticaOptions) -> int:
+    depth: int = 0
 
-
-def get_max_swim_depth(state: "CollectionState", player: int) -> int:
-    swim_rule: SwimRule = state.multiworld.swim_rule[player]
-    depth: int = swim_rule.base_depth
-    if swim_rule.consider_items:
-        if has_seaglide(state, player):
-            if has_ultra_high_capacity_tank(state, player):
-                depth += 350  # It's about 800m. Give some room
-            else:
-                depth += 200  # It's about 650m. Give some room
-        # seaglide and fins cannot be used together
-        elif has_ultra_glide_fins(state, player):
-            if has_ultra_high_capacity_tank(state, player):
-                depth += 150
-            elif has_lightweight_high_capacity_tank(state, player):
-                depth += 75
-            else:
-                depth += 50
-        elif has_ultra_high_capacity_tank(state, player):
-            depth += 100
+    if has_seaglide(state, player):
+        if has_ultra_high_capacity_tank(state, player):
+            depth += 350  # It's about 800m. Give some room
+        else:
+            depth += 200  # It's about 650m. Give some room
+    # seaglide and fins cannot be used together
+    elif has_ultra_glide_fins(state, player):
+        if has_ultra_high_capacity_tank(state, player):
+            depth += 150
         elif has_lightweight_high_capacity_tank(state, player):
-            depth += 25
+            depth += 75
+        else:
+            depth += 50
+    elif has_ultra_high_capacity_tank(state, player):
+        depth += 100
+    elif has_lightweight_high_capacity_tank(state, player):
+        depth += 25
+
     return depth
 
 
-def get_seamoth_max_depth(state: "CollectionState", player: int):
-    if has_seamoth(state, player):
-        if has_seamoth_depth_module_mk3(state, player):
-            return 900
-        elif has_seamoth_depth_module_mk2(state, player):  # Will never be the case, 3 is craftable
-            return 500
-        elif has_seamoth_depth_module_mk1(state, player):
-            return 300
-        else:
-            return 200
-    else:
+# Basically, if you have neither the prawn or cyclops in logic, then you're stuck
+# making bases til you hit depth; max needed depth is ~1444, so anything that gets
+# us to 1500 is fine. This is the slow way; better players will use cheats
+# such as multiple tanks and bladderfish but logic can't account for that.
+def get_hardcore_item_depth(state: "CollectionState", player: int, prev_depth: int) -> int:
+    depth: int = 0
+    if has_exterior_growbed(state, player):
+        depth += 200
+
+    nuclear_depth = bio_depth = thermal_depth = 0
+
+    # have to be able to get to uraninite for nuclear reactor to be useful
+    if (prev_depth + depth) >= 250 and has_nuclear_reactor(state, player):
+        nuclear_depth = 1500
+
+    if has_bioreactor(state, player):
+        bio_depth = 1500
+
+    if has_thermal_plant(state, player):
+        thermal_depth = 1500
+
+    return depth + max(nuclear_depth, bio_depth, thermal_depth)
+
+
+def get_seamoth_max_depth(state: "CollectionState", player: int, options: SubnauticaOptions):
+    if not has_seamoth(state, player, options):
         return 0
 
+    if has_seamoth_depth_module_mk3(state, player):
+        return 900
+    if has_seamoth_depth_module_mk2(state, player):  # Will never be the case, 3 is craftable
+        return 500
+    if has_seamoth_depth_module_mk1(state, player):
+        return 300
 
-def get_cyclops_max_depth(state: "CollectionState", player):
-    if has_cyclops(state, player):
-        if has_cyclops_depth_module_mk3(state, player):
-            return 1700
-        elif has_cyclops_depth_module_mk2(state, player):  # Will never be the case, 3 is craftable
-            return 1300
-        elif has_cyclops_depth_module_mk1(state, player):
-            return 900
-        else:
-            return 500
-    else:
+    return 200
+
+
+def get_cyclops_max_depth(state: "CollectionState", player, options: SubnauticaOptions):
+    if not has_cyclops(state, player, options):
         return 0
 
+    if has_cyclops_depth_module_mk3(state, player):
+        return 1700
+    if has_cyclops_depth_module_mk2(state, player):  # Will never be the case, 3 is craftable
+        return 1300
+    if has_cyclops_depth_module_mk1(state, player):
+        return 900
 
-def get_prawn_max_depth(state: "CollectionState", player):
-    if has_prawn(state, player):
-        if has_prawn_depth_module_mk2(state, player):
-            return 1700
-        elif has_prawn_depth_module_mk1(state, player):
-            return 1300
-        else:
-            return 900
-    else:
+    return 500
+
+
+def get_prawn_max_depth(state: "CollectionState", player, options: SubnauticaOptions):
+    if not has_prawn(state, player, options):
         return 0
 
+    if has_prawn_depth_module_mk2(state, player):
+        return 1700
+    if has_prawn_depth_module_mk1(state, player):
+        return 1300
 
-def get_max_depth(state: "CollectionState", player: int):
-    return get_max_swim_depth(state, player) + max(
-        get_seamoth_max_depth(state, player),
-        get_cyclops_max_depth(state, player),
-        get_prawn_max_depth(state, player)
+    return 900
+
+
+def get_max_depth(state: "CollectionState", player: int, options: SubnauticaOptions):
+    max_depth: int = get_max_swim_depth(state, player, options)
+
+    # if include_seamoth is 1 or 2, it doesn't count anyway
+    # We have to be able to get to the last check between seamoth depth and swimming expertise
+    seamoth_can_make_it: bool = False
+    if options.include_seamoth == 0 and get_max_swim_depth(state, player, options, "theoretical") + 900 > 1443:
+        seamoth_can_make_it = True
+
+    # If we don't have a vehicle that can go to 1444m depth, then we have to use "hardcore" methods
+    # PreSeaglide Distance, laser cutter, and radiation will still gate some checks, so it's not completely open
+    if seamoth_can_make_it is False \
+            and options.include_prawn > 0 \
+            and options.include_cyclops > 0:
+        return max_depth + get_hardcore_item_depth(state, player, max_depth)
+
+    return max_depth + max(
+        get_seamoth_max_depth(state, player, options),
+        get_cyclops_max_depth(state, player, options),
+        get_prawn_max_depth(state, player, options)
     )
 
 
@@ -226,7 +307,7 @@ def is_radiated(x: float, y: float, z: float) -> bool:
     return aurora_dist < 950
 
 
-def can_access_location(state: "CollectionState", player: int, loc: LocationDict) -> bool:
+def can_access_location(state: "CollectionState", player: int, options: SubnauticaOptions, loc: LocationDict) -> bool:
     need_laser_cutter = loc.get("need_laser_cutter", False)
     if need_laser_cutter and not has_laser_cutter(state, player):
         return False
@@ -244,30 +325,30 @@ def can_access_location(state: "CollectionState", player: int, loc: LocationDict
     if need_radiation_suit and not state.has("Radiation Suit", player):
         return False
 
-    # Seaglide doesn't unlock anything specific, but just allows for faster movement. 
+    # Seaglide doesn't unlock anything specific, but just allows for faster movement.
     # Otherwise the game is painfully slow.
     map_center_dist = math.sqrt(pos_x ** 2 + pos_z ** 2)
     if (map_center_dist > 800 or pos_y < -200) and not has_seaglide(state, player):
         return False
 
     depth = -pos_y  # y-up
-    return get_max_depth(state, player) >= depth
+    return get_max_depth(state, player, options) >= depth
 
 
-def set_location_rule(world, player: int, loc: LocationDict):
-    set_rule(world.get_location(loc["name"], player), lambda state: can_access_location(state, player, loc))
+def set_location_rule(world, player: int, options: SubnauticaOptions, loc: LocationDict):
+    set_rule(world.get_location(loc["name"], player), lambda state: can_access_location(state, player, options, loc))
 
 
-def can_scan_creature(state: "CollectionState", player: int, creature: str) -> bool:
+def can_scan_creature(state: "CollectionState", player: int, options: SubnauticaOptions, creature: str) -> bool:
     if not has_seaglide(state, player):
         return False
-    return get_max_depth(state, player) >= all_creatures[creature]
+    return get_max_depth(state, player, options) >= all_creatures[creature]
 
 
-def set_creature_rule(world, player: int, creature_name: str) -> "Location":
+def set_creature_rule(world, options: SubnauticaOptions, player: int, creature_name: str) -> "Location":
     location = world.get_location(creature_name + suffix, player)
     set_rule(location,
-             lambda state: can_scan_creature(state, player, creature_name))
+             lambda state: can_scan_creature(state, player, options, creature_name))
     return location
 
 
@@ -293,13 +374,13 @@ def set_rules(subnautica_world: "SubnauticaWorld"):
     multiworld = subnautica_world.multiworld
 
     for loc in location_table.values():
-        set_location_rule(multiworld, player, loc)
+        set_location_rule(multiworld, player, subnautica_world.options, loc)
 
     if subnautica_world.creatures_to_scan:
-        option = multiworld.creature_scan_logic[player]
+        option = subnautica_world.options.creature_scan_logic
 
         for creature_name in subnautica_world.creatures_to_scan:
-            location = set_creature_rule(multiworld, player, creature_name)
+            location = set_creature_rule(multiworld, subnautica_world.options, player, creature_name)
             if creature_name in containment:  # there is no other way, hard-required containment
                 add_rule(location, lambda state: has_containment(state, player))
             elif creature_name in aggressive:
@@ -311,7 +392,7 @@ def set_rules(subnautica_world: "SubnauticaWorld"):
     # Victory locations
     set_rule(multiworld.get_location("Neptune Launch", player),
              lambda state:
-             get_max_depth(state, player) >= 1444 and
+             get_max_depth(state, player, subnautica_world.options) >= 1444 and
              has_mobile_vehicle_bay(state, player) and
              state.has("Neptune Launch Platform", player) and
              state.has("Neptune Gantry", player) and
@@ -320,13 +401,13 @@ def set_rules(subnautica_world: "SubnauticaWorld"):
              state.has("Neptune Cockpit", player) and
              state.has("Ion Power Cell", player) and
              state.has("Ion Battery", player) and
-             has_cyclops_shield(state, player))
+             has_cyclops_shield(state, player, subnautica_world.options))
 
     set_rule(multiworld.get_location("Disable Quarantine", player),
-             lambda state: get_max_depth(state, player) >= 1444)
+             lambda state: get_max_depth(state, player, subnautica_world.options) >= 1444)
 
     set_rule(multiworld.get_location("Full Infection", player),
-             lambda state: get_max_depth(state, player) >= 900)
+             lambda state: get_max_depth(state, player, subnautica_world.options) >= 900)
 
     room = multiworld.get_location("Aurora Drive Room - Upgrade Console", player)
     set_rule(multiworld.get_location("Repair Aurora Drive", player),

--- a/worlds/subnautica/rules.py
+++ b/worlds/subnautica/rules.py
@@ -390,27 +390,31 @@ def set_rules(subnautica_world: "SubnauticaWorld"):
                              lambda state, loc_rule=get_aggression_rule(option, creature_name): loc_rule(state, player))
 
     # Victory locations
-    set_rule(multiworld.get_location("Neptune Launch", player),
-             lambda state:
-             get_max_depth(state, player, subnautica_world.options) >= 1444 and
-             has_mobile_vehicle_bay(state, player) and
-             state.has("Neptune Launch Platform", player) and
-             state.has("Neptune Gantry", player) and
-             state.has("Neptune Boosters", player) and
-             state.has("Neptune Fuel Reserve", player) and
-             state.has("Neptune Cockpit", player) and
-             state.has("Ion Power Cell", player) and
-             state.has("Ion Battery", player) and
-             has_cyclops_shield(state, player, subnautica_world.options))
+    if multiworld.goal[player].get_event_name() == "Neptune Launch":
+        set_rule(multiworld.get_location("Neptune Launch", player),
+                 lambda state:
+                 get_max_depth(state, player, subnautica_world.options) >= 1444 and
+                 has_mobile_vehicle_bay(state, player) and
+                 state.has("Neptune Launch Platform", player) and
+                 state.has("Neptune Gantry", player) and
+                 state.has("Neptune Boosters", player) and
+                 state.has("Neptune Fuel Reserve", player) and
+                 state.has("Neptune Cockpit", player) and
+                 state.has("Ion Power Cell", player) and
+                 state.has("Ion Battery", player) and
+                 has_cyclops_shield(state, player, subnautica_world.options))
 
-    set_rule(multiworld.get_location("Disable Quarantine", player),
-             lambda state: get_max_depth(state, player, subnautica_world.options) >= 1444)
+    if multiworld.goal[player].get_event_name() == "Disable Quarantine":
+        set_rule(multiworld.get_location("Disable Quarantine", player),
+                 lambda state: get_max_depth(state, player, subnautica_world.options) >= 1444)
 
-    set_rule(multiworld.get_location("Full Infection", player),
-             lambda state: get_max_depth(state, player, subnautica_world.options) >= 900)
+    if multiworld.goal[player].get_event_name() == "Full Infection":
+        set_rule(multiworld.get_location("Full Infection", player),
+                 lambda state: get_max_depth(state, player, subnautica_world.options) >= 900)
 
-    room = multiworld.get_location("Aurora Drive Room - Upgrade Console", player)
-    set_rule(multiworld.get_location("Repair Aurora Drive", player),
-             lambda state: room.can_reach(state))
+    if multiworld.goal[player].get_event_name() == "Repair Aurora Drive":
+        room = multiworld.get_location("Aurora Drive Room - Upgrade Console", player)
+        set_rule(multiworld.get_location("Repair Aurora Drive", player),
+                 lambda state: room.can_reach(state))
 
     multiworld.completion_condition[player] = lambda state: state.has("Victory", player)


### PR DESCRIPTION

## What is this fixing or adding?

Add 3x new options to Subnautica to allow removing the vehicles either logically or completely.
Also changes rules to use new options syntax rather than old multiworld syntax.

If all vehicles are exluded then "advanced" logic is triggered which operates off of base building instead. The more likely scenario of using seaglide with extra air tanks cannot be tracked logically, so hopefully this suffices.

NOTE: This is dependent on changes to the archipelago subnautica mod which have been PRed.

## How was this tested?

Generated many games, played quite a few of them.

Used python3.11. Please let me know if I need to test anything on other versions (and which ones).

## If this makes graphical changes, please attach screenshots.

New options:
<img width="468" alt="Screenshot 2024-06-02 at 00 08 04" src="https://github.com/ArchipelagoMW/Archipelago/assets/4594575/f6eec64b-73ce-4dd9-bdaf-ba774b3e0a7d">


Example rollover tip (for cyclops, which has extra text):
<img width="272" alt="Screenshot 2024-06-02 at 00 08 41" src="https://github.com/ArchipelagoMW/Archipelago/assets/4594575/825e97f4-d3b7-4dd0-ac2d-07fef08734c2">


Updated Vehicle Upgrade Console:
<img width="691" alt="Screenshot 2024-05-05 at 21 19 34" src="https://github.com/ArchipelagoMW/Archipelago/assets/4594575/cc1e67e0-a0dd-4701-acf9-9ff8dbb81307">


Shield Generator on Vehicle Upgrade Console:
<img width="1162" alt="Screenshot 2024-05-05 at 21 19 57" src="https://github.com/ArchipelagoMW/Archipelago/assets/4594575/ffaba07e-8e65-429e-9b2c-f436a84b03c1">



