### PR TITLE
TUNIC: Add off and on aliases for the Entrance Rando option

### DIFF
--- a/worlds/tunic/options.py
+++ b/worlds/tunic/options.py
@@ -132,8 +132,10 @@ class EntranceRando(TextChoice):
     internal_name = "entrance_rando"
     display_name = "Entrance Rando"
     alias_false = 0
+    alias_off = 0
     option_no = 0
     alias_true = 1
+    alias_on = 1
     option_yes = 1
     default = 0
 


### PR DESCRIPTION
## What is this fixing or adding?
Adds an off and on alias for the Entrance Rando option.
It is a TextChoice, which doesn't automatically convert off to turning Entrance Rando off, and doesn't automatically convert on to turning Entrance Rando on to a random seed, which is different than how most other option classes work. So if someone does `entrance_rando: off`, I'd imagine they wanted entrance rando to be off, and not set to the seed "off".

## How was this tested?
I didn't do a test gen, it's following the format of the other aliases so it should be fine.

## If this makes graphical changes, please attach screenshots.
N/A