### PR TITLE
id Tech 1 games: Add command line instructions/info

### DIFF
--- a/worlds/doom_1993/docs/setup_en.md
+++ b/worlds/doom_1993/docs/setup_en.md
@@ -17,7 +17,7 @@
    You can find the folder in steam by finding the game in your library,
    right-clicking it and choosing **Manage -> Browse Local Files**. The WAD file is in the `/base/` folder.
 
-## Joining a MultiWorld Game
+## Joining a MultiWorld Game (via Launcher)
 
 1. Launch apdoom-launcher.exe
 2. Select `Ultimate DOOM` from the drop-down
@@ -27,6 +27,24 @@
 
 To continue a game, follow the same connection steps.
 Connecting with a different seed won't erase your progress in other seeds.
+
+## Joining a MultiWorld Game (via command line)
+
+1. In your command line, navigate to the directory where APDOOM is installed.
+2. Run `crispy-apdoom -game doom -apserver <server> -applayer <slot name>`, where:
+    - `<server>` is the Archipelago server address, e.g. "`archipelago.gg:38281`"
+    - `<slot name>` is your slot name; if it contains spaces, surround it with double quotes
+    - If the server has a password, add `-password`, followed by the server password
+3. Enjoy!
+
+Optionally, you can override some randomization settings from the command line:
+- `-apmonsterrando 0` will disable monster rando.
+- `-apitemrando 0` will disable item rando.
+- `-apmusicrando 0` will disable music rando.
+- `-apfliplevels 0` will disable flipping levels.
+- `-apresetlevelondeath 0` will disable resetting the level on death.
+- `-apdeathlinkoff` will force DeathLink off if it's enabled.
+- `-skill <1-5>` changes the game difficulty, from 1 (I'm too young to die) to 5 (Nightmare!)
 
 ## Archipelago Text Client
 

--- a/worlds/doom_ii/docs/setup_en.md
+++ b/worlds/doom_ii/docs/setup_en.md
@@ -15,7 +15,7 @@
    You can find the folder in steam by finding the game in your library,
    right clicking it and choosing *Manage→Browse Local Files*. The WAD file is in the `/base/` folder.
 
-## Joining a MultiWorld Game
+## Joining a MultiWorld Game (via Launcher)
 
 1. Launch apdoom-launcher.exe
 2. Select `DOOM II` from the drop-down
@@ -25,6 +25,24 @@
 
 To continue a game, follow the same connection steps.
 Connecting with a different seed won't erase your progress in other seeds.
+
+## Joining a MultiWorld Game (via command line)
+
+1. In your command line, navigate to the directory where APDOOM is installed.
+2. Run `crispy-apdoom -game doom2 -apserver <server> -applayer <slot name>`, where:
+    - `<server>` is the Archipelago server address, e.g. "`archipelago.gg:38281`"
+    - `<slot name>` is your slot name; if it contains spaces, surround it with double quotes
+    - If the server has a password, add `-password`, followed by the server password
+3. Enjoy!
+
+Optionally, you can override some randomization settings from the command line:
+- `-apmonsterrando 0` will disable monster rando.
+- `-apitemrando 0` will disable item rando.
+- `-apmusicrando 0` will disable music rando.
+- `-apfliplevels 0` will disable flipping levels.
+- `-apresetlevelondeath 0` will disable resetting the level on death.
+- `-apdeathlinkoff` will force DeathLink off if it's enabled.
+- `-skill <1-5>` changes the game difficulty, from 1 (I'm too young to die) to 5 (Nightmare!)
 
 ## Archipelago Text Client
 

--- a/worlds/heretic/docs/setup_en.md
+++ b/worlds/heretic/docs/setup_en.md
@@ -15,7 +15,7 @@
    You can find the folder in steam by finding the game in your library,
    right clicking it and choosing *Manage→Browse Local Files*. The WAD file is in the `/base/` folder.
 
-## Joining a MultiWorld Game
+## Joining a MultiWorld Game (via Launcher)
 
 1. Launch apdoom-launcher.exe
 2. Choose Heretic in the dropdown
@@ -25,6 +25,23 @@
 
 To continue a game, follow the same connection steps.
 Connecting with a different seed won't erase your progress in other seeds.
+
+## Joining a MultiWorld Game (via command line)
+
+1. In your command line, navigate to the directory where APDOOM is installed.
+2. Run `crispy-apheretic -apserver <server> -applayer <slot name>`, where:
+    - `<server>` is the Archipelago server address, e.g. "`archipelago.gg:38281`"
+    - `<slot name>` is your slot name; if it contains spaces, surround it with double quotes
+    - If the server has a password, add `-password`, followed by the server password
+3. Enjoy!
+
+Optionally, you can override some randomization settings from the command line:
+- `-apmonsterrando 0` will disable monster rando.
+- `-apitemrando 0` will disable item rando.
+- `-apmusicrando 0` will disable music rando.
+- `-apresetlevelondeath 0` will disable resetting the level on death.
+- `-apdeathlinkoff` will force DeathLink off if it's enabled.
+- `-skill <1-5>` changes the game difficulty, from 1 (thou needeth a wet-nurse) to 5 (black plague possesses thee)
 
 ## Archipelago Text Client
 


### PR DESCRIPTION
## What is this fixing or adding?

Daivuk and I were discussing this earlier today; there's currently no documentation anywhere of how to start APDOOM from the command line, or information on any of the command line arguments that it adds. This PR adds this documentation to the setup guide. It's especially important to have this here for Linux users, as the launcher is Windows-only.

## How was this tested?

Reading, glancing at the formatted output through a markdown editor, and running the commands I already have been for the past year lol