### PR TITLE
Minecraft: Various item & location adjustments

### DIFF
--- a/worlds/minecraft/Rules.py
+++ b/worlds/minecraft/Rules.py
@@ -197,9 +197,8 @@ def get_rules_lookup(player: int):
             "Sweet Dreams": lambda state: state.has("Bed", player) or state.can_reach('Village', 'Region', player),
             "You Need a Mint": lambda state: can_respawn_ender_dragon(state, player) and has_bottle(state, player),
             "Monsters Hunted": lambda state: (can_respawn_ender_dragon(state, player) and can_kill_ender_dragon(state, player) and 
-                can_kill_wither(state, player) and state.has("Lead", player)) and state.can_reach("Village", "Region", player) and
-                state.can_reach("Pillager Outpost", "Region", player) and state.can_reach("Bastion Remnant", "Region", player) and
-                state.can_reach("End City", "Region", player),
+                can_kill_wither(state, player) and complete_raid(state, player) and state.has("Lead", player)) and
+                state.can_reach("Bastion Remnant", "Region", player) and state.can_reach("End City", "Region", player),
             "Enchanter": lambda state: can_enchant(state, player),
             "Voluntary Exile": lambda state: basic_combat(state, player),
             "Eye Spy": lambda state: enter_stronghold(state, player),

--- a/worlds/minecraft/Rules.py
+++ b/worlds/minecraft/Rules.py
@@ -206,7 +206,7 @@ def get_rules_lookup(player: int):
             "Serious Dedication": lambda state: (state.can_reach("Hidden in the Depths", "Location", player) and
                 state.has("8 Netherite Scrap", player, 3) and has_gold_ingots(state, player)),
             "Postmortal": lambda state: complete_raid(state, player),
