### PR TITLE
SC2 EN/FR documentation update 

### DIFF
--- a/worlds/sc2/docs/en_Starcraft 2.md
+++ b/worlds/sc2/docs/en_Starcraft 2.md
@@ -27,27 +27,27 @@ Since each location has its own rule, it's possible that an item required for pr
 can't reach all of its locations or complete it. 
 However, mission completion is always required to gain access to new missions.
 
-Except for mission completion, these categories can be disabled in the game's settings. 
+Aside from mission completion, the other location categories can be disabled in the player options.
 For instance, you can disable getting items for reaching required milestones.
 
 When you receive items, they will immediately become available, even during a mission, and you will be
 notified via a text box in the top-right corner of the game screen. 
 Item unlocks are also logged in the Archipelago client.
 
-Missions are launched through the Starcraft 2 Archipelago client, through the Starcraft 2 Launcher tab. 
+Missions are launched through the StarCraft 2 Archipelago client, through the StarCraft 2 Launcher tab. 
 The between mission segments on the Hyperion, the Leviathan, and the Spear of Adun are not included. 
 Additionally, metaprogression currencies such as credits and Solarite are not used.
 
 ## What is the goal of this game when randomized?
 
 The goal is to beat the final mission in the mission order. 
-The yaml configuration file controls the mission order (e.g. blitz, grid, etc.), which of the four Starcraft 2 
-campaigns can be used to populate the mission order and how missions are shuffled. 
-Since the first two options determine the number of missions in a Starcraft 2 world, they can be used to customize the 
+The yaml configuration file controls the mission order (e.g. blitz, grid, etc.), which combination of the four 
+StarCraft 2 campaigns can be used to populate the mission order and how missions are shuffled. 
+Since the first two options determine the number of missions in a StarCraft 2 world, they can be used to customize the 
 expected time to complete the world. 
 Note that the evolution missions from Heart of the Swarm are not included in the randomizer.
 
-## What non-randomized changes are there from vanilla Starcraft 2?
+## What non-randomized changes are there from vanilla StarCraft 2?
 
 1. Some missions have more vespene geysers available to allow a wider variety of units.
 2. Many new units and upgrades have been added as items, coming from co-op, melee, later campaigns, later expansions, 
@@ -68,7 +68,7 @@ See the [Advanced YAML Guide](/tutorial/Archipelago/advanced_settings/en) for mo
 
 ## Unique Local Commands
 
-The following commands are only available when using the Starcraft 2 Client to play with Archipelago. 
+The following commands are only available when using the StarCraft 2 Client to play with Archipelago. 
 You can list them any time in the client with `/help`.
 
 * `/download_data` Download the most recent release of the necessary files for playing SC2 with Archipelago. 
@@ -87,7 +87,7 @@ Will overwrite existing files
     amounts, controlling AI allies, etc.
 * `/disable_mission_check` Disables the check to see if a mission is available to play. 
 Meant for co-op runs where one player can play the next mission in a chain the other player is doing.
-* `/play [mission_id]` Starts a Starcraft 2 mission based off of the mission_id provided
+* `/play [mission_id]` Starts a StarCraft 2 mission based off of the mission_id provided
 * `/available` Get what missions are currently available to play
 * `/unfinished` Get what missions are currently available to play and have not had all locations checked
 * `/set_path [path]` Manually set the SC2 install directory (if the automatic detection fails)

--- a/worlds/sc2/docs/en_Starcraft 2.md
+++ b/worlds/sc2/docs/en_Starcraft 2.md
@@ -92,17 +92,19 @@ Meant for co-op runs where one player can play the next mission in a chain the o
 * `/unfinished` Get what missions are currently available to play and have not had all locations checked
 * `/set_path [path]` Manually set the SC2 install directory (if the automatic detection fails)
 
-Note that the behavior of the command `/received` was modified in the StarCraft 2 Client compared to its behavior in 
-the Common Client of Archipelago.
-In the latter, the command returns the list of items received in the reverse order they were received.
-In the StarCraft 2 Client, the list is divided by races (i.e., Any, Protoss, Terran, and Zerg).
+Note that the behavior of the command `/received` was modified in the StarCraft 2 client.
+In the Common client of Archipelago, the command returns the list of items received in the reverse order they were 
+received.
+In the StarCraft 2 client, the returned list will be divided by races (i.e., Any, Protoss, Terran, and Zerg).
 Additionally, upgrades are grouped beneath their corresponding units or buildings.
 A filter parameter can be provided, e.g., `/received Thor`, to limit the number of items shown.
 Every item whose name, race, or group name contains the provided parameter will be shown.
 
 ## Known issues
 
-- StarCraft 2 Archipelago does not support saving or loading during a mission. 
+- StarCraft 2 Archipelago does not support loading a saved game. 
 For this reason, it is recommended to play on a difficulty level lower than what you are normally comfortable with.
+- StarCraft 2 Archipelago does not support the restart of a mission from the StarCraft 2 menu. 
+To restart a mission, use the StarCraft 2 Client.
 - A crash report is often generated when a mission is closed. 
 This does not affect the game and can be ignored.

--- a/worlds/sc2/docs/en_Starcraft 2.md
+++ b/worlds/sc2/docs/en_Starcraft 2.md
@@ -34,10 +34,8 @@ Additionally, metaprogression currencies such as credits and Solarite are not us
 ## What is the goal of this game when randomized?
 
 The goal is to beat the final mission in the mission order. 
-The yaml configuration file controls the mission order and how missions are shuffled. 
-Since the mission order determines the number of missions in a Starcraft 2 world, it can be used to customize the time 
-required to complete the world. 
-Players can choose which of the four Starcraft 2 campaigns will populate the mission order. 
+The yaml configuration file controls the mission order (e.g. blitz, grid, etc.), which of the four Starcraft 2 campaigns can be used to populate the mission order and how missions are shuffled. 
+Since the first two options determine the number of missions in a Starcraft 2 world, they can be used to customize the expected time to complete the world. 
 Note that the evolution missions from Heart of the Swarm are not included in the randomizer.
 
 ## What non-randomized changes are there from vanilla Starcraft 2?

--- a/worlds/sc2/docs/en_Starcraft 2.md
+++ b/worlds/sc2/docs/en_Starcraft 2.md
@@ -92,9 +92,17 @@ Meant for co-op runs where one player can play the next mission in a chain the o
 * `/unfinished` Get what missions are currently available to play and have not had all locations checked
 * `/set_path [path]` Manually set the SC2 install directory (if the automatic detection fails)
 
