### PR TITLE
sm64ex: Add missing indirect condition for BitFS randomized entrance

### DIFF
--- a/worlds/sm64ex/Regions.py
+++ b/worlds/sm64ex/Regions.py
@@ -246,10 +246,10 @@ def create_regions(world: MultiWorld, options: SM64Options, player: int):
     regBitS.subregions = [bits_top]
 
 
-def connect_regions(world: MultiWorld, player: int, source: str, target: str, rule=None):
+def connect_regions(world: MultiWorld, player: int, source: str, target: str, rule=None) -> Entrance:
     sourceRegion = world.get_region(source, player)
     targetRegion = world.get_region(target, player)
-    sourceRegion.connect(targetRegion, rule=rule)
+    return sourceRegion.connect(targetRegion, rule=rule)
 
 
 def create_region(name: str, player: int, world: MultiWorld) -> SM64Region:

--- a/worlds/sm64ex/Rules.py
+++ b/worlds/sm64ex/Rules.py
@@ -92,9 +92,12 @@ def set_rules(world, options: SM64Options, player: int, area_connections: dict, 
     connect_regions(world, player, "Hazy Maze Cave", randomized_entrances_s["Cavern of the Metal Cap"])
     connect_regions(world, player, "Basement", randomized_entrances_s["Vanish Cap under the Moat"],
                     rf.build_rule("GP"))
-    connect_regions(world, player, "Basement", randomized_entrances_s["Bowser in the Fire Sea"],
-                    lambda state: state.has("Power Star", player, star_costs["BasementDoorCost"]) and
-                                  state.can_reach("DDD: Board Bowser's Sub", 'Location', player))
+    entrance = connect_regions(world, player, "Basement", randomized_entrances_s["Bowser in the Fire Sea"],
+                               lambda state: state.has("Power Star", player, star_costs["BasementDoorCost"]) and
+                               state.can_reach("DDD: Board Bowser's Sub", 'Location', player))
+    # Access to "DDD: Board Bowser's Sub" does not require access to other locations or regions, so the only region that
+    # needs to be registered is its parent region.
+    world.register_indirect_condition(world.get_location("DDD: Board Bowser's Sub", player).parent_region, entrance)
 
     connect_regions(world, player, "Menu", "Second Floor", lambda state: state.has("Second Floor Key", player) or state.has("Progressive Key", player, 2))
 


### PR DESCRIPTION
## What is this fixing or adding?

The Bowser in the Fire Sea randomized entrance has an access rule that requires being able to reach "DDD: Board Bowser's Sub", but being able to reach a location also requires being able to reach the region that location is in, so an indirect condition is required.

## How was this tested?

I wrote a test (#3924) to sweep in spheres once as normal and then a second time with `world.explicit_indirect_conditions = False`. When all required indirect conditions are present with `world.explicit_indirect_conditions = True`, the spheres in both sweeps should always be the same.

sm64ex would often fail this test for locations in the `BitFS: Upper` region and a couple of locations in the `Dire, Dire Docks` region whose access rules require access to the `Bowser in the Fire Sea Key` location which is in the `BitFS: Upper` region.

After adding in the missing indirect condition in this PR, the test no longer fails.