### PR TITLE
Pokemon Emerald: Make use of `NamedTuple._replace`

### DIFF
--- a/worlds/pokemon_emerald/data.py
+++ b/worlds/pokemon_emerald/data.py
@@ -276,15 +276,13 @@ def _str_to_pokemon_data_type(string: str) -> TrainerPokemonDataTypeEnum:
         return TrainerPokemonDataTypeEnum.ITEM_CUSTOM_MOVES
 
 
-@dataclass
-class TrainerPokemonData:
+class TrainerPokemonData(NamedTuple):
     species_id: int
     level: int
     moves: Optional[Tuple[int, int, int, int]]
 
 
-@dataclass
-class TrainerPartyData:
+class TrainerPartyData(NamedTuple):
     pokemon: List[TrainerPokemonData]
     pokemon_data_type: TrainerPokemonDataTypeEnum
     address: int

--- a/worlds/pokemon_emerald/opponents.py
+++ b/worlds/pokemon_emerald/opponents.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Dict, List, Set
 
-from .data import NUM_REAL_SPECIES, UNEVOLVED_POKEMON, TrainerPokemonData, data
+from .data import NUM_REAL_SPECIES, UNEVOLVED_POKEMON, data
 from .options import RandomizeTrainerParties
 from .pokemon import filter_species_by_nearby_bst
 from .util import int_to_bool_array
@@ -111,6 +111,6 @@ def randomize_opponent_parties(world: "PokemonEmeraldWorld") -> None:
                 hm_moves[3] if world.random.random() < 0.25 else level_up_moves[3]
             )
 
-            new_party.append(TrainerPokemonData(new_species.species_id, pokemon.level, new_moves))
+            new_party.append(pokemon._replace(species_id=new_species.species_id, moves=new_moves))
 
-        trainer.party.pokemon = new_party
+        trainer.party = trainer.party._replace(pokemon=new_party)

--- a/worlds/pokemon_emerald/pokemon.py
+++ b/worlds/pokemon_emerald/pokemon.py
@@ -4,8 +4,7 @@ Functions related to pokemon species and moves
 import functools
 from typing import TYPE_CHECKING, Dict, List, Set, Optional, Tuple
 
-from .data import (NUM_REAL_SPECIES, OUT_OF_LOGIC_MAPS, EncounterTableData, LearnsetMove, MiscPokemonData,
-                   SpeciesData, data)
+from .data import (NUM_REAL_SPECIES, OUT_OF_LOGIC_MAPS, EncounterTableData, LearnsetMove, SpeciesData, data)
 from .options import (Goal, HmCompatibility, LevelUpMoves, RandomizeAbilities, RandomizeLegendaryEncounters,
                       RandomizeMiscPokemon, RandomizeStarters, RandomizeTypes, RandomizeWildPokemon,
                       TmTutorCompatibility)
@@ -461,7 +460,7 @@ def randomize_learnsets(world: "PokemonEmeraldWorld") -> None:
                                            type_bias, normal_bias, species.types)
             else:
                 new_move = 0
-            new_learnset.append(LearnsetMove(old_learnset[cursor].level, new_move))
+            new_learnset.append(old_learnset[cursor]._replace(move_id=new_move))
             cursor += 1
 
         # All moves from here onward are actual moves.
@@ -473,7 +472,7 @@ def randomize_learnsets(world: "PokemonEmeraldWorld") -> None:
                 new_move = get_random_move(world.random,
                                            {move.move_id for move in new_learnset} | world.blacklisted_moves,
                                            type_bias, normal_bias, species.types)
-            new_learnset.append(LearnsetMove(old_learnset[cursor].level, new_move))
+            new_learnset.append(old_learnset[cursor]._replace(move_id=new_move))
             cursor += 1
 
         species.learnset = new_learnset
@@ -581,8 +580,10 @@ def randomize_starters(world: "PokemonEmeraldWorld") -> None:
             picked_evolution = world.random.choice(potential_evolutions)
 
         for trainer_name, starter_position, is_evolved in rival_teams[i]:
+            new_species_id = picked_evolution if is_evolved else starter.species_id
             trainer_data = world.modified_trainers[data.constants[trainer_name]]
-            trainer_data.party.pokemon[starter_position].species_id = picked_evolution if is_evolved else starter.species_id
+            trainer_data.party.pokemon[starter_position] = \
+                trainer_data.party.pokemon[starter_position]._replace(species_id=new_species_id)
 
 
 def randomize_legendary_encounters(world: "PokemonEmeraldWorld") -> None:
@@ -594,10 +595,7 @@ def randomize_legendary_encounters(world: "PokemonEmeraldWorld") -> None:
         world.random.shuffle(shuffled_species)
 
         for i, encounter in enumerate(data.legendary_encounters):
-            world.modified_legendary_encounters.append(MiscPokemonData(
-                shuffled_species[i],
-                encounter.address
-            ))
+            world.modified_legendary_encounters.append(encounter._replace(species_id=shuffled_species[i]))
     else:
         should_match_bst = world.options.legendary_encounters in {
             RandomizeLegendaryEncounters.option_match_base_stats,
@@ -621,9 +619,8 @@ def randomize_legendary_encounters(world: "PokemonEmeraldWorld") -> None:
             if should_match_bst:
                 candidates = filter_species_by_nearby_bst(candidates, sum(original_species.base_stats))
 
-            world.modified_legendary_encounters.append(MiscPokemonData(
-                world.random.choice(candidates).species_id,
-                encounter.address
+            world.modified_legendary_encounters.append(encounter._replace(
+                species_id=world.random.choice(candidates).species_id
             ))
 
 
@@ -637,10 +634,7 @@ def randomize_misc_pokemon(world: "PokemonEmeraldWorld") -> None:
 
         world.modified_misc_pokemon = []
         for i, encounter in enumerate(data.misc_pokemon):
-            world.modified_misc_pokemon.append(MiscPokemonData(
-                shuffled_species[i],
-                encounter.address
-            ))
+            world.modified_misc_pokemon.append(encounter._replace(species_id=shuffled_species[i]))
     else:
         should_match_bst = world.options.misc_pokemon in {
             RandomizeMiscPokemon.option_match_base_stats,
@@ -672,9 +666,8 @@ def randomize_misc_pokemon(world: "PokemonEmeraldWorld") -> None:
             if len(player_filtered_candidates) > 0:
                 candidates = player_filtered_candidates
 
-            world.modified_misc_pokemon.append(MiscPokemonData(
-                world.random.choice(candidates).species_id,
-                encounter.address
+            world.modified_misc_pokemon.append(encounter._replace(
+                species_id=world.random.choice(candidates).species_id
             ))
 
 


### PR DESCRIPTION
## What is this fixing or adding?

Uses `_replace` instead of rebuilding the class by passing in each property. If I was aware of `_replace` when this was written, I was at least under the impression that it's somewhat improper to use because of the leading underscore. But it's apparently the recommended solution for what's happening here.

## How was this tested?

Generated on `main` and on this branch with the same seed and all relevant randomization turned on and compared the file hashes of the resulting patched ROM. So these changes should all have been hit and resulted in the same values in the output.
