### PR TITLE
CommonClient: forget password when disconnecting

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -61,6 +61,7 @@ class ClientCommandProcessor(CommandProcessor):
         if address:
             self.ctx.server_address = None
             self.ctx.username = None
+            self.ctx.password = None
         elif not self.ctx.server_address:
             self.output("Please specify an address.")
             return False
@@ -514,6 +515,7 @@ class CommonContext:
     async def shutdown(self):
         self.server_address = ""
         self.username = None
+        self.password = None
         self.cancel_autoreconnect()
         if self.server and not self.server.socket.closed:
             await self.server.socket.close()

--- a/kvui.py
+++ b/kvui.py
@@ -596,6 +596,7 @@ class GameManager(App):
 
     def connect_button_action(self, button):
         self.ctx.username = None
+        self.ctx.password = None
         if self.ctx.server:
             async_start(self.ctx.disconnect())
         else:

--- a/kvui.py
+++ b/kvui.py
@@ -599,6 +599,7 @@ class GameManager(App):
             self.ctx.username = None
             async_start(self.ctx.disconnect())
         else:
+            self.ctx.username = None
             async_start(self.ctx.connect(self.server_connect_bar.text.replace("/connect ", "")))
 
     def on_stop(self):

--- a/kvui.py
+++ b/kvui.py
@@ -595,11 +595,10 @@ class GameManager(App):
                                              "!help for server commands.")
 
     def connect_button_action(self, button):
+        self.ctx.username = None
         if self.ctx.server:
-            self.ctx.username = None
             async_start(self.ctx.disconnect())
         else:
-            self.ctx.username = None
             async_start(self.ctx.connect(self.server_connect_bar.text.replace("/connect ", "")))
 
     def on_stop(self):


### PR DESCRIPTION
## What is this fixing or adding?
followup to #3609
this adds to the disconnect workflows clearing out of the password field

## How was this tested?
wasn't; will probably at least run through connect/disconnect later sometime 
would want some input from people who run password'd games more often to see if these changes make swapping slots etc. too frustrating to see if an alternative solution is needed

## If this makes graphical changes, please attach screenshots.
