### PR TITLE
Various worlds: Fix more absolute world imports

### DIFF
--- a/worlds/adventure/Rules.py
+++ b/worlds/adventure/Rules.py
@@ -1,7 +1,5 @@
-from worlds.adventure import location_table
-from worlds.adventure.Options import BatLogic, DifficultySwitchB, DifficultySwitchA
+from .Options import BatLogic, DifficultySwitchB
 from worlds.generic.Rules import add_rule, set_rule, forbid_item
-from BaseClasses import LocationProgressType
 
 
 def set_rules(self) -> None:

--- a/worlds/alttp/Client.py
+++ b/worlds/alttp/Client.py
@@ -682,7 +682,7 @@ def get_alttp_settings(romfile: str):
 
         if 'yes' in choice:
             import LttPAdjuster
-            from worlds.alttp.Rom import get_base_rom_path
+            from .Rom import get_base_rom_path
             last_settings.rom = romfile
             last_settings.baserom = get_base_rom_path()
             last_settings.world = None

--- a/worlds/alttp/EntranceShuffle.py
+++ b/worlds/alttp/EntranceShuffle.py
@@ -1437,7 +1437,7 @@ def connect_mandatory_exits(world, entrances, caves, must_be_exits, player):
     invalid_cave_connections = defaultdict(set)
 
     if world.glitches_required[player] in ['overworld_glitches', 'hybrid_major_glitches', 'no_logic']:
-        from worlds.alttp import OverworldGlitchRules
+        from . import OverworldGlitchRules
         for entrance in OverworldGlitchRules.get_non_mandatory_exits(world.mode[player] == 'inverted'):
             invalid_connections[entrance] = set()
             if entrance in must_be_exits:

--- a/worlds/alttp/Options.py
+++ b/worlds/alttp/Options.py
@@ -486,7 +486,7 @@ class LTTPBosses(PlandoBosses):
 
     @classmethod
     def can_place_boss(cls, boss: str, location: str) -> bool:
-        from worlds.alttp.Bosses import can_place_boss
+        from .Bosses import can_place_boss
         level = ''
         words = location.split(" ")
         if words[-1] in ("top", "middle", "bottom"):

--- a/worlds/alttp/Regions.py
+++ b/worlds/alttp/Regions.py
@@ -406,7 +406,7 @@ def create_dungeon_region(world: MultiWorld, player: int, name: str, hint: str, 
 
 def _create_region(world: MultiWorld, player: int, name: str, type: LTTPRegionType, hint: str, locations=None,
                    exits=None):
-    from worlds.alttp.SubClasses import ALttPLocation
+    from .SubClasses import ALttPLocation
     ret = LTTPRegion(name, type, hint, player, world)
     if exits:
         for exit in exits:
@@ -760,7 +760,7 @@ location_table: typing.Dict[str,
      'Turtle Rock - Prize': (
          [0x120A7, 0x53F24, 0x53F25, 0x18005C, 0x180079, 0xC708], None, True, 'Turtle Rock')}
 
-from worlds.alttp.Shops import shop_table_by_location_id, shop_table_by_location
+from .Shops import shop_table_by_location_id, shop_table_by_location
 lookup_id_to_name = {data[0]: name for name, data in location_table.items() if type(data[0]) == int}
 lookup_id_to_name = {**lookup_id_to_name, **{data[1]: name for name, data in key_drop_data.items()}}
 lookup_id_to_name.update(shop_table_by_location_id)

--- a/worlds/aquaria/test/test_beast_form_access.py
+++ b/worlds/aquaria/test/test_beast_form_access.py
@@ -4,7 +4,7 @@ Date: Thu, 18 Apr 2024 18:45:56 +0000
 Description: Unit test used to test accessibility of locations with and without the beast form
 """
 
-from worlds.aquaria.test import AquariaTestBase
+from . import AquariaTestBase
 
 
 class BeastFormAccessTest(AquariaTestBase):

--- a/worlds/aquaria/test/test_bind_song_access.py
+++ b/worlds/aquaria/test/test_bind_song_access.py
@@ -5,7 +5,7 @@ Description: Unit test used to test accessibility of locations with and without 
              under rock needing bind song option)
 """
 
-from worlds.aquaria.test import AquariaTestBase, after_home_water_locations
+from . import AquariaTestBase, after_home_water_locations
 
 
 class BindSongAccessTest(AquariaTestBase):

--- a/worlds/aquaria/test/test_bind_song_option_access.py
+++ b/worlds/aquaria/test/test_bind_song_option_access.py
@@ -5,8 +5,8 @@ Description: Unit test used to test accessibility of locations with and without 
              under rock needing bind song option)
 """
 
-from worlds.aquaria.test import AquariaTestBase
-from worlds.aquaria.test.test_bind_song_access import after_home_water_locations
+from . import AquariaTestBase
+from .test_bind_song_access import after_home_water_locations
 
 
 class BindSongOptionAccessTest(AquariaTestBase):

--- a/worlds/aquaria/test/test_confined_home_water.py
+++ b/worlds/aquaria/test/test_confined_home_water.py
@@ -4,7 +4,7 @@ Date: Fri, 03 May 2024 14:07:35 +0000
 Description: Unit test used to test accessibility of region with the home water confine via option
 """
 
