### PR TITLE
Core: allow pushing precollected items into item link worlds.

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -190,6 +190,7 @@ class MultiWorld():
         self.worlds[new_id] = world_type.create_group(self, new_id, players)
         self.worlds[new_id].collect_item = classmethod(AutoWorld.World.collect_item).__get__(self.worlds[new_id])
         self.player_name[new_id] = name
+        self.precollected_items[new_id] = []
 
         new_group = self.groups[new_id] = Group(name=name, game=game, players=players,
                                                 world=self.worlds[new_id])

--- a/Main.py
+++ b/Main.py
@@ -327,8 +327,23 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
                     games[slot] = multiworld.game[slot]
                     slot_info[slot] = NetUtils.NetworkSlot(group["name"], multiworld.game[slot], multiworld.player_types[slot],
                                                            group_members=sorted(group["players"]))
-                precollected_items = {player: [item.code for item in world_precollected if type(item.code) == int]
-                                      for player, world_precollected in multiworld.precollected_items.items()}
+                precollected_items = {player: [] for player in multiworld.player_ids}
+                for player, world_precollected in multiworld.precollected_items.items():
+                    if not world_precollected:
+                        continue
+                    if player in multiworld.groups:
+                        targets = multiworld.groups[player]["players"]
+                    else:
+                        targets = [player]
+
+                    current_list = []
+                    for item in world_precollected:
+                        if type(item.code) == int:
+                            current_list.append(item.code)
+
+                    for target_player in targets:
+                        precollected_items[target_player].extend(current_list)
+
                 precollected_hints = {player: set() for player in range(1, multiworld.players + 1 + len(multiworld.groups))}
 
                 for slot in multiworld.player_ids:


### PR DESCRIPTION
## What is this fixing or adding?
no longer crashes multiworld.push_precollected(item_link_item)
https://discord.com/channels/731205301247803413/1249439315004624986
This was probably bound to happen at some point anyway, start inventory panic just happened to be the first related crash.

## How was this tested?
the linked seed no longer crashes