### PR TITLE
Wargroove: Enable running the Wargroove client on non-Windows systems

### DIFF
--- a/WargrooveClient.py
+++ b/WargrooveClient.py
@@ -78,31 +78,33 @@ class WargrooveContext(CommonContext):
         self.syncing = False
         self.awaiting_bridge = False
         # self.game_communication_path: files go in this path to pass data between us and the actual game
+        options = Utils.get_options()
+        root_directory = os.path.join(options["wargroove_options"]["root_directory"])
+        data_directory = os.path.join("lib", "worlds", "wargroove", "data")
+        dev_data_directory = os.path.join("worlds", "wargroove", "data")
+        appdata_wargroove = ""
         if "appdata" in os.environ:
-            options = Utils.get_options()
-            root_directory = os.path.join(options["wargroove_options"]["root_directory"])
-            data_directory = os.path.join("lib", "worlds", "wargroove", "data")
-            dev_data_directory = os.path.join("worlds", "wargroove", "data")
             appdata_wargroove = os.path.expandvars(os.path.join("%APPDATA%", "Chucklefish", "Wargroove"))
-            if not os.path.isfile(os.path.join(root_directory, "win64_bin", "wargroove64.exe")):
-                print_error_and_close("WargrooveClient couldn't find wargroove64.exe. "
-                                      "Unable to infer required game_communication_path")
-            self.game_communication_path = os.path.join(root_directory, "AP")
-            if not os.path.exists(self.game_communication_path):
-                os.makedirs(self.game_communication_path)
-            self.remove_communication_files()
-            atexit.register(self.remove_communication_files)
-            if not os.path.isdir(appdata_wargroove):
-                print_error_and_close("WargrooveClient couldn't find Wargoove in appdata!"
-                                      "Boot Wargroove and then close it to attempt to fix this error")
-            if not os.path.isdir(data_directory):
-                data_directory = dev_data_directory
-            if not os.path.isdir(data_directory):
-                print_error_and_close("WargrooveClient couldn't find Wargoove mod and save files in install!")
-            shutil.copytree(data_directory, appdata_wargroove, dirs_exist_ok=True)
         else:
-            print_error_and_close("WargrooveClient couldn't detect system type. "
+            appdata_wargroove = os.path.join(options["wargroove_options"]["compatdata_directory"], "607050",
+                                             "pfx", "drive_c", "users", "steamuser", "Application Data", "Chucklefish",
+                                             "Wargroove")
+        if not os.path.isfile(os.path.join(root_directory, "win64_bin", "wargroove64.exe")):
+            print_error_and_close("WargrooveClient couldn't find wargroove64.exe. "
                                   "Unable to infer required game_communication_path")
+        self.game_communication_path = os.path.join(root_directory, "AP")
+        if not os.path.exists(self.game_communication_path):
+            os.makedirs(self.game_communication_path)
+        self.remove_communication_files()
+        atexit.register(self.remove_communication_files)
+        if not os.path.isdir(appdata_wargroove):
+            print_error_and_close("WargrooveClient couldn't find Wargoove in appdata!"
+                                  "Boot Wargroove and then close it to attempt to fix this error")
+        if not os.path.isdir(data_directory):
+            data_directory = dev_data_directory
+        if not os.path.isdir(data_directory):
+            print_error_and_close("WargrooveClient couldn't find Wargoove mod and save files in install!")
+        shutil.copytree(data_directory, appdata_wargroove, dirs_exist_ok=True)
 
     async def server_auth(self, password_requested: bool = False):
         if password_requested and not self.password:

--- a/worlds/wargroove/__init__.py
+++ b/worlds/wargroove/__init__.py
@@ -19,7 +19,16 @@ class WargrooveSettings(settings.Group):
         """
         description = "Wargroove root directory"
 
-    root_directory: RootDirectory = RootDirectory("C:/Program Files (x86)/Steam/steamapps/common/Wargroove")
+    class CompatDataDirectory(settings.UserFolderPath):
+        """
+        Locate the proton compatdata directory for running on non-Windows systems.
+        This is used by the Wargroove client, so it knows where to send communication files to.
+        This setting is not used when running on a Windows system.
+        """
+        description = "Wargroove proton compatdata"
+
+    root_directory: RootDirectory = RootDirectory("C:/Program Files (x86)/Steam/steamcompats/common/Wargroove")
+    compatdata_directory: CompatDataDirectory = CompatDataDirectory("$HOME/.steam/debian-installation/compatdata")
 
 
 class WargrooveWeb(WebWorld):

--- a/worlds/wargroove/docs/en_Wargroove.md
+++ b/worlds/wargroove/docs/en_Wargroove.md
@@ -1,4 +1,4 @@
-# Wargroove (Steam, Windows)
+# Wargroove (Steam)
 
 ## Where is the options page?
 

--- a/worlds/wargroove/docs/wargroove_en.md
+++ b/worlds/wargroove/docs/wargroove_en.md
@@ -3,14 +3,20 @@
 ## Required Files
 
 - Wargroove with the Double Trouble DLC installed through Steam on Windows
-  - Only the Steam Windows version is supported. MAC, Switch, Xbox, and Playstation are not supported.
+  - Only the Steam version is supported. Switch, Xbox, and Playstation are not supported.
 - [The most recent Archipelago release](https://github.com/ArchipelagoMW/Archipelago/releases)
 
 ## Backup playerProgress files
 `playerProgress` and `playerProgress.bak` contain save data for all of your Wargroove campaigns. Backing up these files
 is strongly recommended in case they become corrupted.
+### Windows
 1. Type `%appdata%\Chucklefish\Wargroove\save` in the file browser and hit enter.
 2. Copy the `playerProgress` and `playerProgress.bak` files and paste them into a backup directory.
+### Mac/Linux
+1. Open Steam Settings and go to Storage. Select the three dots and then "Browse Folder", then navigate to compatdata. If there there isn't a folder named "607050", select a different drive and try again.
+2. Copy the path to the compatdata folder, you will need it later.
+3. Navigate to `607050/pfx/drive_c/users/steamuser/Application Data/Chucklefish/Wargroove`.
+4. Copy the `playerProgress` and `playerProgress.bak` files and paste them into a backup directory.
 
 ## Update host.yaml to include the Wargroove root directory
 
@@ -21,7 +27,8 @@ is strongly recommended in case they become corrupted.
    `Steam->Right Click Wargroove->Properties->Installed Files->Browse` and copying the path in the address bar.
    - Paste the path in between the quotes next to `root_directory:` in the `host.yaml`.
    - You may have to replace all single \\ with \\\\.
-4. Start the Wargroove client.
+4. (Mac/Linux only) Put the compatdata directory from earlier in the `compatdata_directory:` option.
+5. Start the Wargroove client.
 
 ## Installing the Archipelago Wargroove Mod and Campaign files
 


### PR DESCRIPTION
## What is this fixing or adding?
This changes the Wargroove client to use a user-supplied proton compatibility directory when running on a non-Windows system instead of printing an error and exiting. This also updates the documentation to reflect that the client is no longer Windows-only.

## How was this tested?
I ran two test seeds, one on Ubuntu 23.10 and another on Windows 11. On both seeds I played through three maps and verified that sending checks, changing commanders, recruiting unlocked units, and income boosts all worked as expected.

## If this makes graphical changes, please attach screenshots.
