### PR TITLE
Kvui: assert kivy is not imported before kvui

### DIFF
--- a/kvui.py
+++ b/kvui.py
@@ -5,6 +5,9 @@ import typing
 import re
 from collections import deque
 
+if __debug__:
+    assert "kivy" not in sys.modules, "kvui should be imported before kivy for frozen compatibility"
+
 if sys.platform == "win32":
     import ctypes
 

--- a/kvui.py
+++ b/kvui.py
@@ -5,8 +5,7 @@ import typing
 import re
 from collections import deque
 
-if __debug__:
-    assert "kivy" not in sys.modules, "kvui should be imported before kivy for frozen compatibility"
+assert "kivy" not in sys.modules, "kvui should be imported before kivy for frozen compatibility"
 
 if sys.platform == "win32":
     import ctypes


### PR DESCRIPTION
## What is this fixing or adding?
Because kivy needs `KIVY_DATA_DIR` to be redirected to the appropriate folder in the frozen install, importing kivy directly before kvui can cause crashes on some machines using the frozen install. This adds an assert to make sure this workflow gets caught in dev.

relevant issue: https://discord.com/channels/731205301247803413/1261299992564469780

## How was this tested?
did the same `from kivy.metrics import dp` import manual was doing that was causing the crash, it got caught on source
also ran without changes and the error did not trigger,
did not test on source but i can't imagine it does anything because __debug__ should be false

## If this makes graphical changes, please attach screenshots.
