### PR TITLE
TLOZ: Fix non-deterministic item pool generation

### DIFF
--- a/worlds/tloz/ItemPool.py
+++ b/worlds/tloz/ItemPool.py
@@ -2,6 +2,8 @@ from BaseClasses import ItemClassification
 from .Locations import level_locations, all_level_locations, standard_level_locations, shop_locations
 from .Options import TriforceLocations, StartingPosition
 
+from collections import Counter
+
 # Swords are in starting_weapons
 overworld_items = {
     "Letter": 1,
@@ -58,11 +60,11 @@ map_compass_replacements = {
     "Small Key": 2,
     "Five Rupees": 2
 }
-basic_pool = {
-    item: overworld_items.get(item, 0) + shop_items.get(item, 0)
-    + major_dungeon_items.get(item, 0) + map_compass_replacements.get(item, 0)
-    for item in set(overworld_items) | set(shop_items) | set(major_dungeon_items) | set(map_compass_replacements)
-}
+basic_pool = Counter()
+basic_pool.update(overworld_items)
+basic_pool.update(shop_items)
+basic_pool.update(major_dungeon_items)
+basic_pool.update(map_compass_replacements)
 
 starting_weapons = ["Sword", "White Sword", "Magical Sword", "Magical Rod", "Red Candle"]
 guaranteed_shop_items = ["Small Key", "Bomb", "Water of Life (Red)", "Arrow"]
@@ -135,10 +137,10 @@ def get_pool_core(world):
     # Finish Pool
     final_pool = basic_pool
     if world.options.ExpandedPool:
-        final_pool = {
-            item: basic_pool.get(item, 0) + minor_items.get(item, 0) + take_any_items.get(item, 0)
-            for item in set(basic_pool) | set(minor_items) | set(take_any_items)
-        }
+        final_pool = Counter()
+        final_pool.update(basic_pool)
+        final_pool.update(minor_items)
+        final_pool.update(take_any_items)
         final_pool["Five Rupees"] -= 1
     for item in final_pool.keys():
         for i in range(0, final_pool[item]):

--- a/worlds/tloz/ItemPool.py
+++ b/worlds/tloz/ItemPool.py
@@ -1,8 +1,8 @@
+from collections import Counter
+
 from BaseClasses import ItemClassification
 from .Locations import level_locations, all_level_locations, standard_level_locations, shop_locations
 from .Options import TriforceLocations, StartingPosition
-
-from collections import Counter
 
 # Swords are in starting_weapons
 overworld_items = {


### PR DESCRIPTION
## What is this fixing or adding?

The way the item pool was constructed involved iterating unions of sets. Sets are unordered, so the order of iteration of these combined sets would be non-deterministic, resulting in the items in the item pool being generated in a different order with the same seed.

Rather than creating unions of sets at all, the original code has been replaced with using Counter objects. As a dict subclass, Counter maintains insertion order, and its update() method makes it simple to combine the separate item dictionaries into a single dictionary with the total count of each item across each of the separate item dictionaries.

Fixes #3664 - After investigating more deeply, the only differences I could find between generations of the same seed was the order of items created by TLOZ. The issue appears to have occurred when generating with SMZ3 because SMZ3 removes junk/trap items from the pool during pre_fill, specifically in its `JunkFillGT()` and it could pick different items with the same seed because TLOZ's items were in a non-deterministic order, so this patch appears to fix the non-deterministic generation issue.

## How was this tested?

I modified Main.py to write out the locations of all progression items and what those items were into a file on a single line, but only if the line did not already exist in the file, this way, I ran many generations using `--seed 1 --skip_output` and if there was more than one line in the file at the end, then there was non-deterministic generation.

The simple case of just the template TLOZ and SMZ3 yamls that commonly resulted in non-deterministic generation was tested, as well as with many other template yamls that are known to produce deterministic results..