### PR TITLE
The Witness: Fix hints always displaying the Witness player

### DIFF
--- a/worlds/witness/hints.py
+++ b/worlds/witness/hints.py
@@ -220,7 +220,7 @@ def try_getting_location_group_for_location(world: "WitnessWorld", hint_loc: Loc
 def word_direct_hint(world: "WitnessWorld", hint: WitnessLocationHint) -> WitnessWordedHint:
     location_name = hint.location.name
     if hint.location.player != world.player:
-        location_name += " (" + world.player_name + ")"
+        location_name += " (" + world.multiworld.player_name[hint.location.player] + ")"
 
     item = hint.location.item
 
@@ -229,7 +229,7 @@ def word_direct_hint(world: "WitnessWorld", hint: WitnessLocationHint) -> Witnes
         item_name = item.name
 
         if item.player != world.player:
-            item_name += " (" + world.player_name + ")"
+            item_name += " (" + world.multiworld.player_name[item.player] + ")"
 
     hint_text = ""
     area: Optional[str] = None


### PR DESCRIPTION
Got a bit too trigger happy with changing instances of `world.multiworld.player_name` to `world.player_name` - Some of these were actually *supposed* to be other players.

Alternate title: The Witness doesn't have a Silph Scope