### PR TITLE
Stardew Valley: Properly support Universal Tracker

### DIFF
--- a/worlds/stardew_valley/regions.py
+++ b/worlds/stardew_valley/regions.py
@@ -137,7 +137,8 @@ vanilla_regions = [
                [Entrance.island_west_to_islandfarmhouse, Entrance.island_west_to_gourmand_cave, Entrance.island_west_to_crystals_cave,
                 Entrance.island_west_to_shipwreck, Entrance.island_west_to_qi_walnut_room, Entrance.use_farm_obelisk, Entrance.parrot_express_jungle_to_docks,
                 Entrance.parrot_express_jungle_to_dig_site, Entrance.parrot_express_jungle_to_volcano, LogicEntrance.grow_spring_crops_on_island,
-                LogicEntrance.grow_summer_crops_on_island, LogicEntrance.grow_fall_crops_on_island, LogicEntrance.grow_winter_crops_on_island, LogicEntrance.grow_indoor_crops_on_island],
+                LogicEntrance.grow_summer_crops_on_island, LogicEntrance.grow_fall_crops_on_island, LogicEntrance.grow_winter_crops_on_island,
+                LogicEntrance.grow_indoor_crops_on_island],
                is_ginger_island=True),
     RegionData(Region.island_east, [Entrance.island_east_to_leo_hut, Entrance.island_east_to_island_shrine], is_ginger_island=True),
     RegionData(Region.island_shrine, is_ginger_island=True),
@@ -536,7 +537,7 @@ def create_final_regions(world_options) -> List[RegionData]:
 def create_final_connections_and_regions(world_options) -> Tuple[Dict[str, ConnectionData], Dict[str, RegionData]]:
     regions_data: Dict[str, RegionData] = {region.name: region for region in create_final_regions(world_options)}
     connections = {connection.name: connection for connection in vanilla_connections}
-    connections = modify_connections_for_mods(connections, world_options.mods)
+    connections = modify_connections_for_mods(connections, sorted(world_options.mods.value))
     include_island = world_options.exclude_ginger_island == ExcludeGingerIsland.option_false
     return remove_ginger_island_regions_and_connections(regions_data, connections, include_island)
 
