### PR TITLE
Cleanup: MMBN3 Typo for SloGauge

### DIFF
--- a/worlds/mmbn3/Items.py
+++ b/worlds/mmbn3/Items.py
@@ -171,7 +171,7 @@ chipList: typing.List[ItemData] = [
     ItemData(0xB31063, ItemName.SandStage_C, ItemClassification.filler, ItemType.Chip, 182, chip_code('C')),
     ItemData(0xB31064, ItemName.SideGun_S, ItemClassification.filler, ItemType.Chip, 12, chip_code('S')),
     ItemData(0xB31065, ItemName.Slasher_B, ItemClassification.useful, ItemType.Chip, 43, chip_code('B')),
-    ItemData(0xB31066, ItemName.SloGuage_star, ItemClassification.filler, ItemType.Chip, 157, chip_code('*')),
+    ItemData(0xB31066, ItemName.SloGauge_star, ItemClassification.filler, ItemType.Chip, 157, chip_code('*')),
     ItemData(0xB31067, ItemName.Snake_D, ItemClassification.useful, ItemType.Chip, 131, chip_code('D')),
     ItemData(0xB31068, ItemName.Snctuary_C, ItemClassification.useful, ItemType.Chip, 184, chip_code('C')),
     ItemData(0xB31069, ItemName.Spreader_star, ItemClassification.useful, ItemType.Chip, 13, chip_code('*')),

--- a/worlds/mmbn3/Names/ItemName.py
+++ b/worlds/mmbn3/Names/ItemName.py
@@ -72,7 +72,7 @@ class ItemName():
     SandStage_C = "SandStage C"
     SideGun_S = "SideGun S"
     Slasher_B = "Slasher B"
-    SloGuage_star = "SloGauge *"
+    SloGauge_star = "SloGauge *"
     Snake_D = "Snake D"
     Snctuary_C = "Snctuary C"
     Spreader_star = "Spreader *"

--- a/worlds/mmbn3/Names/ItemName.py
+++ b/worlds/mmbn3/Names/ItemName.py
@@ -72,7 +72,7 @@ class ItemName():
     SandStage_C = "SandStage C"
     SideGun_S = "SideGun S"
     Slasher_B = "Slasher B"
-    SloGuage_star = "SloGuage *"
+    SloGuage_star = "SloGauge *"
     Snake_D = "Snake D"
     Snctuary_C = "Snctuary C"
     Spreader_star = "Spreader *"


### PR DESCRIPTION
## What is this fixing or adding?
This fixes the Archipelago item name for SloGauge in Mega Man Battle Network 3 which was misspelled as SloGuage, causing the typo to appear in the Archipelago client and in games that display AP item names.

## How was this tested?
Not necessary due to the change only being swapping two characters in a single string.

## If this makes graphical changes, please attach screenshots.
N/A