### PR TITLE
Core: Fix non-progression item links

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -336,7 +336,7 @@ class MultiWorld():
                 for _ in range(item_count):
                     new_item = group["world"].create_item(item_name)
 
-                   # Make sure this item is picked up even if it is not progression
+                    # Make sure this item is picked up even if it is not progression
                     # (Monkeypatching a property is kind of hard, this is one of the only ways)
                     class AdvancementTrue(new_item.__class__):
                         advancement = True

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -336,6 +336,8 @@ class MultiWorld():
                 for _ in range(item_count):
                     new_item = group["world"].create_item(item_name)
 
+                   # Make sure this item is picked up even if it is not progression
+                    # (Monkeypatching a property is kind of hard, this is one of the only ways)
                     class AdvancementTrue(new_item.__class__):
                         advancement = True
                     new_item.__class__ = AdvancementTrue

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -335,6 +335,11 @@ class MultiWorld():
             for item_name, item_count in next(iter(common_item_count.values())).items():
                 for _ in range(item_count):
                     new_item = group["world"].create_item(item_name)
+
+                    class AdvancementTrue(new_item.__class__):
+                        advancement = True
+                    new_item.__class__ = AdvancementTrue
+
                     # mangle together all original classification bits
                     new_item.classification |= classifications[item_name]
                     new_itempool.append(new_item)


### PR DESCRIPTION
https://discord.com/channels/731205301247803413/1214608557077700720/1283880700126302228

Basically, non-progression item links are broken right now because they fail accessibility.
The group item will also be non-progression, thus it will never be picked up when sweeping, thus the locations are permanently inaccessible.
Just setting item links groups to `accessibility = minimal` *feels* like it should work, but it does not because it causes crashes.

So, my fix is to force the group item to be an advancement, but without actually changing its classification, by monkeypatching the `advancement` property.

Reproduction steps of the bug:
Generate with 2 of these.
```
name: Player{number}
description: Default Bumper Stickers Template

game: Bumper Stickers
requires:
  version: 0.5.0 # Version of Archipelago required for this yaml to work as expected.

Bumper Stickers:
  item_links:
    # Share part of your item pool with other players.
    - name: BSLink
      item_pool:
        - Everything
      replacement_item: null
      link_replacement: true
```

Alternatives:
https://github.com/ArchipelagoMW/Archipelago/pull/3928
https://github.com/ArchipelagoMW/Archipelago/pull/3930

Discussion:
https://github.com/ArchipelagoMW/Archipelago/pull/3928 is the smallest, potentially least "cursed" fix.
The reason to prefer my solution would be: It is also small, and also only touches the item links code and doesn't make core bend around item links any more than it already does.
The reason to prefer https://github.com/ArchipelagoMW/Archipelago/pull/3930 would be: It is probably the most "correct" fix