### PR TITLE
hk: adds schema to validate plando charm costs

### DIFF
--- a/worlds/hk/Options.py
+++ b/worlds/hk/Options.py
@@ -2,6 +2,7 @@ import typing
 import re
 from .ExtractedData import logic_options, starts, pool_options
 from .Rules import cost_terms
+from schema import And, Schema, Optional
 
 from Options import Option, DefaultOnToggle, Toggle, Choice, Range, OptionDict, NamedRange, DeathLink
 from .Charms import vanilla_costs, names as charm_names
@@ -296,6 +297,9 @@ class PlandoCharmCosts(OptionDict):
     This is set after any random Charm Notch costs, if applicable."""
     display_name = "Charm Notch Cost Plando"
     valid_keys = frozenset(charm_names)
+    schema = Schema({
+        Optional(name): And(int, lambda n: 6 >= n >= 0) for name in charm_names
+        })
 
     def get_costs(self, charm_costs: typing.List[int]) -> typing.List[int]:
         for name, cost in self.value.items():


### PR DESCRIPTION
## What is this fixing or adding?
adds schema to validate plando charm costs

## How was this tested?
just ran generations,
3 charms set to 0, gen'd as expected
each failed as expected: with a typo, with a negative cost, with too high a cost


## If this makes graphical changes, please attach screenshots.
