### PR TITLE
Docs: Add header to FAQ doc referencing other relevant docs

### DIFF
--- a/docs/apworld_dev_faq.md
+++ b/docs/apworld_dev_faq.md
@@ -1,6 +1,8 @@
 # APWorld Dev FAQ
 
 This document is meant as a reference tool to show solutions to common problems when developing an apworld.
+It also is not intended to answer every question about Archipelago and it assumes you have read the other docs, 
+for example: [Contributing](contributing.md), [Adding Games](<adding games.md>), [World Api](<world api.md>)
 
 ---
 

--- a/docs/apworld_dev_faq.md
+++ b/docs/apworld_dev_faq.md
@@ -1,8 +1,8 @@
 # APWorld Dev FAQ
 
 This document is meant as a reference tool to show solutions to common problems when developing an apworld.
-It also is not intended to answer every question about Archipelago and it assumes you have read the other docs, 
-for example, [Contributing](contributing.md), [Adding Games](<adding games.md>), and [World API](<world api.md>).
+It is not intended to answer every question about Archipelago and it assumes you have read the other docs, 
+including [Contributing](contributing.md), [Adding Games](<adding games.md>), and [World API](<world api.md>).
 
 ---
 

--- a/docs/apworld_dev_faq.md
+++ b/docs/apworld_dev_faq.md
@@ -2,7 +2,7 @@
 
 This document is meant as a reference tool to show solutions to common problems when developing an apworld.
 It also is not intended to answer every question about Archipelago and it assumes you have read the other docs, 
-for example: [Contributing](contributing.md), [Adding Games](<adding games.md>), [World Api](<world api.md>)
+for example, [Contributing](contributing.md), [Adding Games](<adding games.md>), and [World API](<world api.md>).
 
 ---
 


### PR DESCRIPTION
## What is this fixing or adding?
A workflow was discussed about devs with stale docs knowledge referencing the FAQ first, since we don't want to replicate data this just adds a header to inform/remind devs of what other docs they can check for their answers as well.

## How was this tested?
reading

## If this makes graphical changes, please attach screenshots.
