### PR TITLE
LADX: Add an item group for instruments

### DIFF
--- a/worlds/ladx/__init__.py
+++ b/worlds/ladx/__init__.py
@@ -98,9 +98,12 @@ class LinksAwakeningWorld(World):
 
     # Items can be grouped using their names to allow easy checking if any item
     # from that group has been collected. Group names can also be used for !hint
-    #item_name_groups = {
-    #    "weapons": {"sword", "lance"}
-    #}
+    item_name_groups = {
+       "Instruments": {
+           "Full Moon Cello", "Conch Horn", "Sea Lily's Bell", "Surf Harp",
+           "Wind Marimba", "Coral Triangle", "Organ of Evening Calm", "Thunder Drum"
+       }
+    }
 
     prefill_dungeon_items = None
 

--- a/worlds/ladx/__init__.py
+++ b/worlds/ladx/__init__.py
@@ -102,7 +102,7 @@ class LinksAwakeningWorld(World):
        "Instruments": {
            "Full Moon Cello", "Conch Horn", "Sea Lily's Bell", "Surf Harp",
            "Wind Marimba", "Coral Triangle", "Organ of Evening Calm", "Thunder Drum"
-       }
+       },
     }
 
     prefill_dungeon_items = None

--- a/worlds/ladx/__init__.py
+++ b/worlds/ladx/__init__.py
@@ -99,10 +99,10 @@ class LinksAwakeningWorld(World):
     # Items can be grouped using their names to allow easy checking if any item
     # from that group has been collected. Group names can also be used for !hint
     item_name_groups = {
-       "Instruments": {
-           "Full Moon Cello", "Conch Horn", "Sea Lily's Bell", "Surf Harp",
-           "Wind Marimba", "Coral Triangle", "Organ of Evening Calm", "Thunder Drum"
-       },
+        "Instruments": {
+            "Full Moon Cello", "Conch Horn", "Sea Lily's Bell", "Surf Harp",
+            "Wind Marimba", "Coral Triangle", "Organ of Evening Calm", "Thunder Drum"
+        },
     }
 
     prefill_dungeon_items = None


### PR DESCRIPTION
## What is this fixing or adding?
Adding an item group for instruments, because LADX players deserve nice things.

## How was this tested?
I did a test gen using the LADX template on my branch, then ran a local server, connected a client to it and ran `!hint Instruments` with a hint cost of 0. This was the outcome.

![image](https://github.com/user-attachments/assets/46a4ebac-7624-48ed-8eb1-1545f43280cf)

## If this makes graphical changes, please attach screenshots.
It does not.

## Other notes

I know LADX doesn't have a maintainer at this point, so I understand if this PR ends up being a low priority, but I do believe it would benefit players quite a lot, and it's a pretty small change. Thank you in advance!