### PR TITLE
Launcher: Update message that displays when installing a custom apworld for a game in main

### DIFF
--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -131,7 +131,7 @@ def _install_apworld(apworld_src: str = "") -> Optional[Tuple[pathlib.Path, path
             found_already_loaded = True
             break
     if found_already_loaded:
-        raise Exception(f"Installed APWorld successfully, but '{module_name}' is already installed,\n"
+        raise Exception(f"Installed APWorld successfully, but '{module_name}' is already loaded,\n"
                         "so a Launcher restart is required to use the new installation.\n"
                         "If the Launcher is not open, no action needs to be taken.")
     world_source = worlds.WorldSource(str(target), is_zip=True)

--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -131,8 +131,9 @@ def _install_apworld(apworld_src: str = "") -> Optional[Tuple[pathlib.Path, path
             found_already_loaded = True
             break
     if found_already_loaded:
-        raise Exception(f"Installed APWorld successfully, but '{module_name}' is already loaded,\n"
-                        "so a Launcher restart is required to use the new installation.")
+        raise Exception(f"Installed APWorld successfully, but '{module_name}' is already installed,\n"
+                        "so a Launcher restart is required to use the new installation.\n"
+                        "If the Launcher is not open, no action needs to be taken.")
     world_source = worlds.WorldSource(str(target), is_zip=True)
     bisect.insort(worlds.world_sources, world_source)
     world_source.load()


### PR DESCRIPTION
## What is this fixing or adding?
![image](https://github.com/ArchipelagoMW/Archipelago/assets/24858499/2ef805a6-3b99-4efc-ac71-9b892d5638c3)
When double-clicking a beta Tunic apworld, I got the above message. I did not have the regular Launcher open, so I could see this being confusing for some users.
So, this PR updates the message that displays to hopefully be a bit clearer.

## How was this tested?
Reading