### PR TITLE
Pokemon Red/Blue: Add new options to slot_data

### DIFF
--- a/worlds/pokemon_rb/__init__.py
+++ b/worlds/pokemon_rb/__init__.py
@@ -661,6 +661,9 @@ class PokemonRedBlueWorld(World):
             "dark_rock_tunnel_logic": self.multiworld.dark_rock_tunnel_logic[self.player].value,
             "split_card_key": self.multiworld.split_card_key[self.player].value,
             "all_elevators_locked": self.multiworld.all_elevators_locked[self.player].value,
+            "require_pokedex": self.multiworld.require_pokedex[self.player].value,
+            "area_1_to_1_mapping": self.multiworld.area_1_to_1_mapping[self.player].value,
+            "blind_trainers": self.multiworld.blind_trainers[self.player].value,
 
         }
 


### PR DESCRIPTION
## What is this fixing or adding?
Added require_pokedex, blind_trainers, and area_1_to_1 mapping, which would be helpful to the poptracker pack to more accurately reflect the checks available to players.

## How was this tested?
Generated a game with 10 games, and checked the spoiler log against the info in slot_data

## If this makes graphical changes, please attach screenshots.
No visual changes