### PR TITLE
Core: Add color conversions for colorama/terminal output

### DIFF
--- a/NetUtils.py
+++ b/NetUtils.py
@@ -273,7 +273,8 @@ class RawJSONtoTextParser(JSONtoTextParser):
 
 color_codes = {'reset': 0, 'bold': 1, 'underline': 4, 'black': 30, 'red': 31, 'green': 32, 'yellow': 33, 'blue': 34,
                'magenta': 35, 'cyan': 36, 'white': 37, 'black_bg': 40, 'red_bg': 41, 'green_bg': 42, 'yellow_bg': 43,
-               'blue_bg': 44, 'magenta_bg': 45, 'cyan_bg': 46, 'white_bg': 47}
+               'blue_bg': 44, 'magenta_bg': 45, 'cyan_bg': 46, 'white_bg': 47,
+               'plum': 35, 'slateblue': 34, 'salmon': 31,}  # convert ui colors to terminal colors
 
 
 def color_code(*args):


### PR DESCRIPTION
## What is this fixing or adding?
adds mappings for item classification colors to usable color codes for terminal/colorama output


## How was this tested?
ran the text client in a multi i'm playing in and saw colored text for prog/useful/trap items

## If this makes graphical changes, please attach screenshots.
