### PR TITLE
Core: Process all player files before reporting errors

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -108,6 +108,7 @@ def main(args=None) -> Tuple[argparse.Namespace, int]:
         meta_weights = None
     player_id = 1
     player_files = {}
+    player_errors = []
     for file in os.scandir(args.player_files_path):
         fname = file.name
         if file.is_file() and not fname.startswith(".") and \
@@ -116,7 +117,11 @@ def main(args=None) -> Tuple[argparse.Namespace, int]:
             try:
                 weights_cache[fname] = read_weights_yamls(path)
             except Exception as e:
-                raise ValueError(f"File {fname} is invalid. Please fix your yaml.") from e
+                logging.exception(f"Exception reading weights in file {fname}")
+                player_errors.append(
+                    f"{len(player_errors) + 1}. "
+                    f"File {fname} is invalid. Please fix your yaml.\n{Utils.get_all_causes(e)}"
+                )
 
     # sort dict for consistent results across platforms:
     weights_cache = {key: value for key, value in sorted(weights_cache.items(), key=lambda k: k[0].casefold())}
@@ -131,6 +136,10 @@ def main(args=None) -> Tuple[argparse.Namespace, int]:
     args.multi = max(player_id - 1, args.multi)
 
     if args.multi == 0:
+        if player_errors:
+            errors = '\n\n'.join(player_errors)
+            raise Exception(f"Encountered {len(player_errors)} error(s) in player files. "
+                            f"See logs for full tracebacks.\n\n{errors}")
         raise ValueError(
             "No individual player files found and number of players is 0. "
             "Provide individual player files or specify the number of players via host.yaml or --multi."
@@ -140,6 +149,10 @@ def main(args=None) -> Tuple[argparse.Namespace, int]:
                  f"{seed_name} Seed {seed} with plando: {args.plando}")
 
     if not weights_cache:
+        if player_errors:
+            errors = '\n\n'.join(player_errors)
+            raise Exception(f"Encountered {len(player_errors)} error(s) in player files. "
+                            f"See logs for full tracebacks.\n\n{errors}")
         raise Exception(f"No weights found. "
                         f"Provide a general weights file ({args.weights_file_path}) or individual player files. "
                         f"A mix is also permitted.")
@@ -185,37 +198,46 @@ def main(args=None) -> Tuple[argparse.Namespace, int]:
     name_counter = Counter()
     erargs.player_options = {}
 
-    player = 1
-    while player <= args.multi:
+    for player in range(1, args.multi + 1):
         path = player_path_cache[player]
-        if path:
-            try:
-                settings: Tuple[argparse.Namespace, ...] = settings_cache[path] if settings_cache[path] else \
-                    tuple(roll_settings(yaml, args.plando) for yaml in weights_cache[path])
-                for settingsObject in settings:
-                    for k, v in vars(settingsObject).items():
-                        if v is not None:
-                            try:
-                                getattr(erargs, k)[player] = v
-                            except AttributeError:
-                                setattr(erargs, k, {player: v})
-                            except Exception as e:
-                                raise Exception(f"Error setting {k} to {v} for player {player}") from e
-
-                    if path == args.weights_file_path:  # if name came from the weights file, just use base player name
-                        erargs.name[player] = f"Player{player}"
-                    elif player not in erargs.name:  # if name was not specified, generate it from filename
-                        erargs.name[player] = os.path.splitext(os.path.split(path)[-1])[0]
-                    erargs.name[player] = handle_name(erargs.name[player], player, name_counter)
-
-                    player += 1
-            except Exception as e:
-                raise ValueError(f"File {path} is invalid. Please fix your yaml.") from e
-        else:
+        if not path:
             raise RuntimeError(f'No weights specified for player {player}')
 
+        try:
+            settings: Tuple[argparse.Namespace, ...] = settings_cache[path] if settings_cache[path] else \
+                tuple(roll_settings(yaml, args.plando) for yaml in weights_cache[path])
+            for settingsObject in settings:
+                for k, v in vars(settingsObject).items():
+                    if v is not None:
+                        try:
+                            getattr(erargs, k)[player] = v
+                        except AttributeError:
+                            setattr(erargs, k, {player: v})
+                        except Exception as e:
+                            raise Exception(f"Error setting {k} to {v} for player {player}") from e
+
+                if path == args.weights_file_path:  # if name came from the weights file, just use base player name
+                    erargs.name[player] = f"Player{player}"
+                elif player not in erargs.name:  # if name was not specified, generate it from filename
+                    erargs.name[player] = os.path.splitext(os.path.split(path)[-1])[0]
+                erargs.name[player] = handle_name(erargs.name[player], player, name_counter)
+        except Exception as e:
+            logging.exception(f"Exception reading settings in file {path}")
+            player_errors.append(
+                f"{len(player_errors) + 1}. "
+                f"File {path} is invalid. Please fix your yaml.\n{Utils.get_all_causes(e)}"
+            )
+
     if len(set(name.lower() for name in erargs.name.values())) != len(erargs.name):
