### PR TITLE
Launcher: handle apworld installation

### DIFF
--- a/inno_setup.iss
+++ b/inno_setup.iss
@@ -209,9 +209,9 @@ Root: HKCR; Subkey: "{#MyAppName}multidata";                     ValueData: "Arc
 Root: HKCR; Subkey: "{#MyAppName}multidata\DefaultIcon";         ValueData: "{app}\ArchipelagoServer.exe,0";                         ValueType: string;  ValueName: "";
 Root: HKCR; Subkey: "{#MyAppName}multidata\shell\open\command";  ValueData: """{app}\ArchipelagoServer.exe"" ""%1""";                ValueType: string;  ValueName: "";
 
-Root: HKCR; Subkey: ".apworld";                                 ValueData: "{#MyAppName}worlddata";   Flags: uninsdeletevalue; ValueType: string;  ValueName: "";
-Root: HKCR; Subkey: "{#MyAppName}worlddata";                    ValueData: "Archipelago Server Data"; Flags: uninsdeletekey;   ValueType: string;  ValueName: "";
-Root: HKCR; Subkey: "{#MyAppName}worlddata\DefaultIcon";        ValueData: "{app}\ArchipelagoLauncher.exe,0";                  ValueType: string;  ValueName: "";
+Root: HKCR; Subkey: ".apworld";                                 ValueData: "{#MyAppName}worlddata";  Flags: uninsdeletevalue; ValueType: string;  ValueName: "";
+Root: HKCR; Subkey: "{#MyAppName}worlddata";                    ValueData: "Archipelago World Data"; Flags: uninsdeletekey;   ValueType: string;  ValueName: "";
+Root: HKCR; Subkey: "{#MyAppName}worlddata\DefaultIcon";        ValueData: "{app}\ArchipelagoLauncher.exe,0";                 ValueType: string;  ValueName: "";
 Root: HKCR; Subkey: "{#MyAppName}worlddata\shell\open\command"; ValueData: """{app}\ArchipelagoLauncher.exe"" ""%1""";
 
 Root: HKCR; Subkey: "archipelago"; ValueType: "string"; ValueData: "Archipegalo Protocol"; Flags: uninsdeletekey;

--- a/inno_setup.iss
+++ b/inno_setup.iss
@@ -209,6 +209,11 @@ Root: HKCR; Subkey: "{#MyAppName}multidata";                     ValueData: "Arc
 Root: HKCR; Subkey: "{#MyAppName}multidata\DefaultIcon";         ValueData: "{app}\ArchipelagoServer.exe,0";                         ValueType: string;  ValueName: "";
 Root: HKCR; Subkey: "{#MyAppName}multidata\shell\open\command";  ValueData: """{app}\ArchipelagoServer.exe"" ""%1""";                ValueType: string;  ValueName: "";
 
+Root: HKCR; Subkey: ".apworld";                                 ValueData: "{#MyAppName}worlddata";   Flags: uninsdeletevalue; ValueType: string;  ValueName: "";
+Root: HKCR; Subkey: "{#MyAppName}worlddata";                    ValueData: "Archipelago Server Data"; Flags: uninsdeletekey;   ValueType: string;  ValueName: "";
+Root: HKCR; Subkey: "{#MyAppName}worlddata\DefaultIcon";        ValueData: "{app}\ArchipelagoLauncher.exe,0";                  ValueType: string;  ValueName: "";
+Root: HKCR; Subkey: "{#MyAppName}worlddata\shell\open\command"; ValueData: """{app}\ArchipelagoLauncher.exe"" ""%1""";
+
 Root: HKCR; Subkey: "archipelago"; ValueType: "string"; ValueData: "Archipegalo Protocol"; Flags: uninsdeletekey;
 Root: HKCR; Subkey: "archipelago"; ValueType: "string"; ValueName: "URL Protocol"; ValueData: "";
 Root: HKCR; Subkey: "archipelago\DefaultIcon"; ValueType: "string"; ValueData: "{app}\ArchipelagoTextClient.exe,0";

--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -96,7 +96,6 @@ def _install_apworld(apworld_path: str = ""):
 
     try:
         import zipfile
-        print(pathlib.Path(apworld_path.name).stem + "/__init__.py")
         zipfile.ZipFile(apworld_path).open(pathlib.Path(apworld_path.name).stem + "/__init__.py")
     except ValueError as e:
         raise Exception("Archive appears invalid or damaged.") from e

--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -117,7 +117,7 @@ def _install_apworld(apworld_path: str = ""):
     return apworld_path, target
 
 
-def install_apworld(apworld_path: str = ""):
+def install_apworld(apworld_path: str = "") -> None:
     try:
         source, target = _install_apworld(apworld_path)
     except Exception as e:

--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -122,7 +122,7 @@ def install_apworld(apworld_path: str = ""):
         source, target = _install_apworld(apworld_path)
     except Exception as e:
         import Utils
-        Utils.messagebox(e.__class__.__name__, str(e))
+        Utils.messagebox(e.__class__.__name__, str(e), error=True)
         logging.exception(e)
     else:
         import Utils

--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -2,7 +2,7 @@ import logging
 import pathlib
 import weakref
 from enum import Enum, auto
-from typing import Optional, Callable, List, Iterable
+from typing import Optional, Callable, List, Iterable, Tuple
 
 from Utils import local_path, open_filename
 
@@ -82,7 +82,7 @@ def launch_textclient():
     launch_subprocess(CommonClient.run_as_textclient, name="TextClient")
 
 
