### PR TITLE
Yacht Dice: setup: change release-link to latest

### DIFF
--- a/worlds/yachtdice/docs/setup_en.md
+++ b/worlds/yachtdice/docs/setup_en.md
@@ -7,7 +7,7 @@
 
 ## Playing the game
 Open the Yacht Dice website. There are two options:
-- Download the latest release from [Yacht Dice Releases](https://github.com/spinerak/ArchipelagoYachtDice/releases) and unzip the Website.zip. Then open player.html in your browser. 
+- Download the latest release from [Yacht Dice Release](https://github.com/spinerak/ArchipelagoYachtDice/releases/latest) and unzip the Website.zip. Then open player.html in your browser. 
 - Cruise over to the [Yacht Dice website](https://yacht-dice-ap.netlify.app/). This also works on mobile. If the website is not available, use the first option.
 
 Both options have an "offline" play option to try out the game without having to generate a game first.


### PR DESCRIPTION
On the installation page, link to the latest release, instead of the page with all releases