### PR TITLE
WebHost: allow getting checksum-specific datapackage via /api/datapackage/<checksum>

### DIFF
--- a/WebHostLib/api/__init__.py
+++ b/WebHostLib/api/__init__.py
@@ -5,7 +5,6 @@ from uuid import UUID
 from flask import Blueprint, abort, url_for
 
 import worlds.Files
-from .. import cache
 from ..models import Room, Seed
 
 api_endpoints = Blueprint('api', __name__, url_prefix="/api")
@@ -49,21 +48,4 @@ def room_info(room: UUID):
     }
 
 
-@api_endpoints.route('/datapackage')
-@cache.cached()
-def get_datapackage():
-    from worlds import network_data_package
-    return network_data_package
-
-
-@api_endpoints.route('/datapackage_checksum')
-@cache.cached()
-def get_datapackage_checksums():
-    from worlds import network_data_package
-    version_package = {
-        game: game_data["checksum"] for game, game_data in network_data_package["games"].items()
-    }
-    return version_package
-
-
-from . import generate, user  # trigger registration
+from . import generate, user, datapackage  # trigger registration

--- a/WebHostLib/api/datapackage.py
+++ b/WebHostLib/api/datapackage.py
@@ -1,0 +1,32 @@
+from flask import abort
+
+from Utils import restricted_loads
+from WebHostLib import cache
+from WebHostLib.api import api_endpoints
+from WebHostLib.models import GameDataPackage
+
+
+@api_endpoints.route('/datapackage')
+@cache.cached()
+def get_datapackage():
+    from worlds import network_data_package
+    return network_data_package
+
+
+@api_endpoints.route('/datapackage/<string:checksum>')
+@cache.memoize(timeout=3600)
+def get_datapackage_by_checksum(checksum: str):
+    package = GameDataPackage.get(checksum=checksum)
+    if package:
+        return restricted_loads(package.data)
+    return abort(404)
+
+
+@api_endpoints.route('/datapackage_checksum')
+@cache.cached()
+def get_datapackage_checksums():
+    from worlds import network_data_package
+    version_package = {
+        game: game_data["checksum"] for game, game_data in network_data_package["games"].items()
+    }
+    return version_package

--- a/WebHostLib/api/datapackage.py
+++ b/WebHostLib/api/datapackage.py
@@ -2,8 +2,8 @@ from flask import abort
 
 from Utils import restricted_loads
 from WebHostLib import cache
-from WebHostLib.api import api_endpoints
 from WebHostLib.models import GameDataPackage
+from . import api_endpoints
 
 
 @api_endpoints.route('/datapackage')


### PR DESCRIPTION
## What is this fixing or adding?
Adds /api/datapackage/<checksum> which may be useful if we want to add  /api/tracker stuff and return raw data, possibly has other uses.

## How was this tested?
Locally, in which I realized not all checksums from currently loaded worlds can be accessed, as only datapackages that have been generated with, or hosted with, exist. Then I came to the follow up realization, that that doesn't matter, as the only time something would request that checksum is when it's hosted in some way on that website, which means it will be in the DB.

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/3189725/ada8f096-d82c-485f-a917-224aa4c34f53)
