### PR TITLE
Generate: split ERmain out of main

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -235,8 +235,7 @@ def main(args=None):
         with open(os.path.join(args.outputpath if args.outputpath else ".", f"generate_{seed_name}.yaml"), "wt") as f:
             yaml.dump(important, f)
 
-    from Main import main as ERmain
-    return ERmain(erargs, seed)
+    return erargs, seed
 
 
 def read_weights_yamls(path) -> Tuple[Any, ...]:
@@ -545,7 +544,9 @@ def roll_alttp_settings(ret: argparse.Namespace, weights):
 if __name__ == '__main__':
     import atexit
     confirmation = atexit.register(input, "Press enter to close.")
-    multiworld = main()
+    erargs, seed = main()
+    from Main import main as ERmain
+    multiworld = ERmain(erargs, seed)
     if __debug__:
         import gc
         import sys

--- a/Generate.py
+++ b/Generate.py
@@ -65,7 +65,7 @@ def get_seed_name(random_source) -> str:
     return f"{random_source.randint(0, pow(10, seeddigits) - 1)}".zfill(seeddigits)
 
 
-def main(args=None):
+def main(args=None) -> Tuple[argparse.Namespace, int]:
     if not args:
         args = mystery_argparse()
 

--- a/test/hosting/generate.py
+++ b/test/hosting/generate.py
@@ -26,6 +26,7 @@ def _generate_local_inner(games: Iterable[str],
         with TemporaryDirectory() as players_dir:
             with TemporaryDirectory() as output_dir:
                 import Generate
+                import Main
 
                 for n, game in enumerate(games, 1):
                     player_path = Path(players_dir) / f"{n}.yaml"
@@ -42,7 +43,7 @@ def _generate_local_inner(games: Iterable[str],
                 sys.argv = [sys.argv[0], "--seed", str(hash(tuple(games))),
                             "--player_files_path", players_dir,
                             "--outputpath", output_dir]
-                Generate.main()
+                Main.main(*Generate.main())
                 output_files = list(Path(output_dir).glob('*.zip'))
                 assert len(output_files) == 1
                 final_file = dest / output_files[0].name

--- a/test/programs/test_generate.py
+++ b/test/programs/test_generate.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import Generate
+import Main
 
 
 class TestGenerateMain(unittest.TestCase):
@@ -58,7 +59,7 @@ class TestGenerateMain(unittest.TestCase):
                     '--player_files_path', str(self.abs_input_dir),
                     '--outputpath', self.output_tempdir.name]
         print(f'Testing Generate.py {sys.argv} in {os.getcwd()}')
-        Generate.main()
+        Main.main(*Generate.main())
 
         self.assertOutput(self.output_tempdir.name)
 
@@ -67,7 +68,7 @@ class TestGenerateMain(unittest.TestCase):
                     '--player_files_path', str(self.rel_input_dir),
                     '--outputpath', self.output_tempdir.name]
         print(f'Testing Generate.py {sys.argv} in {os.getcwd()}')
-        Generate.main()
+        Main.main(*Generate.main())
 
         self.assertOutput(self.output_tempdir.name)
 
@@ -86,7 +87,7 @@ class TestGenerateMain(unittest.TestCase):
             sys.argv = [sys.argv[0], '--seed', '0',
                         '--outputpath', self.output_tempdir.name]
             print(f'Testing Generate.py {sys.argv} in {os.getcwd()}, player_files_path={self.yaml_input_dir}')
-            Generate.main()
+            Main.main(*Generate.main())
         finally:
             user_path.cached_path = user_path_backup
 


### PR DESCRIPTION
## What is this fixing or adding?
splits up  main and ERmain, which might be required for Universal Tracker to work again.
It also  allows deallocation of a few objects, as main().__locals__ can be cleaned up.
Both functions might also be in need of a better name,  maybe in a follow up PR?

## How was this tested?
I ran generate.

## If this makes graphical changes, please attach screenshots.
