### PR TITLE
Core: make component.game_name a required field and allow multiple names

### DIFF
--- a/Launcher.py
+++ b/Launcher.py
@@ -99,12 +99,12 @@ def update_settings():
 
 components.extend([
     # Functions
-    Component("Open host.yaml", func=open_host_yaml),
-    Component("Open Patch", func=open_patch),
-    Component("Generate Template Options", func=generate_yamls),
-    Component("Discord Server", icon="discord", func=lambda: webbrowser.open("https://discord.gg/8Z65BR2")),
-    Component("Unrated/18+ Discord Server", icon="discord", func=lambda: webbrowser.open("https://discord.gg/fqvNCCRsu4")),
-    Component("Browse Files", func=browse_files),
+    Component("Open host.yaml", "Archipelago", func=open_host_yaml),
+    Component("Open Patch", "Archipelago", func=open_patch),
+    Component("Generate Template Options", "Archipelago", func=generate_yamls),
+    Component("Discord Server", "Archipelago", icon="discord", func=lambda: webbrowser.open("https://discord.gg/8Z65BR2")),
+    Component("Unrated/18+ Discord Server", "Archipelago", icon="discord", func=lambda: webbrowser.open("https://discord.gg/fqvNCCRsu4")),
+    Component("Browse Files", "Archipelago", func=browse_files),
 ])
 
 

--- a/Launcher.py
+++ b/Launcher.py
@@ -119,8 +119,9 @@ def handle_uri(path: str, launch_args: Tuple[str, ...]) -> None:
     else:  # TODO around 0.6.0 - this is for pre this change webhost uri's
         game = "Archipelago"
     for component in components:
-        if component.supports_uri and component.game_name == game:
-            client_component = component
+        if component.supports_uri:
+            if component.game_name == game or (isinstance(component.game_name, list) and game in component.game_name):
+                client_component = component
         elif component.display_name == "Text Client":
             text_client_component = component
 

--- a/worlds/AutoSNIClient.py
+++ b/worlds/AutoSNIClient.py
@@ -10,7 +10,7 @@ from worlds.LauncherComponents import Component, SuffixIdentifier, Type, compone
 if TYPE_CHECKING:
     from SNIClient import SNIContext
 
-component = Component('SNI Client', 'SNIClient', component_type=Type.CLIENT, file_identifier=SuffixIdentifier(".apsoe"))
+component = Component('SNI Client', ["Archipelago"], 'SNIClient', component_type=Type.CLIENT, file_identifier=SuffixIdentifier(".apsoe"))
 components.append(component)
 
 
@@ -39,6 +39,7 @@ class AutoSNIClientRegister(abc.ABCMeta):
         new_class = super().__new__(cls, name, bases, dct)
         if "game" in dct:
             AutoSNIClientRegister.game_handlers[dct["game"]] = new_class()
+            component.game_name.append(dct["game"])
 
         if "patch_suffix" in dct:
             patch_suffix = dct["patch_suffix"]

--- a/worlds/AutoSNIClient.py
+++ b/worlds/AutoSNIClient.py
@@ -39,6 +39,7 @@ class AutoSNIClientRegister(abc.ABCMeta):
         new_class = super().__new__(cls, name, bases, dct)
         if "game" in dct:
             AutoSNIClientRegister.game_handlers[dct["game"]] = new_class()
+            assert isinstance(component.game_name, list)
             component.game_name.append(dct["game"])
 
         if "patch_suffix" in dct:

--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -3,7 +3,7 @@ import logging
 import pathlib
 import weakref
 from enum import Enum, auto
-from typing import Optional, Callable, List, Iterable, Tuple
+from typing import Optional, Callable, List, Iterable, Tuple, Union
 
 from Utils import local_path, open_filename
 
@@ -26,13 +26,13 @@ class Component:
     cli: bool
     func: Optional[Callable]
     file_identifier: Optional[Callable[[str], bool]]
-    game_name: Optional[str]
+    game_name: Union[str, List[str]]
     supports_uri: Optional[bool]
 
-    def __init__(self, display_name: str, script_name: Optional[str] = None, frozen_name: Optional[str] = None,
-                 cli: bool = False, icon: str = 'icon', component_type: Optional[Type] = None,
-                 func: Optional[Callable] = None, file_identifier: Optional[Callable[[str], bool]] = None,
-                 game_name: Optional[str] = None, supports_uri: Optional[bool] = False):
+    def __init__(self, display_name: str, game_name: Union[str, List[str]], script_name: Optional[str] = None,
+                 frozen_name: Optional[str] = None, cli: bool = False, icon: str = 'icon',
+                 component_type: Optional[Type] = None, func: Optional[Callable] = None,
+                 file_identifier: Optional[Callable[[str], bool]] = None, supports_uri: Optional[bool] = False):
         self.display_name = display_name
         self.script_name = script_name
         self.frozen_name = frozen_name or f'Archipelago{script_name}' if script_name else None
