### PR TITLE
The Messenger: remove 3.8 compatibility

### DIFF
--- a/worlds/messenger/__init__.py
+++ b/worlds/messenger/__init__.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, ClassVar, Dict, List, Optional, Set, TextIO
+from typing import Any, ClassVar, TextIO
 
 from BaseClasses import CollectionState, Entrance, Item, ItemClassification, MultiWorld, Tutorial
 from Options import Accessibility
@@ -120,16 +120,16 @@ class MessengerWorld(World):
     required_seals: int = 0
     created_seals: int = 0
     total_shards: int = 0
-    shop_prices: Dict[str, int]
-    figurine_prices: Dict[str, int]
-    _filler_items: List[str]
-    starting_portals: List[str]
-    plando_portals: List[str]
-    spoiler_portal_mapping: Dict[str, str]
-    portal_mapping: List[int]
-    transitions: List[Entrance]
+    shop_prices: dict[str, int]
+    figurine_prices: dict[str, int]
+    _filler_items: list[str]
+    starting_portals: list[str]
+    plando_portals: list[str]
+    spoiler_portal_mapping: dict[str, str]
+    portal_mapping: list[int]
+    transitions: list[Entrance]
     reachable_locs: int = 0
-    filler: Dict[str, int]
+    filler: dict[str, int]
 
     def generate_early(self) -> None:
         if self.options.goal == Goal.option_power_seal_hunt:
@@ -178,7 +178,7 @@ class MessengerWorld(World):
                            for reg_name in sub_region]
 
         for region in complex_regions:
-            region_name = region.name.replace(f"{region.parent} - ", "")
+            region_name = region.name.removeprefix(f"{region.parent} - ")
             connection_data = CONNECTIONS[region.parent][region_name]
             for exit_region in connection_data:
                 region.connect(self.multiworld.get_region(exit_region, self.player))
@@ -191,7 +191,7 @@ class MessengerWorld(World):
         # create items that are always in the item pool
         main_movement_items = ["Rope Dart", "Wingsuit"]
         precollected_names = [item.name for item in self.multiworld.precollected_items[self.player]]
