### PR TITLE
Core: cull events from multidata spheres

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -516,6 +516,49 @@ class MultiWorld():
                 state.collect(location.item, True, location)
             locations -= sphere
 
+    def get_sendable_spheres(self) -> Iterator[Set[Location]]:
+        """
+        yields a set of multiserver sendable locations (location.item.code: int) for each logical sphere
+
+        If there are unreachable locations, the last sphere of reachable locations is followed by an empty set,
+        and then a set of all of the unreachable locations.
+        """
+        state = CollectionState(self)
+        locations = set()
+        events = set()
+        for location in self.get_filled_locations():
+            if type(location.item.code) == int:
+                locations.add(location)
+            else:
+                events.add(location)
+
+        while locations:
+            sphere: Set[Location] = set()
+
+            # cull events out
+            done_events = {None}
+            while done_events:
+                done_events = set()
+                for event in events:
+                    if event.can_reach(state):
+                        state.collect(event.item, True, event)
+                        done_events.add(event)
+                events -= done_events
+
+            for location in locations:
+                if location.can_reach(state):
+                    sphere.add(location)
+
+            yield sphere
+            if not sphere:
+                if locations:
+                    yield locations  # unreachable locations
+                break
+
+            for location in sphere:
+                state.collect(location.item, True, location)
+            locations -= sphere
+
     def fulfills_accessibility(self, state: Optional[CollectionState] = None):
         """Check if accessibility rules are fulfilled with current or supplied state."""
         if not state:

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -524,10 +524,10 @@ class MultiWorld():
         and then a set of all of the unreachable locations.
         """
         state = CollectionState(self)
-        locations = set()
-        events = set()
+        locations: Set[Location] = set()
+        events: Set[Location] = set()
         for location in self.get_filled_locations():
-            if type(location.item.code) == int:
+            if type(location.item.code) is int:
                 locations.add(location)
             else:
                 events.add(location)
@@ -536,7 +536,7 @@ class MultiWorld():
             sphere: Set[Location] = set()
 
             # cull events out
-            done_events = {None}
+            done_events: Set[Union[Location, None]] = {None}
             while done_events:
                 done_events = set()
                 for event in events:

--- a/Main.py
+++ b/Main.py
@@ -374,11 +374,10 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
 
                 # get spheres -> filter address==None -> skip empty
                 spheres: List[Dict[int, Set[int]]] = []
-                for sphere in multiworld.get_spheres():
+                for sphere in multiworld.get_sendable_spheres():
                     current_sphere: Dict[int, Set[int]] = collections.defaultdict(set)
                     for sphere_location in sphere:
-                        if type(sphere_location.address) is int:
-                            current_sphere[sphere_location.player].add(sphere_location.address)
+                        current_sphere[sphere_location.player].add(sphere_location.address)
 
                     if current_sphere:
                         spheres.append(dict(current_sphere))


### PR DESCRIPTION
## What is this fixing or adding?
Currently, when using say !hint worlds with heavy use of events get pushed back in priority. This recursively culls events out while making the spheres, giving them similar priority.

The feature, at least on the Sphere Tracker, is told to the user to only look at sendable items, so it makes sense for the feature to consistently work that way to meet user expectations.

## How was this tested?
locally. I had 1 HK and 1 LTTP with set seed, it turned 42 spheres, of which many spheres were one-player only, into 15 spheres in which both players had things to send, which is closer to what I'd expect.

## If this makes graphical changes, please attach screenshots.
:( -> :)