### PR TITLE
Core: add new keywords to include leading zeroes to player number

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -12,6 +12,7 @@ import urllib.request
 from collections import Counter
 from typing import Any, Dict, Tuple, Union
 from itertools import chain
+import math
 
 import ModuleUpdate
 
@@ -184,6 +185,7 @@ def main(args=None) -> Tuple[argparse.Namespace, int]:
     erargs.player_options = {}
 
     player = 1
+    max_digits = calculate_digit_length(args.multi)
     while player <= args.multi:
         path = player_path_cache[player]
         if path:
@@ -204,7 +206,7 @@ def main(args=None) -> Tuple[argparse.Namespace, int]:
                         erargs.name[player] = f"Player{player}"
                     elif not erargs.name[player]:  # if name was not specified, generate it from filename
                         erargs.name[player] = os.path.splitext(os.path.split(path)[-1])[0]
-                    erargs.name[player] = handle_name(erargs.name[player], player, name_counter)
+                    erargs.name[player] = handle_name(erargs.name[player], player, name_counter, max_digits)
 
                     player += 1
             except Exception as e:
@@ -295,20 +297,36 @@ class SafeDict(dict):
         return '{' + key + '}'
 
 
-def handle_name(name: str, player: int, name_counter: Counter):
+def handle_name(name: str, player: int, name_counter: Counter, max_digits: int):
     name_counter[name.lower()] += 1
     number = name_counter[name.lower()]
     new_name = "%".join([x.replace("%number%", "{number}").replace("%player%", "{player}") for x in name.split("%%")])
     new_name = string.Formatter().vformat(new_name, (), SafeDict(number=number,
                                                                  NUMBER=(number if number > 1 else ''),
                                                                  player=player,
-                                                                 PLAYER=(player if player > 1 else '')))
+                                                                 PLAYER=(player if player > 1 else ''),
+                                                                 zplayer=str(player).zfill(max_digits),
+                                                                 ZPLAYER=(str(player).zfill(max_digits) if player > 1
+                                                                          else '')))
     # Run .strip twice for edge case where after the initial .slice new_name has a leading whitespace.
     # Could cause issues for some clients that cannot handle the additional whitespace.
     new_name = new_name.strip()[:16].strip()
     if new_name == "Archipelago":
         raise Exception(f"You cannot name yourself \"{new_name}\"")
     return new_name
+
+
+def calculate_digit_length(slot_count: int):
+    # Should never run anything but the initial if statement, but on the off chance 'slot_count'
+    # is a non-positive number for some reason, the elif and else will at least prevent it from
+    # blowing up or throwing an exception.
+    if slot_count > 0:
+        digit_count = int(math.log10(slot_count)) + 1
+    elif slot_count == 0:
+        digit_count = 1
+    else:
+        digit_count = int(math.log10(-slot_count)) + 2
+    return digit_count
 
 
 def roll_percentage(percentage: Union[int, float]) -> bool:
@@ -560,3 +578,4 @@ if __name__ == '__main__':
                            " This would be a memory leak."
     # in case of error-free exit should not need confirmation
     atexit.unregister(confirmation)
+

--- a/Generate.py
+++ b/Generate.py
@@ -578,4 +578,3 @@ if __name__ == '__main__':
                            " This would be a memory leak."
     # in case of error-free exit should not need confirmation
     atexit.unregister(confirmation)
-


### PR DESCRIPTION
## What is this fixing or adding?
Addition of new keywords (`zplayer`, `ZPLAYER`) which function like their `player` equivalents but with leading zeroes based on the number of total slots generated. This is to aid in searching through a large session of randomly generated slots such as the Big Async. This is done by calculating the number of total digits in the final slot count via `log10 + 1` and then using that value in zfill to ensure that the resulting string is at least `max_digits` long.

The same principle can be applied to the generic `Player{player}` used when using `weights.yaml` should that be desirable but would obviously be hardcoded as it is now rather than relying on the keyword itself.

## How was this tested?
Generated several sessions with 10 or more players using the new keywords to ensure that leading zeroes were included. This includes generating 100 slots with a slightly modified version of Scooty's PR for game-specific names in the AsyncTools which uses the new `zplayer` keyword instead of `player` in the triggers as this was a major impetus for me to make this change. This resulted in up to two leading zeroes and would go up to three in the case of the Big Async:
![image](https://github.com/user-attachments/assets/03aedc67-422c-4e46-98e4-c4063f9f14f7)

## If this makes graphical changes, please attach screenshots.
N/A