### PR TITLE
Allow worlds to add options to prebuilt groups

### DIFF
--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -123,8 +123,8 @@ class WebWorldRegister(type):
             assert group.options, "A custom defined Option Group must contain at least one Option."
             # catch incorrectly titled versions of the prebuilt groups so they don't create extra groups
             title_name = group.name.title()
-            if title_name in prebuilt_options:
-                group.name = title_name
+            assert title_name not in prebuilt_options or title_name == group.name, \
+                f"Prebuilt group name \"{group.name}\" must be \"{title_name}\""
 
             if group.name == "Item & Location Options":
                 assert not any(option in item_and_loc_options for option in group.options), \


### PR DESCRIPTION
## What is this fixing or adding?

Previously, this crashed because `typing.NamedTuple` fields such as
`group.name` aren't assignable. Now it will only fail for group names
that are actually incorrectly cased, and will fail with a better error
message.

## How was this tested?

I updated the DS3 beta to add options to a prebuilt group.