### PR TITLE
Docs: Add ConnectUpdate to the list of client packets in the network protocol documentation

### DIFF
--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -268,6 +268,7 @@ Additional arguments added to the [Set](#Set) package that triggered this [SetRe
 These packets are sent purely from client to server. They are not accepted by clients.
 
 * [Connect](#Connect)
+* [ConnectUpdate](#ConnectUpdate)
 * [Sync](#Sync)
 * [LocationChecks](#LocationChecks)
 * [LocationScouts](#LocationScouts)


### PR DESCRIPTION
## What is this fixing or adding?

just noticed `ConnectUpdate` wasn't in the list of client packets even though it was documented lower down, so I added it.

## How was this tested?

wasn't

## If this makes graphical changes, please attach screenshots.
