### PR TITLE
Core: Crash on full accessibility if there are unreachable locations

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -636,6 +636,12 @@ class MultiWorld():
                     sphere.append(locations.pop(n))
 
             if not sphere:
+                if __debug__:
+                    from Fill import FillError
+                    raise FillError(
+                        f"Could not access required locations for accessibility check. Missing: {locations}",
+                        multiworld=self,
+                    )
                 # ran out of places and did not finish yet, quit
                 logging.warning(f"Could not access required locations for accessibility check."
                                 f" Missing: {locations}")


### PR DESCRIPTION
If you're like, "What do you mean?", then I have bad news, this currently doesn't happen. It's a warning at the moment.

Currently unsure whether this should be wrapped in `if __debug__` or not. I can see the value in having this disabled on frozen for the sake of large async generations. Let me know what you think. Even just the `if __debug__` version would have saved me tons and tons of headaches in the past.