### PR TITLE
CommonClient: fix bug when using Connect button without a disconnect

### DIFF
--- a/kvui.py
+++ b/kvui.py
@@ -599,6 +599,7 @@ class GameManager(App):
             self.ctx.username = None
             async_start(self.ctx.disconnect())
         else:
+            self.ctx.username = None
             async_start(self.ctx.connect(self.server_connect_bar.text.replace("/connect ", "")))
 
     def on_stop(self):

--- a/kvui.py
+++ b/kvui.py
@@ -595,11 +595,10 @@ class GameManager(App):
                                              "!help for server commands.")
 
     def connect_button_action(self, button):
+        self.ctx.username = None
         if self.ctx.server:
-            self.ctx.username = None
             async_start(self.ctx.disconnect())
         else:
-            self.ctx.username = None
             async_start(self.ctx.connect(self.server_connect_bar.text.replace("/connect ", "")))
 
     def on_stop(self):


### PR DESCRIPTION
## What is this fixing or adding?
makes the kivy connect button do the same username forgetting that /connect does to fix an issue where losing connection would make you unable to connect to a different server

## How was this tested?
With two servers that have different valid slot names

* connect to server1, enter slot name when prompted
* close server1 to simulate the server losing connection for any reason
* enter server2 server address (with just host:port), click Connect button
* notice without the fix the connection is rejected for invalid slot (even without a prompt)
* notice with the fix the client prompts for slot name and can connect without issue after inputting it

## If this makes graphical changes, please attach screenshots.
