### PR TITLE
Core: force Groups to have minimal accessibility

### DIFF
--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -480,6 +480,8 @@ class World(metaclass=AutoWorldRegister):
         group = cls(multiworld, new_player_id)
         group.options = cls.options_dataclass(**{option_key: option.from_any(option.default)
                                                  for option_key, option in cls.options_dataclass.type_hints.items()})
+        from Options import Accessibility
+        group.options.accessibility.value = Accessibility.option_minimal
 
         return group
 


### PR DESCRIPTION
## What is this fixing or adding?
force Groups to have minimal accessibility

## How was this tested?
same as #3928 

## If this makes graphical changes, please attach screenshots.
