### PR TITLE
Core: Give the option to worlds to have a remaining fill that respects excluded locations

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -229,7 +229,7 @@ def remaining_fill(multiworld: MultiWorld,
     total = min(len(itempool),  len(locations))
     placed = 0
 
-    # Optimisation: Decide whether to do full location.can_fill check (excluded), or only check the item rule
+    # Optimisation: Decide whether to do full location.can_fill check (respect excluded), or only check the item rule
     if check_location_can_fill:
         state = CollectionState(multiworld)
 

--- a/Fill.py
+++ b/Fill.py
@@ -221,18 +221,30 @@ def remaining_fill(multiworld: MultiWorld,
                    locations: typing.List[Location],
                    itempool: typing.List[Item],
                    name: str = "Remaining", 
-                   move_unplaceable_to_start_inventory: bool = False) -> None:
+                   move_unplaceable_to_start_inventory: bool = False,
+                   check_location_can_fill: bool = False) -> None:
     unplaced_items: typing.List[Item] = []
     placements: typing.List[Location] = []
     swapped_items: typing.Counter[typing.Tuple[int, str]] = Counter()
     total = min(len(itempool),  len(locations))
     placed = 0
+
+    # Optimisation: Decide whether to do full location.can_fill check (excluded), or only check the item rule
+    if check_location_can_fill:
+        state = CollectionState(multiworld)
+
+        def location_can_fill_item(location_to_fill: Location, item_to_fill: Item):
+            return location_to_fill.can_fill(state, item_to_fill, check_access=False)
+    else:
+        def location_can_fill_item(location_to_fill: Location, item_to_fill: Item):
+            return location_to_fill.item_rule(item_to_fill)
+
     while locations and itempool:
         item_to_place = itempool.pop()
         spot_to_fill: typing.Optional[Location] = None
 
         for i, location in enumerate(locations):
-            if location.item_rule(item_to_place):
+            if location_can_fill_item(location, item_to_place):
                 # popping by index is faster than removing by content,
                 spot_to_fill = locations.pop(i)
                 # skipping a scan for the element
@@ -253,7 +265,7 @@ def remaining_fill(multiworld: MultiWorld,
 
                 location.item = None
                 placed_item.location = None
-                if location.item_rule(item_to_place):
+                if location_can_fill_item(location, item_to_place):
                     # Add this item to the existing placement, and
                     # add the old item to the back of the queue
                     spot_to_fill = placements.pop(i)


### PR DESCRIPTION
### Use case:
World dev wants to fill useful, filler and trap locally.

### Problem:
`fill_restrictive` is slow because it thinks it needs to do location access stuff.
`remaining_fill` **does not respect excluded locations** inherently for useful items - Fill actually does two calls to it, once with `excludedlocations` and `filleritempool`, then with `defaultlocations` and `restitempool`

### Result:
World dev chooses to reimplement their own random fill with `location.can_fill`
This has happened at least twice now, as far as I know.

## What this PR does
Add an argument to `remaining_fill` for whether to check only the item rule or do a full location.can_fill check

## Alternatives
- Just always check `location.can_fill`? Idk, that'd be slower, but is remaining fill really our bottleneck?
- Move the two calls to remaining fill *inside* of remaining fill, splitting the itempool into useful and non-useful in there

## Tested
Not really