### PR TITLE
Pokemon Emerald: Prevent client from spamming goal status update

### DIFF
--- a/worlds/pokemon_emerald/client.py
+++ b/worlds/pokemon_emerald/client.py
@@ -350,6 +350,7 @@ class PokemonEmeraldClient(BizHawkClient):
 
             # Send game clear
             if not ctx.finished_game and game_clear:
+                ctx.finished_game = True
                 await ctx.send_msgs([{
                     "cmd": "StatusUpdate",
                     "status": ClientStatus.CLIENT_GOAL,


### PR DESCRIPTION
## What is this fixing or adding?

Must've thought `ctx.finished_game` updated itself based on the server status. But it doesn't and that's not its purpose. So as long as the player is in the overworld and their save file has victory flag set, the goal status update will get sent once per watcher loop, between 2 and 3 times a second. The spam doesn't make any noise in most logs unless you log the network.

## How was this tested?

Connected to a server with the network on the server logged. Observed the spam, reset the server save data, changed branches, observed the goal get sent exactly once.