+Note that the behavior of the command `/received` was modified in the StarCraft 2 Client compared to its behavior in 
+the Common Client of Archipelago.
+In the latter, the command returns the list of items received in the reverse order they were received.
+In the StarCraft 2 Client, the list is divided by races (i.e., Any, Protoss, Terran, and Zerg).
+Additionally, upgrades are grouped beneath their corresponding units or buildings.
+A filter parameter can be provided, e.g., `/received Thor`, to limit the number of items shown.
+Every item whose name, race, or group name contains the provided parameter will be shown.
+
 ## Known issues
 
-- Starcraft 2 Archipelago does not support saving or loading during a mission. 
+- StarCraft 2 Archipelago does not support saving or loading during a mission. 
 For this reason, it is recommended to play on a difficulty level lower than what you are normally comfortable with.
 - A crash report is often generated when a mission is closed. 
 This does not affect the game and can be ignored.

--- a/worlds/sc2/docs/en_Starcraft 2.md
+++ b/worlds/sc2/docs/en_Starcraft 2.md
@@ -1,4 +1,4 @@
-# Starcraft 2
+# StarCraft 2
 
 ## Game page in other languages:
 * [Français](/games/Starcraft%202/info/fr)
@@ -19,6 +19,13 @@ You find items by making progress in these categories:
 * Completing bonus objectives (like by gathering lab research material in Wings of Liberty)
 * Reaching milestones in the mission, such as completing part of a main objective
 * Completing challenges based on achievements in the base game, such as clearing all Zerg on Devil's Playground
+
+In Archipelago's nomenclature, these are the locations where items can be found.
+Each location, including mission completion, has a set of rules that specify the items required to access it.
+These rules were designed assuming that StarCraft 2 is played on the Brutal difficulty.
+Since each location has its own rule, it's possible that an item required for progression is in a mission where you 
+can't reach all of its locations or complete it. 
+However, mission completion is always required to gain access to new missions.
 
 Except for mission completion, these categories can be disabled in the game's settings. 
 For instance, you can disable getting items for reaching required milestones.

--- a/worlds/sc2/docs/en_Starcraft 2.md
+++ b/worlds/sc2/docs/en_Starcraft 2.md
@@ -7,9 +7,11 @@
 
 The following unlocks are randomized as items:
 1. Your ability to build any non-worker unit.
-2. Unit specific upgrades including some combinations not available in the vanilla campaigns, such as both strain choices simultaneously for Zerg and every Spear of Adun upgrade simultaneously for Protoss!
+2. Unit specific upgrades including some combinations not available in the vanilla campaigns, such as both strain 
+choices simultaneously for Zerg and every Spear of Adun upgrade simultaneously for Protoss!
 3. Your ability to get the generic unit upgrades, such as attack and armour upgrades.
-4. Other miscellaneous upgrades such as laboratory upgrades and mercenaries for Terran, Kerrigan levels and upgrades for Zerg, and Spear of Adun upgrades for Protoss.
+4. Other miscellaneous upgrades such as laboratory upgrades and mercenaries for Terran, Kerrigan levels and upgrades 
+for Zerg, and Spear of Adun upgrades for Protoss.
 5. Small boosts to your starting mineral, vespene gas, and supply totals on each mission.
 
 You find items by making progress in these categories:
@@ -18,50 +20,74 @@ You find items by making progress in these categories:
 * Reaching milestones in the mission, such as completing part of a main objective
 * Completing challenges based on achievements in the base game, such as clearing all Zerg on Devil's Playground
 
-Except for mission completion, these categories can be disabled in the game's settings. For instance, you can disable getting items for reaching required milestones.
+Except for mission completion, these categories can be disabled in the game's settings. 
+For instance, you can disable getting items for reaching required milestones.
 
 When you receive items, they will immediately become available, even during a mission, and you will be
-notified via a text box in the top-right corner of the game screen. Item unlocks are also logged in the Archipelago client.
+notified via a text box in the top-right corner of the game screen. 
+Item unlocks are also logged in the Archipelago client.
 
-Missions are launched through the Starcraft 2 Archipelago client, through the Starcraft 2 Launcher tab. The between mission segments on the Hyperion, the Leviathan, and the Spear of Adun are not included. Additionally, metaprogression currencies such as credits and Solarite are not used.
+Missions are launched through the Starcraft 2 Archipelago client, through the Starcraft 2 Launcher tab. 
+The between mission segments on the Hyperion, the Leviathan, and the Spear of Adun are not included. 
+Additionally, metaprogression currencies such as credits and Solarite are not used.
 
 ## What is the goal of this game when randomized?
 
-The goal is to beat the final mission in the mission order. The yaml configuration file controls the mission order and how missions are shuffled.
+The goal is to beat the final mission in the mission order. 
+The yaml configuration file controls the mission order and how missions are shuffled. 
+Since the mission order determines the number of missions in a Starcraft 2 world, it can be used to customize the time 
+required to complete the world. 
+Players can choose which of the four Starcraft 2 campaigns will populate the mission order. 
+Note that the evolution missions from Heart of the Swarm are not included in the randomizer.
 
 ## What non-randomized changes are there from vanilla Starcraft 2?
 
 1. Some missions have more vespene geysers available to allow a wider variety of units.
-2. Many new units and upgrades have been added as items, coming from co-op, melee, later campaigns, later expansions, brood war, and original ideas.
-3. Higher-tech production structures, including Factories, Starports, Robotics Facilities, and Stargates, no longer have tech requirements.
+2. Many new units and upgrades have been added as items, coming from co-op, melee, later campaigns, later expansions, 
+brood war, and original ideas.
+3. Higher-tech production structures, including Factories, Starports, Robotics Facilities, and Stargates, no longer 
+have tech requirements.
 4. Zerg missions have been adjusted to give the player a starting Lair where they would only have Hatcheries.
-5. Upgrades with a downside have had the downside removed, such as automated refineries costing more or tech reactors taking longer to build.
-6. Unit collision within the vents in Enemy Within has been adjusted to allow larger units to travel through them without getting stuck in odd places.
+5. Upgrades with a downside have had the downside removed, such as automated refineries costing more or tech reactors 
+taking longer to build.
+6. Unit collision within the vents in Enemy Within has been adjusted to allow larger units to travel through them 
+without getting stuck in odd places.
 7. Several vanilla bugs have been fixed.
 
 ## Which of my items can be in another player's world?
 
