### PR TITLE
Generate: improve logging capture

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -72,7 +72,8 @@ def main(args=None):
         options = get_settings()
 
     seed = get_seed(args.seed)
-    if "worlds" in sys.modules:
+    # __name__ == "__main__" check so unittests that already imported worlds don't trip this.
+    if __name__ == "__main__" and "worlds" in sys.modules:
         raise Exception("Worlds system should not be loaded before logging init.")
     Utils.init_logging(f"Generate_{seed}", loglevel=args.log_level)
     random.seed(seed)

--- a/Generate.py
+++ b/Generate.py
@@ -25,7 +25,8 @@ from Utils import parse_yamls, version_tuple, __version__, tuplize_version
 
 def mystery_argparse():
     from settings import get_settings
-    defaults = get_settings().generator
+    settings = get_settings()
+    defaults = settings.generator
 
     parser = argparse.ArgumentParser(description="CMD Generation Interface, defaults come from host.yaml.")
     parser.add_argument('--weights_file_path', default=defaults.weights_file_path,
@@ -37,7 +38,7 @@ def mystery_argparse():
     parser.add_argument('--seed', help='Define seed number to generate.', type=int)
     parser.add_argument('--multi', default=defaults.players, type=lambda value: max(int(value), 1))
     parser.add_argument('--spoiler', type=int, default=defaults.spoiler)
-    parser.add_argument('--outputpath', default=options.general_options.output_path,
+    parser.add_argument('--outputpath', default=settings.general_options.output_path,
                         help="Path to output folder. Absolute or relative to cwd.")  # absolute or relative to cwd
     parser.add_argument('--race', action='store_true', default=defaults.race)
     parser.add_argument('--meta_file_path', default=defaults.meta_file_path)

--- a/Generate.py
+++ b/Generate.py
@@ -20,13 +20,12 @@ ModuleUpdate.update()
 import Utils
 import Options
 from BaseClasses import seeddigits, get_seed, PlandoOptions
-from settings import get_settings
 from Utils import parse_yamls, version_tuple, __version__, tuplize_version
 
 
 def mystery_argparse():
-    options = get_settings()
-    defaults = options.generator
+    from settings import get_settings
+    defaults = get_settings().generator
 
     parser = argparse.ArgumentParser(description="CMD Generation Interface, defaults come from host.yaml.")
     parser.add_argument('--weights_file_path', default=defaults.weights_file_path,
@@ -58,7 +57,7 @@ def mystery_argparse():
     if not os.path.isabs(args.meta_file_path):
         args.meta_file_path = os.path.join(args.player_files_path, args.meta_file_path)
     args.plando: PlandoOptions = PlandoOptions.from_option_string(args.plando)
-    return args, options
+    return args
 
 
 def get_seed_name(random_source) -> str:
@@ -67,9 +66,7 @@ def get_seed_name(random_source) -> str:
 
 def main(args=None):
     if not args:
-        args, options = mystery_argparse()
-    else:
-        options = get_settings()
+        args = mystery_argparse()
 
     seed = get_seed(args.seed)
     # __name__ == "__main__" check so unittests that already imported worlds don't trip this.

--- a/Utils.py
+++ b/Utils.py
@@ -553,6 +553,7 @@ def init_logging(name: str, loglevel: typing.Union[str, int] = logging.INFO, wri
         f"Archipelago ({__version__}) logging initialized"
         f" on {platform.platform()}"
         f" running Python {sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+        f"{' (frozen)' if is_frozen() else ''}"
     )
 
 


### PR DESCRIPTION
## What is this fixing or adding?
inpsired by https://discord.com/channels/731205301247803413/731214249828941884/1248629204845596682, this ensures worlds are loaded after logging is initialized, so that load errors appear in the log. It also appends " (frozen)" to Python if we're operating in a frozen environment.

## How was this tested?
(Observe the option system spam being inside the log now.)
```
Archipelago (0.5.0) logging initialized on Windows-10-10.0.19045-SP0 running Python 3.11.5
P1 Weights: A Link to the Past.yaml >> Default A Link to the Past Template
P2 Weights: The_Witness.yaml >> Default The Witness Template
Generating for 2 players, 75984463335213314275 Seed 98538513751088280759 with plando: items, texts, bosses
AdventureWorld Assigned options through option_definitions which is now deprecated. Please use options_dataclass instead.
ALTTPWorld Assigned options through option_definitions which is now deprecated. Please use options_dataclass instead.
BlasphemousWorld Assigned options through option_definitions which is now deprecated. Please use options_dataclass instead.
ChecksFinderWorld Assigned options through option_definitions which is now deprecated. Please use options_dataclass instead.
CliqueWorld Assigned options through option_definitions which is now deprecated. Please use options_dataclass instead.
DarkSouls3World Assigned options through option_definitions which is now deprecated. Please use options_dataclass instead.
Factorio Assigned options through option_definitions which is now deprecated. Please use options_dataclass instead.
FFMQWorld Assigned options through option_definitions which is now deprecated. Please use options_dataclass instead.
HKWorld Assigned options through option_definitions which is now deprecated. Please use options_dataclass instead.
LinksAwakeningWorld Assigned options through option_definitions which is now deprecated. Please use options_dataclass instead.
MinecraftWorld Assigned options through option_definitions which is now deprecated. Please use options_dataclass instead.
OOTWorld Assigned options through option_definitions which is now deprecated. Please use options_dataclass instead.
PokemonRedBlueWorld Assigned options through option_definitions which is now deprecated. Please use options_dataclass instead.
RaftWorld Assigned options through option_definitions which is now deprecated. Please use options_dataclass instead.
RLWorld Assigned options through option_definitions which is now deprecated. Please use options_dataclass instead.
SMWorld Assigned options through option_definitions which is now deprecated. Please use options_dataclass instead.
SMZ3World Assigned options through option_definitions which is now deprecated. Please use options_dataclass instead.
SpireWorld Assigned options through option_definitions which is now deprecated. Please use options_dataclass instead.
TimespinnerWorld Assigned options through option_definitions which is now deprecated. Please use options_dataclass instead.
UndertaleWorld Assigned options through option_definitions which is now deprecated. Please use options_dataclass instead.
[...]
```