-def _install_apworld(apworld_path: str = ""):
+def _install_apworld(apworld_path: str = "") -> Tuple[pathlib.Path, pathlib.Path]:
     if not apworld_path:
         apworld_path = open_filename('Select APWorld file to install', (('APWorld', ('.apworld',)),))
         if not apworld_path:

--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -1,8 +1,10 @@
+import logging
+import pathlib
 import weakref
 from enum import Enum, auto
 from typing import Optional, Callable, List, Iterable
 
-from Utils import local_path
+from Utils import local_path, open_filename
 
 
 class Type(Enum):
@@ -49,7 +51,9 @@ class Component:
     def __repr__(self):
         return f"{self.__class__.__name__}({self.display_name})"
 
+
 processes = weakref.WeakSet()
+
 
 def launch_subprocess(func: Callable, name: str = None):
     global processes
@@ -57,6 +61,7 @@ def launch_subprocess(func: Callable, name: str = None):
     process = multiprocessing.Process(target=func, name=name)
     process.start()
     processes.add(process)
+
 
 class SuffixIdentifier:
     suffixes: Iterable[str]
@@ -77,6 +82,55 @@ def launch_textclient():
     launch_subprocess(CommonClient.run_as_textclient, name="TextClient")
 
 
+def _install_apworld(apworld_path: str = ""):
+    if not apworld_path:
+        apworld_path = open_filename('Select APWorld file to install', (('APWorld', ('.apworld',)),))
+        if not apworld_path:
+            # user closed menu
+            return
+
+    if not apworld_path.endswith(".apworld"):
+        raise Exception(f"Wrong file format, looking for .apworld. File identified: {apworld_path}")
+
+    apworld_path = pathlib.Path(apworld_path)
+
+    try:
+        import zipfile
+        print(pathlib.Path(apworld_path.name).stem + "/__init__.py")
+        zipfile.ZipFile(apworld_path).open(pathlib.Path(apworld_path.name).stem + "/__init__.py")
+    except ValueError as e:
+        raise Exception("Archive appears invalid or damaged.") from e
+    except KeyError as e:
+        raise Exception("Archive appears to not be an apworld. (missing __init__.py)") from e
+
+    import worlds
+    for world_source in worlds.world_sources:
+        if apworld_path.samefile(world_source.resolved_path):
+            raise Exception(f"APWorld is already installed at {world_source.resolved_path}.")
+
+    # TODO: run generic test suite over the apworld.
+    # TODO: have some kind of version system to tell from metadata if the apworld should be compatible.
+
+    target = pathlib.Path(worlds.user_folder) / apworld_path.name
+    import shutil
+    shutil.copyfile(apworld_path, target)
+
+    return apworld_path, target
+
+
+def install_apworld(apworld_path: str = ""):
+    try:
+        source, target = _install_apworld(apworld_path)
+    except Exception as e:
+        import Utils
+        Utils.messagebox(e.__class__.__name__, str(e))
+        logging.exception(e)
+    else:
+        import Utils
+        logging.info(f"Installed APWorld successfully, copied {source} to {target}.")
+        Utils.messagebox("Install complete.", f"Installed APWorld from {source}.")
+
+
 components: List[Component] = [
     # Launcher
     Component('Launcher', 'Launcher', component_type=Type.HIDDEN),
@@ -84,6 +138,7 @@ components: List[Component] = [
     Component('Host', 'MultiServer', 'ArchipelagoServer', cli=True,
               file_identifier=SuffixIdentifier('.archipelago', '.zip')),
     Component('Generate', 'Generate', cli=True),
+    Component("Install APWorld", func=install_apworld, file_identifier=SuffixIdentifier(".apworld")),
     Component('Text Client', 'CommonClient', 'ArchipelagoTextClient', func=launch_textclient),
     Component('Links Awakening DX Client', 'LinksAwakeningClient',
               file_identifier=SuffixIdentifier('.apladx')),

--- a/worlds/__init__.py
+++ b/worlds/__init__.py
@@ -11,7 +11,10 @@ from Utils import local_path, user_path
 
 local_folder = os.path.dirname(__file__)
 user_folder = user_path("worlds") if user_path() != local_path() else user_path("custom_worlds")
-os.makedirs(user_folder, exist_ok=True)
+try:
+    os.makedirs(user_folder, exist_ok=True)
+except OSError:  # can't access/write?
+    user_folder = None
 
 __all__ = {
     "network_data_package",

--- a/worlds/__init__.py
+++ b/worlds/__init__.py
@@ -10,7 +10,8 @@ from typing import Dict, List, TypedDict, Optional
 from Utils import local_path, user_path
 
 local_folder = os.path.dirname(__file__)
-user_folder = user_path("worlds") if user_path() != local_path() else None
+user_folder = user_path("worlds") if user_path() != local_path() else user_path("custom_worlds")
+os.makedirs(user_folder, exist_ok=True)
 
 __all__ = {
     "network_data_package",


### PR DESCRIPTION
## What is this fixing or adding?
Running Launcher with an APWorld will now install that APWorld. On Windows this can be triggered by double click an .apworld file.

## How was this tested?
On Win10.

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/3189725/1faa5bf1-bf53-4ade-ae22-f8cb5c18b102)
![image](https://github.com/ArchipelagoMW/Archipelago/assets/3189725/247a3bf9-c3fa-4260-8003-4942a6f34da7)

Before:
![image](https://github.com/ArchipelagoMW/Archipelago/assets/3189725/42f7e42a-27d9-4956-b71d-4deba858e156)
After:
![image](https://github.com/ArchipelagoMW/Archipelago/assets/3189725/bb9bde66-f27a-4844-bbd9-36c6e48e6d95)
