### PR TITLE
Core: use shlex splitting instead of whitespace splitting for client and server commands

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -15,6 +15,7 @@ import math
 import operator
 import pickle
 import random
+import shlex
 import threading
 import time
 import typing
@@ -1150,7 +1151,7 @@ class CommandProcessor(metaclass=CommandMeta):
         if not raw:
             return
         try:
-            command = raw.split()
+            command = shlex.split(raw, comments=False)
             basecommand = command[0]
             if basecommand[0] == self.marker:
                 method = self.commands.get(basecommand[1:].lower(), None)


### PR DESCRIPTION
## What is this fixing or adding?
`/send "Ber ser ker" some bread`
is now interpreted as sending the player `Ber ser ker` `some bread`

## How was this tested?
locally, mostly in a command prompt to see how it behaves and then a handful of tests post integration.
