### PR TITLE
AHIT: Fix moderate logic rules using add_rule instead of set_rule

### DIFF
--- a/worlds/ahit/Rules.py
+++ b/worlds/ahit/Rules.py
@@ -381,8 +381,8 @@ def set_moderate_rules(world: "HatInTimeWorld"):
              lambda state: can_use_hat(state, world, HatType.ICE), "or")
 
     # Moderate: Clock Tower Chest + Ruined Tower with nothing
-    add_rule(world.multiworld.get_location("Mafia Town - Clock Tower Chest", world.player), lambda state: True)
-    add_rule(world.multiworld.get_location("Mafia Town - Top of Ruined Tower", world.player), lambda state: True)
+    set_rule(world.multiworld.get_location("Mafia Town - Clock Tower Chest", world.player), lambda state: True)
+    set_rule(world.multiworld.get_location("Mafia Town - Top of Ruined Tower", world.player), lambda state: True)
 
     # Moderate: enter and clear The Subcon Well without Hookshot and without hitting the bell
     for loc in world.multiworld.get_region("The Subcon Well", world.player).locations:
@@ -432,8 +432,8 @@ def set_moderate_rules(world: "HatInTimeWorld"):
 
     if world.is_dlc1():
         # Moderate: clear Rock the Boat without Ice Hat
-        add_rule(world.multiworld.get_location("Rock the Boat - Post Captain Rescue", world.player), lambda state: True)
-        add_rule(world.multiworld.get_location("Act Completion (Rock the Boat)", world.player), lambda state: True)
+        set_rule(world.multiworld.get_location("Rock the Boat - Post Captain Rescue", world.player), lambda state: True)
+        set_rule(world.multiworld.get_location("Act Completion (Rock the Boat)", world.player), lambda state: True)
 
         # Moderate: clear Deep Sea without Ice Hat
         set_rule(world.multiworld.get_location("Act Completion (Time Rift - Deep Sea)", world.player),


### PR DESCRIPTION
## What is this fixing or adding?

The moderate logic for the Mafia Town Clock Tower Chest and Top of Ruined Tower with nothing, and for clearing Rock the Boat without Ice Hat were mistakenly using `add_rule` instead of `set_rule`, which was adding the condition of `and True` which had no effect.

This patch corrects these moderate logic rules to use `set_rule` instead.

## How was this tested?
 A YAML was used with moderate logic difficulty and that act-plandos Rock the Boat onto the starting act and Barrel Battle onto the second act. The playthrough spheres in the spoiler were compared before and after. From additional generations with this YAML after the patch, both `Mafia Town - Top of Ruined Tower` and `Mafia Town - Clock Tower Chest` have been observed in sphere 1 of a playthrough as expected.