### PR TITLE
Stardew Valley: Take shipsanity moss out of shipsanity crops

### DIFF
--- a/worlds/stardew_valley/data/locations.csv
+++ b/worlds/stardew_valley/data/locations.csv
@@ -2212,7 +2212,7 @@ id,region,name,tags,mod_name
 3808,Shipping,Shipsanity: Mystery Box,"SHIPSANITY",
 3809,Shipping,Shipsanity: Golden Tag,"SHIPSANITY",
 3810,Shipping,Shipsanity: Deluxe Bait,"SHIPSANITY",
-3811,Shipping,Shipsanity: Moss,"SHIPSANITY,SHIPSANITY_CROP,SHIPSANITY_FULL_SHIPMENT",
+3811,Shipping,Shipsanity: Moss,"SHIPSANITY,SHIPSANITY_FULL_SHIPMENT",
 3812,Shipping,Shipsanity: Mossy Seed,"SHIPSANITY",
 3813,Shipping,Shipsanity: Sonar Bobber,"SHIPSANITY",
 3814,Shipping,Shipsanity: Tent Kit,"SHIPSANITY",


### PR DESCRIPTION
## What is this fixing or adding?
It was mentioned to me that, in game, Moss is a "resource" (like wood), not a forageable or a crop. So it made no sense to have it in shipsanity crops. I just removed that flag

## How was this tested?
Automated tests