### PR TITLE
Core: add race mode to multidata and datastore

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -325,6 +325,7 @@ class CommonContext:
             "collect": "disabled",
             "remaining": "disabled",
         }
+        self.race_mode: int = 0
 
         # own state
         self.finished_game = False
@@ -454,6 +455,7 @@ class CommonContext:
         if kwargs:
             payload.update(kwargs)
         await self.send_msgs([payload])
+        await self.send_msgs([{"cmd": "Get", "keys": ["race_mode"]}])
 
     async def console_input(self) -> str:
         if self.ui:

--- a/Main.py
+++ b/Main.py
@@ -338,6 +338,7 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
                     "seed_name": multiworld.seed_name,
                     "spheres": spheres,
                     "datapackage": data_package,
+                    "race_mode": int(multiworld.is_race),
                 }
                 AutoWorld.call_all(multiworld, "modify_multidata", multidata)
 

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -427,6 +427,8 @@ class Context:
               use_embedded_server_options: bool):
 
         self.read_data = {}
+        # there might be a better place to put this.
+        self.stored_data["race_mode"] = decoded_obj.get("race_mode", 0)
         mdata_ver = decoded_obj["minimum_versions"]["server"]
         if mdata_ver > version_tuple:
             raise RuntimeError(f"Supplied Multidata (.archipelago) requires a server of at least version {mdata_ver},"

--- a/kvui.py
+++ b/kvui.py
@@ -243,6 +243,8 @@ class ServerLabel(HovererableLabel):
                             f"\nYou currently have {ctx.hint_points} points."
                 elif ctx.hint_cost == 0:
                     text += "\n!hint is free to use."
+                if ctx.stored_data and "race_mode" in ctx.stored_data:
+                    text += "\nRace mode is enabled." if ctx.stored_data["race_mode"] else "\nRace mode is disabled."
             else:
                 text += f"\nYou are not authenticated yet."
 


### PR DESCRIPTION
## What is this fixing or adding?
Adds race mode to the multidata on generation then the server adds it to datastorage. i think the api for https://github.com/ArchipelagoMW/Archipelago/pull/2561 would probably be better but this works and was quick and easy so 🤷. also adds whether race mode is enabled/disabled to the commonclient tooltip ui (sorry silvris).

## How was this tested?
Generated games with race mode enabled/disabled and checked the packets and tooltip ui.

## If this makes graphical changes, please attach screenshots.
![Screenshot_428](https://github.com/user-attachments/assets/3d6256f0-c62b-4d16-826f-946bd3ef5fcc)
