### PR TITLE
Core: Two Small Fixes

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1427,7 +1427,7 @@ class Spoiler:
                 # Maybe move the big bomb over to the Event system instead?
                 if any(exit_path == 'Pyramid Fairy' for path in self.paths.values()
                        for (_, exit_path) in path):
-                    if multiworld.mode[player] != 'inverted':
+                    if multiworld.worlds[player].options.mode != 'inverted':
                         self.paths[str(multiworld.get_region('Big Bomb Shop', player))] = \
                             get_path(state, multiworld.get_region('Big Bomb Shop', player))
                     else:

--- a/Launcher.py
+++ b/Launcher.py
@@ -266,7 +266,7 @@ def run_gui():
             if file and component:
                 run_component(component, file)
             else:
-                logging.warning(f"unable to identify component for {filename}")
+                logging.warning(f"unable to identify component for {file}")
 
         def _stop(self, *largs):
             # ran into what appears to be https://groups.google.com/g/kivy-users/c/saWDLoYCSZ4 with PyCharm.


### PR DESCRIPTION
## What is this fixing or adding?

Changes an option getter in `BaseClasses` for ALttP

Changes an output to use decoded bytes for the filename instead

## How was this tested?

Finding a generation that hit the ALttP path and seeing it still work.

Printing `file` and `filepath` and seeing that filepath was `b'text'` instead of just `text`
