### PR TITLE
DS3: Make Red Eye Orb always require Lift Chamber Key

### DIFF
--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -612,9 +612,7 @@ class DarkSouls3World(World):
                 self._add_entrance_rule("Painted World of Ariandel (Before Contraption)", "Basin of Vows")
 
         # Define the access rules to some specific locations
-        if self._is_location_available("FS: Lift Chamber Key - Leonhard"):
-            self._add_location_rule("HWL: Red Eye Orb - wall tower, miniboss",
-                                    "Lift Chamber Key")
+        self._add_location_rule("HWL: Red Eye Orb - wall tower, miniboss", "Lift Chamber Key")
         self._add_location_rule("ID: Bellowing Dragoncrest Ring - drop from B1 towards pit",
                                 "Jailbreaker's Key")
         self._add_location_rule("ID: Covetous Gold Serpent Ring - Siegward's cell", "Old Cell Key")


### PR DESCRIPTION
## What is this fixing or adding?

This is the only case of an access rule requiring a location to be randomized to be applied. This was originally added due to the ways we handled excluded/missable/non-randomized locations in order to prevent unreachable locations, however, these methods have since changed and the conditional is no longer required.

This is technically a bug fix, since it adds the Lift Chamber Key requirement even when it isn't randomized. I say technically because the location would be excluded anyway, so it couldn't actually matter.

## How was this tested?

Every combination of missable and excluded locations with combinations of Lift Chamber Key, Leonerd's Garb, and the Black Eye Orb in `exclude_locations` and seeing that there were no unreachable locations. Also reading through the current code to see where/how these cases are being properly handled now.