-from worlds.aquaria.test import AquariaTestBase
+from . import AquariaTestBase
 
 
 class ConfinedHomeWaterAccessTest(AquariaTestBase):

--- a/worlds/aquaria/test/test_dual_song_access.py
+++ b/worlds/aquaria/test/test_dual_song_access.py
@@ -4,7 +4,7 @@ Date: Thu, 18 Apr 2024 18:45:56 +0000
 Description: Unit test used to test accessibility of locations with and without the dual song
 """
 
-from worlds.aquaria.test import AquariaTestBase
+from . import AquariaTestBase
 
 
 class LiAccessTest(AquariaTestBase):

--- a/worlds/aquaria/test/test_energy_form_access.py
+++ b/worlds/aquaria/test/test_energy_form_access.py
@@ -5,7 +5,7 @@ Description: Unit test used to test accessibility of locations with and without 
              energy form option)
 """
 
-from worlds.aquaria.test import AquariaTestBase
+from . import AquariaTestBase
 
 
 class EnergyFormAccessTest(AquariaTestBase):

--- a/worlds/aquaria/test/test_fish_form_access.py
+++ b/worlds/aquaria/test/test_fish_form_access.py
@@ -4,7 +4,7 @@ Date: Thu, 18 Apr 2024 18:45:56 +0000
 Description: Unit test used to test accessibility of locations with and without the fish form
 """
 
-from worlds.aquaria.test import AquariaTestBase
+from . import AquariaTestBase
 
 
 class FishFormAccessTest(AquariaTestBase):

--- a/worlds/aquaria/test/test_li_song_access.py
+++ b/worlds/aquaria/test/test_li_song_access.py
@@ -4,7 +4,7 @@ Date: Thu, 18 Apr 2024 18:45:56 +0000
 Description: Unit test used to test accessibility of locations with and without Li
 """
 
-from worlds.aquaria.test import AquariaTestBase
+from . import AquariaTestBase
 
 
 class LiAccessTest(AquariaTestBase):

--- a/worlds/aquaria/test/test_light_access.py
+++ b/worlds/aquaria/test/test_light_access.py
@@ -4,7 +4,7 @@ Date: Thu, 18 Apr 2024 18:45:56 +0000
 Description: Unit test used to test accessibility of locations with and without a light (Dumbo pet or sun form)
 """
 
-from worlds.aquaria.test import AquariaTestBase
+from . import AquariaTestBase
 
 
 class LightAccessTest(AquariaTestBase):

--- a/worlds/aquaria/test/test_nature_form_access.py
+++ b/worlds/aquaria/test/test_nature_form_access.py
@@ -4,7 +4,7 @@ Date: Thu, 18 Apr 2024 18:45:56 +0000
 Description: Unit test used to test accessibility of locations with and without the nature form
 """
 
-from worlds.aquaria.test import AquariaTestBase
+from . import AquariaTestBase
 
 
 class NatureFormAccessTest(AquariaTestBase):

--- a/worlds/aquaria/test/test_no_progression_hard_hidden_locations.py
+++ b/worlds/aquaria/test/test_no_progression_hard_hidden_locations.py
@@ -4,7 +4,7 @@ Date: Fri, 03 May 2024 14:07:35 +0000
 Description: Unit test used to test that no progression items can be put in hard or hidden locations when option enabled
 """
 
-from worlds.aquaria.test import AquariaTestBase
+from . import AquariaTestBase
 from BaseClasses import ItemClassification
 
 

--- a/worlds/aquaria/test/test_progression_hard_hidden_locations.py
+++ b/worlds/aquaria/test/test_progression_hard_hidden_locations.py
@@ -4,8 +4,7 @@ Date: Fri, 03 May 2024 14:07:35 +0000
 Description: Unit test used to test that progression items can be put in hard or hidden locations when option disabled
 """
 
