### PR TITLE
Core: save default settings before opening file for users

### DIFF
--- a/Launcher.py
+++ b/Launcher.py
@@ -35,7 +35,9 @@ from Utils import is_frozen, user_path, local_path, init_logging, open_filename,
 
 
 def open_host_yaml():
-    file = settings.get_settings().filename
+    s = settings.get_settings()
+    file = s.filename
+    s.save()
     assert file, "host.yaml missing"
     if is_linux:
         exe = which('sensible-editor') or which('gedit') or \


### PR DESCRIPTION
## What is this fixing or adding?
saves the settings before opening host.yaml so all defaults are populated

## How was this tested?
had an outdated host.yaml for TUNIC, installed the new one, clicked the open host.yaml button in the launcher, saw the new settings values populated

## If this makes graphical changes, please attach screenshots.
