### PR TITLE
TUNIC: Fix event region for Quarry fuse

### DIFF
--- a/worlds/tunic/er_scripts.py
+++ b/worlds/tunic/er_scripts.py
@@ -67,7 +67,7 @@ tunic_events: Dict[str, str] = {
     "Eastern Vault West Fuses": "Eastern Vault Fortress",
     "Eastern Vault East Fuse": "Eastern Vault Fortress",
     "Quarry Connector Fuse": "Quarry Connector",
-    "Quarry Fuse": "Quarry",
+    "Quarry Fuse": "Quarry Entry",
     "Ziggurat Fuse": "Rooted Ziggurat Lower Back",
     "West Garden Fuse": "West Garden",
     "Library Fuse": "Library Lab",


### PR DESCRIPTION
## What is this fixing or adding?
The event location for the Quarry Fuse event item was in the wrong region, making it incorrectly require a sword or wand to reach if you enter Quarry from either the portal, the shop, or the main entrance.
This is now fixed.

## How was this tested?
Test gens.

## If this makes graphical changes, please attach screenshots.
N/A