-            "Adventuring Time": lambda state: can_adventure(state, player),
+            "Adventuring Time": lambda state: can_adventure(state, player) and has_iron_ingots(state, player) and state.has("Progressive Tools", player, 2),
             "Hero of the Village": lambda state: complete_raid(state, player),
             "Hidden in the Depths": lambda state: can_brew_potions(state, player) and state.has("Bed", player) and has_diamond_pickaxe(state, player),
             "Beaconator": lambda state: (can_kill_wither(state, player) and has_diamond_pickaxe(state, player) and

--- a/worlds/minecraft/Rules.py
+++ b/worlds/minecraft/Rules.py
@@ -158,6 +158,8 @@ def get_rules_lookup(player: int):
             "Local Brewery": lambda state: can_brew_potions(state, player),
             "The Next Generation": lambda state: can_respawn_ender_dragon(state, player) and can_kill_ender_dragon(state, player),
             "Fishy Business": lambda state: state.has("Fishing Rod", player),
+            "Hot Tourist Destinations": lambda state: ((fortress_loot(state, player) or complete_raid(state, player)) and
+                state.has("Saddle", player) and state.has("Fishing Rod", player)),
             "This Boat Has Legs": lambda state: ((fortress_loot(state, player) or complete_raid(state, player)) and 
                 state.has("Saddle", player) and state.has("Fishing Rod", player)),
             "Sniper Duel": lambda state: state.has("Archery", player),
@@ -172,7 +174,7 @@ def get_rules_lookup(player: int):
             "Bullseye": lambda state: (state.has("Archery", player) and state.has("Progressive Tools", player, 2) and
                 has_iron_ingots(state, player)),
             "Spooky Scary Skeleton": lambda state: basic_combat(state, player),
-            "Two by Two": lambda state: has_iron_ingots(state, player) and state.has("Bucket", player) and can_adventure(state, player),
+            "Two by Two": lambda state: has_iron_ingots(state, player) and state.has("Bucket", player) and state.can_reach("Village", "Region", player),
             "Two Birds, One Arrow": lambda state: craft_crossbow(state, player) and can_enchant(state, player),
             "Who's the Pillager Now?": lambda state: craft_crossbow(state, player),
             "Getting an Upgrade": lambda state: state.has("Progressive Tools", player),
@@ -188,19 +190,21 @@ def get_rules_lookup(player: int):
             "The End... Again...": lambda state: can_respawn_ender_dragon(state, player) and can_kill_ender_dragon(state, player),
             "Acquire Hardware": lambda state: has_iron_ingots(state, player),
             "Not Quite \"Nine\" Lives": lambda state: can_piglin_trade(state, player) and state.has("Progressive Resource Crafting", player, 2),
-            "Cover Me With Diamonds": lambda state: (state.has("Progressive Armor", player, 2) and
+            "Cover Me with Diamonds": lambda state: (state.has("Progressive Armor", player, 2) and
                 state.has("Progressive Tools", player, 2) and has_iron_ingots(state, player)),
             "Sky's the Limit": lambda state: basic_combat(state, player),
             "Hired Help": lambda state: state.has("Progressive Resource Crafting", player, 2) and has_iron_ingots(state, player),
             "Sweet Dreams": lambda state: state.has("Bed", player) or state.can_reach('Village', 'Region', player),
             "You Need a Mint": lambda state: can_respawn_ender_dragon(state, player) and has_bottle(state, player),
             "Monsters Hunted": lambda state: (can_respawn_ender_dragon(state, player) and can_kill_ender_dragon(state, player) and 
-                can_kill_wither(state, player) and state.has("Fishing Rod", player)),
+                can_kill_wither(state, player) and state.has("Lead", player)) and state.can_reach("Village", "Region", player) and
+                state.can_reach("Pillager Outpost", "Region", player) and state.can_reach("Bastion Remnant", "Region", player) and
+                state.can_reach("End City", "Region", player),
             "Enchanter": lambda state: can_enchant(state, player),
             "Voluntary Exile": lambda state: basic_combat(state, player),
             "Eye Spy": lambda state: enter_stronghold(state, player),
-            "Serious Dedication": lambda state: (can_brew_potions(state, player) and state.has("Bed", player) and
-                has_diamond_pickaxe(state, player) and has_gold_ingots(state, player)),
+            "Serious Dedication": lambda state: (state.can_reach("Hidden in the Depths", "Location", player) and
+                state.has("8 Netherite Scrap", player, 3) and has_gold_ingots(state, player)),
             "Postmortal": lambda state: complete_raid(state, player),
             "Adventuring Time": lambda state: can_adventure(state, player),
             "Hero of the Village": lambda state: complete_raid(state, player),
@@ -208,10 +212,12 @@ def get_rules_lookup(player: int):
             "Beaconator": lambda state: (can_kill_wither(state, player) and has_diamond_pickaxe(state, player) and
                 state.has("Progressive Resource Crafting", player, 2)),
             "Withering Heights": lambda state: can_kill_wither(state, player),
-            "A Balanced Diet": lambda state: (has_bottle(state, player) and has_gold_ingots(state, player) and  # honey bottle; gapple
-                state.has("Progressive Resource Crafting", player, 2) and state.can_reach('The End', 'Region', player)),  # notch apple, chorus fruit
+            "A Balanced Diet": lambda state: (has_bottle(state, player) and state.has("Campfire", player) and # honey bottle
+                state.can_reach("Overpowered", "Location", player) and state.can_reach("The End", "Region", player) and # notch apple; chorus fruit
+                state.has("Fishing Rod", player)), # pufferfish
             "Subspace Bubble": lambda state: has_diamond_pickaxe(state, player),
-            "Country Lode, Take Me Home": lambda state: state.can_reach("Hidden in the Depths", "Location", player) and has_gold_ingots(state, player),
+            "Country Lode, Take Me Home": lambda state: (state.can_reach("Hidden in the Depths", "Location", player) and
+                state.has("8 Netherite Scrap", player, 3) and has_gold_ingots(state, player)),
             "Bee Our Guest": lambda state: state.has("Campfire", player) and has_bottle(state, player),
             "Uneasy Alliance": lambda state: has_diamond_pickaxe(state, player) and state.has('Fishing Rod', player),
             "Diamonds!": lambda state: state.has("Progressive Tools", player, 2) and has_iron_ingots(state, player),
@@ -219,9 +225,7 @@ def get_rules_lookup(player: int):
             "Sticky Situation": lambda state: state.has("Campfire", player) and has_bottle(state, player),
             "Ol' Betsy": lambda state: craft_crossbow(state, player),
             "Cover Me in Debris": lambda state: (state.has("Progressive Armor", player, 2) and
-                state.has("8 Netherite Scrap", player, 2) and state.has("Progressive Resource Crafting", player) and
-                has_diamond_pickaxe(state, player) and has_iron_ingots(state, player) and
-                can_brew_potions(state, player) and state.has("Bed", player)),
+                 state.has("8 Netherite Scrap", player, 3) and state.can_reach("Hidden in the Depths", "Location", player)),
             "Hot Topic": lambda state: state.has("Progressive Resource Crafting", player),
             "The Lie": lambda state: has_iron_ingots(state, player) and state.has("Bucket", player),
             "On a Rail": lambda state: has_iron_ingots(state, player) and state.has('Progressive Tools', player, 2),
