### PR TITLE
Rogue Legacy: Raise Exception when there are overlapping IDs

### DIFF
--- a/worlds/rogue_legacy/__init__.py
+++ b/worlds/rogue_legacy/__init__.py
@@ -49,6 +49,30 @@ class RLWorld(World):
         return {option_name: self.get_setting(option_name).value for option_name in rl_options}
 
     def generate_early(self):
+        location_ids_used_per_game = {
+            world.game: set(world.location_id_to_name) for world in self.multiworld.worlds.values()
+        }
+        item_ids_used_per_game = {
+            world.game: set(world.item_id_to_name) for world in self.multiworld.worlds.values()
+        }
+        overlapping_games = set()
+
+        for id_lookup in (location_ids_used_per_game, item_ids_used_per_game):
+            for game_1, ids_1 in id_lookup.items():
+                for game_2, ids_2 in id_lookup.items():
+                    if game_1 == game_2:
+                        continue
+
+                    if ids_1 & ids_2:
+                        overlapping_games.add(tuple(sorted([game_1, game_2])))
+
+        if overlapping_games:
+            raise RuntimeError(
+                "In this multiworld, there are games with overlapping item/location IDs.\n"
+                "The current Rogue Legacy does not support these and a fix is not currently planned.\n"
+                f"The overlapping games are: {overlapping_games}"
+            )
+        
         # Check validation of names.
         additional_lady_names = len(self.get_setting("additional_lady_names").value)
         additional_sir_names = len(self.get_setting("additional_sir_names").value)


### PR DESCRIPTION
The client literally does not work when there are overlapping IDs. It crashes completely after connection, making the game unplayable.
https://discord.com/channels/731205301247803413/1279859793661788261/1279859793661788261

While overlapping IDs are not "officially supported" yet, this has unfortunately ruined many seeds in several **unsupported** asyncs, including one of mine, where the RL seeds just have to be straight up released through the server console due to an overlap between ALTTP and Pokemon Crystal IDs.

Phar is not currently intending to fix it until further notice:
https://discord.com/channels/731205301247803413/929585237695029268/1269684436853723156