### PR TITLE
Core: make shlex split an attempt with regular split retry

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1153,7 +1153,10 @@ class CommandProcessor(metaclass=CommandMeta):
         if not raw:
             return
         try:
-            command = shlex.split(raw, comments=False)
+            try:
+                command = shlex.split(raw, comments=False)
+            except ValueError:  # most likely: "ValueError: No closing quotation"
+                command = raw.split()
             basecommand = command[0]
             if basecommand[0] == self.marker:
                 method = self.commands.get(basecommand[1:].lower(), None)


### PR DESCRIPTION
## What is this fixing or adding?
Makes it so users don't need to fiddle with shlex escaping on !hint Link's House. Also it would error on regular messages that happen to contain quotation marks without a closing one.

## How was this tested?
quickly
