### PR TITLE
MultiServer: Add slot to SetReply packets

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1857,6 +1857,7 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
             args["cmd"] = "SetReply"
             value = ctx.stored_data.get(args["key"], args.get("default", 0))
             args["original_value"] = copy.copy(value)
+            args["slot"] = client.slot
             for operation in args["operations"]:
                 func = modify_functions[operation["operation"]]
                 value = func(value, operation["value"])

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -261,6 +261,7 @@ Sent to clients in response to a [Set](#Set) package if want_reply was set to tr
 | key            | str  | The key that was updated.                                                                  |
 | value          | any  | The new value for the key.                                                                 |
 | original_value | any  | The value the key had before it was updated. Not present on "_read" prefixed special keys. |
+| slot           | int  | The slot that originally sent the Set package causing this change.                         |
 
 Additional arguments added to the [Set](#Set) package that triggered this [SetReply](#SetReply) will also be passed along.
 


### PR DESCRIPTION
Alternative / generic solution for https://github.com/ArchipelagoMW/Archipelago/pull/3117

Upside of this one being that clients do not need to change to support the new EnergyLink protocol.

Tested: Ran `MultiServer.py --log_network`, connected with a client that sends datastorage Set operations, verified that outgoing SetReply packets contain `slot: 1`