### PR TITLE
LTTP: Add Missing Blind's Cell rule

### DIFF
--- a/worlds/alttp/Rules.py
+++ b/worlds/alttp/Rules.py
@@ -405,16 +405,14 @@ def global_rules(multiworld: MultiWorld, player: int):
         set_rule(multiworld.get_location('Swamp Palace - Waterway Pot Key', player), lambda state: can_use_bombs(state, player))
 
     set_rule(multiworld.get_entrance('Thieves Town Big Key Door', player), lambda state: state.has('Big Key (Thieves Town)', player))
-
     if multiworld.worlds[player].dungeons["Thieves Town"].boss.enemizer_name == "Blind":
         set_rule(multiworld.get_entrance('Blind Fight', player), lambda state: state._lttp_has_key('Small Key (Thieves Town)', player, 3) and can_use_bombs(state, player))
-
     set_rule(multiworld.get_location('Thieves\' Town - Big Chest', player),
              lambda state: ((state._lttp_has_key('Small Key (Thieves Town)', player, 3)) or (location_item_name(state, 'Thieves\' Town - Big Chest', player) == ("Small Key (Thieves Town)", player)) and state._lttp_has_key('Small Key (Thieves Town)', player, 2)) and state.has('Hammer', player))
-
+    set_rule(multiworld.get_location('Thieves\' Town - Blind\'s Cell', player),
+             lambda state: state._lttp_has_key('Small Key (Thieves Town)', player))
     if multiworld.accessibility[player] != 'locations' and not multiworld.key_drop_shuffle[player]:
         set_always_allow(multiworld.get_location('Thieves\' Town - Big Chest', player), lambda state, item: item.name == 'Small Key (Thieves Town)' and item.player == player)
-
     set_rule(multiworld.get_location('Thieves\' Town - Attic', player), lambda state: state._lttp_has_key('Small Key (Thieves Town)', player, 3))
     set_rule(multiworld.get_location('Thieves\' Town - Spike Switch Pot Key', player),
              lambda state: state._lttp_has_key('Small Key (Thieves Town)', player))

--- a/worlds/alttp/test/dungeons/TestThievesTown.py
+++ b/worlds/alttp/test/dungeons/TestThievesTown.py
@@ -37,7 +37,8 @@ class TestThievesTown(TestDungeon):
 
             ["Thieves' Town - Blind's Cell", False, []],
             ["Thieves' Town - Blind's Cell", False, [], ['Big Key (Thieves Town)']],
-            ["Thieves' Town - Blind's Cell", True, ['Big Key (Thieves Town)']],
+            ["Thieves' Town - Blind's Cell", False, [], ['Small Key (Thieves Town)']],
+            ["Thieves' Town - Blind's Cell", True, ['Big Key (Thieves Town)', 'Small Key (Thieves Town)']],
 
             ["Thieves' Town - Boss", False, []],
             ["Thieves' Town - Boss", False, [], ['Big Key (Thieves Town)']],


### PR DESCRIPTION
## What is this fixing or adding?
Adds a missing rule for Blind's Cell.

## How was this tested?
Only generated to ensure no crash.