### PR TITLE
Pokemon Emerald: Ensure dig tutor is always usable

### DIFF
--- a/worlds/pokemon_emerald/rom.py
+++ b/worlds/pokemon_emerald/rom.py
@@ -817,6 +817,8 @@ def _randomize_opponent_battle_type(world: "PokemonEmeraldWorld", patch: Pokemon
 
 
 def _randomize_move_tutor_moves(world: "PokemonEmeraldWorld", patch: PokemonEmeraldProcedurePatch, easter_egg: Tuple[int, int]) -> None:
+    FORTREE_MOVE_TUTOR_INDEX = 24
+
     if easter_egg[0] == 2:
         for i in range(30):
             patch.write_token(
@@ -840,18 +842,26 @@ def _randomize_move_tutor_moves(world: "PokemonEmeraldWorld", patch: PokemonEmer
     # Always set Fortree move tutor to Dig
     patch.write_token(
         APTokenTypes.WRITE,
-        data.rom_addresses["gTutorMoves"] + (24 * 2),
+        data.rom_addresses["gTutorMoves"] + (FORTREE_MOVE_TUTOR_INDEX * 2),
         struct.pack("<H", data.constants["MOVE_DIG"])
     )
 
     # Modify compatibility
     if world.options.tm_tutor_compatibility.value != -1:
         for species in data.species.values():
+            compatibility = bool_array_to_int([
+                world.random.randrange(0, 100) < world.options.tm_tutor_compatibility.value
+                for _ in range(32)
+            ])
+
+            # Make sure Dig tutor has reasonable (>50%) compatibility
+            if world.options.tm_tutor_compatibility.value < 50:
+                compatibility &= ~(1 << FORTREE_MOVE_TUTOR_INDEX)
+                if world.random.random() < 0.5:
+                    compatibility |= 1 << FORTREE_MOVE_TUTOR_INDEX
+
             patch.write_token(
                 APTokenTypes.WRITE,
                 data.rom_addresses["sTutorLearnsets"] + (species.species_id * 4),
-                struct.pack("<I", bool_array_to_int([
-                    world.random.randrange(0, 100) < world.options.tm_tutor_compatibility.value
-                    for _ in range(32)
-                ]))
+                struct.pack("<I", compatibility)
             )

--- a/worlds/pokemon_emerald/rom.py
+++ b/worlds/pokemon_emerald/rom.py
@@ -854,7 +854,7 @@ def _randomize_move_tutor_moves(world: "PokemonEmeraldWorld", patch: PokemonEmer
                 for _ in range(32)
             ])
 
-            # Make sure Dig tutor has reasonable (>50%) compatibility
+            # Make sure Dig tutor has reasonable (>=50%) compatibility
             if world.options.tm_tutor_compatibility.value < 50:
                 compatibility &= ~(1 << FORTREE_MOVE_TUTOR_INDEX)
                 if world.random.random() < 0.5:


### PR DESCRIPTION
## What is this fixing or adding?

Dig is required to reach the three regis for legendary hunt, but the vanilla enforcement of access to Dig is the ability to find pokemon in the wild that are able to learn Dig; it isn't tied to any permanent items. So the apworld forces a static move tutor to always teach Dig, regardless of options, and access to that tutor is used for logic. But if a player sets their tutor compatibility to zero or near zero, they're effectively unable to use the tutor.

This sets a floor for how low the compatibility can be at 50% (or vanilla compatibility with the tutor's original move, Sleep Talk, which is nearly 100%).

If a player were to blacklist every wild pokemon except ~10 specific species that don't have evolution lines, it might be possible to get extremely unlucky and have 50% not be enough. The same is true for HM compatibility. I don't think such an edge case is worth addressing right now, but I suppose it's worth mentioning here. So many things have to line up for such a problem to be possible that it has not been worth building a safety net to account for it.

## How was this tested?

Only by generating above and below the threshold to make sure it didn't cause an exception. When I have time to test it in a game to verify it had the correct effect, I'll add a new comment here.
