### PR TITLE
customserver: preemtively run GC before starting room

### DIFF
--- a/WebHostLib/customserver.py
+++ b/WebHostLib/customserver.py
@@ -325,6 +325,7 @@ def run_server_process(name: str, ponyconfig: dict, static_server_data: dict,
         def run(self):
             while 1:
                 next_room = rooms_to_run.get(block=True,  timeout=None)
+                gc.collect(0)
                 task = asyncio.run_coroutine_threadsafe(start_room(next_room), loop)
                 self._tasks.append(task)
                 task.add_done_callback(self._done)


### PR DESCRIPTION
## What is this fixing or adding?

GC seems to be lazy.

## How was this tested?

Adding a weakref with callback to ctx and to auto_save_thread and watching it **not** trigger before the change while there is no pressure, and then watching it actually trigger after the change whenever hosting a new room.

Side note: `gc.collect(0)` should be the cheapest variation and is already enough to find the two objects.