### PR TITLE
HK: Fix Egg_Shop typo in costsanity

### DIFF
--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -405,7 +405,7 @@ class HKWorld(World):
                     continue
                 if setting == CostSanity.option_shopsonly and location.basename not in multi_locations:
                     continue
-                if location.basename in {'Grubfather', 'Seer', 'Eggshop'}:
+                if location.basename in {'Grubfather', 'Seer', 'Egg_Shop'}:
                     our_weights = dict(weights_geoless)
                 else:
                     our_weights = dict(weights)


### PR DESCRIPTION
## What is this fixing or adding?
fixes a typo in costsanity code that checked for the wrong eggshop basename

## How was this tested?
generated with my normal costsanity settings: saw geo in eggshop
rerolled after the fix: saw only non-geo costs in eggshop

## If this makes graphical changes, please attach screenshots.
