### PR TITLE
MLSS: Fix for Xp scaling when set to 0

### DIFF
--- a/worlds/mlss/Rom.py
+++ b/worlds/mlss/Rom.py
@@ -306,8 +306,7 @@ def write_tokens(world: "MLSSWorld", patch: MLSSProcedurePatch) -> None:
     if world.options.scale_stats:
         patch.write_token(APTokenTypes.WRITE, 0xD00002, bytes([0x1]))
 
-    if world.options.xp_multiplier:
-        patch.write_token(APTokenTypes.WRITE, 0xD00003, bytes([world.options.xp_multiplier.value]))
+    patch.write_token(APTokenTypes.WRITE, 0xD00003, bytes([world.options.xp_multiplier.value]))
 
     if world.options.tattle_hp:
         patch.write_token(APTokenTypes.WRITE, 0xD00000, bytes([0x1]))


### PR DESCRIPTION
## What is this fixing or adding?
Removes an unnecessary if statement that would equate to false if Xp scaling was set to the minimum range of 0.

## How was this tested?
Generated a game with yaml option set to 0 for xp scaling and successfully patched a game.