### PR TITLE
Docs: Use ModuleUpdate.py

### DIFF
--- a/docs/running from source.md
+++ b/docs/running from source.md
@@ -41,9 +41,9 @@ Recommended steps
      [Discord in #archipelago-dev](https://discord.com/channels/731205301247803413/731214280439103580/905154456377757808)
 
  * It is recommended to use [PyCharm IDE](https://www.jetbrains.com/pycharm/)
- * Run Generate.py which will prompt installation of missing modules, press enter to confirm
-   * In PyCharm: right-click Generate.py and select `Run 'Generate'`
-   * Without PyCharm: open a command prompt in the source folder and type `py Generate.py`
+ * Run ModuleUpdate.py which will prompt installation of missing modules, press enter to confirm
+   * In PyCharm: right-click ModuleUpdate.py and select `Run 'ModuleUpdate'`
+   * Without PyCharm: open a command prompt in the source folder and type `py ModuleUpdate.py`
 
 
 ## macOS


### PR DESCRIPTION
## What is this fixing or adding?
changes docs to reference moduleupdate directly when describing how to install source requirements

if there's a reason it should be generate instead i couldn't figure it out, 
the section could be potentially removed instead as we already mention `Then run any of the starting point scripts, like Generate.py, and the included ModuleUpdater should prompt to install or update the required modules and after pressing enter proceed to install everything automatically.` earlier in the doc

## How was this tested?
ran moduleupdate and it updated my requirements just like generate would

## If this makes graphical changes, please attach screenshots.
