### PR TITLE
settings: safer writing

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -807,10 +807,12 @@ class Settings(Group):
         # can't use utf-8-sig because it breaks backward compat: pyyaml on Windows with bytes does not strip the BOM
         with open(temp_location, "w", encoding="utf-8") as f:
             self.dump(f)
-        # replace old with new
-        if os.path.exists(location):
+        # replace old with new, try atomic operation first
+        try:
+            os.rename(temp_location, location)
+        except (OSError, FileExistsError):
             os.unlink(location)
-        os.rename(temp_location, location)
+            os.rename(temp_location, location)
         self._filename = location
 
     def dump(self, f: TextIO, level: int = 0) -> None:

--- a/settings.py
+++ b/settings.py
@@ -3,6 +3,7 @@ Application settings / host.yaml interface using type hints.
 This is different from player options.
 """
 
+import os
 import os.path
 import shutil
 import sys
@@ -11,7 +12,6 @@ import warnings
 from enum import IntEnum
 from threading import Lock
 from typing import cast, Any, BinaryIO, ClassVar, Dict, Iterator, List, Optional, TextIO, Tuple, Union, TypeVar
-import os
 
 __all__ = [
     "get_settings", "fmt_doc", "no_gui",
@@ -832,7 +832,6 @@ def get_settings() -> Settings:
     with _lock:  # make sure we only have one instance
         res = getattr(get_settings, "_cache", None)
         if not res:
-            import os
             from Utils import user_path, local_path
             filenames = ("options.yaml", "host.yaml")
             locations: List[str] = []


### PR DESCRIPTION
## What is this fixing or adding?

* try to use atomic rename if available
* flush new file to disk - possibly fixing whatever happened to that one file that was all zeroes
* try to parse new file before swapping out the old one - this might've found #3096 without breaking the user's host.yaml as well as that one file with all zeroes
* minor cleanup in imports

## How was this tested?

upgraded an existing yaml via file browser
created a fresh host.yaml by deleting the host.yaml