### PR TITLE
TUNIC: Add note to Universal Tracker stuff

### DIFF
--- a/worlds/tunic/__init__.py
+++ b/worlds/tunic/__init__.py
@@ -410,7 +410,9 @@ class TunicWorld(World):
         return slot_data
 
     # for the universal tracker, doesn't get called in standard gen
+    # docs: https://github.com/FarisTheAncient/Archipelago/blob/tracker/worlds/tracker/docs/re-gen-passthrough.md
     @staticmethod
     def interpret_slot_data(slot_data: Dict[str, Any]) -> Dict[str, Any]:
         # returning slot_data so it regens, giving it back in multiworld.re_gen_passthrough
+        # we are using re_gen_passthrough over modifying the world here due to complexities with ER
         return slot_data


### PR DESCRIPTION
## What is this fixing or adding?
People copy Tunic's implementation for Universal Tracker a lot, so I figured I should include a link to its docs, and a brief explanation of why we're just returning slot data in `interpret_slot_data`

## How was this tested?
Reading

## If this makes graphical changes, please attach screenshots.
N/A