### PR TITLE
Pokemon RB: make stage_post_fill deterministic

### DIFF
--- a/worlds/pokemon_rb/__init__.py
+++ b/worlds/pokemon_rb/__init__.py
@@ -526,6 +526,7 @@ class PokemonRedBlueWorld(World):
         # This cuts down on time spent calculating the spoiler playthrough.
         found_mons = set()
         for sphere in multiworld.get_spheres():
+            mon_locations_in_sphere = {}
             for location in sphere:
                 if (location.game == "Pokemon Red and Blue" and (location.item.name in poke_data.pokemon_data.keys()
                                                                  or "Static " in location.item.name)
@@ -534,7 +535,15 @@ class PokemonRedBlueWorld(World):
                     if key in found_mons:
                         location.item.classification = ItemClassification.useful
                     else:
-                        found_mons.add(key)
+                        mon_locations_in_sphere.setdefault(key, []).append(location)
+            for key, mon_locations in mon_locations_in_sphere.items():
+                found_mons.add(key)
+                if len(mon_locations) > 1:
+                    # Sort for deterministic results.
+                    mon_locations.sort()
+                    # Convert all but the first to useful classification.
+                    for location in mon_locations[1:]:
+                        location.item.classification = ItemClassification.useful
 
     def create_regions(self):
         if (self.options.old_man == "vanilla" or


### PR DESCRIPTION
## What is this fixing or adding?
stage_post_fill iterates sets of locations, so the iteration order is non-deterministic, resulting in different items being converted from Progression to Useful when generating with the same seed.

I don't think this currently causes any problems because the main use of these locations after stage_post_fill is playthrough calculation, which is non-deterministic to begin with, but maybe there could be problems in the future.

This patch makes stage_post_fill deterministic by sorting the duplicate pokemon locations in each sphere before choosing which of the duplicates should remain as progression.

## How was this tested?
I added debug checks for deterministic results to the end of the generator (dumping the locations and items to a file with a unique name per seed and yaml combinations and comparing against the file when it already exists).

Pokemon RB would constantly fail this check beforehand. With this patch, Pokemon RB passes the check every time.