-from worlds.aquaria.test import AquariaTestBase
-from BaseClasses import ItemClassification
+from . import AquariaTestBase
 
 
 class UNoProgressionHardHiddenTest(AquariaTestBase):

--- a/worlds/aquaria/test/test_spirit_form_access.py
+++ b/worlds/aquaria/test/test_spirit_form_access.py
@@ -4,7 +4,7 @@ Date: Thu, 18 Apr 2024 18:45:56 +0000
 Description: Unit test used to test accessibility of locations with and without the spirit form
 """
 
-from worlds.aquaria.test import AquariaTestBase
+from . import AquariaTestBase
 
 
 class SpiritFormAccessTest(AquariaTestBase):

--- a/worlds/aquaria/test/test_sun_form_access.py
+++ b/worlds/aquaria/test/test_sun_form_access.py
@@ -4,7 +4,7 @@ Date: Thu, 18 Apr 2024 18:45:56 +0000
 Description: Unit test used to test accessibility of locations with and without the sun form
 """
 
-from worlds.aquaria.test import AquariaTestBase
+from . import AquariaTestBase
 
 
 class SunFormAccessTest(AquariaTestBase):

--- a/worlds/aquaria/test/test_unconfine_home_water_via_both.py
+++ b/worlds/aquaria/test/test_unconfine_home_water_via_both.py
@@ -5,7 +5,7 @@ Description: Unit test used to test accessibility of region with the unconfined 
              turtle and energy door
 """
 
-from worlds.aquaria.test import AquariaTestBase
+from . import AquariaTestBase
 
 
 class UnconfineHomeWaterBothAccessTest(AquariaTestBase):

--- a/worlds/aquaria/test/test_unconfine_home_water_via_energy_door.py
+++ b/worlds/aquaria/test/test_unconfine_home_water_via_energy_door.py
@@ -4,7 +4,7 @@ Date: Fri, 03 May 2024 14:07:35 +0000
 Description: Unit test used to test accessibility of region with the unconfined home water option via the energy door
 """
 
-from worlds.aquaria.test import AquariaTestBase
+from . import AquariaTestBase
 
 
 class UnconfineHomeWaterEnergyDoorAccessTest(AquariaTestBase):