@@ -247,7 +251,7 @@ def get_rules_lookup(player: int):
             "Glow and Behold!": lambda state: can_adventure(state, player),
             "Whatever Floats Your Goat!": lambda state: can_adventure(state, player),
             "Caves & Cliffs": lambda state: has_iron_ingots(state, player) and state.has('Bucket', player) and state.has('Progressive Tools', player, 2),
-            "Feels like home": lambda state: (has_iron_ingots(state, player) and state.has('Bucket', player) and state.has('Fishing Rod', player) and
+            "Feels Like Home": lambda state: (has_iron_ingots(state, player) and state.has('Bucket', player) and state.has('Fishing Rod', player) and
                 (fortress_loot(state, player) or complete_raid(state, player)) and state.has("Saddle", player)),
             "Sound of Music": lambda state: state.has("Progressive Tools", player, 2) and has_iron_ingots(state, player) and basic_combat(state, player),
             "Star Trader": lambda state: (has_iron_ingots(state, player) and state.has('Bucket', player) and

--- a/worlds/minecraft/data/items.json
+++ b/worlds/minecraft/data/items.json
@@ -103,7 +103,7 @@
 	    "Progressive Weapons": 3,
 	    "Progressive Tools": 3,
 	    "Progressive Armor": 2,
-	    "8 Netherite Scrap": 2,
+	    "8 Netherite Scrap": 3,
 	    "Channeling Book": 1,
 	    "Silk Touch Book": 1,
 	    "Sharpness III Book": 1,

--- a/worlds/minecraft/data/locations.json
+++ b/worlds/minecraft/data/locations.json
@@ -41,7 +41,7 @@
         "The End... Again...",
         "Acquire Hardware",
         "Not Quite \"Nine\" Lives",
-        "Cover Me With Diamonds",
+        "Cover Me with Diamonds",
         "Sky's the Limit",
         "Hired Help",
         "Return to Sender",
@@ -104,7 +104,7 @@
         "Glow and Behold!",
         "Whatever Floats Your Goat!",
         "Caves & Cliffs",
-        "Feels like home",
+        "Feels Like Home",
         "Sound of Music",
         "Star Trader",
         "Birthday Song",
@@ -138,7 +138,7 @@
             "Total Beelocation",
             "Arbalistic",
             "Acquire Hardware",
-            "Cover Me With Diamonds",
+            "Cover Me with Diamonds",
             "Hired Help",
             "Sweet Dreams",
             "Adventure",
@@ -190,14 +190,12 @@
             "We Need to Go Deeper",
             "Not Quite \"Nine\" Lives",
             "Return to Sender",
-            "Serious Dedication",
             "Hidden in the Depths",
             "Subspace Bubble",
             "Country Lode, Take Me Home",
             "Uneasy Alliance",
-            "Cover Me in Debris",
             "Is It a Balloon?",
-            "Feels like home",
+            "Feels Like Home",
             "With Our Powers Combined!"
         ],
         "The End": [
@@ -238,7 +236,9 @@
         ],
         "Bastion Remnant": [
             "War Pigs",
+            "Serious Dedication",
             "Those Were the Days",
+            "Cover Me in Debris",
             "Overpowered"
         ],
         "End City": [

--- a/worlds/minecraft/test/TestAdvancements.py
+++ b/worlds/minecraft/test/TestAdvancements.py
@@ -776,9 +776,10 @@ class TestAdvancements(MCTestBase):
         self.run_location_tests([
             ["Adventuring Time", False, []],
             ["Adventuring Time", False, [], ['Progressive Weapons']],
-            ["Adventuring Time", False, [], ['Campfire', 'Progressive Resource Crafting']],
-            ["Adventuring Time", True, ['Progressive Weapons', 'Campfire']],
-            ["Adventuring Time", True, ['Progressive Weapons', 'Progressive Resource Crafting']],
+            ["Adventuring Time", False, [], ['Progressive Resource Crafting']],
+            ["Adventuring Time", False, [], ['Progressive Tools', 'Progressive Tools']],
+            ["Adventuring Time", True, ['Progressive Weapons', 'Progressive Resource Crafting',
+                                        'Progressive Tools', 'Progressive Tools']],
             ])
 
     def test_42057(self):

--- a/worlds/minecraft/test/TestAdvancements.py
+++ b/worlds/minecraft/test/TestAdvancements.py
@@ -658,6 +658,7 @@ class TestAdvancements(MCTestBase):
             ["Monsters Hunted", False, [], ['Progressive Tools']],
             ["Monsters Hunted", False, ['Progressive Weapons'], ['Progressive Weapons', 'Progressive Weapons']],
             ["Monsters Hunted", False, [], ['Progressive Armor']],
+            ["Monsters Hunted", False, [], ['Shield']],
             ["Monsters Hunted", False, [], ['Brewing']],
             ["Monsters Hunted", False, ['Progressive Tools', 'Progressive Tools'], ['Bucket', 'Progressive Tools']],
             ["Monsters Hunted", False, ['3 Ender Pearls', '3 Ender Pearls', '3 Ender Pearls'], ['3 Ender Pearls']],
@@ -666,7 +667,7 @@ class TestAdvancements(MCTestBase):
             ["Monsters Hunted", False, [], ['Lead']],
             ["Monsters Hunted", True, ['Progressive Resource Crafting', 'Progressive Tools', 'Flint and Steel', 'Progressive Tools', 'Progressive Tools',
                                        'Progressive Weapons', 'Progressive Weapons', 'Progressive Weapons', 'Archery',
-                                       'Progressive Armor', 'Progressive Armor', 'Enchanting',
+                                       'Progressive Armor', 'Progressive Armor', 'Enchanting', 'Shield',
                                        'Lead', 'Brewing', 'Bottles', '3 Ender Pearls', '3 Ender Pearls', '3 Ender Pearls', '3 Ender Pearls']],
             ])
 

