### PR TITLE
WebHost: Fix Named Range displays on Player Options page

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -737,9 +737,9 @@ class NamedRange(Range):
                             f"and is also not one of the supported named special values: {self.special_range_names}")
 
         for key in self.special_range_names:
-            if key != key.lower() or " " in key:
+            if key != key.lower():
                 raise Exception(f"{self.__class__.__name__} has an invalid special_range_names key: {key}. "
-                                f"NamedRange keys must use only lowercase letters and underscores.")
+                                f"NamedRange keys must use only lowercase letters, and ideally should be snake_case.")
         self.value = value
 
     @classmethod

--- a/Options.py
+++ b/Options.py
@@ -735,7 +735,8 @@ class NamedRange(Range):
         elif value > self.range_end and value not in self.special_range_names.values():
             raise Exception(f"{value} is higher than maximum {self.range_end} for option {self.__class__.__name__} " +
                             f"and is also not one of the supported named special values: {self.special_range_names}")
-
+        
+        # See docstring
         for key in self.special_range_names:
             if key != key.lower():
                 raise Exception(f"{self.__class__.__name__} has an invalid special_range_names key: {key}. "

--- a/Options.py
+++ b/Options.py
@@ -735,6 +735,11 @@ class NamedRange(Range):
         elif value > self.range_end and value not in self.special_range_names.values():
             raise Exception(f"{value} is higher than maximum {self.range_end} for option {self.__class__.__name__} " +
                             f"and is also not one of the supported named special values: {self.special_range_names}")
+
+        for key in self.special_range_names:
+            if key != key.lower() or " " in key:
+                raise Exception(f"{self.__class__.__name__} has an invalid special_range_names key: {key}. "
+                                f"NamedRange keys must use only lowercase letters and underscores.")
         self.value = value
 
     @classmethod

--- a/WebHostLib/templates/playerOptions/macros.html
+++ b/WebHostLib/templates/playerOptions/macros.html
@@ -57,9 +57,9 @@
         <select id="{{ option_name }}-select" data-option-name="{{ option_name }}" {{ "disabled" if option.default == "random" }}>
             {% for key, val in option.special_range_names.items() %}
                 {% if option.default == val %}
-                    <option value="{{ val }}" selected>{{ key }} ({{ val }})</option>
+                    <option value="{{ val }}" selected>{{ key|title|replace("_", " ") }} ({{ val }})</option>
                 {% else %}
-                    <option value="{{ val }}">{{ key }} ({{ val }})</option>
+                    <option value="{{ val }}">{{ key|title|replace("_", " ") }} ({{ val }})</option>
                 {% endif %}
             {% endfor %}
             <option value="custom" hidden>Custom</option>

--- a/WebHostLib/templates/playerOptions/macros.html
+++ b/WebHostLib/templates/playerOptions/macros.html
@@ -57,9 +57,9 @@
         <select id="{{ option_name }}-select" data-option-name="{{ option_name }}" {{ "disabled" if option.default == "random" }}>
             {% for key, val in option.special_range_names.items() %}
                 {% if option.default == val %}
-                    <option value="{{ val }}" selected>{{ key|title|replace("_", " ") }} ({{ val }})</option>
+                    <option value="{{ val }}" selected>{{ key|replace("_", " ")|title }} ({{ val }})</option>
                 {% else %}
-                    <option value="{{ val }}">{{ key|title|replace("_", " ") }} ({{ val }})</option>
+                    <option value="{{ val }}">{{ key|replace("_", " ")|title }} ({{ val }})</option>
                 {% endif %}
             {% endfor %}
             <option value="custom" hidden>Custom</option>

--- a/WebHostLib/templates/weightedOptions/macros.html
+++ b/WebHostLib/templates/weightedOptions/macros.html
@@ -41,7 +41,7 @@
             The following values have special meanings, and may fall outside the normal range.
             <ul>
                 {% for name, value in option.special_range_names.items() %}
-                    <li>{{ value }}: {{ name }}</li>
+                    <li>{{ value }}: {{ name|replace("_", " ")|title }}</li>
                 {% endfor %}
             </ul>
         {% endif %}


### PR DESCRIPTION
As with my other two WebHost PRs, I have no idea if this is "structurally" the best fix.

Note: Just telling worlds to change the option names in `special_range_names` to what they want **does not work**. If any of the names in there contain capital letters, your yaml will never generate (unless you use the numeric values instead)

Before:

![image](https://github.com/ArchipelagoMW/Archipelago/assets/57900059/d6d46a70-2bc9-419c-8c3c-13da9ef26f5b)

After:

![image](https://github.com/ArchipelagoMW/Archipelago/assets/57900059/19824787-ea35-47ca-852e-3224861a5d2a)
