### PR TITLE
[LTTP] Fix a bug in Triforce Pieces Mode: Extra

### DIFF
--- a/worlds/alttp/ItemPool.py
+++ b/worlds/alttp/ItemPool.py
@@ -682,7 +682,7 @@ def get_pool_core(world, player: int):
     if 'triforce_hunt' in goal:
 
         if world.triforce_pieces_mode[player].value == TriforcePiecesMode.option_extra:
-            treasure_hunt_total = (world.triforce_pieces_available[player].value
+            treasure_hunt_total = (world.triforce_pieces_required[player].value
                                    + world.triforce_pieces_extra[player].value)
         elif world.triforce_pieces_mode[player].value == TriforcePiecesMode.option_percentage:
             percentage = float(world.triforce_pieces_percentage[player].value) / 100


### PR DESCRIPTION
## What is this fixing or adding?
When triforce_pieces_mode is set to "extra", the number of Triforce pieces in the pool should be equal to the number required plus the number extra. The number available was being used in this calculation, instead of the number required. This is correcting that typo.

## How was this tested?
By generating a game of LTTP with triforce_pieces_mode set to "extra", 50 "required", 90 "available", 10 "extra" and talking to Murahdala to confirm how many pieces are in the item pool.
Before this fix, these settings produced a game with 100 available pieces. After, they produced a game with the expected 60 available pieces.

## If this makes graphical changes, please attach screenshots.
N/A