### PR TITLE
Installer: Fix .apworld registration

### DIFF
--- a/inno_setup.iss
+++ b/inno_setup.iss
@@ -219,7 +219,7 @@ Root: HKCR; Subkey: "{#MyAppName}multidata\shell\open\command";  ValueData: """{
 Root: HKCR; Subkey: ".apworld";                                 ValueData: "{#MyAppName}worlddata";  Flags: uninsdeletevalue; ValueType: string;  ValueName: "";
 Root: HKCR; Subkey: "{#MyAppName}worlddata";                    ValueData: "Archipelago World Data"; Flags: uninsdeletekey;   ValueType: string;  ValueName: "";
 Root: HKCR; Subkey: "{#MyAppName}worlddata\DefaultIcon";        ValueData: "{app}\ArchipelagoLauncher.exe,0";                 ValueType: string;  ValueName: "";
-Root: HKCR; Subkey: "{#MyAppName}worlddata\shell\open\command"; ValueData: """{app}\ArchipelagoLauncher.exe"" ""%1""";
+Root: HKCR; Subkey: "{#MyAppName}worlddata\shell\open\command"; ValueData: """{app}\ArchipelagoLauncher.exe"" ""%1""";        ValueType: string;  ValueName: "";
 
 Root: HKCR; Subkey: "archipelago"; ValueType: "string"; ValueData: "Archipegalo Protocol"; Flags: uninsdeletekey;
 Root: HKCR; Subkey: "archipelago"; ValueType: "string"; ValueName: "URL Protocol"; ValueData: "";


### PR DESCRIPTION
## What is this fixing or adding?

Fixes .apworld registration in Windows so users can double-click a .apworld to install it. Previously the registry entry for `shell\open\command` wasn't actually being added.

## How was this tested?

Created an installer with this inno_setup.iss change, and installed Archipelago. Observed `HKCR\Archipelagoworlddata\shell\open\command` is now populated in regedit. Also checked my file associations in Windows, .apworld is now associated with Archipelago. Double-clicked pokemon_crystal.apworld and it was copied into custom_worlds with a success message.
