### PR TITLE
Core: fix pickling plando connections

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -423,7 +423,7 @@ class RestrictedUnpickler(pickle.Unpickler):
         if module == "NetUtils" and name in {"NetworkItem", "ClientStatus", "Hint", "SlotType", "NetworkSlot"}:
             return getattr(self.net_utils_module, name)
         # Options and Plando are unpickled by WebHost -> Generate
-        if module == "worlds.generic" and name in {"PlandoItem", "PlandoConnection"}:
+        if module == "worlds.generic" and name == "PlandoItem":
             if not self.generic_properties_module:
                 self.generic_properties_module = importlib.import_module("worlds.generic")
             return getattr(self.generic_properties_module, name)
@@ -435,6 +435,8 @@ class RestrictedUnpickler(pickle.Unpickler):
                 mod = importlib.import_module(module)
             obj = getattr(mod, name)
             if issubclass(obj, self.options_module.Option):
+                return obj
+            elif issubclass(obj, self.options_module.PlandoConnection):
                 return obj
         # Forbid everything else.
         raise pickle.UnpicklingError(f"global '{module}.{name}' is forbidden")

--- a/Utils.py
+++ b/Utils.py
@@ -434,9 +434,7 @@ class RestrictedUnpickler(pickle.Unpickler):
             else:
                 mod = importlib.import_module(module)
             obj = getattr(mod, name)
-            if issubclass(obj, self.options_module.Option):
-                return obj
-            elif issubclass(obj, self.options_module.PlandoConnection):
+            if issubclass(obj, (self.options_module.Option, self.options_module.PlandoConnection)):
                 return obj
         # Forbid everything else.
         raise pickle.UnpicklingError(f"global '{module}.{name}' is forbidden")


### PR DESCRIPTION
## What is this fixing or adding?
PlandoConnection had a hack that allowed it to be pickled from `worlds.generic`. #2904 moved PlandoConnection from worlds.generic to Options, so this hack had to be adjusted.

## How was this tested?
Ran Webhost locally and generated a Minecraft game featuring a plando connection

## If this makes graphical changes, please attach screenshots.
