### PR TITLE
Core: move game choice to options system

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -78,7 +78,7 @@ class MultiWorld():
     start_location_hints: Dict[int, Options.StartLocationHints]
     item_links: Dict[int, Options.ItemLinks]
 
-    game: Dict[int, str]
+    game: Dict[int, Options.Game]
 
     random: random.Random
     per_slot_randoms: Utils.DeprecateDict[int, random.Random]
@@ -184,7 +184,7 @@ class MultiWorld():
         new_id: int = self.players + len(self.groups) + 1
 
         self.regions.add_group(new_id)
-        self.game[new_id] = game
+        self.game[new_id] = Options.Game.from_any(game)
         self.player_types[new_id] = NetUtils.SlotType.group
         world_type = AutoWorld.AutoWorldRegister.world_types[game]
         self.worlds[new_id] = world_type.create_group(self, new_id, players)
@@ -215,6 +215,9 @@ class MultiWorld():
         all_keys: Set[str] = {key for player in self.player_ids for key in
                               AutoWorld.AutoWorldRegister.world_types[self.game[player]].options_dataclass.type_hints}
         for option_key in all_keys:
+            # for now, root only options get directly assigned to the multiworld, and we don't want/need to override them
+            if option_key in Options.RootOnlyOptions.type_hints:
+                continue
             option = Utils.DeprecateDict(f"Getting options from multiworld is now deprecated. "
                                          f"Please use `self.options.{option_key}` instead.")
             option.update(getattr(args, option_key, {}))
@@ -253,7 +256,7 @@ class MultiWorld():
                         "players": {player: item_link["replacement_item"]},
                         "item_pool": set(item_link["item_pool"]),
                         "exclude": set(item_link.get("exclude", [])),
-                        "game": self.game[player],
+                        "game": self.game[player].value,
                         "local_items": set(item_link.get("local_items", [])),
                         "non_local_items": set(item_link.get("non_local_items", [])),
                         "link_replacement": replacement_prio.index(item_link["link_replacement"]),

--- a/Main.py
+++ b/Main.py
@@ -320,12 +320,12 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
                     player_world: AutoWorld.World = multiworld.worlds[slot]
                     minimum_versions["server"] = max(minimum_versions["server"], player_world.required_server_version)
                     client_versions[slot] = player_world.required_client_version
-                    games[slot] = multiworld.game[slot]
-                    slot_info[slot] = NetUtils.NetworkSlot(names[0][slot - 1], multiworld.game[slot],
+                    games[slot] = multiworld.game[slot].value
+                    slot_info[slot] = NetUtils.NetworkSlot(names[0][slot - 1], games[slot],
                                                            multiworld.player_types[slot])
                 for slot, group in multiworld.groups.items():
-                    games[slot] = multiworld.game[slot]
-                    slot_info[slot] = NetUtils.NetworkSlot(group["name"], multiworld.game[slot], multiworld.player_types[slot],
+                    games[slot] = multiworld.game[slot].value
+                    slot_info[slot] = NetUtils.NetworkSlot(group["name"], games[slot], multiworld.player_types[slot],
                                                            group_members=sorted(group["players"]))
                 precollected_items = {player: [item.code for item in world_precollected if type(item.code) == int]
                                       for player, world_precollected in multiworld.precollected_items.items()}


### PR DESCRIPTION
## What is this fixing or adding?
Moves the choice of game to the options system. Makes `FreeText` hashable, so that it can be used in dictionaries and so `option in etc` works. Adds a new `RootOnlyOptions` dataclass for options that can only exist at the root level of a yaml and not within a game section (so that name, requires, description, and possible future additions can be on the options system). Biggest flaw with this and that I haven't decided on a solution yet is that this will assign the option in to the worlds' `World.options` and can be changed there. Omitting it from that dataclass should be relatively trivial, but unsure if the way that the multiworld itself checks games should be changed so haven't done that.

## How was this tested?
Messed with yaml and debugged through all the relevant changes to make sure all the text output correctly, and all the dictionaries, etc. worked the same as they did before. Did not test meta or triggers so those still need testing. Didn't check if any worlds reference the changed attribute, but most everything should be backwards compatible.

## If this makes graphical changes, please attach screenshots.
![Screenshot_265](https://github.com/ArchipelagoMW/Archipelago/assets/13184667/68d417c2-96a9-4fe3-83dc-9c068b49a4a5)
