### PR TITLE
TUNIC: Make the shop checks require a sword

### DIFF
--- a/worlds/tunic/er_rules.py
+++ b/worlds/tunic/er_rules.py
@@ -1538,3 +1538,13 @@ def set_er_location_rules(world: "TunicWorld", ability_unlocks: Dict[str, int]) 
              lambda state: has_ability(state, player, prayer, options, ability_unlocks))
     set_rule(multiworld.get_location("Library Fuse", player),
              lambda state: has_ability(state, player, prayer, options, ability_unlocks))
+
+    # Shop
+    set_rule(multiworld.get_location("Shop - Potion 1", player),
+             lambda state: has_sword(state, player))
+    set_rule(multiworld.get_location("Shop - Potion 2", player),
+             lambda state: has_sword(state, player))
+    set_rule(multiworld.get_location("Shop - Coin 1", player),
+             lambda state: has_sword(state, player))
+    set_rule(multiworld.get_location("Shop - Coin 2", player),
+             lambda state: has_sword(state, player))

--- a/worlds/tunic/rules.py
+++ b/worlds/tunic/rules.py
@@ -337,3 +337,13 @@ def set_location_rules(world: "TunicWorld", ability_unlocks: Dict[str, int]) -> 
              lambda state: state.has(laurels, player) and has_ability(state, player, prayer, options, ability_unlocks))
     set_rule(multiworld.get_location("Hero's Grave - Feathers Relic", player),
              lambda state: state.has(laurels, player) and has_ability(state, player, prayer, options, ability_unlocks))
+
+    # Shop
+    set_rule(multiworld.get_location("Shop - Potion 1", player),
+             lambda state: has_sword(state, player))
+    set_rule(multiworld.get_location("Shop - Potion 2", player),
+             lambda state: has_sword(state, player))
+    set_rule(multiworld.get_location("Shop - Coin 1", player),
+             lambda state: has_sword(state, player))
+    set_rule(multiworld.get_location("Shop - Coin 2", player),
+             lambda state: has_sword(state, player))


### PR DESCRIPTION
## What is this fixing or adding?
There has been enough feedback about this that it's about time to add it, especially since people keep doing single player ladder shuffle.

Normally I would add the rule to the entrance, but for the er_rules, there are either 1 or 6 (default 6) entrances that lead to the shop, so it's probably better to just add the rule directly to the location.

## How was this tested?
Ran gen

## If this makes graphical changes, please attach screenshots.
N/A