### PR TITLE
Docs: Change setup_en.md to use Latest releases page

### DIFF
--- a/worlds/generic/docs/setup_en.md
+++ b/worlds/generic/docs/setup_en.md
@@ -11,8 +11,8 @@ Some steps also assume use of Windows, so may vary with your OS.
 
 ## Installing the Archipelago software
 
-The most recent public release of Archipelago can be found on the GitHub Releases page:
-[Archipelago Releases Page](https://github.com/ArchipelagoMW/Archipelago/releases/latest).
+The most recent public release of Archipelago can be found on GitHub:
+[Archipelago Lastest Release](https://github.com/ArchipelagoMW/Archipelago/releases/latest).
 
 Run the exe file, and after accepting the license agreement you will be asked which components you would like to
 install.

--- a/worlds/generic/docs/setup_en.md
+++ b/worlds/generic/docs/setup_en.md
@@ -12,7 +12,7 @@ Some steps also assume use of Windows, so may vary with your OS.
 ## Installing the Archipelago software
 
 The most recent public release of Archipelago can be found on the GitHub Releases page:
-[Archipelago Releases Page](https://github.com/ArchipelagoMW/Archipelago/releases).
+[Archipelago Releases Page](https://github.com/ArchipelagoMW/Archipelago/releases/latest).
 
 Run the exe file, and after accepting the license agreement you will be asked which components you would like to
 install.


### PR DESCRIPTION
Really simple change to point users to the Latest release page instead of the Releases page.  Saw a user accidentally download 0.3.6 because it was the last item on the page (they're accustomed to scrolling down to the bottom of the page in GitHub for the Assets section), and this change prevents that outright.

Was tested by opening a single link in my preferred web browser.