### PR TITLE
TUNIC: Update Plando Connections description

### DIFF
--- a/worlds/tunic/options.py
+++ b/worlds/tunic/options.py
@@ -174,6 +174,13 @@ class ShuffleLadders(Toggle):
     
     
 class TunicPlandoConnections(PlandoConnections):
+    """
+    Generic connection plando. Format is:
+    - entrance: "Entrance Name"
+      exit: "Exit Name"
+      percentage: 100
+    Percentage is an integer from 0 to 100 which determines whether that connection will be made. Defaults to 100 if omitted.
+    """
     entrances = {*(portal.name for portal in portal_mapping), "Shop", "Shop Portal"}
     exits = {*(portal.name for portal in portal_mapping), "Shop", "Shop Portal"}
 


### PR DESCRIPTION
## What is this fixing or adding?
Updates the description to use a custom one instead of the generic one, since the generic description includes `direction`, which Tunic ignores.

## How was this tested?
Reading, generating template yaml.

## If this makes graphical changes, please attach screenshots.
N/A