### PR TITLE
TUNIC: Fix missing traversal req

### DIFF
--- a/worlds/tunic/er_data.py
+++ b/worlds/tunic/er_data.py
@@ -1183,6 +1183,8 @@ traversal_requirements: Dict[str, Dict[str, List[List[str]]]] = {
             [],
         "Library Hero's Grave Region":
             [],
+        "Library Hall to Rotunda":
+            [],
     },
     "Library Hero's Grave Region": {
         "Library Hall":


### PR DESCRIPTION
## What is this fixing or adding?
I had missed a traversal requirement, which I'm surprised I never ran into any failures from it before, and I still haven't run into any failures with it from testing this -- only found out because I'm writing a direction pairing thing for ER, where that failure is much much more likely to show up.

## How was this tested?
Test gens in a branch with more features.

## If this makes graphical changes, please attach screenshots.
N/A