### PR TITLE
Core: gitignore custom_worlds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ Output Logs/
 /installdelete.iss
 /data/user.kv
 /datapackage
+/custom_worlds
 
 # Byte-compiled / optimized / DLL files
 __pycache__/


### PR DESCRIPTION
## What is this fixing or adding?

https://github.com/ArchipelagoMW/Archipelago/pull/3472 made a new `custom_worlds` directory and didn't gitignore it

## How was this tested?

git status