### PR TITLE
TUNIC: Update plando connection option call to use options API

### DIFF
--- a/worlds/tunic/__init__.py
+++ b/worlds/tunic/__init__.py
@@ -121,7 +121,7 @@ class TunicWorld(World):
                 cls.seed_groups[group] = SeedGroup(logic_rules=tunic.options.logic_rules.value,
                                                    laurels_at_10_fairies=tunic.options.laurels_location == 3,
                                                    fixed_shop=bool(tunic.options.fixed_shop),
-                                                   plando=multiworld.plando_connections[tunic.player])
+                                                   plando=tunic.options.plando_connections)
                 continue
                 
             # lower value is more restrictive
@@ -134,9 +134,9 @@ class TunicWorld(World):
             if tunic.options.fixed_shop:
                 cls.seed_groups[group]["fixed_shop"] = True
 
-            if multiworld.plando_connections[tunic.player]:
+            if tunic.options.plando_connections:
                 # loop through the connections in the player's yaml
-                for cxn in multiworld.plando_connections[tunic.player]:
+                for cxn in tunic.options.plando_connections:
                     new_cxn = True
                     for group_cxn in cls.seed_groups[group]["plando"]:
                         # if neither entrance nor exit match anything in the group, add to group


### PR DESCRIPTION
## What is this fixing or adding?
Was still using the old version of the option call for plando connections in a couple spots, those are now adjusted to use the new system.

## How was this tested?
Test gens.

## If this makes graphical changes, please attach screenshots.
N/A