### PR TITLE
kvui: Implemented and tested hint autocomplete suggestions

### DIFF
--- a/data/client.kv
+++ b/data/client.kv
@@ -152,3 +152,13 @@
     height: dp(30)
     multiline: False
     write_tab: False
+<AutocompleteHintDropdownButton>
+    size_hint_y: None
+    height: dp(30)
+    padding: [dp(5), 0]
+    text_size: self.size
+    shorten: True
+    multiline: False
+    halign: 'left'
+    valign: 'center'
+    markup: True

--- a/kvui.py
+++ b/kvui.py
@@ -300,10 +300,14 @@ class SelectableLabel(RecycleDataViewBehavior, TooltipLabel):
         self.selected = is_selected
 
 
+class AutocompleteHintDropdownButton(Button):
+    pass
+
+
 class AutocompleteHintInput(TextInput):
     min_chars = NumericProperty(3)
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
 
         self.dropdown = DropDown()
@@ -319,7 +323,7 @@ class AutocompleteHintInput(TextInput):
             ctx: context_type = App.get_running_app().ctx
             item_names = ctx.item_names._game_store[ctx.game].values()
 
-            def on_press(button: Button):
+            def on_press(button: AutocompleteHintDropdownButton):
                 split_text = MarkupLabel(text=button.text).markup
                 return self.dropdown.select("".join(text_frag for text_frag in split_text
                                                     if not text_frag.startswith("[")))
@@ -332,7 +336,7 @@ class AutocompleteHintInput(TextInput):
                 else:
                     text = escape_markup(item_name)
                     text = text[:index] + "[b]" + text[index:index+len(value)]+"[/b]"+text[index+len(value):]
-                    btn = Button(text=text, size_hint_y=None, height=dp(30), markup=True)
+                    btn = AutocompleteHintDropdownButton(text=text)
                     btn.bind(on_release=on_press)
                     self.dropdown.add_widget(btn)
             if not self.dropdown.attach_to:


### PR DESCRIPTION
## What is this fixing or adding?
Replacing changes with multiple commits, and trying to get some better code quality out of them. Currently ported changes:
* Dropdown text is left-aligned and displays nicely when the text is too wide for the window

![image](https://github.com/ArchipelagoMW/Archipelago/assets/31861583/dbd46aed-ccdf-4523-a5c5-315fecd8547a)
![image](https://github.com/ArchipelagoMW/Archipelago/assets/31861583/3db19a75-f063-40ef-bfad-05619bdf0b4a)


### Old changes:
* I've archived the branch locally so can bring these changes back up on request, or you can look at the archived branch here: https://github.com/MatthewMarinets/Archipelago/tree/mm/archive/autocomplete_hint_updates

Various fixes and improvements for PR #3535:
* Focus remains on the hint text box after selecting something, so the user doesn't have to click it before hitting enter
* Text in the dropdown is now left-aligned
* The dropdown is now navigable with up/down keys
* Fixed a mypy issue

## How was this tested?
Played around with it on the sc2 client:
* Tested clicking a dropdown option put it in the textbox, with focus on the textbox
* Tested up/down keys navigate the dropdown
* Tested pressing enter while a dropdown option is highlighted pastes the dropdown option's item name in the text box
* Tested pressing enter while no dropdown option is highlighted immediately tries to hint the contents of the textbox
* Tested selecting an option with the mouse while a dropdown option is highlighted behaves the same as clicking an option without keyboard dropdown highlight
* Tested focus remains on the textbox after a hint command is sent out

### Remaining issues
* There was some slowdown holding delete when the list item name matches is large (noticed with "Progressive" in the sc2 item pool)
* ~~Navigating down with arrow keys doesn't scroll the dropdown when selection goes off-screen~~
* Narrowing the window causes search result text to squish onto multiple lines in a bit of a mess rather than truncating
* Fuzzy search could be better
* Search results don't include item groups
* Decision point: should the textbox be cleared when a hint is sent out?

## If this makes graphical changes, please attach screenshots.
Navigating with arrow keys, deleting, then navigating to "Marine" with arrow keys and selecting "Laser Targeting System" with the mouse:
![hint_search_demo](https://github.com/ArchipelagoMW/Archipelago/assets/31861583/92050e40-0e5a-4c57-9d79-6a7d8068337d)

