### PR TITLE
Core: remove the `numbers` module

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -4,7 +4,6 @@ import abc
 import functools
 import logging
 import math
-import numbers
 import random
 import typing
 import enum
@@ -216,7 +215,7 @@ class FreeText(Option[str]):
     def get_option_name(cls, value: str) -> str:
         return value
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, self.__class__):
             return other.value == self.value
         elif isinstance(other, str):
@@ -225,15 +224,8 @@ class FreeText(Option[str]):
             raise TypeError(f"Can't compare {self.__class__.__name__} with {other.__class__.__name__}")
 
 
-class NumericOption(Option[int], numbers.Integral, abc.ABC):
+class NumericOption(Option[int]):
     default = 0
-
-    # note: some of the `typing.Any`` here is a result of unresolved issue in python standards
-    # `int` is not a `numbers.Integral` according to the official typestubs
-    # (even though isinstance(5, numbers.Integral) == True)
-    # https://github.com/python/typing/issues/272
-    # https://github.com/python/mypy/issues/3186
-    # https://github.com/microsoft/pyright/issues/1575
 
     def __eq__(self, other: typing.Any) -> bool:
         if isinstance(other, NumericOption):
@@ -267,6 +259,9 @@ class NumericOption(Option[int], numbers.Integral, abc.ABC):
 
     def __bool__(self) -> bool:
         return bool(self.value)
+
+    def __index__(self) -> int:
+        return self.value
 
     def __int__(self) -> int:
         return self.value
@@ -352,11 +347,11 @@ class NumericOption(Option[int], numbers.Integral, abc.ABC):
     def __pos__(self) -> int:
         return +(self.value)
 
-    def __pow__(self, exponent: numbers.Complex, modulus: typing.Optional[numbers.Integral] = None) -> int:
-        if not (modulus is None):
-            assert isinstance(exponent, numbers.Integral)
-            return pow(self.value, exponent, modulus)  # type: ignore
-        return self.value ** exponent  # type: ignore
+    def __pow__(self, exponent: complex, modulus: typing.Optional[int] = None) -> typing.Any:
+        if modulus is None:
+            return self.value ** exponent
+        assert isinstance(exponent, typing.SupportsIndex)
+        return pow(self.value, exponent, modulus)  # type: ignore
 
     def __rand__(self, other: typing.Any) -> int:
         return int(other) & self.value


### PR DESCRIPTION
## What is this fixing or adding?

removes the `numbers` module that is not necessary and not type safe

Many Python typing experts, including CPython core devs recommend against using the `numbers` module.
https://discuss.python.org/t/typing-the-numbers-module/52663/3

It looks likes some recent updates to mypy/typeshed brought some problems with it.

If you need to make typing for code that uses numerical operators, the recommendation is to make a `Protocol` specifically for what you need.

## How was this tested?

just unit tests