### PR TITLE
Core: don't do accessibility check for Groups

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -612,7 +612,8 @@ class MultiWorld():
             "full": set()
         }
         for player, world in self.worlds.items():
-            players[world.options.accessibility.current_key].add(player)
+            if player in self.player_ids:  # skip Groups
+                players[world.options.accessibility.current_key].add(player)
 
         beatable_fulfilled = False
 


### PR DESCRIPTION
## What is this fixing or adding?
skips Groups in accessibility check

## How was this tested?
ran an everything linked bumpersticker yaml with itself and saw accessibility warnings before but not after

## If this makes graphical changes, please attach screenshots.
