### PR TITLE
Pokemon Emerald: Remove README

### DIFF
--- a/worlds/pokemon_emerald/README.md
+++ b/worlds/pokemon_emerald/README.md
@@ -1,3 +1,0 @@
-# Pokemon Emerald
-
-Version 2.0.0


### PR DESCRIPTION
## What is this fixing or adding?

Information that used to be in here was moved into `docs/`. Version number being in here and CHANGELOG only really makes it a pain to keep them in line with each other.

## How was this tested?

N/A
