### PR TITLE
LADX: enable deathlink

### DIFF
--- a/LinksAwakeningClient.py
+++ b/LinksAwakeningClient.py
@@ -534,7 +534,7 @@ class LinksAwakeningContext(CommonContext):
                 "data": {
                     "time": self.last_death_link,
                     "source": self.slot_info[self.slot].name,
-                    "cause": self.slot_info[self.slot].name + " had a nightmare"
+                    "cause": self.slot_info[self.slot].name + " had a nightmare."
                 }
             }])
 

--- a/LinksAwakeningClient.py
+++ b/LinksAwakeningClient.py
@@ -455,7 +455,7 @@ class LinksAwakeningCommandProcessor(ClientCommandProcessor):
     def _cmd_deathlink(self):
         """Toggles deathlink."""
         if isinstance(self.ctx, LinksAwakeningContext):
-            Utils.async_start(self.ctx.update_death_link(!("DeathLink" in self.tags)))
+            Utils.async_start(self.ctx.update_death_link("DeathLink" not in self.tags))
 
     def _cmd_check_tags(self):
         """Prints current tags."""

--- a/LinksAwakeningClient.py
+++ b/LinksAwakeningClient.py
@@ -546,9 +546,9 @@ class LinksAwakeningContext(CommonContext):
             await self.send_msgs(message)
             self.won = True
 
-    async def on_deathlink(self, data: typing.Dict[str, typing.Any]) -> None:
+    def on_deathlink(self, data: typing.Dict[str, typing.Any]) -> None:
         self.client.pending_deathlink = True
-        await super(LinksAwakeningContext, self).on_deathlink(data)
+        super(LinksAwakeningContext, self).on_deathlink(data)
 
 
     def new_checks(self, item_ids, ladxr_ids):

--- a/LinksAwakeningClient.py
+++ b/LinksAwakeningClient.py
@@ -517,15 +517,17 @@ class LinksAwakeningContext(CommonContext):
         self.disconnected_intentionally = True
         CommonContext.event_invalid_slot(self)
 
-    enable_deathlink = False
     async def send_deathlink(self):
-        if self.enable_deathlink:
-            message = [{"cmd": 'Deathlink',
-                        'time': time.time(),
-                        'cause': 'Had a nightmare',
-                        # 'source': self.slot_info[self.slot].name,
-                        }]
-            await self.send_msgs(message)
+        if "DeathLink" in self.tags:
+            await self.send_msgs([{
+                "cmd": "Bounce",
+                "tags": ["Deathlink"],
+                "data": {
+                    "time": time.time(),
+                    "source": self.slot_info[self.slot].name,
+                    "cause": self.slot_info[self.slot].name + " had a nightmare",
+                }
+            }])
 
     async def send_victory(self):
         if not self.won:
@@ -536,7 +538,7 @@ class LinksAwakeningContext(CommonContext):
             self.won = True
 
     async def on_deathlink(self, data: typing.Dict[str, typing.Any]) -> None:
-        if self.enable_deathlink:
+        if "DeathLink" in self.tags:
             self.client.pending_deathlink = True
 
     def new_checks(self, item_ids, ladxr_ids):
@@ -565,7 +567,7 @@ class LinksAwakeningContext(CommonContext):
         if cmd == "Connected":
             self.game = self.slot_info[self.slot].game
             if 'death_link' in args['slot_data'] and args['slot_data']['death_link']:
-                self.enable_deathlink = true
+                self.update_death_link(true)
         # TODO - use watcher_event
         if cmd == "ReceivedItems":
             for index, item in enumerate(args["items"], start=args["index"]):

--- a/LinksAwakeningClient.py
+++ b/LinksAwakeningClient.py
@@ -418,7 +418,6 @@ class LinksAwakeningClient():
             self.deathlink_debounce = True
 
         if self.pending_deathlink:
-            logger.info("Got a deathlink")
             self.gameboy.write_memory(LAClientConstants.wLinkHealth, [0])
             self.pending_deathlink = False
             self.deathlink_debounce = True
@@ -529,10 +528,11 @@ class LinksAwakeningContext(CommonContext):
     async def send_deathlink(self):
         if "DeathLink" in self.tags:
             logger.info("DeathLink: Sending death to your friends...")
