### PR TITLE
Launcher: Allow importing an apworld from a zip file

### DIFF
--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -87,7 +87,10 @@ def _install_apworld(apworld_src: str = "") -> Optional[Tuple[pathlib.Path, path
     import tempfile, zipfile, shutil
 
     if not apworld_src:
-        apworld_src = open_filename('Select APWorld file to install', (('APWorld', ('.apworld', '.zip')),))
+        apworld_src = open_filename(
+            'Select APWorld file to install',
+            (('APWorld', ('.apworld', '.zip')),),
+        )
         if not apworld_src:
             # user closed menu
             return
@@ -99,11 +102,13 @@ def _install_apworld(apworld_src: str = "") -> Optional[Tuple[pathlib.Path, path
             temp = pathlib.Path(tempfile.mkdtemp(prefix="apworld"))
 
             archive = zipfile.ZipFile(apworld_path)
-            archive_apworld = next(
-                n for n in archive.namelist() if n.endswith(".apworld")
-            )
-            archive.extract(archive_apworld, path=temp)
-            return _install_apworld(temp / archive_apworld)
+            try:
+                archive_apworld = next(n for n in archive.namelist() if n.endswith(".apworld"))
+                archive.extract(archive_apworld, path=temp)
+                return _install_apworld(temp / archive_apworld)
+
+            except StopIteration:
+                raise Exception(f"{apworld_path} does not contain any .apworld files")
 
         finally:
             shutil.rmtree(temp, ignore_errors=True)

--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -84,20 +84,35 @@ def launch_textclient():
 
 
 def _install_apworld(apworld_src: str = "") -> Optional[Tuple[pathlib.Path, pathlib.Path]]:
+    import tempfile, zipfile, shutil
+
     if not apworld_src:
-        apworld_src = open_filename('Select APWorld file to install', (('APWorld', ('.apworld',)),))
+        apworld_src = open_filename('Select APWorld file to install', (('APWorld', ('.apworld', '.zip')),))
         if not apworld_src:
             # user closed menu
             return
 
-    if not apworld_src.endswith(".apworld"):
-        raise Exception(f"Wrong file format, looking for .apworld. File identified: {apworld_src}")
-
     apworld_path = pathlib.Path(apworld_src)
+
+    if apworld_path.suffix == ".zip":
+        try:
+            temp = pathlib.Path(tempfile.mkdtemp(prefix="apworld"))
+
+            archive = zipfile.ZipFile(apworld_path)
+            archive_apworld = next(
+                n for n in archive.namelist() if n.endswith(".apworld")
+            )
+            archive.extract(archive_apworld, path=temp)
+            return _install_apworld(temp / archive_apworld)
+
+        finally:
+            shutil.rmtree(temp, ignore_errors=True)
+
+    elif apworld_path.suffix != ".apworld":
+        raise Exception(f"Wrong file format, looking for .apworld. File identified: {apworld_src}")
 
     module_name = pathlib.Path(apworld_path.name).stem
     try:
-        import zipfile
         zipfile.ZipFile(apworld_path).open(module_name + "/__init__.py")
     except ValueError as e:
         raise Exception("Archive appears invalid or damaged.") from e
@@ -118,7 +133,6 @@ def _install_apworld(apworld_src: str = "") -> Optional[Tuple[pathlib.Path, path
     # TODO: have some kind of version system to tell from metadata if the apworld should be compatible.
 
     target = pathlib.Path(worlds.user_folder) / apworld_path.name
-    import shutil
     shutil.copyfile(apworld_path, target)
 
     # If a module with this name is already loaded, then we can't load it now.


### PR DESCRIPTION
## What is this fixing or adding?

Allow importing an APWorld that is in a zip file. This way you don't have to manually extract the APWorld from other releases.

## How was this tested?

I downloaded and directly imported [metroidprime_apworld-v0.3.2.zip](https://github.com/Electro1512/MetroidAPrime/releases/tag/v0.3.2)

## If this makes graphical changes, please attach screenshots.

![image](https://github.com/user-attachments/assets/3829b9cd-38d4-46cc-adc4-bf8adfa7dde7)
![image](https://github.com/user-attachments/assets/a14f3e35-679a-47df-8e1f-8763b75990aa)
![image](https://github.com/user-attachments/assets/827d8df7-e1d5-4d23-b002-a55ef10f0e5a)
