### PR TITLE
Core: force item link items to progression

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -63,6 +63,7 @@ class MultiWorld():
     plando_connections: List
     worlds: Dict[int, "AutoWorld.World"]
     groups: Dict[int, Group]
+    group_classifications: Dict[str, int]
     regions: RegionManager
     itempool: List[Item]
     is_race: bool = False
@@ -327,7 +328,7 @@ class MultiWorld():
                             del (counters[player][item])
                 return counters, classifications
 
-            common_item_count, classifications = find_common_pool(group["players"], group["item_pool"])
+            common_item_count, self.group_classifications = find_common_pool(group["players"], group["item_pool"])
             if not common_item_count:
                 continue
 
@@ -336,7 +337,7 @@ class MultiWorld():
                 for _ in range(item_count):
                     new_item = group["world"].create_item(item_name)
                     # mangle together all original classification bits
-                    new_item.classification |= classifications[item_name]
+                    new_item.classification = ItemClassification.progression
                     new_itempool.append(new_item)
 
             region = Region("Menu", group_id, self, "ItemLink")

--- a/Main.py
+++ b/Main.py
@@ -290,6 +290,8 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
                         assert location.address not in locations_data[location.player], (
                             f"Locations with duplicate address. {location} and "
                             f"{locations_data[location.player][location.address]}")
+                        if location.item.player in multiworld.groups:
+                            location.item.code = multiworld.group_classifications[location.item.name]
                         locations_data[location.player][location.address] = \
                             location.item.code, location.item.player, location.item.flags
                         if location.name in multiworld.worlds[location.player].options.start_location_hints:


### PR DESCRIPTION
## What is this fixing or adding?
Forces item link group items to be progression so that their locations can be properly collected. Reverts them back to the common classification when writing multidata

## How was this tested?
Wasn't, not sure if this is the solution we should go with.

## If this makes graphical changes, please attach screenshots.
