### PR TITLE
SC2: Fix item origins, so including/excluding NCO/BW/EXT items works properly

### DIFF
--- a/worlds/sc2/Items.py
+++ b/worlds/sc2/Items.py
@@ -1274,16 +1274,16 @@ item_table = {
                  description="Defensive structure. Slows the attack and movement speeds of all nearby Zerg units."),
     ItemNames.STRUCTURE_ARMOR:
         ItemData(620 + SC2WOL_ITEM_ID_OFFSET, "Laboratory", 9, SC2Race.TERRAN,
-                 description="Increases armor of all Terran structures by 2."),
+                 description="Increases armor of all Terran structures by 2.", origin={"ext"}),
     ItemNames.HI_SEC_AUTO_TRACKING:
         ItemData(621 + SC2WOL_ITEM_ID_OFFSET, "Laboratory", 10, SC2Race.TERRAN,
-                 description="Increases attack range of all Terran structures by 1."),
+                 description="Increases attack range of all Terran structures by 1.", origin={"ext"}),
     ItemNames.ADVANCED_OPTICS:
         ItemData(622 + SC2WOL_ITEM_ID_OFFSET, "Laboratory", 11, SC2Race.TERRAN,
-                 description="Increases attack range of all Terran mechanical units by 1."),
+                 description="Increases attack range of all Terran mechanical units by 1.", origin={"ext"}),
     ItemNames.ROGUE_FORCES:
         ItemData(623 + SC2WOL_ITEM_ID_OFFSET, "Laboratory", 12, SC2Race.TERRAN,
-                 description="Mercenary calldowns are no longer limited by charges."),
+                 description="Mercenary calldowns are no longer limited by charges.", origin={"ext"}),
 
     ItemNames.ZEALOT:
         ItemData(700 + SC2WOL_ITEM_ID_OFFSET, "Unit", 0, SC2Race.PROTOSS,
@@ -2369,7 +2369,8 @@ progressive_if_ext = {
     ItemNames.BATTLECRUISER_PROGRESSIVE_MISSILE_PODS,
     ItemNames.THOR_PROGRESSIVE_IMMORTALITY_PROTOCOL,
     ItemNames.PROGRESSIVE_FIRE_SUPPRESSION_SYSTEM,
-    ItemNames.DIAMONDBACK_PROGRESSIVE_TRI_LITHIUM_POWER_CELL
+    ItemNames.DIAMONDBACK_PROGRESSIVE_TRI_LITHIUM_POWER_CELL,
+    ItemNames.PROGRESSIVE_ORBITAL_COMMAND
 }
 
 kerrigan_actives: typing.List[typing.Set[str]] = [


### PR DESCRIPTION
## What is this fixing or adding?
Fixes a bug that some non-vanilla items spawned when shouldn't

## How was this tested?
Generated a game without NCO. Turned all non-vanilla items off. Collected the game and checked items in the tracker. 

## If this makes graphical changes, please attach screenshots.
No