### PR TITLE
MultiServer: put some limits in place

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1203,6 +1203,10 @@ class CommonCommandProcessor(CommandProcessor):
             timer = int(seconds, 10)
         except ValueError:
             timer = 10
+        else:
+            if timer > 60 * 60:
+                raise ValueError(f"{timer} is considered an unreasonably high number.")
+
         async_start(countdown(self.ctx, timer))
         return True
 
@@ -2039,6 +2043,8 @@ class ServerCommandProcessor(CommonCommandProcessor):
             item_name, usable, response = get_intended_text(item_name, names)
             if usable:
                 amount: int = int(amount)
+                if amount > 100:
+                    raise ValueError(f"{amount} is considered an unreasonably high number.")
                 new_items = [NetworkItem(names[item_name], -1, 0) for _ in range(int(amount))]
                 send_items_to(self.ctx, team, slot, *new_items)
 

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1205,7 +1205,7 @@ class CommonCommandProcessor(CommandProcessor):
             timer = 10
         else:
             if timer > 60 * 60:
-                raise ValueError(f"{timer} is considered an unreasonably high number.")
+                raise ValueError(f"{timer} is invalid. Maximum is 1 hour.")
 
         async_start(countdown(self.ctx, timer))
         return True
@@ -2044,7 +2044,7 @@ class ServerCommandProcessor(CommonCommandProcessor):
             if usable:
                 amount: int = int(amount)
                 if amount > 100:
-                    raise ValueError(f"{amount} is considered an unreasonably high number.")
+                    raise ValueError(f"{amount} is invalid. Maximum is 100.")
                 new_items = [NetworkItem(names[item_name], -1, 0) for _ in range(int(amount))]
                 send_items_to(self.ctx, team, slot, *new_items)
 


### PR DESCRIPTION
## What is this fixing or adding?
UserError

## How was this tested?
```
/send_multiple 1000000000 Player1 Power Star
Traceback (most recent call last):
  File "\Archipelago\MultiServer.py", line 1149, in __call__
    return method(self, *command[1:])  # pass each word as argument
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "\Archipelago\MultiServer.py", line 2047, in _cmd_send_multiple
    raise ValueError(f"{amount} is considered an unreasonably high number.")
ValueError: 1000000000 is considered an unreasonably high number.

```
## If this makes graphical changes, please attach screenshots.
![image](https://github.com/user-attachments/assets/aac86cb0-535b-429b-886a-1f7f5d9d041c)
