### PR TITLE
Core: load frozen decompressed worlds

### DIFF
--- a/worlds/__init__.py
+++ b/worlds/__init__.py
@@ -107,8 +107,9 @@ for folder in (folder for folder in (user_folder, local_folder) if folder):
         if not entry.name.startswith(("_", ".")):
             file_name = entry.name if relative else os.path.join(folder, entry.name)
             if entry.is_dir():
-                init_file_path = os.path.join(entry.path, '__init__.py')
-                if os.path.isfile(init_file_path):
+                if os.path.isfile(os.path.join(entry.path, '__init__.py')):
+                    world_sources.append(WorldSource(file_name, relative=relative))
+                elif os.path.isfile(os.path.join(entry.path, '__init__.pyc')):
                     world_sources.append(WorldSource(file_name, relative=relative))
                 else:
                     logging.warning(f"excluding {entry.name} from world sources because it has no __init__.py")


### PR DESCRIPTION
## What is this fixing or adding?
loads frozen decompiled worlds again, like non-apworld supported worlds

## How was this tested?
With cx freeze 7.0.0 on python 3.11 on windows
Also needs https://github.com/ArchipelagoMW/Archipelago/pull/3224/ for full fix.