+            self.last_death_link = time.time()
             await self.send_msgs([{
                 "cmd": "Bounce", "tags": ["DeathLink"],
                 "data": {
-                    "time": time.time(),
+                    "time": self.last_death_link,
                     "source": self.slot_info[self.slot].name,
                     "cause": self.slot_info[self.slot].name + " had a nightmare"
                 }

--- a/LinksAwakeningClient.py
+++ b/LinksAwakeningClient.py
@@ -455,11 +455,11 @@ class LinksAwakeningCommandProcessor(ClientCommandProcessor):
     def _cmd_deathlink(self):
         """Toggles deathlink."""
         if isinstance(self.ctx, LinksAwakeningContext):
-            Utils.async_start(self.ctx.update_death_link("DeathLink" not in self.tags))
+            Utils.async_start(self.ctx.update_death_link("DeathLink" not in self.ctx.tags))
 
     def _cmd_check_tags(self):
         """Prints current tags."""
-        logger.info(f"Tags: {self.tags}")
+        logger.info(f"Tags: {self.ctx.tags}")
 
 class LinksAwakeningContext(CommonContext):
     tags = {"AP"}

--- a/LinksAwakeningClient.py
+++ b/LinksAwakeningClient.py
@@ -457,10 +457,6 @@ class LinksAwakeningCommandProcessor(ClientCommandProcessor):
         if isinstance(self.ctx, LinksAwakeningContext):
             Utils.async_start(self.ctx.update_death_link("DeathLink" not in self.ctx.tags))
 
-    def _cmd_check_tags(self):
-        """Prints current tags."""
-        logger.info(f"Tags: {self.ctx.tags}")
-
 class LinksAwakeningContext(CommonContext):
     tags = {"AP"}
     game = "Links Awakening DX"
@@ -551,8 +547,9 @@ class LinksAwakeningContext(CommonContext):
             self.won = True
 
     async def on_deathlink(self, data: typing.Dict[str, typing.Any]) -> None:
-        if "DeathLink" in self.tags:
-            self.client.pending_deathlink = True
+        self.client.pending_deathlink = True
+        super(LinksAwakeningContext, self).on_deathlink(data)
+
 
     def new_checks(self, item_ids, ladxr_ids):
         self.found_checks += item_ids

--- a/LinksAwakeningClient.py
+++ b/LinksAwakeningClient.py
@@ -517,9 +517,9 @@ class LinksAwakeningContext(CommonContext):
         self.disconnected_intentionally = True
         CommonContext.event_invalid_slot(self)
 
-    ENABLE_DEATHLINK = False
+    enable_deathlink = False
     async def send_deathlink(self):
-        if self.ENABLE_DEATHLINK:
+        if self.enable_deathlink:
             message = [{"cmd": 'Deathlink',
                         'time': time.time(),
                         'cause': 'Had a nightmare',
@@ -536,7 +536,7 @@ class LinksAwakeningContext(CommonContext):
             self.won = True
 
     async def on_deathlink(self, data: typing.Dict[str, typing.Any]) -> None:
-        if self.ENABLE_DEATHLINK:
+        if self.enable_deathlink:
             self.client.pending_deathlink = True
 
     def new_checks(self, item_ids, ladxr_ids):
@@ -564,6 +564,8 @@ class LinksAwakeningContext(CommonContext):
     def on_package(self, cmd: str, args: dict):
         if cmd == "Connected":
             self.game = self.slot_info[self.slot].game
+            if 'death_link' in args['slot_data'] and args['slot_data']['death_link']:
+                self.enable_deathlink = true
         # TODO - use watcher_event
         if cmd == "ReceivedItems":
             for index, item in enumerate(args["items"], start=args["index"]):

--- a/LinksAwakeningClient.py
+++ b/LinksAwakeningClient.py
@@ -519,13 +519,13 @@ class LinksAwakeningContext(CommonContext):
 
     async def send_deathlink(self):
         if "DeathLink" in self.tags:
+            loggerin.info("DeathLink: Sending death to your friends...")
             await self.send_msgs([{
-                "cmd": "Bounce",
-                "tags": ["Deathlink"],
+                "cmd": "Bounce", "tags": ["DeathLink"],
                 "data": {
                     "time": time.time(),
                     "source": self.slot_info[self.slot].name,
-                    "cause": self.slot_info[self.slot].name + " had a nightmare",
+                    "cause": self.slot_info[self.slot].name + " had a nightmare"
                 }
             }])
 

--- a/LinksAwakeningClient.py
+++ b/LinksAwakeningClient.py
@@ -548,7 +548,7 @@ class LinksAwakeningContext(CommonContext):
 
     async def on_deathlink(self, data: typing.Dict[str, typing.Any]) -> None:
         self.client.pending_deathlink = True
-        super(LinksAwakeningContext, self).on_deathlink(data)
+        await super(LinksAwakeningContext, self).on_deathlink(data)
 
 
     def new_checks(self, item_ids, ladxr_ids):

--- a/worlds/ladx/Options.py
+++ b/worlds/ladx/Options.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import os.path
 import typing
 import logging
-from Options import Choice, Toggle, DefaultOnToggle, Range, FreeText, PerGameCommonOptions, OptionGroup
+from Options import Choice, Toggle, DefaultOnToggle, Range, FreeText, PerGameCommonOptions, OptionGroup, DeathLink
 from collections import defaultdict
 import Utils
 
@@ -523,7 +523,8 @@ ladx_option_groups = [
         Rooster,
         TrendyGame,
         NagMessages,
-        BootsControls
+        BootsControls,
+        DeathLink
     ]),
     OptionGroup("Experimental", [
         DungeonShuffle,
@@ -579,3 +580,4 @@ class LinksAwakeningOptions(PerGameCommonOptions):
     nag_messages: NagMessages
     ap_title_screen: APTitleScreen
     boots_controls: BootsControls
+    death_link: DeathLink

--- a/worlds/ladx/__init__.py
+++ b/worlds/ladx/__init__.py
@@ -510,7 +510,7 @@ class LinksAwakeningWorld(World):
             state.prog_items[self.player]["RUPEES"] -= self.rupees[item.name]
         return change
 
-    def fill_slot_data(self) => dict:
+    def fill_slot_data(self) -> dict:
         return {
             "death_link": self.options.death_link
         }

--- a/worlds/ladx/__init__.py
+++ b/worlds/ladx/__init__.py
@@ -509,3 +509,8 @@ class LinksAwakeningWorld(World):
         if change and item.name in self.rupees:
             state.prog_items[self.player]["RUPEES"] -= self.rupees[item.name]
         return change
+
+    def fill_slot_data(self) => dict:
+        return {
+            "death_link": self.options.death_link
+        }

--- a/worlds/ladx/__init__.py
+++ b/worlds/ladx/__init__.py
@@ -512,5 +512,5 @@ class LinksAwakeningWorld(World):
 
     def fill_slot_data(self) -> dict:
         return {
-            "death_link": self.options.death_link
+            "death_link": self.options.death_link.value
         }


### PR DESCRIPTION
## What is this fixing or adding?
Adds deathlink support to LADX. There was already existing work on it but it wasn't quite finished. This also adds a command to the client for toggling deathlink.

## How was this tested?
Tested sending and receiving deathlinks in a few multiworlds.
