### PR TITLE
Pokemon Emerald: Fix client crash on certain systems

### DIFF
--- a/worlds/pokemon_emerald/client.py
+++ b/worlds/pokemon_emerald/client.py
@@ -122,6 +122,7 @@ class PokemonEmeraldClient(BizHawkClient):
     game = "Pokemon Emerald"
     system = "GBA"
     patch_suffix = ".apemerald"
+
     local_checked_locations: Set[int]
     local_set_events: Dict[str, bool]
     local_found_key_items: Dict[str, bool]
@@ -139,8 +140,7 @@ class PokemonEmeraldClient(BizHawkClient):
 
     current_map: Optional[int]
 
-    def __init__(self) -> None:
-        super().__init__()
+    def initialize_client(self):
         self.local_checked_locations = set()
         self.local_set_events = {}
         self.local_found_key_items = {}
@@ -182,9 +182,7 @@ class PokemonEmeraldClient(BizHawkClient):
         ctx.want_slot_data = True
         ctx.watcher_timeout = 0.125
 
-        self.death_counter = None
-        self.previous_death_link = 0
-        self.ignore_next_death_link = False
+        self.initialize_client()
 
         return True
 


### PR DESCRIPTION
## What is this fixing or adding?

The constructor is the wrong place to initialize these variables because clients get instantiated once right after the class is defined, not when a game is found. This doesn't really matter for most users, because they'll only open the client once to connect to one slot in one room and then close everything down.

It did, however, result in a crash on someone running from source on Mac using Python 3.9 because the `wonder_trade_update_event`, an `asyncio.Event`, was created while the world was being imported, and then `await`ed in the game watcher loop, which is running in a different Python event loop. I didn't track down exactly where the new event loop is split off, but the reported error was pretty clear, and was resolved with these changes. It was always improper, it just worked anyway for common AP setups.

## How was this tested?

Ran this client on my usual setup of source/Windows/3.11 while the original reporter used source/Mac/3.9. The crash disappeared on their end with the fix, and they were able to finish the rest of their game normally.
