### PR TITLE
SMZ3: Use useful item classification for nice items

### DIFF
--- a/worlds/smz3/__init__.py
+++ b/worlds/smz3/__init__.py
@@ -215,7 +215,6 @@ class SMZ3World(World):
 
         niceItems = TotalSMZ3Item.Item.CreateNicePool(self.smz3World)
         junkItems = TotalSMZ3Item.Item.CreateJunkPool(self.smz3World)
-        allJunkItems = niceItems + junkItems
         self.junkItemsNames = [item.Type.name for item in junkItems]
 
         if (self.smz3World.Config.Keysanity):
@@ -228,7 +227,8 @@ class SMZ3World(World):
                 self.multiworld.push_precollected(SMZ3Item(item.Type.name, ItemClassification.filler, item.Type, self.item_name_to_id[item.Type.name], self.player, item))
 
         itemPool = [SMZ3Item(item.Type.name, ItemClassification.progression, item.Type, self.item_name_to_id[item.Type.name], self.player, item) for item in progressionItems] + \
-                    [SMZ3Item(item.Type.name, ItemClassification.filler, item.Type, self.item_name_to_id[item.Type.name], self.player, item) for item in allJunkItems]
+                    [SMZ3Item(item.Type.name, ItemClassification.useful, item.Type, self.item_name_to_id[item.Type.name], self.player, item) for item in niceItems] + \
+                    [SMZ3Item(item.Type.name, ItemClassification.filler, item.Type, self.item_name_to_id[item.Type.name], self.player, item) for item in junkItems]
         self.smz3DungeonItems = [SMZ3Item(item.Type.name, ItemClassification.progression, item.Type, self.item_name_to_id[item.Type.name], self.player, item) for item in self.dungeon]
         self.multiworld.itempool += itemPool
 


### PR DESCRIPTION
## What is this fixing or adding?
Re-classifies the items in SMZ3's nice item pool from filler to useful. As a result, the extra swords, bottles, and the like are excluded from the Ganon's Tower junk fill.

## How was this tested?
Generated 30 each of 1, 2, and 3-player SMZ3 multiworlds with default settings before and after the change. None of the worlds after the change had swords, silver arrows, or any other nice item in GT.

As a secondary observation, the multiplayer games before the change had significantly more useful items per player in GT than the single player games:
- 1 player: 0-4, average 2.23
- 2 players: 14-29, average 22.07 (11.03 per player)
- 3 players: 33-51, average 42.60 (14.20 per player)

## If this makes graphical changes, please attach screenshots.
![Screenshot 2024-07-24 105820](https://github.com/user-attachments/assets/bb7e38b3-a1ff-4056-a428-234e5189eb05)