### PR TITLE
UT integration for OSRS to support chunksanity

### DIFF
--- a/worlds/osrs/__init__.py
+++ b/worlds/osrs/__init__.py
@@ -84,16 +84,18 @@ class OSRSWorld(World):
 
         rnd = self.random
         starting_area = self.options.starting_area
+        
+        #UT specific override, if we are in normal gen, resolve starting area, we will get it from slot_data in UT
+        if not hasattr(self.multiworld, "generation_is_fake"): 
+            if starting_area.value == StartingArea.option_any_bank:
+                self.starting_area_item = rnd.choice(starting_area_dict)
+            elif starting_area.value < StartingArea.option_chunksanity:
+                self.starting_area_item = starting_area_dict[starting_area.value]
+            else:
+                self.starting_area_item = rnd.choice(chunksanity_starting_chunks)
 
-        if starting_area.value == StartingArea.option_any_bank:
-            self.starting_area_item = rnd.choice(starting_area_dict)
-        elif starting_area.value < StartingArea.option_chunksanity:
-            self.starting_area_item = starting_area_dict[starting_area.value]
-        else:
-            self.starting_area_item = rnd.choice(chunksanity_starting_chunks)
-
-        # Set Starting Chunk
-        self.multiworld.push_precollected(self.create_item(self.starting_area_item))
+            # Set Starting Chunk
+            self.multiworld.push_precollected(self.create_item(self.starting_area_item))
 
     """
     This function pulls from LogicCSVToPython so that it sends the correct tag of the repository to the client.
@@ -103,7 +105,22 @@ class OSRSWorld(World):
     def fill_slot_data(self):
         data = self.options.as_dict("brutal_grinds")
         data["data_csv_tag"] = data_csv_tag
+        data["starting_area"] = str(self.starting_area_item) #these aren't actually strings, they just play them on tv
         return data
+
+    def interpret_slot_data(self, slot_data: typing.Dict[str, typing.Any]) -> None:
+        if "starting_area" in slot_data:
+            self.starting_area_item = slot_data["starting_area"]
+            menu_region = self.multiworld.get_region("Menu",self.player)
+            menu_region.exits.clear() #prevent making extra exits if players just reconnect to a differnet slot
+            if self.starting_area_item in chunksanity_special_region_names:
+                starting_area_region = chunksanity_special_region_names[self.starting_area_item]
+            else:
+                starting_area_region = self.starting_area_item[6:]  # len("Area: ")
+            starting_entrance = menu_region.create_exit(f"Start->{starting_area_region}")
+            starting_entrance.access_rule = lambda state: state.has(self.starting_area_item, self.player)
+            starting_entrance.connect(self.region_name_to_data[starting_area_region])
+
 
     def create_regions(self) -> None:
         """
@@ -122,13 +139,14 @@ class OSRSWorld(World):
 
         # Removes the word "Area: " from the item name to get the region it applies to.
         # I figured tacking "Area: " at the beginning would make it _easier_ to tell apart. Turns out it made it worse
-        if self.starting_area_item in chunksanity_special_region_names:
-            starting_area_region = chunksanity_special_region_names[self.starting_area_item]
-        else:
-            starting_area_region = self.starting_area_item[6:]  # len("Area: ")
-        starting_entrance = menu_region.create_exit(f"Start->{starting_area_region}")
-        starting_entrance.access_rule = lambda state: state.has(self.starting_area_item, self.player)
-        starting_entrance.connect(self.region_name_to_data[starting_area_region])
+        if self.starting_area_item != "": #if area hasn't been set, then we shouldn't connect it
+            if self.starting_area_item in chunksanity_special_region_names:
+                starting_area_region = chunksanity_special_region_names[self.starting_area_item]
+            else:
+                starting_area_region = self.starting_area_item[6:]  # len("Area: ")
+            starting_entrance = menu_region.create_exit(f"Start->{starting_area_region}")
+            starting_entrance.access_rule = lambda state: state.has(self.starting_area_item, self.player)
+            starting_entrance.connect(self.region_name_to_data[starting_area_region])
 
         # Create entrances between regions
         for region_row in region_rows:


### PR DESCRIPTION
Adding/Fixing the UT integration of OSRS

## What is this fixing or adding?
Currently UT support in OSRS works... except if you play with chunksanity (any chunk area can be the starting location)

in UT for any_bank starting location can be updated via the user changing their yaml, but for chunksanity, it requires then to receive a bank chunk connected to their accessible area network, and THEN UT will work

This PR puts the starting area in slot_data (will be useful for Digi when they add local tracker support anyway) and connects Menu to the correct starting location regardless of yaml settings

## How was this tested?
generate multiworld with chunksanity enabled, looked at spoiler log to confirm that a non-bank chunk got rolled, (HAM Hideout) then changed yaml to be a chunk nowhere near that rolled chunk (Wilderness)

Launched MultiServer and connected UT to that slot, confirmed that UT task list matched expected in rolled chunk, then /send adjacent chunk that has obvious task only doable in that chunk (Area: Lumbridge Swamp / Kill Giant Frog)

Also did /send to send a chunk that would have a task that exists in the multiworld, and would be accessible if we _did_ have the incorrect starting chunk and the newly sent one, but _wouldn't_ if we had the correct starting chunk and the sent one (Area: Edgeville / Ride a canoe)
