### PR TITLE
Muse Dash: Update installation guides to recommend installing v0.6.1.

### DIFF
--- a/worlds/musedash/docs/setup_en.md
+++ b/worlds/musedash/docs/setup_en.md
@@ -17,11 +17,12 @@
 ## Installing the Archipelago mod to Muse Dash
 
 1. Download [MelonLoader.Installer.exe](https://github.com/LavaGang/MelonLoader/releases/latest) and run it.
-2. Choose the automated tab, click the select button and browse to `MuseDash.exe`. Then click install.
+2. Choose the automated tab, click the select button and browse to `MuseDash.exe`.
   - You can find the folder in steam by finding the game in your library, right clicking it and choosing *Manage→Browse Local Files*.
   - If you click the bar at the top telling you your current folder, this will give you a path you can copy. If you paste that into the window popped up by **MelonLoader**, it will automatically go to the same folder.
-3. Run the game once, and wait until you get to the Muse Dash start screen before exiting.
-4. Download the latest [Muse Dash Archipelago Mod](https://github.com/DeamonHunter/ArchipelagoMuseDash/releases/latest) and then extract that into the newly created `/Mods/` folder in MuseDash's install location.
+3. Uncheck "Latest" and select v0.6.1. Then click install.
+4. Run the game once, and wait until you get to the Muse Dash start screen before exiting.
+5. Download the latest [Muse Dash Archipelago Mod](https://github.com/DeamonHunter/ArchipelagoMuseDash/releases/latest) and then extract that into the newly created `/Mods/` folder in MuseDash's install location.
   - All files must be under the `/Mods/` folder and not within a sub folder inside of `/Mods/`
 
 If you've successfully installed everything, a button will appear in the bottom right which will allow you to log into an Archipelago server.

--- a/worlds/musedash/docs/setup_es.md
+++ b/worlds/musedash/docs/setup_es.md
@@ -22,7 +22,7 @@
   - Si haces clic en la barra superior que te indica la carpeta en la que estas, te dará la dirección de ésta para que puedas copiarla. Al pegar esa dirección en la ventana que **MelonLoader** abre, irá automaticamente a esa carpeta.
 3. Desmarque "Latest" y seleccione v0.6.1. Luego haz clic en "install".
 4. Ejecuta el juego una vez, y espera hasta que aparezca la pantalla de inicio de Muse Dash antes de cerrarlo.
-5Descarga la última version de [Muse Dash Archipelago Mod](https://github.com/DeamonHunter/ArchipelagoMuseDash/releases/latest) y extraelo en la nueva carpeta creada llamada `/Mods/`, localizada en la carpeta de instalación de Muse Dash.
+5. Descarga la última version de [Muse Dash Archipelago Mod](https://github.com/DeamonHunter/ArchipelagoMuseDash/releases/latest) y extraelo en la nueva carpeta creada llamada `/Mods/`, localizada en la carpeta de instalación de Muse Dash.
   - Todos los archivos deben ir directamente en la carpeta `/Mods/`, y NO en una subcarpeta dentro de la carpeta `/Mods/`
 
 Si todo fue instalado correctamente, un botón aparecerá en la parte inferior derecha del juego una vez abierto, que te permitirá conectarte al servidor de Archipelago.

--- a/worlds/musedash/docs/setup_es.md
+++ b/worlds/musedash/docs/setup_es.md
@@ -20,7 +20,7 @@
 2. Elije la pestaña "automated", haz clic en el botón "select" y busca tu `MuseDash.exe`.
   - Puedes encontrar la carpeta en Steam buscando el juego en tu biblioteca, haciendo clic derecho sobre el y elegir *Administrar→Ver archivos locales*.
   - Si haces clic en la barra superior que te indica la carpeta en la que estas, te dará la dirección de ésta para que puedas copiarla. Al pegar esa dirección en la ventana que **MelonLoader** abre, irá automaticamente a esa carpeta.
-3. Desmarque "Latest" y seleccione v0.6.1. Luego haz clic en "install".
+3. Desmarca "Latest" y selecciona v0.6.1. Luego haz clic en "install".
 4. Ejecuta el juego una vez, y espera hasta que aparezca la pantalla de inicio de Muse Dash antes de cerrarlo.
 5. Descarga la última version de [Muse Dash Archipelago Mod](https://github.com/DeamonHunter/ArchipelagoMuseDash/releases/latest) y extraelo en la nueva carpeta creada llamada `/Mods/`, localizada en la carpeta de instalación de Muse Dash.
   - Todos los archivos deben ir directamente en la carpeta `/Mods/`, y NO en una subcarpeta dentro de la carpeta `/Mods/`

--- a/worlds/musedash/docs/setup_es.md
+++ b/worlds/musedash/docs/setup_es.md
@@ -17,11 +17,12 @@
 ## Instalar el mod de Archipelago en Muse Dash
 
 1. Descarga [MelonLoader.Installer.exe](https://github.com/LavaGang/MelonLoader/releases/latest) y ejecutalo.
-2. Elije la pestaña "automated", haz clic en el botón "select" y busca tu `MuseDash.exe`. Luego haz clic en "install".
+2. Elije la pestaña "automated", haz clic en el botón "select" y busca tu `MuseDash.exe`.
   - Puedes encontrar la carpeta en Steam buscando el juego en tu biblioteca, haciendo clic derecho sobre el y elegir *Administrar→Ver archivos locales*.
   - Si haces clic en la barra superior que te indica la carpeta en la que estas, te dará la dirección de ésta para que puedas copiarla. Al pegar esa dirección en la ventana que **MelonLoader** abre, irá automaticamente a esa carpeta.
-3. Ejecuta el juego una vez, y espera hasta que aparezca la pantalla de inicio de Muse Dash antes de cerrarlo.
-4. Descarga la última version de [Muse Dash Archipelago Mod](https://github.com/DeamonHunter/ArchipelagoMuseDash/releases/latest) y extraelo en la nueva carpeta creada llamada `/Mods/`, localizada en la carpeta de instalación de Muse Dash.
+3. Desmarque "Latest" y seleccione v0.6.1. Luego haz clic en "install".
+4. Ejecuta el juego una vez, y espera hasta que aparezca la pantalla de inicio de Muse Dash antes de cerrarlo.
+5Descarga la última version de [Muse Dash Archipelago Mod](https://github.com/DeamonHunter/ArchipelagoMuseDash/releases/latest) y extraelo en la nueva carpeta creada llamada `/Mods/`, localizada en la carpeta de instalación de Muse Dash.
   - Todos los archivos deben ir directamente en la carpeta `/Mods/`, y NO en una subcarpeta dentro de la carpeta `/Mods/`
 
 Si todo fue instalado correctamente, un botón aparecerá en la parte inferior derecha del juego una vez abierto, que te permitirá conectarte al servidor de Archipelago.


### PR DESCRIPTION
## What is this fixing or adding?
The current version of MelonLoader (v0.6.4) causes internal errors while loading dlls required for network connectivity. (DLL Not Found: System.Security.Permissions)

This rewrites the guides to explicitly mention installing v0.6.1

## How was this tested?
Checked rendering on webhost.
