### PR TITLE
Pokemon Emerald: Update changelog

### DIFF
--- a/worlds/pokemon_emerald/CHANGELOG.md
+++ b/worlds/pokemon_emerald/CHANGELOG.md
@@ -1,3 +1,21 @@
+# 2.3.0
+
+### Features
+
+- Added a Swedish translation of the setup guide.
+- The client communicates map transitions to any trackers connected to the slot.
+- Added the player's Normalize Encounter Rates option to slot data for trackers.
+
+### Fixes
+
+- Fixed a logic issue where the "Mauville City - Coin Case from Lady in House" location only required a Harbor Mail if
+the player randomized NPC gifts.
+- The Dig tutor has its compatibility percentage raised to 50% if the player's TM/tutor compatibility is set lower.
+- A Team Magma Grunt in the Space Center which could become unreachable while trainersanity is active by overlapping
+with another NPC was moved to an unoccupied space.
+- Fixed a problem where the client would crash on certain operating systems while using certain python versions if the
+player tried to wonder trade.
+
 # 2.2.0
 
 ### Features
@@ -175,6 +193,7 @@ turn to face you when you run.
 species equally likely to appear, but makes rare encounters less rare.
 - Added `Trick House` location group.
 - Removed `Postgame Locations` location group.
+- Added a Spanish translation of the setup guide.
 
 ### QoL
 


### PR DESCRIPTION
## What is this fixing or adding?

Updates the changelog according to what has been merged since AP 0.5.0 / Emerald 2.2.0.

Retroactively adds when the Spanish translation was added for consistency.

## How was this tested?

Reading