-By default, any of StarCraft 2's items (specified above) can be in another player's world. See the
-[Advanced YAML Guide](/tutorial/Archipelago/advanced_settings/en)
-for more information on how to change this.
+By default, any of StarCraft 2's items (specified above) can be in another player's world. 
+See the [Advanced YAML Guide](/tutorial/Archipelago/advanced_settings/en) for more information on how to change this.
 
 ## Unique Local Commands
 
-The following commands are only available when using the Starcraft 2 Client to play with Archipelago. You can list them any time in the client with `/help`.
+The following commands are only available when using the Starcraft 2 Client to play with Archipelago. 
+You can list them any time in the client with `/help`.
 
-* `/download_data` Download the most recent release of the necessary files for playing SC2 with Archipelago. Will overwrite existing files
+* `/download_data` Download the most recent release of the necessary files for playing SC2 with Archipelago. 
+Will overwrite existing files
 * `/difficulty [difficulty]` Overrides the difficulty set for the world.
     * Options: casual, normal, hard, brutal
 * `/game_speed [game_speed]` Overrides the game speed for the world
     * Options: default, slower, slow, normal, fast, faster
 * `/color [faction] [color]` Changes your color for one of your playable factions.
     * Faction options: raynor, kerrigan, primal, protoss, nova
-    * Color options: white, red, blue, teal, purple, yellow, orange, green, lightpink, violet, lightgrey, darkgreen, brown, lightgreen, darkgrey, pink, rainbow, random, default
+    * Color options: white, red, blue, teal, purple, yellow, orange, green, lightpink, violet, lightgrey, darkgreen, 
+    brown, lightgreen, darkgrey, pink, rainbow, random, default
 * `/option [option_name] [option_value]` Sets an option normally controlled by your yaml after generation.
     * Run without arguments to list all options.
-    * Options pertain to automatic cutscene skipping, Kerrigan presence, Spear of Adun presence, starting resource amounts, controlling AI allies, etc.
-* `/disable_mission_check` Disables the check to see if a mission is available to play. Meant for co-op runs where one player can play the next mission in a chain the other player is doing.
+    * Options pertain to automatic cutscene skipping, Kerrigan presence, Spear of Adun presence, starting resource 
+    amounts, controlling AI allies, etc.
+* `/disable_mission_check` Disables the check to see if a mission is available to play. 
+Meant for co-op runs where one player can play the next mission in a chain the other player is doing.
 * `/play [mission_id]` Starts a Starcraft 2 mission based off of the mission_id provided
 * `/available` Get what missions are currently available to play
 * `/unfinished` Get what missions are currently available to play and have not had all locations checked
 * `/set_path [path]` Manually set the SC2 install directory (if the automatic detection fails)
+
+## Known issues
+
+- Starcraft 2 Archipelago does not support saving or loading during a mission. 
+For this reason, it is recommended to play on a difficulty level lower than what you are normally comfortable with.
+- A crash report is often generated when a mission is closed. 
+This does not affect the game and can be ignored.

--- a/worlds/sc2/docs/en_Starcraft 2.md
+++ b/worlds/sc2/docs/en_Starcraft 2.md
@@ -34,8 +34,10 @@ Additionally, metaprogression currencies such as credits and Solarite are not us
 ## What is the goal of this game when randomized?
 
 The goal is to beat the final mission in the mission order. 
-The yaml configuration file controls the mission order (e.g. blitz, grid, etc.), which of the four Starcraft 2 campaigns can be used to populate the mission order and how missions are shuffled. 
-Since the first two options determine the number of missions in a Starcraft 2 world, they can be used to customize the expected time to complete the world. 
+The yaml configuration file controls the mission order (e.g. blitz, grid, etc.), which of the four Starcraft 2 
+campaigns can be used to populate the mission order and how missions are shuffled. 
+Since the first two options determine the number of missions in a Starcraft 2 world, they can be used to customize the 
+expected time to complete the world. 
 Note that the evolution missions from Heart of the Swarm are not included in the randomizer.
 
 ## What non-randomized changes are there from vanilla Starcraft 2?

--- a/worlds/sc2/docs/fr_Starcraft 2.md
+++ b/worlds/sc2/docs/fr_Starcraft 2.md
@@ -40,6 +40,8 @@ Archipelago*.
 Le but est de réussir la mission finale dans la disposition des missions (e.g. *blitz*, *grid*, etc.).
 Les choix faits dans le fichier *yaml* définissent la disposition des missions et comment elles sont mélangées.
 
+dsa mission order
+
 ## Quelles sont les modifications non aléatoires comparativement à la version de base de *StarCraft 2*
 
 1. Certaines des missions ont plus de *vespene geysers* pour permettre l'utilisation d'une plus grande variété d'unités.

--- a/worlds/sc2/docs/fr_Starcraft 2.md
+++ b/worlds/sc2/docs/fr_Starcraft 2.md
@@ -106,3 +106,19 @@ mission de la chaîne qu'un autre joueur est en train d'entamer.
 l'accès à un *item* n'ont pas été accomplis.
 * `/set_path [path]` Permet de définir manuellement où *StarCraft 2* est installé ce qui est pertinent seulement si la 
 détection automatique de cette dernière échoue.
+
+Notez que le comportement de la commande `/received` a été modifié dans le client *StarCraft 2* par rapport à son 
+utilisation dans le client *Common* d'Archipelago.
+Dans ce dernier, la commande renvoie la liste des *items* reçus dans l'ordre inverse de leur réception.
+Dans le client de *StarCraft 2*, la liste est divisée par races (i.e., *Any*, *Protoss*, *Terran*, et *Zerg*).
+De plus, les améliorations sont regroupées sous leurs unités/bâtiments correspondants.
+Un paramètre de filtrage peut être fourni, e.g., `/received Thor`, pour limiter le nombre d'*items* affichés.
+Tous les *items* dont le nom, la race ou le nom de groupe contient le paramètre fourni seront affichés.
+
+## Problèmes connus
+
+- *StarCraft 2 Archipelago* ne supporte pas la sauvegarde ou le chargement pendant une mission. 
+Pour cette raison, il est recommandé de jouer à un niveau de difficulté inférieur à celui avec lequel vous êtes 
+normalement à l'aise.
+- Un rapport d'erreur est souvent généré lorsqu'une mission est fermée. 
+Cela n'affecte pas le jeu et peut être ignoré.

--- a/worlds/sc2/docs/fr_Starcraft 2.md
+++ b/worlds/sc2/docs/fr_Starcraft 2.md
@@ -36,12 +36,14 @@ De plus, les points de progression tels que les crédits ou la Solarite ne sont 
 Archipelago*.
 
 ## Quel est le but de ce jeu quand il est *randomized*?
