### PR TITLE
Core: add a hook for worlds to modify early_locations

### DIFF
--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -378,6 +378,19 @@ class World(metaclass=AutoWorldRegister):
         """Optional method that is supposed to be used for special fill stages. This is run *after* plando."""
         pass
 
+    def modify_early_locations(self, early_locations: Dict[int, List["Location"]]) -> None:
+        """
+        Gets called as part of distribute_early_items and early items plando.
+        Can be used to modify which locations are considered early.
+        """
+        # make a clean copy of state with just start inventory
+        sweep_state = self.multiworld.state.copy()
+        # collect any events from our already reachable locations
+        for location in early_locations[self.player]:
+            if location.is_event:
+                sweep_state.collect(location.item, location=location)
+        early_locations[self.player] += self.multiworld.get_reachable_locations(sweep_state, self.player)
+
     def fill_hook(self,
                   progitempool: List["Item"],
                   usefulitempool: List["Item"],
@@ -391,6 +404,7 @@ class World(metaclass=AutoWorldRegister):
         Optional Method that is called after regular fill. Can be used to do adjustments before output generation.
         This happens before progression balancing, so the items may not be in their final locations yet.
         """
+        pass
 
     def generate_output(self, output_directory: str) -> None:
         """


### PR DESCRIPTION
## What is this fixing or adding?
title. this also removes the bit where the fill function was just collecting all events in the entire multiworld.

## How was this tested?
tested some plando, modified my world to check that i could properly modify the early_locations. tested that factorio had any early_locations at all after filtering.

## If this makes graphical changes, please attach screenshots.
