### PR TITLE
Core: Add auto updating support to launcher

### DIFF
--- a/Launcher.py
+++ b/Launcher.py
@@ -385,14 +385,14 @@ def check_for_update() -> None:
                 exe = which('sensible-editor') or which('gedit') or \
                       which('xdg-open') or which('gnome-open') or which('kde-open')
                 subprocess.Popen([exe, os.getcwd()])
-                
+
             messagebox("Update Downloaded Successfully", f"{asset} has been downloaded successfully!")
 
         download_selection(to_download)
 
     ButtonsPrompt(
         "Update Available",
-        f"Update available: {version.as_simple_string()}. "
+        f"Update available: {version.as_simple_string()}.\n"
         f"Currently installed: {Utils.version_tuple.as_simple_string()}.\n"
         f"Would you like to update?",
         handle_user_update,

--- a/Launcher.py
+++ b/Launcher.py
@@ -13,6 +13,7 @@ import argparse
 import itertools
 import logging
 import multiprocessing
+import platform
 import shlex
 import subprocess
 import sys
@@ -325,49 +326,74 @@ def main(args: Optional[Union[argparse.Namespace, dict]] = None):
 
 def check_for_update() -> None:
     """Checks if an update is available, and prompts the user if they'd like to update."""
+    # no mac release and dropping windows 7
+    if is_macos or (is_windows and platform.release() == "NT"):
+        return
     update, version = Utils.available_update()
     logging.info(f"Update available: {update}. New version: {version.as_simple_string()}")
-    if update:
-        from kvui import ButtonsPrompt
+    if not update:
+        return
+    if settings.get_settings().general_options.skip_update == version.as_simple_string():
+        return
 
-        def handle_user_update(answer: str) -> None:
-            if answer == "Yes":
-                # download and install the latest Archipelago release
-                release_url = "https://api.github.com/repos/ArchipelagoMW/Archipelago/releases"
-                latest_release = Utils.request_remote_json_data(release_url)[0]["assets"]
-                latest_files: Dict[str, Any] = {
-                    asset["name"]: asset["browser_download_url"] for asset in latest_release
-                }
-            
-                def download_selection(asset: str) -> None:
-                    import os
-                    nonlocal latest_files
+    from kvui import ButtonsPrompt
 
-                    download_url = latest_files[asset]
-                    response = urllib.request.urlopen(download_url)
-                    content = response.read()
-                    response.close()
-                    if os.path.exists(asset):
-                        os.remove(asset)
-                    with open(asset, "wb") as f:
-                        f.write(content)
-                    launch([asset], True)
+    def handle_user_update(answer: str) -> None:
+        if answer == "No":
+            return
+        elif answer == "Skip Version":
+            settings.get_settings().general_options.skip_update = version.as_simple_string()
+            update_settings()
+            return
+        # download and install the latest Archipelago release
+        release_url = "https://api.github.com/repos/ArchipelagoMW/Archipelago/releases"
+        latest_release = Utils.request_remote_json_data(release_url)[0]["assets"]
+        latest_files: Dict[str, Any] = {
+            asset["name"]: asset["browser_download_url"] for asset in latest_release
+        }
+        linux_names = []
+        windows_name = None
+        for name in latest_files:
+            if name.endswith(".AppImage") or name.endswith(".tar.gz"):
+                linux_names.append(name)
+            elif name.endswith(".exe") and windows_name is None:
+                windows_name = name
+    
+        def download_selection(asset: str) -> None:
+            import os
+            nonlocal latest_files
 
-                ButtonsPrompt(
-                    "Select File",
-                    "Select file to download and install.",
-                    download_selection,
-                    *latest_files
-                ).open()
+            download_url = latest_files[asset]
+            response = urllib.request.urlopen(download_url)
+            content = response.read()
+            response.close()
+            if os.path.exists(asset):
+                os.remove(asset)
+            with open(asset, "wb") as f:
+                f.write(content)
+            if is_windows:
+                launch([asset], True)
+            messagebox("Update Downloaded Successfully", f"{asset} has been downloaded successfully!")
+
+        if is_windows:
+            download_selection(windows_name)
+            return
 
         ButtonsPrompt(
-            "Update Available",
-            f"Update available: {version.as_simple_string()}. "
-            f"Currently installed: {Utils.version_tuple.as_simple_string()}.\n"
-            f"Would you like to update?",
-            handle_user_update,
-            "Yes", "No"
+            "Select File",
+            "Select file to download and install.",
+            download_selection,
+            *linux_names
         ).open()
+
+    ButtonsPrompt(
+        "Update Available",
+        f"Update available: {version.as_simple_string()}. "
+        f"Currently installed: {Utils.version_tuple.as_simple_string()}.\n"
+        f"Would you like to update?",
+        handle_user_update,
+        "Yes", "No", "Skip Version"
+    ).open()
 
 
 if __name__ == '__main__':

--- a/Utils.py
+++ b/Utils.py
@@ -49,7 +49,7 @@ class Version(typing.NamedTuple):
         return ".".join(str(item) for item in self)
 
 
-__version__ = "0.4.5"
+__version__ = "0.5.0"
 version_tuple = tuplize_version(__version__)
 
 is_linux = sys.platform.startswith("linux")

--- a/settings.py
+++ b/settings.py
@@ -508,7 +508,12 @@ class GeneralOptions(Group):
     class AutoUpdate(Bool):
         """Whether the launcher should check for an available update on startup."""
 
+    class SkipUpdate(str):
+        """Version to skip auto updating to as simple string."""
+
     output_path: OutputPath = OutputPath("output")
+    auto_update: Union[AutoUpdate, bool] = True
+    skip_update: SkipUpdate = SkipUpdate("")
 
 
 class ServerOptions(Group):

--- a/settings.py
+++ b/settings.py
@@ -505,6 +505,9 @@ class GeneralOptions(Group):
         """
         # created on demand, so marked as optional
 
+    class AutoUpdate(Bool):
+        """Whether the launcher should check for an available update on startup."""
+
     output_path: OutputPath = OutputPath("output")
 
 


### PR DESCRIPTION
## What is this fixing or adding?
Has the launcher check for available updates on startup and prompts the user if one is available. explicitly disallows the check for windows 7 since we don't support updating those systems after 0.5.0. On windows it will download and start the installer, on linux it will download the file relevant to the users' currently running method and open a file browser to let the user decide what to do with it.
requires #3470 

## How was this tested?
On windows both source and frozen, confirmed it downloaded and started the installer correctly.

## If this makes graphical changes, please attach screenshots.
![Screenshot_254](https://github.com/ArchipelagoMW/Archipelago/assets/13184667/40d3f251-4dbc-41ba-9d13-0f3478ac1a0e)
