### PR TITLE
MultiServer: Add originating slot to bounce packets

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1826,8 +1826,8 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
             tags = set(args.get("tags", []))
             slots = set(args.get("slots", []))
             args["cmd"] = "Bounced"
+            args["slot"] = client.slot
             msg = ctx.dumper([args])
-            msg["slot"] = client.slot
 
             for bounceclient in ctx.endpoints:
                 if client.team == bounceclient.team and (ctx.games[bounceclient.slot] in games or

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1827,6 +1827,7 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
             slots = set(args.get("slots", []))
             args["cmd"] = "Bounced"
             msg = ctx.dumper([args])
+            msg["slot"] = client.slot
 
             for bounceclient in ctx.endpoints:
                 if client.team == bounceclient.team and (ctx.games[bounceclient.slot] in games or

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -223,6 +223,7 @@ Sent to clients after a client requested this message be sent to them, more info
 | slots | list\[int\] | Optional. Player slot IDs that this message is targeting |
 | tags | list\[str\] | Optional. Client [Tags](#Tags) this message is targeting |
 | data | dict | The data in the [Bounce](#Bounce) package copied |
+| slot | int | The slot that originally sent the Bounce package |
 
 ### InvalidPacket
 Sent to clients if the server caught a problem with a packet. This only occurs for errors that are explicitly checked for.


### PR DESCRIPTION
Sister PR to https://github.com/ArchipelagoMW/Archipelago/pull/3747

Always wondered why bounce packets don't do this anyway 🤷
I know some clients need to distinguish between clients connected to the same slot, so this isn't universally useful. But still it's always seemed like a gap to me. In a way it seems weird to me that clients stay "anonymous" when sending bounce packets? I feel like they should be forced to self-report. Idk

Tested: Ran `MultiServer.py --log_network`, connected with a client that has DeathLink, died, verified that the outgoing bounce packet contains `slot: 1`