### PR TITLE
WebHost: Fix default values that are 2 or more words in Weighted Options

### DIFF
--- a/WebHostLib/templates/weightedOptions/macros.html
+++ b/WebHostLib/templates/weightedOptions/macros.html
@@ -19,7 +19,7 @@
             {% for id, name in option.name_lookup.items() %}
                 {% if name != 'random' %}
                     {% if option.default != 'random' %}
-                        {{ RangeRow(option_name, option, option.get_option_name(id), name, False, name if option.get_option_name(option.default) == option.get_option_name(id) else None) }}
+                        {{ RangeRow(option_name, option, option.get_option_name(id), name, False, name if option.default == id else None) }}
                     {% else %}
                         {{ RangeRow(option_name, option, option.get_option_name(id), name) }}
                     {% endif %}
@@ -97,7 +97,7 @@
             {% for id, name in option.name_lookup.items() %}
                 {% if name != 'random' %}
                     {% if option.default != 'random' %}
-                        {{ RangeRow(option_name, option, option.get_option_name(id), name, False, name if option.get_option_name(option.default) == option.get_option_name(id) else None) }}
+                        {{ RangeRow(option_name, option, option.get_option_name(id), name, False, name if option.default == id else None) }}
                     {% else %}
                         {{ RangeRow(option_name, option, option.get_option_name(id), name) }}
                     {% endif %}

--- a/WebHostLib/templates/weightedOptions/macros.html
+++ b/WebHostLib/templates/weightedOptions/macros.html
@@ -19,7 +19,7 @@
             {% for id, name in option.name_lookup.items() %}
                 {% if name != 'random' %}
                     {% if option.default != 'random' %}
-                        {{ RangeRow(option_name, option, option.get_option_name(id), name, False, name if option.get_option_name(option.default)|lower == name else None) }}
+                        {{ RangeRow(option_name, option, option.get_option_name(id), name, False, name if option.get_option_name(option.default) == option.get_option_name(id) else None) }}
                     {% else %}
                         {{ RangeRow(option_name, option, option.get_option_name(id), name) }}
                     {% endif %}
@@ -97,7 +97,7 @@
             {% for id, name in option.name_lookup.items() %}
                 {% if name != 'random' %}
                     {% if option.default != 'random' %}
-                        {{ RangeRow(option_name, option, option.get_option_name(id), name, False, name if option.get_option_name(option.default)|lower == name else None) }}
+                        {{ RangeRow(option_name, option, option.get_option_name(id), name, False, name if option.get_option_name(option.default) == option.get_option_name(id) else None) }}
                     {% else %}
                         {{ RangeRow(option_name, option, option.get_option_name(id), name) }}
                     {% endif %}


### PR DESCRIPTION
The default option value for the Old Man option in Pokemon RB is "Early Parcel"

To check for the default in `weightedOptions/macros.html`, we compare:
`option.get_option_name(option.default)|lower == name`
 
Problem:
`"Early Parcel"|lower != "early_parcel`
The underscore is missing.

Alterate fixes that I considered:
- `|lower|replace(" ","_")`

Things that I could do ontop of this:
- rename `name` to `readable_name` and assign `option.get_option_name(id)` to a new variable called `internal_name`. Bc either solution makes already long lines even longer.

Lmk if either of those are better / desirable

Before:
![image](https://github.com/ArchipelagoMW/Archipelago/assets/57900059/787a6ea5-70b1-456c-b5ba-e9ad9d59a1cd)

After:
![image](https://github.com/ArchipelagoMW/Archipelago/assets/57900059/b9e3b3d4-456f-4a63-baad-547535937993)