-        itempool: List[MessengerItem] = [
+        itempool: list[MessengerItem] = [
             self.create_item(item)
             for item in self.item_name_to_id
             if item not in {
@@ -290,7 +290,7 @@ class MessengerWorld(World):
             for portal, output in portal_info:
                 spoiler.set_entrance(f"{portal} Portal", output, "I can write anything I want here lmao", self.player)
 
-    def fill_slot_data(self) -> Dict[str, Any]:
+    def fill_slot_data(self) -> dict[str, Any]:
         slot_data = {
             "shop": {SHOP_ITEMS[item].internal_name: price for item, price in self.shop_prices.items()},
             "figures": {FIGURINES[item].internal_name: price for item, price in self.figurine_prices.items()},
@@ -316,7 +316,7 @@ class MessengerWorld(World):
         return self._filler_items.pop(0)
 
     def create_item(self, name: str) -> MessengerItem:
-        item_id: Optional[int] = self.item_name_to_id.get(name, None)
+        item_id: int | None = self.item_name_to_id.get(name, None)
         return MessengerItem(
             name,
             ItemClassification.progression if item_id is None else self.get_item_classification(name),
@@ -351,7 +351,7 @@ class MessengerWorld(World):
         return ItemClassification.filler
 
     @classmethod
-    def create_group(cls, multiworld: "MultiWorld", new_player_id: int, players: Set[int]) -> World:
+    def create_group(cls, multiworld: "MultiWorld", new_player_id: int, players: set[int]) -> World:
         group = super().create_group(multiworld, new_player_id, players)
         assert isinstance(group, MessengerWorld)
         

--- a/worlds/messenger/client_setup.py
+++ b/worlds/messenger/client_setup.py
@@ -5,7 +5,7 @@ import os.path
 import subprocess
 import urllib.request
 from shutil import which
-from typing import Any, Optional
+from typing import Any
 from zipfile import ZipFile
 from Utils import open_file
 
@@ -17,7 +17,7 @@ from Utils import is_windows, messagebox, tuplize_version
 MOD_URL = "https://api.github.com/repos/alwaysintreble/TheMessengerRandomizerModAP/releases/latest"
 
 
-def ask_yes_no_cancel(title: str, text: str) -> Optional[bool]:
+def ask_yes_no_cancel(title: str, text: str) -> bool | None:
     """
     Wrapper for tkinter.messagebox.askyesnocancel, that creates a popup dialog box with yes, no, and cancel buttons.
 
@@ -31,7 +31,6 @@ def ask_yes_no_cancel(title: str, text: str) -> Optional[bool]:
     ret = messagebox.askyesnocancel(title, text)
     root.update()
     return ret
-
 
 
 def launch_game(*args) -> None:

--- a/worlds/messenger/connections.py
+++ b/worlds/messenger/connections.py
@@ -1,6 +1,4 @@
-from typing import Dict, List
-
-CONNECTIONS: Dict[str, Dict[str, List[str]]] = {
+CONNECTIONS: dict[str, dict[str, list[str]]] = {
     "Ninja Village": {
         "Right": [
             "Autumn Hills - Left",
@@ -640,7 +638,7 @@ CONNECTIONS: Dict[str, Dict[str, List[str]]] = {
     },
 }
 
-RANDOMIZED_CONNECTIONS: Dict[str, str] = {
+RANDOMIZED_CONNECTIONS: dict[str, str] = {
     "Ninja Village - Right": "Autumn Hills - Left",
     "Autumn Hills - Left": "Ninja Village - Right",
     "Autumn Hills - Right": "Forlorn Temple - Left",
@@ -680,7 +678,7 @@ RANDOMIZED_CONNECTIONS: Dict[str, str] = {
     "Sunken Shrine - Left": "Howling Grotto - Bottom",
 }
 
-TRANSITIONS: List[str] = [
+TRANSITIONS: list[str] = [
     "Ninja Village - Right",
     "Autumn Hills - Left",
     "Autumn Hills - Right",

--- a/worlds/messenger/constants.py
+++ b/worlds/messenger/constants.py
@@ -2,7 +2,7 @@ from .shop import FIGURINES, SHOP_ITEMS
 
 # items
 # listing individual groups first for easy lookup
-NOTES = [
+NOTES: list[str] = [
     "Key of Hope",
     "Key of Chaos",
     "Key of Courage",
@@ -11,7 +11,7 @@ NOTES = [
     "Key of Symbiosis",
 ]
 
-PROG_ITEMS = [
+PROG_ITEMS: list[str] = [
     "Wingsuit",
     "Rope Dart",
     "Lightfoot Tabi",
@@ -28,18 +28,18 @@ PROG_ITEMS = [
     "Seashell",
 ]
 
-PHOBEKINS = [
+PHOBEKINS: list[str] = [
     "Necro",
     "Pyro",
     "Claustro",
     "Acro",
 ]
 
-USEFUL_ITEMS = [
+USEFUL_ITEMS: list[str] = [
     "Windmill Shuriken",
 ]
 
-FILLER = {
+FILLER: dict[str, int] = {
     "Time Shard": 5,
     "Time Shard (10)": 10,
     "Time Shard (50)": 20,
@@ -48,13 +48,13 @@ FILLER = {
     "Time Shard (500)": 5,
 }
 
-TRAPS = {
+TRAPS: dict[str, int] = {
     "Teleport Trap": 5,
     "Prophecy Trap": 10,
 }
 
 # item_name_to_id needs to be deterministic and match upstream
-ALL_ITEMS = [
+ALL_ITEMS: list[str] = [
     *NOTES,
     "Windmill Shuriken",
     "Wingsuit",
@@ -83,7 +83,7 @@ ALL_ITEMS = [
 # locations
 # the names of these don't actually matter, but using the upstream's names for now
 # order must be exactly the same as upstream
-ALWAYS_LOCATIONS = [
+ALWAYS_LOCATIONS: list[str] = [
     # notes
     "Sunken Shrine - Key of Love",
     "Corrupted Future - Key of Courage",
@@ -160,7 +160,7 @@ ALWAYS_LOCATIONS = [
     "Elemental Skylands Seal - Fire",
 ]
 
-BOSS_LOCATIONS = [
+BOSS_LOCATIONS: list[str] = [
     "Autumn Hills - Leaf Golem",
     "Catacombs - Ruxxtin",
     "Howling Grotto - Emerald Golem",

--- a/worlds/messenger/options.py
+++ b/worlds/messenger/options.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import Dict
 
 from schema import And, Optional, Or, Schema
 
@@ -167,7 +166,7 @@ class ShopPrices(Range):
     default = 100
 
 
-def planned_price(location: str) -> Dict[Optional, Or]:
+def planned_price(location: str) -> dict[Optional, Or]:
     return {
         Optional(location): Or(
             And(int, lambda n: n >= 0),

--- a/worlds/messenger/portals.py
+++ b/worlds/messenger/portals.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import List, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from BaseClasses import CollectionState, PlandoOptions
 from Options import PlandoConnection
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from . import MessengerWorld
 
 
-PORTALS = [
+PORTALS: list[str] = [
     "Autumn Hills",
     "Riviere Turquoise",
     "Howling Grotto",
@@ -18,7 +18,7 @@ PORTALS = [
 ]
 
 
-SHOP_POINTS = {
+SHOP_POINTS: dict[str, list[str]] = {
     "Autumn Hills": [
         "Climbing Claws",
         "Hope Path",
@@ -113,7 +113,7 @@ SHOP_POINTS = {
 }
 
 
-CHECKPOINTS = {
+CHECKPOINTS: dict[str, list[str]] = {
     "Autumn Hills": [
         "Hope Latch",
         "Key of Hope",
@@ -186,7 +186,7 @@ CHECKPOINTS = {
 }
 
 
-REGION_ORDER = [
+REGION_ORDER: list[str] = [
     "Autumn Hills",
     "Forlorn Temple",
     "Catacombs",
@@ -228,7 +228,7 @@ def shuffle_portals(world: "MessengerWorld") -> None:
 
         return parent
 
-    def handle_planned_portals(plando_connections: List[PlandoConnection]) -> None:
+    def handle_planned_portals(plando_connections: list[PlandoConnection]) -> None:
         """checks the provided plando connections for portals and connects them"""
         nonlocal available_portals
 

--- a/worlds/messenger/regions.py
+++ b/worlds/messenger/regions.py
@@ -1,7 +1,4 @@
-from typing import Dict, List
-
-
-LOCATIONS: Dict[str, List[str]] = {
+LOCATIONS: dict[str, list[str]] = {
     "Ninja Village - Nest": [
         "Ninja Village - Candle",
         "Ninja Village - Astral Seed",
@@ -201,7 +198,7 @@ LOCATIONS: Dict[str, List[str]] = {
 }
 
 
-SUB_REGIONS: Dict[str, List[str]] = {
+SUB_REGIONS: dict[str, list[str]] = {
     "Ninja Village": [
         "Right",
     ],
@@ -385,7 +382,7 @@ SUB_REGIONS: Dict[str, List[str]] = {
 
 
 # order is slightly funky here for back compat
-MEGA_SHARDS: Dict[str, List[str]] = {
+MEGA_SHARDS: dict[str, list[str]] = {
     "Autumn Hills - Lakeside Checkpoint": ["Autumn Hills Mega Shard"],
     "Forlorn Temple - Outside Shop": ["Hidden Entrance Mega Shard"],
     "Catacombs - Top Left": ["Catacombs Mega Shard"],
@@ -414,7 +411,7 @@ MEGA_SHARDS: Dict[str, List[str]] = {
 }
 
 
-REGION_CONNECTIONS: Dict[str, Dict[str, str]] = {
+REGION_CONNECTIONS: dict[str, dict[str, str]] = {
     "Menu": {"Tower HQ": "Start Game"},
     "Tower HQ": {
         "Autumn Hills - Portal": "ToTHQ Autumn Hills Portal",
@@ -436,7 +433,7 @@ REGION_CONNECTIONS: Dict[str, Dict[str, str]] = {
 
 
 # regions that don't have sub-regions
-LEVELS: List[str] = [
+LEVELS: list[str] = [
     "Menu",
     "Tower HQ",
     "The Shop",

--- a/worlds/messenger/rules.py
+++ b/worlds/messenger/rules.py
@@ -1,4 +1,4 @@
-from typing import Dict, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from BaseClasses import CollectionState
 from worlds.generic.Rules import CollectionRule, add_rule, allow_self_locking_items
@@ -12,9 +12,9 @@ if TYPE_CHECKING:
 class MessengerRules:
     player: int
     world: "MessengerWorld"
-    connection_rules: Dict[str, CollectionRule]
-    region_rules: Dict[str, CollectionRule]
-    location_rules: Dict[str, CollectionRule]
+    connection_rules: dict[str, CollectionRule]
+    region_rules: dict[str, CollectionRule]
+    location_rules: dict[str, CollectionRule]
     maximum_price: int
     required_seals: int
 

--- a/worlds/messenger/shop.py
+++ b/worlds/messenger/shop.py
@@ -1,11 +1,11 @@
-from typing import Dict, List, NamedTuple, Optional, Set, TYPE_CHECKING, Tuple, Union
+from typing import NamedTuple, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from . import MessengerWorld
 else:
     MessengerWorld = object
 
-PROG_SHOP_ITEMS: List[str] = [
+PROG_SHOP_ITEMS: list[str] = [
     "Path of Resilience",
     "Meditation",
     "Strike of the Ninja",
@@ -14,7 +14,7 @@ PROG_SHOP_ITEMS: List[str] = [
     "Aerobatics Warrior",
 ]
 
-USEFUL_SHOP_ITEMS: List[str] = [
+USEFUL_SHOP_ITEMS: list[str] = [
     "Karuta Plates",
     "Serendipitous Bodies",
     "Kusari Jacket",
@@ -29,10 +29,10 @@ class ShopData(NamedTuple):
     internal_name: str
     min_price: int
     max_price: int
-    prerequisite: Optional[Union[str, Set[str]]] = None
+    prerequisite: str | set[str] | None = None
 
 
-SHOP_ITEMS: Dict[str, ShopData] = {
+SHOP_ITEMS: dict[str, ShopData] = {
     "Karuta Plates":        ShopData("HP_UPGRADE_1", 20, 200),
     "Serendipitous Bodies": ShopData("ENEMY_DROP_HP", 20, 300, "The Shop - Karuta Plates"),
     "Path of Resilience":   ShopData("DAMAGE_REDUCTION", 100, 500, "The Shop - Serendipitous Bodies"),
@@ -56,7 +56,7 @@ SHOP_ITEMS: Dict[str, ShopData] = {
     "Focused Power Sense":  ShopData("POWER_SEAL_WORLD_MAP", 300, 600, "The Shop - Power Sense"),
 }
 
-FIGURINES: Dict[str, ShopData] = {
+FIGURINES: dict[str, ShopData] = {
     "Green Kappa Figurine":         ShopData("GREEN_KAPPA", 100, 500),
     "Blue Kappa Figurine":          ShopData("BLUE_KAPPA", 100, 500),
     "Ountarde Figurine":            ShopData("OUNTARDE", 100, 500),
@@ -73,12 +73,12 @@ FIGURINES: Dict[str, ShopData] = {
 }
 
 
-def shuffle_shop_prices(world: MessengerWorld) -> Tuple[Dict[str, int], Dict[str, int]]:
+def shuffle_shop_prices(world: MessengerWorld) -> tuple[dict[str, int], dict[str, int]]:
     shop_price_mod = world.options.shop_price.value
     shop_price_planned = world.options.shop_price_plan
 
-    shop_prices: Dict[str, int] = {}
-    figurine_prices: Dict[str, int] = {}
+    shop_prices: dict[str, int] = {}
+    figurine_prices: dict[str, int] = {}
     for item, price in shop_price_planned.value.items():
         if not isinstance(price, int):
             price = world.random.choices(list(price.keys()), weights=list(price.values()))[0]

--- a/worlds/messenger/subclasses.py
+++ b/worlds/messenger/subclasses.py
@@ -1,5 +1,5 @@
 from functools import cached_property
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from BaseClasses import CollectionState, Entrance, Item, ItemClassification, Location, Region
 from .regions import LOCATIONS, MEGA_SHARDS
@@ -10,14 +10,14 @@ if TYPE_CHECKING:
 
 
 class MessengerEntrance(Entrance):
-    world: Optional["MessengerWorld"] = None
+    world: "MessengerWorld | None" = None
 
 
 class MessengerRegion(Region):
     parent: str
     entrance_type = MessengerEntrance
 
-    def __init__(self, name: str, world: "MessengerWorld", parent: Optional[str] = None) -> None:
+    def __init__(self, name: str, world: "MessengerWorld", parent: str | None = None) -> None:
         super().__init__(name, world.player, world.multiworld)
         self.parent = parent
         locations = []
@@ -48,7 +48,7 @@ class MessengerRegion(Region):
 class MessengerLocation(Location):
     game = "The Messenger"
 
-    def __init__(self, player: int, name: str, loc_id: Optional[int], parent: MessengerRegion) -> None:
+    def __init__(self, player: int, name: str, loc_id: int | None, parent: MessengerRegion) -> None:
         super().__init__(player, name, loc_id, parent)
         if loc_id is None:
             if name == "Rescue Phantom":
@@ -59,7 +59,7 @@ class MessengerLocation(Location):
 class MessengerShopLocation(MessengerLocation):
     @cached_property
     def cost(self) -> int:
-        name = self.name.replace("The Shop - ", "")  # TODO use `remove_prefix` when 3.8 finally gets dropped
+        name = self.name.removeprefix("The Shop - ")
         world = self.parent_region.multiworld.worlds[self.player]
         shop_data = SHOP_ITEMS[name]
         if shop_data.prerequisite:

--- a/worlds/messenger/test/test_shop.py
+++ b/worlds/messenger/test/test_shop.py
@@ -76,7 +76,7 @@ class PlandoTest(MessengerTestBase):
 
                 loc = f"The Shop - {loc}"
                 self.assertLessEqual(price, self.multiworld.get_location(loc, self.player).cost)
-                self.assertTrue(loc.replace("The Shop - ", "") in SHOP_ITEMS)
+                self.assertTrue(loc.removeprefix("The Shop - ") in SHOP_ITEMS)
         self.assertEqual(len(prices), len(SHOP_ITEMS))
 
         figures = self.world.figurine_prices


### PR DESCRIPTION
## What is this fixing or adding?
Updates typing to 3.10+ and replaces str.replace with str.remove_prefix where relevant for a minimal speed increase.

## How was this tested?
A few gens and tests. Existing tests hit all of the code paths that were touched here

## If this makes graphical changes, please attach screenshots.