--- a/worlds/minecraft/test/TestAdvancements.py
+++ b/worlds/minecraft/test/TestAdvancements.py
@@ -198,9 +198,15 @@ class TestAdvancements(MCTestBase):
             ["Hot Tourist Destinations", False, [], ['Progressive Resource Crafting']],
             ["Hot Tourist Destinations", False, [], ['Flint and Steel']],
             ["Hot Tourist Destinations", False, [], ['Progressive Tools']],
+            ["Hot Tourist Destinations", False, [], ['Progressive Weapons']],
+            ["Hot Tourist Destinations", False, [], ['Progressive Armor', 'Shield']],
+            ["Hot Tourist Destinations", False, [], ['Fishing Rod']],
+            ["Hot Tourist Destinations", False, [], ['Saddle']],
             ["Hot Tourist Destinations", False, ['Progressive Tools', 'Progressive Tools'], ['Bucket', 'Progressive Tools']],
-            ["Hot Tourist Destinations", True, ['Progressive Resource Crafting', 'Progressive Tools', 'Flint and Steel', 'Bucket']],
-            ["Hot Tourist Destinations", True, ['Progressive Resource Crafting', 'Progressive Tools', 'Flint and Steel', 'Progressive Tools', 'Progressive Tools']],
+            ["Hot Tourist Destinations", True, ['Saddle', 'Progressive Resource Crafting', 'Progressive Tools', 'Progressive Weapons', 'Progressive Armor', 'Flint and Steel', 'Bucket', 'Fishing Rod']],
+            ["Hot Tourist Destinations", True, ['Saddle', 'Progressive Resource Crafting', 'Progressive Tools', 'Progressive Weapons', 'Progressive Armor', 'Flint and Steel', 'Progressive Tools', 'Progressive Tools', 'Fishing Rod']],
+            ["Hot Tourist Destinations", True, ['Saddle', 'Progressive Resource Crafting', 'Progressive Tools', 'Progressive Weapons', 'Shield', 'Flint and Steel', 'Bucket', 'Fishing Rod']],
+            ["Hot Tourist Destinations", True, ['Saddle', 'Progressive Resource Crafting', 'Progressive Tools', 'Progressive Weapons', 'Shield', 'Flint and Steel', 'Progressive Tools', 'Progressive Tools', 'Fishing Rod']],
             ])
 
     def test_42015(self):
@@ -552,11 +558,11 @@ class TestAdvancements(MCTestBase):
 
     def test_42041(self):
         self.run_location_tests([
-            ["Cover Me With Diamonds", False, []],
-            ["Cover Me With Diamonds", False, ['Progressive Armor'], ['Progressive Armor']],
-            ["Cover Me With Diamonds", False, ['Progressive Tools'], ['Progressive Tools', 'Progressive Tools']],
-            ["Cover Me With Diamonds", False, [], ['Progressive Resource Crafting']],
-            ["Cover Me With Diamonds", True, ['Progressive Resource Crafting', 'Progressive Tools', 'Progressive Tools', 'Progressive Armor', 'Progressive Armor']],
+            ["Cover Me with Diamonds", False, []],
+            ["Cover Me with Diamonds", False, ['Progressive Armor'], ['Progressive Armor']],
+            ["Cover Me with Diamonds", False, ['Progressive Tools'], ['Progressive Tools', 'Progressive Tools']],
+            ["Cover Me with Diamonds", False, [], ['Progressive Resource Crafting']],
+            ["Cover Me with Diamonds", True, ['Progressive Resource Crafting', 'Progressive Tools', 'Progressive Tools', 'Progressive Armor', 'Progressive Armor']],
             ])
 
     def test_42042(self):
