### PR TITLE
Core: Remove broken unused code from Options.py

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -1518,31 +1518,3 @@ def generate_yaml_templates(target_folder: typing.Union[str, "pathlib.Path"], ge
 
             with open(os.path.join(target_folder, game_name + ".yaml"), "w", encoding="utf-8-sig") as f:
                 f.write(res)
-
-
-if __name__ == "__main__":
-
-    from worlds.alttp.Options import Logic
-    import argparse
-
-    map_shuffle = Toggle
-    compass_shuffle = Toggle
-    key_shuffle = Toggle
-    big_key_shuffle = Toggle
-    hints = Toggle
-    test = argparse.Namespace()
-    test.logic = Logic.from_text("no_logic")
-    test.map_shuffle = map_shuffle.from_text("ON")
-    test.hints = hints.from_text('OFF')
-    try:
-        test.logic = Logic.from_text("overworld_glitches_typo")
-    except KeyError as e:
-        print(e)
-    try:
-        test.logic_owg = Logic.from_text("owg")
-    except KeyError as e:
-        print(e)
-    if test.map_shuffle:
-        print("map_shuffle is on")
-    print(f"Hints are {bool(test.hints)}")
-    print(test)


### PR DESCRIPTION
"Unused" is an assertion for which I have no direct evidence, but this code path has been [crashing on the first statement for 6 months](https://discord.com/channels/731205301247803413/731214280439103580/1272568415277678605) and noone's complained