### PR TITLE
Core: Improve death link option description

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -1335,7 +1335,7 @@ class PriorityLocations(LocationSet):
 
 
 class DeathLink(Toggle):
-    """When you die, everyone dies. Of course the reverse is true too."""
+    """When you die, everyone who enabled death link dies. Of course, the reverse is true too."""
     display_name = "Death Link"
     rich_text_doc = True
 


### PR DESCRIPTION
## What is this fixing or adding?

Minor clarification to the default death link option description to answer something that gets asked pretty frequently by newcomers. Also comma.

There are a handful of worlds that subclass the option to add an extra line to explain a behavior specific to that game, most of which more or less duplicate this line. But they can decide whether they care to make the same clarification individually.

## How was this tested?

Reading