### PR TITLE
WebHost: Disable flask caching if `DEBUG` is enabled.

### DIFF
--- a/WebHost.py
+++ b/WebHost.py
@@ -35,6 +35,9 @@ def get_app() -> "Flask":
         logging.info("Getting public IP, as HOST_ADDRESS is empty.")
         app.config["HOST_ADDRESS"] = Utils.get_public_ipv4()
         logging.info(f"HOST_ADDRESS was set to {app.config['HOST_ADDRESS']}")
+    if app.config["DEBUG"]:
+        app.config["CACHE_TYPE"] = "NullCache"
+        logging.info(f"CACHE_TYPE was set to 'NullCache' in DEBUG mode.")
 
     register()
     cache.init_app(app)


### PR DESCRIPTION
## What is this fixing or adding?
This disables flask caching of templates when `DEBUG` is set to `True` in the webhost config file, which allows hotreloading of jinja templates without restarting the flask app.

## How was this tested?
Ran webhost with `DEBUG` enabled and disabled and confirmed caching is disabled in `DEBUG` mode. 

## If this makes graphical changes, please attach screenshots.
N/A