### PR TITLE
bumpstik: add hazard bumpers to completion

### DIFF
--- a/worlds/bumpstik/__init__.py
+++ b/worlds/bumpstik/__init__.py
@@ -125,7 +125,6 @@ class BumpStikWorld(World):
             lambda state: state.has("Hazard Bumper", self.player, 25)
             
         self.multiworld.completion_condition[self.player] = \
-            lambda state: state.has("Booster Bumper", self.player, 5) and \
-            state.has("Treasure Bumper", self.player, 32) and \
-            state.has("Hazard Bumper", self.player, 25)
+            lambda state: state.has_all_counts({"Booster Bumper": 5, "Treasure Bumper": 32, "Hazard Bumper": 25}, \
+                self.player)
 

--- a/worlds/bumpstik/__init__.py
+++ b/worlds/bumpstik/__init__.py
@@ -126,5 +126,6 @@ class BumpStikWorld(World):
             
         self.multiworld.completion_condition[self.player] = \
             lambda state: state.has("Booster Bumper", self.player, 5) and \
-            state.has("Treasure Bumper", self.player, 32)
+            state.has("Treasure Bumper", self.player, 32) and \
+            state.has("Hazard Bumper", self.player, 25)
 


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?
Hazard bumpers were not specified as part of world completion, causing logic issues as reported [here](https://discord.com/channels/731205301247803413/1287853629461758035/1287853629461758035). This adds hazard bumpers to the world completion condition.

## How was this tested?
Unit tests run locally and on Github.

## If this makes graphical changes, please attach screenshots.