-dsa retraduire 
-Le but est de réussir la mission finale dans la disposition des missions.
-Les choix faits dans le fichier *yaml* définissent la disposition des missions (e.g. *blitz*, *grid*, etc.) et comment elles sont mélangées.
-L'option sur la disposition des missions fixe affecte le nombre de missions dans un monde de *StarCraft 2*, alors elle peut être utilisée pour moduler le temps nécessaire pour terminer le monde. 
-Les joueurs peuvent choisir quelles des quatre campagnes de *Starcraft 2* va être utilisé pour  l'ordre des missions. 
-Notez que les missions d'évolution de *Heart of the Swarm* ne sont pas incluses dans le *randomizer*.
+
+Le but est de réussir la mission finale du *mission order* (e.g. *blitz*, *grid*, etc.).
+Le fichier de configuration yaml permet de spécifier le *mission order*, lesquelles des quatre campagnes de 
+*StarCraft 2* peuvent être utilisées pour remplir le *mission order* et comment les missions sont distribuées dans le 
+*mission order*. 
+Étant donné que les deux premières options déterminent le nombre de missions dans un monde de *StarCraft 2*, elles 
+peuvent être utilisées pour moduler le temps nécessaire pour terminer le monde. 
+Notez que les missions d'évolution de Heart of the Swarm ne sont pas incluses dans le *randomizer*.
 
 ## Quelles sont les modifications non aléatoires comparativement à la version de base de *StarCraft 2*
 

--- a/worlds/sc2/docs/fr_Starcraft 2.md
+++ b/worlds/sc2/docs/fr_Starcraft 2.md
@@ -107,18 +107,19 @@ l'accès à un *item* n'ont pas été accomplis.
 * `/set_path [path]` Permet de définir manuellement où *StarCraft 2* est installé ce qui est pertinent seulement si la 
 détection automatique de cette dernière échoue.
 
-Notez que le comportement de la commande `/received` a été modifié dans le client *StarCraft 2* par rapport à son 
-utilisation dans le client *Common* d'Archipelago.
-Dans ce dernier, la commande renvoie la liste des *items* reçus dans l'ordre inverse de leur réception.
+Notez que le comportement de la commande `/received` a été modifié dans le client *StarCraft 2*.
+Dans le client *Common* d'Archipelago, elle renvoie la liste des *items* reçus dans l'ordre inverse de leur réception.
 Dans le client de *StarCraft 2*, la liste est divisée par races (i.e., *Any*, *Protoss*, *Terran*, et *Zerg*).
 De plus, les améliorations sont regroupées sous leurs unités/bâtiments correspondants.
-Un paramètre de filtrage peut être fourni, e.g., `/received Thor`, pour limiter le nombre d'*items* affichés.
+Un paramètre de filtrage peut aussi être fourni, e.g., `/received Thor`, pour limiter le nombre d'*items* affichés.
 Tous les *items* dont le nom, la race ou le nom de groupe contient le paramètre fourni seront affichés.
 
 ## Problèmes connus
 
-- *StarCraft 2 Archipelago* ne supporte pas la sauvegarde ou le chargement pendant une mission. 
+- *StarCraft 2 Archipelago* ne supporte pas le chargement d'une sauvegarde. 
 Pour cette raison, il est recommandé de jouer à un niveau de difficulté inférieur à celui avec lequel vous êtes 
 normalement à l'aise.
+- *StarCraft 2 Archipelago* ne supporte pas le redémarrage d'une mission depuis le menu de *StarCraft 2*.
+Pour redémarrer une mission, utilisez le client de *StarCraft 2 Archipelago*.
 - Un rapport d'erreur est souvent généré lorsqu'une mission est fermée. 
 Cela n'affecte pas le jeu et peut être ignoré.

--- a/worlds/sc2/docs/fr_Starcraft 2.md
+++ b/worlds/sc2/docs/fr_Starcraft 2.md
@@ -36,11 +36,12 @@ De plus, les points de progression tels que les crédits ou la Solarite ne sont 
 Archipelago*.
 
 ## Quel est le but de ce jeu quand il est *randomized*?
-
-Le but est de réussir la mission finale dans la disposition des missions (e.g. *blitz*, *grid*, etc.).
-Les choix faits dans le fichier *yaml* définissent la disposition des missions et comment elles sont mélangées.
-
-dsa mission order
+dsa retraduire 
+Le but est de réussir la mission finale dans la disposition des missions.
+Les choix faits dans le fichier *yaml* définissent la disposition des missions (e.g. *blitz*, *grid*, etc.) et comment elles sont mélangées.
+L'option sur la disposition des missions fixe affecte le nombre de missions dans un monde de *StarCraft 2*, alors elle peut être utilisée pour moduler le temps nécessaire pour terminer le monde. 
+Les joueurs peuvent choisir quelles des quatre campagnes de *Starcraft 2* va être utilisé pour  l'ordre des missions. 
+Notez que les missions d'évolution de *Heart of the Swarm* ne sont pas incluses dans le *randomizer*.
 
 ## Quelles sont les modifications non aléatoires comparativement à la version de base de *StarCraft 2*
 

--- a/worlds/sc2/docs/fr_Starcraft 2.md
+++ b/worlds/sc2/docs/fr_Starcraft 2.md
@@ -21,6 +21,12 @@ Les *items* sont trouvés en accomplissant du progrès dans les catégories suiv
 * Réussir des défis basés sur les succès du jeu de base, e.g. éliminer tous les *Zerg* dans la mission 
 *Devil's Playground*
 
+Dans la nomenclature d'Archipelago, il s'agit des *locations* où l'on peut trouver des *items*.
+Pour chaque *location*, incluant le fait de terminer une mission, il y a des règles qui définissent les *items* nécessaires pour y accéder.
+Ces règles ont été conçues en assumant que *StarCraft 2* est joué à la difficulté *Brutal*.
+Étant donné que chaque *location* a ses propres règles, il est possible qu'un *item* nécessaire à la progression se trouve dans une mission dont vous ne pouvez pas atteindre toutes les *locations* ou que vous ne pouvez pas terminer. 
+Cependant, il est toujours nécessaire de terminer une mission pour pouvoir accéder à de nouvelles missions.
+
 Ces catégories, outre la première, peuvent être désactivées dans les options du jeu. 
 Par exemple, vous pouvez désactiver le fait d'obtenir des *items*  lorsque des étapes importantes d'une mission sont 
 accomplies.

