### PR TITLE
Muse Dash: 6th Anniversary Song update

### DIFF
--- a/worlds/musedash/MuseDashData.txt
+++ b/worlds/musedash/MuseDashData.txt
@@ -562,7 +562,7 @@ Test Me feat. Uyeon|43-55|MD Plus Project|True|3|5|9|
 Assault TAXI|43-56|MD Plus Project|True|4|7|10|
 No|43-57|MD Plus Project|False|4|6|9|
 Pop it|43-58|MD Plus Project|True|1|3|6|
-HEARTBEAT!キュンキュン!iKz feat.Warma|43-59|MD Plus Project|True|4|6|9|
+HEARTBEAT! KyunKyun!|43-59|MD Plus Project|True|4|6|9|
 SUPERHERO|75-0|Novice Rider Pack|False|2|4|7|
 Highway_Summer|75-1|Novice Rider Pack|True|2|4|6|
 Mx. Black Box|75-2|Novice Rider Pack|True|5|7|9|

--- a/worlds/musedash/MuseDashData.txt
+++ b/worlds/musedash/MuseDashData.txt
@@ -557,3 +557,13 @@ Tsukuyomi Ni Naru|74-2|CHUNITHM COURSE MUSE|False|5|7|9|
 The wheel to the right|74-3|CHUNITHM COURSE MUSE|True|5|7|9|11
 Climax|74-4|CHUNITHM COURSE MUSE|True|4|8|11|11
 Spider's Thread|74-5|CHUNITHM COURSE MUSE|True|5|8|10|12
+HIT ME UP|43-54|MD Plus Project|True|4|6|8|
+Test Me feat. Uyeon|43-55|MD Plus Project|True|3|5|9|
+Assault TAXI|43-56|MD Plus Project|True|4|7|10|
+No|43-57|MD Plus Project|False|4|6|9|
+Pop it|43-58|MD Plus Project|True|1|3|6|
+HEARTBEAT!キュンキュン!iKz feat.Warma|43-59|MD Plus Project|True|4|6|9|
+SUPERHERO|75-0|Novice Rider Pack|False|2|4|7|
+Highway_Summer|75-1|Novice Rider Pack|True|2|4|6|
+Mx. Black Box|75-2|Novice Rider Pack|True|5|7|9|
+Sweet Encounter|75-3|Novice Rider Pack|True|2|4|7|


### PR DESCRIPTION
## What is this fixing or adding?
Adds 6th anniversary songs.

Note: Territory Battles has not been updated yet. So will keep the same info as the last PR.

## How was this tested?
With tests.
