### PR TITLE
BizHawkClient: Remove `run_gui` in favor of `make_gui`

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -662,7 +662,7 @@ class CommonContext:
         logger.exception(msg, exc_info=exc_info, extra={'compact_gui': True})
         self._messagebox_connection_loss = self.gui_error(msg, exc_info[1])
 
-    def make_gui(self) -> type:
+    def make_gui(self) -> typing.Type["kvui.GameManager"]:
         """To return the Kivy App class needed for run_gui so it can be overridden before being built"""
         from kvui import GameManager
 

--- a/worlds/_bizhawk/context.py
+++ b/worlds/_bizhawk/context.py
@@ -59,14 +59,10 @@ class BizHawkClientContext(CommonContext):
         self.bizhawk_ctx = BizHawkContext()
         self.watcher_timeout = 0.5
 
-    def run_gui(self):
-        from kvui import GameManager
-
-        class BizHawkManager(GameManager):
-            base_title = "Archipelago BizHawk Client"
-
-        self.ui = BizHawkManager(self)
-        self.ui_task = asyncio.create_task(self.ui.async_run(), name="UI")
+    def make_gui(self):
+        ui = super().make_gui()
+        ui.base_title = "Archipelago BizHawk Client"
+        return ui
 
     def on_package(self, cmd, args):
         if cmd == "Connected":


### PR DESCRIPTION
## What is this fixing or adding?

Makes use of the changes in #3297.

Also improves the typing of `CommonContext.make_gui`

## How was this tested?

Ran `BizHawkClient.py` and also opened it from the launcher.
