### PR TITLE
DLC Quest - Add option groups to DLC Quest

### DIFF
--- a/worlds/dlcquest/__init__.py
+++ b/worlds/dlcquest/__init__.py
@@ -8,11 +8,13 @@ from .Locations import DLCQuestLocation, location_table
 from .Options import DLCQuestOptions
 from .Regions import create_regions
 from .Rules import set_rules
+from .option_groups import dlcq_option_groups
 
 client_version = 0
 
 
 class DLCqwebworld(WebWorld):
+    option_groups = dlcq_option_groups
     setup_en = Tutorial(
         "Multiworld Setup Guide",
         "A guide to setting up the Archipelago DLCQuest game on your computer.",

--- a/worlds/dlcquest/option_groups.py
+++ b/worlds/dlcquest/option_groups.py
@@ -8,14 +8,14 @@ dlcq_option_groups = [
         ItemShuffle,
         CoinSanity,
     ]),
-    OptionGroup("Tedious and Grind", [
-        TimeIsMoney,
-        DoubleJumpGlitch,
-    ]),
-    OptionGroup("Extra Customization", [
+    OptionGroup("Customization", [
         EndingChoice,
         PermanentCoins,
         CoinSanityRange,
+    ]),
+    OptionGroup("Tedious and Grind", [
+        TimeIsMoney,
+        DoubleJumpGlitch,
     ]),
     OptionGroup("Advanced Options", [
         DeathLink,

--- a/worlds/dlcquest/option_groups.py
+++ b/worlds/dlcquest/option_groups.py
@@ -1,0 +1,25 @@
+from Options import DeathLink, ProgressionBalancing, Accessibility, OptionGroup
+from .Options import (Campaign, ItemShuffle, TimeIsMoney, EndingChoice, PermanentCoins, DoubleJumpGlitch, CoinSanity,
+                      CoinSanityRange, DeathLink)
+
+dlcq_option_groups = [
+    OptionGroup("General", [
+        Campaign,
+        ItemShuffle,
+        CoinSanity,
+    ]),
+    OptionGroup("Tedious and Grind", [
+        TimeIsMoney,
+        DoubleJumpGlitch,
+    ]),
+    OptionGroup("Extra Customization", [
+        EndingChoice,
+        PermanentCoins,
+        CoinSanityRange,
+    ]),
+    OptionGroup("Advanced Options", [
+        DeathLink,
+        ProgressionBalancing,
+        Accessibility,
+    ]),
+]

--- a/worlds/dlcquest/option_groups.py
+++ b/worlds/dlcquest/option_groups.py
@@ -1,8 +1,10 @@
-from Options import DeathLink, ProgressionBalancing, Accessibility, OptionGroup
+from typing import List
+
+from Options import ProgressionBalancing, Accessibility, OptionGroup
 from .Options import (Campaign, ItemShuffle, TimeIsMoney, EndingChoice, PermanentCoins, DoubleJumpGlitch, CoinSanity,
                       CoinSanityRange, DeathLink)
 
-dlcq_option_groups = [
+dlcq_option_groups: List[OptionGroup] = [
     OptionGroup("General", [
         Campaign,
         ItemShuffle,


### PR DESCRIPTION
## What is this fixing or adding?
Added option groups to DLC Quest, to categorize options in a more intuitive and user friendly way. It will also hopefully keep unsuspecting users away from the more evil options available in this game

## How was this tested?
It's just option groups