### PR TITLE
KH2: Fixing Start Inventory bug, limiting CustomItemPool keys, fixing two typos

### DIFF
--- a/worlds/kh2/Options.py
+++ b/worlds/kh2/Options.py
@@ -308,14 +308,14 @@ class CorSkipToggle(Toggle):
 
     Full Cor Skip is also affected by this Toggle.
     """
-    display_name = "CoR Skip Toggle."
+    display_name = "CoR Skip Toggle"
     default = False
 
 
 class CustomItemPoolQuantity(ItemDict):
     """Add more of an item into the itempool. Note: You cannot take out items from the pool."""
     display_name = "Custom Item Pool"
-    verify_item_name = True
+    valid_keys = default_itempool_option.keys()
     default = default_itempool_option
 
 

--- a/worlds/kh2/__init__.py
+++ b/worlds/kh2/__init__.py
@@ -435,7 +435,7 @@ class KH2World(World):
                 # cannot have more than the quantity for abilties
                 if value > item_dictionary_table[item].quantity:
                     logging.info(
-                            f"{self.multiworld.get_file_safe_player_name(self.player)} cannot have more than {item_dictionary_table[item].quantity} of {item}"
+                            f"{self.multiworld.get_file_safe_player_name(self.player)} cannot have more than {item_dictionary_table[item].quantity} of {item}."
                             f" Changing the amount to the max amount")
                     value = item_dictionary_table[item].quantity
                 self.item_quantity_dict[item] -= value

--- a/worlds/kh2/__init__.py
+++ b/worlds/kh2/__init__.py
@@ -430,7 +430,7 @@ class KH2World(World):
         """
         for item, value in self.options.start_inventory.value.items():
             if item in ActionAbility_Table \
-                    or item in SupportAbility_Table or exclusion_item_table["StatUps"] \
+                    or item in SupportAbility_Table or item in exclusion_item_table["StatUps"] \
                     or item in DonaldAbility_Table or item in GoofyAbility_Table:
                 # cannot have more than the quantity for abilties
                 if value > item_dictionary_table[item].quantity:

--- a/worlds/kh2/__init__.py
+++ b/worlds/kh2/__init__.py
@@ -436,7 +436,7 @@ class KH2World(World):
                 if value > item_dictionary_table[item].quantity:
                     logging.info(
                             f"{self.multiworld.get_file_safe_player_name(self.player)} cannot have more than {item_dictionary_table[item].quantity} of {item}"
-                            f"Changing the amount to the max amount")
+                            f" Changing the amount to the max amount")
                     value = item_dictionary_table[item].quantity
                 self.item_quantity_dict[item] -= value
 


### PR DESCRIPTION
## What is this fixing or adding?

* [Start Inventory error](https://discord.com/channels/731205301247803413/1236770508360388768)
* * You could not include more than one of various items in `start_inventory` because `item in A or B` evaluates as `(item in A) or B`
* [Custom Item Pool error](https://discord.com/channels/731205301247803413/1090817012416118815/1246841288708325458)
* * Only [certain items](https://github.com/ArchipelagoMW/Archipelago/blob/main/worlds/kh2/__init__.py#L216C57-L216C92) actually have an effect in the CustomItemPool option, however they are all displayed on WebHost. This adds a `valid_keys` argument and removes `verify_item_name = True` as that's already the default.
* Typos
* * WebHost showed "CoR Skip Toggle.:"
* * Output showed " [...] cannot have more than X of itemChanging the amount [...]"

## How was this tested?

Generations and running WebHost.

## If this makes graphical changes, please attach screenshots.

![Screenshot 2024-06-02 151053](https://github.com/ArchipelagoMW/Archipelago/assets/60412657/270a19ae-cdd3-42ec-9538-b7e81cf4e1f9)
![Screenshot 2024-06-02 152013](https://github.com/ArchipelagoMW/Archipelago/assets/60412657/eb823194-6ce1-41db-8351-179b781945ce)

![Screenshot 2024-06-02 151725](https://github.com/ArchipelagoMW/Archipelago/assets/60412657/190366f0-4601-4015-8097-6514e1e200cf)
![Screenshot 2024-06-02 151759](https://github.com/ArchipelagoMW/Archipelago/assets/60412657/59a6e720-1482-4522-8503-75fed794c82f)

![Screenshot 2024-06-02 152103](https://github.com/ArchipelagoMW/Archipelago/assets/60412657/17d99bae-6811-403b-9a00-88546e41df0a)
![Screenshot 2024-06-02 152114](https://github.com/ArchipelagoMW/Archipelago/assets/60412657/2377869f-f83b-4be6-9e03-ed8a9e3c29a8)
