### PR TITLE
Blasphemous: Move pre_fill to create_items

### DIFF
--- a/worlds/blasphemous/__init__.py
+++ b/worlds/blasphemous/__init__.py
@@ -199,8 +199,6 @@ class BlasphemousWorld(World):
 
         self.multiworld.itempool += pool
 
-
-    def pre_fill(self):
         self.place_items_from_dict(unrandomized_dict)
 
         if self.options.thorn_shuffle == "vanilla":


### PR DESCRIPTION
## What is this fixing or adding?
Two different bugs that resulted from these being done during `pre_fill`:
1. Plando could mess up any of these item placements, causing generation to fail with a far less-clear error in Blasphemous's `pre_fill` instead of a plando error.
2. This added "Thorn Upgrade" to `local_items` during `pre_fill`. This does not actually work, because `locality_rules` is called earlier and it also allows a player to put them in both `non_local_items` and `local_items` (with `non_local` taking priority due to the timing).

## How was this tested?

Generations using plando and option configurations that would hit these code paths. Also comparing spoilers before and after the changes.