@@ -657,11 +663,11 @@ class TestAdvancements(MCTestBase):
             ["Monsters Hunted", False, ['3 Ender Pearls', '3 Ender Pearls', '3 Ender Pearls'], ['3 Ender Pearls']],
             ["Monsters Hunted", False, [], ['Archery']],
             ["Monsters Hunted", False, [], ['Enchanting']],
-            ["Monsters Hunted", False, [], ['Fishing Rod']],
+            ["Monsters Hunted", False, [], ['Lead']],
             ["Monsters Hunted", True, ['Progressive Resource Crafting', 'Progressive Tools', 'Flint and Steel', 'Progressive Tools', 'Progressive Tools',
                                        'Progressive Weapons', 'Progressive Weapons', 'Progressive Weapons', 'Archery',
                                        'Progressive Armor', 'Progressive Armor', 'Enchanting',
-                                       'Fishing Rod', 'Brewing', 'Bottles', '3 Ender Pearls', '3 Ender Pearls', '3 Ender Pearls', '3 Ender Pearls']],
+                                       'Lead', 'Brewing', 'Bottles', '3 Ender Pearls', '3 Ender Pearls', '3 Ender Pearls', '3 Ender Pearls']],
             ])
 
     def test_42049(self):
@@ -741,10 +747,13 @@ class TestAdvancements(MCTestBase):
             ["Serious Dedication", False, [], ['Brewing']],
             ["Serious Dedication", False, [], ['Bottles']],
             ["Serious Dedication", False, [], ['Bed']],
+            ["Serious Dedication", False, ['8 Netherite Scrap', '8 Netherite Scrap'], ['8 Netherite Scrap']],
             ["Serious Dedication", True, ['Progressive Resource Crafting', 'Progressive Tools', 'Flint and Steel', 'Progressive Tools', 'Progressive Tools',
-                                          'Progressive Weapons', 'Progressive Armor', 'Brewing', 'Bottles', 'Bed']],
+                                          'Progressive Weapons', 'Progressive Armor', 'Brewing', 'Bottles', 'Bed',
+                                          '8 Netherite Scrap', '8 Netherite Scrap', '8 Netherite Scrap']],
             ["Serious Dedication", True, ['Progressive Resource Crafting', 'Progressive Tools', 'Flint and Steel', 'Progressive Tools', 'Progressive Tools',
-                                          'Progressive Weapons', 'Shield', 'Brewing', 'Bottles', 'Bed']],
+                                          'Progressive Weapons', 'Shield', 'Brewing', 'Bottles', 'Bed',
+                                          '8 Netherite Scrap', '8 Netherite Scrap', '8 Netherite Scrap']],
             ])
 
     def test_42054(self):
