### PR TITLE
Tests: Add test that local/non local items aren't modified late

### DIFF
--- a/test/general/test_items.py
+++ b/test/general/test_items.py
@@ -80,3 +80,21 @@ class TestBase(unittest.TestCase):
                         call_all(multiworld, step)
                         self.assertEqual(created_items, multiworld.itempool,
                                          f"{game_name} modified the itempool during {step}")
+
+    def test_locality_not_modified(self):
+        """Test that worlds don't modify the locality of items after duplicates are resolved"""
+        gen_steps = ("generate_early", "create_regions", "create_items")
+        additional_steps = ("set_rules", "generate_basic", "pre_fill")
+        worlds_to_test = {game: world for game, world in AutoWorldRegister.world_types.items()}
+        for game_name, world_type in worlds_to_test.items():
+            with self.subTest("Game", game=game_name):
+                multiworld = setup_solo_multiworld(world_type, gen_steps)
+                local_items = multiworld.worlds[1].options.local_items.value.copy()
+                non_local_items = multiworld.worlds[1].options.non_local_items.value.copy()
+                for step in additional_steps:
+                    with self.subTest("step", step=step):
+                        call_all(multiworld, step)
+                        self.assertEqual(local_items, multiworld.worlds[1].options.local_items.value,
+                                         f"{game_name} modified local_items during {step}")
+                        self.assertEqual(non_local_items, multiworld.worlds[1].options.non_local_items.value,
+                                         f"{game_name} modified non_local_items during {step}")


### PR DESCRIPTION
## What is this fixing or adding?

Adds a unit test that `local_items` and `non_local_items` are not modified in `set_rules`, `generate_basic`, or `pre_fill`.

## How was this tested?

Unit testing. Specifically tested Blasphemous with modified default options and reverting https://github.com/ArchipelagoMW/Archipelago/pull/3901 and saw that it failed this test.

This could test other/later stages, but those would all require fill/distribute_items_restrictive which is time-consuming.