### PR TITLE
MultiServer: Allow (limited) LocationScouts of other players' slots

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1804,7 +1804,7 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
                                           "original_cmd": cmd}])
                     return
 
-                target_item, target_player, flags = ctx.locations[client.slot][location]
+                target_item, target_player, flags = ctx.locations[desired_player][location]
 
                 if client_player != desired_player:
                     # Only allow scouting other players' locations if the item is for client_player,

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1807,10 +1807,11 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
                     return
                 target_item, target_player, flags = ctx.locations[client.slot][location]
 
-                # Only allow scouting other players' locations if the item is for the slot that sent the scout
-                # TODO: Allow scouting Item Links items that *lead* to an item for client_player?
-                if client_player != desired_player and client_player != target_player:
-                    continue
+                if client_player != desired_player:
+                    # Only allow scouting other players' locations if the item is for client_player,
+                    # or if the target_player is an item links group that the client_player is a part of.
+                    if not (client_player == target_player or client_player in ctx.groups.get(target_player, set())):
+                        continue
 
                 if create_as_hint:
                     hints.extend(collect_hint_location_id(ctx, client.team, desired_player, location))

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1805,6 +1805,7 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
                                         [{'cmd': 'InvalidPacket', "type": "arguments", "text": 'LocationScouts',
                                           "original_cmd": cmd}])
                     return
+
                 target_item, target_player, flags = ctx.locations[client.slot][location]
 
                 if client_player != desired_player:

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1810,7 +1810,7 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
                 if client_player != desired_player:
                     # Only allow scouting other players' locations if the item is for client_player,
                     # or if the target_player is an item links group that the client_player is a part of.
-                    if not (client_player == target_player or client_player in ctx.groups.get(target_player, set())):
+                    if client_player not in ctx.groups.get(target_player, {target_player}):
                         continue
 
                 if create_as_hint:

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1794,9 +1794,7 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
             locs = []
             create_as_hint: int = int(args.get("create_as_hint", 0))
             client_player = client.slot
-            desired_player = client_player
-            if "player" in args:
-                desired_player = int(args["player"])
+            desired_player = int(args.get("player", client_player))
 
             hints = []
             for location in args["locations"]:

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -340,11 +340,11 @@ For the purpose of in-game hints, it is also possible to scout other slots' loca
 Only locations that contain items for your slot will actually be processed if you set the `player` parameter to a different slot's player number than your own.
 
 #### Arguments
