### PR TITLE
Stardew Valley: Make Fairy Dust a Ginger Island only item and location

### DIFF
--- a/worlds/stardew_valley/data/items.csv
+++ b/worlds/stardew_valley/data/items.csv
@@ -307,7 +307,7 @@ id,name,classification,groups,mod_name
 322,Phoenix Ring,useful,"RING,RESOURCE_PACK,MAXIMUM_ONE",
 323,Immunity Band,useful,"RING,RESOURCE_PACK,MAXIMUM_ONE",
 324,Glowstone Ring,useful,"RING,RESOURCE_PACK,MAXIMUM_ONE",
-325,Fairy Dust Recipe,progression,,
+325,Fairy Dust Recipe,progression,"GINGER_ISLAND",
 326,Heavy Tapper Recipe,progression,"QI_CRAFTING_RECIPE,GINGER_ISLAND",
 327,Hyper Speed-Gro Recipe,progression,"QI_CRAFTING_RECIPE,GINGER_ISLAND",
 328,Deluxe Fertilizer Recipe,progression,QI_CRAFTING_RECIPE,

--- a/worlds/stardew_valley/data/locations.csv
+++ b/worlds/stardew_valley/data/locations.csv
@@ -2088,7 +2088,7 @@ id,region,name,tags,mod_name
 3472,Farm,Craft Life Elixir,CRAFTSANITY,
 3473,Farm,Craft Oil of Garlic,CRAFTSANITY,
 3474,Farm,Craft Monster Musk,CRAFTSANITY,
-3475,Farm,Craft Fairy Dust,CRAFTSANITY,
+3475,Farm,Craft Fairy Dust,"CRAFTSANITY,GINGER_ISLAND",
 3476,Farm,Craft Warp Totem: Beach,CRAFTSANITY,
 3477,Farm,Craft Warp Totem: Mountains,CRAFTSANITY,
 3478,Farm,Craft Warp Totem: Farm,CRAFTSANITY,

--- a/worlds/stardew_valley/items.py
+++ b/worlds/stardew_valley/items.py
@@ -409,8 +409,9 @@ def create_special_quest_rewards(item_factory: StardewItemFactory, options: Star
     else:
         items.append(item_factory(Wallet.bears_knowledge, ItemClassification.useful))  # Not necessary outside of SVE
     items.append(item_factory(Wallet.iridium_snake_milk))
-    items.append(item_factory("Fairy Dust Recipe"))
     items.append(item_factory("Dark Talisman"))
+    if options.exclude_ginger_island == ExcludeGingerIsland.option_false:
+        items.append(item_factory("Fairy Dust Recipe"))
 
 
 def create_help_wanted_quest_rewards(item_factory: StardewItemFactory, options: StardewValleyOptions, items: List[Item]):


### PR DESCRIPTION
## What is this fixing or adding?
We used to give the Fairy Dust recipe as a freebie even if a player excluded ginger island, but in an attempt to make Stardew more open to very low-check settings in the future, it has now been removed when it should not be accessible, since it is a ginger island recipe in the base game.

## How was this tested?
Automated Tests
