### PR TITLE
Launcher: support Component icons inside apworlds

### DIFF
--- a/Launcher.py
+++ b/Launcher.py
@@ -164,9 +164,8 @@ refresh_components: Optional[Callable[[], None]] = None
 
 
 def run_gui():
-    from kvui import App, ContainerLayout, GridLayout, Button, Label, ScrollBox, Widget
+    from kvui import App, ContainerLayout, GridLayout, Button, Label, ScrollBox, Widget, ApAsyncImage
     from kivy.core.window import Window
-    from kivy.uix.image import AsyncImage
     from kivy.uix.relativelayout import RelativeLayout
 
     class Launcher(App):
@@ -199,8 +198,8 @@ def run_gui():
                 button.component = component
                 button.bind(on_release=self.component_action)
                 if component.icon != "icon":
-                    image = AsyncImage(source=icon_paths[component.icon],
-                                       size=(38, 38), size_hint=(None, 1), pos=(5, 0))
+                    image = ApAsyncImage(source=icon_paths[component.icon],
+                                         size=(38, 38), size_hint=(None, 1), pos=(5, 0))
                     box_layout = RelativeLayout(size_hint_y=None, height=40)
                     box_layout.add_widget(button)
                     box_layout.add_widget(image)

--- a/kvui.py
+++ b/kvui.py
@@ -3,6 +3,8 @@ import logging
 import sys
 import typing
 import re
+import io
+import pkgutil
 from collections import deque
 
 if sys.platform == "win32":
@@ -35,6 +37,7 @@ from kivy.app import App
 from kivy.core.window import Window
 from kivy.core.clipboard import Clipboard
 from kivy.core.text.markup import MarkupLabel
+from kivy.core.image import ImageLoader, ImageLoaderBase, ImageData
 from kivy.base import ExceptionHandler, ExceptionManager
 from kivy.clock import Clock
 from kivy.factory import Factory
@@ -61,6 +64,7 @@ from kivy.uix.recycleboxlayout import RecycleBoxLayout
 from kivy.uix.recycleview.layout import LayoutSelectionBehavior
 from kivy.animation import Animation
 from kivy.uix.popup import Popup
+from kivy.uix.image import AsyncImage
 
 fade_in_animation = Animation(opacity=0, duration=0) + Animation(opacity=1, duration=0.25)
 
@@ -768,6 +772,42 @@ class HintLog(RecycleView):
         for element in self.children[0].children:
             max_height = max(child.texture_size[1] for child in element.children)
             element.height = max_height
+
+
+class ApAsyncImage(AsyncImage):
+    def is_uri(self, filename):
+        if filename[:3] == "ap:":
+            return True
+        else:
+            return super().is_uri(filename)
+
+
+class ImageLoaderPkgutil(ImageLoaderBase):
+    def load(self, filename):
+        # take off the "ap:" prefix
+        module, path = filename[3:].split("/", 1)
+        data = pkgutil.get_data(module, path)
+        return self._bytes_to_data(data)
+
+    def _bytes_to_data(self, data):
+        from PIL import Image as PImage
+        p_im = PImage.open(io.BytesIO(data)).convert("RGBA")
+        im_d = ImageData(p_im.size[0], p_im.size[1], p_im.mode.lower(), p_im.tobytes())
+        return [im_d]
+
+
+# grab the default loader method so we can override it but use it as a fallback
+DefaultLoad = ImageLoader.load
+
+
+def load_override(filename, default_load=DefaultLoad, **kwargs):
+    if filename[:3] == "ap:":
+        return ImageLoaderPkgutil(filename)
+    else:
+        return default_load(filename, **kwargs)
+
+
+ImageLoader.load = load_override
 
 
 class E(ExceptionHandler):

--- a/kvui.py
+++ b/kvui.py
@@ -775,21 +775,21 @@ class HintLog(RecycleView):
 
 
 class ApAsyncImage(AsyncImage):
-    def is_uri(self, filename):
-        if filename[:3] == "ap:":
+    def is_uri(self, filename: str) -> bool:
+        if filename.startswith("ap:"):
             return True
         else:
             return super().is_uri(filename)
 
 
 class ImageLoaderPkgutil(ImageLoaderBase):
-    def load(self, filename):
+    def load(self, filename: str) -> typing.List[ImageData]:
         # take off the "ap:" prefix
         module, path = filename[3:].split("/", 1)
         data = pkgutil.get_data(module, path)
         return self._bytes_to_data(data)
 
