### PR TITLE
DLC Quest: Remove April's Fool from the datapackage outside of April

### DIFF
--- a/worlds/dlcquest/Items.py
+++ b/worlds/dlcquest/Items.py
@@ -1,6 +1,7 @@
 import csv
 import enum
 import math
+import datetime
 from dataclasses import dataclass, field
 from random import Random
 from typing import Dict, List, Set
@@ -74,7 +75,7 @@ items_by_group: Dict[Group, List[ItemData]] = {}
 
 
 def initialize_item_table():
-    item_table.update({item.name: item for item in all_items})
+    item_table.update({item.name: item for item in all_items if datetime.datetime.today().month == 4 or Group.Piece not in item.groups})
 
 
 def initialize_groups():

--- a/worlds/dlcquest/Locations.py
+++ b/worlds/dlcquest/Locations.py
@@ -1,3 +1,5 @@
+import datetime
+
 from BaseClasses import Location
 
 
@@ -80,10 +82,11 @@ for i in range(1, 890):
 
 offset_special = 3829200000
 
-for i in range(1, 8251):
-    item_coin_piece = f"DLC Quest: {i} Coin Piece"
-    location_table[item_coin_piece] = offset_special + i
+if datetime.datetime.today().month == 4:
+    for i in range(1, 8251):
+        item_coin_piece = f"DLC Quest: {i} Coin Piece"
+        location_table[item_coin_piece] = offset_special + i
 
-for i in range(1, 8891):
-    item_coin_piece_freemium = f"Live Freemium or Die: {i} Coin Piece"
-    location_table[item_coin_piece_freemium] = offset_special + 8250 + i
+    for i in range(1, 8891):
+        item_coin_piece_freemium = f"Live Freemium or Die: {i} Coin Piece"
+        location_table[item_coin_piece_freemium] = offset_special + 8250 + i


### PR DESCRIPTION
## What is this fixing or adding?
DLC Quest's April's Fool joke adds about 17 000 locations, which works as a joke, but has negative impacts on the rest of everything.

Originally, it was just the datapackage, which was cluttered by DLC Quest's high locations count. That was not a very big deal, if a bit annoying.

But now, with a recent rework of the options page, some feature actively try to display all possible locations of a given apworld (ex: `exclude_locations`), so the inflate count leads to very, **very** bad performance.

This PR just makes it so the items and locations don't exist outside of april. The assumption is that anyone playing an april's fool world will be done by April 30th, and anyone playing it outside of April, for example in a very strange themed game, will be using an non-official version of the apworld anyway.

## How was this tested?
Automated tests
