### PR TITLE
Core: Allow 0 in ItemDicts, by just cleaning them out

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -855,7 +855,12 @@ class ItemDict(OptionDict):
     verify_item_name = True
 
     def __init__(self, value: typing.Dict[str, int]):
-        value = { item_name: value for item_name, value in value.items() if value != 0 }
+        if any(item_count < 0 for item_count in value.values()):
+            raise Exception("Cannot have negative item counts.")
+
+        # clean out 0s, but don't have them crash
+        value = {item_name: value for item_name, value in value.items() if value != 0}
+
         super(ItemDict, self).__init__(value)
 
 

--- a/Options.py
+++ b/Options.py
@@ -855,8 +855,7 @@ class ItemDict(OptionDict):
     verify_item_name = True
 
     def __init__(self, value: typing.Dict[str, int]):
-        if any(item_count < 1 for item_count in value.values()):
-            raise Exception("Cannot have non-positive item counts.")
+        value = { item_name: value for item_name, value in value.items() if value != 0 }
         super(ItemDict, self).__init__(value)
 
 


### PR DESCRIPTION
The Website displays this:

![image](https://github.com/user-attachments/assets/b5f35966-e5f6-471a-b19a-ac6932fa37b0)

So why should
```
starting_inventory: {"Arrows": 0}
```
be invalid in a yaml?

The website has to do [special handling](https://github.com/ArchipelagoMW/Archipelago/blob/c66a8605da1ba1aaaaac57bc2722ee1b585d4c5d/WebHostLib/options.py#L218-L225) to work around this. *Well, to be fair, it is nice not to have 100 keys for all those options in your yaml, so that'll probably stay. But either way*
Don't really get it 🤷 Tbh if it were up to me, ItemDict would convert the value to a **Counter**. I mean, I'm opening a PR, so I guess it is up to me. Is that preferred? Is this a non issue in the first place?

Basically, I *am* slightly annoyed that the action of removing something from an ItemDict is completely different between website (set to 0 works, can't delete) and yaml (delete works, set to 0 crashes), meaning I can't instruct the user how to do it in the option tooltip.

This should also be backwards compatible because any scenario that acts differently now would have *crashed* before, so this doesn't allow for any new option values, just more ways to write the same thing.