-        raise Exception(f"Names have to be unique. Names: {Counter(name.lower() for name in erargs.name.values())}")
+        player_errors.append(
+            f"{len(player_errors) + 1}. "
+            f"Names have to be unique. Names: {Counter(name.lower() for name in erargs.name.values())}"
+        )
+
+    if player_errors:
+        errors = '\n\n'.join(player_errors)
+        raise Exception(f"Encountered {len(player_errors)} error(s) in player files. "
+                        f"See logs for full tracebacks.\n\n{errors}")
 
     return erargs, seed
 

--- a/Utils.py
+++ b/Utils.py
@@ -1026,3 +1026,23 @@ def is_iterable_except_str(obj: object) -> TypeGuard[typing.Iterable[typing.Any]
     if isinstance(obj, str):
         return False
     return isinstance(obj, typing.Iterable)
+
+
+def get_all_causes(ex: Exception) -> str:
+    """Return a string describing the recursive causes of this exception.
+    
+    For example:
+        
+    ```
+    Exception: Invalid value 'bad'.
+     Which caused: Options.OptionError: Error generating option
+      Which caused: ValueError: File bad.yaml is invalid.
+    ```
+    """
+    cause = ex
+    causes = [str(ex)]
+    while cause := cause.__cause__:
+        causes.append(str(cause))
+    top = causes[-1]
+    others = '\n'.join(f"{' ' * (i + 1)}Which caused: {c}" for i, c in enumerate(reversed(causes[:-1])))
+    return f"Exception: {top}\n{others}"

--- a/Utils.py
+++ b/Utils.py
@@ -1028,6 +1028,13 @@ def is_iterable_except_str(obj: object) -> TypeGuard[typing.Iterable[typing.Any]
     return isinstance(obj, typing.Iterable)
 
 
+def get_full_typename(t: type) -> str:
+    if module := getattr(t, "__module__"):
+        if module and module != str.__module__:
+            return f"{module}.{t.__qualname__}"
+    return t.__qualname__
+
+
 def get_all_causes(ex: Exception) -> str:
     """Return a string describing the recursive causes of this exception.
     
@@ -1040,9 +1047,9 @@ def get_all_causes(ex: Exception) -> str:
     ```
     """
     cause = ex
-    causes = [str(ex)]
+    causes = [f"{get_full_typename(type(ex))}: {ex}"]
     while cause := cause.__cause__:
-        causes.append(str(cause))
+        causes.append(f"{get_full_typename(type(cause))}: {cause}")
     top = causes[-1]
-    others = '\n'.join(f"{' ' * (i + 1)}Which caused: {c}" for i, c in enumerate(reversed(causes[:-1])))
-    return f"Exception: {top}\n{others}"
+    others = ''.join(f"\n{' ' * (i + 1)}Which caused: {c}" for i, c in enumerate(reversed(causes[:-1])))
+    return f"{top}{others}"


### PR DESCRIPTION
## What is this fixing or adding?

Instead of generating large multiworlds several times, each time finding one file with an error and dealing with it (whether finding the owner of the file, fixing the problem yourself, or dropping the file entirely), then initiating a re-run, Archipelago should instead collect all the errors in one run and then present them all.

The final exception output only contains the original exception messages, which makes it more condensed (and hopefully more useful), but the tracebacks are still logged as they are encountered.

## How was this tested?

Created three player yaml files with various errors.

Before: only one error is reported.
After:

```
Exception: Encountered 3 error(s) in player files. See logs for full tracebacks.

1. File Ocarina of Time.yaml is invalid. Please fix your yaml.
yaml.parser.ParserError: while parsing a block mapping
  in "<unicode string>", line 60, column 5
did not find expected key
  in "<unicode string>", line 62, column 5

2. File Noita.yaml is invalid. Please fix your yaml.
ValueError: invalid literal for int() with base 10: 'garbl'
 Which caused: Options.OptionError: Error generating option progression_balancing in Noita

3. File Overcooked! 2.yaml is invalid. Please fix your yaml.
ValueError: invalid literal for int() with base 10: 'normally'
 Which caused: Options.OptionError: Error generating option progression_balancing in Overcooked! 2
Press enter to close.
```

