### PR TITLE
Core: update error message for mismatched "event" placements

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -289,7 +289,7 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
                     if type(location.address) == int:
                         assert location.item.code is not None, "item code None should be event, " \
                                                                "location.address should then also be None. Location: " \
-                                                               f" {location}"
+                                                               f" {location}, Item: {location.item}"
                         assert location.address not in locations_data[location.player], (
                             f"Locations with duplicate address. {location} and "
                             f"{locations_data[location.player][location.address]}")


### PR DESCRIPTION
## What is this fixing or adding?
Adds the item to the assert message confirming event item/locations are only paired with eachother

## How was this tested?
had an issue where a normal location had event items placed on it
this change let me debug which item was being treated as an event erroneously 

## If this makes graphical changes, please attach screenshots.
