### PR TITLE
WebHost: fix option doc indent

### DIFF
--- a/WebHostLib/templates/playerOptions/macros.html
+++ b/WebHostLib/templates/playerOptions/macros.html
@@ -196,7 +196,7 @@
 {% macro OptionTitle(option_name, option) %}
     <label for="{{ option_name }}">
         {{ option.display_name|default(option_name) }}:
-        <span class="interactive" data-tooltip="{% filter dedent %}{{(option.__doc__ | default("Please document me!"))|escape }}{% endfilter %}">(?)</span>
+        <span class="interactive" data-tooltip="{{(option.__doc__ | default("Please document me!"))|replace('\n    ', '\n')|escape|trim|indent(0, first=False)}}">(?)</span>
     </label>
 {% endmacro %}
 

--- a/WebHostLib/templates/playerOptions/macros.html
+++ b/WebHostLib/templates/playerOptions/macros.html
@@ -196,7 +196,7 @@
 {% macro OptionTitle(option_name, option) %}
     <label for="{{ option_name }}">
         {{ option.display_name|default(option_name) }}:
-        <span class="interactive" data-tooltip="{{(option.__doc__ | default("Please document me!"))|replace('\n    ', '\n')|escape|trim|indent(0, first=False)}}">(?)</span>
+        <span class="interactive" data-tooltip="{{(option.__doc__ | default("Please document me!"))|replace('\n    ', '\n')|escape|trim}}">(?)</span>
     </label>
 {% endmacro %}
 


### PR DESCRIPTION
## What is this fixing or adding?
Apparently in the big option website  revamp the rendering of option documentation diverged from how it is rendered to yaml. So this copy pastes and adapts the yaml  filters for webhost, so they look the same/similar.

## How was this tested?
localhost.

## If this makes graphical changes, please attach screenshots.
Before:
![image](https://github.com/ArchipelagoMW/Archipelago/assets/3189725/ef54ab7b-95aa-4033-bf2e-6d6a7c09da77)
After:
![image](https://github.com/ArchipelagoMW/Archipelago/assets/3189725/44203407-9ca2-4bf1-b467-8b173213cc6e)
YAML:
![image](https://github.com/ArchipelagoMW/Archipelago/assets/3189725/6ef77667-6a33-4fde-82a6-b024219442d3)
