### PR TITLE
Docs: Restore WebHost display for ProgressionBalancing

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -1142,9 +1142,9 @@ class ProgressionBalancing(NamedRange):
     range_end = 99
     display_name = "Progression Balancing"
     special_range_names = {
-        "disabled": 0,
-        "normal": 50,
-        "extreme": 99,
+        "Disabled": 0,
+        "Normal": 50,
+        "Extreme": 99,
     }
 
 

--- a/worlds/rogue_legacy/Presets.py
+++ b/worlds/rogue_legacy/Presets.py
@@ -40,7 +40,7 @@ rl_options_presets: Dict[str, Dict[str, Any]] = {
     },
     # A preset I actually use, using some literal values and some from the option itself.
     "Limited Potential": {
-        "progression_balancing":    "Disabled",
+        "progression_balancing":    0,
         "fairy_chests_per_zone":    2,
         "starting_class":           "random",
         "chests_per_zone":          30,

--- a/worlds/rogue_legacy/Presets.py
+++ b/worlds/rogue_legacy/Presets.py
@@ -40,7 +40,7 @@ rl_options_presets: Dict[str, Dict[str, Any]] = {
     },
     # A preset I actually use, using some literal values and some from the option itself.
     "Limited Potential": {
-        "progression_balancing":    "disabled",
+        "progression_balancing":    "Disabled",
         "fairy_chests_per_zone":    2,
         "starting_class":           "random",
         "chests_per_zone":          30,


### PR DESCRIPTION
## What is this fixing or adding?

Changing the display on WebHost for ProgressionBalancing to better match how it used to look

## How was this tested?

Running WebHost

## If this makes graphical changes, please attach screenshots.

Before the Options Overhaul:
![Screenshot 2024-06-13 110127](https://github.com/ArchipelagoMW/Archipelago/assets/60412657/1939218c-936d-4a99-99e9-5eb62d5da5bc)

After the Options Overhaul:
![Screenshot 2024-06-13 110139](https://github.com/ArchipelagoMW/Archipelago/assets/60412657/e7a6ec56-e6b6-416a-a23c-86f8354c0939)

After the Options Overhaul + PR:
![Screenshot 2024-06-13 110149](https://github.com/ArchipelagoMW/Archipelago/assets/60412657/2d8ee2a4-1acc-4fc6-a98f-3c2f5e18aabb)
