### PR TITLE
Core: update required_server_version to 0.5.0

### DIFF
--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -280,7 +280,7 @@ class World(metaclass=AutoWorldRegister):
     future. Protocol level compatibility check moved to MultiServer.min_client_version.
     """
 
-    required_server_version: Tuple[int, int, int] = (0, 2, 4)
+    required_server_version: Tuple[int, int, int] = (0, 5, 0)
     """update this if the resulting multidata breaks forward-compatibility of the server"""
 
     hint_blacklist: ClassVar[FrozenSet[str]] = frozenset()


### PR DESCRIPTION
## What is this fixing or adding?
To load a 0.5.0 multidata you need a 0.5.0+ server. This was however not marked in our required versions.

## How was this tested?
I changed a value of a system that was hopefully tested long ago.