### PR TITLE
DS3: Update link to DS3 AP client

### DIFF
--- a/worlds/dark_souls_3/docs/setup_en.md
+++ b/worlds/dark_souls_3/docs/setup_en.md
@@ -3,7 +3,7 @@
 ## Required Software
 
 - [Dark Souls III](https://store.steampowered.com/app/374320/DARK_SOULS_III/)
-- [Dark Souls III AP Client](https://github.com/Marechal-L/Dark-Souls-III-Archipelago-client/releases)
+- [Dark Souls III AP Client](https://github.com/nex3/Dark-Souls-III-Archipelago-client/releases)
 
 ## Optional Software
 


### PR DESCRIPTION
## What is this fixing or adding?
Setup guide had the wrong link here. The link currently in the setup guide leads to the old version, which does not appear to be compatible with 3.0.0.

## How was this tested?
Clicking the link.

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/user-attachments/assets/b0b42f9f-0032-484d-b62c-108e34e33025)