--- a/worlds/sc2/docs/fr_Starcraft 2.md
+++ b/worlds/sc2/docs/fr_Starcraft 2.md
@@ -22,9 +22,11 @@ Les *items* sont trouvés en accomplissant du progrès dans les catégories suiv
 *Devil's Playground*
 
 Dans la nomenclature d'Archipelago, il s'agit des *locations* où l'on peut trouver des *items*.
-Pour chaque *location*, incluant le fait de terminer une mission, il y a des règles qui définissent les *items* nécessaires pour y accéder.
+Pour chaque *location*, incluant le fait de terminer une mission, il y a des règles qui définissent les *items* 
+nécessaires pour y accéder.
 Ces règles ont été conçues en assumant que *StarCraft 2* est joué à la difficulté *Brutal*.
-Étant donné que chaque *location* a ses propres règles, il est possible qu'un *item* nécessaire à la progression se trouve dans une mission dont vous ne pouvez pas atteindre toutes les *locations* ou que vous ne pouvez pas terminer. 
+Étant donné que chaque *location* a ses propres règles, il est possible qu'un *item* nécessaire à la progression se 
+trouve dans une mission dont vous ne pouvez pas atteindre toutes les *locations* ou que vous ne pouvez pas terminer. 
 Cependant, il est toujours nécessaire de terminer une mission pour pouvoir accéder à de nouvelles missions.
 
 Ces catégories, outre la première, peuvent être désactivées dans les options du jeu. 

--- a/worlds/sc2/docs/setup_en.md
+++ b/worlds/sc2/docs/setup_en.md
@@ -59,7 +59,7 @@ For StarCraft 2, this option doesn't have much impact.
 It is an Archipelago option designed to balance world progression by swapping items in spheres. 
 If the Progression Balancing of one world is greater than that of others, items in that world are more likely to be 
 obtained early, and vice versa if its value is smaller. 
