### PR TITLE
Core: Fix Generate's slot parsing to default unknown slot names to file name

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -184,6 +184,7 @@ def main(args=None) -> Tuple[argparse.Namespace, int]:
     erargs.player_options = {}
 
     player = 1
+    erargs.name = {}
     while player <= args.multi:
         path = player_path_cache[player]
         if path:
@@ -200,8 +201,6 @@ def main(args=None) -> Tuple[argparse.Namespace, int]:
                             except Exception as e:
                                 raise Exception(f"Error setting {k} to {v} for player {player}") from e
 
-                    if not getattr(erargs, "name", None):
-                        setattr(erargs, "name", {})  # if the first slot does not define a name we won't have a name obj to look up
                     if path == args.weights_file_path:  # if name came from the weights file, just use base player name
                         erargs.name[player] = f"Player{player}"
                     elif player not in erargs.name:  # if name was not specified, generate it from filename

--- a/Generate.py
+++ b/Generate.py
@@ -155,6 +155,7 @@ def main(args=None) -> Tuple[argparse.Namespace, int]:
     erargs.outputpath = args.outputpath
     erargs.skip_prog_balancing = args.skip_prog_balancing
     erargs.skip_output = args.skip_output
+    erargs.name = {}
 
     settings_cache: Dict[str, Tuple[argparse.Namespace, ...]] = \
         {fname: (tuple(roll_settings(yaml, args.plando) for yaml in yamls) if args.sameoptions else None)
@@ -184,7 +185,6 @@ def main(args=None) -> Tuple[argparse.Namespace, int]:
     erargs.player_options = {}
 
     player = 1
-    erargs.name = {}
     while player <= args.multi:
         path = player_path_cache[player]
         if path:

--- a/Generate.py
+++ b/Generate.py
@@ -200,9 +200,11 @@ def main(args=None) -> Tuple[argparse.Namespace, int]:
                             except Exception as e:
                                 raise Exception(f"Error setting {k} to {v} for player {player}") from e
 
+                    if not getattr(erargs, "name", None):
+                        setattr(erargs, "name", {})  # if the first slot does not define a name we won't have a name obj to look up
                     if path == args.weights_file_path:  # if name came from the weights file, just use base player name
                         erargs.name[player] = f"Player{player}"
-                    elif not erargs.name[player]:  # if name was not specified, generate it from filename
+                    elif player not in erargs.name:  # if name was not specified, generate it from filename
                         erargs.name[player] = os.path.splitext(os.path.split(path)[-1])[0]
                     erargs.name[player] = handle_name(erargs.name[player], player, name_counter)
 


### PR DESCRIPTION
## What is this fixing or adding?
make Generate handle slots without names defined better; fix existing code that seemed to want to handle missing names but was no longer functioning correctly

if there is a better solution than what the existing code was trying to do then i differ to that

## How was this tested?
https://discord.com/channels/731205301247803413/1273345114198118502
tested with the original provided yaml and with a copy that moved the slot without a name to the bottom of the yaml and confirmed with pdb that the args.name got created properly and defaulted to file name when name was missing
also tested with two slots missing name in the same yaml and saw it throw an error mentioning the duplicate names, not sure if that's the best error handling but it works enough for me

## If this makes graphical changes, please attach screenshots.
