### PR TITLE
WebHost: update dependencies

### DIFF
--- a/WebHostLib/requirements.txt
+++ b/WebHostLib/requirements.txt
@@ -1,9 +1,10 @@
-flask>=3.0.0
+flask>=3.0.3
+werkzeug>=3.0.3
 pony>=0.7.17
-waitress>=2.1.2
-Flask-Caching>=2.1.0
-Flask-Compress>=1.14
-Flask-Limiter>=3.5.0
+waitress>=3.0.0
+Flask-Caching>=2.3.0
+Flask-Compress>=1.15
+Flask-Limiter>=3.7.0
 bokeh>=3.1.1; python_version <= '3.8'
-bokeh>=3.3.2; python_version >= '3.9'
-markupsafe>=2.1.3
+bokeh>=3.4.1; python_version >= '3.9'
+markupsafe>=2.1.5


### PR DESCRIPTION
flask - should only be bug fixes - [all commits](https://github.com/pallets/flask/compare/3.0.0...3.0.3)
werkzeug - flask dependency, adding to the list to force a security update (that shouldn't really matter for us)
waitress - [release notes](https://github.com/Pylons/waitress/releases/tag/v3.0.0) look somewhat safe - [all commits](https://github.com/Pylons/waitress/compare/v2.1.2...v3.0.0)
flask-caching - looks safe - [changelog](https://github.com/pallets-eco/flask-caching/blob/master/CHANGES.rst)
flask-compress - adds zstd, should be fast (we may have to bench and tweak options), but uses more memory than zlib - [all commits](https://github.com/colour-science/flask-compress/compare/v1.14...v1.15)
flask-limiter - only bugfixes - [changelog](https://github.com/alisaifee/flask-limiter/blob/master/HISTORY.rst)
bokeh - [release notes](https://docs.bokeh.org/en/latest/docs/releases.html) look good, but will need testing - [all commits](https://github.com/bokeh/bokeh/compare/3.3.2...3.4.1)
markupsafe - only performance and bugfixes - [changelog](https://markupsafe.palletsprojects.com/en/2.1.x/changes/#version-2-1-5)
