### PR TITLE
Core: Fix incorrect default state checked in MultiWorld.can_beat_game

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -541,9 +541,9 @@ class MultiWorld():
                 return True
             state = starting_state.copy()
         else:
-            if self.has_beaten_game(self.state):
-                return True
             state = CollectionState(self)
+            if self.has_beaten_game(state):
+                return True
         prog_locations = {location for location in self.get_locations() if location.item
                           and location.item.advancement and location not in state.locations_checked}
 


### PR DESCRIPTION
## What is this fixing or adding?

`MultiWorld.can_beat_game()` with no arguments would initially check if `self.state` is beatable, but then would create an empty state, `state = CollectionState(self)`, to sweep spheres from to determine if the game is beatable. The issue was that `self.state` and the new empty state could be different.

Currently, it seems that everywhere in Archipelago's codebase that calls `MultiWorld.can_beat_game()` with no arguments or `starting_state=None` has a `self.state` that only contains precollected items, so the new empty state happens to result in an equivalent state, but this should not be relied upon to always be the case.

This patch changes `can_beat_game()` to initially check if the new empty state is beatable instead of `self.state`.

This appears to be a bug introduced way back in 27b6dd8bd761

Fixes #3742

This has been separated from #3688 to be PR-ed as a separate, simpler fix.

## How was this tested?

The same seeds were generated before and after using template yamls of games known to be deterministic and then compared.
