### PR TITLE
customserver: fix minor memory leak

### DIFF
--- a/WebHostLib/customserver.py
+++ b/WebHostLib/customserver.py
@@ -329,6 +329,7 @@ def run_server_process(name: str, ponyconfig: dict, static_server_data: dict,
                 self._tasks.append(task)
                 task.add_done_callback(self._done)
                 logging.info(f"Starting room {next_room} on {name}.")
+                del task  # delete reference to task object
 
     starter = Starter()
     starter.daemon = True


### PR DESCRIPTION
## What is this fixing or adding?

Old code keeps ref to last started room's task and thus never fully cleans it up.

## How was this tested?

Looking at weakref pointing to `None` after the change.