### PR TITLE
WebHost: Maybe fix OptionList somehow?

### DIFF
--- a/WebHostLib/templates/weightedOptions/macros.html
+++ b/WebHostLib/templates/weightedOptions/macros.html
@@ -138,7 +138,7 @@
                     id="{{ option_name }}-{{ key }}"
                     name="{{ option_name }}||{{ key }}"
                     value="1"
-                    checked="{{ "checked" if key in option.default else "" }}"
+                    {{ "checked" if key in option.default }}
                 />
                 <label for="{{ option_name }}-{{ key }}">
                     {{ key }}


### PR DESCRIPTION
## What is this fixing or adding?

OptionLists do not display their proper default values on the advanced/weighted options page for a game, instead always selecting all members of the list. I literally just looked at the player options version of OptionList and other options in the file and saw that this one was different, this is truly a guess.

## How was this tested?

Loading WebHost and looking at Timespinner Traps and Ocarina of Time Logic Tricks options, including modifying their default values to see that the defaults were always shown.