### PR TITLE
Fix !remaining for cross-world items

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1350,10 +1350,10 @@ class ClientMessageProcessor(CommonCommandProcessor):
     def _cmd_remaining(self) -> bool:
         """List remaining items in your game, but not their location or recipient"""
         if self.ctx.remaining_mode == "enabled":
-            remaining_item_ids = get_remaining(self.ctx, self.client.team, self.client.slot)
-            if remaining_item_ids:
-                self.output("Remaining items: " + ", ".join(self.ctx.item_names[self.ctx.games[self.client.slot]][item_id]
-                                                            for item_id in remaining_item_ids))
+            rest_locations = get_remaining(self.ctx, self.client.team, self.client.slot)
+            if rest_locations:
+                self.output("Remaining items: " + ", ".join(self.ctx.item_names[self.ctx.games[slot]][item_id]
+                                                            for slot, item_id in rest_locations))
             else:
                 self.output("No remaining items found.")
             return True
@@ -1363,10 +1363,10 @@ class ClientMessageProcessor(CommonCommandProcessor):
             return False
         else:  # is goal
             if self.ctx.client_game_state[self.client.team, self.client.slot] == ClientStatus.CLIENT_GOAL:
-                remaining_item_ids = get_remaining(self.ctx, self.client.team, self.client.slot)
-                if remaining_item_ids:
-                    self.output("Remaining items: " + ", ".join(self.ctx.item_names[self.ctx.games[self.client.slot]][item_id]
-                                                                for item_id in remaining_item_ids))
+                rest_locations = get_remaining(self.ctx, self.client.team, self.client.slot)
+                if rest_locations:
+                    self.output("Remaining items: " + ", ".join(self.ctx.item_names[self.ctx.games[slot]][item_id]
+                                                                for slot, item_id in rest_locations))
                 else:
                     self.output("No remaining items found.")
                 return True

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -991,7 +991,7 @@ def collect_player(ctx: Context, team: int, slot: int, is_group: bool = False):
                     collect_player(ctx, team, group, True)
 
 
-def get_remaining(ctx: Context, team: int, slot: int) -> typing.List[int]:
+def get_remaining(ctx: Context, team: int, slot: int) -> typing.List[typing.Tuple[int, int]]:
     return ctx.locations.get_remaining(ctx.location_checks, team, slot)
 
 

--- a/NetUtils.py
+++ b/NetUtils.py
@@ -397,7 +397,7 @@ class _LocationStore(dict, typing.MutableMapping[int, typing.Dict[int, typing.Tu
                 location_id not in checked]
 
     def get_remaining(self, state: typing.Dict[typing.Tuple[int, int], typing.Set[int]], team: int, slot: int
-                      ) -> typing.List[int]:
+                      ) -> typing.List[typing.Tuple[int, int]]:
         checked = state[team, slot]
         player_locations = self[slot]
         return sorted([(player_locations[location_id][1], player_locations[location_id][0]) for

--- a/NetUtils.py
+++ b/NetUtils.py
@@ -400,9 +400,9 @@ class _LocationStore(dict, typing.MutableMapping[int, typing.Dict[int, typing.Tu
                       ) -> typing.List[int]:
         checked = state[team, slot]
         player_locations = self[slot]
-        return sorted([player_locations[location_id][0] for
-                       location_id in player_locations if
-                       location_id not in checked])
+        return sorted([(player_locations[location_id][1], player_locations[location_id][0]) for
+                        location_id in player_locations if
+                        location_id not in checked])
 
 
 if typing.TYPE_CHECKING:  # type-check with pure python implementation until we have a typing stub

--- a/_speedups.pyx
+++ b/_speedups.pyx
@@ -287,7 +287,7 @@ cdef class LocationStore:
                     entry in self.entries[start:start + count] if
                     entry.location not in checked]
 
-    def get_remaining(self, state: State, team: int, slot: int) -> List[int]:
+    def get_remaining(self, state: State, team: int, slot: int) -> List[Tuple[int, int]]:
         cdef LocationEntry* entry
         cdef ap_player_t sender = slot
         cdef size_t start = self.sender_index[sender].start

--- a/_speedups.pyx
+++ b/_speedups.pyx
@@ -293,9 +293,9 @@ cdef class LocationStore:
         cdef size_t start = self.sender_index[sender].start
         cdef size_t count = self.sender_index[sender].count
         cdef set checked = state[team, slot]
-        return sorted([entry.item for
-                       entry in self.entries[start:start+count] if
-                       entry.location not in checked])
+        return sorted([(entry.receiver, entry.item) for
+                        entry in self.entries[start:start+count] if
+                        entry.location not in checked])
 
 
 @cython.auto_pickle(False)


### PR DESCRIPTION
## What is this fixing or adding?

While #3611 fixed !remaining to not throw an exception in all cases, items that were for players playing different games would all show up as "Unknown item", greatly limiting its use outside of single-player or single-game multiworlds. This changes get_remaining to return a tuple of (slot, item_id) instead of just the item_id on its own, and then changes cmd_remaining to use that newly given information to fetch item names from the correct game.

## How was this tested?

Running a multiworld with multiple different games, enabling and using !remaining.

## If this makes graphical changes, please attach screenshots.

[Screenshot of !remaining working with cross-game items after this change](https://github.com/user-attachments/assets/5cc75e95-1ae4-4b49-841c-f9c66d07ad3a)
