### PR TITLE
Rogue Legacy: Remove item/location id overlap rejection code.

### DIFF
--- a/worlds/rogue_legacy/__init__.py
+++ b/worlds/rogue_legacy/__init__.py
@@ -48,31 +48,7 @@ class RLWorld(World):
     def fill_slot_data(self) -> dict:
         return {option_name: self.get_setting(option_name).value for option_name in rl_options}
 
-    def generate_early(self):
-        location_ids_used_per_game = {
-            world.game: set(world.location_id_to_name) for world in self.multiworld.worlds.values()
-        }
-        item_ids_used_per_game = {
-            world.game: set(world.item_id_to_name) for world in self.multiworld.worlds.values()
-        }
-        overlapping_games = set()
-
-        for id_lookup in (location_ids_used_per_game, item_ids_used_per_game):
-            for game_1, ids_1 in id_lookup.items():
-                for game_2, ids_2 in id_lookup.items():
-                    if game_1 == game_2:
-                        continue
-
-                    if ids_1 & ids_2:
-                        overlapping_games.add(tuple(sorted([game_1, game_2])))
-
-        if overlapping_games:
-            raise RuntimeError(
-                "In this multiworld, there are games with overlapping item/location IDs.\n"
-                "The current Rogue Legacy does not support these and a fix is not currently planned.\n"
-                f"The overlapping games are: {overlapping_games}"
-            )
-        
+    def generate_early(self):        
         # Check validation of names.
         additional_lady_names = len(self.get_setting("additional_lady_names").value)
         additional_sir_names = len(self.get_setting("additional_sir_names").value)

--- a/worlds/rogue_legacy/__init__.py
+++ b/worlds/rogue_legacy/__init__.py
@@ -48,7 +48,7 @@ class RLWorld(World):
     def fill_slot_data(self) -> dict:
         return {option_name: self.get_setting(option_name).value for option_name in rl_options}
 
-    def generate_early(self):        
+    def generate_early(self):
         # Check validation of names.
         additional_lady_names = len(self.get_setting("additional_lady_names").value)
         additional_sir_names = len(self.get_setting("additional_sir_names").value)


### PR DESCRIPTION
## What is this fixing or adding?
RL has been updated to support id overlaps. This removes that code that rejects.

## How was this tested?
It wasn't.

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/user-attachments/assets/49beabea-ddb1-4256-94ac-a3b67bd544ad)
