### PR TITLE
oc2: Remove recursive level star check and check only one level of global reqs

### DIFF
--- a/worlds/overcooked2/Logic.py
+++ b/worlds/overcooked2/Logic.py
@@ -35,17 +35,13 @@ def has_requirements_for_level_star(
         state: CollectionState, level: Overcooked2GenericLevel, stars: int, player: int) -> bool:
     assert 0 <= stars <= 3
 
-    # First ensure that previous stars are obtainable
-    if stars > 1:
-        if not has_requirements_for_level_star(state, level, stars-1, player):
-            return False
-
-    # Second, ensure that global requirements are met
+    # First, ensure that global requirements for this many stars are met.
+    # Lower numbers of stars are implied meetable if this level is meetable.
     if not meets_requirements(state, "*", stars, player):
         return False
 
-    # Finally, return success only if this level's requirements are met
-    return meets_requirements(state, level.shortname, stars, player)
+    # Then return success only if this level's requirements are met at all stars up through this one
+    return all(meets_requirements(state, level.shortname, s, player) for s in range(1, stars + 1))
 
 
 def meets_requirements(state: CollectionState, name: str, stars: int, player: int):
@@ -421,6 +417,7 @@ level_logic = {
             },
         ),
         (  # 3-star
+            # Necessarily implies 2-star
             [  # Exclusive
                 "Progressive Dash",
                 "Spare Plate",


### PR DESCRIPTION
@toasterparty 

## What is this fixing or adding?

`meets_requirements` is presently one of the largest callers of `CollectionState.count`, at about 6.6 million calls in a seed with 1 slot per currently supported game. I noticed that `has_requirements_for_level_star` recursively checks that earlier stars are available, including global requirements at each star. However, within the global requirements for 3 stars are exclusive requirements that imply the 2-star additive requirements are met (0.4 + .35 + .2 + .2 = 1.15), and 1-star has no requirements at all, so we can just test only the current star's global requirement. The remaining level-specific checks per star can be done in a loop.

(Arguably we can go even further and pre-combine all of the requirements together but I can save that for later.)

This eliminates about 1 million calls to `meets_requirements` in the test seed and 3.3 million calls to `CollectionState.count`, for a savings of around 4% (637s -> 614s).

## How was this tested?

* Profiled before and after.
* Confirmed spoiler output is exactly the same before and after.
* automated unittests
