### PR TITLE
OoT: Add aliases for Progressive Hookshot

### DIFF
--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -184,6 +184,10 @@ class OOTWorld(World):
                  "Small Key Ring (Spirit Temple)", "Small Key Ring (Thieves Hideout)", "Small Key Ring (Water Temple)",
                  "Boss Key (Fire Temple)", "Boss Key (Forest Temple)", "Boss Key (Ganons Castle)",
                  "Boss Key (Shadow Temple)", "Boss Key (Spirit Temple)", "Boss Key (Water Temple)"},
+
+        # aliases
+        "Longshot": {"Progressive Hookshot"},  # fuzzy hinting though Longshot was Slingshot
+        "Hookshot": {"Progressive Hookshot"},  # for consistency, mostly
     }
 
     location_name_groups = build_location_name_groups()

--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -186,7 +186,7 @@ class OOTWorld(World):
                  "Boss Key (Shadow Temple)", "Boss Key (Spirit Temple)", "Boss Key (Water Temple)"},
 
         # aliases
-        "Longshot": {"Progressive Hookshot"},  # fuzzy hinting though Longshot was Slingshot
+        "Longshot": {"Progressive Hookshot"},  # fuzzy hinting thought Longshot was Slingshot
         "Hookshot": {"Progressive Hookshot"},  # for consistency, mostly
     }
 


### PR DESCRIPTION
## What is this fixing or adding?
Person hinted Longshot, fuzzy matching decided that was close enough to Slingshot to hint that instead.

Adds a Longshot item name group containing Progressive Hookshot to prevent this issue going forwards.
Also adds a Hookshot item name group with the same contents, mostly for consistency, since it'd be weird to be able to !hint Longshot and that works, but !hint Hookshot and that says "oh did you mean slingshot? 69% sure"

## How was this tested?
Test gen, !hint

## If this makes graphical changes, please attach screenshots.
N/A