### PR TITLE
LADX: ghost fills ammo to initial max

### DIFF
--- a/worlds/ladx/LADXR/patches/owl.py
+++ b/worlds/ladx/LADXR/patches/owl.py
@@ -81,23 +81,23 @@ talking:
 
     ; Give powder
     ld   a, [$DB4C]
-    cp   $10
+    cp   $20
     jr   nc, doNotGivePowder
-    ld   a, $10
+    ld   a, $20
     ld   [$DB4C], a
 doNotGivePowder:
 
     ld   a, [$DB4D]
-    cp   $10
+    cp   $30
     jr   nc, doNotGiveBombs
-    ld   a, $10
+    ld   a, $30
     ld   [$DB4D], a
 doNotGiveBombs:
 
     ld   a, [$DB45]
-    cp   $10
+    cp   $30
     jr   nc, doNotGiveArrows
-    ld   a, $10
+    ld   a, $30
     ld   [$DB45], a
 doNotGiveArrows:
 

--- a/worlds/ladx/LADXR/patches/owl.py
+++ b/worlds/ladx/LADXR/patches/owl.py
@@ -80,26 +80,14 @@ talking:
     ret  nz
 
     ; Give powder
-    ld   a, [$DB4C]
-    cp   $10
-    jr   nc, doNotGivePowder
-    ld   a, $10
+    ld   a, [$DB76]
     ld   [$DB4C], a
-doNotGivePowder:
-
-    ld   a, [$DB4D]
-    cp   $10
-    jr   nc, doNotGiveBombs
-    ld   a, $10
+    ; Give bombs
+    ld   a, [$DB77]
     ld   [$DB4D], a
-doNotGiveBombs:
-
-    ld   a, [$DB45]
-    cp   $10
-    jr   nc, doNotGiveArrows
-    ld   a, $10
+    ; Give arrows
+    ld   a, [$DB78]
     ld   [$DB45], a
-doNotGiveArrows:
 
     ld   a, $C1
     call $2385 ; open dialog

--- a/worlds/ladx/LADXR/patches/owl.py
+++ b/worlds/ladx/LADXR/patches/owl.py
@@ -80,14 +80,26 @@ talking:
     ret  nz
 
     ; Give powder
-    ld   a, [$DB76]
+    ld   a, [$DB4C]
+    cp   $10
+    jr   nc, doNotGivePowder
+    ld   a, $10
     ld   [$DB4C], a
-    ; Give bombs
-    ld   a, [$DB77]
+doNotGivePowder:
+
+    ld   a, [$DB4D]
+    cp   $10
+    jr   nc, doNotGiveBombs
+    ld   a, $10
     ld   [$DB4D], a
-    ; Give arrows
-    ld   a, [$DB78]
+doNotGiveBombs:
+
+    ld   a, [$DB45]
+    cp   $10
+    jr   nc, doNotGiveArrows
+    ld   a, $10
     ld   [$DB45], a
+doNotGiveArrows:
 
     ld   a, $C1
     call $2385 ; open dialog


### PR DESCRIPTION
## What is this fixing or adding?
Change: Make the Ghost in your starting house fill up your consumables (Magic Powder, Bombs, Arrows) up to initial max (20/30/30) instead of just up to 10.

The reason is that in Vanilla Magic Powder is logically restored through Trendy Minigame and Bomb & Arrows are filled with the Shop. But with Entrance Shuffle and minimal accessibility, this cannot be guaranteed. Even on full accessibility it could create scenarios where refillables are only possible up to 10 but logic requires more than 10 consumables to get from start to a specific check.

TL;DR: Currently, AP can create logically impossible seeds with ER if logic requires a lot of consumables. The ghost-refill-change will fix this. Thus, this will also not be a YAML-option but a specific change.

The original maintainer, zig, also wanted to do this months ago but didn't get to it. 

## How was this tested?
Generated locally and tested with item cheating.