### PR TITLE
The Witness: Ban Excluded Panels from Panel Hunt

### DIFF
--- a/worlds/witness/__init__.py
+++ b/worlds/witness/__init__.py
@@ -90,7 +90,7 @@ class WitnessWorld(World):
             "laser_ids_to_hints": self.laser_ids_to_hints,
             "progressive_item_lists": self.player_items.get_progressive_item_ids_in_pool(),
             "obelisk_side_id_to_EPs": static_witness_logic.OBELISK_SIDE_ID_TO_EP_HEXES,
-            "precompleted_puzzles": [int(h, 16) for h in self.player_logic.EXCLUDED_LOCATIONS],
+            "precompleted_puzzles": [int(h, 16) for h in self.player_logic.EXCLUDED_ENTITIES],
             "entity_to_name": static_witness_logic.ENTITY_ID_TO_NAME,
             "panel_hunt_required_absolute": self.panel_hunt_required_count
         }

--- a/worlds/witness/entity_hunt.py
+++ b/worlds/witness/entity_hunt.py
@@ -77,7 +77,7 @@ class EntityHuntPicker:
 
         return (
             self.player_logic.solvability_guaranteed(panel_hex)
-            and panel_hex not in self.player_logic.PRECOMPLETED_LOCATIONS
+            and panel_hex not in self.player_logic.EXCLUDED_ENTITIES
             and not (
                 # Due to an edge case, Discards have to be on in disable_non_randomized even if Discard Shuffle is off.
                 # However, I don't think they should be hunt panels in this case.

--- a/worlds/witness/entity_hunt.py
+++ b/worlds/witness/entity_hunt.py
@@ -77,6 +77,7 @@ class EntityHuntPicker:
 
         return (
             self.player_logic.solvability_guaranteed(panel_hex)
+            and panel_hex not in self.player_logic.PRECOMPLETED_LOCATIONS
             and not (
                 # Due to an edge case, Discards have to be on in disable_non_randomized even if Discard Shuffle is off.
                 # However, I don't think they should be hunt panels in this case.

--- a/worlds/witness/locations.py
+++ b/worlds/witness/locations.py
@@ -44,7 +44,7 @@ class WitnessPlayerLocations:
 
         self.CHECK_LOCATIONS = self.CHECK_LOCATIONS - {
             static_witness_logic.ENTITIES_BY_HEX[entity_hex]["checkName"]
-            for entity_hex in player_logic.COMPLETELY_DISABLED_ENTITIES | player_logic.PRECOMPLETED_LOCATIONS
+            for entity_hex in player_logic.COMPLETELY_DISABLED_ENTITIES
         }
 
         self.CHECK_PANELHEX_TO_ID = {

--- a/worlds/witness/player_logic.py
+++ b/worlds/witness/player_logic.py
@@ -108,7 +108,6 @@ class WitnessPlayerLogic:
         self.EVENT_ITEM_PAIRS: Dict[str, Tuple[str, str]] = {}
         self.COMPLETELY_DISABLED_ENTITIES: Set[str] = set()
         self.DISABLE_EVERYTHING_BEHIND: Set[str] = set()
-        self.PRECOMPLETED_LOCATIONS: Set[str] = set()
         self.EXCLUDED_ENTITIES: Set[str] = set()
         self.ADDED_CHECKS: Set[str] = set()
         self.VICTORY_LOCATION = "0x0356B"

--- a/worlds/witness/player_logic.py
+++ b/worlds/witness/player_logic.py
@@ -109,7 +109,7 @@ class WitnessPlayerLogic:
         self.COMPLETELY_DISABLED_ENTITIES: Set[str] = set()
         self.DISABLE_EVERYTHING_BEHIND: Set[str] = set()
         self.PRECOMPLETED_LOCATIONS: Set[str] = set()
-        self.EXCLUDED_LOCATIONS: Set[str] = set()
+        self.EXCLUDED_ENTITIES: Set[str] = set()
         self.ADDED_CHECKS: Set[str] = set()
         self.VICTORY_LOCATION = "0x0356B"
 
@@ -659,7 +659,7 @@ class WitnessPlayerLogic:
                 self.COMPLETELY_DISABLED_ENTITIES.add(loc_obj["entity_hex"])
 
             elif loc_obj["entityType"] == "Panel":
-                self.EXCLUDED_LOCATIONS.add(loc_obj["entity_hex"])
+                self.EXCLUDED_ENTITIES.add(loc_obj["entity_hex"])
 
         for adjustment_lineset in adjustment_linesets_in_order:
             current_adjustment_type = None


### PR DESCRIPTION
This one just kinda slipped my mind

(This won't "take care of panel sets" automatically, but that's just something I'm not currently supporting generation-side in general. The user *can* exclude every panel in a set individually and that will work.)

Also renames one of the variables to be more precise

Also removes an unused field