### PR TITLE
Core: skip creating item linked locations for non prog items

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -347,6 +347,8 @@ class MultiWorld():
             for item in self.itempool:
                 count = common_item_count.get(item.player, {}).get(item.name, 0)
                 if count:
+                    if ItemClassification.progression not in item.classification:
+                        continue
                     loc = Location(group_id, f"Item Link: {item.name} -> {self.player_name[item.player]} {count}",
                         None, region)
                     loc.access_rule = lambda state, item_name = item.name, group_id_ = group_id, count_ = count: \

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -347,7 +347,7 @@ class MultiWorld():
             for item in self.itempool:
                 count = common_item_count.get(item.player, {}).get(item.name, 0)
                 if count:
-                    if ItemClassification.progression not in item.classification:
+                    if not item.advancement:
                         continue
                     loc = Location(group_id, f"Item Link: {item.name} -> {self.player_name[item.player]} {count}",
                         None, region)


### PR DESCRIPTION
## What is this fixing or adding?
removes any headache from core trying to do accessibility checks on unreachable items (because they are logically locked behind the Group's non-prog copies)

## How was this tested?
generated a single player world with an item link on filler, hosted locally, connected, hinted the filler item, sent the location through postman, saw the hints, recievedItem go through without issue, also inspected the spoiler log and the link was still fully described in the spoiler

## If this makes graphical changes, please attach screenshots.
