### PR TITLE
TUNIC: Add note about bushes to logic section of game info page

### DIFF
--- a/worlds/tunic/docs/en_TUNIC.md
+++ b/worlds/tunic/docs/en_TUNIC.md
@@ -53,6 +53,7 @@ You can also use the Universal Tracker (by Faris and qwint) to find a complete l
 ## What should I know regarding logic?
 In general:
 - Nighttime is not considered in logic. Every check in the game is obtainable during the day.
+- Bushes are not considered in logic. It is assumed that the player will find a way past them, whether it is with a sword, a bomb, fire, luring an enemy, etc. There is also an option within the randomizer settings -> general settings to clear some early bushes.
 - The Cathedral is accessible during the day by using the Hero's Laurels to reach the Overworld fuse near the Swamp entrance.
 - The Secret Legend chest at the Cathedral can be obtained during the day by opening the Holy Cross door from the outside.
 

--- a/worlds/tunic/docs/en_TUNIC.md
+++ b/worlds/tunic/docs/en_TUNIC.md
@@ -53,7 +53,7 @@ You can also use the Universal Tracker (by Faris and qwint) to find a complete l
 ## What should I know regarding logic?
 In general:
 - Nighttime is not considered in logic. Every check in the game is obtainable during the day.
-- Bushes are not considered in logic. It is assumed that the player will find a way past them, whether it is with a sword, a bomb, fire, luring an enemy, etc. There is also an option within the randomizer settings -> general settings to clear some early bushes.
+- Bushes are not considered in logic. It is assumed that the player will find a way past them, whether it is with a sword, a bomb, fire, luring an enemy, etc. There is also an option in the in-game randomizer settings menu to clear some of the early bushes.
 - The Cathedral is accessible during the day by using the Hero's Laurels to reach the Overworld fuse near the Swamp entrance.
 - The Secret Legend chest at the Cathedral can be obtained during the day by opening the Holy Cross door from the outside.
 


### PR DESCRIPTION
## What is this fixing or adding?
Bush logic is weird, since there's many different ways past them. Some require progression items, some require items that are not currently marked progression, some require no items but require effort. Ultimately, the decision made was that they are not considered in logic, since they would force a sword or wand to show up basically immediately, especially in single player.

So, this just adds a note regarding it to the game info page that we can point at.

## How was this tested?
Reading

## If this makes graphical changes, please attach screenshots.
N/A