### PR TITLE
Core: Require excluded locations to be reachable with full/locations accessibility

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -616,8 +616,7 @@ class MultiWorld():
 
         def location_relevant(location: Location) -> bool:
             """Determine if this location is relevant to sweep."""
-            return location.progress_type != LocationProgressType.EXCLUDED \
-                and (location.player in players["full"] or location.advancement)
+            return location.player in players["full"] or location.advancement
 
         def all_done() -> bool:
             """Check if all access rules are fulfilled"""

--- a/test/bases.py
+++ b/test/bases.py
@@ -293,13 +293,11 @@ class WorldTestBase(unittest.TestCase):
         if not (self.run_default_tests and self.constructed):
             return
         with self.subTest("Game", game=self.game, seed=self.multiworld.seed):
-            excluded = self.multiworld.worlds[self.player].options.exclude_locations.value
             state = self.multiworld.get_all_state(False)
             for location in self.multiworld.get_locations():
-                if location.name not in excluded:
-                    with self.subTest("Location should be reached", location=location.name):
-                        reachable = location.can_reach(state)
-                        self.assertTrue(reachable, f"{location.name} unreachable")
+                with self.subTest("Location should be reached", location=location.name):
+                    reachable = location.can_reach(state)
+                    self.assertTrue(reachable, f"{location.name} unreachable")
             with self.subTest("Beatable"):
                 self.multiworld.state = state
                 self.assertBeatable(True)

--- a/test/general/test_reachability.py
+++ b/test/general/test_reachability.py
@@ -37,12 +37,10 @@ class TestBase(unittest.TestCase):
             unreachable_regions = self.default_settings_unreachable_regions.get(game_name, set())
             with self.subTest("Game", game=game_name):
                 multiworld = setup_solo_multiworld(world_type)
-                excluded = multiworld.worlds[1].options.exclude_locations.value
                 state = multiworld.get_all_state(False)
                 for location in multiworld.get_locations():
-                    if location.name not in excluded:
-                        with self.subTest("Location should be reached", location=location.name):
-                            self.assertTrue(location.can_reach(state), f"{location.name} unreachable")
+                    with self.subTest("Location should be reached", location=location.name):
+                        self.assertTrue(location.can_reach(state), f"{location.name} unreachable")
 
                 for region in multiworld.get_regions():
                     if region.name in unreachable_regions:


### PR DESCRIPTION
## What is this fixing or adding?

Changes full/locations accessibility and all_state_can_reach_everything tests to require excluded locations to still be reachable.

## How was this tested?

Unit tests and a generations with every game with default options except for DKC3.