### PR TITLE
LADX: Moved ROM requirement from generate_output to stage_assert_generate.

### DIFF
--- a/worlds/ladx/__init__.py
+++ b/worlds/ladx/__init__.py
@@ -7,7 +7,7 @@ import typing
 import bsdiff4
 
 import settings
-from BaseClasses import Entrance, Item, ItemClassification, Location, Tutorial
+from BaseClasses import Entrance, Item, ItemClassification, Location, Tutorial, MultiWorld
 from Fill import fill_restrictive
 from worlds.AutoWorld import WebWorld, World
 from .Common import *
@@ -24,7 +24,7 @@ from .LADXR.worldSetup import WorldSetup as LADXRWorldSetup
 from .Locations import (LinksAwakeningLocation, LinksAwakeningRegion,
                         create_regions_from_ladxr, get_locations_to_id)
 from .Options import DungeonItemShuffle, links_awakening_options, ShuffleInstruments
-from .Rom import LADXDeltaPatch
+from .Rom import LADXDeltaPatch, get_base_rom_path
 
 DEVELOPER_MODE = False
 
@@ -432,6 +432,12 @@ class LinksAwakeningWorld(World):
                 return self.name_cache[name]
         
         return "TRADING_ITEM_LETTER"
+
+    @classmethod
+    def stage_assert_generate(cls, multiworld: MultiWorld):
+        rom_file = get_base_rom_path()
+        if not os.path.exists(rom_file):
+            raise FileNotFoundError(rom_file)
 
     def generate_output(self, output_directory: str):
         # copy items back to locations


### PR DESCRIPTION
## What is this fixing or adding?
LADX was requesting the ROM for the output in generate_output. This leads to some issues while generating. Now this part is moved to stage_assert_generate like it is done i.e. in ALttP and DKC3.

## How was this tested?
Removed any ROMs from the dev folder. Generated locally and observed that the ROM request comes in the same step like SMW.

## If this makes graphical changes, please attach screenshots.
Console shows that the ROM request is now similar to other games.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/68022469/675d4c3c-a65f-4729-9386-bbadeb8b6b26)