@@ -855,31 +864,36 @@ class TestAdvancements(MCTestBase):
     def test_42063(self):
         self.run_location_tests([
             ["A Balanced Diet", False, []],
+            ["A Balanced Diet", False, [], ['Fishing Rod']],
+            ["A Balanced Diet", False, [], ['Campfire']],
             ["A Balanced Diet", False, [], ['Bottles']],
-            ["A Balanced Diet", False, ['Progressive Resource Crafting'], ['Progressive Resource Crafting']],
+            ["A Balanced Diet", False, [], ['Progressive Resource Crafting']],
             ["A Balanced Diet", False, [], ['Flint and Steel']],
-            ["A Balanced Diet", False, [], ['Progressive Tools']],
             ["A Balanced Diet", False, [], ['Progressive Weapons']],
             ["A Balanced Diet", False, [], ['Progressive Armor', 'Shield']],
             ["A Balanced Diet", False, [], ['Brewing']],
             ["A Balanced Diet", False, ['Progressive Tools', 'Progressive Tools'], ['Bucket', 'Progressive Tools']],
             ["A Balanced Diet", False, ['3 Ender Pearls', '3 Ender Pearls', '3 Ender Pearls'], ['3 Ender Pearls']],
-            ["A Balanced Diet", True, ['Progressive Resource Crafting', 'Progressive Resource Crafting',
-                                       'Progressive Tools', 'Flint and Steel', 'Bucket',
-                                       'Progressive Weapons', 'Progressive Armor', 'Bottles',
-                                       'Brewing', '3 Ender Pearls', '3 Ender Pearls', '3 Ender Pearls', '3 Ender Pearls']],
-            ["A Balanced Diet", True, ['Progressive Resource Crafting', 'Progressive Resource Crafting',
-                                       'Progressive Tools', 'Flint and Steel', 'Progressive Tools', 'Progressive Tools',
-                                       'Progressive Weapons', 'Progressive Armor', 'Bottles',
-                                       'Brewing', '3 Ender Pearls', '3 Ender Pearls', '3 Ender Pearls', '3 Ender Pearls']],
-            ["A Balanced Diet", True, ['Progressive Resource Crafting', 'Progressive Resource Crafting',
-                                       'Progressive Tools', 'Flint and Steel', 'Bucket',
-                                       'Progressive Weapons', 'Shield', 'Bottles',
-                                       'Brewing', '3 Ender Pearls', '3 Ender Pearls', '3 Ender Pearls', '3 Ender Pearls']],
-            ["A Balanced Diet", True, ['Progressive Resource Crafting', 'Progressive Resource Crafting',
-                                       'Progressive Tools', 'Flint and Steel', 'Progressive Tools', 'Progressive Tools',
-                                       'Progressive Weapons', 'Shield', 'Bottles',
-                                       'Brewing', '3 Ender Pearls', '3 Ender Pearls', '3 Ender Pearls', '3 Ender Pearls']],
+            ["A Balanced Diet", True, ['Progressive Resource Crafting', 'Bottles', 'Campfire', 'Fishing Rod',
+                                       'Progressive Tools', 'Progressive Tools', 'Progressive Weapons',
+                                       'Flint and Steel', 'Brewing',
+                                       '3 Ender Pearls', '3 Ender Pearls', '3 Ender Pearls', '3 Ender Pearls',
+                                       'Progressive Tools', 'Progressive Armor']],
+            ["A Balanced Diet", True, ['Progressive Resource Crafting', 'Bottles', 'Campfire', 'Fishing Rod',
+                                       'Progressive Tools', 'Progressive Tools', 'Progressive Weapons',
+                                       'Flint and Steel', 'Brewing',
+                                       '3 Ender Pearls', '3 Ender Pearls', '3 Ender Pearls', '3 Ender Pearls',
+                                       'Bucket', 'Progressive Armor']],
+            ["A Balanced Diet", True, ['Progressive Resource Crafting', 'Bottles', 'Campfire', 'Fishing Rod',
+                                       'Progressive Tools', 'Progressive Tools', 'Progressive Weapons',
+                                       'Flint and Steel', 'Brewing',
+                                       '3 Ender Pearls', '3 Ender Pearls', '3 Ender Pearls', '3 Ender Pearls',
+                                       'Progressive Tools', 'Shield']],
+            ["A Balanced Diet", True, ['Progressive Resource Crafting', 'Bottles', 'Campfire', 'Fishing Rod',
+                                       'Progressive Tools', 'Progressive Tools', 'Progressive Weapons',
+                                       'Flint and Steel', 'Brewing',
+                                       '3 Ender Pearls', '3 Ender Pearls', '3 Ender Pearls', '3 Ender Pearls',
+                                       'Bucket', 'Shield']],
             ])
 
     def test_42064(self):
@@ -907,10 +921,13 @@ class TestAdvancements(MCTestBase):
             ["Country Lode, Take Me Home", False, [], ['Brewing']],
             ["Country Lode, Take Me Home", False, [], ['Bottles']],
             ["Country Lode, Take Me Home", False, [], ['Bed']],
+            ["Country Lode, Take Me Home", False, ['8 Netherite Scrap', '8 Netherite Scrap'], ['8 Netherite Scrap']],
             ["Country Lode, Take Me Home", True, ['Progressive Resource Crafting', 'Progressive Tools', 'Flint and Steel', 'Progressive Tools', 'Progressive Tools',
-                                                  'Progressive Weapons', 'Progressive Armor', 'Brewing', 'Bottles', 'Bed']],
+                                                  'Progressive Weapons', 'Progressive Armor', 'Brewing', 'Bottles', 'Bed',
+                                                  '8 Netherite Scrap', '8 Netherite Scrap', '8 Netherite Scrap']],
             ["Country Lode, Take Me Home", True, ['Progressive Resource Crafting', 'Progressive Tools', 'Flint and Steel', 'Progressive Tools', 'Progressive Tools',
-                                                  'Progressive Weapons', 'Shield', 'Brewing', 'Bottles', 'Bed']],
+                                                  'Progressive Weapons', 'Shield', 'Brewing', 'Bottles', 'Bed',
+                                                  '8 Netherite Scrap', '8 Netherite Scrap', '8 Netherite Scrap']],
             ])
 
     def test_42067(self):
