### PR TITLE
sc2: Fixing typo in itemgroups.py causing spurious item groups

### DIFF
--- a/worlds/sc2/ItemGroups.py
+++ b/worlds/sc2/ItemGroups.py
@@ -51,7 +51,7 @@ for item, data in Items.get_full_item_list().items():
     item_name_groups.setdefault(data.type, []).append(item)
     # Numbered flaggroups get sorted into an unnumbered group
     # Currently supports numbers of one or two digits
-    if data.type[-2:].strip().isnumeric:
+    if data.type[-2:].strip().isnumeric():
         type_group = data.type[:-2].strip()
         item_name_groups.setdefault(type_group, []).append(item)
         # Flaggroups with numbers are unlisted


### PR DESCRIPTION
## What is this fixing or adding?
Fixing spurious item groups created by a typo.
![image](https://github.com/Ziktofel/Archipelago/assets/31861583/58f9e5d9-36da-48c1-9a17-2fef2f612479)

Note this is already fixed in the sc2-next beta, looks like we just forgot to port the fix back to main.

## How was this tested?
Put a temporary printout of all item group names, verified "Abili", "Un", etc didn't appear in the list.

## If this makes graphical changes, please attach screenshots.
None