### PR TITLE
CommonClient: Use `lookup_in_game` instead of `lookup_in_slot` in case of own-game name lookup when disconnected from server.

### DIFF
--- a/AdventureClient.py
+++ b/AdventureClient.py
@@ -112,7 +112,7 @@ class AdventureContext(CommonContext):
             if ': !' not in msg:
                 self._set_message(msg, SYSTEM_MESSAGE_ID)
         elif cmd == "ReceivedItems":
-            msg = f"Received {', '.join([self.item_names.lookup_in_slot(item.item) for item in args['items']])}"
+            msg = f"Received {', '.join([self.item_names.lookup_in_game(item.item) for item in args['items']])}"
             self._set_message(msg, SYSTEM_MESSAGE_ID)
         elif cmd == "Retrieved":
             if f"adventure_{self.auth}_freeincarnates_used" in args["keys"]:

--- a/CommonClient.py
+++ b/CommonClient.py
@@ -225,6 +225,9 @@ class CommonContext:
         def lookup_in_slot(self, code: int, slot: typing.Optional[int] = None) -> str:
             """Returns the name for an item/location id in the context of a specific slot or own slot if `slot` is
             omitted.
+
+            Use of `lookup_in_slot` should not be used when not connected to a server. If looking in own game, set
+            `ctx.game` and use `lookup_in_game` method instead.
             """
             if slot is None:
                 slot = self.ctx.slot

--- a/UndertaleClient.py
+++ b/UndertaleClient.py
@@ -247,8 +247,8 @@ async def process_undertale_cmd(ctx: UndertaleContext, cmd: str, args: dict):
             with open(os.path.join(ctx.save_game_folder, filename), "w") as f:
                 toDraw = ""
                 for i in range(20):
-                    if i < len(str(ctx.item_names.lookup_in_slot(l.item))):
-                        toDraw += str(ctx.item_names.lookup_in_slot(l.item))[i]
+                    if i < len(str(ctx.item_names.lookup_in_game(l.item))):
+                        toDraw += str(ctx.item_names.lookup_in_game(l.item))[i]
                     else:
                         break
                 f.write(toDraw)

--- a/WargrooveClient.py
+++ b/WargrooveClient.py
@@ -176,7 +176,7 @@ class WargrooveContext(CommonContext):
                 if not os.path.isfile(path):
                     open(path, 'w').close()
                     # Announcing commander unlocks
-                    item_name = self.item_names.lookup_in_slot(network_item.item)
+                    item_name = self.item_names.lookup_in_game(network_item.item)
                     if item_name in faction_table.keys():
                         for commander in faction_table[item_name]:
                             logger.info(f"{commander.name} has been unlocked!")
@@ -197,7 +197,7 @@ class WargrooveContext(CommonContext):
                     open(print_path, 'w').close()
                     with open(print_path, 'w') as f:
                         f.write("Received " +
-                                self.item_names.lookup_in_slot(network_item.item) +
+                                self.item_names.lookup_in_game(network_item.item) +
                                 " from " +
                                 self.player_names[network_item.player])
                         f.close()
@@ -342,7 +342,7 @@ class WargrooveContext(CommonContext):
             faction_items = 0
             faction_item_names = [faction + ' Commanders' for faction in faction_table.keys()]
             for network_item in self.items_received:
-                if self.item_names.lookup_in_slot(network_item.item) in faction_item_names:
+                if self.item_names.lookup_in_game(network_item.item) in faction_item_names:
                     faction_items += 1
             starting_groove = (faction_items - 1) * self.starting_groove_multiplier
             # Must be an integer larger than 0

--- a/Zelda1Client.py
+++ b/Zelda1Client.py
@@ -152,7 +152,7 @@ def get_payload(ctx: ZeldaContext):
 
 
 def reconcile_shops(ctx: ZeldaContext):
-    checked_location_names = [ctx.location_names.lookup_in_slot(location) for location in ctx.checked_locations]
+    checked_location_names = [ctx.location_names.lookup_in_game(location) for location in ctx.checked_locations]
     shops = [location for location in checked_location_names if "Shop" in location]
     left_slots = [shop for shop in shops if "Left" in shop]
     middle_slots = [shop for shop in shops if "Middle" in shop]
