### PR TITLE
Core: (CommonClient) Making local datapackage load correctly if it was overriden by a custom one

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -555,7 +555,7 @@ class CommonContext:
                 continue
 
             cached_version: int = self.versions.get(game, 0)
-            cached_checksum: typing.Optional[str] = self.checksums.get("checksum")
+            cached_checksum: typing.Optional[str] = self.checksums.get(game)
             # no action required if cached version is new enough
             if (not remote_checksum and (remote_version > cached_version or remote_version == 0)) \
                     or remote_checksum != cached_checksum:

--- a/CommonClient.py
+++ b/CommonClient.py
@@ -343,6 +343,8 @@ class CommonContext:
 
         self.item_names = self.NameLookupDict(self, "item")
         self.location_names = self.NameLookupDict(self, "location")
+        self.versions = {}
+        self.checksums = {}
 
         self.jsontotextparser = JSONtoTextParser(self)
         self.rawjsontotextparser = RawJSONtoTextParser(self)
@@ -552,8 +554,8 @@ class CommonContext:
                 needed_updates.add(game)
                 continue
 
-            local_version: int = network_data_package["games"].get(game, {}).get("version", 0)
-            local_checksum: typing.Optional[str] = network_data_package["games"].get(game, {}).get("checksum")
+            local_version: int = self.versions.get(game, 0)
+            local_checksum: typing.Optional[str] = self.checksums.get("checksum")
             # no action required if local version is new enough
             if (not remote_checksum and (remote_version > local_version or remote_version == 0)) \
                     or remote_checksum != local_checksum:
@@ -572,6 +574,8 @@ class CommonContext:
     def update_game(self, game_package: dict, game: str):
         self.item_names.update_game(game, game_package["item_name_to_id"])
         self.location_names.update_game(game, game_package["location_name_to_id"])
+        self.versions[game] = game_package.get("version", 0)
+        self.checksums[game] = game_package.get("checksum")
 
     def update_data_package(self, data_package: dict):
         for game, game_data in data_package["games"].items():


### PR DESCRIPTION
## What is this fixing or adding?
After joining a game with a datapackage for a given game different to the one in the installed world then joining a room with the same game but the installed datapackage, the cached datapackage isn't updated on CommonClient. 
I also made so that the local datapackage could be loaded if it is the right one

## How was this tested?
I tried with a modified clique, worked fine.

## If this makes graphical changes, please attach screenshots.
