### PR TITLE
HK: lower max egg cost

### DIFF
--- a/worlds/hk/Options.py
+++ b/worlds/hk/Options.py
@@ -212,7 +212,7 @@ class MinimumEggPrice(Range):
     Only takes effect if the EggSlotShops option is greater than 0."""
     display_name = "Minimum Egg Price"
     range_start = 1
-    range_end = 21
+    range_end = 20
     default = 1
 
 


### PR DESCRIPTION
## What is this fixing or adding?
per extractedData pool_options, only 20 eggs are created by default, so if a random filler egg isn't generated 21 max egg costs can be unreachable

could be updated when/if tuk check adds an egg to the default pool 

## How was this tested?
wasn't

## If this makes graphical changes, please attach screenshots.
