### PR TITLE
Raft: Move to new Options API

### DIFF
--- a/worlds/raft/Options.py
+++ b/worlds/raft/Options.py
@@ -1,4 +1,5 @@
-from Options import Range, Toggle, DefaultOnToggle, Choice, DeathLink
+from dataclasses import dataclass
+from Options import Range, Toggle, DefaultOnToggle, Choice, DeathLink, PerGameCommonOptions
 
 class MinimumResourcePackAmount(Range):
     """The minimum amount of resources available in a resource pack"""
@@ -70,16 +71,16 @@ class PaddleboardMode(Toggle):
     recommended."""
     display_name = "Paddleboard Mode"
 
-raft_options = {
-    "minimum_resource_pack_amount": MinimumResourcePackAmount,
-    "maximum_resource_pack_amount": MaximumResourcePackAmount,
-    "duplicate_items": DuplicateItems,
-    "filler_item_types": FillerItemTypes,
-    "island_frequency_locations": IslandFrequencyLocations,
-    "island_generation_distance": IslandGenerationDistance,
-    "expensive_research": ExpensiveResearch,
-    "progressive_items": ProgressiveItems,
-    "big_island_early_crafting": BigIslandEarlyCrafting,
-    "paddleboard_mode": PaddleboardMode,
-    "death_link": DeathLink
-}
+@dataclass
+class RaftOptions(PerGameCommonOptions):
+    minimum_resource_pack_amount: MinimumResourcePackAmount
+    maximum_resource_pack_amount: MaximumResourcePackAmount
+    duplicate_items: DuplicateItems
+    filler_item_types: FillerItemTypes
+    island_frequency_locations: IslandFrequencyLocations
+    island_generation_distance: IslandGenerationDistance
+    expensive_research: ExpensiveResearch
+    progressive_items: ProgressiveItems
+    big_island_early_crafting: BigIslandEarlyCrafting
+    paddleboard_mode: PaddleboardMode
+    death_link: DeathLink

--- a/worlds/raft/Options.py
+++ b/worlds/raft/Options.py
@@ -42,6 +42,8 @@ class IslandFrequencyLocations(Choice):
     option_progressive = 4
     option_anywhere = 5
     default = 2
+    def is_filling_frequencies_in_world(self):
+        return self.value <= self.option_random_on_island_random_order
 
 class IslandGenerationDistance(Choice):
     """Sets how far away islands spawn from you when you input their coordinates into the Receiver."""

--- a/worlds/raft/Rules.py
+++ b/worlds/raft/Rules.py
@@ -5,10 +5,10 @@ from ..AutoWorld import LogicMixin
 
 class RaftLogic(LogicMixin):
     def raft_paddleboard_mode_enabled(self, player):
-        return bool(self.multiworld.worlds[player].options.paddleboard_mode.value)
+        return bool(self.multiworld.worlds[player].options.paddleboard_mode)
     
     def raft_big_islands_available(self, player):
-        return bool(self.multiworld.worlds[player].options.big_island_early_crafting.value) or self.raft_can_access_radio_tower(player)
+        return bool(self.multiworld.worlds[player].options.big_island_early_crafting) or self.raft_can_access_radio_tower(player)
 
     def raft_can_smelt_items(self, player):
         return self.has("Smelter", player)

--- a/worlds/raft/Rules.py
+++ b/worlds/raft/Rules.py
@@ -5,10 +5,10 @@ from ..AutoWorld import LogicMixin
 
 class RaftLogic(LogicMixin):
     def raft_paddleboard_mode_enabled(self, player):
-        return self.multiworld.paddleboard_mode[player].value
+        return bool(self.multiworld.worlds[player].options.paddleboard_mode.value)
     
     def raft_big_islands_available(self, player):
-        return self.multiworld.big_island_early_crafting[player].value or self.raft_can_access_radio_tower(player)
+        return bool(self.multiworld.worlds[player].options.big_island_early_crafting.value) or self.raft_can_access_radio_tower(player)
 
     def raft_can_smelt_items(self, player):
         return self.has("Smelter", player)

--- a/worlds/raft/__init__.py
+++ b/worlds/raft/__init__.py
@@ -6,7 +6,7 @@ from .Items import (createResourcePackName, item_table, progressive_table, progr
 
 from .Regions import create_regions, getConnectionName
 from .Rules import set_rules
-from .Options import raft_options
+from .Options import RaftOptions
 
 from BaseClasses import Region, Entrance, Location, MultiWorld, Item, ItemClassification, Tutorial
 from ..AutoWorld import World, WebWorld
@@ -37,16 +37,17 @@ class RaftWorld(World):
     lastItemId = max(filter(lambda val: val is not None, item_name_to_id.values()))
 
     location_name_to_id = locations_lookup_name_to_id
-    option_definitions = raft_options
+    options_dataclass = RaftOptions
+    options: RaftOptions
 
     required_client_version = (0, 3, 4)
 
     def create_items(self):
-        minRPSpecified = self.multiworld.minimum_resource_pack_amount[self.player].value
-        maxRPSpecified = self.multiworld.maximum_resource_pack_amount[self.player].value
+        minRPSpecified = self.options.minimum_resource_pack_amount.value
+        maxRPSpecified = self.options.maximum_resource_pack_amount.value
         minimumResourcePackAmount = min(minRPSpecified, maxRPSpecified)
         maximumResourcePackAmount = max(minRPSpecified, maxRPSpecified)
-        isFillingFrequencies = self.multiworld.island_frequency_locations[self.player].value <= 3
+        isFillingFrequencies = self.options.island_frequency_locations.value <= 3
         # Generate item pool
         pool = []
         frequencyItems = []
@@ -64,20 +65,20 @@ class RaftWorld(World):
         extraItemNamePool = []
         extras = len(location_table) - len(item_table) - 1 # Victory takes up 1 unaccounted-for slot
         if extras > 0:
-            if (self.multiworld.filler_item_types[self.player].value != 1): # Use resource packs
+            if (self.options.filler_item_types.value != 1): # Use resource packs
                 for packItem in resourcePackItems:
                     for i in range(minimumResourcePackAmount, maximumResourcePackAmount + 1):
                         extraItemNamePool.append(createResourcePackName(i, packItem))
 
-            if self.multiworld.filler_item_types[self.player].value != 0: # Use duplicate items
+            if self.options.filler_item_types.value != 0: # Use duplicate items
                 dupeItemPool = item_table.copy()
                 # Remove frequencies if necessary
-                if self.multiworld.island_frequency_locations[self.player].value != 5: # Not completely random locations
+                if self.options.island_frequency_locations.value != 5: # Not completely random locations
                     # If we let frequencies stay in with progressive-frequencies, the progressive-frequency item
                     # will be included 7 times. This is a massive flood of progressive-frequency items, so we
                     # instead add progressive-frequency as its own item a smaller amount of times to prevent
                     # flooding the duplicate item pool with them.
-                    if self.multiworld.island_frequency_locations[self.player].value == 4:
+                    if self.options.island_frequency_locations.value == 4:
                         for _ in range(2):
                             # Progressives are not in item_pool, need to create faux item for duplicate item pool
                             # This can still be filtered out later by duplicate_items setting
@@ -86,9 +87,9 @@ class RaftWorld(World):
                     dupeItemPool = (itm for itm in dupeItemPool if "Frequency" not in itm["name"])
                 
                 # Remove progression or non-progression items if necessary
-                if (self.multiworld.duplicate_items[self.player].value == 0): # Progression only
+                if (self.options.duplicate_items.value == 0): # Progression only
                     dupeItemPool = (itm for itm in dupeItemPool if itm["progression"] == True)
-                elif (self.multiworld.duplicate_items[self.player].value == 1): # Non-progression only
+                elif (self.options.duplicate_items.value == 1): # Non-progression only
                     dupeItemPool = (itm for itm in dupeItemPool if itm["progression"] == False)
                 
                 dupeItemPool = list(dupeItemPool)
@@ -115,14 +116,14 @@ class RaftWorld(World):
         create_regions(self.multiworld, self.player)
     
     def get_pre_fill_items(self):
-        if self.multiworld.island_frequency_locations[self.player] in [0, 1, 2, 3]:
+        if self.options.island_frequency_locations.value in [0, 1, 2, 3]:
             return [loc.item for loc in self.multiworld.get_filled_locations()]
         return []
     
     def create_item_replaceAsNecessary(self, name: str) -> Item:
         isFrequency = "Frequency" in name
-        shouldUseProgressive = ((isFrequency and self.multiworld.island_frequency_locations[self.player].value == 4)
-            or (not isFrequency and self.multiworld.progressive_items[self.player].value))
+        shouldUseProgressive = ((isFrequency and self.options.island_frequency_locations.value == 4)
+            or (not isFrequency and self.options.progressive_items.value))
         if shouldUseProgressive and name in progressive_table:
             name = progressive_table[name]
         return self.create_item(name)
@@ -152,7 +153,7 @@ class RaftWorld(World):
         return super(RaftWorld, self).collect_item(state, item, remove)
 
     def pre_fill(self):
-        if self.multiworld.island_frequency_locations[self.player] == 0: # Vanilla
+        if self.options.island_frequency_locations.value == 0: # Vanilla
             self.setLocationItem("Radio Tower Frequency to Vasagatan", "Vasagatan Frequency")
             self.setLocationItem("Vasagatan Frequency to Balboa", "Balboa Island Frequency")
             self.setLocationItem("Relay Station quest", "Caravan Island Frequency")
@@ -160,7 +161,7 @@ class RaftWorld(World):
             self.setLocationItem("Tangaroa Frequency to Varuna Point", "Varuna Point Frequency")
             self.setLocationItem("Varuna Point Frequency to Temperance", "Temperance Frequency")
             self.setLocationItem("Temperance Frequency to Utopia", "Utopia Frequency")
-        elif self.multiworld.island_frequency_locations[self.player] == 1: # Random on island
+        elif self.options.island_frequency_locations.value == 1: # Random on island
             self.setLocationItemFromRegion("RadioTower", "Vasagatan Frequency")
             self.setLocationItemFromRegion("Vasagatan", "Balboa Island Frequency")
             self.setLocationItemFromRegion("BalboaIsland", "Caravan Island Frequency")
@@ -168,7 +169,7 @@ class RaftWorld(World):
             self.setLocationItemFromRegion("Tangaroa", "Varuna Point Frequency")
             self.setLocationItemFromRegion("Varuna Point", "Temperance Frequency")
             self.setLocationItemFromRegion("Temperance", "Utopia Frequency")
-        elif self.multiworld.island_frequency_locations[self.player] in [2, 3]:
+        elif self.options.island_frequency_locations.value in [2, 3]:
             locationToFrequencyItemMap = {
                 "Vasagatan": "Vasagatan Frequency",
                 "BalboaIsland": "Balboa Island Frequency",
@@ -196,9 +197,9 @@ class RaftWorld(World):
                 else:
                     currentLocation = availableLocationList[0] # Utopia (only one left in list)
                 availableLocationList.remove(currentLocation)
-                if self.multiworld.island_frequency_locations[self.player] == 2: # Random island order
+                if self.options.island_frequency_locations.value == 2: # Random island order
                     self.setLocationItem(locationToVanillaFrequencyLocationMap[previousLocation], locationToFrequencyItemMap[currentLocation])
-                elif self.multiworld.island_frequency_locations[self.player] == 3: # Random on island random order
+                elif self.options.island_frequency_locations.value == 3: # Random on island random order
                     self.setLocationItemFromRegion(previousLocation, locationToFrequencyItemMap[currentLocation])
                 previousLocation = currentLocation
     
@@ -215,9 +216,9 @@ class RaftWorld(World):
     
     def fill_slot_data(self):
         return {
-            "IslandGenerationDistance": self.multiworld.island_generation_distance[self.player].value,
-            "ExpensiveResearch": bool(self.multiworld.expensive_research[self.player].value),
-            "DeathLink": bool(self.multiworld.death_link[self.player].value)
+            "IslandGenerationDistance": self.options.island_generation_distance.value,
+            "ExpensiveResearch": bool(self.options.expensive_research.value),
+            "DeathLink": bool(self.options.death_link.value)
         }
 
 def create_region(world: MultiWorld, player: int, name: str, locations=None, exits=None):

--- a/worlds/raft/__init__.py
+++ b/worlds/raft/__init__.py
@@ -65,20 +65,20 @@ class RaftWorld(World):
         extraItemNamePool = []
         extras = len(location_table) - len(item_table) - 1 # Victory takes up 1 unaccounted-for slot
         if extras > 0:
-            if (self.options.filler_item_types.value != self.options.filler_item_types.option_duplicates): # Use resource packs
+            if (self.options.filler_item_types != self.options.filler_item_types.option_duplicates): # Use resource packs
                 for packItem in resourcePackItems:
                     for i in range(minimumResourcePackAmount, maximumResourcePackAmount + 1):
                         extraItemNamePool.append(createResourcePackName(i, packItem))
 
-            if self.options.filler_item_types.value != self.options.filler_item_types.option_resource_packs: # Use duplicate items
+            if self.options.filler_item_types != self.options.filler_item_types.option_resource_packs: # Use duplicate items
                 dupeItemPool = item_table.copy()
                 # Remove frequencies if necessary
-                if self.options.island_frequency_locations.value != self.options.island_frequency_locations.option_anywhere: # Not completely random locations
+                if self.options.island_frequency_locations != self.options.island_frequency_locations.option_anywhere: # Not completely random locations
                     # If we let frequencies stay in with progressive-frequencies, the progressive-frequency item
                     # will be included 7 times. This is a massive flood of progressive-frequency items, so we
                     # instead add progressive-frequency as its own item a smaller amount of times to prevent
                     # flooding the duplicate item pool with them.
-                    if self.options.island_frequency_locations.value == self.options.island_frequency_locations.option_progressive:
+                    if self.options.island_frequency_locations == self.options.island_frequency_locations.option_progressive:
                         for _ in range(2):
                             # Progressives are not in item_pool, need to create faux item for duplicate item pool
                             # This can still be filtered out later by duplicate_items setting
@@ -87,9 +87,9 @@ class RaftWorld(World):
                     dupeItemPool = (itm for itm in dupeItemPool if "Frequency" not in itm["name"])
                 
                 # Remove progression or non-progression items if necessary
-                if (self.options.duplicate_items.value == self.options.duplicate_items.option_progression): # Progression only
+                if (self.options.duplicate_items == self.options.duplicate_items.option_progression): # Progression only
                     dupeItemPool = (itm for itm in dupeItemPool if itm["progression"] == True)
-                elif (self.options.duplicate_items.value == self.options.duplicate_items.option_non_progression): # Non-progression only
+                elif (self.options.duplicate_items == self.options.duplicate_items.option_non_progression): # Non-progression only
                     dupeItemPool = (itm for itm in dupeItemPool if itm["progression"] == False)
                 
                 dupeItemPool = list(dupeItemPool)
@@ -122,7 +122,7 @@ class RaftWorld(World):
     
     def create_item_replaceAsNecessary(self, name: str) -> Item:
         isFrequency = "Frequency" in name
-        shouldUseProgressive = bool((isFrequency and self.options.island_frequency_locations.value == self.options.island_frequency_locations.option_progressive)
+        shouldUseProgressive = bool((isFrequency and self.options.island_frequency_locations == self.options.island_frequency_locations.option_progressive)
             or (not isFrequency and self.options.progressive_items))
         if shouldUseProgressive and name in progressive_table:
             name = progressive_table[name]
@@ -153,7 +153,7 @@ class RaftWorld(World):
         return super(RaftWorld, self).collect_item(state, item, remove)
 
     def pre_fill(self):
-        if self.options.island_frequency_locations.value == self.options.island_frequency_locations.option_vanilla:
+        if self.options.island_frequency_locations == self.options.island_frequency_locations.option_vanilla:
             self.setLocationItem("Radio Tower Frequency to Vasagatan", "Vasagatan Frequency")
             self.setLocationItem("Vasagatan Frequency to Balboa", "Balboa Island Frequency")
             self.setLocationItem("Relay Station quest", "Caravan Island Frequency")
@@ -161,7 +161,7 @@ class RaftWorld(World):
             self.setLocationItem("Tangaroa Frequency to Varuna Point", "Varuna Point Frequency")
             self.setLocationItem("Varuna Point Frequency to Temperance", "Temperance Frequency")
             self.setLocationItem("Temperance Frequency to Utopia", "Utopia Frequency")
-        elif self.options.island_frequency_locations.value == self.options.island_frequency_locations.option_random_on_island:
+        elif self.options.island_frequency_locations == self.options.island_frequency_locations.option_random_on_island:
             self.setLocationItemFromRegion("RadioTower", "Vasagatan Frequency")
             self.setLocationItemFromRegion("Vasagatan", "Balboa Island Frequency")
             self.setLocationItemFromRegion("BalboaIsland", "Caravan Island Frequency")
@@ -169,7 +169,7 @@ class RaftWorld(World):
             self.setLocationItemFromRegion("Tangaroa", "Varuna Point Frequency")
             self.setLocationItemFromRegion("Varuna Point", "Temperance Frequency")
             self.setLocationItemFromRegion("Temperance", "Utopia Frequency")
-        elif self.options.island_frequency_locations.value in [
+        elif self.options.island_frequency_locations in [
             self.options.island_frequency_locations.option_random_island_order,
             self.options.island_frequency_locations.option_random_on_island_random_order
         ]:
@@ -200,9 +200,9 @@ class RaftWorld(World):
                 else:
                     currentLocation = availableLocationList[0] # Utopia (only one left in list)
                 availableLocationList.remove(currentLocation)
-                if self.options.island_frequency_locations.value == self.options.island_frequency_locations.option_random_island_order:
+                if self.options.island_frequency_locations == self.options.island_frequency_locations.option_random_island_order:
                     self.setLocationItem(locationToVanillaFrequencyLocationMap[previousLocation], locationToFrequencyItemMap[currentLocation])
-                elif self.options.island_frequency_locations.value == self.options.island_frequency_locations.option_random_on_island_random_order:
+                elif self.options.island_frequency_locations == self.options.island_frequency_locations.option_random_on_island_random_order:
                     self.setLocationItemFromRegion(previousLocation, locationToFrequencyItemMap[currentLocation])
                 previousLocation = currentLocation
     


### PR DESCRIPTION
## What is this fixing or adding?
This moves Raft off of the old deprecated Options API and on to the new Options API to address #3284 

## How was this tested?
Manually. Made sure logical values were still being respected via debugging during generation. Ran with multiple different options.

## If this makes graphical changes, please attach screenshots.
N/A