### PR TITLE
Core: fix single player item links

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -334,6 +334,7 @@ class MultiWorld():
             region = Region("Menu", group_id, self, "ItemLink")
             self.regions.append(region)
             locations = region.locations
+            self.itempool.sort(key=lambda item: item.classification)
             for item in self.itempool:
                 count = common_item_count.get(item.player, {}).get(item.name, 0)
                 if count:

--- a/Fill.py
+++ b/Fill.py
@@ -473,8 +473,8 @@ def distribute_items_restrictive(multiworld: MultiWorld,
     if prioritylocations:
         # "priority fill"
         fill_restrictive(multiworld, multiworld.state, prioritylocations, progitempool,
-                         single_player_placement=multiworld.players == 1, swap=False, on_place=mark_for_locking,
-                         name="Priority")
+                         single_player_placement=multiworld.players == 1 and len(multiworld.groups) == 0, swap=False,
+                         on_place=mark_for_locking, name="Priority")
         accessibility_corrections(multiworld, multiworld.state, prioritylocations, progitempool)
         defaultlocations = prioritylocations + defaultlocations
 
@@ -483,15 +483,18 @@ def distribute_items_restrictive(multiworld: MultiWorld,
         if panic_method == "swap":
             fill_restrictive(multiworld, multiworld.state, defaultlocations, progitempool,
                              swap=True,
-                             name="Progression", single_player_placement=multiworld.players == 1)
+                             name="Progression",
+                             single_player_placement=multiworld.players == 1 and len(multiworld.groups) == 0)
         elif panic_method == "raise":
             fill_restrictive(multiworld, multiworld.state, defaultlocations, progitempool,
                              swap=False,
-                             name="Progression", single_player_placement=multiworld.players == 1)
+                             name="Progression",
+                             single_player_placement=multiworld.players == 1 and len(multiworld.groups) == 0)
         elif panic_method == "start_inventory":
             fill_restrictive(multiworld, multiworld.state, defaultlocations, progitempool,
                              swap=False, allow_partial=True,
-                             name="Progression", single_player_placement=multiworld.players == 1)
+                             name="Progression",
+                             single_player_placement=multiworld.players == 1 and len(multiworld.groups) == 0)
             if progitempool:
                 for item in progitempool:
                     logging.debug(f"Moved {item} to start_inventory to prevent fill failure.")


### PR DESCRIPTION
## What is this fixing or adding?
A regression from #2415 that caused generation to fail when a player tried to generate a single player game with an item link group (such as for "remote" items).

Additionally, a secondary fix was added to solve an issue with item linking items with multiple classifications (primarily filler and progression) having the filler items become available before the progression items.

This latter fix is a bit hacky and will change any seeded generation that includes an item linked world, so an alternative solution may be better here.

## How was this tested?
[SilvrisKDL3_2.zip](https://github.com/user-attachments/files/16445124/SilvrisKDL3_2.zip)

The attached yaml on seed 73239063241706949923 will fail without both fixes applied.