-| Name           | Type        | Notes                                                                                                                                                                                           |
-|----------------|-------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| locations      | list\[int\] | The ids of the locations seen by the client. May contain any number of locations, even ones sent before; duplicates do not cause issues with the Archipelago server.                            |
-| create_as_hint | int         | If non-zero, the scouted locations get created and broadcasted as a player-visible hint. <br/>If 2 only new hints are broadcast, however this does not remove them from the LocationInfo reply. |
-| player         | int         | Determines the player whose locations will be scouted. If this is a different player than the requesting slot, only locations that contain the requesting slot's items will be processed. Optional; defaults to the requesting slot.                       |
+| Name           | Type        | Notes                                                                                                                                                                                                                                |
+|----------------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| locations      | list\[int\] | The ids of the locations seen by the client. May contain any number of locations, even ones sent before; duplicates do not cause issues with the Archipelago server.                                                                 |
+| create_as_hint | int         | If non-zero, the scouted locations get created and broadcasted as a player-visible hint. <br/>If 2 only new hints are broadcast, however this does not remove them from the LocationInfo reply.                                      |
+| player         | int         | Determines the player whose locations will be scouted. If this is a different player than the requesting slot, only locations that contain the requesting slot's items will be processed. Optional; defaults to the requesting slot. |
 
 
 ### StatusUpdate

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -148,8 +148,8 @@ Sent to clients when they receive an item.
 ### LocationInfo
 Sent to clients to acknowledge a received [LocationScouts](#LocationScouts) packet and responds with the item in the location(s) being scouted.
 #### Arguments
-| Name      | Type                                | Notes                                                   |
-|-----------|-------------------------------------|---------------------------------------------------------|
+| Name      | Type                       | Notes                                                   |
+|-----------|----------------------------|---------------------------------------------------------|
 | locations | list\[[NetworkItem](#NetworkItem)\] | Contains list of item(s) in the location(s) scouted.    |
 | player    | int                        | The player number for the slot the locations belong to. |
 

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -148,10 +148,10 @@ Sent to clients when they receive an item.
 ### LocationInfo
 Sent to clients to acknowledge a received [LocationScouts](#LocationScouts) packet and responds with the item in the location(s) being scouted.
 #### Arguments
-| Name      | Type                       | Notes                                                   |
-|-----------|----------------------------|---------------------------------------------------------|
+| Name      | Type                                | Notes                                                   |
+|-----------|-------------------------------------|---------------------------------------------------------|
 | locations | list\[[NetworkItem](#NetworkItem)\] | Contains list of item(s) in the location(s) scouted.    |
-| player    | int                        | The player number for the slot the locations belong to. |
+| player    | int                                 | The player number for the slot the locations belong to. |
 
 ### RoomUpdate
 Sent when there is a need to update information about the present game session.

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -148,9 +148,10 @@ Sent to clients when they receive an item.
 ### LocationInfo
 Sent to clients to acknowledge a received [LocationScouts](#LocationScouts) packet and responds with the item in the location(s) being scouted.
 #### Arguments
-| Name | Type | Notes |
-| ---- | ---- | ----- |
-| locations | list\[[NetworkItem](#NetworkItem)\] | Contains list of item(s) in the location(s) scouted. |
+| Name      | Type                                | Notes                                                   |
+|-----------|-------------------------------------|---------------------------------------------------------|
+| locations | list\[[NetworkItem](#NetworkItem)\] | Contains list of item(s) in the location(s) scouted.    |
+| player    | int                        | The player number for the slot the locations belong to. |
 
 ### RoomUpdate
 Sent when there is a need to update information about the present game session.
@@ -335,11 +336,16 @@ Fully remote clients without a patch file may use this to "place" items onto the
 LocationScouts can also be used to inform the server of locations the client has seen, but not checked. This creates a hint as if the player had run `!hint_location` on a location, but without deducting hint points.
 This is useful in cases where an item appears in the game world, such as 'ledge items' in _A Link to the Past_. To do this, set the `create_as_hint` parameter to a non-zero value.
 
+For the purpose of in-game hints, it is also possible to scout other slots' locations. You can do this by setting the `player` parameter. 
+Only locations that contain items for your slot will actually be processed if you set the `player` parameter to a different slot's player number than your own.
+
 #### Arguments
-| Name | Type | Notes |
-| ---- | ---- | ----- |
-| locations | list\[int\] | The ids of the locations seen by the client. May contain any number of locations, even ones sent before; duplicates do not cause issues with the Archipelago server. |
-| create_as_hint | int | If non-zero, the scouted locations get created and broadcasted as a player-visible hint. <br/>If 2 only new hints are broadcast, however this does not remove them from the LocationInfo reply. |
+| Name           | Type        | Notes                                                                                                                                                                                           |
+|----------------|-------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| locations      | list\[int\] | The ids of the locations seen by the client. May contain any number of locations, even ones sent before; duplicates do not cause issues with the Archipelago server.                            |
+| create_as_hint | int         | If non-zero, the scouted locations get created and broadcasted as a player-visible hint. <br/>If 2 only new hints are broadcast, however this does not remove them from the LocationInfo reply. |
+| player         | int         | Determines the player whose locations will be scouted. If this is a different player than the requesting slot, only locations that contain their items will be processed.                       |
+
 
 ### StatusUpdate
 Sent to the server to update on the sender's status. Examples include readiness or goal completion. (Example: defeated Ganon in A Link to the Past)

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -344,7 +344,7 @@ Only locations that contain items for your slot will actually be processed if yo
 |----------------|-------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | locations      | list\[int\] | The ids of the locations seen by the client. May contain any number of locations, even ones sent before; duplicates do not cause issues with the Archipelago server.                            |
 | create_as_hint | int         | If non-zero, the scouted locations get created and broadcasted as a player-visible hint. <br/>If 2 only new hints are broadcast, however this does not remove them from the LocationInfo reply. |
-| player         | int         | Determines the player whose locations will be scouted. If this is a different player than the requesting slot, only locations that contain their items will be processed.                       |
+| player         | int         | Determines the player whose locations will be scouted. If this is a different player than the requesting slot, only locations that contain the requesting slot's items will be processed. Optional; defaults to the requesting slot.                       |
 
 
 ### StatusUpdate


### PR DESCRIPTION
Add a "player" argument to the LocationScouts package that specifies which player's locations to scout.

If this is a different player than the requesting slot, this only processes locations that contain that slot's items.

This can be used to 
1. "find all items in a different slot" (probably a bad usecase, this should be ItemScouts instead)
2. Create a free Archipelago hint matching an in-game hint.

That second use case is why this is important to me. The Witness (like a couple other games) has hints of the format: 
"Progressive Dots can be found on Player69's Link's Uncle".
I cannot currently create Archipelago hints from hints like that, and I want to be able to.
ItemScouts would not solve my problem because there are multi-copy items (e.g. Progressive Dots), and I want to be able to hint a *specific copy*, **not all of them** and **not a random one**. This means that the location is the only uniquely identifying key for a hint like this.

I released a Special Witness Client that can be used to test this feature in action:
https://github.com/NewSoupVi/The-Witness-Randomizer-for-Archipelago/releases/tag/locationscoutsspecial

**Tested**
Minimally, by making a simple modification to apclientpp and the Witness client and testing it "in action".
While playing slot 1, I got this audio log hint:
![image](https://github.com/ArchipelagoMW/Archipelago/assets/57900059/cd03fd3b-5b7a-4bc1-aac7-d94c8d737765)

This correctly appeared in the TextClient:
![image](https://github.com/ArchipelagoMW/Archipelago/assets/57900059/88e69225-2217-4f76-8f45-0537ba297940)

Haven't tested ItemLinks, I did add code for it but it's untested