### PR TITLE
The Messenger: Fix missing rules for Double Swing Saws

### DIFF
--- a/worlds/messenger/rules.py
+++ b/worlds/messenger/rules.py
@@ -379,9 +379,6 @@ class MessengerHardRules(MessengerRules):
                     self.has_dart,
                 "Autumn Hills - Climbing Claws Shop -> Autumn Hills - Key of Hope Checkpoint":
                     self.true,  # super easy normal clip - also possible with moderately difficult cloud stepping
-                "Autumn Hills Seal - Double Swing Saws":
-                    lambda state: self.has_vertical(state) or self.has_windmill(state) or
-                                  self.can_destroy_projectiles(state),
                 # Howling Grotto
                 "Howling Grotto - Portal -> Howling Grotto - Crushing Pits Shop":
                     self.true,
@@ -435,6 +432,9 @@ class MessengerHardRules(MessengerRules):
             {
                 "Autumn Hills Seal - Spike Ball Darts":
                     lambda state: self.has_vertical(state) and self.has_windmill(state) or self.is_aerobatic(state),
+                "Autumn Hills Seal - Double Swing Saws":
+                    lambda state: self.has_vertical(state) or self.has_windmill(state) or
+                                  self.can_destroy_projectiles(state),
                 "Bamboo Creek - Claustro":
                     self.has_wingsuit,
                 "Bamboo Creek Seal - Spike Ball Pits":

--- a/worlds/messenger/rules.py
+++ b/worlds/messenger/rules.py
@@ -231,6 +231,8 @@ class MessengerRules:
                 self.is_aerobatic,
             "Autumn Hills Seal - Trip Saws":
                 self.has_wingsuit,
+            "Autumn Hills Seal - Double Swing Saws":
+                self.has_vertical,
             # forlorn temple
             "Forlorn Temple Seal - Rocket Maze":
                 self.has_vertical,
@@ -377,6 +379,9 @@ class MessengerHardRules(MessengerRules):
                     self.has_dart,
                 "Autumn Hills - Climbing Claws Shop -> Autumn Hills - Key of Hope Checkpoint":
                     self.true,  # super easy normal clip - also possible with moderately difficult cloud stepping
+                "Autumn Hills Seal - Double Swing Saws":
+                    lambda state: self.has_vertical(state) or self.has_windmill(state) or
+                                  self.can_destroy_projectiles(state),
                 # Howling Grotto
                 "Howling Grotto - Portal -> Howling Grotto - Crushing Pits Shop":
                     self.true,

--- a/worlds/messenger/rules.py
+++ b/worlds/messenger/rules.py
@@ -433,8 +433,7 @@ class MessengerHardRules(MessengerRules):
                 "Autumn Hills Seal - Spike Ball Darts":
                     lambda state: self.has_vertical(state) and self.has_windmill(state) or self.is_aerobatic(state),
                 "Autumn Hills Seal - Double Swing Saws":
-                    lambda state: self.has_vertical(state) or self.has_windmill(state) or
-                                  self.can_destroy_projectiles(state),
+                    lambda state: self.has_vertical(state) or self.can_destroy_projectiles(state),
                 "Bamboo Creek - Claustro":
                     self.has_wingsuit,
                 "Bamboo Creek Seal - Spike Ball Pits":


### PR DESCRIPTION
## What is this fixing or adding?
Fixes a missing rule on the double swing saws seal.

## How was this tested?
Wasn't, but there's no risk here. Only affects portal rando.