### PR TITLE
Fix weighted-options page crashing if a Choice option's default is "random"

### DIFF
--- a/WebHostLib/templates/weightedOptions/macros.html
+++ b/WebHostLib/templates/weightedOptions/macros.html
@@ -18,7 +18,11 @@
         <tbody>
             {% for id, name in option.name_lookup.items() %}
                 {% if name != 'random' %}
-                    {{ RangeRow(option_name, option, option.get_option_name(id), name, False, name if option.get_option_name(option.default)|lower == name|lower else None) }}
+                    {% if option.default != 'random' %}
+                        {{ RangeRow(option_name, option, option.get_option_name(id), name, False, name if option.get_option_name(option.default)|lower == name else None) }}
+                    {% else %}
+                        {{ RangeRow(option_name, option, option.get_option_name(id), name) }}
+                    {% endif %}
                 {% endif %}
             {% endfor %}
             {{ RandomRow(option_name, option) }}
@@ -92,7 +96,11 @@
         <tbody>
             {% for id, name in option.name_lookup.items() %}
                 {% if name != 'random' %}
-                    {{ RangeRow(option_name, option, option.get_option_name(id), name, False, name if option.get_option_name(option.default)|lower == name else None) }}
+                    {% if option.default != 'random' %}
+                        {{ RangeRow(option_name, option, option.get_option_name(id), name, False, name if option.get_option_name(option.default)|lower == name else None) }}
+                    {% else %}
+                        {{ RangeRow(option_name, option, option.get_option_name(id), name) }}
+                    {% endif %}
                 {% endif %}
             {% endfor %}
             {{ RandomRow(option_name, option) }}


### PR DESCRIPTION
## What is this fixing or adding?
See title.

## How was this tested?
Run locally and tested that weighted-options pages with Choice and TextChoice options whose defaults' were "random" loaded properly.