### PR TITLE
KH2: Add missing indirect conditions for Final region access

### DIFF
--- a/worlds/kh2/Rules.py
+++ b/worlds/kh2/Rules.py
@@ -355,6 +355,16 @@ class KH2FormRules(KH2Rules):
             RegionName.Master: lambda state: self.multi_form_region_access(),
             RegionName.Final:  lambda state: self.final_form_region_access(state)
         }
+        # Accessing Final requires being able to reach one of the locations in final_leveling_access, but reaching a
+        # location requires being able to reach the region the location is in, so an indirect condition is required.
+        # The access rules of each of the locations in final_leveling_access do not check for being able to reach other
+        # locations or other regions, so it is only the parent region of each location that needs to be added as an
+        # indirect condition.
+        self.form_region_indirect_condition_regions = {
+            RegionName.Final: {
+                self.multiworld.get_location(location, self.player).parent_region for location in final_leveling_access
+            }
+        }
 
     def final_form_region_access(self, state: CollectionState) -> bool:
         """
@@ -388,12 +398,15 @@ class KH2FormRules(KH2Rules):
         for region_name in drive_form_list:
             if region_name == RegionName.Summon and not self.world.options.SummonLevelLocationToggle:
                 continue
+            indirect_condition_regions = self.form_region_indirect_condition_regions.get(region_name, ())
             # could get the location of each of these, but I feel like that would be less optimal
             region = self.multiworld.get_region(region_name, self.player)
             # if region_name in form_region_rules
             if region_name != RegionName.Summon:
                 for entrance in region.entrances:
                     entrance.access_rule = self.form_region_rules[region_name]
+                    for indirect_condition_region in indirect_condition_regions:
+                        self.multiworld.register_indirect_condition(indirect_condition_region, entrance)
             for loc in region.locations:
                 loc.access_rule = self.form_rules[loc.name]
 

--- a/worlds/kh2/Rules.py
+++ b/worlds/kh2/Rules.py
@@ -362,7 +362,7 @@ class KH2FormRules(KH2Rules):
         # indirect condition.
         self.form_region_indirect_condition_regions = {
             RegionName.Final: {
-                self.multiworld.get_location(location, self.player).parent_region for location in final_leveling_access
+                self.get_location(location).parent_region for location in final_leveling_access
             }
         }
 

--- a/worlds/kh2/Rules.py
+++ b/worlds/kh2/Rules.py
@@ -362,7 +362,7 @@ class KH2FormRules(KH2Rules):
         # indirect condition.
         self.form_region_indirect_condition_regions = {
             RegionName.Final: {
-                self.get_location(location).parent_region for location in final_leveling_access
+                self.world.get_location(location).parent_region for location in final_leveling_access
             }
         }
 


### PR DESCRIPTION
## What is this fixing or adding?

Entrances to the Final region require being able to reach any one of a number of locations, but for a location to be reachable, its parent region must also be reachable, so indirect conditions must be added for these regions.

## How was this tested?

I wrote a test (#3924) to sweep in spheres once as normal and then a second time with `world.explicit_indirect_conditions = False`. When all required indirect conditions are present with `world.explicit_indirect_conditions = True`, the spheres in both sweeps should always be the same. KH2 would often fail this test for locations in the Final region.

After adding in the missing indirect conditions in this PR, the test no longer fails.