### PR TITLE
[PKMN RB] Adds slot data that tells the tracker V5 logic should be considered

### DIFF
--- a/worlds/pokemon_rb/__init__.py
+++ b/worlds/pokemon_rb/__init__.py
@@ -703,6 +703,7 @@ class PokemonRedBlueWorld(World):
             "require_pokedex": self.options.require_pokedex.value,
             "area_1_to_1_mapping": self.options.area_1_to_1_mapping.value,
             "blind_trainers": self.options.blind_trainers.value,
+            "v5_update": True
 
         }
         if self.options.type_chart_seed == "random" or self.options.type_chart_seed.value.isdigit():

--- a/worlds/pokemon_rb/__init__.py
+++ b/worlds/pokemon_rb/__init__.py
@@ -703,7 +703,7 @@ class PokemonRedBlueWorld(World):
             "require_pokedex": self.options.require_pokedex.value,
             "area_1_to_1_mapping": self.options.area_1_to_1_mapping.value,
             "blind_trainers": self.options.blind_trainers.value,
-            "v5_update": True
+            "v5_update": True,
 
         }
         if self.options.type_chart_seed == "random" or self.options.type_chart_seed.value.isdigit():


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?
Adds a flag to slot data that is just dummy-true so the poptracker can test for whether the slot data exists to apply 0.5.1 or 0.5.0 logic for Pokémon RB.

## How was this tested?
Generated a game successfully. Connected with a Debug Pack, verified slot data was present.

## If this makes graphical changes, please attach screenshots.
N/A