### PR TITLE
sc2: Fixed sc2 client's /received command breaking after PR 1933 merged

### DIFF
--- a/worlds/sc2/Client.py
+++ b/worlds/sc2/Client.py
@@ -107,10 +107,10 @@ class ColouredMessage:
     def coloured(self, text: str, colour: str) -> 'ColouredMessage':
         add_json_text(self.parts, text, type="color", color=colour)
         return self
-    def location(self, location_id: int, player_id: int = 0) -> 'ColouredMessage':
+    def location(self, location_id: int, player_id: int) -> 'ColouredMessage':
         add_json_location(self.parts, location_id, player_id)
         return self
-    def item(self, item_id: int, player_id: int = 0, flags: int = 0) -> 'ColouredMessage':
+    def item(self, item_id: int, player_id: int, flags: int = 0) -> 'ColouredMessage':
         add_json_item(self.parts, item_id, player_id, flags)
         return self
     def player(self, player_id: int) -> 'ColouredMessage':
@@ -256,7 +256,7 @@ class StarcraftClientProcessor(ClientCommandProcessor):
                     for item in received_items_of_this_type:
                         print_faction_title()
                         has_printed_faction_title = True
-                        (ColouredMessage('* ').item(item.item, flags=item.flags)
+                        (ColouredMessage('* ').item(item.item, self.ctx.slot, flags=item.flags)
                             (" from ").location(item.location, self.ctx.slot)
                             (" by ").player(item.player)
                         ).send(self.ctx)
@@ -277,7 +277,7 @@ class StarcraftClientProcessor(ClientCommandProcessor):
                         received_items_of_this_type = items_received.get(child_item, [])
                         for item in received_items_of_this_type:
                             filter_match_count += len(received_items_of_this_type)
-                            (ColouredMessage('  * ').item(item.item, flags=item.flags)
+                            (ColouredMessage('  * ').item(item.item, self.ctx.slot, flags=item.flags)
                                 (" from ").location(item.location, self.ctx.slot)
                                 (" by ").player(item.player)
                             ).send(self.ctx)


### PR DESCRIPTION
## What is this fixing or adding?
After PR #1933 merged, it seems to have broken the custom `/received` command in the Starcraft 2 client. The root of the issue was that the item printout just used the default player ID of 0, but that's not considered an actual player by the decoder and it needs that information to translate a local item ID to an actual item name.

## How was this tested?
Ran `/received` from the starcraft 2 client with a start inventory and a few items collected from doing a mission. It now prints correctly and no longer returns a stack trace. Didn't test this with items that were collected by slots playing a different game, not sure if that's a potential issue.

## If this makes graphical changes, please attach screenshots.
None