### PR TITLE
Core: move race_mode to read_data instead of stored_data

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -325,7 +325,6 @@ class CommonContext:
             "collect": "disabled",
             "remaining": "disabled",
         }
-        self.race_mode: int = 0
 
         # own state
         self.finished_game = False
@@ -455,7 +454,7 @@ class CommonContext:
         if kwargs:
             payload.update(kwargs)
         await self.send_msgs([payload])
-        await self.send_msgs([{"cmd": "Get", "keys": ["race_mode"]}])
+        await self.send_msgs([{"cmd": "Get", "keys": ["_read_race_mode"]}])
 
     async def console_input(self) -> str:
         if self.ui:

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -428,7 +428,7 @@ class Context:
 
         self.read_data = {}
         # there might be a better place to put this.
-        self.stored_data["race_mode"] = decoded_obj.get("race_mode", 0)
+        self.read_data["race_mode"] = lambda: decoded_obj.get("race_mode", 0)
         mdata_ver = decoded_obj["minimum_versions"]["server"]
         if mdata_ver > version_tuple:
             raise RuntimeError(f"Supplied Multidata (.archipelago) requires a server of at least version {mdata_ver},"

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -395,6 +395,7 @@ Some special keys exist with specific return data, all of them have the prefix `
 | item_name_groups_{game_name}     | dict\[str, list\[str\]\]      | item_name_groups belonging to the requested game.     |
 | location_name_groups_{game_name} | dict\[str, list\[str\]\]      | location_name_groups belonging to the requested game. |
 | client_status_{team}_{slot}      | [ClientStatus](#ClientStatus) | The current game status of the requested player.      |
+| race_mode                        | int                           | 0 if race mode is disabled, and 1 if it's enabled.    |
 
 ### Set
 Used to write data to the server's data storage, that data can then be shared across worlds or just saved for later. Values for keys in the data storage can be retrieved with a [Get](#Get) package, or monitored with a [SetNotify](#SetNotify) package.

--- a/kvui.py
+++ b/kvui.py
@@ -243,8 +243,9 @@ class ServerLabel(HovererableLabel):
                             f"\nYou currently have {ctx.hint_points} points."
                 elif ctx.hint_cost == 0:
                     text += "\n!hint is free to use."
-                if ctx.stored_data and "race_mode" in ctx.stored_data:
-                    text += "\nRace mode is enabled." if ctx.stored_data["race_mode"] else "\nRace mode is disabled."
+                if ctx.stored_data and "_read_race_mode" in ctx.stored_data:
+                    text += "\nRace mode is enabled." \
+                        if ctx.stored_data["_read_race_mode"] else "\nRace mode is disabled."
             else:
                 text += f"\nYou are not authenticated yet."
 


### PR DESCRIPTION
## What is this fixing or adding?
From my miniscule understanding at the time stored_data seemed more appropriate but API wise, read_data is actually the more appropriate place for this so this moves it there. also adds it to the docs which was previously forgotten.