### PR TITLE
Stardew Valley: Add Quality Bobber in the logic rules for fish quality gold and above

### DIFF
--- a/worlds/stardew_valley/logic/fishing_logic.py
+++ b/worlds/stardew_valley/logic/fishing_logic.py
@@ -14,6 +14,7 @@ from ..options import ExcludeGingerIsland
 from ..options import SpecialOrderLocations
 from ..stardew_rule import StardewRule, True_, False_
 from ..strings.ap_names.mods.mod_items import SVEQuestItem
+from ..strings.craftable_names import Fishing
 from ..strings.fish_names import SVEFish
 from ..strings.machine_names import Machine
 from ..strings.quality_names import FishQuality
@@ -74,15 +75,17 @@ class FishingLogic(BaseLogic[Union[HasLogicMixin, FishingLogicMixin, ReceivedLog
     def can_catch_quality_fish(self, fish_quality: str) -> StardewRule:
         if fish_quality == FishQuality.basic:
             return True_()
-        rod_rule = self.logic.tool.has_fishing_rod(2)
         if fish_quality == FishQuality.silver:
-            return rod_rule
+            return self.logic.tool.has_fishing_rod(2)
         if fish_quality == FishQuality.gold:
-            return rod_rule & self.logic.skill.has_level(Skill.fishing, 4)
+            return self.logic.skill.has_level(Skill.fishing, 4) & self.can_use_tackle(Fishing.quality_bobber)
         if fish_quality == FishQuality.iridium:
-            return rod_rule & self.logic.skill.has_level(Skill.fishing, 10)
+            return self.logic.skill.has_level(Skill.fishing, 10) & self.can_use_tackle(Fishing.quality_bobber)
 
         raise ValueError(f"Quality {fish_quality} is unknown.")
+
+    def can_use_tackle(self, tackle: str) -> StardewRule:
+        return self.logic.tool.has_fishing_rod(4) & self.logic.has(tackle)
 
     def can_catch_every_fish(self) -> StardewRule:
         rules = [self.has_max_fishing()]


### PR DESCRIPTION
## What is this fixing or adding?
Fish qualities in stardew depend of a few factors. The quality bobber, and doing a "perfect catch" both increase it by one tier exactly.

Since not everyone is very good at fishing, it's not really reasonably to expect perfect catches, even when the fishing level is theoretically high enough. And since some fish live in areas where the line cannot be thrown far at all (ex: submarine), sometimes it was actually necessary to perfect catch.

This adds a logic rule for gold quality fish to have access to a quality bobber instead, so that even less proficient players don't get softlocked by a skill issue.

## How was this tested?
Unit tests
