### PR TITLE
Docs: Mention indirect_conditions and that they are a *hard requirement* (with a few sharp exception cases)

### DIFF
--- a/docs/world api.md
+++ b/docs/world api.md
@@ -303,7 +303,7 @@ generation (entrance randomization).
 An access rule is a function that returns `True` or `False` for a `Location` or `Entrance` based on the current `state`
 (items that have been collected).
 
-The two possible ways to make a CollectionRule are:
+The two possible ways to make a [CollectionRule](https://github.com/ArchipelagoMW/Archipelago/blob/main/worlds/generic/Rules.py#L10) are:
 - `def rule(state: CollectionState) -> bool:`
 - `lambda state: ... boolean expression ...`
 
@@ -654,7 +654,7 @@ def set_rules(self) -> None:
 
 Custom methods can be defined for your logic rules. The access rule that ultimately gets assigned to the Location or
 Entrance should be
-a [`CollectionRule`](https://github.com/ArchipelagoMW/Archipelago/blob/main/worlds/generic/Rules.py#L9).
+a [`CollectionRule`](https://github.com/ArchipelagoMW/Archipelago/blob/main/worlds/generic/Rules.py#L10).
 Typically, this is done by defining a lambda expression on demand at the relevant bit, typically calling other
 functions, but this can also be achieved by defining a method with the appropriate format and assigning it directly.
 For an example, see [The Messenger](/worlds/messenger/rules.py).

--- a/docs/world api.md
+++ b/docs/world api.md
@@ -315,7 +315,7 @@ Access rules usually check for one of two things.
 Keep in mind that entrances and locations implicitly check for the accessibility of their parent region, so you do not need to check explicitly for it.
 
 #### An important note on Entrance access rules:
-When using `state.can_reach` on an entrance access condition, you must also use `multiworld.register_indirect_condition`.
+When using `state.can_reach` within an entrance access condition, you must also use `multiworld.register_indirect_condition`.
 
 For efficiency reasons, every time reachable regions are searched, every entrance is only checked once in a somewhat non-deterministic order.
 This is fine when checking for items using `state.has`, because items do not change during a region sweep.

--- a/docs/world api.md
+++ b/docs/world api.md
@@ -317,8 +317,9 @@ Keep in mind that entrances and locations implicitly check for the accessibility
 #### An important note on Entrance access rules:
 For efficiency reasons, every time reachable regions are searched, every entrance is only checked once in a somewhat non-deterministic order.
 This is fine when checking for items using `state.has`, because items do not change during a region sweep.
-However, `state.can_reach` checks for the very same thing we are updating: Regions. Even doing `state.can_reach_location` or `state.can_reach_entrance` will also check that location's or entrance's parent region.
+However, `state.can_reach` checks for the very same thing we are updating: Regions.
 This can lead to non-deterministic behavior and, in the worst case, even generation failures.
+Even doing `state.can_reach_location` or `state.can_reach_entrance` is problematic, as these functions call `state.can_reach_region` on the location's/entrance's parent region.
 
 **Hence, it is considered unsafe to perform `state.can_reach` from within an access condition for an entrance**, unless you are checking for something that sits in the source region of the entrance.
 There is a solution to this issue: `multiworld.register_indirect_condition(region, entrance)`. It is an explicit way to tell the generator that when a given region becomes accessible, it is necessary to re-check a specific entrance.

--- a/docs/world api.md
+++ b/docs/world api.md
@@ -306,6 +306,7 @@ An access rule is a function that returns `True` or `False` for a `Location` or 
 The two possible ways to make a CollectionRule are:
 - `def rule(state: CollectionState) -> bool:`
 - `lambda state: ... boolean expression ...`
+
 An access rule can be assigned through `set_rule(location, rule)`.
 
 Access rules usually check for one of two things.

--- a/docs/world api.md
+++ b/docs/world api.md
@@ -1,4 +1,4 @@
-![image](https://github.com/ArchipelagoMW/Archipelago/assets/57900059/b3f5499b-229b-4562-a8f7-5e7f171fa716)# Archipelago API
+# Archipelago API
 
 This document tries to explain some aspects of the Archipelago World API used when implementing the generation logic of
 a game.

--- a/docs/world api.md
+++ b/docs/world api.md
@@ -310,7 +310,7 @@ An access rule can be assigned through `set_rule(location, rule)`.
 
 Access rules usually check for one of two things.
 - Items that have been collected (e.g. `state.has("Sword", player)`)
-- Locations, Regions or Entrances that have been reached (e.g. `state.can_reach_region("Boss Room"))
+- Locations, Regions or Entrances that have been reached (e.g. `state.can_reach_region("Boss Room")`)
 
 Keep in mind that entrances and locations implicitly check for the accessibility of their parent region, so you do not need to check explicitly for it.
 

--- a/docs/world api.md
+++ b/docs/world api.md
@@ -315,14 +315,16 @@ Access rules usually check for one of two things.
 Keep in mind that entrances and locations implicitly check for the accessibility of their parent region, so you do not need to check explicitly for it.
 
 #### An important note on Entrance access rules:
+When using `state.can_reach` on an entrance access condition, you must also use `multiworld.register_indirect_condition`.
+
 For efficiency reasons, every time reachable regions are searched, every entrance is only checked once in a somewhat non-deterministic order.
 This is fine when checking for items using `state.has`, because items do not change during a region sweep.
 However, `state.can_reach` checks for the very same thing we are updating: Regions.
 This can lead to non-deterministic behavior and, in the worst case, even generation failures.
 Even doing `state.can_reach_location` or `state.can_reach_entrance` is problematic, as these functions call `state.can_reach_region` on the respective parent region.
 
-**Hence, it is considered unsafe to perform `state.can_reach` from within an access condition for an entrance**, unless you are checking for something that sits in the source region of the entrance.
-There is a solution to this issue: `multiworld.register_indirect_condition(region, entrance)`. It is an explicit way to tell the generator that when a given region becomes accessible, it is necessary to re-check a specific entrance.
+**Therefore, it is considered unsafe to perform `state.can_reach` from within an access condition for an entrance**, unless you are checking for something that sits in the source region of the entrance.
+You can use `multiworld.register_indirect_condition(region, entrance)` to explicitly tell the generator that, when a given region becomes accessible, it is necessary to re-check a specific entrance.
 You **must** use `multiworld.register_indirect_condition` if you perform this kind of `can_reach` from an entrance access rule, unless you have a **very** good technical understanding of the relevant code and can reason why it will never lead to problems in your case.
 
 ### Item Rules

--- a/docs/world api.md
+++ b/docs/world api.md
@@ -319,11 +319,11 @@ For efficiency reasons, every time reachable regions are searched, every entranc
 This is fine when checking for items using `state.has`, because items do not change during a region sweep.
 However, `state.can_reach` checks for the very same thing we are updating: Regions.
 This can lead to non-deterministic behavior and, in the worst case, even generation failures.
-Even doing `state.can_reach_location` or `state.can_reach_entrance` is problematic, as these functions call `state.can_reach_region` on the location's/entrance's parent region.
+Even doing `state.can_reach_location` or `state.can_reach_entrance` is problematic, as these functions call `state.can_reach_region` on the respective parent region.
 
 **Hence, it is considered unsafe to perform `state.can_reach` from within an access condition for an entrance**, unless you are checking for something that sits in the source region of the entrance.
 There is a solution to this issue: `multiworld.register_indirect_condition(region, entrance)`. It is an explicit way to tell the generator that when a given region becomes accessible, it is necessary to re-check a specific entrance.
-You **must** use `multiworld.register_indirect_condition` if you perform this kind of `can_reach` from an entrance access rule, unless you have a **very** good technical understanding of the issue and can reason why it can never lead to issues in your case.
+You **must** use `multiworld.register_indirect_condition` if you perform this kind of `can_reach` from an entrance access rule, unless you have a **very** good technical understanding of the relevant code and can reason why it will never lead to problems in your case.
 
 ### Item Rules
 


### PR DESCRIPTION
I definitely don't feel like I wrote this in the best way, or in the best place, but it is a precedent that I think is necessary so we can treat it as "the law of the land" in discussions, instead of it being a secret thing that unsuspecting world devs stumble across at some point while reading a random discussion & are then told they need to change it, leading to confusion about why it is necessary and subsequently debate about whether it is necessary

I would like to save us all some emotional labor and time :D