### PR TITLE
Pokemon Emerald: Fix unguarded wonder trade write

### DIFF
--- a/worlds/pokemon_emerald/client.py
+++ b/worlds/pokemon_emerald/client.py
@@ -133,6 +133,7 @@ class PokemonEmeraldClient(BizHawkClient):
     latest_wonder_trade_reply: dict
     wonder_trade_cooldown: int
     wonder_trade_cooldown_timer: int
+    queued_received_trade: Optional[str]
 
     death_counter: Optional[int]
     previous_death_link: float
@@ -153,6 +154,7 @@ class PokemonEmeraldClient(BizHawkClient):
         self.previous_death_link = 0
         self.ignore_next_death_link = False
         self.current_map = None
+        self.queued_received_trade = None
 
     async def validate_rom(self, ctx: "BizHawkClientContext") -> bool:
         from CommonClient import logger
@@ -548,22 +550,29 @@ class PokemonEmeraldClient(BizHawkClient):
                     (sb1_address + 0x37CC, [1], "System Bus"),
                 ])
             elif trade_is_sent != 0 and wonder_trade_pokemon_data[19] != 2:
-                # Game is waiting on receiving a trade. See if there are any available trades that were not
-                # sent by this player, and if so, try to receive one.
-                if self.wonder_trade_cooldown_timer <= 0 and f"pokemon_wonder_trades_{ctx.team}" in ctx.stored_data:
+                # Game is waiting on receiving a trade.
+                if self.queued_received_trade is not None:
+                    # Client is holding a trade, ready to write it into the game
+                    success = await bizhawk.guarded_write(ctx.bizhawk_ctx, [
+                        (sb1_address + 0x377C, json_to_pokemon_data(self.queued_received_trade), "System Bus"),
+                    ], [guards["SAVE BLOCK 1"]])
+
+                    # Notify the player if it was written, otherwise hold it for the next loop
+                    if success:
+                        logger.info("Wonder trade received!")
+                        self.queued_received_trade = None
+
+                elif self.wonder_trade_cooldown_timer <= 0 and f"pokemon_wonder_trades_{ctx.team}" in ctx.stored_data:
+                    # See if there are any available trades that were not sent by this player. If so, try to receive one.
                     if any(item[0] != ctx.slot
                             for key, item in ctx.stored_data.get(f"pokemon_wonder_trades_{ctx.team}", {}).items()
                             if key != "_lock" and orjson.loads(item[1])["species"] <= 386):
-                        received_trade = await self.wonder_trade_receive(ctx)
-                        if received_trade is None:
+                        self.queued_received_trade = await self.wonder_trade_receive(ctx)
+                        if self.queued_received_trade is None:
                             self.wonder_trade_cooldown_timer = self.wonder_trade_cooldown
                             self.wonder_trade_cooldown *= 2
                             self.wonder_trade_cooldown += random.randrange(0, 500)
                         else:
-                            await bizhawk.write(ctx.bizhawk_ctx, [
-                                (sb1_address + 0x377C, json_to_pokemon_data(received_trade), "System Bus"),
-                            ])
-                            logger.info("Wonder trade received!")
                             self.wonder_trade_cooldown = 5000
 
                 else:


### PR DESCRIPTION
## What is this fixing or adding?

When a client receives a wonder trade and tries to write it to the game's save data, it does a `bizhawk.write` when it should have done a `bizhawk.guarded_write` that protects against the save data moving (`guards["SAVE BLOCK 1"]`). If the save data does happen to move between the start of the game watcher loop and this write, it may corrupt a small part of the save data. Unfortunately, it's pretty likely that this small part includes the "items received" counter, so if it happens it will probably prevent the player from receiving any more items.

This adds the guard to the write, and then reworks the code a bit to cache the received trade so that it can keep trying to write it every game loop until it's successful.

## How was this tested?

Put two clients in a multi and traded between them. Everything worked as expected. I sort of tried to trigger the issue, but it's pretty hard to reproduce. You have to receive a trade on the same iteration of a game watcher loop where you've changed maps. But failing to test it only leaves the code path `if success:` where `success` is `False` untested.
