### PR TITLE
Docs: Update Trap classification comment

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1099,7 +1099,7 @@ class ItemClassification(IntFlag):
     filler = 0b0000  # aka trash, as in filler items like ammo, currency etc,
     progression = 0b0001  # Item that is logically relevant
     useful = 0b0010  # Item that is generally quite useful, but not required for anything logical
-    trap = 0b0100  # detrimental or entirely useless (nothing) item
+    trap = 0b0100  # detrimental item
     skip_balancing = 0b1000  # should technically never occur on its own
     # Item that is logically relevant, but progression balancing should not touch.
     # Typically currency or other counted items.


### PR DESCRIPTION
## What is this fixing or adding?

It no longer says Nothing items should be traps.

## How was this tested?

Reading