### PR TITLE
WebHost: config override

### DIFF
--- a/WebHost.py
+++ b/WebHost.py
@@ -32,6 +32,7 @@ def get_app() -> "Flask":
         import yaml
         app.config.from_file(configpath, yaml.safe_load)
         logging.info(f"Updated config from {configpath}")
+    # inside get_app() so it's usable in systems like gunicorn, which do not run WebHost.py, but import it.
     parser = argparse.ArgumentParser()
     parser.add_argument('--config_override', default=None,
                         help="Path to yaml config file that overrules config.yaml.")

--- a/WebHost.py
+++ b/WebHost.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import multiprocessing
 import logging
@@ -31,6 +32,14 @@ def get_app() -> "Flask":
         import yaml
         app.config.from_file(configpath, yaml.safe_load)
         logging.info(f"Updated config from {configpath}")
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--config_override', default=None,
+                        help="Path to yaml config file that overrules config.yaml.")
+    args = parser.parse_known_args()[0]
+    if args.config_override:
+        import yaml
+        app.config.from_file(os.path.abspath(args.config_override), yaml.safe_load)
+        logging.info(f"Updated config from {args.config_override}")
     if not app.config["HOST_ADDRESS"]:
         logging.info("Getting public IP, as HOST_ADDRESS is empty.")
         app.config["HOST_ADDRESS"] = Utils.get_public_ipv4()


### PR DESCRIPTION
## What is this fixing or adding?
allows --config_override just_generation.yaml

with 
```
SELFHOST: false
SELFGEN: true
SELFLAUNCH: false 
```

which in turn should make it a lot easier to make generation and room hosting into services that can be controlled via systemctl

## How was this tested?
locally
