### PR TITLE
DOOM II: Fix sector 95 assignment in DOOM II MAP17 to correctly flag …

### DIFF
--- a/worlds/doom_ii/Locations.py
+++ b/worlds/doom_ii/Locations.py
@@ -1470,7 +1470,7 @@ location_table: Dict[int, LocationDict] = {
              'map': 6,
              'index': 102,
              'doom_type': 2006,
-             'region': "Tenements (MAP17) Main"},
+             'region': "Tenements (MAP17) Yellow"},
     361243: {'name': 'Tenements (MAP17) - Plasma gun',
              'episode': 2,
              'map': 6,


### PR DESCRIPTION
…the BFG9000 location as in the Yellow Key area


## What is this fixing or adding?
Related to APDOOM fix https://github.com/Daivuk/apdoom/pull/21, this fixes a logic error in the DOOM II apworld.

## How was this tested?
Double checking locally after making the change that granting access to MAP17 does not flag the BFG9000 location as accessible - only after getting access the MAP17 yellow key area (requiring both the red and yellow keys) is the item considered accessible.

## If this makes graphical changes, please attach screenshots.
N/A