### PR TITLE
Core: smarter fill logging

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -27,6 +27,10 @@ class FillLogger():
         self.cur_time = time.time()
         self.step: int = max(round(total_items * 0.1), 1000)
         self.total_items: int = total_items
+        self.is_debug: bool   = False
+
+        if logging.getLogger().isEnabledFor(logging.DEBUG):
+            self.is_debug = True
 
     def log_fill_progress(self, name: str, placed: int, final: bool = False) -> None:
         # never print the small stuff
@@ -34,14 +38,21 @@ class FillLogger():
             return
 
         self.log_nontty(name, placed, final)
-        self.log_tty(name, placed, final)
+        if not self.is_debug:
+            self.log_tty(name, placed, final)
 
     def log_nontty(self, name: str, placed: int, final: bool) -> None:
-        if final or placed % self.step == 0:
-            status: str = "Finished" if final else "Current"
-            pct: float = round(100 * (placed / self.total_items), 2)
-            logging.info(f"{status} fill step ({name}) at {placed}/{self.total_items} ({pct}%) items placed.",
-                         extra={"NoStream": True})
+        if not final and placed % self.step:
+            return
+
+        extra_args: Dict[Str, Bool] = {}
+        if not self.is_debug:
+            extra_args = {"NoStream": True}
+
+        status: str = "Finished" if final else "Current"
+        pct: float = round(100 * (placed / self.total_items), 2)
+        logging.info(f"{status} fill step ({name}) at {placed}/{self.total_items} ({pct}%) items placed.",
+                     extra=extra_args)
 
     def log_tty(self, name: str, placed: int, final: bool) -> None:
         self.cur_time = time.time()

--- a/Fill.py
+++ b/Fill.py
@@ -18,15 +18,12 @@ class FillError(RuntimeError):
 
 
 class FillLogger():
-    """
-        FillLogger class variables:
-        min_size -- minimum number of items we care about reporting
-        min_time -- minimum time (in seconds) between reports (used in dynamic logging only)
-        step     -- number of items between reports (used in fixed logging only)
-    """
     min_size: int = 1000
+    """ min_size -- minimum number of items we care about reporting """
     min_time: float = 0.25
+    """ min_time -- minimum time (in seconds) between reports (for dynamic logging) """
     step: int = 1000
+    """ step -- minimum number of items between reports (for fixed logging) """
     is_debug: bool = False
 
     def __init__(self, total_items: int):

--- a/Fill.py
+++ b/Fill.py
@@ -61,7 +61,7 @@ class FillLogger():
             logging.StreamHandler.terminator = '\r'
 
         pct: float = round(100 * (placed / self.total_items), 2)
-        elapsed: str = time.strftime("%H:%M:%S", time.gmtime(round(self.cur_time - self.start_time)))
+        elapsed: str = time.strftime("%Hh:%Mm:%Ss", time.gmtime(round(self.cur_time - self.start_time)))
         logging.info(f"Current fill step ({name}) at {placed}/{self.total_items} ({pct}%) items placed [{elapsed} elapsed].")
 
         # restore the terminator

--- a/Fill.py
+++ b/Fill.py
@@ -33,7 +33,7 @@ class FillLogger():
         if self.total_items < self.min_size:
             return
 
-        if sys.stdin.isatty():
+        if sys.stdin.isatty() and sys.stdout.isatty():
             self.log_tty(name, placed, final)
         else:
             self.log_nontty(name, placed, final)

