### PR TITLE
Pokemon Emerald: Another wonder trade fix

### DIFF
--- a/worlds/pokemon_emerald/client.py
+++ b/worlds/pokemon_emerald/client.py
@@ -545,11 +545,12 @@ class PokemonEmeraldClient(BizHawkClient):
             if trade_is_sent == 0 and wonder_trade_pokemon_data[19] == 2:
                 # Game has wonder trade data to send. Send it to data storage, remove it from the game's memory,
                 # and mark that the game is waiting on receiving a trade
-                Utils.async_start(self.wonder_trade_send(ctx, pokemon_data_to_json(wonder_trade_pokemon_data)))
-                await bizhawk.guarded_write(ctx.bizhawk_ctx, [
+                success = await bizhawk.guarded_write(ctx.bizhawk_ctx, [
                     (sb1_address + 0x377C, bytes(0x50), "System Bus"),
                     (sb1_address + 0x37CC, [1], "System Bus"),
                 ], [guards["SAVE BLOCK 1"]])
+                if success:
+                    Utils.async_start(self.wonder_trade_send(ctx, pokemon_data_to_json(wonder_trade_pokemon_data)))
             elif trade_is_sent != 0 and wonder_trade_pokemon_data[19] != 2:
                 # Game is waiting on receiving a trade.
                 if self.queued_received_trade is not None:

--- a/worlds/pokemon_emerald/client.py
+++ b/worlds/pokemon_emerald/client.py
@@ -546,10 +546,10 @@ class PokemonEmeraldClient(BizHawkClient):
                 # Game has wonder trade data to send. Send it to data storage, remove it from the game's memory,
                 # and mark that the game is waiting on receiving a trade
                 Utils.async_start(self.wonder_trade_send(ctx, pokemon_data_to_json(wonder_trade_pokemon_data)))
-                await bizhawk.write(ctx.bizhawk_ctx, [
+                await bizhawk.guarded_write(ctx.bizhawk_ctx, [
                     (sb1_address + 0x377C, bytes(0x50), "System Bus"),
                     (sb1_address + 0x37CC, [1], "System Bus"),
-                ])
+                ], [guards["SAVE BLOCK 1"]])
             elif trade_is_sent != 0 and wonder_trade_pokemon_data[19] != 2:
                 # Game is waiting on receiving a trade.
                 if self.queued_received_trade is not None:


### PR DESCRIPTION
## What is this fixing or adding?

The same fix as #3939. Only write the data (and only send the trade) if the save block hasn't moved.

This one is even rarer because your client would need to try to send a trade while your map is transitioning, which would be exceptional. And slightly less destructive because you'd just receive all your items again. But still a problem.

## How was this tested?

Did a wonder trade between two clients.
