### PR TITLE
LttP: fix single-player no-logic generation

### DIFF
--- a/worlds/alttp/OverworldGlitchRules.py
+++ b/worlds/alttp/OverworldGlitchRules.py
@@ -220,26 +220,7 @@ def get_invalid_bunny_revival_dungeons():
     yield 'Sanctuary'
 
 
-def no_logic_rules(world, player):
-    """
-    Add OWG transitions to no logic player's world
-    """
-    create_no_logic_connections(player, world, get_boots_clip_exits_lw(world.mode[player] == 'inverted'))
-    create_no_logic_connections(player, world, get_boots_clip_exits_dw(world.mode[player] == 'inverted', player))
-
-    # Glitched speed drops.
-    create_no_logic_connections(player, world, get_glitched_speed_drops_dw(world.mode[player] == 'inverted'))
-
-    # Mirror clip spots.
-    if world.mode[player] != 'inverted':
-        create_no_logic_connections(player, world, get_mirror_clip_spots_dw())
-        create_no_logic_connections(player, world, get_mirror_offset_spots_dw())
-    else:
-        create_no_logic_connections(player, world, get_mirror_offset_spots_lw(player))
-
-
 def overworld_glitch_connections(world, player):
-
     # Boots-accessible locations.
     create_owg_connections(player, world, get_boots_clip_exits_lw(world.mode[player] == 'inverted'))
     create_owg_connections(player, world, get_boots_clip_exits_dw(world.mode[player] == 'inverted', player))

--- a/worlds/alttp/Rules.py
+++ b/worlds/alttp/Rules.py
@@ -10,7 +10,7 @@ from . import OverworldGlitchRules
 from .Bosses import GanonDefeatRule
 from .Items import item_factory, item_name_groups, item_table, progression_items
 from .Options import small_key_shuffle
-from .OverworldGlitchRules import no_logic_rules, overworld_glitches_rules
+from .OverworldGlitchRules import overworld_glitches_rules
 from .Regions import LTTPRegionType, location_table
 from .StateHelpers import (can_extend_magic, can_kill_most_things,
                            can_lift_heavy_rocks, can_lift_rocks,
@@ -33,7 +33,6 @@ def set_rules(world):
                 'WARNING! Seeds generated under this logic often require major glitches and may be impossible!')
 
         if world.players == 1:
-            no_logic_rules(world, player)
             for exit in world.get_region('Menu', player).exits:
                 exit.hide_path = True
             return


### PR DESCRIPTION
## What is this fixing or adding?
As far as I could tell, overworld_glitch_connections is a direct copy of no_logic_rules, and in single-player no-logic both get run, creating duplicated connections. Those dupes then trip the cache's checker.

## How was this tested?
By seeing the gen no longer error and the playthrough looking correct. Which for no-logic is:
0: {}

I'd appreciate some no-logic players confirming this didn't break something unanticipated though.

## If this makes graphical changes, please attach screenshots.
