### PR TITLE
CI: Update Linux builds to use py3.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,10 +111,10 @@ jobs:
       - name: Get a recent python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Install build-time dependencies
         run: |
-          echo "PYTHON=python3.11" >> $GITHUB_ENV
+          echo "PYTHON=python3.12" >> $GITHUB_ENV
           wget -nv https://github.com/AppImage/AppImageKit/releases/download/$APPIMAGETOOL_VERSION/appimagetool-x86_64.AppImage
           chmod a+rx appimagetool-x86_64.AppImage
           ./appimagetool-x86_64.AppImage --appimage-extract

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,10 +44,10 @@ jobs:
       - name: Get a recent python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Install build-time dependencies
         run: |
-          echo "PYTHON=python3.11" >> $GITHUB_ENV
+          echo "PYTHON=python3.12" >> $GITHUB_ENV
           wget -nv https://github.com/AppImage/AppImageKit/releases/download/$APPIMAGETOOL_VERSION/appimagetool-x86_64.AppImage
           chmod a+rx appimagetool-x86_64.AppImage
           ./appimagetool-x86_64.AppImage --appimage-extract


### PR DESCRIPTION
## What is this fixing or adding?

Now that we have Py 3.12 compat, update Linux builds to use Py 3.12.

## How was this tested?

Not yet.

***Don't merge before we know 3.12 doesn't break anything!***
