### PR TITLE
WebHost: Allowing options that work on WebHost to be used in presets

### DIFF
--- a/WebHostLib/options.py
+++ b/WebHostLib/options.py
@@ -91,7 +91,7 @@ def option_presets(game: str) -> Response:
                     f"Expected {option.special_range_names.keys()} or {option.range_start}-{option.range_end}."
 
                 presets[preset_name][preset_option_name] = option.value
-            elif isinstance(option, Options.Range):
+            elif isinstance(option, (Options.Range, Options.OptionSet, Options.OptionList, Options.ItemDict)):
                 presets[preset_name][preset_option_name] = option.value
             elif isinstance(preset_option, str):
                 # Ensure the option value is valid for Choice and Toggle options

--- a/test/webhost/test_option_presets.py
+++ b/test/webhost/test_option_presets.py
@@ -1,7 +1,7 @@
 import unittest
 
 from worlds import AutoWorldRegister
-from Options import Choice, NamedRange, Toggle, Range
+from Options import ItemDict, NamedRange, NumericOption, OptionList, OptionSet
 
 
 class TestOptionPresets(unittest.TestCase):
@@ -14,7 +14,7 @@ class TestOptionPresets(unittest.TestCase):
                     with self.subTest(game=game_name, preset=preset_name, option=option_name):
                         try:
                             option = world_type.options_dataclass.type_hints[option_name].from_any(option_value)
-                            supported_types = [Choice, Toggle, Range, NamedRange]
+                            supported_types = [NumericOption, OptionSet, OptionList, ItemDict]
                             if not any([issubclass(option.__class__, t) for t in supported_types]):
                                 self.fail(f"'{option_name}' in preset '{preset_name}' for game '{game_name}' "
                                           f"is not a supported type for webhost. "


### PR DESCRIPTION
## What is this fixing or adding?

[Issue 3439](https://github.com/ArchipelagoMW/Archipelago/issues/3439)

OptionLists, OptionSets, and ItemDicts can all display just fine on the new WebHost but the preset test still prevents them from being used in presets despite them working just fine. This changes the test and also simplifies explicitly including Choice, Toggle, Range, and NamedRange by just including NumericOption

## How was this tested?

Unit Tests and modifying worlds to use these new options, seeing the test go from failing to passing and seeing WebHost no longer throw errors from these being in presets.