### PR TITLE
Stardew Valley: Make sure number of month in time logic is a int to improve performance by ~20%

### DIFF
--- a/worlds/stardew_valley/logic/bundle_logic.py
+++ b/worlds/stardew_valley/logic/bundle_logic.py
@@ -27,8 +27,8 @@ class BundleLogicMixin(BaseLogicMixin):
         self.bundle = BundleLogic(*args, **kwargs)
 
 
-class BundleLogic(BaseLogic[Union[ReceivedLogicMixin, HasLogicMixin, TimeLogicMixin, RegionLogicMixin, MoneyLogicMixin, QualityLogicMixin, FishingLogicMixin, SkillLogicMixin,
-QuestLogicMixin]]):
+class BundleLogic(BaseLogic[Union[ReceivedLogicMixin, HasLogicMixin, TimeLogicMixin, RegionLogicMixin, MoneyLogicMixin, QualityLogicMixin, FishingLogicMixin,
+SkillLogicMixin, QuestLogicMixin]]):
     # Should be cached
     def can_complete_bundle(self, bundle: Bundle) -> StardewRule:
         item_rules = []
@@ -45,7 +45,7 @@ QuestLogicMixin]]):
             qualities.append(bundle_item.quality)
         quality_rules = self.get_quality_rules(qualities)
         item_rules = self.logic.has_n(*item_rules, count=bundle.number_required)
-        time_rule = True_() if time_to_grind <= 0 else self.logic.time.has_lived_months(time_to_grind)
+        time_rule = self.logic.time.has_lived_months(time_to_grind)
         return can_speak_junimo & item_rules & quality_rules & time_rule
 
     def get_quality_rules(self, qualities: List[str]) -> StardewRule:

