### PR TITLE
Pokemon Emerald: Add flag for shoal cave to bounces

### DIFF
--- a/worlds/pokemon_emerald/client.py
+++ b/worlds/pokemon_emerald/client.py
@@ -117,6 +117,11 @@ LEGENDARY_NAMES = {k.lower(): v for k, v in {
 DEFEATED_LEGENDARY_FLAG_MAP = {data.constants[f"FLAG_DEFEATED_{name}"]: name for name in LEGENDARY_NAMES.values()}
 CAUGHT_LEGENDARY_FLAG_MAP = {data.constants[f"FLAG_CAUGHT_{name}"]: name for name in LEGENDARY_NAMES.values()}
 
+SHOAL_CAVE_MAPS = tuple(data.constants[map_name] for map_name in [
+    "MAP_SHOAL_CAVE_LOW_TIDE_ENTRANCE_ROOM",
+    "MAP_SHOAL_CAVE_LOW_TIDE_INNER_ROOM",
+])
+
 
 class PokemonEmeraldClient(BizHawkClient):
     game = "Pokemon Emerald"
@@ -414,13 +419,17 @@ class PokemonEmeraldClient(BizHawkClient):
 
         read_result = await bizhawk.guarded_read(
             ctx.bizhawk_ctx,
-            [(sb1_address + 0x4, 2, "System Bus")],
+            [
+                (sb1_address + 0x4, 2, "System Bus"),  # Current map
+                (sb1_address + 0x1450 + (data.constants["FLAG_SYS_SHOAL_TIDE"] // 8), 1, "System Bus"),
+            ],
             [guards["SAVE BLOCK 1"]]
         )
         if read_result is None:  # Save block moved
             return
 
         current_map = int.from_bytes(read_result[0], "big")
+        shoal_cave = int(read_result[0][0] & (1 << (data.constants["FLAG_SYS_SHOAL_TIDE"] % 8)) > 0)
         if current_map != self.current_map:
             self.current_map = current_map
             await ctx.send_msgs([{
@@ -429,6 +438,7 @@ class PokemonEmeraldClient(BizHawkClient):
                 "data": {
                     "type": "MapUpdate",
                     "mapId": current_map,
+                    **({"tide": shoal_cave} if current_map in SHOAL_CAVE_MAPS else {}),
                 },
             }])
 

--- a/worlds/pokemon_emerald/client.py
+++ b/worlds/pokemon_emerald/client.py
@@ -423,13 +423,13 @@ class PokemonEmeraldClient(BizHawkClient):
                 (sb1_address + 0x4, 2, "System Bus"),  # Current map
                 (sb1_address + 0x1450 + (data.constants["FLAG_SYS_SHOAL_TIDE"] // 8), 1, "System Bus"),
             ],
-            [guards["SAVE BLOCK 1"]]
+            [guards["IN OVERWORLD"], guards["SAVE BLOCK 1"]]
         )
         if read_result is None:  # Save block moved
             return
 
         current_map = int.from_bytes(read_result[0], "big")
-        shoal_cave = int(read_result[0][0] & (1 << (data.constants["FLAG_SYS_SHOAL_TIDE"] % 8)) > 0)
+        shoal_cave = int(read_result[1][0] & (1 << (data.constants["FLAG_SYS_SHOAL_TIDE"] % 8)) > 0)
         if current_map != self.current_map:
             self.current_map = current_map
             await ctx.send_msgs([{


### PR DESCRIPTION
## What is this fixing or adding?

Shoal cave is a special place that has 2 states: high tide and low tide. Both states exist within the low tide map, except that the game updates the layout to the high tide layout based on the state of a flag. The high tide map exists as a stub. Trackers that care about map updates care which state the tide is in if the player enters one of these maps.

Adds a field that forwards the state of the tide flag with the map update if the new map is relevant to being high or low tide. Also adds the `IN OVERWORLD` guard to map updates. The map and tide flag aren't updated on the same frame, so this delays sending the update until the map has finished transitioning.

## How was this tested?

```
Outgoing message: [{"cmd":"Bounced","slots":[1],"data":{"type":"MapUpdate","mapId":256}}]
Outgoing message: [{"cmd":"Bounced","slots":[1],"data":{"type":"MapUpdate","mapId":9}}]
Outgoing message: [{"cmd":"Bounced","slots":[1],"data":{"type":"MapUpdate","mapId":6190,"tide":0}}]
Outgoing message: [{"cmd":"Bounced","slots":[1],"data":{"type":"MapUpdate","mapId":9}}]
Outgoing message: [{"cmd":"Bounced","slots":[1],"data":{"type":"MapUpdate","mapId":6190,"tide":1}}]
Outgoing message: [{"cmd":"Bounced","slots":[1],"data":{"type":"MapUpdate","mapId":9}}]
Outgoing message: [{"cmd":"Bounced","slots":[1],"data":{"type":"MapUpdate","mapId":6190,"tide":0}}]
```
