### PR TITLE
Core: Added Handler for math operations and check for math operator in Triggers.

### DIFF
--- a/worlds/generic/docs/triggers_en.md
+++ b/worlds/generic/docs/triggers_en.md
@@ -160,3 +160,56 @@ Super Metroid:
 In this example, if the `start_location` option rolls `landing_site`, only a starting hint for Morph Ball will be 
 created. If `aqueduct` is rolled, a starting hint for Gravity Suit will also be created alongside the hint for Morph 
 Ball.
+
+## Using Arithmetic to Determine Output Values
+
+By adding a * at the end of an option name when specifying changes, you can perform
+addition, subtraction, multiplication, or division of values. This is done under 
+```
+options: 
+  game_name:
+```
+
+When performing arithmetic, the value should be either a string, or a weight list of string
+in the form: "value1 [+, -, *, /] value2". 
+
+Values can be either constants or option names whose values you wish to use. Options used this way must be either 
+weighted lists of values, or a constant value, and the values must be numeric.
+
+For example:
+```yaml
+math_door: 
+  true: 1
+  false: 1
+
+triggers:
+  - option_category: Super Mario 64
+    option_name: math_door
+    option_result: true
+    options:
+      Super Mario 64:
+        first_bowser_star_door_cost*: "amount_of_stars / 10"
+        basement_star_door_cost*: 
+          "amount_of_stars / 5": 2
+          "amount_of_stars - 10": 3
+        second_floor_star_door_cost: 20
+        stars_to_finish*: "amount_of_stars + 0"
+```
+
+This first checks the option math_door. If it rolled true, then the options take effect:
+
+`first_bowser_star_door_cost*: "amount_of_stars / 10"` takes whatever value
+amount_of_stars has, and divides it by 10.
+
+```
+basement_star_door_cost*:
+  "amount_of_stars / 5": 2
+  "amount_of_stars - 10": 3
+```
+This says there is a 2/5 chance that the basement door will cost 1/5 of the stars selected by
+amount_of_stars, and a 3/5 chance that the basement door will cost 10 less stars than selected by
+amount_of_stars.
+
+`second_floor_star_door_cost: 20` says that the second door will take 20 stars to open.
+
+`stars_to_finish*: "amount_of_stars + 0"` says that you will need every star to finish. 


### PR DESCRIPTION
## What is this fixing or adding?
Adds the ability to perform basic arithmetic operations in trigger options, used by adding a * to the end of the option you are performing arithmetic to determine. Values are restricted to numeric values between -1,000,000 and 1,000,000 for security. 

For example: 
`first_bowser_star_door_cost*: "amount_of_stars / 10"` in Super Mario 64 would set the first bowser door star requirement to 1/10 the total number of stars. Weighted lists of options are also accepted:

```
basement_star_door_cost*:
  "amount_of_stars / 5": 2
  "amount_of_stars - 10": 3
```

This would make the basement door require either 1/5 of the stars, or 10 less than the total number of stars.

## How was this tested?

Trying various values to check that it fails properly when bad data is entered, and appropriately sets the yaml option values when formatted properly. Additional testing to ensure I did not miss a test case would be appreciated.

## If this makes graphical changes, please attach screenshots.
None.