### PR TITLE
Pokemon Emerald: Add normalize encounter rate option to slot data

### DIFF
--- a/worlds/pokemon_emerald/__init__.py
+++ b/worlds/pokemon_emerald/__init__.py
@@ -711,6 +711,7 @@ class PokemonEmeraldWorld(World):
             "trainersanity",
             "modify_118",
             "death_link",
+            "normalize_encounter_rates",
         )
         slot_data["free_fly_location_id"] = self.free_fly_location_id
         slot_data["hm_requirements"] = self.hm_requirements


### PR DESCRIPTION
## What is this fixing or adding?

Adds a new option value for slot data. The tracker already believed it was receiving this. Just got missed.

## How was this tested?

Generated a world and it didn't crash
