### PR TITLE
Core: Added new role_triggers functionality and created two helper functions to support it.

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -399,30 +399,89 @@ def roll_linked_options(weights: dict) -> dict:
     return weights
 
 
+def compare_results(
+        yaml_value: Union[str, int, bool, dict, list],
+        trigger_value: Union[str, int, bool, dict, list],
+        comparator: str):
+    if comparator == "=":
+        return yaml_value == trigger_value
+    if type(yaml_value) is int and type(trigger_value) is int:
+        if comparator == "<":
+            return yaml_value < trigger_value
+        elif comparator == ">":
+            return yaml_value > trigger_value
+    else:
+        raise Exception("Comparing non-integer values is not possible with < or >")
+
+
+def compare_triggers(option_set: dict, currently_targeted_weights: dict) -> bool:
+    result = True
+    advanced = copy.deepcopy(option_set["option_advanced"])
+    # Check whether first trigger condition is true.
+    result = result and compare_results(currently_targeted_weights[advanced[0][0]], advanced[0][2], advanced[0][1])
+    # Cycle through remaining conditions, if any, in union + condition pairs.
+    for x in range(1, len(advanced), 2):
+        if advanced[x] == "|" or advanced[x] == 1:
+            if result:
+                return True
+            else:
+                result = True
+        elif advanced[x] == "&" or advanced[x] == 0:
+            if not result:
+                continue
+        else:
+            raise Exception(f"Unions must be chosen from: &, 0, |, 1. Please check trigger entry {x+1}")
+        entry = advanced[x+1]
+        result = result and compare_results(currently_targeted_weights[entry[0]], entry[2], entry[1])
+    return result
+
+
 def roll_triggers(weights: dict, triggers: list, valid_keys: set) -> dict:
     weights = copy.deepcopy(weights)  # make sure we don't write back to other weights sets in same_settings
     weights["_Generator_Version"] = Utils.__version__
     for i, option_set in enumerate(triggers):
         try:
+            if "option_advanced" not in option_set:
+                option_set["option_advanced"] = [[option_set["option_name"], "=", option_set["option_result"]]]
             currently_targeted_weights = weights
             category = option_set.get("option_category", None)
             if category:
                 currently_targeted_weights = currently_targeted_weights[category]
-            key = get_choice("option_name", option_set)
-            if key not in currently_targeted_weights:
-                logging.warning(f'Specified option name {option_set["option_name"]} did not '
-                                f'match with a root option. '
-                                f'This is probably in error.')
-            trigger_result = get_choice("option_result", option_set)
-            result = get_choice(key, currently_targeted_weights)
-            currently_targeted_weights[key] = result
-            if result == trigger_result and roll_percentage(get_choice("percentage", option_set, 100)):
+            advanced = option_set["option_advanced"]
+            if len(advanced) % 2 != 1:
+                raise Exception("option_advanced has an illegal number of entries. Please check trigger and fix.")
+            for x in range(0, len(advanced), 2):
+                result = get_choice(advanced[x][0], currently_targeted_weights)
+                if advanced[x][0] not in currently_targeted_weights:
+                    logging.warning(f"Specified option name {advanced[x][0]} did not "
+                                    f"match with a root option. "
+                                    f"This is probably in error.")
+                if type(result) is str:
+                    if len(result) > 12 and result[0:13] == "random-range-" and len(result.split("-")) == 4:
+                        result = result.split("-")
+                        result_min = int(result[2])
+                        result_max = int(result[3])
+                        result = random.randrange(result_min, result_max)
+                currently_targeted_weights[advanced[x][0]] = result
+                if len(advanced[x]) == 2:
+                    advanced[x].insert(1, "=")
+                if len(advanced[x]) == 3:
+                    if advanced[x][1] != "<" and advanced[x][1] != "=" and advanced[x][1] != ">":
+                        raise Exception(f"option_advanced has an illegal comparator in block {x}. "
+                                        f"Please check trigger and fix.")
+                else:
+                    raise Exception(f"options_advanced is malformed. "
+                                    f"Block {x} should have either 2 or 3 entries, but had {len(advanced[x])}.\n")
+            if (compare_triggers(option_set, currently_targeted_weights)
+                    and roll_percentage(get_choice("percentage", option_set, 100))):
                 for category_name, category_options in option_set["options"].items():
                     currently_targeted_weights = weights
                     if category_name:
                         currently_targeted_weights = currently_targeted_weights[category_name]
-                    update_weights(currently_targeted_weights, category_options, "Triggered", option_set["option_name"])
-            valid_keys.add(key)
+                    update_weights(currently_targeted_weights, category_options, "Triggered",
+                             f"Trigger {i + 1}")
+            for x in range(0, len(advanced), 2):
+                valid_keys.add(advanced[x][0])
         except Exception as e:
             raise ValueError(f"Your trigger number {i + 1} is invalid. "
                              f"Please fix your triggers.") from e


### PR DESCRIPTION
## What is this fixing or adding?
Keeps the current trigger functionality, while adding the ability to use comparators (<, >) for numerical values, and to and/or multiple conditions together for more complex triggers. This required adding random-range-min-max resolution to roll_triggers. random/random-range-low/high are not included in this resolution.
If the new option "option_advanced" is not included, triggers will work exactly as before, with the exception of resolving random-range-min-max.
For multiple option comparison, And takes priority, so if you look for options: A & B & C | B & D | A & E & F it will logically group them as: (A & B & C) | (B & D) | (A & E & F)

Format is as follows in the trigger options, replace list dots with - :
option_advanced:
  - ['option name1', (optional comparator), {trigger value}]
  - &/0 or |/1
  - ['option name2', (optional comparator), {trigger value}]
  - ...
  - ['option nameN', (optional comparator), {trigger value}]

the comparator accepts '<', '=', '>' and defaults to '=' if only two entries are given.
&/0 both represent an AND operation, while |/0 both represent and OR operation.

option_name/option_result are un-needed when option_advanced is present.

Example:
triggers:
  - option_category: 'A Link to the Past'
    option_advanced: 
      - ['crystals_needed_for_gt', '>', 2]
      - 0
      - ['crystals_needed_for_gt', '<', 6]
      - '&'
      - ['crystals_needed_for_ganon', '=', 4]
      - '|'
      - ['goal', 'triforce_hunt]
      - '&'
      - ['triforce_pieces_mode', '=', 'percentage']]
    options:
      A Link to the Past:
        swordless: true

This says that if crystals needed for gt is more than 2 and less than 6, and crystals needed for ganon is 4 OR if goal is triforce hunt and triforce pieces mode is set to percentage, then swordless will be set to true.

## How was this tested?
Unit tests were run to see if anything outside triggers had broken, and I tried old trigger styles to ensure they still worked, and then tried each new feature separately, and in multiple combinations while checking that the resulting settings were as expected, including making sure random-range-min-max permanently resolved to a constant value for that game's generation. 
Finally, I ran a generation with every supported game that A: Does not require you to possess a copy of, or B: That I possess a copy of. including both old and new triggers in two of them. 
The generation was successful with no errors, and all the game's settings were as expected, including merged values for start_inventory.

## If this makes graphical changes, please attach screenshots.
No graphical changes were made.