### PR TITLE
Lingo: Changed minimum progression requirement

### DIFF
--- a/worlds/lingo/__init__.py
+++ b/worlds/lingo/__init__.py
@@ -9,7 +9,7 @@ from worlds.AutoWorld import WebWorld, World
 from .datatypes import Room, RoomEntrance
 from .items import ALL_ITEM_TABLE, ITEMS_BY_GROUP, TRAP_ITEMS, LingoItem
 from .locations import ALL_LOCATION_TABLE, LOCATIONS_BY_GROUP
-from .options import LingoOptions, lingo_option_groups
+from .options import LingoOptions, lingo_option_groups, SunwarpAccess, VictoryCondition
 from .player_logic import LingoPlayerLogic
 from .regions import create_regions
 
@@ -54,14 +54,17 @@ class LingoWorld(World):
     player_logic: LingoPlayerLogic
 
     def generate_early(self):
-        if not (self.options.shuffle_doors or self.options.shuffle_colors or self.options.shuffle_sunwarps):
+        if not (self.options.shuffle_doors or self.options.shuffle_colors or
+                (self.options.sunwarp_access >= SunwarpAccess.option_unlock and
+                 self.options.victory_condition == VictoryCondition.option_pilgrimage)):
             if self.multiworld.players == 1:
-                warning(f"{self.multiworld.get_player_name(self.player)}'s Lingo world doesn't have any progression"
-                        f" items. Please turn on Door Shuffle, Color Shuffle, or Sunwarp Shuffle if that doesn't seem"
-                        f" right.")
+                warning(f"{self.player_name}'s Lingo world doesn't have any progression items. Please turn on Door"
+                        f" Shuffle or Color Shuffle, or use item-blocked sunwarps with the Pilgrimage victory condition"
+                        f" if that doesn't seem right.")
             else:
-                raise OptionError(f"{self.multiworld.get_player_name(self.player)}'s Lingo world doesn't have any"
-                                  f" progression items. Please turn on Door Shuffle, Color Shuffle or Sunwarp Shuffle.")
+                raise OptionError(f"{self.player_name}'s Lingo world doesn't have any progression items. Please turn on"
+                                  f" Door Shuffle or Color Shuffle, or use item-blocked sunwarps with the Pilgrimage"
+                                  f" victory condition.")
 
         self.player_logic = LingoPlayerLogic(self)
 


### PR DESCRIPTION
## What is this fixing or adding?
Lingo shows a warning (in a solo game) or throws an exception (in a multiworld) if a slot does not have progression. Door shuffle, color shuffle, and sunwarp access all contribute progression items to the world. Disabling pilgrimage also adds a progression item, but it is not taken into consideration here.

Previously, this check erroneously looked for sunwarp shuffle, not item-locked sunwarp access. This change fixes that. Additionally, item-locked sunwarp access now must be combined with the Pilgrimage victory condition in order to pass the progression requirement.


## How was this tested?
pytest and test generations.


## If this makes graphical changes, please attach screenshots.
