### PR TITLE
HK: adds split movement items to 'skills' item group

### DIFF
--- a/worlds/hk/Items.py
+++ b/worlds/hk/Items.py
@@ -64,3 +64,4 @@ item_name_groups = ({
 })
 item_name_groups['Horizontal'] = item_name_groups['Cloak'] | item_name_groups['CDash']
 item_name_groups['Vertical'] = item_name_groups['Claw'] | {'Monarch_Wings'}
+item_name_groups['Skills'] |= item_name_groups['Vertical'] | item_name_groups['Horizontal']


### PR DESCRIPTION
## What is this fixing or adding?
because of extractedData labling, split movement items weren't in the 'skills' category, this adds all movement to skills appropriately 

## How was this tested?
added some prints before and after and imported the class in a shell, visually confirmed that the only things added to the group were the right/left/split movement items and that nothing was removed

## If this makes graphical changes, please attach screenshots.
