### PR TITLE
The Witness: Make location order in the spoiler log deterministic

### DIFF
--- a/worlds/witness/data/static_logic.py
+++ b/worlds/witness/data/static_logic.py
@@ -106,7 +106,7 @@ class StaticWitnessLogicObj:
                     "entityType": location_id,
                     "locationType": None,
                     "area": current_area,
-                    "order": len(self.ENTITIES_BY_HEX)
+                    "order": len(self.ENTITIES_BY_HEX),
                 }
 
                 self.ENTITIES_BY_NAME[self.ENTITIES_BY_HEX[entity_hex]["checkName"]] = self.ENTITIES_BY_HEX[entity_hex]

--- a/worlds/witness/data/static_logic.py
+++ b/worlds/witness/data/static_logic.py
@@ -106,6 +106,7 @@ class StaticWitnessLogicObj:
                     "entityType": location_id,
                     "locationType": None,
                     "area": current_area,
+                    "order": len(self.ENTITIES_BY_HEX)
                 }
 
                 self.ENTITIES_BY_NAME[self.ENTITIES_BY_HEX[entity_hex]["checkName"]] = self.ENTITIES_BY_HEX[entity_hex]
@@ -186,6 +187,7 @@ class StaticWitnessLogicObj:
                 "entityType": entity_type,
                 "locationType": location_type,
                 "area": current_area,
+                "order": len(self.ENTITIES_BY_HEX),
             }
 
             self.ENTITY_ID_TO_NAME[entity_hex] = full_entity_name


### PR DESCRIPTION
The Witness adds its locations to its regions in a non-deterministic order.
This is mostly fine, but it does mean the spoiler log is not fully deterministic (the only thing I'm aware of that cares about insertion order of locations)

This PR makes it so that the order of processing of entities is tracked when creating the entity list from WitnessLogic.txt, and then uses that to sort the locations before adding them to the regions.

This also looks quite nice:

```
Symmetry Island Lower Panel: Monastery Entry Right (Panel)
Symmetry Island Right 3 (Panel Hunt): +1 Panel Hunt
Symmetry Island Right 5: Power Surge
Symmetry Island Back 6: Treehouse Drawbridge (Panel)
Symmetry Island Left 7: Bunker Entry (Panel)
```

The Panel Hunt event "Symmetry Island Right 3 (Panel Hunt)" now shows up "in its proper place" ahead of the actual real location check "Symmetry Island Right 5"