### PR TITLE
Core: apworld metadata and versioning

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -466,6 +466,14 @@ def roll_settings(weights: dict, plando_options: PlandoOptions = PlandoOptions.b
             if required_plando_options:
                 raise Exception(f"Settings reports required plando module {str(required_plando_options)}, "
                                 f"which is not enabled.")
+        games = requirements.get("game", {})
+        for game, version in games.items():
+            if game not in AutoWorldRegister.world_types:
+                raise Exception(f"Settings reports required world \"{game}\", which is not present")
+            if tuplize_version(version) > AutoWorldRegister.world_types[game].world_version:
+                raise Exception(f"Settings reports required version of world \"{game}\" is at least {version}, "
+                                f"however world is of version "
+                                f"{AutoWorldRegister.world_types[game].world_version.as_simple_string()}")
 
     ret = argparse.Namespace()
     for option_key in Options.PerGameCommonOptions.type_hints:

--- a/Utils.py
+++ b/Utils.py
@@ -34,16 +34,21 @@ if typing.TYPE_CHECKING:
 
 
 def tuplize_version(version: str) -> Version:
-    return Version(*(int(piece, 10) for piece in version.split(".")))
+    if "-" in version:
+        version, tag = version.rsplit("-")
+    else:
+        tag = ""
+    return Version(*(int(piece, 10) for piece in version.split(".")), tag)
 
 
 class Version(typing.NamedTuple):
     major: int
     minor: int
     build: int
+    tag: str = ""
 
     def as_simple_string(self) -> str:
-        return ".".join(str(item) for item in self)
+        return f"{self.major}.{self.minor}.{self.build}{f'-{self.tag}' if self.tag else ''}"
 
 
 __version__ = "0.5.0"

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -7,11 +7,13 @@ import sys
 import time
 from random import Random
 from dataclasses import make_dataclass
+from copy import deepcopy
 from typing import (Any, Callable, ClassVar, Dict, FrozenSet, List, Mapping, Optional, Set, TextIO, Tuple,
                     TYPE_CHECKING, Type, Union)
 
 from Options import item_and_loc_options, OptionGroup, PerGameCommonOptions
 from BaseClasses import CollectionState
+from Utils import Version, version_tuple
 
 if TYPE_CHECKING:
     from BaseClasses import MultiWorld, Item, Location, Tutorial, Region, Entrance
@@ -272,6 +274,25 @@ class World(metaclass=AutoWorldRegister):
 
     location_name_groups: ClassVar[Dict[str, Set[str]]] = {}
     """maps location group names to sets of locations. Example: {"Sewer": {"Sewer Key Drop 1", "Sewer Key Drop 2"}}"""
+
+    world_version: ClassVar[Version] = Version(0, 0, 0)
+    """
+    Increment this every time you make a new release. Used for confirming yaml validity (for now).
+    
+    Of the form:
+    Major.Minor.Patch-Tag
+    """
+
+    min_generator_version: ClassVar[Version] = deepcopy(version_tuple)
+    """
+    The minimum generator version of Archipelago required for this world to function.
+    """
+
+    max_generator_version: ClassVar[Optional[Version]] = None
+    """
+    The maximum generator version of Archipelago allowed to import this world. Intended for known breakages across
+    generator versions.
+    """
 
     required_client_version: Tuple[int, int, int] = (0, 1, 6)
     """

--- a/worlds/ExportWorld.py
+++ b/worlds/ExportWorld.py
@@ -70,8 +70,10 @@ def export_world(libfolder, world_type, output_dir, is_frozen):
                          compresslevel=9) as zf:
         for path in world_directory.rglob("*.*"):
             relative_path = os.path.join(*path.parts[path.parts.index("worlds") + 1:])
+            if any(part.startswith(".") or part == "__pycache__" for part in Path(relative_path).parts):
+                continue
             zf.write(path, relative_path)
-        zf.writestr("metadata.json", json.dumps(metadata, indent=4))
+        zf.writestr(os.path.join(world_key, "metadata.json"), json.dumps(metadata, indent=4))
         zf.close()
     return output_name
 

--- a/worlds/ExportWorld.py
+++ b/worlds/ExportWorld.py
@@ -1,0 +1,89 @@
+# TODO: handle data
+# TODO: handle clients
+# TODO: handle yaml templates
+import argparse
+import json
+import os.path
+import platform
+import sys
+import zipfile
+from pathlib import Path
+
+if __name__ == "__main__":
+    sys.path.remove(os.path.dirname(__file__))
+    ap_root = os.path.normpath(os.path.join(os.path.dirname(__file__), os.pardir))
+    os.chdir(ap_root)
+    sys.path.append(ap_root)
+
+from worlds.AutoWorld import AutoWorldRegister, World
+
+METADATA_KEYS = [
+    "game",
+    # license
+    # description
+    # maintainers
+]
+
+VERSION_KEYS = [
+    "world_version",
+    "min_generator_version",
+    "max_generator_version",
+]
+
+
+def create_world_meta(world_key, world_type, is_frozen):
+    metadata = {}
+    for key in METADATA_KEYS:
+        if getattr(world_type, key, None):  # avoid writing optional keys if they aren't set
+            metadata[key] = getattr(world_type, key)
+    for key in VERSION_KEYS:
+        if getattr(world_type, key, None):  # avoid writing optional keys if they aren't set
+            metadata[key] = getattr(world_type, key).as_simple_string()
+    if world_type.__doc__ != World.__doc__:
+        metadata["description"] = world_type.__doc__.strip()
+    metadata["game_id"] = world_key
+    metadata["frozen"] = is_frozen
+    if is_frozen:
+        metadata["arch"] = platform.machine()
+        metadata["os"] = platform.system()  # TODO: linux
+        metadata["pyversion"] = f"{sys.version_info[0]}.{sys.version_info[1]}"
+    else:
+        metadata["arch"] = "any"
+        metadata["os"] = "any"
+        metadata["pyversion"] = "any"
+    return metadata
+
+
+def export_world(libfolder, world_type, output_dir, is_frozen):
+    world_key = os.path.split(os.path.dirname(world_type.__file__))[1]
+    world_directory = libfolder / "worlds" / world_key
+
+    metadata = create_world_meta(world_key, world_type, is_frozen)
+
+    arch = metadata["arch"]
+    os_type = metadata["os"]
+    base_file_name = f"{world_key}-{arch}-{os_type}-py{metadata['pyversion']}-{metadata['world_version']}"
+    world_file_name = f"{base_file_name}.apworld"
+
+    output_name = output_dir / world_file_name
+    with zipfile.ZipFile(output_name, "x", zipfile.ZIP_DEFLATED,
+                         compresslevel=9) as zf:
+        for path in world_directory.rglob("*.*"):
+            relative_path = os.path.join(*path.parts[path.parts.index("worlds") + 1:])
+            zf.write(path, relative_path)
+        zf.writestr("metadata.json", json.dumps(metadata, indent=4))
+        zf.close()
+    return output_name
+
+
+if __name__ == "__main__":
+    ap_root_path = Path(ap_root)
+
+    parser = argparse.ArgumentParser("simple_example")
+    parser.add_argument("world_name", help="World to be exported.", type=str)
+    parser.add_argument("output_dir", help="Export directory.", type=Path, default=ap_root_path / "worlds", nargs='?')
+    args = parser.parse_args()
+
+    output = export_world(ap_root_path, AutoWorldRegister.world_types[args.world_name], args.output_dir,
+                          is_frozen=False)
+    print(f"Output to {output}")

--- a/worlds/ExportWorld.py
+++ b/worlds/ExportWorld.py
@@ -62,8 +62,17 @@ def export_world(libfolder, world_type, output_dir, is_frozen):
 
     arch = metadata["arch"]
     os_type = metadata["os"]
-    base_file_name = f"{world_key}-{arch}-{os_type}-py{metadata['pyversion']}-{metadata['world_version']}"
-    world_file_name = f"{base_file_name}.apworld"
+    base_file_name = f"{world_key}"
+    parts = [base_file_name]
+    if arch != "any":
+        parts.append(arch)
+    if os_type != "any":
+        parts.append(os_type)
+    if metadata['pyversion'] != "any":
+        parts.append(f"py{metadata['pyversion']}")
+    if metadata["world_version"] != "0.0.0":
+        parts.append(metadata["world_version"])
+    world_file_name = f"{'-'.join(parts)}.apworld"
 
     output_name = output_dir / world_file_name
     with zipfile.ZipFile(output_name, "x", zipfile.ZIP_DEFLATED,

--- a/worlds/__init__.py
+++ b/worlds/__init__.py
@@ -33,7 +33,7 @@ __all__ = {
 }
 
 
-failed_world_loads: List[Tuple[str, str]] = []
+failed_world_loads: List[str] = []
 
 
 class GamesPackage(TypedDict, total=False):
@@ -133,7 +133,7 @@ class WorldSource:
             traceback.print_exc(file=file_like)
             file_like.seek(0)
             logging.exception(file_like.read())
-            failed_world_loads.append((os.path.basename(self.path).rsplit(".", 1)[0], traceback.format_exc()))
+            failed_world_loads.append(os.path.basename(self.path).rsplit(".", 1)[0])
             return False
 
 

--- a/worlds/__init__.py
+++ b/worlds/__init__.py
@@ -93,16 +93,16 @@ class WorldSource:
             start = time.perf_counter()
             if self.is_zip:
                 with zipfile.ZipFile(self.resolved_path) as zf:
-                    if zipfile.Path(zf, "metadata.json").exists():
-                        manifest = json.loads(zf.read("metadata.json"))
+                    if zipfile.Path(zf, os.path.join(self.path, "metadata.json")).exists():
+                        manifest = json.loads(zf.read(os.path.join(self.path, "metadata.json")))
                         self.check_manifest(manifest)
                 importer = zipimport.zipimporter(self.resolved_path)
                 if hasattr(importer, "find_spec"):  # new in Python 3.10
-                    spec = importer.find_spec(os.path.basename(self.path).rsplit(".", 1)[0])
+                    spec = importer.find_spec(os.path.basename(self.path).rsplit(".", 1)[0].split('-', 1)[0])
                     assert spec, f"{self.path} is not a loadable module"
                     mod = importlib.util.module_from_spec(spec)
                 else:  # TODO: remove with 3.8 support
-                    mod = importer.load_module(os.path.basename(self.path).rsplit(".", 1)[0])
+                    mod = importer.load_module(os.path.basename(self.path).rsplit(".", 1)[0].split('-', 1)[0])
 
                 if mod.__package__ is not None:
                     mod.__package__ = f"worlds.{mod.__package__}"


### PR DESCRIPTION
## What is this fixing or adding?
Adds the ability to include an optional metadata file that defines specific information about a given apworld. These include
* world version
* minimum generator version
* maximum generator version
* architecture/os/python version

Additionally, exposes the ability to require a certain world version from within a player yaml.

It should be noted that the ExportWorld.py is used (with permission) from @zig-for 's [apworld manager](https://github.com/zig-for/Archipelago/tree/zig/apworld_manager) with minor changes.

## How was this tested?
Manually, via attempting to reach every codepath with customized metadata/yaml. No automated testing was added.

Opening as draft for additional testing and other missed locations (such as docs updates).

Some points of discussion:
* Should more be included on the world metadata immediately, such as authors/maintainers?
* Should ExportWorld be used within setup.py, and should it be moved to being a base-level script? (Notably, this fixes LADX compatibility)
* Defaults for `min_generator_version` and `max_generator_version`

## If this makes graphical changes, please attach screenshots.
Example metadata:
```
{
    "game": "Mega Man 2",
    "world_version": "0.3.1",
    "min_generator_version": "0.5.0",
    "description": "In the year 200X, following his prior defeat by Mega Man, the evil Dr. Wily has returned to take over the world with\n    his own group of Robot Masters. Mega Man once again sets out to defeat the eight Robot Masters and stop Dr. Wily.",
    "game_id": "mm2",
    "frozen": false,
    "arch": "any",
    "os": "any",
    "pyversion": "any"
}
```