### PR TITLE
Core: Remove call to inaccessible_location_rules

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -521,8 +521,6 @@ def distribute_items_restrictive(multiworld: MultiWorld,
             location.locked = True
     del mark_for_locking, lock_later
 
-    inaccessible_location_rules(multiworld, multiworld.state, defaultlocations)
-
     remaining_fill(multiworld, excludedlocations, filleritempool, "Remaining Excluded",
                    move_unplaceable_to_start_inventory=panic_method=="start_inventory")
 


### PR DESCRIPTION
## What is this fixing or adding?

This function was being called but never did anything.

## How was this tested?

Checking that generations before and after the change were the same. Specifically checked every world with `items` accessibility and generating with multiple Witness players where one was on `minimal` accessibility.