### PR TITLE
Options: fix yaml export corner case "6_2"

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -1426,14 +1426,18 @@ def generate_yaml_templates(target_folder: typing.Union[str, "pathlib.Path"], ge
 
         return data, notes
 
+    def yaml_dump_scalar(scalar) -> str:
+        # yaml dump may add end of document marker and newlines.
+        return yaml.dump(scalar).replace("...\n", "").strip()
+
     for game_name, world in AutoWorldRegister.world_types.items():
         if not world.hidden or generate_hidden:
-            grouped_options = get_option_groups(world)
+            option_groups = get_option_groups(world)
             with open(local_path("data", "options.yaml")) as f:
                 file_data = f.read()
             res = Template(file_data).render(
-                option_groups=grouped_options,
-                __version__=__version__, game=game_name, yaml_dump=yaml.dump,
+                option_groups=option_groups,
+                __version__=__version__, game=game_name, yaml_dump=yaml_dump_scalar,
                 dictify_range=dictify_range,
             )
 

--- a/data/options.yaml
+++ b/data/options.yaml
@@ -68,21 +68,21 @@ requires:
 
     {%- elif option.options -%}
     {%- for suboption_option_id, sub_option_name in option.name_lookup.items() %}
-    {{ sub_option_name }}: {% if suboption_option_id == option.default %}50{% else %}0{% endif %}
+    {{ yaml_dump(sub_option_name) }}: {% if suboption_option_id == option.default %}50{% else %}0{% endif %}
     {%- endfor -%}
 
     {%- if option.name_lookup[option.default] not in option.options %}
-    {{ option.default }}: 50
+    {{ yaml_dump(option.default) }}: 50
     {%- endif -%}
 
     {%- elif option.default is string %}
-    {{ option.default }}: 50
+    {{ yaml_dump(option.default) }}: 50
 
     {%- elif option.default is iterable and option.default is not mapping %}
     {{ option.default | list }}
 
     {%- else %}
-    {{ yaml_dump(option.default) | trim | indent(4, first=false) }}
+    {{ yaml_dump(option.default) | indent(4, first=false) }}
     {%- endif -%}
     {{ "\n" }}
   {%- endfor %}


### PR DESCRIPTION
## What is this fixing or adding?
https://discord.com/channels/731205301247803413/731214280439103580/1250848259677618196
Some strings  like "6_2" may be dumped raw, which then get interpreted as for example 62 back. This runs it all through the yaml dumper, so if any special handling is needed it should get applied.

## How was this tested?
https://discord.com/channels/731205301247803413/731214280439103580/1250857822153867264
I have since moved the instructions from the template to the new function in Options.py, but it does the same thing,

As far as I know, nothing should change for currently supported games.