--- a/Fill.py
+++ b/Fill.py
@@ -277,6 +277,7 @@ def remaining_fill(multiworld: MultiWorld,
     placements: typing.List[Location] = []
     swapped_items: typing.Counter[typing.Tuple[int, str]] = Counter()
     total = min(len(itempool),  len(locations))
+    fill_log = FillLogger(total)
     placed = 0
     while locations and itempool:
         item_to_place = itempool.pop()

--- a/Fill.py
+++ b/Fill.py
@@ -1,7 +1,9 @@
 import collections
 import itertools
 import logging
+import sys
 import typing
+import time
 from collections import Counter, deque
 
 from BaseClasses import CollectionState, Item, Location, LocationProgressType, MultiWorld
@@ -15,8 +17,55 @@ class FillError(RuntimeError):
     pass
 
 
-def _log_fill_progress(name: str, placed: int, total_items: int) -> None:
-    logging.info(f"Current fill step ({name}) at {placed}/{total_items} items placed.")
+class FillLogger():
+    min_size: int   = 1000
+    min_time: float = 0.25
+
+    def __init__(self, total_items: int):
+        self.start_time       = time.time()
+        self.prev_time        = time.time()
+        self.cur_time         = time.time()
+        self.step: int        = max(round(total_items * 0.1), 1000)
+        self.total_items: int = total_items
+
+    def log_fill_progress(self, name: str, placed: int, final: bool = False) -> None:
+        # never print the small stuff
+        if self.total_items < self.min_size:
+            return
+
+        if sys.stdin.isatty():
+            self.log_tty(name, placed, final)
+        else:
+            self.log_nontty(name, placed, final)
+
+    # any non-CLI logging; just log 10x times (or fewer), no need for anything fancy
+    def log_nontty(self, name: str, placed: int, final: bool) -> None:
+        if final or placed % self.step == 0:
+            pct: float = round(100 * (placed / self.total_items), 2)
+            logging.info(f"Current fill step ({name}) at {placed}/{self.total_items} ({pct}%) items placed.")
+
+    # on CLI, be a little friendlier
+    def log_tty(self, name: str, placed: int, final: bool) -> None:
+        self.cur_time = time.time()
+
+        # Always print final, otherwise skip if the time between prints is too short
+        if not final and self.cur_time - self.prev_time < self.min_time:
+            return
+
+        # Update our sliding window
+        self.prev_time = self.cur_time
+
+        # Store the terminator in case someone else is doing something interesting
+        old_term: str = logging.StreamHandler.terminator
+        if not final:
+            logging.StreamHandler.terminator = '\r'
+
+        pct: float = round(100 * (placed / self.total_items), 2)
+        elapsed: str = time.strftime("%H:%M:%S", time.gmtime(round(self.cur_time - self.start_time)))
+        logging.info(f"Current fill step ({name}) at {placed}/{self.total_items} ({pct}%) items placed [{elapsed} elapsed].")
+
+        # restore the terminator
+        logging.StreamHandler.terminator = old_term
 
 
 def sweep_from_pool(base_state: CollectionState, itempool: typing.Sequence[Item] = tuple(),
@@ -56,6 +105,8 @@ def fill_restrictive(multiworld: MultiWorld, base_state: CollectionState, locati
     # for progress logging
     total = min(len(item_pool), len(locations))
     placed = 0
+
+    fill_log = FillLogger(total)
 
     while any(reachable_items.values()) and locations:
         # grab one item per player
@@ -164,13 +215,13 @@ def fill_restrictive(multiworld: MultiWorld, base_state: CollectionState, locati
             spot_to_fill.locked = lock
             placements.append(spot_to_fill)
             placed += 1
-            if not placed % 1000:
-                _log_fill_progress(name, placed, total)
+
+            fill_log.log_fill_progress(name, placed)
+
             if on_place:
                 on_place(spot_to_fill)
 
-    if total > 1000:
-        _log_fill_progress(name, placed, total)
+    fill_log.log_fill_progress(name, placed, final=True)
 
     if cleanup_required:
         # validate all placements and remove invalid ones
@@ -277,11 +328,9 @@ def remaining_fill(multiworld: MultiWorld,
         multiworld.push_item(spot_to_fill, item_to_place, False)
         placements.append(spot_to_fill)
         placed += 1
-        if not placed % 1000:
-            _log_fill_progress(name, placed, total)
+        fill_log.log_fill_progress(name, placed)
 
-    if total > 1000:
-        _log_fill_progress(name, placed, total)
+    fill_log.log_fill_progress(name, placed, final=True)
 
     if unplaced_items and locations:
         # There are leftover unplaceable items and locations that won't accept them

--- a/Fill.py
+++ b/Fill.py
@@ -41,8 +41,9 @@ class FillLogger():
     # any non-CLI logging; just log 10x times (or fewer), no need for anything fancy
     def log_nontty(self, name: str, placed: int, final: bool) -> None:
         if final or placed % self.step == 0:
+            status: str = "Finished" if final else "Current"
             pct: float = round(100 * (placed / self.total_items), 2)
-            logging.info(f"Current fill step ({name}) at {placed}/{self.total_items} ({pct}%) items placed.")
+            logging.info(f"{status} fill step ({name}) at {placed}/{self.total_items} ({pct}%) items placed.")
 
     # on CLI, be a little friendlier
     def log_tty(self, name: str, placed: int, final: bool) -> None:
@@ -60,9 +61,10 @@ class FillLogger():
         if not final:
             logging.StreamHandler.terminator = '\r'
 
+        status: str = "Finished" if final else "Current"
         pct: float = round(100 * (placed / self.total_items), 2)
         elapsed: str = time.strftime("%Hh:%Mm:%Ss", time.gmtime(round(self.cur_time - self.start_time)))
-        logging.info(f"Current fill step ({name}) at {placed}/{self.total_items} ({pct}%) items placed [{elapsed} elapsed].")
+        logging.info(f"{status} fill step ({name}) at {placed}/{self.total_items} ({pct}%) items placed [{elapsed} elapsed].")
 
         # restore the terminator
         logging.StreamHandler.terminator = old_term


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?

Replace current Fill logging with a more dynamic logging mechanism. Scales appropriately between small, medium, and large seeds.

It doesn't log anything smaller than "min_size" (currently set to 1000 to match pre-existing logic).
It doesn't log any faster than "min_time" (currently 1/4 second).

Because of the introduction of carriage return, safeguards are put in to make sure any output heading to a non-tty location don't include said carriage return (it does nasty things to log files).

## How was this tested?

Generating many, many seeds and watching them.
Genned:
- On CLI (mac)  
- On CLI (Windows)
- via Launcher (Windows)
- via WebHost

All tests were done with python 3.11.

## If this makes graphical changes, please attach screenshots.

Note status when done:
<img width="642" alt="Screenshot 2024-06-20 at 17 44 20" src="https://github.com/ArchipelagoMW/Archipelago/assets/4594575/4dd6024e-7197-42c5-9256-68e5e14500f7">

Action shot:
![smarter_fill_logging-20240620-short](https://github.com/ArchipelagoMW/Archipelago/assets/4594575/56d69612-76bd-4b36-a62f-8f04f30f0963)

[edit to add: log files are also changed; this can be rolled back easily if requested]
In the log file:
<img width="717" alt="Screenshot 2024-07-04 at 15 55 49" src="https://github.com/ArchipelagoMW/Archipelago/assets/4594575/53e9c242-e86f-4ea0-9433-efaf95714e56">
