### PR TITLE
The Messenger: add race mode to slot_data

### DIFF
--- a/worlds/messenger/__init__.py
+++ b/worlds/messenger/__init__.py
@@ -302,6 +302,7 @@ class MessengerWorld(World):
                              else TRANSITIONS.index(RANDOMIZED_CONNECTIONS[transition.parent_region.name]),
                              TRANSITIONS.index(transition.connected_region.name)]
                             for transition in self.transitions],
+            "race": int(self.multiworld.is_race),
             **self.options.as_dict("music_box", "death_link", "logic_level"),
         }
         return slot_data


### PR DESCRIPTION
## What is this fixing or adding?
The Messenger has special client behavior for race mode now so I need this information and for some godforsaken reason we all have to do this instead of just adding this int to the networking protocol.