-However, StarCraft 2 is more permissive regarding the items that can be used to progress, so this setting has little 
+However, StarCraft 2 is more permissive regarding the items that can be used to progress, so this option has little 
 influence on progression in a StarCraft 2 world. 
 StarCraft 2. 
 Since this option increases the time required to generate a MultiWorld, we recommend deactivating it (i.e., setting it 

--- a/worlds/sc2/docs/setup_en.md
+++ b/worlds/sc2/docs/setup_en.md
@@ -19,7 +19,8 @@ Archipelago installer.
 2. Run ArchipelagoStarcraft2Client.exe.
    - macOS users should instead follow the instructions found at ["Running in macOS"](#running-in-macos) for this step 
    only.
-3. Type the command `/download_data`. This will automatically install the Maps and Data files needed to play StarCraft 2 Archipelago.
+3. Type the command `/download_data`. 
+This will automatically install the Maps and Data files needed to play StarCraft 2 Archipelago.
 
 ## Where do I get a config file (aka "YAML") for this game?
 
@@ -66,8 +67,8 @@ obtained early, and vice versa if its value is smaller.
 However, StarCraft 2 is more permissive regarding the items that can be used to progress, so this setting has little 
 influence on progression in a StarCraft 2 world. 
 StarCraft 2. 
-As it increases the time required to generate a MultiWorld, we recommend deactivating it (i.e., setting it to zero) for 
-StarCraft 2.
+Since this option increases the time required to generate a MultiWorld, we recommend deactivating it (i.e., setting it 
+to zero) for a StarCraft 2 world.
 
 #### How do I specify items in a list, like in excluded items?
 
@@ -127,9 +128,10 @@ Unreachable missions will have greyed-out text. Just click on an available missi
 
 ## The game isn't launching when I try to start a mission.
 
-First, check the log file for issues (stored at `[Archipelago Directory]/logs/SC2Client.txt`). If you can't figure out
-the log file, visit our [Discord's](https://discord.com/invite/8Z65BR2) tech-support channel for help. Please include a
-specific description of what's going wrong and attach your log file to your message.
+First, check the log file for issues (stored at `[Archipelago Directory]/logs/SC2Client.txt`). 
+If you can't figure out the log file, visit our [Discord's](https://discord.com/invite/8Z65BR2) tech-support channel 
+for help. 
+Please include a specific description of what's going wrong and attach your log file to your message.
 
 ## My keyboard shortcuts profile is not available when I play *StarCraft 2 Archipelago*.
 

--- a/worlds/sc2/docs/setup_en.md
+++ b/worlds/sc2/docs/setup_en.md
@@ -19,7 +19,7 @@ Archipelago installer.
 2. Run ArchipelagoStarcraft2Client.exe.
    - macOS users should instead follow the instructions found at ["Running in macOS"](#running-in-macos) for this step 
    only.
-3. Type the command `/download_data`. This will automatically install the Maps and Data files from the third link above.
+3. Type the command `/download_data`. This will automatically install the Maps and Data files needed to play StarCraft 2 Archipelago.
 
 ## Where do I get a config file (aka "YAML") for this game?
 

--- a/worlds/sc2/docs/setup_en.md
+++ b/worlds/sc2/docs/setup_en.md
@@ -38,11 +38,6 @@ The template includes descriptions of each option, you just have to edit it in y
 
 Remember the name you enter in the options page or in the yaml file, you'll need it to connect later!
 
-The *Player options* page does not allow you to set some advanced options, such as the exclusion of certain units or 
-their upgrades. 
-You can use the [*Weighted Options*](/weighted-options) page to access these settings.
-
-
 Check out [Creating a YAML](/tutorial/Archipelago/setup/en#creating-a-yaml) for more game-agnostic information.
 
 ### Common yaml questions

--- a/worlds/sc2/docs/setup_en.md
+++ b/worlds/sc2/docs/setup_en.md
@@ -59,15 +59,15 @@ If you don't like terminals, you can also check the log file in the `logs/` fold
 
 #### What does Progression Balancing do?
 
-For Starcraft 2, this option doesn't have much impact. 
+For StarCraft 2, this option doesn't have much impact. 
 It is an Archipelago option designed to balance world progression by swapping items in spheres. 
 If the Progression Balancing of one world is greater than that of others, items in that world are more likely to be 
 obtained early, and vice versa if its value is smaller. 
-However, Starcraft 2 is more permissive regarding the items that can be used to progress, so this setting has little 
+However, StarCraft 2 is more permissive regarding the items that can be used to progress, so this setting has little 
 influence on progression in a StarCraft 2 world. 
-Starcraft 2. 
+StarCraft 2. 
 As it increases the time required to generate a MultiWorld, we recommend deactivating it (i.e., setting it to zero) for 
-Starcraft 2.
+StarCraft 2.
 
 #### How do I specify items in a list, like in excluded items?
 
@@ -138,7 +138,7 @@ For your keyboard shortcuts profile to work in Archipelago, you need to copy you
 If the folder doesn't exist, create it.
 
 To enable StarCraft 2 Archipelago to use your profile, follow these steps:
-1. Launch Starcraft 2 via the Battle.net application.
+1. Launch StarCraft 2 via the Battle.net application.
 2. Change your hotkey profile to the standard mode and accept.
 3. Select your custom profile and accept.
 

--- a/worlds/sc2/docs/setup_en.md
+++ b/worlds/sc2/docs/setup_en.md
@@ -1,33 +1,46 @@
 # StarCraft 2 Randomizer Setup Guide
 
-This guide contains instructions on how to install and troubleshoot the StarCraft 2 Archipelago client, as well as where
-to obtain a config file for StarCraft 2.
+This guide contains instructions on how to install and troubleshoot the StarCraft 2 Archipelago client, as well as 
+where to obtain a config file for StarCraft 2.
 
 ## Required Software
 
 - [StarCraft 2](https://starcraft2.com/en-us/)
+   - While all four campaigns are supported by StarCraft 2 Archipelago, they are not required to play the randomizer. 
+   If you do not own some of the campaigns, you will need to exclude them in your world's configuration file.
 - [The most recent Archipelago release](https://github.com/ArchipelagoMW/Archipelago/releases)
 
 ## How do I install this randomizer?
 
-1. Install StarCraft 2 and Archipelago using the links above. The StarCraft 2 Archipelago client is downloaded by the Archipelago installer.
+1. Install StarCraft 2 and Archipelago using the links above. The StarCraft 2 Archipelago client is downloaded by the 
+Archipelago installer.
    - Linux users should also follow the instructions found at the bottom of this page 
      (["Running in Linux"](#running-in-linux)).
 2. Run ArchipelagoStarcraft2Client.exe.
-   - macOS users should instead follow the instructions found at ["Running in macOS"](#running-in-macos) for this step only.
+   - macOS users should instead follow the instructions found at ["Running in macOS"](#running-in-macos) for this step 
+   only.
 3. Type the command `/download_data`. This will automatically install the Maps and Data files from the third link above.
 
 ## Where do I get a config file (aka "YAML") for this game?
 
-Yaml files are configuration files that tell Archipelago how you'd like your game to be randomized, even if you're only using default options.
+Yaml files are configuration files that tell Archipelago how you'd like your game to be randomized, even if you're only 
+using default options.
 When you're setting up a multiworld, every world needs its own yaml file.
 
 There are three basic ways to get a yaml:
-* You can go to the [Player Options](/games/Starcraft%202/player-options) page, set your options in the GUI, and export the yaml.
-* You can generate a template, either by downloading it from the [Player Options](/games/Starcraft%202/player-options) page or by generating it from the Launcher (ArchipelagoLauncher.exe). The template includes descriptions of each option, you just have to edit it in your text editor of choice.
+* You can go to the [Player Options](/games/Starcraft%202/player-options) page, set your options in the GUI, and export 
+the yaml.
+* You can generate a template, either by downloading it from the [Player Options](/games/Starcraft%202/player-options) 
+page or by generating it from the Launcher (`ArchipelagoLauncher.exe`). 
+The template includes descriptions of each option, you just have to edit it in your text editor of choice.
 * You can ask someone else to share their yaml to use it for yourself or adjust it as you wish.
 
 Remember the name you enter in the options page or in the yaml file, you'll need it to connect later!
+
+The *Player options* page does not allow you to set some advanced options, such as the exclusion of certain units or 
+their upgrades. 
+You can use the [*Weighted Options*](/weighted-options) page to access these settings.
+
 
 Check out [Creating a YAML](/tutorial/Archipelago/setup/en#creating-a-yaml) for more game-agnostic information.
 
@@ -36,15 +49,31 @@ Check out [Creating a YAML](/tutorial/Archipelago/setup/en#creating-a-yaml) for 
 
 The simplest way to check is to use the website [validator](/check). 
 
-You can also test it by attempting to generate a multiworld with your yaml. Save your yaml to the Players/ folder within your Archipelago installation and run ArchipelagoGenerate.exe. You should see a new .zip file within the output/ folder of your Archipelago installation if things worked correctly. It's advisable to run ArchipelagoGenerate through a terminal so that you can see the printout, which will include any errors and the precise output file name if it's successful. If you don't like terminals, you can also check the log file in the logs/ folder.
+You can also test it by attempting to generate a multiworld with your yaml. Save your yaml to the `Players/` folder 
+within your Archipelago installation and run `ArchipelagoGenerate.exe`. 
+You should see a new `.zip` file within the `output/` folder of your Archipelago installation if things worked 
+correctly. 
+It's advisable to run `ArchipelagoGenerate.exe` through a terminal so that you can see the printout, which will include 
+any errors and the precise output file name if it's successful. 
+If you don't like terminals, you can also check the log file in the `logs/` folder.
 
 #### What does Progression Balancing do?
 
-For Starcraft 2, not much. It's an Archipelago-wide option meant to shift required items earlier in the playthrough, but Starcraft 2 tends to be much more open in what items you can use. As such, this adjustment isn't very noticeable. It can also increase generation times, so we generally recommend turning it off.
+For Starcraft 2, this option doesn't have much impact. 
+It is an Archipelago option designed to balance world progression by swapping items in spheres. 
+If the Progression Balancing of one world is greater than that of others, items in that world are more likely to be 
+obtained early, and vice versa if its value is smaller. 
+However, Starcraft 2 is more permissive regarding the items that can be used to progress, so this setting has little 
+influence on progression in a StarCraft 2 world. 
+Starcraft 2. 
+As it increases the time required to generate a MultiWorld, we recommend deactivating it (i.e., setting it to zero) for 
+Starcraft 2.
 
 #### How do I specify items in a list, like in excluded items?
 
-You can look up the syntax for yaml collections in the [YAML specification](https://yaml.org/spec/1.2.2/#21-collections). For lists, every item goes on its own line, started with a hyphen:
+You can look up the syntax for yaml collections in the 
+[YAML specification](https://yaml.org/spec/1.2.2/#21-collections). 
+For lists, every item goes on its own line, started with a hyphen:
 
 ```yaml
 excluded_items:
@@ -52,11 +81,13 @@ excluded_items:
   - Drop-Pods (Kerrigan Tier 7)
 ```
 
-An empty list is just a matching pair of square brackets: `[]`. That's the default value in the template, which should let you know to use this syntax.
+An empty list is just a matching pair of square brackets: `[]`. 
+That's the default value in the template, which should let you know to use this syntax.
 
 #### How do I specify items for the starting inventory?
 
-The starting inventory is a YAML mapping rather than a list, which associates an item with the amount you start with. The syntax looks like the item name, followed by a colon, then a whitespace character, and then the value:
+The starting inventory is a YAML mapping rather than a list, which associates an item with the amount you start with. 
+The syntax looks like the item name, followed by a colon, then a whitespace character, and then the value:
 
 ```yaml
 start_inventory:
@@ -64,27 +95,35 @@ start_inventory:
   Additional Starting Vespene: 5
 ```
 
-An empty mapping is just a matching pair of curly braces: `{}`. That's the default value in the template, which should let you know to use this syntax.
+An empty mapping is just a matching pair of curly braces: `{}`. 
+That's the default value in the template, which should let you know to use this syntax.
 
 #### How do I know the exact names of items and locations?
 
-The [*datapackage*](/datapackage) page of the Archipelago website provides a complete list of the items and locations for each game that it currently supports, including StarCraft 2.
+The [*datapackage*](/datapackage) page of the Archipelago website provides a complete list of the items and locations 
+for each game that it currently supports, including StarCraft 2.
 
-You can also look up a complete list of the item names in the [Icon Repository](https://matthewmarinets.github.io/ap_sc2_icons/) page.
+You can also look up a complete list of the item names in the 
+[Icon Repository](https://matthewmarinets.github.io/ap_sc2_icons/) page.
 This page also contains supplementary information of each item.
-However, the items shown in that page might differ from those shown in the datapackage page of Archipelago since the former is generated, most of the time, from beta versions of StarCraft 2 Archipelago undergoing development.
+However, the items shown in that page might differ from those shown in the datapackage page of Archipelago since the 
+former is generated, most of the time, from beta versions of StarCraft 2 Archipelago undergoing development.
 
-As for the locations, you can see all the locations associated to a mission in your world by placing your cursor over the mission in the 'StarCraft 2 Launcher' tab in the client.
+As for the locations, you can see all the locations associated to a mission in your world by placing your cursor over 
+the mission in the 'StarCraft 2 Launcher' tab in the client.
 
 ## How do I join a MultiWorld game?
 
 1. Run ArchipelagoStarcraft2Client.exe.
-   - macOS users should instead follow the instructions found at ["Running in macOS"](#running-in-macos) for this step only.
+   - macOS users should instead follow the instructions found at ["Running in macOS"](#running-in-macos) for this step 
+   only.
 2. Type `/connect [server ip]`.
    - If you're running through the website, the server IP should be displayed near the top of the room page.
 3. Type your slot name from your YAML when prompted.
 4. If the server has a password, enter that when prompted.
-5. Once connected, switch to the 'StarCraft 2 Launcher' tab in the client. There, you can see all the missions in your world. Unreachable missions will have greyed-out text. Just click on an available mission to start it!
+5. Once connected, switch to the 'StarCraft 2 Launcher' tab in the client. There, you can see all the missions in your 
+world. 
+Unreachable missions will have greyed-out text. Just click on an available mission to start it!
 
 ## The game isn't launching when I try to start a mission.
 
@@ -92,9 +131,24 @@ First, check the log file for issues (stored at `[Archipelago Directory]/logs/SC
 the log file, visit our [Discord's](https://discord.com/invite/8Z65BR2) tech-support channel for help. Please include a
 specific description of what's going wrong and attach your log file to your message.
 
+## My keyboard shortcuts profile is not available when I play *StarCraft 2 Archipelago*.
+
+For your keyboard shortcuts profile to work in Archipelago, you need to copy your shortcuts file from 
+`Documents/StarCraft II/Accounts/######/Hotkeys` to `Documents/StarCraft II/Hotkeys`. 
+If the folder doesn't exist, create it.
+
+To enable StarCraft 2 Archipelago to use your profile, follow these steps:
+1. Launch Starcraft 2 via the Battle.net application.
+2. Change your hotkey profile to the standard mode and accept.
+3. Select your custom profile and accept.
+
+You will only need to do this once.
+
 ## Running in macOS
 
-To run StarCraft 2 through Archipelago in macOS, you will need to run the client via source as seen here: [macOS Guide](/tutorial/Archipelago/mac/en). Note: to launch the client, you will need to run the command `python3 Starcraft2Client.py`.
+To run StarCraft 2 through Archipelago in macOS, you will need to run the client via source as seen here: 
+[macOS Guide](/tutorial/Archipelago/mac/en). 
+Note: to launch the client, you will need to run the command `python3 Starcraft2Client.py`.
 
 ## Running in Linux
 
@@ -102,9 +156,9 @@ To run StarCraft 2 through Archipelago in Linux, you will need to install the ga
 of the Archipelago client.
 
 Make sure you have StarCraft 2 installed using Wine, and that you have followed the
-[installation procedures](#how-do-i-install-this-randomizer?) to add the Archipelago maps to the correct location. You will not
-need to copy the .dll files. If you're having trouble installing or running StarCraft 2 on Linux, I recommend using the
-Lutris installer.
+[installation procedures](#how-do-i-install-this-randomizer?) to add the Archipelago maps to the correct location. 
+You will not need to copy the `.dll` files. 
+If you're having trouble installing or running StarCraft 2 on Linux, it is recommend to use the Lutris installer.
 
 Copy the following into a .sh file, replacing the values of **WINE** and **SC2PATH** variables with the relevant
 locations, as well as setting **PATH_TO_ARCHIPELAGO** to the directory containing the AppImage if it is not in the same
@@ -139,5 +193,5 @@ below, replacing **${ID}** with the numerical ID.
     lutris lutris:rungameid/${ID} --output-script sc2.sh
 
 This will get all of the relevant environment variables Lutris sets to run StarCraft 2 in a script, including the path
-to the Wine binary that Lutris uses. You can then remove the line that runs the Battle.Net launcher and copy the code
-above into the existing script.
+to the Wine binary that Lutris uses. 
+You can then remove the line that runs the Battle.Net launcher and copy the code above into the existing script.

--- a/worlds/sc2/docs/setup_en.md
+++ b/worlds/sc2/docs/setup_en.md
@@ -6,8 +6,8 @@ where to obtain a config file for StarCraft 2.
 ## Required Software
 
 - [StarCraft 2](https://starcraft2.com/en-us/)
-   - While all four campaigns are supported by StarCraft 2 Archipelago, they are not required to play the randomizer. 
-   If you do not own some of the campaigns, you will need to exclude them in your world's configuration file.
+   - While StarCraft 2 Archipelago supports all four campaigns, they are not mandatory to play the randomizer. 
+   If you do not own certain campaigns, you only need to exclude them in the configuration file of your world.
 - [The most recent Archipelago release](https://github.com/ArchipelagoMW/Archipelago/releases)
 
 ## How do I install this randomizer?

--- a/worlds/sc2/docs/setup_fr.md
+++ b/worlds/sc2/docs/setup_fr.md
@@ -6,7 +6,10 @@ indications pour obtenir un fichier de configuration de *StarCraft 2 Archipelago
 ## Logiciels requis
 
 - [*StarCraft 2*](https://starcraft2.com/en-us/)
-   dsa
+   - Bien que *StarCraft 2 Archipelago* supporte les quatre campagnes, elles ne sont pas obligatoires pour jouer au 
+   *randomizer*. 
+   Si vous ne possédez pas certaines campagnes, il vous suffit de les exclure dans le fichier de configuration de 
+   votre monde.
 - [La version la plus récente d'Archipelago](https://github.com/ArchipelagoMW/Archipelago/releases)
 
 ## Comment est-ce que j'installe ce *randomizer*?

--- a/worlds/sc2/docs/setup_fr.md
+++ b/worlds/sc2/docs/setup_fr.md
@@ -6,6 +6,7 @@ indications pour obtenir un fichier de configuration de *StarCraft 2 Archipelago
 ## Logiciels requis
 
 - [*StarCraft 2*](https://starcraft2.com/en-us/)
+   dsa
 - [La version la plus récente d'Archipelago](https://github.com/ArchipelagoMW/Archipelago/releases)
 
 ## Comment est-ce que j'installe ce *randomizer*?
@@ -121,6 +122,8 @@ Notez que cette page contient diverses informations supplémentaires sur chacun 
 Cependant, l'information présente dans cette dernière peut différer de celle du *datapackage* d'Archipelago 
 puisqu'elle est générée, habituellement, à partir de la version en développement de *StarCraft 2 Archipelago* qui 
 n'ont peut-être pas encore été inclus dans le site web d'Archipelago.
+
+dsa
 
 ## Comment est-ce que je peux joindre un *MultiWorld*?
 

--- a/worlds/sc2/docs/setup_fr.md
+++ b/worlds/sc2/docs/setup_fr.md
@@ -45,10 +45,6 @@ préférences.
 Prenez soin de vous rappeler du nom de joueur que vous avez inscrit dans la page à options ou dans le fichier *yaml* 
 puisque vous en aurez besoin pour vous connecter à votre monde!
 
-Notez que la page *Player options* ne permet pas de définir certaines des options avancées, e.g., l'exclusion de 
-certaines unités ou de leurs améliorations. 
-Utilisez la page [*Weighted Options*](/weighted-options) pour avoir accès à ces dernières.
-
 Si vous désirez des informations et/ou instructions générales sur l'utilisation d'un fichier *yaml* pour Archipelago, 
 veuillez consulter [*Creating a YAML*](/tutorial/Archipelago/setup/en#creating-a-yaml).
 

--- a/worlds/sc2/docs/setup_fr.md
+++ b/worlds/sc2/docs/setup_fr.md
@@ -67,15 +67,15 @@ dans le dossier `logs/`.
 
 #### À quoi sert l'option *Progression Balancing*?
 
-Pour *Starcraft 2*, cette option ne fait pas grand-chose.
+Pour *StarCraft 2*, cette option ne fait pas grand-chose.
 Il s'agit d'une option d'Archipelago permettant d'équilibrer la progression des mondes en interchangeant les *items* 
 dans les *spheres*. 
 Si le *Progression Balancing* d'un monde est plus grand que ceux des autres, les *items* de progression de ce monde ont 
 plus de chance d'être obtenus tôt et vice-versa si sa valeur est plus petite que celle des autres mondes. 
-Cependant, *Starcraft 2* est beaucoup plus permissif en termes d'*items* qui permettent de progresser, ce réglage à 
+Cependant, *StarCraft 2* est beaucoup plus permissif en termes d'*items* qui permettent de progresser, ce réglage à 
 donc peu d'influence sur la progression dans *StarCraft 2*. 
 Vu qu'il augmente le temps de génération d'un *MultiWorld*, nous recommandons de le désactiver, c-à-d le définir à 
-zéro, pour *Starcraft 2*. 
+zéro, pour *StarCraft 2*. 
 
 
 #### Comment est-ce que je définis une liste d'*items*, e.g. pour l'option *excluded items*?
@@ -123,7 +123,9 @@ Cependant, l'information présente dans cette dernière peut différer de celle 
 puisqu'elle est générée, habituellement, à partir de la version en développement de *StarCraft 2 Archipelago* qui 
 n'ont peut-être pas encore été inclus dans le site web d'Archipelago.
 
-dsa
+Pour ce qui concerne les *locations*, vous pouvez consulter tous les *locations* associés à une mission dans votre 
+monde en plaçant votre curseur sur la case correspondante dans l'onglet *StarCraft 2 Launcher* du client.
+
 
 ## Comment est-ce que je peux joindre un *MultiWorld*?
 
@@ -155,7 +157,7 @@ qui se trouve dans `Documents/StarCraft II/Accounts/######/Hotkeys` vers `Docume
 Si le dossier n'existe pas, créez-le.
 
 Pour que *StarCraft 2 Archipelago* utilise votre profil, suivez les étapes suivantes.
-Lancez *Starcraft 2* via l'application *Battle.net*. 
+Lancez *StarCraft 2* via l'application *Battle.net*. 
 Changez votre profil de raccourcis clavier pour le mode standard et acceptez, puis sélectionnez votre profil 
 personnalisé et acceptez. 
 Vous n'aurez besoin de faire ça qu'une seule fois.


### PR DESCRIPTION
## What is this fixing or adding?
Adding the following in the English version of SC2 documentation:
- Instructions for custom hotkey
- Known issues with Starcraft 2 Archipelago

Enhanced the following in the English version of SC2 documentation:
- Goal description 
- Explicit that while all SC2 campaigns are supported, the player is required to play those he possesses
- The explanation of progress balancing in SC2
- Applied the 120 characters limit rule on the Markdown file
- Syncing the SC2 EN documentation with the SC2 FR documentation. 

## How was this tested?
By locally hosting the website, it was confirmed that the English setup and game page remains correctly rendered. 

## If this makes graphical changes, please attach screenshots.
None that are relevant.
