### PR TITLE
Core: deepcopy plando items

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -511,7 +511,7 @@ def roll_settings(weights: dict, plando_options: PlandoOptions = PlandoOptions.b
             continue
         logging.warning(f"{option_key} is not a valid option name for {ret.game} and is not present in triggers.")
     if PlandoOptions.items in plando_options:
-        ret.plando_items = game_weights.get("plando_items", [])
+        ret.plando_items = copy.deepcopy(game_weights.get("plando_items", []))
     if ret.game == "A Link to the Past":
         roll_alttp_settings(ret, game_weights)
 


### PR DESCRIPTION
## What is this fixing or adding?
At some point, the `game_weights` object was made to be reused across several players when `weights.yaml` is being used. This breaks plando items, as plando items expects a unique object per player while the same object would be stored per player.

## How was this tested?
Tested weights.yaml with plando items that would fail before this change. (The plando still fails as it places items into invalid locations, but it fails with the proper FillError).

## If this makes graphical changes, please attach screenshots.
