### PR TITLE
DS3: Prevent prioritized+excluded locations

### DIFF
--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -1252,6 +1252,9 @@ class DarkSouls3World(World):
                 lambda item: not item.advancement
             )
 
+        # Prevent the player from prioritizing and "excluding" the same location
+        self.options.priority_locations.value -= allow_useful_locations
+
         if self.options.excluded_location_behavior == "allow_useful":
             self.options.exclude_locations.value.clear()
 


### PR DESCRIPTION
## What is this fixing or adding?

A player could make a location DS3-excluded to allow Useful items. Thus, an item that was both DS3-excluded and AP-prioritized would have unfulfillable requirements (progression and not progression). This simply removes `allow_useful` locations from `priority_locations` to prevent this case.

## How was this tested?

Generations with `allow_useful` missables and prioritized "CD: Black Eye Orb - Rosaria from Leonhard's quest" (a missable location) and generations with `allow_useful` excludeds and a location in both `exclude_locations` and `priority_locations`.