### PR TITLE
LADX: text shuffle exclusions

### DIFF
--- a/worlds/ladx/LADXR/generator.py
+++ b/worlds/ladx/LADXR/generator.py
@@ -342,11 +342,53 @@ def generateRom(args, world: "LinksAwakeningWorld"):
         patches.enemies.doubleTrouble(rom)
 
     if world.options.text_shuffle:
+        excluded_ids = [
+            # Overworld owl statues
+            0x1B6, 0x1B7, 0x1B8, 0x1B9, 0x1BA, 0x1BB, 0x1BC, 0x1BD, 0x1BE, 0x22D,
+
+            # Dungeon owls
+            0x288, 0x280,  # D1
+            0x28A, 0x289, 0x281,  # D2
+            0x282, 0x28C, 0x28B,  # D3
+            0x283,  # D4
+            0x28D, 0x284,  # D5
+            0x285, 0x28F, 0x28E,  # D6
+            0x291, 0x290, 0x286,  # D7
+            0x293, 0x287, 0x292,  # D8
+            0x263,  # D0
+
+            # Hint books
+            0x267,  # color dungeon
+            0x200, 0x201,
+            0x202, 0x203,
+            0x204, 0x205,
+            0x206, 0x207,
+            0x208, 0x209,
+            0x20A, 0x20B,
+            0x20C,
+            0x20D, 0x20E,
+            0x217, 0x218, 0x219, 0x21A,
+
+            # Goal sign
+            0x1A3,
+
+            # Signpost maze
+            0x1A9, 0x1AA, 0x1AB, 0x1AC, 0x1AD,
+
+            # Prices
+            0x02C, 0x02D, 0x030, 0x031, 0x032, 0x033, # Shop items
+            0x03B, # Trendy Game
+            0x045, # Fisherman
+            0x018, 0x019, # Crazy Tracy
+            0x0DC, # Mamu
+            0x0F0, # Raft ride
+        ]
+        excluded_texts = [ rom.texts[b_id] for b_id in excluded_ids]
         buckets = defaultdict(list)
         # For each ROM bank, shuffle text within the bank
         for n, data in enumerate(rom.texts._PointerTable__data):
             # Don't muck up which text boxes are questions and which are statements
-            if type(data) != int and data and data != b'\xFF':
+            if type(data) != int and data and data != b'\xFF' and data not in excluded_texts:
                 buckets[(rom.texts._PointerTable__banks[n], data[len(data) - 1] == 0xfe)].append((n, data))
         for bucket in buckets.values():
             # For each bucket, make a copy and shuffle

--- a/worlds/ladx/LADXR/generator.py
+++ b/worlds/ladx/LADXR/generator.py
@@ -383,7 +383,7 @@ def generateRom(args, world: "LinksAwakeningWorld"):
             0x0DC, # Mamu
             0x0F0, # Raft ride
         ]
-        excluded_texts = [ rom.texts[b_id] for b_id in excluded_ids]
+        excluded_texts = [ rom.texts[excluded_id] for excluded_id in excluded_ids]
         buckets = defaultdict(list)
         # For each ROM bank, shuffle text within the bank
         for n, data in enumerate(rom.texts._PointerTable__data):


### PR DESCRIPTION
## What is this fixing or adding?

Creates a list of exclusions for text shuffle.

zig wanted to exclude this when he initially implemented text shuffle but simply forgot and since then just didn't have time. This is preserving nobody's idea.

Having these options in text shuffle lessens the experience for all users as, for example, the Egg Path Textbox WILL be on another object but WILL NOT display the correct text (which path it is) which leads to users being confused and frustrated because they believe the shuffled textbox is correct. They also shuffle the path when talking to the book for the first time WITHOUT being able to EVER find out the right path without having the meta knowledge of knowing all four paths.

Excludes:

- Owl statues (hints)
- Library books (hints, egg path)
- Signpost by egg indicating goal
- Signs in the signpost maze
- All text containing rupee prices


## How was this tested?
Generated solo seeds, verified intended text was unshuffled.