### PR TITLE
Core: fix missing import for `MultiWorld.link_items()`

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -290,6 +290,8 @@ class MultiWorld():
 
     def link_items(self) -> None:
         """Called to link together items in the itempool related to the registered item link groups."""
+        from worlds import AutoWorld
+
         for group_id, group in self.groups.items():
             def find_common_pool(players: Set[int], shared_pool: Set[str]) -> Tuple[
                 Optional[Dict[int, Dict[str, int]]], Optional[Dict[str, int]]
@@ -300,15 +302,15 @@ class MultiWorld():
                     if item.player in counters and item.name in shared_pool:
                         counters[item.player][item.name] += 1
                         classifications[item.name] |= item.classification
-        
+
                 for player in players.copy():
                     if all([counters[player][item] == 0 for item in shared_pool]):
                         players.remove(player)
                         del (counters[player])
-        
+
                 if not players:
                     return None, None
-        
+
                 for item in shared_pool:
                     count = min(counters[player][item] for player in players)
                     if count:
@@ -318,11 +320,11 @@ class MultiWorld():
                         for player in players:
                             del (counters[player][item])
                 return counters, classifications
-        
+
             common_item_count, classifications = find_common_pool(group["players"], group["item_pool"])
             if not common_item_count:
                 continue
-        
+
             new_itempool: List[Item] = []
             for item_name, item_count in next(iter(common_item_count.values())).items():
                 for _ in range(item_count):
@@ -330,7 +332,7 @@ class MultiWorld():
                     # mangle together all original classification bits
                     new_item.classification |= classifications[item_name]
                     new_itempool.append(new_item)
-        
+
             region = Region("Menu", group_id, self, "ItemLink")
             self.regions.append(region)
             locations = region.locations
@@ -341,16 +343,16 @@ class MultiWorld():
                         None, region)
                     loc.access_rule = lambda state, item_name = item.name, group_id_ = group_id, count_ = count: \
                         state.has(item_name, group_id_, count_)
-        
+
                     locations.append(loc)
                     loc.place_locked_item(item)
                     common_item_count[item.player][item.name] -= 1
                 else:
                     new_itempool.append(item)
-        
+
             itemcount = len(self.itempool)
             self.itempool = new_itempool
-        
+
             while itemcount > len(self.itempool):
                 items_to_add = []
                 for player in group["players"]:


### PR DESCRIPTION
## What is this fixing or adding?
missing local import of AutoWorld for the usage of call_all/call_single

## How was this tested?
generated before and after with 2 copies of a test yaml
[The Messenger.txt](https://github.com/user-attachments/files/16484439/The.Messenger.txt)
