### PR TITLE
Hollow Knight: Clean outdated slot data code and comments

### DIFF
--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -534,25 +534,15 @@ class HKWorld(World):
         for option_name in hollow_knight_options:
             option = getattr(self.options, option_name)
             try:
+                # exclude more complex types - we only care about int, bool, enum for player options; the client
+                # can get them back to the necessary type.
                 optionvalue = int(option.value)
-            except TypeError:
-                pass  # C# side is currently typed as dict[str, int], drop what doesn't fit
-            else:
                 options[option_name] = optionvalue
+            except TypeError:
+                pass
 
         # 32 bit int
         slot_data["seed"] = self.random.randint(-2147483647, 2147483646)
-
-        # Backwards compatibility for shop cost data (HKAP < 0.1.0)
-        if not self.options.CostSanity:
-            for shop, terms in shop_cost_types.items():
-                unit = cost_terms[next(iter(terms))].option
-                if unit == "Geo":
-                    continue
-                slot_data[f"{unit}_costs"] = {
-                    loc.name: next(iter(loc.costs.values()))
-                    for loc in self.created_multi_locations[shop]
-                }
 
         # HKAP 0.1.0 and later cost data.
         location_costs = {}
@@ -566,7 +556,7 @@ class HKWorld(World):
 
         slot_data["grub_count"] = self.grub_count
 
-        slot_data["is_race"] = int(self.settings.disable_spoilers or self.multiworld.is_race)
+        slot_data["is_race"] = self.settings.disable_spoilers or self.multiworld.is_race
 
         return slot_data
 


### PR DESCRIPTION
## What is this fixing or adding?

Cleans up some outdated stuff in the slot data which was discovered due to #3971. Specifically,

* Updates a comment to be clear about its scope and correct in its content
* Removes very old backwards compatibility slot data - clients that old will not work with new generations and newer clients already don't read them anymore.
* Removes an unnecessary int cast
* Move a questionable `else` block into the related `try` block

## How was this tested?

Tested the client can connect and read slot data correctly before and after the change
