### PR TITLE
Core: Import `TypeGuard` from native typing instead of typing_extentions

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -18,8 +18,7 @@ import warnings
 
 from argparse import Namespace
 from settings import Settings, get_settings
-from typing import BinaryIO, Coroutine, Optional, Set, Dict, Any, Union
-from typing_extensions import TypeGuard
+from typing import BinaryIO, Coroutine, Optional, Set, Dict, Any, Union, TypeGuard
 from yaml import load, load_all, dump
 
 try:

--- a/worlds/AutoSNIClient.py
+++ b/worlds/AutoSNIClient.py
@@ -1,9 +1,7 @@
 
 from __future__ import annotations
 import abc
-from typing import TYPE_CHECKING, ClassVar, Dict, Iterable, Tuple, Any, Optional, Union
-
-from typing_extensions import TypeGuard
+from typing import TYPE_CHECKING, ClassVar, Dict, Iterable, Tuple, Any, Optional, Union, TypeGuard
 
 from worlds.LauncherComponents import Component, SuffixIdentifier, Type, components
 

--- a/worlds/zillion/options.py
+++ b/worlds/zillion/options.py
@@ -1,7 +1,6 @@
 from collections import Counter
 from dataclasses import dataclass
-from typing import ClassVar, Dict, Literal, Tuple
-from typing_extensions import TypeGuard  # remove when Python >= 3.10
+from typing import ClassVar, Dict, Literal, Tuple, TypeGuard
 
 from Options import Choice, DefaultOnToggle, NamedRange, OptionGroup, PerGameCommonOptions, Range, Removed, Toggle
 


### PR DESCRIPTION
## What is this fixing or adding?
Import `TypeGuard` from native typing instead of typing_extentions. I'm not removing typing_extentions from the `requirements.txt` tho, because it's used for other stuff only supported since 3.11 and 3.12

## How was this tested?
Ran the unit tests

## If this makes graphical changes, please attach screenshots.
N/A