### PR TITLE
MultiServer: !status shows Ready status

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -925,7 +925,11 @@ def get_status_string(ctx: Context, team: int, tag: str):
         tagged = len([client for client in ctx.clients[team][slot] if tag in client.tags])
         completion_text = f"({len(ctx.location_checks[team, slot])}/{len(ctx.locations[slot])})"
         tag_text = f" {tagged} of which are tagged {tag}" if connected and tag else ""
-        goal_text = " and has finished." if ctx.client_game_state[team, slot] == ClientStatus.CLIENT_GOAL else "."
+        goal_text = (
+            " and has finished." if ctx.client_game_state[team, slot] == ClientStatus.CLIENT_GOAL else
+            " and is ready." if ctx.client_game_state[team, slot] == ClientStatus.CLIENT_READY else
+            "."
+            )
         text += f"\n{ctx.get_aliased_name(team, slot)} has {connected} connection{'' if connected == 1 else 's'}" \
                 f"{tag_text}{goal_text} {completion_text}"
     return text

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -925,13 +925,13 @@ def get_status_string(ctx: Context, team: int, tag: str):
         tagged = len([client for client in ctx.clients[team][slot] if tag in client.tags])
         completion_text = f"({len(ctx.location_checks[team, slot])}/{len(ctx.locations[slot])})"
         tag_text = f" {tagged} of which are tagged {tag}" if connected and tag else ""
-        goal_text = (
+        status_text = (
             " and has finished." if ctx.client_game_state[team, slot] == ClientStatus.CLIENT_GOAL else
             " and is ready." if ctx.client_game_state[team, slot] == ClientStatus.CLIENT_READY else
             "."
             )
         text += f"\n{ctx.get_aliased_name(team, slot)} has {connected} connection{'' if connected == 1 else 's'}" \
-                f"{tag_text}{goal_text} {completion_text}"
+                f"{tag_text}{status_text} {completion_text}"
     return text
 
 


### PR DESCRIPTION
## What is this fixing or adding?
Makes !status show a note if the slot is in Status Ready

## How was this tested?
lightly,
running a server, connecting with text client, running !status, /ready, !status and seeing the output text change before/after setting ready

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/4809984/8c0f6d1d-d85b-4f59-bca7-a2f64badf80a)
