### PR TITLE
Core: Deduplicate console exception output

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -528,7 +528,8 @@ def init_logging(name: str, loglevel: typing.Union[str, int] = logging.INFO, wri
                 sys.__excepthook__(exc_type, exc_value, exc_traceback)
                 return
             logging.getLogger(exception_logger).exception("Uncaught exception",
-                                                          exc_info=(exc_type, exc_value, exc_traceback))
+                                                          exc_info=(exc_type, exc_value, exc_traceback),
+                                                          extra={"NoStream": exception_logger is None})
             return orig_hook(exc_type, exc_value, exc_traceback)
 
         handle_exception._wrapped = True


### PR DESCRIPTION
## What is this fixing or adding?
When running Generate.py, uncaught exceptions are logged once to a file and twice to the console due to keeping the original excepthook. We can avoid this by filtering the file log out of the stream handler, and letting the original excepthook print the traceback.

## How was this tested?
Created a player yaml file with
```
Noita:
  progression_balancing:
    garbl: 10
```

and ran `python Generate.py --skip_output`.

### Results
<details><summary>Before</summary>

```
Uncaught exception
Traceback (most recent call last):
  File "Documents\GitHub\Archipelago\Generate.py", line 417, in handle_option
    player_option = option.from_any(get_choice(option_key, game_weights))
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Documents\GitHub\Archipelago\Options.py", line 732, in from_any
    return cls.from_text(str(data))
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "Documents\GitHub\Archipelago\Options.py", line 770, in from_text
    return super().from_text(text)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "Documents\GitHub\Archipelago\Options.py", line 687, in from_text
    return cls(int(text))
               ^^^^^^^^^
ValueError: invalid literal for int() with base 10: 'garbl'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "Documents\GitHub\Archipelago\Generate.py", line 194, in main
    tuple(roll_settings(yaml, args.plando) for yaml in weights_cache[path])
  File "Documents\GitHub\Archipelago\Generate.py", line 194, in <genexpr>
    tuple(roll_settings(yaml, args.plando) for yaml in weights_cache[path])
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Documents\GitHub\Archipelago\Generate.py", line 487, in roll_settings
    handle_option(ret, game_weights, option_key, option, plando_options)
  File "Documents\GitHub\Archipelago\Generate.py", line 422, in handle_option
    raise Options.OptionError(f"Error generating option {option_key} in {ret.game}") from e
Options.OptionError: Error generating option progression_balancing in Noita

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "Documents\GitHub\Archipelago\Generate.py", line 530, in <module>
    erargs, seed = main()
                   ^^^^^^
  File "Documents\GitHub\Archipelago\Generate.py", line 213, in main
    raise ValueError(f"File {path} is invalid. Please fix your yaml.") from e
ValueError: File Noita.yaml is invalid. Please fix your yaml.
Traceback (most recent call last):
  File "Documents\GitHub\Archipelago\Generate.py", line 417, in handle_option
    player_option = option.from_any(get_choice(option_key, game_weights))
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Documents\GitHub\Archipelago\Options.py", line 732, in from_any
    return cls.from_text(str(data))
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "Documents\GitHub\Archipelago\Options.py", line 770, in from_text
    return super().from_text(text)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "Documents\GitHub\Archipelago\Options.py", line 687, in from_text
    return cls(int(text))
               ^^^^^^^^^
ValueError: invalid literal for int() with base 10: 'garbl'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "Documents\GitHub\Archipelago\Generate.py", line 194, in main
    tuple(roll_settings(yaml, args.plando) for yaml in weights_cache[path])
  File "Documents\GitHub\Archipelago\Generate.py", line 194, in <genexpr>
    tuple(roll_settings(yaml, args.plando) for yaml in weights_cache[path])
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Documents\GitHub\Archipelago\Generate.py", line 487, in roll_settings
    handle_option(ret, game_weights, option_key, option, plando_options)
  File "Documents\GitHub\Archipelago\Generate.py", line 422, in handle_option
    raise Options.OptionError(f"Error generating option {option_key} in {ret.game}") from e

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "Documents\GitHub\Archipelago\Generate.py", line 530, in <module>
    erargs, seed = main()
                   ^^^^^^
  File "Documents\GitHub\Archipelago\Generate.py", line 213, in main
    raise ValueError(f"File {path} is invalid. Please fix your yaml.") from e
ValueError: File Noita.yaml is invalid. Please fix your yaml.
Press enter to close.
```
</details>

<details><summary>After</summary>

```
Traceback (most recent call last):
  File "Documents\GitHub\Archipelago\Generate.py", line 417, in handle_option
    player_option = option.from_any(get_choice(option_key, game_weights))
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Documents\GitHub\Archipelago\Options.py", line 732, in from_any
    return cls.from_text(str(data))
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "Documents\GitHub\Archipelago\Options.py", line 770, in from_text
    return super().from_text(text)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "Documents\GitHub\Archipelago\Options.py", line 687, in from_text
    return cls(int(text))
               ^^^^^^^^^
ValueError: invalid literal for int() with base 10: 'garbl'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "Documents\GitHub\Archipelago\Generate.py", line 194, in main
    tuple(roll_settings(yaml, args.plando) for yaml in weights_cache[path])
  File "Documents\GitHub\Archipelago\Generate.py", line 194, in <genexpr>
    tuple(roll_settings(yaml, args.plando) for yaml in weights_cache[path])
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "Documents\GitHub\Archipelago\Generate.py", line 487, in roll_settings
    handle_option(ret, game_weights, option_key, option, plando_options)
  File "Documents\GitHub\Archipelago\Generate.py", line 422, in handle_option
    raise Options.OptionError(f"Error generating option {option_key} in {ret.game}") from e
Options.OptionError: Error generating option progression_balancing in Noita

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "Documents\GitHub\Archipelago\Generate.py", line 530, in <module>
    erargs, seed = main()
                   ^^^^^^
  File "Documents\GitHub\Archipelago\Generate.py", line 213, in main
    raise ValueError(f"File {path} is invalid. Please fix your yaml.") from e
ValueError: File Noita.yaml is invalid. Please fix your yaml.
Press enter to close.
```
</details>