### PR TITLE
Core: fix invalid __package__ of zipped worlds

### DIFF
--- a/worlds/__init__.py
+++ b/worlds/__init__.py
@@ -76,6 +76,8 @@ class WorldSource:
                 if mod.__package__ is not None:
                     mod.__package__ = f"worlds.{mod.__package__}"
                 else:
+                    # load_module does not populate package, we'll have to assume mod.__name__ is correct here
+                    # probably safe to remove with 3.8 support
                     mod.__package__ = f"worlds.{mod.__name__}"
                 mod.__name__ = f"worlds.{mod.__name__}"
                 sys.modules[mod.__name__] = mod

--- a/worlds/__init__.py
+++ b/worlds/__init__.py
@@ -73,7 +73,10 @@ class WorldSource:
                 else:  # TODO: remove with 3.8 support
                     mod = importer.load_module(os.path.basename(self.path).rsplit(".", 1)[0])
 
-                mod.__package__ = f"worlds.{mod.__package__}"
+                if mod.__package__ is not None:
+                    mod.__package__ = f"worlds.{mod.__package__}"
+                else:
+                    mod.__package__ = f"worlds.{mod.__name__}"
                 mod.__name__ = f"worlds.{mod.__name__}"
                 sys.modules[mod.__name__] = mod
                 with warnings.catch_warnings():


### PR DESCRIPTION
## What is this fixing or adding?
`ModuleNotFound: No module named 'worlds.None'`

Presumably as a part of the differences between `module_from_spec` and `load_module`, modules loaded with `load_module` do not actually populate `__package__` and instead have it as None. For 90% of use cases, the invalid package would not cause any issues. However, when an import occurs within a function (such as the import of a client from within a launcher subprocess), the invalid package would be checked and the import could not resolve.

Currently, this populates `__package__` to be the same as `__name__`. While this is not always the case with Python, our zipimport scheme only attempts to import the `__init__.py` of each world, where this will always be true.

## How was this tested?
Manually, by attempting to load Universal Tracker from within custom_worlds on a 3.8 venv. The most recent release would normally fail with `No module named 'worlds.None'`, but with this fix, it instead fails with an actual 3.8 incompatibility (that has been fixed separately). 

## If this makes graphical changes, please attach screenshots.
