### PR TITLE
The Witness: Fix nondeterministic entity hunt

### DIFF
--- a/worlds/witness/entity_hunt.py
+++ b/worlds/witness/entity_hunt.py
@@ -145,7 +145,7 @@ class EntityHuntPicker:
 
         remaining_entities, remaining_entity_weights = [], []
         for area, eligible_entities in self.ELIGIBLE_ENTITIES_PER_AREA.items():
-            for panel in eligible_entities - self.HUNT_ENTITIES:
+            for panel in sorted(eligible_entities - self.HUNT_ENTITIES):
                 remaining_entities.append(panel)
                 remaining_entity_weights.append(allowance_per_area[area])
 


### PR DESCRIPTION
## What is this fixing or adding?

In `_get_next_random_batch()`, the `remaining_entities` and `remaining_entity_weights` lists were being constructed by iterating sets.

This patch changes the function to iterate a sorted copy of each set instead.


## How was this tested?

Generated with a fixed seed (`1`) before and after and observed that the same locations with the same items were present in the spoiler when generating with this patch, compared to before.

Yaml used: [jkxWitness.zip](https://github.com/user-attachments/files/16902284/jkxWitness.zip)

Even with this change, the locations are not always in the same order, so I'm not sure if that implies other issues.
