### PR TITLE
DOOM, DOOM II: Update Steam URLs

### DIFF
--- a/worlds/doom_1993/docs/setup_en.md
+++ b/worlds/doom_1993/docs/setup_en.md
@@ -2,7 +2,7 @@
 
 ## Required Software
 
-- [DOOM 1993 (e.g. Steam version)](https://store.steampowered.com/app/2280/DOOM_1993/)
+- [DOOM 1993 (e.g. Steam version)](https://store.steampowered.com/app/2280/DOOM__DOOM_II/)
 - [Archipelago Crispy DOOM](https://github.com/Daivuk/apdoom/releases)
 
 ## Optional Software

--- a/worlds/doom_ii/docs/setup_en.md
+++ b/worlds/doom_ii/docs/setup_en.md
@@ -2,7 +2,7 @@
 
 ## Required Software
 
-- [DOOM II (e.g. Steam version)](https://store.steampowered.com/app/2300/DOOM_II/)
+- [DOOM II (e.g. Steam version)](https://store.steampowered.com/app/2280/DOOM__DOOM_II/)
 - [Archipelago Crispy DOOM](https://github.com/Daivuk/apdoom/releases)
 
 ## Optional Software


### PR DESCRIPTION
## What is this fixing or adding?

As of August 8, 2024, Doom and Doom 2 have been merged into the same game ID on Steam. This updates the URLs for both games in their setup guides to point to the correct location.

## How was this tested?

Reading and clicking on links
