### PR TITLE
LADX: Adding 'Option Groups' to the player options page.

### DIFF
--- a/worlds/ladx/Options.py
+++ b/worlds/ladx/Options.py
@@ -510,6 +510,13 @@ ladx_option_groups = [
         WarpImprovements,
         AdditionalWarpPoints,
     ]),
+    OptionGroup("Miscellaneous", [
+        TradeQuest,
+        Rooster,
+        TrendyGame,
+        NagMessages,
+        BootsControls
+    ]),
     OptionGroup("Experimental", [
         DungeonShuffle,
         EntranceShuffle
@@ -522,13 +529,6 @@ ladx_option_groups = [
         GfxMod,
         Music,
         MusicChangeCondition
-    ]),
-    OptionGroup("Miscellaneous", [
-        TradeQuest,
-        Rooster,
-        TrendyGame,
-        NagMessages,
-        BootsControls
     ])
 ]
 

--- a/worlds/ladx/Options.py
+++ b/worlds/ladx/Options.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import os.path
 import typing
 import logging
-from Options import Choice, Toggle, DefaultOnToggle, Range, FreeText, PerGameCommonOptions
+from Options import Choice, Toggle, DefaultOnToggle, Range, FreeText, PerGameCommonOptions, OptionGroup
 from collections import defaultdict
 import Utils
 
@@ -493,6 +493,44 @@ class AdditionalWarpPoints(DefaultOffToggle):
     [Off] No change
     """
 
+ladx_option_groups = [
+    OptionGroup("Goal Options", [
+        Goal,
+        InstrumentCount,
+    ]),
+    OptionGroup("Shuffles", [
+        ShuffleInstruments,
+        ShuffleNightmareKeys,
+        ShuffleSmallKeys,
+        ShuffleMaps,
+        ShuffleCompasses,
+        ShuffleStoneBeaks
+    ]),
+    OptionGroup("Warp Points", [
+        WarpImprovements,
+        AdditionalWarpPoints,
+    ]),
+    OptionGroup("Experimental", [
+        DungeonShuffle,
+        EntranceShuffle
+    ]),
+    OptionGroup("Visuals & Sound", [
+        LinkPalette,
+        Palette,
+        TextShuffle,
+        APTitleScreen,
+        GfxMod,
+        Music,
+        MusicChangeCondition
+    ]),
+    OptionGroup("Miscellaneous", [
+        TradeQuest,
+        Rooster,
+        TrendyGame,
+        NagMessages,
+        BootsControls
+    ])
+]
 
 @dataclass
 class LinksAwakeningOptions(PerGameCommonOptions):

--- a/worlds/ladx/__init__.py
+++ b/worlds/ladx/__init__.py
@@ -24,7 +24,7 @@ from .LADXR.settings import Settings as LADXRSettings
 from .LADXR.worldSetup import WorldSetup as LADXRWorldSetup
 from .Locations import (LinksAwakeningLocation, LinksAwakeningRegion,
                         create_regions_from_ladxr, get_locations_to_id)
-from .Options import DungeonItemShuffle, ShuffleInstruments, LinksAwakeningOptions
+from .Options import DungeonItemShuffle, ShuffleInstruments, LinksAwakeningOptions, ladx_option_groups
 from .Rom import LADXDeltaPatch, get_base_rom_path
 
 DEVELOPER_MODE = False
@@ -65,7 +65,7 @@ class LinksAwakeningWebWorld(WebWorld):
         ["zig"]
     )]
     theme = "dirt"
-
+    option_groups = ladx_option_groups
 
 class LinksAwakeningWorld(World):
     """


### PR DESCRIPTION
## What is this fixing or adding?
Adding the option groups to the options page for LADX.
This PR is a separated part of #3541 which was a duplicate of #3542. So this one is an addition of the already merged #3542.

## How was this tested?
Starting the webhost locally and open the player options page. Also configuring and exporting configs, compare with a config from before the change and take a look if the result is the same.

## If this makes graphical changes, please attach screenshots.
![Screenshot 2024-06-16 101018](https://github.com/ArchipelagoMW/Archipelago/assets/68022469/fce5393d-d61f-4930-b833-20b857787744)
