### PR TITLE
DS3: Don't return early in the location loop

### DIFF
--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -1292,10 +1292,10 @@ class DarkSouls3World(World):
         locations = location if isinstance(location, list) else [location]
         for location in locations:
             data = location_dictionary[location]
-            if data.dlc and not self.options.enable_dlc: return
-            if data.ngp and not self.options.enable_ngp: return
+            if data.dlc and not self.options.enable_dlc: continue
+            if data.ngp and not self.options.enable_ngp: continue
 
-            if not self._is_location_available(location): return
+            if not self._is_location_available(location): continue
             if isinstance(rule, str):
                 assert item_dictionary[rule].classification == ItemClassification.progression
                 rule = lambda state, item=rule: state.has(item, self.player)


### PR DESCRIPTION
## What is this fixing or adding?

This fixed a bug that appeared when some locations in a group were excluded and others were not.

## How was this tested?

I ran some local generations with known-bad settings and seeds and verified that the error no longer occurs.