### PR TITLE
ChecksFinder: itempool naming/typing

### DIFF
--- a/worlds/checksfinder/__init__.py
+++ b/worlds/checksfinder/__init__.py
@@ -44,14 +44,14 @@ class ChecksFinderWorld(World):
         self.multiworld.regions += [menu, board]
 
     def create_items(self):
-        # Generate item pool
+        # Generate list of items
         items_to_create = []
         # Add the map width and height stuff
         items_to_create += ["Map Width"] * 5  # 10 - 5
         items_to_create += ["Map Height"] * 5  # 10 - 5
         # Add the map bombs
         items_to_create += ["Map Bombs"] * 15  # 20 - 5
-        # Convert itempool into real items
+        # Convert list into real items
         itempool = [self.create_item(item) for item in items_to_create]
 
         self.multiworld.itempool += itempool

--- a/worlds/checksfinder/__init__.py
+++ b/worlds/checksfinder/__init__.py
@@ -45,14 +45,14 @@ class ChecksFinderWorld(World):
 
     def create_items(self):
         # Generate item pool
-        itempool = []
+        items_to_create = []
         # Add the map width and height stuff
-        itempool += ["Map Width"] * 5  # 10 - 5
-        itempool += ["Map Height"] * 5  # 10 - 5
+        items_to_create += ["Map Width"] * 5  # 10 - 5
+        items_to_create += ["Map Height"] * 5  # 10 - 5
         # Add the map bombs
-        itempool += ["Map Bombs"] * 15  # 20 - 5
+        items_to_create += ["Map Bombs"] * 15  # 20 - 5
         # Convert itempool into real items
-        itempool = [self.create_item(item) for item in itempool]
+        itempool = [self.create_item(item) for item in items_to_create]
 
         self.multiworld.itempool += itempool
 


### PR DESCRIPTION
## What is this fixing or adding?

Appeasing mypy
`itempool` did not have a consistent typing since it went from a list of strings to a list of ChecksFinderItems. This just changes the name to avoid this typing error.

## How was this tested?

A generation and connecting to a world.