### PR TITLE
Stardew Valley: Removed Stardrop Tea from Full Shipment

### DIFF
--- a/worlds/stardew_valley/data/locations.csv
+++ b/worlds/stardew_valley/data/locations.csv
@@ -2221,7 +2221,7 @@ id,region,name,tags,mod_name
 3817,Shipping,Shipsanity: Raisins,"SHIPSANITY,SHIPSANITY_FULL_SHIPMENT",
 3818,Shipping,Shipsanity: Dried Fruit,"SHIPSANITY,SHIPSANITY_FULL_SHIPMENT",
 3819,Shipping,Shipsanity: Dried Mushrooms,"SHIPSANITY,SHIPSANITY_FULL_SHIPMENT",
-3820,Shipping,Shipsanity: Stardrop Tea,"SHIPSANITY,SHIPSANITY_FULL_SHIPMENT",
+3820,Shipping,Shipsanity: Stardrop Tea,"SHIPSANITY",
 3821,Shipping,Shipsanity: Prize Ticket,"SHIPSANITY",
 3822,Shipping,Shipsanity: Treasure Totem,"SHIPSANITY,REQUIRES_MASTERIES",
 3823,Shipping,Shipsanity: Challenge Bait,"SHIPSANITY,REQUIRES_MASTERIES",


### PR DESCRIPTION
## What is this fixing or adding?
Stardrop Tea, even though it's a tea, is not an artisan good, is not in the shipping collection tab and shouldn't be on the list of checks for shipsanity full shipment. This was a simple oversight.

## How was this tested?
Automated Tests