### PR TITLE
Bomb Rush Cyberfunk: Fix Coil quest being in glitched logic too early

### DIFF
--- a/worlds/bomb_rush_cyberfunk/Rules.py
+++ b/worlds/bomb_rush_cyberfunk/Rules.py
@@ -1007,7 +1007,7 @@ def rules(brcworld):
     set_rule(multiworld.get_location("Mataan: Score challenge reward", player),
         lambda state: mataan_challenge3(state, player))
     set_rule(multiworld.get_location("Mataan: Coil joins the crew", player),
-        lambda state: mataan_crew_battle(state, player, limit, glitched))
+        lambda state: mataan_deepest(state, player, limit, glitched))
     if photos:
         set_rule(multiworld.get_location("Mataan: Trash Polo", player),
             lambda state: camera(state, player))

--- a/worlds/bomb_rush_cyberfunk/Rules.py
+++ b/worlds/bomb_rush_cyberfunk/Rules.py
@@ -1006,6 +1006,8 @@ def rules(brcworld):
         lambda state: mataan_challenge2(state, player, limit, glitched))
     set_rule(multiworld.get_location("Mataan: Score challenge reward", player),
         lambda state: mataan_challenge3(state, player))
+    set_rule(multiworld.get_location("Mataan: Coil joins the crew", player),
+        lambda state: mataan_crew_battle(state, player, limit, glitched))
     if photos:
         set_rule(multiworld.get_location("Mataan: Trash Polo", player),
             lambda state: camera(state, player))


### PR DESCRIPTION
This doesn't happen on glitchless logic because of entrance rules, but (most) entrance rules don't exist on glitched logic.