@@ -190,7 +190,7 @@ async def parse_locations(locations_array, ctx: ZeldaContext, force: bool, zone=
         locations_checked = []
         location = None
         for location in ctx.missing_locations:
-            location_name = ctx.location_names.lookup_in_slot(location)
+            location_name = ctx.location_names.lookup_in_game(location)
 
             if location_name in Locations.overworld_locations and zone == "overworld":
                 status = locations_array[Locations.major_location_offsets[location_name]]

--- a/worlds/alttp/Client.py
+++ b/worlds/alttp/Client.py
@@ -339,7 +339,7 @@ async def track_locations(ctx, roomid, roomdata) -> bool:
     def new_check(location_id):
         new_locations.append(location_id)
         ctx.locations_checked.add(location_id)
-        location = ctx.location_names.lookup_in_slot(location_id)
+        location = ctx.location_names.lookup_in_game(location_id)
         snes_logger.info(
             f'New Check: {location} ' +
             f'({len(ctx.checked_locations) + 1 if ctx.checked_locations else len(ctx.locations_checked)}/' +
@@ -552,7 +552,7 @@ class ALTTPSNIClient(SNIClient):
             item = ctx.items_received[recv_index]
             recv_index += 1
             logging.info('Received %s from %s (%s) (%d/%d in list)' % (
-                color(ctx.item_names.lookup_in_slot(item.item), 'red', 'bold'),
+                color(ctx.item_names.lookup_in_game(item.item), 'red', 'bold'),
                 color(ctx.player_names[item.player], 'yellow'),
                 ctx.location_names.lookup_in_slot(item.location, item.player), recv_index, len(ctx.items_received)))
 

--- a/worlds/cv64/client.py
+++ b/worlds/cv64/client.py
@@ -146,7 +146,7 @@ class Castlevania64Client(BizHawkClient):
                         text_color = bytearray([0xA2, 0x0B])
                     else:
                         text_color = bytearray([0xA2, 0x02])
-                    received_text, num_lines = cv64_text_wrap(f"{ctx.item_names.lookup_in_slot(next_item.item)}\n"
+                    received_text, num_lines = cv64_text_wrap(f"{ctx.item_names.lookup_in_game(next_item.item)}\n"
                                                               f"from {ctx.player_names[next_item.player]}", 96)
                     await bizhawk.guarded_write(ctx.bizhawk_ctx,
                                                 [(0x389BE1, [next_item.item & 0xFF], "RDRAM"),

--- a/worlds/dkc3/Client.py
+++ b/worlds/dkc3/Client.py
@@ -86,7 +86,7 @@ class DKC3SNIClient(SNIClient):
 
         for new_check_id in new_checks:
             ctx.locations_checked.add(new_check_id)
-            location = ctx.location_names.lookup_in_slot(new_check_id)
+            location = ctx.location_names.lookup_in_game(new_check_id)
             snes_logger.info(
                 f'New Check: {location} ({len(ctx.locations_checked)}/{len(ctx.missing_locations) + len(ctx.checked_locations)})')
             await ctx.send_msgs([{"cmd": 'LocationChecks', "locations": [new_check_id]}])
@@ -99,7 +99,7 @@ class DKC3SNIClient(SNIClient):
             item = ctx.items_received[recv_index]
             recv_index += 1
             logging.info('Received %s from %s (%s) (%d/%d in list)' % (
-                color(ctx.item_names.lookup_in_slot(item.item), 'red', 'bold'),
+                color(ctx.item_names.lookup_in_game(item.item), 'red', 'bold'),
                 color(ctx.player_names[item.player], 'yellow'),
                 ctx.location_names.lookup_in_slot(item.location, item.player), recv_index, len(ctx.items_received)))
 

--- a/worlds/factorio/Client.py
+++ b/worlds/factorio/Client.py
@@ -247,7 +247,7 @@ async def game_watcher(ctx: FactorioContext):
                     if ctx.locations_checked != research_data:
                         bridge_logger.debug(
                             f"New researches done: "
-                            f"{[ctx.location_names.lookup_in_slot(rid) for rid in research_data - ctx.locations_checked]}")
+                            f"{[ctx.location_names.lookup_in_game(rid) for rid in research_data - ctx.locations_checked]}")
                         ctx.locations_checked = research_data
                         await ctx.send_msgs([{"cmd": 'LocationChecks', "locations": tuple(research_data)}])
                     death_link_tick = data.get("death_link_tick", 0)
@@ -360,7 +360,7 @@ async def factorio_server_watcher(ctx: FactorioContext):
                     transfer_item: NetworkItem = ctx.items_received[ctx.send_index]
                     item_id = transfer_item.item
                     player_name = ctx.player_names[transfer_item.player]
-                    item_name = ctx.item_names.lookup_in_slot(item_id)
+                    item_name = ctx.item_names.lookup_in_game(item_id)
                     factorio_server_logger.info(f"Sending {item_name} to Nauvis from {player_name}.")
                     commands[ctx.send_index] = f"/ap-get-technology {item_name}\t{ctx.send_index}\t{player_name}"
                     ctx.send_index += 1

--- a/worlds/kdl3/Client.py
+++ b/worlds/kdl3/Client.py
@@ -330,7 +330,7 @@ class KDL3SNIClient(SNIClient):
                 item = ctx.items_received[recv_amount]
                 recv_amount += 1
                 logging.info('Received %s from %s (%s) (%d/%d in list)' % (
-                    color(ctx.item_names.lookup_in_slot(item.item), 'red', 'bold'),
+                    color(ctx.item_names.lookup_in_game(item.item), 'red', 'bold'),
                     color(ctx.player_names[item.player], 'yellow'),
                     ctx.location_names.lookup_in_slot(item.location, item.player), recv_amount, len(ctx.items_received)))
 
@@ -415,7 +415,7 @@ class KDL3SNIClient(SNIClient):
 
             for new_check_id in new_checks:
                 ctx.locations_checked.add(new_check_id)
-                location = ctx.location_names.lookup_in_slot(new_check_id)
+                location = ctx.location_names.lookup_in_game(new_check_id)
                 snes_logger.info(
                     f'New Check: {location} ({len(ctx.locations_checked)}/'
                     f'{len(ctx.missing_locations) + len(ctx.checked_locations)})')

--- a/worlds/lufia2ac/Client.py
+++ b/worlds/lufia2ac/Client.py
@@ -147,7 +147,7 @@ class L2ACSNIClient(SNIClient):
                 snes_items_received += 1
 
                 snes_logger.info("Received %s from %s (%s) (%d/%d in list)" % (
-                    ctx.item_names.lookup_in_slot(item.item),
+                    ctx.item_names.lookup_in_game(item.item),
                     ctx.player_names[item.player],
                     ctx.location_names.lookup_in_slot(item.location, item.player),
                     snes_items_received, len(ctx.items_received)))

--- a/worlds/sc2/Client.py
+++ b/worlds/sc2/Client.py
@@ -243,10 +243,10 @@ class StarcraftClientProcessor(ClientCommandProcessor):
                     self.formatted_print(f" [u]{faction.name}[/u] ")
             
             for item_id in categorized_items[faction]:
-                item_name = self.ctx.item_names.lookup_in_slot(item_id)
+                item_name = self.ctx.item_names.lookup_in_game(item_id)
                 received_child_items = items_received_set.intersection(parent_to_child.get(item_id, []))
                 matching_children = [child for child in received_child_items
-                                     if item_matches_filter(self.ctx.item_names.lookup_in_slot(child))]
+                                     if item_matches_filter(self.ctx.item_names.lookup_in_game(child))]
                 received_items_of_this_type = items_received.get(item_id, [])
                 item_is_match = item_matches_filter(item_name)
                 if item_is_match or len(matching_children) > 0:
@@ -1164,7 +1164,7 @@ def request_unfinished_missions(ctx: SC2Context) -> None:
             objectives = set(ctx.locations_for_mission(mission))
             if objectives:
                 remaining_objectives = objectives.difference(ctx.checked_locations)
-                unfinished_locations[mission] = [ctx.location_names.lookup_in_slot(location_id) for location_id in remaining_objectives]
+                unfinished_locations[mission] = [ctx.location_names.lookup_in_game(location_id) for location_id in remaining_objectives]
             else:
                 unfinished_locations[mission] = []
 

--- a/worlds/sc2/ClientGui.py
+++ b/worlds/sc2/ClientGui.py
@@ -269,7 +269,7 @@ class SC2Manager(GameManager):
         for loc in self.ctx.locations_for_mission(mission_name):
             if loc in self.ctx.missing_locations:
                 count += 1
-                locations[lookup_location_id_to_type[loc]].append(self.ctx.location_names.lookup_in_slot(loc))
+                locations[lookup_location_id_to_type[loc]].append(self.ctx.location_names.lookup_in_game(loc))
 
         plando_locations = []
         for plando_loc in self.ctx.plando_locations:

--- a/worlds/sm/Client.py
+++ b/worlds/sm/Client.py
@@ -123,7 +123,7 @@ class SMSNIClient(SNIClient):
             location_id = locations_start_id + item_index
 
             ctx.locations_checked.add(location_id)
-            location = ctx.location_names.lookup_in_slot(location_id)
+            location = ctx.location_names.lookup_in_game(location_id)
             snes_logger.info(
                 f'New Check: {location} ({len(ctx.locations_checked)}/{len(ctx.missing_locations) + len(ctx.checked_locations)})')
             await ctx.send_msgs([{"cmd": 'LocationChecks', "locations": [location_id]}])
@@ -151,7 +151,7 @@ class SMSNIClient(SNIClient):
             snes_buffered_write(ctx, SM_RECV_QUEUE_WCOUNT,
                                 bytes([item_out_ptr & 0xFF, (item_out_ptr >> 8) & 0xFF]))
             logging.info('Received %s from %s (%s) (%d/%d in list)' % (
-                color(ctx.item_names.lookup_in_slot(item.item), 'red', 'bold'),
+                color(ctx.item_names.lookup_in_game(item.item), 'red', 'bold'),
                 color(ctx.player_names[item.player], 'yellow'),
                 ctx.location_names.lookup_in_slot(item.location, item.player), item_out_ptr, len(ctx.items_received)))
 

--- a/worlds/smw/Client.py
+++ b/worlds/smw/Client.py
@@ -448,7 +448,7 @@ class SMWSNIClient(SNIClient):
 
         for new_check_id in new_checks:
             ctx.locations_checked.add(new_check_id)
-            location = ctx.location_names.lookup_in_slot(new_check_id)
+            location = ctx.location_names.lookup_in_game(new_check_id)
             snes_logger.info(
                 f'New Check: {location} ({len(ctx.locations_checked)}/{len(ctx.missing_locations) + len(ctx.checked_locations)})')
             await ctx.send_msgs([{"cmd": 'LocationChecks', "locations": [new_check_id]}])
@@ -501,14 +501,14 @@ class SMWSNIClient(SNIClient):
             recv_index += 1
             sending_game = ctx.slot_info[item.player].game
             logging.info('Received %s from %s (%s) (%d/%d in list)' % (
-                color(ctx.item_names.lookup_in_slot(item.item), 'red', 'bold'),
+                color(ctx.item_names.lookup_in_game(item.item), 'red', 'bold'),
                 color(ctx.player_names[item.player], 'yellow'),
                 ctx.location_names.lookup_in_slot(item.location, item.player), recv_index, len(ctx.items_received)))
 
             if self.should_show_message(ctx, item):
                 if item.item != 0xBC0012 and item.item not in trap_rom_data:
                     # Don't send messages for Boss Tokens
-                    item_name = ctx.item_names.lookup_in_slot(item.item)
+                    item_name = ctx.item_names.lookup_in_game(item.item)
                     player_name = ctx.player_names[item.player]
 
                     receive_message = generate_received_text(item_name, player_name)
@@ -516,7 +516,7 @@ class SMWSNIClient(SNIClient):
 
             snes_buffered_write(ctx, SMW_RECV_PROGRESS_ADDR, bytes([recv_index&0xFF, (recv_index>>8)&0xFF]))
             if item.item in trap_rom_data:
-                item_name = ctx.item_names.lookup_in_slot(item.item)
+                item_name = ctx.item_names.lookup_in_game(item.item)
                 player_name = ctx.player_names[item.player]
 
                 receive_message = generate_received_text(item_name, player_name)
@@ -597,7 +597,7 @@ class SMWSNIClient(SNIClient):
         for loc_id in ctx.checked_locations:
             if loc_id not in ctx.locations_checked:
                 ctx.locations_checked.add(loc_id)
-                loc_name = ctx.location_names.lookup_in_slot(loc_id)
+                loc_name = ctx.location_names.lookup_in_game(loc_id)
 
                 if loc_name not in location_id_to_level_id:
                     continue

--- a/worlds/smz3/Client.py
+++ b/worlds/smz3/Client.py
@@ -109,7 +109,7 @@ class SMZ3SNIClient(SNIClient):
             location_id = locations_start_id + convertLocSMZ3IDToAPID(item_index)
 
             ctx.locations_checked.add(location_id)
-            location = ctx.location_names.lookup_in_slot(location_id)
+            location = ctx.location_names.lookup_in_game(location_id)
             snes_logger.info(f'New Check: {location} ({len(ctx.locations_checked)}/{len(ctx.missing_locations) + len(ctx.checked_locations)})')
             await ctx.send_msgs([{"cmd": 'LocationChecks', "locations": [location_id]}])
 
@@ -132,7 +132,7 @@ class SMZ3SNIClient(SNIClient):
             item_out_ptr += 1
             snes_buffered_write(ctx, SMZ3_RECV_PROGRESS_ADDR + recv_progress_addr_table_offset, bytes([item_out_ptr & 0xFF, (item_out_ptr >> 8) & 0xFF]))
             logging.info('Received %s from %s (%s) (%d/%d in list)' % (
-                color(ctx.item_names.lookup_in_slot(item.item), 'red', 'bold'), color(ctx.player_names[item.player], 'yellow'),
+                color(ctx.item_names.lookup_in_game(item.item), 'red', 'bold'), color(ctx.player_names[item.player], 'yellow'),
                 ctx.location_names.lookup_in_slot(item.location, item.player), item_out_ptr, len(ctx.items_received)))
 
         await snes_flush_writes(ctx)

--- a/worlds/yoshisisland/Client.py
+++ b/worlds/yoshisisland/Client.py
@@ -116,7 +116,7 @@ class YoshisIslandSNIClient(SNIClient):
 
         for new_check_id in new_checks:
             ctx.locations_checked.add(new_check_id)
-            location = ctx.location_names.lookup_in_slot(new_check_id)
+            location = ctx.location_names.lookup_in_game(new_check_id)
             total_locations = len(ctx.missing_locations) + len(ctx.checked_locations)
             snes_logger.info(f"New Check: {location} ({len(ctx.locations_checked)}/{total_locations})")
             await ctx.send_msgs([{"cmd": "LocationChecks", "locations": [new_check_id]}])
@@ -127,7 +127,7 @@ class YoshisIslandSNIClient(SNIClient):
             item = ctx.items_received[recv_index]
             recv_index += 1
             logging.info("Received %s from %s (%s) (%d/%d in list)" % (
-                color(ctx.item_names.lookup_in_slot(item.item), "red", "bold"),
+                color(ctx.item_names.lookup_in_game(item.item), "red", "bold"),
                 color(ctx.player_names[item.player], "yellow"),
                 ctx.location_names.lookup_in_slot(item.location, item.player), recv_index, len(ctx.items_received)))
 


### PR DESCRIPTION
## What is this fixing or adding?
Bug Report: https://discord.com/channels/731205301247803413/1249434122212872252

There are some code paths that attempt to lookup names prior to connection to the Archipelago server, and I foolishly used `lookup_in_slot` everywhere when I refactored for #1933. This caused some areas to raise an exception and not finish prior to queuing LocationChecks packets, causing a failure to sync local state with server (like in Factorio's case in the bug report).

This changes those methods to `lookup_in_game` as CommonContext-derived clients should have already set the game value, so this lookup for own-game items should work even while disconnected.

## How was this tested?
Ran before and after with a Factorio world that had a location checked prior to connection. The location did not resync before, but did successfully after the changes. Other clients are not tested, but assumed to work correctly based on similar usage.

## If this makes graphical changes, please attach screenshots.
N/A