### PR TITLE
Stardew Valley: Remove Accessibility and progression balancing from presets

### DIFF
--- a/worlds/stardew_valley/presets.py
+++ b/worlds/stardew_valley/presets.py
@@ -57,8 +57,6 @@ all_random_settings = {
 }
 
 easy_settings = {
-    "progression_balancing":                ProgressionBalancing.default,
-    "accessibility":                        Accessibility.option_full,
     Goal.internal_name:                     Goal.option_community_center,
     FarmType.internal_name:                 "random",
     StartingMoney.internal_name:            "very rich",
@@ -103,8 +101,6 @@ easy_settings = {
 }
 
 medium_settings = {
-    "progression_balancing":                25,
-    "accessibility":                        Accessibility.option_full,
     Goal.internal_name:                     Goal.option_community_center,
     FarmType.internal_name:                 "random",
     StartingMoney.internal_name:            "rich",
@@ -149,8 +145,6 @@ medium_settings = {
 }
 
 hard_settings = {
-    "progression_balancing":                0,
-    "accessibility":                        Accessibility.option_full,
     Goal.internal_name:                     Goal.option_grandpa_evaluation,
     FarmType.internal_name:                 "random",
     StartingMoney.internal_name:            "extra",
@@ -195,8 +189,6 @@ hard_settings = {
 }
 
 nightmare_settings = {
-    "progression_balancing":                0,
-    "accessibility":                        Accessibility.option_full,
     Goal.internal_name:                     Goal.option_community_center,
     FarmType.internal_name:                 "random",
     StartingMoney.internal_name:            "vanilla",
@@ -241,8 +233,6 @@ nightmare_settings = {
 }
 
 short_settings = {
-    "progression_balancing":                ProgressionBalancing.default,
-    "accessibility":                        Accessibility.option_full,
     Goal.internal_name:                     Goal.option_bottom_of_the_mines,
     FarmType.internal_name:                 "random",
     StartingMoney.internal_name:            "filthy rich",
@@ -287,8 +277,6 @@ short_settings = {
 }
 
 minsanity_settings = {
-    "progression_balancing":                ProgressionBalancing.default,
-    "accessibility":                        Accessibility.option_minimal,
     Goal.internal_name:                     Goal.default,
     FarmType.internal_name:                 "random",
     StartingMoney.internal_name:            StartingMoney.default,
@@ -333,8 +321,6 @@ minsanity_settings = {
 }
 
 allsanity_settings = {
-    "progression_balancing":                ProgressionBalancing.default,
-    "accessibility":                        Accessibility.option_full,
     Goal.internal_name:                     Goal.default,
     FarmType.internal_name:                 "random",
     StartingMoney.internal_name:            StartingMoney.default,


### PR DESCRIPTION
## What is this fixing or adding?
Accessibility has recently had a non-backward compatible rename in core, which has broken compatibility between 0.5.0 and main (upcoming 0.5.1). So I decided that I'd rather not have my apworld compatibility be reliant on that, and unexpectedly break like this sometimes.

There is no good way to make it compatible with both versions at once. So the next best thing is, not depending on it at all. Plus, these settings were never really critical for the presets anyway.

## How was this tested?
Test the main-based apworld on 0.5.0 to make sure it's no longer incompatible.