### PR TITLE
SC2: don't close all SC2 instances when one quits

### DIFF
--- a/worlds/_sc2common/bot/sc2process.py
+++ b/worlds/_sc2common/bot/sc2process.py
@@ -29,6 +29,11 @@ class kill_switch:
         cls._to_kill.append(value)
 
     @classmethod
+    def kill(cls, value):
+        logger.info(f"kill_switch: Process cleanup for 1 process")
+        value._clean(verbose=False)
+
+    @classmethod
     def kill_all(cls):
         logger.info(f"kill_switch: Process cleanup for {len(cls._to_kill)} processes")
         for p in cls._to_kill:
@@ -116,7 +121,7 @@ class SC2Process:
     async def __aexit__(self, *args):
         logger.exception("async exit")
         await self._close_connection()
-        kill_switch.kill_all()
+        kill_switch.kill(self)
         signal.signal(signal.SIGINT, signal.SIG_DFL)
 
     @property


### PR DESCRIPTION
## What is this fixing or adding?
Currently, when any SC2 instance quits, all of them get terminated. Every now and then  I want to run two missions at the same time, but that means timing them correctly to not have it close on me. This removes that frustration.

I kept to the "style" of the surrounding code. Though in my opinion this is in dire need of a cleanup, but that's beyond the scope of this PR.

## How was this tested?
By starting two missions, then closing one, then the other still worked.
