### PR TITLE
HK: fix iterating all worlds instead of only HK worlds in stage_pre_fill

### DIFF
--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -467,7 +467,7 @@ class HKWorld(World):
         worlds = [world for world in multiworld.get_game_worlds(cls.game) if world.options.Goal in ["any", "grub_hunt"]]
         if worlds:
             grubs = [item for item in multiworld.get_items() if item.name == "Grub"]
-        all_grub_players = [world.player for world in multiworld.worlds.values() if world.options.GrubHuntGoal == GrubHuntGoal.special_range_names["all"]]
+        all_grub_players = [world.player for world in worlds if world.options.GrubHuntGoal == GrubHuntGoal.special_range_names["all"]]
 
         if all_grub_players:
             group_lookup = defaultdict(set)


### PR DESCRIPTION
## What is this fixing or adding?

Would cause generation to fail when generating with HK and another game.

Mistake in 6803c373e5ff.

## How was this tested?

Ran generation with one of every game before and after the patch