### PR TITLE
SoE: fix determinism

### DIFF
--- a/worlds/soe/__init__.py
+++ b/worlds/soe/__init__.py
@@ -188,6 +188,7 @@ class SoEWorld(World):
     connect_name: str
 
     _halls_ne_chest_names: typing.List[str] = [loc.name for loc in _locations if 'Halls NE' in loc.name]
+    _fillers = sorted(item_name_groups["Ingredients"])
 
     def __init__(self, multiworld: "MultiWorld", player: int):
         self.connect_name_available_event = threading.Event()
@@ -469,7 +470,7 @@ class SoEWorld(World):
             multidata["connect_names"][self.connect_name] = payload
 
     def get_filler_item_name(self) -> str:
-        return self.random.choice(list(self.item_name_groups["Ingredients"]))
+        return self.random.choice(self._fillers)
 
 
 class SoEItem(Item):


### PR DESCRIPTION
## What is this fixing or adding?

Fixes randomly placed ingredients not being deterministic (depending on settings) and in turn also fixes logic not being deterministic if they get replaced by fragments.

## How was this tested?

Running `python Generate.py --seed 5555` twice and comparing output for a yaml that has
* Energy Core = Fragments
* Sniffamizer = Everywhere
* Ingredients = Random Ingredients