--- a/worlds/stardew_valley/logic/museum_logic.py
+++ b/worlds/stardew_valley/logic/museum_logic.py
@@ -41,7 +41,7 @@ class MuseumLogic(BaseLogic[Union[ReceivedLogicMixin, HasLogicMixin, TimeLogicMi
         else:
             geodes_rule = False_()
         # monster_rule = self.can_farm_monster(item.monsters)
-        time_needed_to_grind = (20 - item.difficulty) / 2
+        time_needed_to_grind = int((20 - item.difficulty) // 2)
         time_rule = self.logic.time.has_lived_months(time_needed_to_grind)
         pan_rule = False_()
         if item.item_name == Mineral.earth_crystal or item.item_name == Mineral.fire_quartz or item.item_name == Mineral.frozen_tear:

--- a/worlds/stardew_valley/logic/time_logic.py
+++ b/worlds/stardew_valley/logic/time_logic.py
@@ -25,10 +25,10 @@ class TimeLogicMixin(BaseLogicMixin):
 class TimeLogic(BaseLogic[Union[TimeLogicMixin, HasLogicMixin]]):
 
     @cache_self1
-    def has_lived_months(self, number: Union[int, float]) -> StardewRule:
+    def has_lived_months(self, number: int) -> StardewRule:
+        assert isinstance(number, int), "Can't have lived a fraction of a month. Use // instead of / when dividing."
         if number <= 0:
             return self.logic.true_
-        number = int(number)
 
         number = min(number, MAX_MONTHS)
         return HasProgressionPercent(self.player, number * MONTH_COEFFICIENT)
@@ -38,11 +38,11 @@ class TimeLogic(BaseLogic[Union[TimeLogicMixin, HasLogicMixin]]):
         return self.logic.time.has_lived_months(MAX_MONTHS)
 
     @cache_self1
-    def has_lived_year(self, number: Union[int, float]) -> StardewRule:
+    def has_lived_year(self, number: int) -> StardewRule:
         return self.logic.time.has_lived_months(number * ONE_YEAR)
 
     @cache_self1
-    def has_year(self, number: Union[int, float]) -> StardewRule:
+    def has_year(self, number: int) -> StardewRule:
         return self.logic.time.has_lived_year(number - 1)
 
     @cached_property

--- a/worlds/stardew_valley/logic/time_logic.py
+++ b/worlds/stardew_valley/logic/time_logic.py
@@ -25,9 +25,11 @@ class TimeLogicMixin(BaseLogicMixin):
 class TimeLogic(BaseLogic[Union[TimeLogicMixin, HasLogicMixin]]):
 
     @cache_self1
-    def has_lived_months(self, number: int) -> StardewRule:
+    def has_lived_months(self, number: Union[int, float]) -> StardewRule:
         if number <= 0:
             return self.logic.true_
+        number = int(number)
+
         number = min(number, MAX_MONTHS)
         return HasProgressionPercent(self.player, number * MONTH_COEFFICIENT)
 
@@ -36,11 +38,11 @@ class TimeLogic(BaseLogic[Union[TimeLogicMixin, HasLogicMixin]]):
         return self.logic.time.has_lived_months(MAX_MONTHS)
 
     @cache_self1
-    def has_lived_year(self, number: int) -> StardewRule:
+    def has_lived_year(self, number: Union[int, float]) -> StardewRule:
         return self.logic.time.has_lived_months(number * ONE_YEAR)
 
     @cache_self1
-    def has_year(self, number: int) -> StardewRule:
+    def has_year(self, number: Union[int, float]) -> StardewRule:
         return self.logic.time.has_lived_year(number - 1)
 
     @cached_property

--- a/worlds/stardew_valley/stardew_rule/base.py
+++ b/worlds/stardew_valley/stardew_rule/base.py
@@ -431,7 +431,7 @@ class Count(BaseStardewRule):
         return len(self.rules)
 
     def __repr__(self):
-        return f"Received {self.count} {repr(self.rules)}"
+        return f"Received {self.count} [{', '.join(f'{value}x {repr(rule)}' for rule, value in self.counter.items())}]"
 
 
 @dataclass(frozen=True)

--- a/worlds/stardew_valley/stardew_rule/state.py
+++ b/worlds/stardew_valley/stardew_rule/state.py
@@ -122,4 +122,4 @@ class HasProgressionPercent(CombinableStardewRule):
         return self, self(state)
 
     def __repr__(self):
-        return f"Received {self.percent}% progression items."
+        return f"Received {self.percent}% progression items"


### PR DESCRIPTION
## What is this fixing or adding?
The improves performances when generating with museum sanity. Here is why:
- Museum sanity rules make a heavy usage of `Count` rule, which is not very efficient at short-circuiting. 
- The `Count` rule was improved in #2984 (which ended up being merged with the 6.x.x branch). This improvement consist of grouping the equal rules. They are then only evaluated once, but count multiple times in the total.
- With 6.x.x, time logic was added to the museum rules, so museum locations are spread through spheres. However, the months were calculated as `float` and not as `int`. That slowed down the generation by a lot.  See benchmarks below for more visual details on that.
- `HasProgressionPercent` are only equal when they have the exact same number, which never happen with the months calculated as `float`. This is really relevant when the rules are being used in `Count`, because they don't get grouped.

So, by making sure the number of month is a `int`, rules in `Count` are more often equals, so they are grouped, so fewer sub-rules are evaluated, which improves performances. 

I also improved the `explain` so it says how the rules are grouped.

## How was this tested?
Run the performance tests that generate ~80 seeds. This on average improve performances by around 20%.

<details><summary>Global benchmark for different options</summary>
<p>

![image](https://github.com/user-attachments/assets/b3121e0d-79a0-442b-9a9c-4af0528ae927)

</p>
</details> 

<details><summary>Benchmark of `Museumsanity: 20 Artifacts` before</summary>
<p>

Notice that rules are nearly never not grouped. 

![image](https://github.com/user-attachments/assets/ae21b8de-4eb5-4241-a8ca-e7a2efcac477)

</p>
</details> 

<details><summary>Benchmark of `Museumsanity: 20 Artifacts` after</summary>
<p>

Now rules are grouped. Evaluation time divided by ~3 with all state for this specific rule.

![image](https://github.com/user-attachments/assets/42eadb7e-ba6c-45cf-af5a-f535e0ead536)

</p>
</details> 


## If this makes graphical changes, please attach screenshots.
N/A