@@ -165,39 +165,39 @@ def install_apworld(apworld_path: str = "") -> None:
 
 components: List[Component] = [
     # Launcher
-    Component('Launcher', 'Launcher', component_type=Type.HIDDEN),
+    Component('Launcher', "Archipelago", 'Launcher', component_type=Type.HIDDEN),
     # Core
-    Component('Host', 'MultiServer', 'ArchipelagoServer', cli=True,
+    Component('Host', "Archipelago", 'MultiServer', 'ArchipelagoServer', cli=True,
               file_identifier=SuffixIdentifier('.archipelago', '.zip')),
-    Component('Generate', 'Generate', cli=True),
-    Component("Install APWorld", func=install_apworld, file_identifier=SuffixIdentifier(".apworld")),
-    Component('Text Client', 'CommonClient', 'ArchipelagoTextClient', func=launch_textclient),
-    Component('Links Awakening DX Client', 'LinksAwakeningClient',
+    Component('Generate', "Archipelago", 'Generate', cli=True),
+    Component("Install APWorld", "Archipelago", func=install_apworld, file_identifier=SuffixIdentifier(".apworld")),
+    Component('Text Client', "Archipelago", 'CommonClient', 'ArchipelagoTextClient', func=launch_textclient),
+    Component('Links Awakening DX Client', "Links Awakening DX", 'LinksAwakeningClient',
               file_identifier=SuffixIdentifier('.apladx')),
-    Component('LttP Adjuster', 'LttPAdjuster'),
+    Component('LttP Adjuster', "A Link to the Past", 'LttPAdjuster'),
     # Minecraft
-    Component('Minecraft Client', 'MinecraftClient', icon='mcicon', cli=True,
+    Component('Minecraft Client', "Minecraft", 'MinecraftClient', icon='mcicon', cli=True,
               file_identifier=SuffixIdentifier('.apmc')),
     # Ocarina of Time
-    Component('OoT Client', 'OoTClient',
+    Component('OoT Client', "Ocarina of Time", 'OoTClient',
               file_identifier=SuffixIdentifier('.apz5')),
-    Component('OoT Adjuster', 'OoTAdjuster'),
+    Component('OoT Adjuster', "Ocarina of Time", 'OoTAdjuster'),
     # FF1
-    Component('FF1 Client', 'FF1Client'),
+    Component('FF1 Client', "Final Fantasy", 'FF1Client'),
     # TLoZ
-    Component('Zelda 1 Client', 'Zelda1Client', file_identifier=SuffixIdentifier('.aptloz')),
+    Component('Zelda 1 Client', "The Legend of Zelda", 'Zelda1Client', file_identifier=SuffixIdentifier('.aptloz')),
     # ChecksFinder
-    Component('ChecksFinder Client', 'ChecksFinderClient'),
+    Component('ChecksFinder Client', "ChecksFinder", 'ChecksFinderClient'),
     # Starcraft 2
-    Component('Starcraft 2 Client', 'Starcraft2Client'),
+    Component('Starcraft 2 Client', "Starcraft 2", 'Starcraft2Client'),
     # Wargroove
-    Component('Wargroove Client', 'WargrooveClient'),
+    Component('Wargroove Client', "Wargroove", 'WargrooveClient'),
     # Zillion
-    Component('Zillion Client', 'ZillionClient',
+    Component('Zillion Client', "Zillion", 'ZillionClient',
               file_identifier=SuffixIdentifier('.apzl')),
 
-    #MegaMan Battle Network 3
-    Component('MMBN3 Client', 'MMBN3Client', file_identifier=SuffixIdentifier('.apbn3'))
+    # MegaMan Battle Network 3
+    Component('MMBN3 Client', "MegaMan Battle Network 3", 'MMBN3Client', file_identifier=SuffixIdentifier('.apbn3'))
 ]
 
 

--- a/worlds/_bizhawk/client.py
+++ b/worlds/_bizhawk/client.py
@@ -18,7 +18,7 @@ def launch_client(*args) -> None:
     launch_subprocess(launch, name="BizHawkClient")
 
 
-component = Component("BizHawk Client", "BizHawkClient", component_type=Type.CLIENT, func=launch_client,
+component = Component("BizHawk Client", ["Archipelago"], "BizHawkClient", component_type=Type.CLIENT, func=launch_client,
                       file_identifier=SuffixIdentifier())
 components.append(component)
 
@@ -37,6 +37,7 @@ class AutoBizHawkClientRegister(abc.ABCMeta):
 
             if "game" in namespace:
                 AutoBizHawkClientRegister.game_handlers[systems][namespace["game"]] = new_class()
+                component.game_name.append(namespace["game"])
 
         # Update launcher component's suffixes
         if "patch_suffix" in namespace:

--- a/worlds/_bizhawk/client.py
+++ b/worlds/_bizhawk/client.py
@@ -37,6 +37,7 @@ class AutoBizHawkClientRegister(abc.ABCMeta):
 
             if "game" in namespace:
                 AutoBizHawkClientRegister.game_handlers[systems][namespace["game"]] = new_class()
+                assert isinstance(component.game_name, list)
                 component.game_name.append(namespace["game"])
 
         # Update launcher component's suffixes

--- a/worlds/adventure/__init__.py
+++ b/worlds/adventure/__init__.py
@@ -31,7 +31,7 @@ from .Rules import set_rules
 from worlds.LauncherComponents import Component, components, SuffixIdentifier
 
 # Adventure
-components.append(Component('Adventure Client', 'AdventureClient', file_identifier=SuffixIdentifier('.apadvn')))
+components.append(Component('Adventure Client', 'Adventure', 'AdventureClient', file_identifier=SuffixIdentifier('.apadvn')))
 
 
 class AdventureSettings(settings.Group):

--- a/worlds/ahit/__init__.py
+++ b/worlds/ahit/__init__.py
@@ -21,7 +21,7 @@ def launch_client():
     launch_subprocess(launch, name="AHITClient")
 
 
-components.append(Component("A Hat in Time Client", "AHITClient", func=launch_client,
+components.append(Component("A Hat in Time Client", "A Hat in Time", "AHITClient", func=launch_client,
                             component_type=Type.CLIENT, icon='yatta'))
 
 icon_paths['yatta'] = local_path('data', 'yatta.png')

--- a/worlds/factorio/__init__.py
+++ b/worlds/factorio/__init__.py
@@ -25,7 +25,7 @@ def launch_client():
     launch_subprocess(launch, name="FactorioClient")
 
 
-components.append(Component("Factorio Client", "FactorioClient", func=launch_client, component_type=Type.CLIENT))
+components.append(Component("Factorio Client", "Factorio", "FactorioClient", func=launch_client, component_type=Type.CLIENT))
 
 
 class FactorioSettings(settings.Group):

--- a/worlds/kh1/__init__.py
+++ b/worlds/kh1/__init__.py
@@ -17,7 +17,7 @@ def launch_client():
     launch_subprocess(launch, name="KH1 Client")
 
 
-components.append(Component("KH1 Client", "KH1Client", func=launch_client, component_type=Type.CLIENT))
+components.append(Component("KH1 Client", "Kingdom Hearts", "KH1Client", func=launch_client, component_type=Type.CLIENT))
 
 
 class KH1Web(WebWorld):

--- a/worlds/kh2/__init__.py
+++ b/worlds/kh2/__init__.py
@@ -20,7 +20,7 @@ def launch_client():
     launch_subprocess(launch, name="KH2Client")
 
 
-components.append(Component("KH2 Client", "KH2Client", func=launch_client, component_type=Type.CLIENT))
+components.append(Component("KH2 Client", "Kingdom Hearts 2", "KH2Client", func=launch_client, component_type=Type.CLIENT))
 
 
 class KingdomHearts2Web(WebWorld):

--- a/worlds/undertale/__init__.py
+++ b/worlds/undertale/__init__.py
@@ -18,7 +18,7 @@ def run_client():
     p.start()
 
 
-components.append(Component("Undertale Client", "UndertaleClient"))
+components.append(Component("Undertale Client", "Undertale", "UndertaleClient"))
 # components.append(Component("Undertale Client", func=run_client))
 
 

--- a/worlds/zork_grand_inquisitor/__init__.py
+++ b/worlds/zork_grand_inquisitor/__init__.py
@@ -11,6 +11,7 @@ def launch_client() -> None:
 LauncherComponents.components.append(
     LauncherComponents.Component(
         "Zork Grand Inquisitor Client",
+        "Zork Grand Inquisitor",
         func=launch_client,
         component_type=LauncherComponents.Type.CLIENT
     )


### PR DESCRIPTION
## What is this fixing or adding?
This makes it so that `LauncherComponent`'s `game_name` field is required. It also allows for a list of games. This is needed for lazy loading, as we don't have any other way to know what world/s need to be loaded in order for a component to behave as it should. "Archipelago" is designated for those that either don't require a world or are "meta components". This will absolutely break unsupported worlds, so should probably not be merged until after 0.5.1?

## How was this tested?
Wasn't
