### PR TITLE
AHIT: Fix Time Rift - Alpine Skyline entrance logic

### DIFF
--- a/worlds/ahit/Rules.py
+++ b/worlds/ahit/Rules.py
@@ -855,6 +855,9 @@ def set_rift_rules(world: "HatInTimeWorld", regions: Dict[str, Region]):
 
     for entrance in regions["Time Rift - Alpine Skyline"].entrances:
         add_rule(entrance, lambda state: has_relic_combo(state, world, "Crayon"))
+        if entrance.parent_region.name == "Alpine Free Roam":
+            add_rule(entrance,
+                     lambda state: can_use_hookshot(state, world) and can_hit(state, world, umbrella_only=True))
 
     if world.is_dlc1():
         for entrance in regions["Time Rift - Balcony"].entrances:
@@ -933,6 +936,9 @@ def set_default_rift_rules(world: "HatInTimeWorld"):
 
     for entrance in world.multiworld.get_region("Time Rift - Alpine Skyline", world.player).entrances:
         add_rule(entrance, lambda state: has_relic_combo(state, world, "Crayon"))
+        if entrance.parent_region.name == "Alpine Free Roam":
+            add_rule(entrance,
+                     lambda state: can_use_hookshot(state, world) and can_hit(state, world, umbrella_only=True))
 
     if world.is_dlc1():
         for entrance in world.multiworld.get_region("Time Rift - Balcony", world.player).entrances:


### PR DESCRIPTION
## What is this fixing or adding?

The `Time Rift - Alpine Skyline` region was incorrectly accessible from Alpine Free Roam without Hookshot Badge or Umbrella.

One of the two regions that connects to the `Time Rift - Alpine Skyline` region is `Alpine Free Roam`. The problem here is that `Alpine Free Roam` corresponds to the intro section of Alpine Free Roam, but the Time Rift is actually found in-game in what equates to the `Alpine Skyline Area` region.

The entrance connecting `Alpine Free Roam` to `Alpine Skyline Area` (`AFR -> Alpine Skyline Area`) requires the Hookshot Badge (and Umbrella if umbrella logic is enabled), but because the entrance to `Time Rift - Alpine Skyline` is placed in `Alpine Free Roam` instead, it was missing the hookshot/umbrella requirements.

The missing Hookshot Badge and Umbrella requirements have been added to `Rules.set_rift_rules()` and `Rules.set_default_rift_rules()`.

The entrances to the `Time Rift - Curly Tail Trail` and `Time Rift - The Twilight Bell` regions are also in the `Alpine Free Roam` region, but the logic for both of those entrances require event items that are only accessible from the `Alpine Skyline Area` region.

## How was this tested?

With act randomizer disabled, item plando was used to place the Hookshot Badge at `Act Completion (Time Rift - Alpine Skyline)`, which should always be unreachable because it requires Hookshot Badge to reach (with no act randomizer The Illness has Spread would also be vanilla so would also require Hookshot Badge). Seeds generated before this patch would generate despite being impossible. After this patch, generated seeds correctly determine that the game is unbeatable and raise an error.

With act randomizer enabled, item plando was again used to place the Hookshot Badge at `Act Completion (Time Rift - Alpine Skyline)` and act plando was used to make `Time Rift - Alpine Skyline` and `The Illness has Spread` vanilla and to place `Alpine Free Roam` at the Act 1 entrance in the Chapter 2 telescope (the template yaml always starts in Chapter 1 so this could not be overwritten to an allowed starting act). Seeds generated before this patch would generate despite being impossible. After this patch, generated seeds correctly determine that the game is unbeatable and raise an error.