### PR TITLE
The Messenger: remove an invalid entrance

### DIFF
--- a/worlds/messenger/connections.py
+++ b/worlds/messenger/connections.py
@@ -114,7 +114,6 @@ CONNECTIONS: Dict[str, Dict[str, List[str]]] = {
             "Forlorn Temple - Rocket Maze Checkpoint",
         ],
         "Rocket Maze Checkpoint": [
-            "Forlorn Temple - Sunny Day Checkpoint",
             "Forlorn Temple - Climb Shop",
         ],
     },


### PR DESCRIPTION
## What is this fixing or adding?
Removes an entrance that shouldn't be there. When I was testing out these pathings, this connection made sense. Turns out that it's actually wrong because there's a gate between the two areas with the switch being on the other side. The gates stay permanently open, but you can't get to it from the right side. The entrance is still technically valid, but it requires the region on the other side is reachable first at which point the entrance itself is redundant.

## How was this tested?
Re-genned a known seed where this caused an issue and checked the results were different.