@@ -563,10 +564,8 @@ def remove_ginger_island_regions_and_connections(regions_by_name: Dict[str, Regi
     return connections, regions_by_name
 
 
-def modify_connections_for_mods(connections: Dict[str, ConnectionData], mods) -> Dict[str, ConnectionData]:
-    if mods is None:
-        return connections
-    for mod in mods.value:
+def modify_connections_for_mods(connections: Dict[str, ConnectionData], mods: Iterable) -> Dict[str, ConnectionData]:
+    for mod in mods:
         if mod not in ModDataList:
             continue
         if mod in vanilla_connections_to_remove_by_mod:

--- a/worlds/stardew_valley/test/__init__.py
+++ b/worlds/stardew_valley/test/__init__.py
@@ -441,6 +441,16 @@ def setup_multiworld(test_options: Iterable[Dict[str, int]] = None, seed=None) -
     for i in range(1, len(test_options) + 1):
         multiworld.game[i] = StardewValleyWorld.game
         multiworld.player_name.update({i: f"Tester{i}"})
+    args = create_args(test_options)
+    multiworld.set_options(args)
+
+    for step in gen_steps:
+        call_all(multiworld, step)
+
+    return multiworld
+
+
+def create_args(test_options):
     args = Namespace()
     for name, option in StardewValleyWorld.options_dataclass.type_hints.items():
         options = {}
@@ -449,9 +459,4 @@ def setup_multiworld(test_options: Iterable[Dict[str, int]] = None, seed=None) -
             value = option(player_options[name]) if name in player_options else option.from_any(option.default)
             options.update({i: value})
         setattr(args, name, options)
-    multiworld.set_options(args)
-
-    for step in gen_steps:
-        call_all(multiworld, step)
-
-    return multiworld
+    return args

--- a/worlds/stardew_valley/test/rules/TestBundles.py
+++ b/worlds/stardew_valley/test/rules/TestBundles.py
@@ -37,7 +37,7 @@ class TestRaccoonBundlesLogic(SVTestBase):
         options.BundlePrice: options.BundlePrice.option_normal,
         options.Craftsanity: options.Craftsanity.option_all,
     }
-    seed = 1234  # Magic seed that does what I want. Might need to get changed if we change the randomness behavior of raccoon bundles
+    seed = 2  # Magic seed that does what I want. Might need to get changed if we change the randomness behavior of raccoon bundles
 
     def test_raccoon_bundles_rely_on_previous_ones(self):
         # The first raccoon bundle is a fishing one

--- a/worlds/stardew_valley/test/stability/StabilityOutputScript.py
+++ b/worlds/stardew_valley/test/stability/StabilityOutputScript.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 
+from ...options import FarmType, EntranceRandomization
 from ...test import setup_solo_multiworld, allsanity_mods_6_x_x
 
 if __name__ == "__main__":
@@ -10,21 +11,23 @@ if __name__ == "__main__":
     args = parser.parse_args()
     seed = args.seed
 
-    multi_world = setup_solo_multiworld(
-        allsanity_mods_6_x_x(),
-        seed=seed
-    )
+    options = allsanity_mods_6_x_x()
+    options[FarmType.internal_name] = FarmType.option_standard
+    options[EntranceRandomization.internal_name] = EntranceRandomization.option_buildings
+    multi_world = setup_solo_multiworld(options, seed=seed)
 
+    world = multi_world.worlds[1]
     output = {
         "bundles": {
             bundle_room.name: {
                 bundle.name: str(bundle.items)
                 for bundle in bundle_room.bundles
             }
-            for bundle_room in multi_world.worlds[1].modified_bundles
+            for bundle_room in world.modified_bundles
         },
         "items": [item.name for item in multi_world.get_items()],
-        "location_rules": {location.name: repr(location.access_rule) for location in multi_world.get_locations(1)}
+        "location_rules": {location.name: repr(location.access_rule) for location in multi_world.get_locations(1)},
+        "slot_data": world.fill_slot_data()
     }
 
     print(json.dumps(output))

--- a/worlds/stardew_valley/test/stability/TestStability.py
+++ b/worlds/stardew_valley/test/stability/TestStability.py
@@ -25,7 +25,7 @@ class TestGenerationIsStable(SVTestCase):
             raise unittest.SkipTest("Long tests disabled")
 
         # seed = get_seed(33778671150797368040) # troubleshooting seed
-        seed = get_seed(74716545478307145559)
+        seed = get_seed()
 
         output_a = subprocess.check_output([sys.executable, '-m', 'worlds.stardew_valley.test.stability.StabilityOutputScript', '--seed', str(seed)])
         output_b = subprocess.check_output([sys.executable, '-m', 'worlds.stardew_valley.test.stability.StabilityOutputScript', '--seed', str(seed)])
@@ -54,3 +54,6 @@ class TestGenerationIsStable(SVTestCase):
             # We check that the actual rule has the same order to make sure it is evaluated in the same order,
             #  so performance tests are repeatable as much as possible.
             self.assertEqual(rule_a, rule_b, f"Location rule of {location_a} at index {i} is different between both executions. Seed={seed}")
+
+        for key, value in result_a["slot_data"].items():
+            self.assertEqual(value, result_b["slot_data"][key], f"Slot data {key} is different between both executions. Seed={seed}")

--- a/worlds/stardew_valley/test/stability/TestStability.py
+++ b/worlds/stardew_valley/test/stability/TestStability.py
@@ -24,7 +24,6 @@ class TestGenerationIsStable(SVTestCase):
         if self.skip_long_tests:
             raise unittest.SkipTest("Long tests disabled")
 
-        # seed = get_seed(33778671150797368040) # troubleshooting seed
         seed = get_seed()
 
         output_a = subprocess.check_output([sys.executable, '-m', 'worlds.stardew_valley.test.stability.StabilityOutputScript', '--seed', str(seed)])

--- a/worlds/stardew_valley/test/stability/TestUniversalTracker.py
+++ b/worlds/stardew_valley/test/stability/TestUniversalTracker.py
@@ -18,6 +18,7 @@ class TestUniversalTrackerGenerationIsStable(SVTestBase):
             raise unittest.SkipTest("Long tests disabled")
 
         try:
+            # This test only run if UT is present, so no risk of running in the CI.
             from worlds.tracker.TrackerClient import TrackerGameContext  # noqa
         except ImportError:
             raise unittest.SkipTest("UT not loaded, skipping test")

--- a/worlds/stardew_valley/test/stability/TestUniversalTracker.py
+++ b/worlds/stardew_valley/test/stability/TestUniversalTracker.py
@@ -1,0 +1,49 @@
+import unittest
+from unittest.mock import Mock
+
+from .. import SVTestBase, create_args
+from ... import STARDEW_VALLEY, options
+
+
+class TestUniversalTrackerGenerationIsStable(SVTestBase):
+    options = {
+        options.EntranceRandomization.internal_name: options.EntranceRandomization.option_buildings,
+        options.BundleRandomization.internal_name: options.BundleRandomization.option_shuffled,
+        options.FarmType.internal_name: options.FarmType.option_standard,  # Need to choose one  otherwise it's random
+    }
+
+    def test_all_locations_and_items_are_the_same_between_two_generations(self):
+        # This might open a kivy window temporarily, but it's the only way to test this...
+        if self.skip_long_tests:
+            raise unittest.SkipTest("Long tests disabled")
+
+        try:
+            from worlds.tracker.TrackerClient import TrackerGameContext  # noqa
+        except ImportError:
+            raise unittest.SkipTest("UT not loaded, skipping test")
+
+        slot_data = self.world.fill_slot_data()
+        ut_data = self.world.interpret_slot_data(slot_data)
+
+        fake_context = Mock()
+        fake_context.re_gen_passthrough = {STARDEW_VALLEY: ut_data}
+        args = create_args({0: self.options})
+        args.outputpath = None
+        args.outputname = None
+        args.multi = 1
+        args.race = None
+        args.plando_options = self.multiworld.plando_options
+        args.plando_items = self.multiworld.plando_items
+        args.plando_texts = self.multiworld.plando_texts
+        args.plando_connections = self.multiworld.plando_connections
+        args.game = self.multiworld.game
+        args.name = self.multiworld.player_name
+        args.sprite = {}
+        args.sprite_pool = {}
+        args.skip_output = True
+
+        generated_multi_world = TrackerGameContext.TMain(fake_context, args, self.multiworld.seed)
+        generated_slot_data = generated_multi_world.worlds[1].fill_slot_data()
+
+        # Just checking slot data should prove that UT generates the same result as AP generation.
+        self.assertEqual(slot_data, generated_slot_data)

--- a/worlds/stardew_valley/test/stability/TestUniversalTracker.py
+++ b/worlds/stardew_valley/test/stability/TestUniversalTracker.py
@@ -1,16 +1,17 @@
 import unittest
 from unittest.mock import Mock
 
-from .. import SVTestBase, create_args
-from ... import STARDEW_VALLEY, options
+from .. import SVTestBase, create_args, allsanity_mods_6_x_x
+from ... import STARDEW_VALLEY, FarmType, BundleRandomization, EntranceRandomization
 
 
 class TestUniversalTrackerGenerationIsStable(SVTestBase):
-    options = {
-        options.EntranceRandomization.internal_name: options.EntranceRandomization.option_buildings,
-        options.BundleRandomization.internal_name: options.BundleRandomization.option_shuffled,
-        options.FarmType.internal_name: options.FarmType.option_standard,  # Need to choose one  otherwise it's random
-    }
+    options = allsanity_mods_6_x_x()
+    options.update({
+        EntranceRandomization.internal_name: EntranceRandomization.option_buildings,
+        BundleRandomization.internal_name: BundleRandomization.option_shuffled,
+        FarmType.internal_name: FarmType.option_standard,  # Need to choose one  otherwise it's random
+    })
 
     def test_all_locations_and_items_are_the_same_between_two_generations(self):
         # This might open a kivy window temporarily, but it's the only way to test this...
@@ -47,4 +48,5 @@ class TestUniversalTrackerGenerationIsStable(SVTestBase):
         generated_slot_data = generated_multi_world.worlds[1].fill_slot_data()
 
         # Just checking slot data should prove that UT generates the same result as AP generation.
+        self.maxDiff = None
         self.assertEqual(slot_data, generated_slot_data)


### PR DESCRIPTION
## What is this fixing or adding?
This fix 
- Universal Tracker when used with Stardew Valley. This however only work with seeds generated with this fix. 
- The stability of the entrance randomizer, which could generate different layout when playing with mods.

The fix in itself is pretty simple. Instead of using the seed provider by the multiworld, a new seed is generated and saved in the slot data. Then the saved seed is reused to generate with UT. 

Note that there is a limitation to this fix. The generation and the player need the same version of the apworld (which should usually be the case). If someone is outdated, the random might end up in a different state. For instance, you will not be able to track a 5.x.x game if you have 6.x.x installed.

## How was this tested?
Unit test, and also generated a couple seed to confirm it works. Compared spoiler with added log to confirm bundles and entrances are the same.

## If this makes graphical changes, please attach screenshots.
N/A
