### PR TITLE
Rogue Legacy: Split Additional Names into two option classes

### DIFF
--- a/worlds/rogue_legacy/Options.py
+++ b/worlds/rogue_legacy/Options.py
@@ -175,13 +175,21 @@ class NumberOfChildren(Range):
     default = 3
 
 
-class AdditionalNames(OptionSet):
+class AdditionalLadyNames(OptionSet):
     """
     Set of additional names your potential offspring can have. If Allow Default Names is disabled, this is the only list
     of names your children can have. The first value will also be your initial character's name depending on Starting
     Gender.
     """
-    display_name = "Additional Names"
+    display_name = "Additional Lady Names"
+
+class AdditionalSirNames(OptionSet):
+    """
+    Set of additional names your potential offspring can have. If Allow Default Names is disabled, this is the only list
+    of names your children can have. The first value will also be your initial character's name depending on Starting
+    Gender.
+    """
+    display_name = "Additional Sir Names"
 
 
 class AllowDefaultNames(DefaultOnToggle):
@@ -374,6 +382,6 @@ class RLOptions(PerGameCommonOptions):
     crit_chance_pool: CritChanceUpPool
     crit_damage_pool: CritDamageUpPool
     allow_default_names: AllowDefaultNames
-    additional_lady_names: AdditionalNames
-    additional_sir_names: AdditionalNames
+    additional_lady_names: AdditionalLadyNames
+    additional_sir_names: AdditionalSirNames
     death_link: DeathLink


### PR DESCRIPTION
## What is this fixing or adding?

Technically, nothing. But it allows for https://github.com/ArchipelagoMW/Archipelago/pull/3530 which is soft-required for https://github.com/ArchipelagoMW/Archipelago/pull/3393. This changes the AdditionalNames option class into two classes (one for each type)

## How was this tested?

Unit tests, generations, and connecting to and playing games that use these options.