### PR TITLE
Stardew Valley - Prize Ticket and Mystery Box grinding requires the abilty to redeem them

### DIFF
--- a/worlds/stardew_valley/logic/grind_logic.py
+++ b/worlds/stardew_valley/logic/grind_logic.py
@@ -5,6 +5,7 @@ from .base_logic import BaseLogic, BaseLogicMixin
 from .book_logic import BookLogicMixin
 from .has_logic import HasLogicMixin
 from .received_logic import ReceivedLogicMixin
+from .region_logic import RegionLogicMixin
 from .time_logic import TimeLogicMixin
 from ..options import Booksanity
 from ..stardew_rule import StardewRule, HasProgressionPercent
@@ -13,6 +14,7 @@ from ..strings.craftable_names import Consumable
 from ..strings.currency_names import Currency
 from ..strings.fish_names import WaterChest
 from ..strings.geode_names import Geode
+from ..strings.region_names import Region
 from ..strings.tool_names import Tool
 
 if TYPE_CHECKING:
@@ -31,26 +33,28 @@ class GrindLogicMixin(BaseLogicMixin):
         self.grind = GrindLogic(*args, **kwargs)
 
 
-class GrindLogic(BaseLogic[Union[GrindLogicMixin, HasLogicMixin, ReceivedLogicMixin, BookLogicMixin, TimeLogicMixin, ToolLogicMixin]]):
+class GrindLogic(BaseLogic[Union[GrindLogicMixin, HasLogicMixin, ReceivedLogicMixin, RegionLogicMixin, BookLogicMixin, TimeLogicMixin, ToolLogicMixin]]):
 
     def can_grind_mystery_boxes(self, quantity: int) -> StardewRule:
+        opening_rule = self.logic.region.can_reach(Region.blacksmith)
         mystery_box_rule = self.logic.has(Consumable.mystery_box)
         book_of_mysteries_rule = self.logic.true_ \
             if self.options.booksanity == Booksanity.option_none \
             else self.logic.book.has_book_power(Book.book_of_mysteries)
         # Assuming one box per day, but halved because we don't know how many months have passed before Mr. Qi's Plane Ride.
         time_rule = self.logic.time.has_lived_months(quantity // 14)
-        return self.logic.and_(mystery_box_rule,
-                               book_of_mysteries_rule,
-                               time_rule)
+        return self.logic.and_(opening_rule, mystery_box_rule,
+                               book_of_mysteries_rule, time_rule,)
 
     def can_grind_artifact_troves(self, quantity: int) -> StardewRule:
-        return self.logic.and_(self.logic.has(Geode.artifact_trove),
+        opening_rule = self.logic.region.can_reach(Region.blacksmith)
+        return self.logic.and_(opening_rule, self.logic.has(Geode.artifact_trove),
                                # Assuming one per month if the player does not grind it.
                                self.logic.time.has_lived_months(quantity))
 
     def can_grind_prize_tickets(self, quantity: int) -> StardewRule:
-        return self.logic.and_(self.logic.has(Currency.prize_ticket),
+        claiming_rule = self.logic.region.can_reach(Region.mayor_house)
+        return self.logic.and_(claiming_rule, self.logic.has(Currency.prize_ticket),
                                # Assuming two per month if the player does not grind it.
                                self.logic.time.has_lived_months(quantity // 2))
 


### PR DESCRIPTION
## What is this fixing or adding?
Owning a Mystery Box or a Prize Ticket isn't enough to get rewards from it. Mystery boxes must be opened at the blacksmith, and Prize tickets must be redeemed at the prize machine in Lewis's house.

With Entrance Randomization, these two areas are not always available. But they were missing from the condition when grinding these items. Now I added it

Note: You do **not** require these areas to own a mystery box or prize ticket, for checks like "Shipsanity: X". You only need access to claim these items to use the rewards from them, which at the moment includes very few things. The most notable one is the book "Friendship 101", which was the reason the bug was discovered.

## How was this tested?
Unit tests and local generation with spheres
