### PR TITLE
MM2: fix Air Shooter minimum damage

### DIFF
--- a/worlds/mm2/rules.py
+++ b/worlds/mm2/rules.py
@@ -37,7 +37,7 @@ weapons_to_name: Dict[int, str] = {
 minimum_weakness_requirement: Dict[int, int] = {
     0: 1,  # Mega Buster is free
     1: 14,  # 2 shots of Atomic Fire
-    2: 1,  # 14 shots of Air Shooter, although you likely hit more than one shot
+    2: 2,  # 14 shots of Air Shooter
     3: 4,  # 9 uses of Leaf Shield, 3 ends up 1 damage off
     4: 1,  # 56 uses of Bubble Lead
     5: 1,  # 224 uses of Quick Boomerang


### PR DESCRIPTION
## What is this fixing or adding?
Currently, Air Shooter is allowed to logically defeat a boss if it does at least one damage. However, hit detection for Air Shooter is jank to the point its very easy to have shots completely phase through the boss, thus making the boss impossible without an energy refill. We just up the minimum to 2 so at least one shot needs to land properly.

## How was this tested?
Ran unittests.

## If this makes graphical changes, please attach screenshots.
