### PR TITLE
Docs: Clarify docs for `create_items` stage

### DIFF
--- a/docs/world api.md
+++ b/docs/world api.md
@@ -457,7 +457,8 @@ In addition, the following methods can be implemented and are called in this ord
   If it's hard to separate, this can be done during `generate_early` or `create_items` as well.
 * `create_items(self)`
   called to place player's items into the MultiWorld's itempool. After this step all regions
-  and items have to be in the MultiWorld's regions and itempool, and these lists should not be modified afterward.
+  and items have to be in the MultiWorld's regions and itempool, all locations must be created
+  in regions, and these lists should not be modified afterwards.
 * `set_rules(self)`
   called to set access and item rules on locations and entrances.
 * `generate_basic(self)`

--- a/docs/world api.md
+++ b/docs/world api.md
@@ -456,9 +456,8 @@ In addition, the following methods can be implemented and are called in this ord
   called to place player's regions and their locations into the MultiWorld's regions list.
   If it's hard to separate, this can be done during `generate_early` or `create_items` as well.
 * `create_items(self)`
-  called to place player's items into the MultiWorld's itempool. After this step all regions
-  and items have to be in the MultiWorld's regions and itempool, all locations must be created
-  in regions, and these lists should not be modified afterwards.
+  called to place player's items into the MultiWorld's itempool. You cannot modify the region, location, or item
+  pool after this step.
 * `set_rules(self)`
   called to set access and item rules on locations and entrances.
 * `generate_basic(self)`

--- a/docs/world api.md
+++ b/docs/world api.md
@@ -456,8 +456,9 @@ In addition, the following methods can be implemented and are called in this ord
   called to place player's regions and their locations into the MultiWorld's regions list.
   If it's hard to separate, this can be done during `generate_early` or `create_items` as well.
 * `create_items(self)`
-  called to place player's items into the MultiWorld's itempool. You cannot modify the region, location, or item
-  pool after this step.
+  called to place player's items into the MultiWorld's itempool. By the end of this step all regions, locations and
+  items have to be in the MultiWorld's regions and itempool. You cannot add or remove items, locations, or regions
+  after this step. Locations cannot be moved to different regions after this step.
 * `set_rules(self)`
   called to set access and item rules on locations and entrances.
 * `generate_basic(self)`


### PR DESCRIPTION
## What is this fixing or adding?
Clarifying that locations are included in the list of things that shouldn't change after `create_items`
[Relevant discord chat](https://discord.com/channels/731205301247803413/1214608557077700720/1257378767286964280)

## How was this tested?
Viewed the `.md` in github's viewer.

## If this makes graphical changes, please attach screenshots.
just markdown, can preview the rich diff