### PR TITLE
WebHost: move api/room_status out of __init__.py

### DIFF
--- a/WebHostLib/api/__init__.py
+++ b/WebHostLib/api/__init__.py
@@ -1,51 +1,15 @@
 """API endpoints package."""
 from typing import List, Tuple
-from uuid import UUID
 
-from flask import Blueprint, abort, url_for
+from flask import Blueprint
 
-import worlds.Files
-from ..models import Room, Seed
+from ..models import Seed
 
 api_endpoints = Blueprint('api', __name__, url_prefix="/api")
-
-# unsorted/misc endpoints
 
 
 def get_players(seed: Seed) -> List[Tuple[str, str]]:
     return [(slot.player_name, slot.game) for slot in seed.slots]
 
 
-@api_endpoints.route('/room_status/<suuid:room>')
-def room_info(room: UUID):
-    room = Room.get(id=room)
-    if room is None:
-        return abort(404)
-    
-    def supports_apdeltapatch(game: str):
-        return game in worlds.Files.AutoPatchRegister.patch_types
-    downloads = []
-    for slot in sorted(room.seed.slots):
-        if slot.data and not supports_apdeltapatch(slot.game):
-            slot_download = {
-                "slot": slot.player_id,
-                "download": url_for("download_slot_file", room_id=room.id, player_id=slot.player_id)
-            }
-            downloads.append(slot_download)
-        elif slot.data:
-            slot_download = {
-                "slot": slot.player_id,
-                "download": url_for("download_patch", patch_id=slot.id, room_id=room.id)
-            }
-            downloads.append(slot_download)
-    return {
-        "tracker": room.tracker,
-        "players": get_players(room.seed),
-        "last_port": room.last_port,
-        "last_activity": room.last_activity,
-        "timeout": room.timeout,
-        "downloads": downloads,
-    }
-
-
-from . import generate, user, datapackage  # trigger registration
+from . import datapackage, generate, room, user  # trigger registration

--- a/WebHostLib/api/room.py
+++ b/WebHostLib/api/room.py
@@ -8,13 +8,13 @@ from . import api_endpoints, get_players
 from ..models import Room
 
 
-@api_endpoints.route('/room_status/<suuid:room>')
-def room_info(room: UUID) -> Dict[str, Any]:
-    room = Room.get(id=room)
+@api_endpoints.route('/room_status/<suuid:room_id>')
+def room_info(room_id: UUID) -> Dict[str, Any]:
+    room = Room.get(id=room_id)
     if room is None:
         return abort(404)
 
-    def supports_apdeltapatch(game: str):
+    def supports_apdeltapatch(game: str) -> bool:
         return game in worlds.Files.AutoPatchRegister.patch_types
 
     downloads = []

--- a/WebHostLib/api/room.py
+++ b/WebHostLib/api/room.py
@@ -1,0 +1,42 @@
+from typing import Any, Dict
+from uuid import UUID
+
+from flask import abort, url_for
+
+import worlds.Files
+from . import api_endpoints, get_players
+from ..models import Room
+
+
+@api_endpoints.route('/room_status/<suuid:room>')
+def room_info(room: UUID) -> Dict[str, Any]:
+    room = Room.get(id=room)
+    if room is None:
+        return abort(404)
+
+    def supports_apdeltapatch(game: str):
+        return game in worlds.Files.AutoPatchRegister.patch_types
+
+    downloads = []
+    for slot in sorted(room.seed.slots):
+        if slot.data and not supports_apdeltapatch(slot.game):
+            slot_download = {
+                "slot": slot.player_id,
+                "download": url_for("download_slot_file", room_id=room.id, player_id=slot.player_id)
+            }
+            downloads.append(slot_download)
+        elif slot.data:
+            slot_download = {
+                "slot": slot.player_id,
+                "download": url_for("download_patch", patch_id=slot.id, room_id=room.id)
+            }
+            downloads.append(slot_download)
+
+    return {
+        "tracker": room.tracker,
+        "players": get_players(room.seed),
+        "last_port": room.last_port,
+        "last_activity": room.last_activity,
+        "timeout": room.timeout,
+        "downloads": downloads,
+    }


### PR DESCRIPTION
## What is this fixing or adding?

The old location is unexpected and easy to miss.
This simply moves the one endpoint to its own file and fixes some typing while we're at it.

Note: this changes `room` to `room_id`, so typing does not collide between the UUID and the actual room. This change should probably be made in the non-API routes as well, but there we'll need to fix calls to url_for().

## How was this tested?

* Opening the endpoint in a browser.
* `mypy --strict WebHostLib/api/room.py`