### PR TITLE
TUNIC: Add note about plando items to ER hint-creation failure error message

### DIFF
--- a/worlds/tunic/__init__.py
+++ b/worlds/tunic/__init__.py
@@ -339,7 +339,8 @@ class TunicWorld(World):
                 except KeyError:
                     # logic bug, proceed with warning since it takes a long time to update AP
                     warning(f"{location.name} is not logically accessible for {self.player_name}. "
-                            "Creating entrance hint Inaccessible. Please report this to the TUNIC rando devs.")
+                            "Creating entrance hint Inaccessible. Please report this to the TUNIC rando devs. "
+                            "If you are using Plando Items (excluding early locations), then this is likely the cause.")
                     hint_text = "Inaccessible"
                 else:
                     while connection != ("Menu", None):

--- a/worlds/tunic/options.py
+++ b/worlds/tunic/options.py
@@ -128,6 +128,8 @@ class EntranceRando(TextChoice):
     
     If you set this option's value to a string, it will be used as a custom seed.
     Every player who uses the same custom seed will have the same entrances, choosing the most restrictive settings among these players for the purpose of pairing entrances.
+
+    Note: Entrance Rando does not play nicely with Plando Items. Use them at your own risk.
     """
     internal_name = "entrance_rando"
     display_name = "Entrance Rando"

--- a/worlds/tunic/options.py
+++ b/worlds/tunic/options.py
@@ -128,8 +128,6 @@ class EntranceRando(TextChoice):
     
     If you set this option's value to a string, it will be used as a custom seed.
     Every player who uses the same custom seed will have the same entrances, choosing the most restrictive settings among these players for the purpose of pairing entrances.
-
-    Note: Entrance Rando does not play nicely with Plando Items. Use them at your own risk.
     """
     internal_name = "entrance_rando"
     display_name = "Entrance Rando"


### PR DESCRIPTION
## What is this fixing or adding?
Adding a note about plando items not playing nicely with entrance rando.

Plando happens after entrance rando pairs portals, so it can sometimes lead to inaccessible locations. Because it happens after entrance rando, I can't make entrance rando deal with item plando properly.

If there was a way to tell where an item would be placed before entrance rando happens, or of items were only allowed to be placed with logic with plando items, then it would be a lot better.

Since we're not allowed to modify regions and such after create_items, the only real solution here would be to disconnect and reconnect entrances during pre_fill, which would be an absolute mess and make this pretty difficult to maintain.

## How was this tested?
Reading

## If this makes graphical changes, please attach screenshots.
N/A