### PR TITLE
TUNIC: Add forgotten Laurels rule for Beneath the Vault Boxes

### DIFF
--- a/worlds/tunic/er_rules.py
+++ b/worlds/tunic/er_rules.py
@@ -764,7 +764,7 @@ def set_er_region_rules(world: "TunicWorld", regions: Dict[str, Region], portal_
         rule=lambda state: has_ladder("Ladder to Beneath the Vault", state, world)
         and has_lantern(state, world)
         # there's some boxes in the way
-        and (has_stick(state, player) or state.has_any((gun, grapple, fire_wand), player)))
+        and (has_stick(state, player) or state.has_any((gun, grapple, fire_wand, laurels), player)))
     # on the reverse trip, you can lure an enemy over to break the boxes if needed
     regions["Beneath the Vault Main"].connect(
         connecting_region=regions["Beneath the Vault Ladder Exit"],


### PR DESCRIPTION
## What is this fixing or adding?
Forgot to add the Laurels as a viable way to get past the boxes in the previous PR, woops.

## How was this tested?
Test gen.

## If this makes graphical changes, please attach screenshots.
N/A