### PR TITLE
APSudoku: Update setup guide, remove extraneous options page link

### DIFF
--- a/worlds/apsudoku/__init__.py
+++ b/worlds/apsudoku/__init__.py
@@ -4,7 +4,7 @@ from BaseClasses import Tutorial
 from ..AutoWorld import WebWorld, World
 
 class AP_SudokuWebWorld(WebWorld):
-    options_page = "games/Sudoku/info/en"
+    options_page = False
     theme = 'partyTime'
 
     setup_en = Tutorial(

--- a/worlds/apsudoku/docs/setup_en.md
+++ b/worlds/apsudoku/docs/setup_en.md
@@ -17,7 +17,7 @@ Go to the latest release from the [APSudoku Releases page](https://github.com/AP
 
 1. Run the APSudoku executable.
 2. Under `Settings` &rarr; `Connection` at the top-right:
-	- Enter the server IP & port number
+	- Enter the server IP and port number
 	- Enter the name of the slot you wish to connect to
 	- Enter the room password (optional)
 	- Select DeathLink related settings (optional)
@@ -38,6 +38,6 @@ Go to the latest release from the [APSudoku Releases page](https://github.com/AP
 ## DeathLink Support
 
 If `DeathLink` is enabled when you click `Connect`:
-- Lose a life if you check an incorrect puzzle (not an _incomplete_ puzzle- if any cells are empty, you get off with a warning), or quit a puzzle without solving it (including disconnecting).
+- Lose a life if you check an incorrect puzzle (not an _incomplete_ puzzle- if any cells are empty, you get off with a warning), or if you quit a puzzle without solving it (including disconnecting).
 - Your life count is customizable (default 0). Dying with 0 lives left kills linked players AND resets your puzzle.
 - On receiving a DeathLink from another player, your puzzle resets. 

--- a/worlds/apsudoku/docs/setup_en.md
+++ b/worlds/apsudoku/docs/setup_en.md
@@ -22,19 +22,19 @@ Go to the latest release from the [APSudoku Releases page](https://github.com/AP
 	- Enter the room password (optional)
 	- Select DeathLink related settings (optional)
 	- Press `Connect`
-3. Optional things:
-	- You can check other settings under `Settings` &rarr; `Sudoku`, and can change the colors used under `Settings` &rarr; `Theme`.
-	- While connected, you can view the `Console` and `Hints` tabs for standard TextClient-like features
-	- You can also use the `Tracking` tab to view either a basic tracker or a valid [GodotAP tracker pack](https://github.com/EmilyV99/GodotAP/blob/main/tracker_packs/GET_PACKS.md)
 4. Under the `Sudoku` tab
-	- While connected, the number of "unhinted" locations for your slot is shown in the upper-left. (If this reads 0, no further hints can be earned for this slot, as every locations is already hinted)
-	- Click the various `?` buttons for information on how to play/control
 	- Choose puzzle difficulty
 	- Click `Start` to generate a puzzle
 5. Try to solve the Sudoku. Click `Check` when done
 	- A correct solution rewards you with 1 hint for a location in the world you are connected to
 	- An incorrect solution has no penalty, unless DeathLink is enabled (see below)
 
+Info:
+- You can set various settings under `Settings` &rarr; `Sudoku`, and can change the colors used under `Settings` &rarr; `Theme`.
+- While connected, you can view the `Console` and `Hints` tabs for standard TextClient-like features
+- You can also use the `Tracking` tab to view either a basic tracker or a valid [GodotAP tracker pack](https://github.com/EmilyV99/GodotAP/blob/main/tracker_packs/GET_PACKS.md)
+- While connected, the number of "unhinted" locations for your slot is shown in the upper-left of the the `Sudoku` tab. (If this reads 0, no further hints can be earned for this slot, as every locations is already hinted)
+- Click the various `?` buttons for information on controls/how to play
 ## DeathLink Support
 
 If `DeathLink` is enabled when you click `Connect`:

--- a/worlds/apsudoku/docs/setup_en.md
+++ b/worlds/apsudoku/docs/setup_en.md
@@ -11,33 +11,33 @@ Does not need to be added at the start of a seed, as it does not create any slot
 
 ## Installation Procedures
 
-Go to the latest release from the [APSudoku Releases page](https://github.com/APSudoku/APSudoku/releases). Download and extract the appropriate file for your platform.
+Go to the latest release from the [APSudoku Releases page](https://github.com/APSudoku/APSudoku/releases/latest). Download and extract the appropriate file for your platform.
 
 ## Joining a MultiWorld Game
 
-1. Run the APSudoku .exe (name varies by platform)
-2. Under `Settings`->`Connection` at the top-right:
-	- Enter the server ip & port number
+1. Run the APSudoku executable.
+2. Under `Settings` &rarr; `Connection` at the top-right:
+	- Enter the server IP & port number
 	- Enter the name of the slot you wish to connect to
 	- Enter the room password (optional)
 	- Select DeathLink related settings (optional)
 	- Press `Connect`
 3. Optional things:
-	- You can check other settings under `Settings`->`Sudoku`, and can change the colors used under `Settings`->`Theme`.
-	- While connected, you can view the `Console` and `Hints` tabs for standard TextClient like features
-	- You can also use the `Tracking` tab to view either a basic tracker, or a valid [GodotAP tracker pack](https://github.com/EmilyV99/GodotAP/blob/main/tracker_packs/GET_PACKS.md)
+	- You can check other settings under `Settings` &rarr; `Sudoku`, and can change the colors used under `Settings` &rarr; `Theme`.
+	- While connected, you can view the `Console` and `Hints` tabs for standard TextClient-like features
+	- You can also use the `Tracking` tab to view either a basic tracker or a valid [GodotAP tracker pack](https://github.com/EmilyV99/GodotAP/blob/main/tracker_packs/GET_PACKS.md)
 4. Under the `Sudoku` tab
-	- While connected, the number of 'unhinted' locations for your slot is shown in the upper-left. (If this reads 0, no further hints can be earned for this slot, as every locations is already hinted)
-	- Click the various `?` buttons for information on how to play / control
+	- While connected, the number of "unhinted" locations for your slot is shown in the upper-left. (If this reads 0, no further hints can be earned for this slot, as every locations is already hinted)
+	- Click the various `?` buttons for information on how to play/control
 	- Choose puzzle difficulty
 	- Click `Start` to generate a puzzle
-5. Try to solve the Sudoku. Click `Check` when done.
-	- Correct solution rewards you with 1 hint for a location in the world you are connected to.
-	- Incorrect solution has no penalty, unless DeathLink is enabled (see below)
+5. Try to solve the Sudoku. Click `Check` when done
+	- A correct solution rewards you with 1 hint for a location in the world you are connected to
+	- An incorrect solution has no penalty, unless DeathLink is enabled (see below)
 
 ## DeathLink Support
 
 If `DeathLink` is enabled when you click `Connect`:
 - Lose a life if you check an incorrect puzzle (not an _incomplete_ puzzle- if any cells are empty, you get off with a warning), or quit a puzzle without solving it (including disconnecting).
-- Life count customizable (default 0). Dying with 0 lives left kills linked players AND resets your puzzle.
+- Your life count is customizable (default 0). Dying with 0 lives left kills linked players AND resets your puzzle.
 - On receiving a DeathLink from another player, your puzzle resets. 

--- a/worlds/apsudoku/docs/setup_en.md
+++ b/worlds/apsudoku/docs/setup_en.md
@@ -1,9 +1,7 @@
 # APSudoku Setup Guide
 
 ## Required Software
-- [APSudoku](https://github.com/EmilyV99/APSudoku)
-- Windows (most tested on Win10)
-- Other platforms might be able to build from source themselves; and may be included in the future.
+- [APSudoku](https://github.com/APSudoku/APSudoku)
 
 ## General Concept
 
@@ -13,25 +11,33 @@ Does not need to be added at the start of a seed, as it does not create any slot
 
 ## Installation Procedures
 
-Go to the latest release from the [APSudoku Releases page](https://github.com/EmilyV99/APSudoku/releases). Download and extract the `APSudoku.zip` file.
+Go to the latest release from the [APSudoku Releases page](https://github.com/APSudoku/APSudoku/releases). Download and extract the appropriate file for your platform.
 
 ## Joining a MultiWorld Game
 
-1. Run APSudoku.exe
-2. Under the 'Archipelago' tab at the top-right:
-	- Enter the server url & port number
+1. Run the APSudoku .exe (name varies by platform)
+2. Under `Settings`->`Connection` at the top-right:
+	- Enter the server ip & port number
 	- Enter the name of the slot you wish to connect to
 	- Enter the room password (optional)
 	- Select DeathLink related settings (optional)
-	- Press connect
-3. Go back to the 'Sudoku' tab
-	- Click the various '?' buttons for information on how to play / control
-4. Choose puzzle difficulty
-5. Try to solve the Sudoku. Click 'Check' when done.
+	- Press `Connect`
+3. Optional things:
+	- You can check other settings under `Settings`->`Sudoku`, and can change the colors used under `Settings`->`Theme`.
+	- While connected, you can view the `Console` and `Hints` tabs for standard TextClient like features
+	- You can also use the `Tracking` tab to view either a basic tracker, or a valid [GodotAP tracker pack](https://github.com/EmilyV99/GodotAP/blob/main/tracker_packs/GET_PACKS.md)
+4. Under the `Sudoku` tab
+	- While connected, the number of 'unhinted' locations for your slot is shown in the upper-left. (If this reads 0, no further hints can be earned for this slot, as every locations is already hinted)
+	- Click the various `?` buttons for information on how to play / control
+	- Choose puzzle difficulty
+	- Click `Start` to generate a puzzle
+5. Try to solve the Sudoku. Click `Check` when done.
+	- Correct solution rewards you with 1 hint for a location in the world you are connected to.
+	- Incorrect solution has no penalty, unless DeathLink is enabled (see below)
 
 ## DeathLink Support
 
-If 'DeathLink' is enabled when you click 'Connect':
+If `DeathLink` is enabled when you click `Connect`:
 - Lose a life if you check an incorrect puzzle (not an _incomplete_ puzzle- if any cells are empty, you get off with a warning), or quit a puzzle without solving it (including disconnecting).
 - Life count customizable (default 0). Dying with 0 lives left kills linked players AND resets your puzzle.
 - On receiving a DeathLink from another player, your puzzle resets. 

--- a/worlds/apsudoku/docs/setup_en.md
+++ b/worlds/apsudoku/docs/setup_en.md
@@ -17,7 +17,7 @@ Go to the latest release from the [APSudoku Releases page](https://github.com/AP
 
 1. Run the APSudoku executable.
 2. Under `Settings` &rarr; `Connection` at the top-right:
-	- Enter the server IP and port number
+	- Enter the server address and port number
 	- Enter the name of the slot you wish to connect to
 	- Enter the room password (optional)
 	- Select DeathLink related settings (optional)


### PR DESCRIPTION
## What is this fixing or adding?
Remove the "Options Page (External Link)" that just redirected to the Game Page (per [prior discussion](https://discord.com/channels/731205301247803413/731214280439103580/1255343193495441460))
Updated the setup guide:
- some small formatting tweaks
- updated repo URL to point to the Godot-based build which is the current release
- updated instructions based on the Godot-based client

## How was this tested?
Ran webhost locally to view the formatting

## If this makes graphical changes, please attach screenshots.
No more `Options Page (External Link)`:
![image](https://github.com/user-attachments/assets/b1240622-9a7e-4e0c-8f6d-0457fd12551e)
Updated setup guide:
![image](https://github.com/user-attachments/assets/620a1b07-5861-4b13-ae13-d555570a98a4)
![image](https://github.com/user-attachments/assets/fbe418e3-f58b-45a7-9875-10c1135ee9ef)
![image](https://github.com/user-attachments/assets/699a5895-1a19-4e92-844f-2b28072d8cba)
