### PR TITLE
Core: Add __iter__ to VerifyKeys

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -822,7 +822,7 @@ class VerifyKeys(metaclass=FreezeValidKeys):
                                     f"is not a valid location name from {world.game}. "
                                     f"Did you mean '{picks[0][0]}' ({picks[0][1]}% sure)")
 
-    def __iter__(self):
+    def __iter__(self) -> typing.Iterator[typing.Any]:
         return self.value.__iter__()
 
     

--- a/Options.py
+++ b/Options.py
@@ -822,7 +822,10 @@ class VerifyKeys(metaclass=FreezeValidKeys):
                                     f"is not a valid location name from {world.game}. "
                                     f"Did you mean '{picks[0][0]}' ({picks[0][1]}% sure)")
 
+    def __iter__(self):
+        return self.value.__iter__()
 
+    
 class OptionDict(Option[typing.Dict[str, typing.Any]], VerifyKeys, typing.Mapping[str, typing.Any]):
     default = {}
     supports_weighting = False


### PR DESCRIPTION
Allows doing `for item in self.options.locationset` instead of `for item in self.option.locationset.value`