### PR TITLE
Pokemon Emerald: Move Magma Grunt

### DIFF
--- a/worlds/pokemon_emerald/rom.py
+++ b/worlds/pokemon_emerald/rom.py
@@ -114,6 +114,14 @@ class PokemonEmeraldProcedurePatch(APProcedurePatch, APTokenMixin):
 
 
 def write_tokens(world: "PokemonEmeraldWorld", patch: PokemonEmeraldProcedurePatch) -> None:
+    # TODO: Remove when the base patch is updated to include this change
+    # Moves an NPC to avoid overlapping people during trainersanity
+    patch.write_token(
+        APTokenTypes.WRITE,
+        0x53A298 + (0x18 * 7) + 4,  # Space Center 1F event address + 8th event + 4-byte offset for x coord
+        struct.pack("<H", 11)
+    )
+
     # Set free fly location
     if world.options.free_fly_location:
         patch.write_token(


### PR DESCRIPTION
## What is this fixing or adding?

When trainersanity is enabled, some trainers that would usually disappear under certain conditions are instead kept around. In one case, this resulted in the overlap of two NPCs whose presences are normally mutually exclusive, and the wrong NPC happened to be on top, making one trainer potentially missable.

![MOVE](https://github.com/user-attachments/assets/fb884992-67f3-4e5a-b6be-84f870c7dc62)

This PR patches the position of the magma grunt underneath the old man to move him one tile to the right. This is a stopgap solution until an updated base patch, which already includes the fix, is pulled into here. Updating the base patch generally breaks backward compatibility, so I want to bring in as many changes at once in one update as I can.

## How was this tested?

Looked in a hex editor at the relevant address on main and this branch. It was `0A 00` before the change (as expected, the x coordinate is 10 in vanilla), and `0B 00` after.