@@ -1006,10 +1023,11 @@ class TestAdvancements(MCTestBase):
             ["Cover Me in Debris", False, [], ['Brewing']],
             ["Cover Me in Debris", False, [], ['Bottles']],
             ["Cover Me in Debris", False, [], ['Bed']],
-            ["Cover Me in Debris", False, ['8 Netherite Scrap'], ['8 Netherite Scrap']],
+            ["Cover Me in Debris", False, ['8 Netherite Scrap', '8 Netherite Scrap'], ['8 Netherite Scrap']],
             ["Cover Me in Debris", True, ['Progressive Resource Crafting', 'Progressive Tools', 'Flint and Steel', 'Progressive Tools', 'Progressive Tools',
                                           'Progressive Weapons', 'Progressive Armor', 'Progressive Armor',
-                                          'Brewing', 'Bottles', 'Bed', '8 Netherite Scrap', '8 Netherite Scrap']],
+                                          'Brewing', 'Bottles', 'Bed',
+                                          '8 Netherite Scrap', '8 Netherite Scrap', '8 Netherite Scrap']],
             ])
 
     def test_42077(self):
@@ -1296,17 +1314,17 @@ class TestAdvancements(MCTestBase):
     # bucket, fishing rod, saddle, combat
     def test_42104(self):
         self.run_location_tests([
-            ["Feels like home", False, []],
-            ["Feels like home", False, [], ['Progressive Resource Crafting']],
-            ["Feels like home", False, [], ['Progressive Tools']],
-            ["Feels like home", False, [], ['Progressive Weapons']],
-            ["Feels like home", False, [], ['Progressive Armor', 'Shield']],
-            ["Feels like home", False, [], ['Fishing Rod']],
-            ["Feels like home", False, [], ['Saddle']],
-            ["Feels like home", False, [], ['Bucket']],
-            ["Feels like home", False, [], ['Flint and Steel']],
-            ["Feels like home", True, ['Saddle', 'Progressive Resource Crafting', 'Progressive Tools', 'Flint and Steel', 'Bucket', 'Progressive Weapons', 'Progressive Armor', 'Fishing Rod']],
-            ["Feels like home", True, ['Saddle', 'Progressive Resource Crafting', 'Progressive Tools', 'Flint and Steel', 'Bucket', 'Progressive Weapons', 'Shield', 'Fishing Rod']],
+            ["Feels Like Home", False, []],
+            ["Feels Like Home", False, [], ['Progressive Resource Crafting']],
+            ["Feels Like Home", False, [], ['Progressive Tools']],
+            ["Feels Like Home", False, [], ['Progressive Weapons']],
+            ["Feels Like Home", False, [], ['Progressive Armor', 'Shield']],
+            ["Feels Like Home", False, [], ['Fishing Rod']],
+            ["Feels Like Home", False, [], ['Saddle']],
+            ["Feels Like Home", False, [], ['Bucket']],
+            ["Feels Like Home", False, [], ['Flint and Steel']],
+            ["Feels Like Home", True, ['Saddle', 'Progressive Resource Crafting', 'Progressive Tools', 'Flint and Steel', 'Bucket', 'Progressive Weapons', 'Progressive Armor', 'Fishing Rod']],
+            ["Feels Like Home", True, ['Saddle', 'Progressive Resource Crafting', 'Progressive Tools', 'Flint and Steel', 'Bucket', 'Progressive Weapons', 'Shield', 'Fishing Rod']],
             ])
 
     # iron pick, combat


### PR DESCRIPTION
## What is this fixing or adding?
Added 1 extra copy of 8 Netherite Scrap to the pool, both in order to make some Advancements easier to get and to account for certain changes to the logic.

Adjusted the logic rules for the Advancements "Hot Tourist Destinations", "Two by Two", "Monsters Hunted", "Serious Dedication", "Adventuring Time", "A Balanced Diet", "Country Lode, Take Me Home", and "Cover Me in Debris".
Explanations for each:
- Hot Tourist Destinations
  - Added a requirement for Saddles and Fishing Rods, with the idea being that the player can use Striders for easier Nether traversal.
  - I personally consider the current requirements to be too lax, so I asked for opinions in the Minecraft channel. Despite the minimal interaction there was no clear dissent towards tightening the requirements, and the change made was one suggested by a community member.
