### PR TITLE
Minecraft: Set "Two by Two" and "A Complete Catalogue" to "unreasonable" exclusion group

### DIFF
--- a/worlds/minecraft/data/excluded_locations.json
+++ b/worlds/minecraft/data/excluded_locations.json
@@ -2,7 +2,6 @@
 	"hard": [
         "Very Very Frightening",
         "A Furious Cocktail",
-        "Two by Two",
         "Two Birds, One Arrow",
         "Arbalistic",
         "Monsters Hunted",
@@ -10,7 +9,6 @@
         "A Balanced Diet",
         "Uneasy Alliance",
         "Cover Me in Debris",
-        "A Complete Catalogue",
         "Surge Protector",
         "Sound of Music",
         "Star Trader",
@@ -19,6 +17,8 @@
     ],
     "unreasonable": [
         "How Did We Get Here?",
+	"A Complete Catalogue",
+	"Two by Two",
         "Adventuring Time"
     ],
     "ender_dragon": [


### PR DESCRIPTION


Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?
This changes the advancement groups of: 
"Two by Two" and "A Complete Catalogue" 
from "hard" to "unreasonable" exclusion group

## How was this tested?
Running a 63 player all-minecraft with a yaml that enables 'hard' but disables 'unreasonable', and verified that they were all junk items.

## If this makes graphical changes, please attach screenshots.
N/A