### PR TITLE
Core: rename yaml_output to csv_output

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -43,7 +43,7 @@ def mystery_argparse():
     parser.add_argument('--race', action='store_true', default=defaults.race)
     parser.add_argument('--meta_file_path', default=defaults.meta_file_path)
     parser.add_argument('--log_level', default='info', help='Sets log level')
-    parser.add_argument("--yaml_output", action="store_true",
+    parser.add_argument("--csv_output", action="store_true",
                         help="Output rolled player options to csv (made for async multiworld).")
     parser.add_argument("--plando", default=defaults.plando_options,
                         help="List of options that can be set manually. Can be combined, for example \"bosses, items\"")
@@ -156,7 +156,7 @@ def main(args=None) -> Tuple[argparse.Namespace, int]:
     erargs.skip_prog_balancing = args.skip_prog_balancing
     erargs.skip_output = args.skip_output
     erargs.name = {}
-    erargs.yaml_output = args.yaml_output
+    erargs.csv_output = args.csv_output
 
     settings_cache: Dict[str, Tuple[argparse.Namespace, ...]] = \
         {fname: (tuple(roll_settings(yaml, args.plando) for yaml in yamls) if args.sameoptions else None)

--- a/Main.py
+++ b/Main.py
@@ -46,7 +46,7 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
     multiworld.sprite_pool = args.sprite_pool.copy()
 
     multiworld.set_options(args)
-    if args.yaml_output:
+    if args.csv_output:
         from Options import dump_player_options
         dump_player_options(multiworld)
     multiworld.set_item_links()

--- a/WebHostLib/generate.py
+++ b/WebHostLib/generate.py
@@ -134,7 +134,7 @@ def gen_game(gen_options: dict, meta: Optional[Dict[str, Any]] = None, owner=Non
                                                                        {"bosses", "items", "connections", "texts"}))
         erargs.skip_prog_balancing = False
         erargs.skip_output = False
-        erargs.yaml_output = False
+        erargs.csv_output = False
 
         name_counter = Counter()
         for player, (playerfile, settings) in enumerate(gen_options.items(), 1):


### PR DESCRIPTION
## What is this fixing or adding?
yaml_output is meant to indicate that the options are outputted as yaml. It now outputs csv, so is no longer accurate.

## How was this tested?
I did an automatic rename across the project, it shouldn't fail, but no testing was done.
