### PR TITLE
The Witness: Get rid of Menu region, prepare for other worlds to change theirs (hints)

### DIFF
--- a/worlds/witness/__init__.py
+++ b/worlds/witness/__init__.py
@@ -50,6 +50,8 @@ class WitnessWorld(World):
     topology_present = False
     web = WitnessWebWorld()
 
+    origin_region_name = "Entry"
+
     options_dataclass = TheWitnessOptions
     options: TheWitnessOptions
 

--- a/worlds/witness/data/WitnessLogic.txt
+++ b/worlds/witness/data/WitnessLogic.txt
@@ -1,7 +1,5 @@
 ==Tutorial (Inside)==
 
-Menu (Menu) - Entry - True:
-
 Entry (Entry):
 
 Tutorial First Hallway (Tutorial First Hallway) - Entry - True - Tutorial First Hallway Room - 0x00064:

--- a/worlds/witness/data/WitnessLogicExpert.txt
+++ b/worlds/witness/data/WitnessLogicExpert.txt
@@ -1,7 +1,5 @@
 ==Tutorial (Inside)==
 
-Menu (Menu) - Entry - True:
-
 Entry (Entry):
 
 Tutorial First Hallway (Tutorial First Hallway) - Entry - True - Tutorial First Hallway Room - 0x00064:

--- a/worlds/witness/data/WitnessLogicVanilla.txt
+++ b/worlds/witness/data/WitnessLogicVanilla.txt
@@ -1,7 +1,5 @@
 ==Tutorial (Inside)==
 
-Menu (Menu) - Entry - True:
-
 Entry (Entry):
 
 Tutorial First Hallway (Tutorial First Hallway) - Entry - True - Tutorial First Hallway Room - 0x00064:

--- a/worlds/witness/data/WitnessLogicVariety.txt
+++ b/worlds/witness/data/WitnessLogicVariety.txt
@@ -1,7 +1,5 @@
 ==Tutorial (Inside)==
 
-Menu (Menu) - Entry - True:
-
 Entry (Entry):
 
 Tutorial First Hallway (Tutorial First Hallway) - Entry - True - Tutorial First Hallway Room - 0x00064:

--- a/worlds/witness/hints.py
+++ b/worlds/witness/hints.py
@@ -250,8 +250,11 @@ def word_direct_hint(world: "WitnessWorld", hint: WitnessLocationHint) -> Witnes
             elif group_type == "Group":
                 location_name = f"a \"{chosen_group}\" location in {player_name}'s world"
             elif group_type == "Region":
-                if chosen_group == "Menu":
-                    location_name = f"a location near the start of {player_name}'s game (\"Menu\" region)"
+                origin_region_name = world.multiworld.worlds[hint.location.player].origin_region_name
+                if chosen_group == origin_region_name:
+                    location_name = (
+                        f"a location in the origin region of {player_name}'s world (\"{origin_region_name}\" region)"
+                    )
                 else:
                     location_name = f"a location in {player_name}'s \"{chosen_group}\" region"
 


### PR DESCRIPTION
Simple change for Witness, since "Menu" already just led to "Entry", which is the real origin region. So hey, this might actually be a performance boost for Witness too :) It's legit one less region.

Also, Witness' "vague hints" feature has a special case for "Menu" regions of other worlds, so this needs to be adjusted too (technically making this a bugfix? Kind of)