### PR TITLE
SA2B: Fix Incorrect Link Syntax in SA2B Linux Setup

### DIFF
--- a/worlds/sa2b/docs/setup_en.md
+++ b/worlds/sa2b/docs/setup_en.md
@@ -48,7 +48,7 @@
 
 7. Install protontricks, on the Steam Deck this can be done via the Discover store, on other distros instructions vary, [see its github page](https://github.com/Matoking/protontricks).
 
-8. Download the [.NET 7 Desktop Runtime for x64 Windows](https://dotnet.microsoft.com/en-us/download/dotnet/thank-you/runtime-desktop-7.0.17-windows-x64-installer}. If this link does not work, the download can be found on [this page](https://dotnet.microsoft.com/en-us/download/dotnet/7.0).
+8. Download the [.NET 7 Desktop Runtime for x64 Windows](https://dotnet.microsoft.com/en-us/download/dotnet/thank-you/runtime-desktop-7.0.17-windows-x64-installer). If this link does not work, the download can be found on [this page](https://dotnet.microsoft.com/en-us/download/dotnet/7.0).
 
 9. Right click the .NET 7 Desktop Runtime exe, and assuming protontricks was installed correctly, the option to "Open with Protontricks Launcher" should be available. Click that, and in the popup window that opens, select SAModManager.exe. Follow the prompts after this to install the .NET 7 Desktop Runtime for SAModManager. Once it is done, you should be able to successfully launch SAModManager to steam.
 


### PR DESCRIPTION
## What is this fixing or adding?
Fixes a typo in the Linux portion of the SA2B setup guide that prevented the link from getting formatted correctly, it's now following proper markdown syntax.

## How was this tested?
Can view it rendering correctly when looking at it in the GitHub markdown preview, screenshot:
![image](https://github.com/ArchipelagoMW/Archipelago/assets/28993090/731cb5c1-3a62-4ab9-ae21-a4a7980046ec)

## If this makes graphical changes, please attach screenshots.
