### PR TITLE
Factorio: Fix ap-get-technology nil value crashes

### DIFF
--- a/worlds/factorio/data/mod_template/control.lua
+++ b/worlds/factorio/data/mod_template/control.lua
@@ -669,8 +669,8 @@ commands.add_command("ap-get-technology", "Grant a technology, used by the Archi
     local index = chunks[2]
     local source = chunks[3] or "Archipelago"
     if index == nil then
-		game.print("ap-get-technology is only to be used by the Archipelago Factorio Client")
-		return
+        game.print("ap-get-technology is only to be used by the Archipelago Factorio Client")
+        return
     elseif index == -1 then -- for coop sync and restoring from an older savegame
         tech = force.technologies[item_name]
         if tech.researched ~= true then

--- a/worlds/factorio/data/mod_template/control.lua
+++ b/worlds/factorio/data/mod_template/control.lua
@@ -660,11 +660,18 @@ commands.add_command("ap-get-technology", "Grant a technology, used by the Archi
     end
     local tech
     local force = game.forces["player"]
+    if call.parameter == nil then
+        game.print("ap-get-technology is only to be used by the Archipelago Factorio Client")
+        return
+    end
     chunks = split(call.parameter, "\t")
     local item_name = chunks[1]
     local index = chunks[2]
     local source = chunks[3] or "Archipelago"
-    if index == -1 then -- for coop sync and restoring from an older savegame
+    if index == nil then
+		game.print("ap-get-technology is only to be used by the Archipelago Factorio Client")
+		return
+    elseif index == -1 then -- for coop sync and restoring from an older savegame
         tech = force.technologies[item_name]
         if tech.researched ~= true then
             game.print({"", "Received [technology=" .. tech.name .. "] as it is already checked."})


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?

Fixes nil value related crashes where a player happens to attempt to run /ap-get-technology from within the game itself. (This is a potential source for denial of service on public Factorio Archipelago servers (player runs /help, sees various commands, then runs /ap-get-technology out of curiosity))


## How was this tested?

Run /ap-get-technology by itself, and run /ap-get-technology [known tech or trap name] from within the game.


## If this makes graphical changes, please attach screenshots.

![image](https://github.com/ArchipelagoMW/Archipelago/assets/79097/cf8a16c3-bc9f-4ebc-bb77-30a4bb9a3023)

