### PR TITLE
Core: Update cx_freeze to 7.2.0 and freeze it

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 # This is a bit jank. We need cx-Freeze to be able to run anything from this script, so install it
 try:
-    requirement = 'cx-Freeze==7.0.0'
+    requirement = 'cx-Freeze==7.2.0'
     import pkg_resources
     try:
         pkg_resources.require(requirement)


### PR DESCRIPTION
## What is this fixing or adding?

Update cx_freeze to latest version
supersedes ArchipelagoMW/Archipelago#3405

## How was this tested?

Generate and TextClient on AppImage with py3.8 and py3.11.
Windows was not tested,