### PR TITLE
id Tech 1 games: Reintroduce missing items

### DIFF
--- a/worlds/doom_ii/__init__.py
+++ b/worlds/doom_ii/__init__.py
@@ -60,17 +60,18 @@ class DOOM2World(World):
     # Item ratio that scales depending on episode count. These are the ratio for 3 episode. In DOOM1.
     # The ratio have been tweaked seem, and feel good.
     items_ratio: Dict[str, float] = {
-        "Armor": 41,
-        "Mega Armor": 25,
-        "Berserk": 12,
+        "Armor": 39,
+        "Mega Armor": 23,
+        "Berserk": 11,
         "Invulnerability": 10,
         "Partial invisibility": 18,
-        "Supercharge": 28,
+        "Supercharge": 26,
         "Medikit": 15,
         "Box of bullets": 13,
         "Box of rockets": 13,
         "Box of shotgun shells": 13,
-        "Energy cell pack": 10
+        "Energy cell pack": 10,
+        "Megasphere": 7
     }
 
     def __init__(self, multiworld: MultiWorld, player: int):
@@ -233,6 +234,7 @@ class DOOM2World(World):
         self.create_ratioed_items("Invulnerability", itempool)
         self.create_ratioed_items("Partial invisibility", itempool)
         self.create_ratioed_items("Supercharge", itempool)
+        self.create_ratioed_items("Megasphere", itempool)
 
         while len(itempool) < self.location_count:
             itempool.append(self.create_item(self.get_filler_item_name()))

--- a/worlds/heretic/__init__.py
+++ b/worlds/heretic/__init__.py
@@ -71,6 +71,7 @@ class HereticWorld(World):
         "Tome of Power": 16,
         "Silver Shield": 10,
         "Enchanted Shield": 5,
+        "Torch": 5,
         "Morph Ovum": 3,
         "Mystic Urn": 2,
         "Chaos Device": 1,
@@ -242,6 +243,7 @@ class HereticWorld(World):
         self.create_ratioed_items("Mystic Urn", itempool)
         self.create_ratioed_items("Ring of Invincibility", itempool)
         self.create_ratioed_items("Shadowsphere", itempool)
+        self.create_ratioed_items("Torch", itempool)
         self.create_ratioed_items("Timebomb of the Ancients", itempool)
         self.create_ratioed_items("Tome of Power", itempool)
         self.create_ratioed_items("Silver Shield", itempool)


### PR DESCRIPTION
## What is this fixing or adding?

In Doom II, the Megasphere (which was an item not in Doom 1993) is never added to the pool at all, despite already being present in AP's item list. In Heretic, the Torch is in a similar situation, not being added to the pool at all despite existing as a possible item.

Neither of these omissions seem to be intentional, and in fact I recall Daivuk stating in the past that the Megasphere in Doom II was completely forgotten about since so much of that is just copied from Doom 1993. So this PR aims to reintroduce these two items for a bit more added variety in multiworlds.

Also because I swear if I have to go through some of Heretic's darker rooms again without a torch--

## How was this tested?

Generating a multiworld with these changes, and making sure both items appeared and function correctly.

## If this makes graphical changes, please attach screenshots.

[Receiving a Torch in game](https://github.com/ArchipelagoMW/Archipelago/assets/539749/803ed83d-aa11-4ef6-a065-fb4b783673ee) -- functionally identical to using !getitem Torch previously because everything was entirely functional beforehand, it's just now possible to do