### PR TITLE
[DKC3] Add option for (un)swapping final bosses under Knautilus goal

### DIFF
--- a/worlds/dkc3/Options.py
+++ b/worlds/dkc3/Options.py
@@ -8,7 +8,7 @@ class Goal(Choice):
     """
     Determines the goal of the seed
 
-    Knautilus: Scuttle the Knautilus in Krematoa and defeat Baron K. Roolenstein
+    Knautilus: Raise the submarine in Krematoa and defeat Baron K. Roolenstein
 
     Banana Bird Hunt: Find a certain number of Banana Birds and rescue their mother
     """
@@ -16,6 +16,19 @@ class Goal(Choice):
     option_knautilus = 0
     option_banana_bird_hunt = 1
     default = 0
+
+class SwapFinalBoss(DefaultOnToggle):
+    """
+    Swaps Kastle Kaos with the Knautilus, changing which boss has to be beaten to win the game.
+
+    The credits will play after Kastle Kaos is cleared.
+    Swapping Kastle Kaos into Krematoa thus makes for a victory with a bit more fanfare.
+
+    The final boss will be located in Krematoa, regardless of this setting.
+
+    Only applies if Goal is set to Knautilus. Otherwise, this setting has no effect.
+    """
+    display_name = "Swap Final Boss"
 
 
 class IncludeTradeSequence(Toggle):
@@ -187,6 +200,7 @@ class DKC3Options(PerGameCommonOptions):
     #include_trade_sequence: IncludeTradeSequence          # Disabled
 
     goal: Goal
+    swap_final_boss: SwapFinalBoss
     krematoa_bonus_coin_cost: KrematoaBonusCoinCost
     percentage_of_extra_bonus_coins: PercentageOfExtraBonusCoins
     number_of_banana_birds: NumberOfBananaBirds

--- a/worlds/dkc3/Regions.py
+++ b/worlds/dkc3/Regions.py
@@ -901,7 +901,7 @@ def connect_regions(world: World, level_list):
         connect(world, world.player, names, LocationName.krematoa_region, krematoa_levels[i],
                 lambda state, i=i: (state.has(ItemName.bonus_coin, world.player, world.options.krematoa_bonus_coin_cost.value * (i+1))))
 
-    if world.options.goal == "knautilus":
+    if world.options.goal == "knautilus" and world.options.swap_final_boss:
         connect(world, world.player, names, LocationName.kaos_kore_region, LocationName.knautilus_region)
         connect(world, world.player, names, LocationName.krematoa_region, LocationName.kastle_kaos_region,
                 lambda state: (state.has(ItemName.krematoa_cog, world.player, 5)))

--- a/worlds/dkc3/Rom.py
+++ b/worlds/dkc3/Rom.py
@@ -611,7 +611,7 @@ def patch_rom(world: World, rom: LocalRom, active_level_list):
         rom.write_byte(0x34C213, (0x32 + level_dict[active_level_list[25]].levelID))
         rom.write_byte(0x34C21B, (0x32 + level_dict[active_level_list[26]].levelID))
 
-    if world.options.goal == "knautilus":
+    if world.options.goal == "knautilus" and world.options.swap_final_boss:
         # Swap Kastle KAOS and Knautilus
         rom.write_byte(0x34D4E1, 0xC2)
         rom.write_byte(0x34D4E2, 0x24)

--- a/worlds/dkc3/__init__.py
+++ b/worlds/dkc3/__init__.py
@@ -112,7 +112,10 @@ class DKC3World(World):
         self.multiworld.get_location(LocationName.rocket_rush_flag, self.player).place_locked_item(self.create_item(ItemName.krematoa_cog))
         number_of_bosses = 8
         if self.options.goal == "knautilus":
-            self.multiworld.get_location(LocationName.kastle_kaos, self.player).place_locked_item(self.create_item(ItemName.victory))
+            if self.options.swap_final_boss:
+                self.multiworld.get_location(LocationName.kastle_kaos, self.player).place_locked_item(self.create_item(ItemName.victory))
+            else:
+                self.multiworld.get_location(LocationName.knautilus, self.player).place_locked_item(self.create_item(ItemName.victory))
             number_of_bosses = 7
         else:
             self.multiworld.get_location(LocationName.banana_bird_mother, self.player).place_locked_item(self.create_item(ItemName.victory))


### PR DESCRIPTION
## What is this fixing or adding?
Adds a new "Swap Final Boss" option (default On) that determines whether or not to swap the bosses of Kaos Kore and Krematoa. Having this as an option should cut down on player confusion surrounding the swap (which was always developer-intended), and greatly decrease player dissatisfaction and false bug reports.

## How was this tested?
By generating two solo games, one with the new setting On, the other with it Off. Enough items were placed into Start Inventory to go straight to the final boss and confirm that the correct level was there, and that the goal was triggered upon defeating that boss. As expected, turning this setting On makes the final level Kastle Kaos, turning it Off makes the final level the vanilla Knautilus. Both versions successfully marked the goal as cleared upon completion of their respective final boss fights. It was also confirmed that turning this new setting Off keeps Kastle Kaos in its vanilla location, within Kaos Kore.

## If this makes graphical changes, please attach screenshots.
N/A