### PR TITLE
LADX: Rework in-game hints (owl statues, books)

### DIFF
--- a/worlds/ladx/LADXR/generator.py
+++ b/worlds/ladx/LADXR/generator.py
@@ -255,48 +255,17 @@ def generateRom(args, world: "LinksAwakeningWorld"):
 
     world_setup = world.ladxr_logic.world_setup
 
-    JUNK_HINT = 0.33
-    RANDOM_HINT= 0.66
-    # USEFUL_HINT = 1.0
+
     # TODO: filter events, filter unshuffled keys
     all_items = world.multiworld.get_items()
-    our_items = [item for item in all_items
-                 if item.player == world.player
-                 and item.location
-                 and item.code is not None
-                 and item.location.show_in_spoiler]
-    our_useful_items = [item for item in our_items if ItemClassification.progression in item.classification]
-
-    def gen_hint():
-        chance = world.random.uniform(0, 1)
-        if chance < JUNK_HINT:
-            return None
-        elif chance < RANDOM_HINT:
-            location = world.random.choice(our_items).location
-        else: # USEFUL_HINT
-            location = world.random.choice(our_useful_items).location
-
-        if location.item.player == world.player:
-            name = "Your"
-        else:
-            name = f"{world.multiworld.player_name[location.item.player]}'s"
-
-        if isinstance(location, LinksAwakeningLocation):
-            location_name = location.ladxr_item.metadata.name
-        else:
-            location_name = location.name
-
-        hint = f"{name} {location.item} is at {location_name}"
-        if location.player != world.player:
-            hint += f" in {world.multiworld.player_name[location.player]}'s world"
-
-        # Cap hint size at 85
-        # Realistically we could go bigger but let's be safe instead
-        hint = hint[:85]
-
-        return hint
-
-    hints.addHints(rom, world.random, gen_hint)
+    hint_item_pool = [item for item in all_items
+                      if item.location
+                      and item.location.player == world.player
+                      and isinstance(item.location, LinksAwakeningLocation)
+                      and item.code is not None
+                      and item.location.show_in_spoiler
+                      and ItemClassification.progression in item.classification]
+    hints.addHints(rom, world.random, hint_item_pool)
 
     if world_setup.goal == "raft":
         patches.goal.setRaftGoal(rom)

--- a/worlds/ladx/LADXR/hints.py
+++ b/worlds/ladx/LADXR/hints.py
@@ -57,7 +57,7 @@ def addHints(rom, rnd, hint_item_pool):
         if len(pool) > 0:
             chosen_index = rnd.randint(0, len(pool) - 1)
             chosen = pool.pop(chosen_index)
-            hint = rnd.choice(hints.format("{%s}" % (chosen.name), chosen.location.ladxr_item.metadata.area)
+            hint = rnd.choice(hints).format(chosen.name, chosen.location.ladxr_item.metadata.area)
         else:
             hint = rnd.choice(hints).format(*rnd.choice(useless_hint))
         rom.texts[text_id] = formatText(hint)

--- a/worlds/ladx/LADXR/hints.py
+++ b/worlds/ladx/LADXR/hints.py
@@ -49,12 +49,16 @@ useless_hint = [
 ]
 
 
-def addHints(rom, rnd, hint_generator):
+def addHints(rom, rnd, hint_item_pool):
     text_ids = hint_text_ids.copy()
     rnd.shuffle(text_ids)
+    pool = hint_item_pool.copy()
     for text_id in text_ids:
-        hint = hint_generator()
-        if not hint:
+        if len(pool) > 0:
+            chosen_index = rnd.randint(0, len(pool) - 1)
+            chosen = pool.pop(chosen_index)
+            hint = rnd.choice(hints.format("{%s}" % (chosen.name), chosen.location.ladxr_item.metadata.area)
+        else:
             hint = rnd.choice(hints).format(*rnd.choice(useless_hint))
         rom.texts[text_id] = formatText(hint)
 


### PR DESCRIPTION
## What is this fixing or adding?

This reworks the in-game hints from owl statues and books. 

Currently, the hints only target items for the LADX player and give the exact location anywhere in the multiworld. Since this doesn't tie into the Archipelago hint system, this creates a somewhat annoying need to communicate and keep track of these hints manually. These messages are also often too long and get truncated. Additionally, a full third of these hints are forced to be completely useless joke hints. Many players stop interacting with the hints entirely.

This PR changes the hint system to be closer to the upstream randomizer. The hints are now for any progression item of the multiworld, filtered to the ones located in the current world. Instead of giving the exact location of items, the general region in LADX is given instead (such as Tal Tal Heights or Bottle Grotto). In practice this creates a fun balance of useful and vague that makes the hints fun to interact with but not essential.

I found it unnecessary to force any junk hints because there tends to be more than enough undesirable progression items in the pool. Just from LADX there are a lot of rupees and seashells.

## How was this tested?

Tested in a few multiworlds to see that the hints generated as intended.