### PR TITLE
Pokemon Emerald: Fix opponent blacklist checking wrong option for legendaries shortcut

### DIFF
--- a/worlds/pokemon_emerald/__init__.py
+++ b/worlds/pokemon_emerald/__init__.py
@@ -177,7 +177,7 @@ class PokemonEmeraldWorld(World):
             for species_name in self.options.trainer_party_blacklist.value
             if species_name != "_Legendaries"
         }
-        if "_Legendaries" in self.options.starter_blacklist.value:
+        if "_Legendaries" in self.options.trainer_party_blacklist.value:
             self.blacklisted_opponent_pokemon |= LEGENDARY_POKEMON
 
         # In race mode we don't patch any item location information into the ROM


### PR DESCRIPTION
## What is this fixing or adding?

Copy/paste error left the opponent blacklist checking the `_Legendaries` alias in the starter blacklist option instead of the trainer party blacklist option.

## How was this tested?

Inspected the value of `self.blacklisted_opponent_pokemon` after this change when `_Legendaries` is in `trainer_party_blacklist`.
