### PR TITLE
Pokemon Emerald: Fix map update sending to all trackers

### DIFF
--- a/worlds/pokemon_emerald/client.py
+++ b/worlds/pokemon_emerald/client.py
@@ -425,7 +425,6 @@ class PokemonEmeraldClient(BizHawkClient):
             await ctx.send_msgs([{
                 "cmd": "Bounce",
                 "slots": [ctx.slot],
-                "tags": ["Tracker"],
                 "data": {
                     "type": "MapUpdate",
                     "mapId": current_map,


### PR DESCRIPTION
## What is this fixing or adding?

As mentioned in #3726, using slot and tag creates a union, not an intersection. Limiting it to slot is fine; game clients will just ignore it.

## How was this tested?

Watched a server with the network logged.
