### PR TITLE
Core: Better error message for invalid range values

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -684,6 +684,20 @@ class Range(NumericOption):
                 return cls.from_any(cls.default)
             else:  # "false"
                 return cls(0)
+        elif (text[0] == "-" and not text[1:].isnumeric()) \
+                or not text.isnumeric():
+            # Handle conditionally acceptable values here rather than in the f-string
+            default = ""
+            truefalse = ""
+            if hasattr(cls, "default"):
+                default = ", default"
+                if cls.range_start == 0 and cls.default != 0:
+                    truefalse = ", \"true\", \"false\""
+            raise Exception(f"Invalid range value {text!r}. Acceptable values are: "
+                            f"<int>{default}, high, low{truefalse}, "
+                            f"random, random-high, random-middle, random-low, "
+                            f"random-range-low-<min>-<max>, random-range-middle-<min>-<max>, "
+                            f"random-range-high-<min>-<max>, or random-range-<min>-<max>")
         return cls(int(text))
 
     @classmethod


### PR DESCRIPTION
## What is this fixing or adding?

If your yaml includes a named range option typoed, misspelled, or otherwise nonexistent, the error you will get back will be: `ValueError: invalid literal for int() with base 10: 'garbl'`.

Yet, if your named range option starts with `random`, instead you will get: `Exception: random text "garbl" did not resolve to a recognized pattern. Acceptable values are: random, random-high, random-middle, random-low, random-range-low-<min>-<max>, random-range-middle-<min>-<max>, random-range-high-<min>-<max>, or random-range-<min>-<max>`, which is more useful.

I've added an error message listing all accepted options in the case where the text option is not one of them.

## How was this tested?

Created a player file with e.g.
```
Noita:
  progression_balancing:
    garbl: 10
```

and ran `python Generate.py --skip_output`.

<details><summary>Before</summary>

```
Traceback (most recent call last):
  File "c:\Users\bswolf\Documents\GitHub\Archipelago\Generate.py", line 417, in handle_option
    player_option = option.from_any(get_choice(option_key, game_weights))
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\Users\bswolf\Documents\GitHub\Archipelago\Options.py", line 732, in from_any
    return cls.from_text(str(data))
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\Users\bswolf\Documents\GitHub\Archipelago\Options.py", line 770, in from_text
    return super().from_text(text)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\Users\bswolf\Documents\GitHub\Archipelago\Options.py", line 687, in from_text
    return cls(int(text))
               ^^^^^^^^^
ValueError: invalid literal for int() with base 10: 'garbl'
```
</details>

<details><summary>After</summary>

```
Traceback (most recent call last):
  File "c:\Users\bswolf\Documents\GitHub\Archipelago\Generate.py", line 417, in handle_option
    player_option = option.from_any(get_choice(option_key, game_weights))
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\Users\bswolf\Documents\GitHub\Archipelago\Options.py", line 742, in from_any
    return cls.from_text(str(data))
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\Users\bswolf\Documents\GitHub\Archipelago\Options.py", line 780, in from_text
    return super().from_text(text)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\Users\bswolf\Documents\GitHub\Archipelago\Options.py", line 689, in from_text
    raise Exception(f"Invalid range value {text!r}. Acceptable values are: "
Exception: Invalid range value 'garbl'. Acceptable values are: <int>, default, high, low, "true", "false", random, random-high, random-middle, random-low, random-range-low-<min>-<max>, random-range-middle-<min>-<max>, random-range-high-<min>-<max>, or random-range-<min>-<max>
```
</details>