--- a/worlds/aquaria/test/test_unconfine_home_water_via_transturtle.py
+++ b/worlds/aquaria/test/test_unconfine_home_water_via_transturtle.py
@@ -4,7 +4,7 @@ Date: Fri, 03 May 2024 14:07:35 +0000
 Description: Unit test used to test accessibility of region with the unconfined home water option via transturtle
 """
 
-from worlds.aquaria.test import AquariaTestBase
+from . import AquariaTestBase
 
 
 class UnconfineHomeWaterTransturtleAccessTest(AquariaTestBase):

--- a/worlds/dkc3/Client.py
+++ b/worlds/dkc3/Client.py
@@ -60,7 +60,7 @@ class DKC3SNIClient(SNIClient):
             return
 
         new_checks = []
-        from worlds.dkc3.Rom import location_rom_data, item_rom_data, boss_location_ids, level_unlock_map
+        from .Rom import location_rom_data, item_rom_data, boss_location_ids, level_unlock_map
         location_ram_data = await snes_read(ctx, WRAM_START + 0x5FE, 0x81)
         for loc_id, loc_data in location_rom_data.items():
             if loc_id not in ctx.locations_checked:

--- a/worlds/ladx/Tracker.py
+++ b/worlds/ladx/Tracker.py
@@ -1,4 +1,4 @@
-from worlds.ladx.LADXR.checkMetadata import checkMetadataTable
+from .LADXR.checkMetadata import checkMetadataTable
 import json
 import logging
 import websockets

--- a/worlds/overcooked2/test/TestOvercooked2.py
+++ b/worlds/overcooked2/test/TestOvercooked2.py
@@ -4,10 +4,11 @@ from random import Random
 from worlds.AutoWorld import AutoWorldRegister
 from test.general import setup_solo_multiworld
 
-from worlds.overcooked2.Items import *
-from worlds.overcooked2.Overcooked2Levels import Overcooked2Dlc, Overcooked2Level, OverworldRegion, overworld_region_by_level, level_id_to_shortname
-from worlds.overcooked2.Logic import level_logic, overworld_region_logic, level_shuffle_factory
-from worlds.overcooked2.Locations import oc2_location_name_to_id
+from ..Items import *
+from ..Overcooked2Levels import (Overcooked2Dlc, Overcooked2Level, OverworldRegion, overworld_region_by_level,
+                                 level_id_to_shortname)
+from ..Logic import level_logic, overworld_region_logic, level_shuffle_factory
+from ..Locations import oc2_location_name_to_id
 
 
 class Overcooked2Test(unittest.TestCase):

--- a/worlds/rogue_legacy/test/TestUnique.py
+++ b/worlds/rogue_legacy/test/TestUnique.py
@@ -1,8 +1,8 @@
 from typing import Dict
 
 from . import RLTestBase
-from worlds.rogue_legacy.Items import RLItemData, item_table
-from worlds.rogue_legacy.Locations import RLLocationData, location_table
+from ..Items import item_table
+from ..Locations import location_table
 
 
 class UniqueTest(RLTestBase):

--- a/worlds/sc2/Client.py
+++ b/worlds/sc2/Client.py
@@ -22,10 +22,9 @@ from pathlib import Path
 # CommonClient import first to trigger ModuleUpdater
 from CommonClient import CommonContext, server_loop, ClientCommandProcessor, gui_enabled, get_base_parser
 from Utils import init_logging, is_windows, async_start
-from worlds.sc2 import ItemNames
-from worlds.sc2.ItemGroups import item_name_groups, unlisted_item_name_groups
-from worlds.sc2 import Options
-from worlds.sc2.Options import (
+from . import ItemNames, Options
+from .ItemGroups import item_name_groups
+from .Options import (
     MissionOrder, KerriganPrimalStatus, kerrigan_unit_available, KerriganPresence,
     GameSpeed, GenericUpgradeItems, GenericUpgradeResearch, ColorChoice, GenericUpgradeMissions,
     LocationInclusion, ExtraLocations, MasteryLocations, ChallengeLocations, VanillaLocations,
@@ -46,11 +45,12 @@ from worlds._sc2common import bot
 from worlds._sc2common.bot.data import Race
 from worlds._sc2common.bot.main import run_game
 from worlds._sc2common.bot.player import Bot
-from worlds.sc2.Items import lookup_id_to_name, get_full_item_list, ItemData, type_flaggroups, upgrade_numbers, upgrade_numbers_all
-from worlds.sc2.Locations import SC2WOL_LOC_ID_OFFSET, LocationType, SC2HOTS_LOC_ID_OFFSET
-from worlds.sc2.MissionTables import lookup_id_to_mission, SC2Campaign, lookup_name_to_mission, \
-    lookup_id_to_campaign, MissionConnection, SC2Mission, campaign_mission_table, SC2Race, get_no_build_missions
-from worlds.sc2.Regions import MissionInfo
+from .Items import (lookup_id_to_name, get_full_item_list, ItemData, type_flaggroups, upgrade_numbers,
+                    upgrade_numbers_all)
+from .Locations import SC2WOL_LOC_ID_OFFSET, LocationType, SC2HOTS_LOC_ID_OFFSET
+from .MissionTables import (lookup_id_to_mission, SC2Campaign, lookup_name_to_mission,
+                            lookup_id_to_campaign, MissionConnection, SC2Mission, campaign_mission_table, SC2Race)
+from .Regions import MissionInfo
 
 import colorama
 from Options import Option

--- a/worlds/sc2/ClientGui.py
+++ b/worlds/sc2/ClientGui.py
@@ -13,12 +13,12 @@ from kivy.uix.floatlayout import FloatLayout
 from kivy.uix.scrollview import ScrollView
 from kivy.properties import StringProperty
 
-from worlds.sc2.Client import SC2Context, calc_unfinished_missions, parse_unlock
-from worlds.sc2.MissionTables import lookup_id_to_mission, lookup_name_to_mission, campaign_race_exceptions, \
-    SC2Mission, SC2Race, SC2Campaign
-from worlds.sc2.Locations import LocationType, lookup_location_id_to_type
-from worlds.sc2.Options import LocationInclusion
-from worlds.sc2 import SC2World, get_first_mission
+from .Client import SC2Context, calc_unfinished_missions, parse_unlock
+from .MissionTables import (lookup_id_to_mission, lookup_name_to_mission, campaign_race_exceptions, SC2Mission, SC2Race,
+                            SC2Campaign)
+from .Locations import LocationType, lookup_location_id_to_type
+from .Options import LocationInclusion
+from . import SC2World, get_first_mission
 
 
 class HoverableButton(HoverBehavior, Button):

--- a/worlds/smw/Client.py
+++ b/worlds/smw/Client.py
@@ -223,7 +223,7 @@ class SMWSNIClient(SNIClient):
 
         next_trap, message = self.trap_queue.pop(0)
 
-        from worlds.smw.Rom import trap_rom_data
+        from .Rom import trap_rom_data
         if next_trap.item in trap_rom_data:
             trap_active = await snes_read(ctx, WRAM_START + trap_rom_data[next_trap.item][0], 0x3)
 
@@ -349,8 +349,8 @@ class SMWSNIClient(SNIClient):
         blocksanity_flags = bytearray(await snes_read(ctx, SMW_BLOCKSANITY_FLAGS, 0xC))
         blocksanity_active = await snes_read(ctx, SMW_BLOCKSANITY_ACTIVE_ADDR, 0x1)
         level_clear_flags = bytearray(await snes_read(ctx, SMW_LEVEL_CLEAR_FLAGS, 0x60))
-        from worlds.smw.Rom import item_rom_data, ability_rom_data, trap_rom_data, icon_rom_data
-        from worlds.smw.Levels import location_id_to_level_id, level_info_dict, level_blocks_data
+        from .Rom import item_rom_data, ability_rom_data, trap_rom_data, icon_rom_data
+        from .Levels import location_id_to_level_id, level_info_dict, level_blocks_data
         from worlds import AutoWorldRegister
         for loc_name, level_data in location_id_to_level_id.items():
             loc_id = AutoWorldRegister.world_types[ctx.game].location_name_to_id[loc_name]

--- a/worlds/subnautica/test/__init__.py
+++ b/worlds/subnautica/test/__init__.py
@@ -15,7 +15,7 @@ class SubnauticaTest(unittest.TestCase):
                     self.assertGreater(self.scancutoff, id)
 
     def testGroupAssociation(self):
-        from worlds.subnautica import items
+        from .. import items
         for item_id, item_data in items.item_table.items():
             if item_data.type == items.ItemType.group:
                 with self.subTest(item=item_data.name):

--- a/worlds/zillion/test/TestOptions.py
+++ b/worlds/zillion/test/TestOptions.py
@@ -1,6 +1,6 @@
 from . import ZillionTestBase
 
-from worlds.zillion.options import ZillionJumpLevels, ZillionGunLevels, ZillionOptions, validate
+from ..options import ZillionJumpLevels, ZillionGunLevels, ZillionOptions, validate
 from zilliandomizer.options import VBLR_CHOICES
 
 

--- a/worlds/zillion/test/TestReproducibleRandom.py
+++ b/worlds/zillion/test/TestReproducibleRandom.py
@@ -1,7 +1,7 @@
 from typing import cast
 from . import ZillionTestBase
 
-from worlds.zillion import ZillionWorld
+from .. import ZillionWorld
 
 
 class SeedTest(ZillionTestBase):

--- a/worlds/zillion/test/__init__.py
+++ b/worlds/zillion/test/__init__.py
@@ -1,6 +1,6 @@
 from typing import cast
 from test.bases import WorldTestBase
-from worlds.zillion import ZillionWorld
+from .. import ZillionWorld
 
 
 class ZillionTestBase(WorldTestBase):


### PR DESCRIPTION
## What is this fixing or adding?

* For some worlds, this replaces "lazy" absolute imports (i.e. Rom generation or Clients) by relative ones.
  Lazy absolute imports don't fail, even on py3.8, because of how we populate sys.modules currently, however this still violates the current apworld spec and the apworlds wouldn't be self-contained anymore.
* For some worlds, this replaces absolute imports in tests by relative ones.
  This only works "reliably", because we don't run tests on APWorlds at the moment.

I put each world in its own commit so it's easier to review by the individual owners.

This does NOT fix the imports in Alttp tests yet. I was too lazy to change them all and Lttp is not an apworld yet anyway.

## How was this tested?

Only unit tests and loading worlds in Launcher and Generate (frozen, source, 3.8, 3.11) and looking for errors. Sadly I can't roll all changed games, so community testing or a quick test by the owner would be nice.