- Two by Two
  - Added a requirement for accessing Villages.
  - Village access is currently strictly required due to needing to access Camels. Unfortunately Camel spawns are currently broken, but I believe a reasonable fix would be to have them spawn in Villages of all dimensions. Even if this is not chosen, I still believe the requirement should be there as it's the easiest method for finding Cats, which are also required.
- Monsters Hunted
  - Changed the prior Fishing Rod requirement to a Lead requirement. Added requirement for the player to be able to complete a raid. Added requirements for the ability to reach Bastion Remnants and End Cities.
  - The prior purpose of the Fishing Rod requirement was to provide a means for bringing Hoglins to the Overworld in order to transform them into Zoglins. While this behavior is currently broken, were it to ever be fixed, I personally believe that Leads should be required instead due to them being considerably easier to use for this purpose.
  - The raid completion requirement puts Monsters Hunted in line with Postmortal, which logically expects the player to be able to complete a raid in order to obtain a Totem of Undying, which is dropped by the Evokers that spawn during them. This is important as it ensures that Vindicators, Ravagers, Evokers and Vex are all logically accessible, along with the Pillagers that are necessary to spawn them.
  - The Bastion Remnant and End City requirements ensure that both Piglin Brutes and Shulkers are accessible, both of which are required for this Advancement.
- Serious Dedication
  - Added requirements for the player to be able to reach a Bastion Remnant, and for them to have all 3 copies of 8 Netherite Scrap.
  - The Bastion Remnant requirement is necessary due to the addition of Netherite Upgrades, which are required for this Advancement and can only be obtained from Bastions.
  - The 8 Netherite Scrap requirement ensures that the player is logically expected to use the existing Netherite Scrap items in the pool. Requiring all 3 copies is to ensure that the player isn't expected to waste any. A requirement for the player to be able to mine Netherite Scrap is maintained to ensure that they can always get more if necessary.
- Adventuring Time
  - Added requirements for Progressive Resource Crafting and 2 Progressive Tools.
  - This puts it in line with the requirements for Sneak 100 and It Spreads, two other Advancements that require the player to be able to access a Deep Dark biome.
- A Balanced Diet
  - Added a Campfire requirement. Added a Fishing Rod requirement. Added a Bastion Remnant requirement. Removed the Progressive Resource Crafting 2 requirement.
  - This puts A Balanced Diet in line with other Advancements that require related actions: 
    - The Campfire requirement comes from Bee Our Guest (which expects the player to be able to craft Campfires before obtaining a Honey Bottle). 
    - The Fishing Rod requirement comes from How Did We Get Here? (which is specifically noted as expecting a Fishing Rod to obtain a Pufferfish). 
    - The Bastion Remnant requirement, along with the removal of the Progressive Resource Crafting 2 requirement, come from Overpowered (which expects the player to mine Gold Blocks from a Bastion for an Enchanted Golden Apple).
- Country Lode, Take Me Home
  - Added a requirement for the player to have all 3 copies of 8 Netherite Scrap.
  - This ensures that the player is logically expected to use the existing Netherite Scrap items in the pool. Requiring all 3 copies is to ensure that the player isn't expected to waste any. A requirement for the player to be able to mine Netherite Scrap is maintained to ensure that they can always get more if necessary.
- Cover Me in Debris
  - Added a requirement for the player to be able to reach a Bastion Remnant. Also increased the number of 8 Netherite Scrap items required from 2 to 3.
  - The Bastion Remnant requirement is necessary due to the addition of Netherite Upgrades, which are required for this Advancement and can only be obtained from Bastions.
  - The increase from 2 copies of 8 Netherite Scrap to 3 ensures that the player isn't expected to waste any. A requirement for the player to be able to mine Netherite Scrap is maintained to ensure that they can always get more if necessary.

Finally, changed the names of "Cover Me With Diamonds" and "Feels like home" to "Cover Me with Diamonds" and "Feels Like Home" respectively, to match the official spelling of their names.

## How was this tested?
Asked for public opinions on some of the changes to "Hot Tourist Destinations", "Serious Dedication", "A Balanced Diet", "Country Lode, Take Me Home", and "Cover Me in Debris". The rest of the changes were either to be in line with the requirements for similar Advancements, to better support Structure Compasses, or to account for changes to Minecraft itself. Updated the unit tests to reflect all of the new logic changes; all tests passed successfully.
