### PR TITLE
TUNIC: Remove rule for west Quarry bomb wall

### DIFF
--- a/worlds/tunic/er_rules.py
+++ b/worlds/tunic/er_rules.py
@@ -1462,8 +1462,6 @@ def set_er_location_rules(world: "TunicWorld", ability_unlocks: Dict[str, int]) 
     # Quarry
     set_rule(multiworld.get_location("Quarry - [Central] Above Ladder Dash Chest", player),
              lambda state: state.has(laurels, player))
-    set_rule(multiworld.get_location("Quarry - [West] Upper Area Bombable Wall", player),
-             lambda state: has_mask(state, player, options))
 
     # Ziggurat
     set_rule(multiworld.get_location("Rooted Ziggurat Upper - Near Bridge Switch", player),

--- a/worlds/tunic/rules.py
+++ b/worlds/tunic/rules.py
@@ -304,8 +304,6 @@ def set_location_rules(world: "TunicWorld", ability_unlocks: Dict[str, int]) -> 
     # Quarry
     set_rule(multiworld.get_location("Quarry - [Central] Above Ladder Dash Chest", player),
              lambda state: state.has(laurels, player))
-    set_rule(multiworld.get_location("Quarry - [West] Upper Area Bombable Wall", player),
-             lambda state: has_mask(state, player, options))
     # nmg - kill boss scav with orb + firecracker, or similar
     set_rule(multiworld.get_location("Rooted Ziggurat Lower - Hexagon Blue", player),
              lambda state: has_sword(state, player) or (state.has(grapple, player) and options.logic_rules))


### PR DESCRIPTION
## What is this fixing or adding?
Neither of us really remember why we put this rule in the first place, and think the other person convinced them to do it. So we're removing it, since it's really unnecessary.

## How was this tested?
It wasn't -- we are removing a rule, testing seems very unnecessary here.

## If this makes graphical changes, please attach screenshots.
N/A