### PR TITLE
Yacht Dice: Mark YachtWeights.py as "linguist-generated"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 worlds/blasphemous/region_data.py linguist-generated=true
+worlds/yachtdice/YachtWeights.py linguist-generated=true


### PR DESCRIPTION
This means its diff will be collapsed by default on PRs that change it, because it is an "auto generated" file that does not need to be looked at by reviewers