### PR TITLE
Tests: Fix indentation in TestTwoPlayerMulti

### DIFF
--- a/test/multiworld/test_multiworlds.py
+++ b/test/multiworld/test_multiworlds.py
@@ -71,7 +71,7 @@ class TestTwoPlayerMulti(MultiworldTestBase):
             for world in self.multiworld.worlds.values():
                 world.options.accessibility.value = Accessibility.option_full
             self.assertSteps(gen_steps)
-        with self.subTest("filling multiworld", seed=self.multiworld.seed):
-            distribute_items_restrictive(self.multiworld)
-            call_all(self.multiworld, "post_fill")
-            self.assertTrue(self.fulfills_accessibility(), "Collected all locations, but can't beat the game")
+            with self.subTest("filling multiworld", games=world_type.game, seed=self.multiworld.seed):
+                distribute_items_restrictive(self.multiworld)
+                call_all(self.multiworld, "post_fill")
+                self.assertTrue(self.fulfills_accessibility(), "Collected all locations, but can't beat the game")


### PR DESCRIPTION
## What is this fixing or adding?
The "filling multiworld" subtest was at the wrong indentation, so was only running for the last world_type.

"games" has additionally been added to the subtest to help better identify failures.

Now that the subtest is actually being run for each world type, this adds about 20 seconds to the duration of the test on my machine.

## How was this tested?
I ran the test.
