### PR TITLE
kvui: abstract away client tab additions

### DIFF
--- a/WargrooveClient.py
+++ b/WargrooveClient.py
@@ -267,9 +267,7 @@ class WargrooveContext(CommonContext):
 
             def build(self):
                 container = super().build()
-                panel = TabbedPanelItem(text="Wargroove")
-                panel.content = self.build_tracker()
-                self.tabs.add_widget(panel)
+                self.add_client_tab("Wargroove", self.build_tracker())
                 return container
 
             def build_tracker(self) -> TrackerLayout:

--- a/kvui.py
+++ b/kvui.py
@@ -536,9 +536,8 @@ class GameManager(App):
                 # show Archipelago tab if other logging is present
                 self.tabs.add_widget(panel)
 
-        hint_panel = TabbedPanelItem(text="Hints")
-        self.log_panels["Hints"] = hint_panel.content = HintLog(self.json_to_kivy_parser)
-        self.tabs.add_widget(hint_panel)
+        hint_panel = self.add_client_tab("Hints", HintLog(self.json_to_kivy_parser))
+        self.log_panels["Hints"] = hint_panel.content
 
         if len(self.logging_pairs) == 1:
             self.tabs.default_tab_text = "Archipelago"
@@ -571,6 +570,14 @@ class GameManager(App):
         self.server_connect_bar.select_text(port_start if port_start > 0 else host_start, len(s))
 
         return self.container
+
+    def add_client_tab(self, title: str, content: Widget) -> Widget:
+        """Adds a new tab to the client window with a given title, and provides a given Widget as its content.
+         Returns the new tab widget, with the provided content being placed on the tab as content."""
+        new_tab = TabbedPanelItem(text=title)
+        new_tab.content = content
+        self.tabs.add_widget(new_tab)
+        return new_tab
 
     def update_texts(self, dt):
         if hasattr(self.tabs.content.children[0], "fix_heights"):

--- a/worlds/sc2/ClientGui.py
+++ b/worlds/sc2/ClientGui.py
@@ -97,12 +97,9 @@ class SC2Manager(GameManager):
     def build(self):
         container = super().build()
 
-        panel = TabbedPanelItem(text="Starcraft 2 Launcher")
-        panel.content = CampaignScroll()
+        panel = self.add_client_tab("Starcraft 2 Launcher", CampaignScroll())
         self.campaign_panel = MultiCampaignLayout()
         panel.content.add_widget(self.campaign_panel)
-
-        self.tabs.add_widget(panel)
 
         Clock.schedule_interval(self.build_mission_table, 0.5)
 


### PR DESCRIPTION
## What is this fixing or adding?
Intending for this to get in before #3934, this should allow clients to be cross-compatible between the two client versions. The main (currently-only) failure point for current clients on the KivyMD branch is the swap of GameManager.tabs and what types are accepted its children. As such, this abstracts away this behavior into GameManager itself such that clients need only call the function and provide the content for the tab.

## How was this tested?
Loaded up Starcraft 2's client, ensured that tabs worked correctly.

## If this makes graphical changes, please attach screenshots.
