### PR TITLE
Core: Check parent_region.can_reach first in Location.can_reach

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1052,9 +1052,9 @@ class Location:
                     and (not check_access or self.can_reach(state))))
 
     def can_reach(self, state: CollectionState) -> bool:
-        # self.access_rule computes faster on average, so placing it first for faster abort
+        # self.parent_region.can_reach(state) is often cached, so placing it first for faster abort on average
         assert self.parent_region, "Can't reach location without region"
-        return self.access_rule(state) and self.parent_region.can_reach(state)
+        return self.parent_region.can_reach(state) and self.access_rule(state)
 
     def place_locked_item(self, item: Item):
         if self.item:

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1052,7 +1052,7 @@ class Location:
                     and (not check_access or self.can_reach(state))))
 
     def can_reach(self, state: CollectionState) -> bool:
-        # region.can_reach is just a cache lookup, so placing it first for faster abort on average
+        # Region.can_reach is just a cache lookup, so placing it first for faster abort on average
         assert self.parent_region, "Can't reach location without region"
         return self.parent_region.can_reach(state) and self.access_rule(state)
 

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1052,7 +1052,7 @@ class Location:
                     and (not check_access or self.can_reach(state))))
 
     def can_reach(self, state: CollectionState) -> bool:
-        # self.parent_region.can_reach(state) is cached, so placing it first for faster abort on average
+        # region.can_reach is just a cache lookup, so placing it first for faster abort on average
         assert self.parent_region, "Can't reach location without region"
         return self.parent_region.can_reach(state) and self.access_rule(state)
 

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1052,7 +1052,7 @@ class Location:
                     and (not check_access or self.can_reach(state))))
 
     def can_reach(self, state: CollectionState) -> bool:
-        # self.parent_region.can_reach(state) is often cached, so placing it first for faster abort on average
+        # self.parent_region.can_reach(state) is cached, so placing it first for faster abort on average
         assert self.parent_region, "Can't reach location without region"
         return self.parent_region.can_reach(state) and self.access_rule(state)
 


### PR DESCRIPTION
## What is this fixing or adding?

The comment about self.access_rule computing faster on average appears to no longer be correct with the current caching system for region accessibility, resulting in self.parent_region.can_reach computing faster on average.


## How was this tested?

Generation of template yamls for each game (excluding sudoku) that do not require a rom to generate (52 total), generated with `python -O .\Generate.py --seed 1` (all durations averaged over 4 or 5 generations):

Full generation with `spoiler: 1` and no progression balancing: 89.9s -> 72.6s
Only output from above case: 2.6s -> 2.2s

Full generation with `spoiler: 3` and no progression balancing: 769.9s -> 627.1s
Only playthrough calculation + paths from above case: 680.5s -> 555.3s

Full generation with `spoiler: 1` with default progression balancing: 123.5s -> 98.3s
Only progression balancing from above case: 11.3s -> 9.6s

The durations of only output/playthrough/balancing were obtained by comparing log timestamps.
Output duration = `Done` - `Beginning output...`
Playthrough calculation + paths duration = `Creating final archive` - `Calculating playthrough.`
Progression balancing duration = `Beginning output...` - `Balancing multiworld progression for 52 Players.`