### PR TITLE
Project: Add .code-workspace wildcard to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,7 +150,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
-.code-workspace
+*.code-workspace
 shell.nix
 
 # Spyder project settings


### PR DESCRIPTION
## What is this?
This replaces `.code-workspace` with `*.code-workspace` in the root `.gitignore`

## Why is this needed?
VSCode, these days, by default, names the workspace file `foldername.code-workspace`. This change will make life a little easier by no longer requiring vscode users explicitly save the workspace as `.code-workspace`

## How will this affect the project?
This will enhance developer experience. It is unlikely that adding a wildcard to .code-workspace would negatively affect or break the project. It was verified that there wasn't any other files that contained ".code-workspace" in the github project.
