### PR TITLE
LADX: Filter braces out of player names for hint text

### DIFF
--- a/worlds/ladx/LADXR/generator.py
+++ b/worlds/ladx/LADXR/generator.py
@@ -288,7 +288,9 @@ def generateRom(args, world: "LinksAwakeningWorld"):
 
         hint = f"{name} {location.item} is at {location_name}"
         if location.player != world.player:
-            hint += f" in {world.multiworld.player_name[location.player]}'s world"
+            # filter out { and } since they cause issues with string.format later on
+            player_name = world.multiworld.player_name[location.player].replace("{", "").replace("}", "")
+            hint += f" in {player_name}'s world"
 
         # Cap hint size at 85
         # Realistically we could go bigger but let's be safe instead

--- a/worlds/ladx/LADXR/locations/shop.py
+++ b/worlds/ladx/LADXR/locations/shop.py
@@ -18,7 +18,8 @@ class ShopItem(ItemInfo):
         mw_text = ""
         if multiworld:
             mw_text = f" for player {rom.player_names[multiworld - 1].encode('ascii', 'replace').decode()}"
-
+            # filter out { and } since they cause issues with string.format later on
+            mw_text = mw_text.replace("{", "").replace("}", "")
         
         if self.custom_item_name:
             name = self.custom_item_name


### PR DESCRIPTION
## What is this fixing or adding?
If there's braces in a player name, it messes with the `string.format` LADX does for hint text, so this filters it out.

## How was this tested?
Test gens.

## If this makes graphical changes, please attach screenshots.
{} ->