### PR TITLE
Clarify usage of slot data for trackers in World API doc

### DIFF
--- a/docs/world api.md
+++ b/docs/world api.md
@@ -748,13 +748,14 @@ def generate_output(self, output_directory: str) -> None:
 
 ### Slot Data
 
-If the game client needs to know information about the generated seed, a preferred method of transferring the data
-is through the slot data. This is filled with the `fill_slot_data` method of your world by returning
-a `dict` with `str` keys that can be serialized with json.
-But, to not waste resources, it should be limited to data that is absolutely necessary. Slot data is sent to your client
-once it has successfully [connected](network%20protocol.md#connected).
+If a game client (including other clients, trackers, etc.) needs to know information about the generated seed, a 
+preferred method of transferring the data is through the slot data. This is filled with the `fill_slot_data` method of 
+your world by returning a `dict` with `str` keys that can be serialized with json.
+However, in order to not waste resources, it should be limited to data that is absolutely necessary, be it for the 
+client, the game itself, a traker, or otherwise. Slot data is sent to your client once it has successfully [connected](network%20protocol.md#connected).
 If you need to know information about locations in your world, instead of propagating the slot data, it is preferable
-to use [LocationScouts](network%20protocol.md#locationscouts), since that data already exists on the server. The most
+to use [LocationScouts](network%20protocol.md#locationscouts), since that data already exists on the server. You should also avoid adding item/location
+pairs, as the AP server already retains that info and will freely give it to any client that needs it. The most
 common usage of slot data is sending option results that the client needs to be aware of.
 
 ```python

--- a/docs/world api.md
+++ b/docs/world api.md
@@ -752,7 +752,7 @@ If a game client (including other clients, trackers, etc.) needs to know informa
 preferred method of transferring the data is through the slot data. This is filled with the `fill_slot_data` method of 
 your world by returning a `dict` with `str` keys that can be serialized with json.
 However, in order to not waste resources, it should be limited to data that is absolutely necessary, be it for the 
-client, the game itself, a traker, or otherwise. Slot data is sent to your client once it has successfully [connected](network%20protocol.md#connected).
+client, the game itself, a tracker, or otherwise. Slot data is sent to your client once it has successfully [connected](network%20protocol.md#connected).
 If you need to know information about locations in your world, instead of propagating the slot data, it is preferable
 to use [LocationScouts](network%20protocol.md#locationscouts), since that data already exists on the server. You should also avoid adding item/location
 pairs, as the AP server already retains that info and will freely give it to any client that needs it. The most


### PR DESCRIPTION
## What is this fixing or adding?
Adding some language to clarify that using slot data for trackers to keep tabs on your game, your options, etc is acceptable.

## How was this tested?
Proofread myself, found typo already.

## If this makes graphical changes, please attach screenshots.
N/A