-    def _bytes_to_data(self, data):
+    def _bytes_to_data(self, data: typing.Union[bytes, bytearray]) -> typing.List[ImageData]:
         from PIL import Image as PImage
         p_im = PImage.open(io.BytesIO(data)).convert("RGBA")
         im_d = ImageData(p_im.size[0], p_im.size[1], p_im.mode.lower(), p_im.tobytes())

--- a/kvui.py
+++ b/kvui.py
@@ -800,8 +800,8 @@ class ImageLoaderPkgutil(ImageLoaderBase):
 DefaultLoad = ImageLoader.load
 
 
-def load_override(filename, default_load=DefaultLoad, **kwargs):
-    if filename[:3] == "ap:":
+def load_override(filename: str, default_load=DefaultLoad, **kwargs):
+    if filename.startswith("ap:"):
         return ImageLoaderPkgutil(filename)
     else:
         return default_load(filename, **kwargs)

--- a/kvui.py
+++ b/kvui.py
@@ -789,11 +789,9 @@ class ImageLoaderPkgutil(ImageLoaderBase):
         data = pkgutil.get_data(module, path)
         return self._bytes_to_data(data)
 
-    def _bytes_to_data(self, data: typing.Union[bytes, bytearray]) -> typing.List[ImageData]:
-        from PIL import Image as PImage
-        p_im = PImage.open(io.BytesIO(data)).convert("RGBA")
-        im_d = ImageData(p_im.size[0], p_im.size[1], p_im.mode.lower(), p_im.tobytes())
-        return [im_d]
+    def _bytes_to_data(self, data: Union[bytes, bytearray]) -> List[ImageData]:
+        loader = next(loader for loader in ImageLoader.loaders if loader.can_load_memory())
+        return loader.load(loader, io.BytesIO(data))
 
 
 # grab the default loader method so we can override it but use it as a fallback

--- a/kvui.py
+++ b/kvui.py
@@ -797,10 +797,10 @@ class ImageLoaderPkgutil(ImageLoaderBase):
 
 
 # grab the default loader method so we can override it but use it as a fallback
-DefaultLoad = ImageLoader.load
+_original_image_loader_load = ImageLoader.load
 
 
-def load_override(filename: str, default_load=DefaultLoad, **kwargs):
+def load_override(filename: str, default_load=_original_image_loader_load, **kwargs):
     if filename.startswith("ap:"):
         return ImageLoaderPkgutil(filename)
     else:

--- a/kvui.py
+++ b/kvui.py
@@ -789,7 +789,7 @@ class ImageLoaderPkgutil(ImageLoaderBase):
         data = pkgutil.get_data(module, path)
         return self._bytes_to_data(data)
 
-    def _bytes_to_data(self, data: Union[bytes, bytearray]) -> List[ImageData]:
+    def _bytes_to_data(self, data: typing.Union[bytes, bytearray]) -> typing.List[ImageData]:
         loader = next(loader for loader in ImageLoader.loaders if loader.can_load_memory())
         return loader.load(loader, io.BytesIO(data))
 

--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -195,6 +195,7 @@ components: List[Component] = [
 ]
 
 
+# if registering an icon from within an apworld, the format "ap:module.name/path/to/file.png" can be used
 icon_paths = {
     'icon': local_path('data', 'icon.png'),
     'mcicon': local_path('data', 'mcicon.png'),


### PR DESCRIPTION
## What is this fixing or adding?
Add kivy overrides to allow AsyncImage source paths of the format ap:worlds.module/subpath/to/data.png that use pkgutil to load files from within an apworld

## How was this tested?
locally edited the a hat in time world to use `icon_paths['yatta'] = f"ap:{__name__}/data/yatta.png"` instead of the existing icon_paths value, moving said png to inside a "data" folder in the world, and opened the launcher with:
* the world unzipped
* the world zipped as an apworld in /worlds
* the world zipped as an apworld in /custom_worlds

and all displayed the icon, also tested
* with the original icon, loaded quickly with no issue
* with an upscaled icon, which tripped zipbomb protection and did not load
* with a less upscaled icon, which took a few seconds to load, in which the launcher opened, displayed a loading icon, and was interactable until the image finished loading and replaced the loading icon as expected

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/ArchipelagoMW/Archipelago/assets/4809984/0dccfd21-80c7-4237-bc8d-b27c091b6286)

## Testing notes
feel free to reference the branch https://github.com/qwint/Archipelago/tree/apAsyncImage_test to see the ahit changes for testing