### PR TITLE
LADX: Changed option handling to @dataclass.

### DIFF
--- a/worlds/ladx/Options.py
+++ b/worlds/ladx/Options.py
@@ -1,7 +1,8 @@
 import os.path
 import typing
 import logging
-from Options import Choice, Option, Toggle, DefaultOnToggle, Range, FreeText
+from dataclasses import dataclass
+from Options import Choice, Option, Toggle, DefaultOnToggle, Range, FreeText, DeathLink, OptionGroup, PerGameCommonOptions
 from collections import defaultdict
 import Utils
 
@@ -461,44 +462,77 @@ class AdditionalWarpPoints(DefaultOffToggle):
     [On] (requires warp improvements) Adds a warp point at Crazy Tracy's house (the Mambo teleport spot) and Eagle's Tower
     [Off] No change
     """
-     
 
-links_awakening_options: typing.Dict[str, typing.Type[Option]] = {
-    'logic': Logic,
-    # 'heartpiece': DefaultOnToggle, # description='Includes heart pieces in the item pool'),                
-    # 'seashells': DefaultOnToggle, # description='Randomizes the secret sea shells hiding in the ground/trees. (chest are always randomized)'),                
-    # 'heartcontainers': DefaultOnToggle, # description='Includes boss heart container drops in the item pool'),                
-    # 'instruments': DefaultOffToggle, # description='Instruments are placed on random locations, dungeon goal will just contain a random item.'),                
-    'tradequest': TradeQuest, # description='Trade quest items are randomized, each NPC takes its normal trade quest item, but gives a random item'),                
-    # 'witch': DefaultOnToggle, # description='Adds both the toadstool and the reward for giving the toadstool to the witch to the item pool'),                
-    'rooster': Rooster, # description='Adds the rooster to the item pool. Without this option, the rooster spot is still a check giving an item. But you will never find the rooster. Any rooster spot is accessible without rooster by other means.'),                
-    # 'boomerang': Boomerang,
-    # 'randomstartlocation': DefaultOffToggle, # 'Randomize where your starting house is located'),
-    'experimental_dungeon_shuffle': DungeonShuffle, # 'Randomizes the dungeon that each dungeon entrance leads to'),
-    'experimental_entrance_shuffle': EntranceShuffle,
-    # 'bossshuffle': BossShuffle,
-    # 'minibossshuffle': BossShuffle,
-    'goal': Goal,
-    'instrument_count': InstrumentCount,
-    # 'itempool': ItemPool,
-    # 'bowwow': Bowwow,
-    # 'overworld': Overworld,
-    'link_palette': LinkPalette,
-    'warp_improvements': WarpImprovements,
-    'additional_warp_points': AdditionalWarpPoints,
-    'trendy_game': TrendyGame,
-    'gfxmod': GfxMod,
-    'palette': Palette,
-    'text_shuffle': TextShuffle,
-    'shuffle_nightmare_keys': ShuffleNightmareKeys,
-    'shuffle_small_keys': ShuffleSmallKeys,
-    'shuffle_maps': ShuffleMaps,
-    'shuffle_compasses': ShuffleCompasses,
-    'shuffle_stone_beaks': ShuffleStoneBeaks,
-    'music': Music,
-    'shuffle_instruments': ShuffleInstruments,
-    'music_change_condition': MusicChangeCondition,
-    'nag_messages': NagMessages,
-    'ap_title_screen': APTitleScreen,
-    'boots_controls': BootsControls,   
-}
+ladx_option_groups = [
+    OptionGroup("Goal Options", [
+        Goal,
+        InstrumentCount,
+    ]),
+    OptionGroup("Shuffles", [
+        ShuffleInstruments,
+        ShuffleNightmareKeys,
+        ShuffleSmallKeys,
+        ShuffleMaps,
+        ShuffleCompasses,
+        ShuffleStoneBeaks
+    ]),
+    OptionGroup("Warp Points", [
+        WarpImprovements,
+        AdditionalWarpPoints,
+    ]),
+    OptionGroup("Experimental", [
+        DungeonShuffle,
+        EntranceShuffle
+    ]),
+    OptionGroup("Visuals & Sound", [
+        LinkPalette,
+        Palette,
+        TextShuffle,
+        APTitleScreen,
+        GfxMod,
+        Music,
+        MusicChangeCondition
+    ]),
+    OptionGroup("Miscellaneous", [
+        TradeQuest,
+        Rooster,
+        TrendyGame,
+        NagMessages,
+        BootsControls
+    ])
+]
+     
+@dataclass
+class LinksAwakeningOptions(PerGameCommonOptions):
+    death_link: DeathLink
+    logic: Logic
+
+    goal: Goal
+    instrument_count: InstrumentCount
+    
+    shuffle_instruments: ShuffleInstruments
+    shuffle_nightmare_keys: ShuffleNightmareKeys
+    shuffle_small_keys: ShuffleSmallKeys
+    shuffle_maps: ShuffleMaps
+    shuffle_compasses: ShuffleCompasses
+    shuffle_stone_beaks: ShuffleStoneBeaks
+    
+    warp_improvements: WarpImprovements
+    additional_warp_points: AdditionalWarpPoints
+    
+    experimental_dungeon_shuffle: DungeonShuffle # 'Randomizes the dungeon that each dungeon entrance leads to'),
+    experimental_entrance_shuffle: EntranceShuffle
+    
+    link_palette: LinkPalette
+    palette: Palette
+    text_shuffle: TextShuffle
+    ap_title_screen: APTitleScreen
+    gfxmod: GfxMod
+    music: Music
+    music_change_condition: MusicChangeCondition
+    
+    tradequest: TradeQuest # description='Trade quest items are randomized, each NPC takes its normal trade quest item, but gives a random item'),                
+    rooster: Rooster # description='Adds the rooster to the item pool. Without this option, the rooster spot is still a check giving an item. But you will never find the rooster. Any rooster spot is accessible without rooster by other means.'),                
+    trendy_game: TrendyGame
+    nag_messages: NagMessages
+    boots_controls: BootsControls


### PR DESCRIPTION
## What is this fixing or adding?
LADX options didn't implemented dataclass so far. This leads to a lot of errors while generating a seed.
Additionally the player options page got grouped.

## How was this tested?
Generated seeds with LADX players locally.

## If this makes graphical changes, please attach screenshots.
LADX is not mentioned anymore in the warning at the beginning.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/68022469/1f7130e5-8c29-4220-93d2-62e303c32b17)

There are also no warnings anymore while generating a LADX seed which mentioned that getting options from multidata is deprecated.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/68022469/1cdd90a9-cbdc-4129-be12-a38538cc2f41)

The new options groups also changed the visuals on the player options page.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/68022469/1a68e7ed-8c17-4620-b36e-23d131b283bd)