### PR TITLE
DOCS: Option Visibility and removing SpecialRange

### DIFF
--- a/docs/options api.md
+++ b/docs/options api.md
@@ -24,7 +24,7 @@ display as `Value1` on the webhost.
 files, and both will resolve as `value1`. This should be used when changing options around, i.e. changing a Toggle to a
 Choice, and defining `alias_true = option_full`.
 - All options with a fixed set of possible values (i.e. those which inherit from `Toggle`, `(Text)Choice` or
-`(Named/Special)Range`) support `random` as a generic option. `random` chooses from any of the available values for that
+`(Named)Range`) support `random` as a generic option. `random` chooses from any of the available values for that
 option, and is reserved by AP. You can set this as your default value, but you cannot define your own `option_random`.
 However, you can override `from_text` and handle `text == "random"` to customize its behavior or
 implement it for additional option types.
@@ -127,6 +127,21 @@ class Difficulty(Choice):
     option_normal = 1
     option_hard = 2
     default = 1
+```
+
+### Option Visibility
+Every option has a Visibility IntFlag, defaulting to `all` (`0b1111`). This lets you choose where the option will be displayed. The flags are:
+* `none` (`0b0000`): This option is not shown anywhere
+* `template` (`0b0001`): This option shows up in template yamls
+* `simple_ui` (`0b0010`): This option shows up on the options page
+* `complex_ui` (`0b0100`): This option shows up on the advanced/weighted options page
+* `spoiler` (`0b1000`): This option shows up in spoiler logs
+
+```python
+from Options import Visibility
+
+class HiddenChoiceOption(Choice):
+    visibility = Visibility.none
 ```
 
 ### Option Groups

--- a/docs/options api.md
+++ b/docs/options api.md
@@ -130,7 +130,9 @@ class Difficulty(Choice):
 ```
 
 ### Option Visibility
-Every option has a Visibility IntFlag, defaulting to `all` (`0b1111`). This lets you choose where the option will be displayed. The flags are:
+Every option has a Visibility IntFlag, defaulting to `all` (`0b1111`). This lets you choose where the option will be
+displayed. This only impacts where options are displayed, not how they can be used. Hidden options are still valid
+options in a yaml. The flags are as follows:
 * `none` (`0b0000`): This option is not shown anywhere
 * `template` (`0b0001`): This option shows up in template yamls
 * `simple_ui` (`0b0010`): This option shows up on the options page

--- a/docs/options api.md
+++ b/docs/options api.md
@@ -140,7 +140,7 @@ options in a yaml. The flags are as follows:
 * `spoiler` (`0b1000`): This option shows up in spoiler logs
 
 ```python
-from Options import Visibility
+from Options import Choice, Visibility
 
 class HiddenChoiceOption(Choice):
     visibility = Visibility.none


### PR DESCRIPTION
## What is this fixing or adding?

Adds some brief documentation on option visibility because this should exist. Also removes a reference to SpecialRange which doesn't exist.

## How was this tested?

👀
