### PR TITLE
Zillion: more rooms added to map_gen option

### DIFF
--- a/worlds/zillion/client.py
+++ b/worlds/zillion/client.py
@@ -347,6 +347,11 @@ class ZillionContext(CommonContext):
                         "operations": [{"operation": "replace", "value": doors_b64}]
                     }
                     async_start(self.send_msgs([payload]))
+            elif isinstance(event_from_game, events.MapEventFromGame):
+                row = event_from_game.map_index // 8
+                col = event_from_game.map_index % 8
+                room_name = f"({chr(row + 64)}-{col + 1})"
+                logger.info(f"You are at {room_name}")
             else:
                 logger.warning(f"WARNING: unhandled event from game {event_from_game}")
 

--- a/worlds/zillion/gen_data.py
+++ b/worlds/zillion/gen_data.py
@@ -28,6 +28,13 @@ class GenData:
     def from_json(gen_data_str: str) -> "GenData":
         """ the reverse of `to_json` """
         from_json = json.loads(gen_data_str)
+
+        # backwards compatibility for seeds generated before new map_gen options
+        room_gen = from_json["zz_game"]["options"].get("room_gen", None)
+        if room_gen is not None:
+            from_json["zz_game"]["options"]["map_gen"] = {False: "none", True: "rooms"}.get(room_gen, "none")
+            del from_json["zz_game"]["options"]["room_gen"]
+
         return GenData(
             from_json["multi_items"],
             ZzGame.from_jsonable(from_json["zz_game"]),

--- a/worlds/zillion/requirements.txt
+++ b/worlds/zillion/requirements.txt
@@ -1,2 +1,2 @@
-zilliandomizer @ git+https://github.com/beauxq/zilliandomizer@4a2fec0aa1c529df866e510cdfcf6dca4d53679b#0.8.0
+zilliandomizer @ git+https://github.com/beauxq/zilliandomizer@33045067f626266850f91c8045b9d3a9f52d02b0#0.9.0
 typing-extensions>=4.7, <5


### PR DESCRIPTION
## What is this fixing or adding?

an extension to the new option added in https://github.com/ArchipelagoMW/Archipelago/pull/3604

now includes the lower section of the base, including split rooms

plus a backwards compatibility patch for seeds generated before this option

zilliandomizer diff: https://github.com/beauxq/zilliandomizer/compare/v0.8.0...v0.9.0

## How was this tested?

a few games generated and played from zilliandomizer and one from AP
