### PR TITLE
Core: turn MultiServer item_names and location_names into instance vars

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -185,11 +185,9 @@ class Context:
     slot_info: typing.Dict[int, NetworkSlot]
     generator_version = Version(0, 0, 0)
     checksums: typing.Dict[str, str]
-    item_names: typing.Dict[str, typing.Dict[int, str]] = (
-        collections.defaultdict(lambda: Utils.KeyedDefaultDict(lambda code: f'Unknown item (ID:{code})')))
+    item_names: typing.Dict[str, typing.Dict[int, str]]
     item_name_groups: typing.Dict[str, typing.Dict[str, typing.Set[str]]]
-    location_names: typing.Dict[str, typing.Dict[int, str]] = (
-        collections.defaultdict(lambda: Utils.KeyedDefaultDict(lambda code: f'Unknown location (ID:{code})')))
+    location_names: typing.Dict[str, typing.Dict[int, str]]
     location_name_groups: typing.Dict[str, typing.Dict[str, typing.Set[str]]]
     all_item_and_group_names: typing.Dict[str, typing.Set[str]]
     all_location_and_group_names: typing.Dict[str, typing.Set[str]]
@@ -197,7 +195,6 @@ class Context:
     spheres: typing.List[typing.Dict[int, typing.Set[int]]]
     """ each sphere is { player: { location_id, ... } } """
     logger: logging.Logger
-
 
     def __init__(self, host: str, port: int, server_password: str, password: str, location_check_points: int,
                  hint_cost: int, item_cheat: bool, release_mode: str = "disabled", collect_mode="disabled",
@@ -269,6 +266,11 @@ class Context:
         self.location_name_groups = {}
         self.all_item_and_group_names = {}
         self.all_location_and_group_names = {}
+        self.item_names = collections.defaultdict(
+            lambda: Utils.KeyedDefaultDict(lambda code: f'Unknown item (ID:{code})'))
+        item_name_groups: typing.Dict[str, typing.Dict[str, typing.Set[str]]]
+        self.location_names = collections.defaultdict(
+            lambda: Utils.KeyedDefaultDict(lambda code: f'Unknown location (ID:{code})'))
         self.non_hintable_names = collections.defaultdict(frozenset)
 
         self._load_game_data()

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -268,7 +268,6 @@ class Context:
         self.all_location_and_group_names = {}
         self.item_names = collections.defaultdict(
             lambda: Utils.KeyedDefaultDict(lambda code: f'Unknown item (ID:{code})'))
-        item_name_groups: typing.Dict[str, typing.Dict[str, typing.Set[str]]]
         self.location_names = collections.defaultdict(
             lambda: Utils.KeyedDefaultDict(lambda code: f'Unknown location (ID:{code})'))
         self.non_hintable_names = collections.defaultdict(frozenset)


### PR DESCRIPTION
## What is this fixing or adding?
Fixes names leaking into other rooms https://discord.com/channels/731205301247803413/1295089686578200697

## How was this tested?
locally, just made sure that id(ctx.item_names) differs for two rooms on the same hoster process.
