### PR TITLE
CommonClient: Escape markup sent in chat messages

### DIFF
--- a/kvui.py
+++ b/kvui.py
@@ -837,7 +837,9 @@ class KivyJSONtoTextParser(JSONtoTextParser):
 
     def _handle_text(self, node: JSONMessagePart):
         node_type = node.get("type", None)
-        if node_type == "text" or node_type == None: # All other text goes through _handle_color, and we don't want to escape markup twice
+        # All other text goes through _handle_color, and we don't want to escape markup twice,
+        # or mess up text that already has intentional markup applied to it
+        if node_type == "text" or node_type == None:
             node["text"] = escape_markup(node["text"])
         for ref in node.get("refs", []):
             node["text"] = f"[ref={self.ref_count}|{ref}]{node['text']}[/ref]"

--- a/kvui.py
+++ b/kvui.py
@@ -836,6 +836,9 @@ class KivyJSONtoTextParser(JSONtoTextParser):
         return self._handle_text(node)
 
     def _handle_text(self, node: JSONMessagePart):
+        node_type = node.get("type", None)
+        if node_type == "text" or node_type == None: # All other text goes through _handle_color, and we don't want to escape markup twice
+            node["text"] = escape_markup(node["text"])
         for ref in node.get("refs", []):
             node["text"] = f"[ref={self.ref_count}|{ref}]{node['text']}[/ref]"
             self.ref_count += 1

--- a/kvui.py
+++ b/kvui.py
@@ -836,10 +836,9 @@ class KivyJSONtoTextParser(JSONtoTextParser):
         return self._handle_text(node)
 
     def _handle_text(self, node: JSONMessagePart):
-        node_type = node.get("type", None)
         # All other text goes through _handle_color, and we don't want to escape markup twice,
         # or mess up text that already has intentional markup applied to it
-        if node_type == "text" or node_type == None:
+        if node.get("type", "text") == "text":
             node["text"] = escape_markup(node["text"])
         for ref in node.get("refs", []):
             node["text"] = f"[ref={self.ref_count}|{ref}]{node['text']}[/ref]"


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?
Previously, the Common Client would accept kivy markup syntax from user input. This is now fixed by escaping markup for plain text nodes.

This should also fix these issues:
- https://github.com/ArchipelagoMW/Archipelago/issues/2741
- https://github.com/ArchipelagoMW/Archipelago/issues/2742
- https://github.com/ArchipelagoMW/Archipelago/issues/2743

## How was this tested?
Ran the common client, and sent kivy markup to verify that it was properly escaped. I also ran !hint to make sure that text that is intentionally styled isn't messed up.

## If this makes graphical changes, please attach screenshots.
