### PR TITLE
Pokemon Emerald: Fix logic for coin case location

### DIFF
--- a/worlds/pokemon_emerald/rules.py
+++ b/worlds/pokemon_emerald/rules.py
@@ -558,6 +558,10 @@ def set_rules(world: "PokemonEmeraldWorld") -> None:
         get_location("NPC_GIFT_GOT_BASEMENT_KEY_FROM_WATTSON"),
         lambda state: state.has("EVENT_DEFEAT_NORMAN", world.player)
     )
+    set_rule(
+        get_location("NPC_GIFT_RECEIVED_COIN_CASE"),
+        lambda state: state.has("EVENT_BUY_HARBOR_MAIL", world.player)
+    )
 
     # Route 117
     set_rule(
@@ -1637,10 +1641,6 @@ def set_rules(world: "PokemonEmeraldWorld") -> None:
         set_rule(
             get_location("NPC_GIFT_GOT_TM_THUNDERBOLT_FROM_WATTSON"),
             lambda state: state.has("EVENT_DEFEAT_NORMAN", world.player) and state.has("EVENT_TURN_OFF_GENERATOR", world.player)
-        )
-        set_rule(
-            get_location("NPC_GIFT_RECEIVED_COIN_CASE"),
-            lambda state: state.has("EVENT_BUY_HARBOR_MAIL", world.player)
         )
 
         # Fallarbor Town


### PR DESCRIPTION
## What is this fixing or adding?

The coin case is a key item, but it's not progression like almost every other key item is, so it got mixed up in the rules. The rule shouldn't be applied conditionally with the `npc_gifts` option, it should always be applied. Key items are converted to events, so the location will always exist.

## How was this tested?

Generated with all 4 combinations of key items and npc gifts turned on and off.
