### PR TITLE
Core: have item link groups share common option results

### DIFF
--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -480,6 +480,16 @@ class World(metaclass=AutoWorldRegister):
         group = cls(multiworld, new_player_id)
         group.options = cls.options_dataclass(**{option_key: option.from_any(option.default)
                                                  for option_key, option in cls.options_dataclass.type_hints.items()})
+        sorted_players = sorted(players)
+        # loop through player options and if all players have the same option, set the group's option to that
+        for option_key, option in PerGameCommonOptions.type_hints.items():
+            new_value = getattr(multiworld.worlds[sorted_players[0]].options, option_key).value
+            for player in sorted_players:
+                if getattr(multiworld.worlds[player].options, option_key).value != new_value:
+                    break
+            else:
+                # all players option value for this option matches
+                getattr(group.options, option_key).value = new_value
 
         return group
 


### PR DESCRIPTION
## What is this fixing or adding?
Has the created item link groups pool together options that are shared between all players. this only links together the common and per game common options, but could pretty easily expanded to cover all options for the world, just not sure if that should be the default behavior. it'd be just as easy for the world to pool together the similar options they care about without having to rewrite this.

## How was this tested?
Generated an item link with two players and checked the group's options were the same when they were for the players, and default when not.

## If this makes graphical changes, please attach screenshots.
