### PR TITLE
WebHost: Fix NamedRange dropdown being blank instead of Custom for presets

### DIFF
--- a/WebHostLib/static/assets/playerOptions.js
+++ b/WebHostLib/static/assets/playerOptions.js
@@ -288,6 +288,11 @@ const applyPresets = (presetName) => {
         }
       });
       namedRangeSelect.value = trueValue;
+      // It is also possible for a preset to use an unnamed value. If this happens, set the dropdown to "Custom"
+      if (namedRangeSelect.selectedIndex == -1)
+      {
+        namedRangeSelect.value = "custom";
+      }
     }
 
     // Handle options whose presets are "random"


### PR DESCRIPTION
## What is this fixing or adding?

@agilbert1412 wrote up a very good description of the bug in https://discord.com/channels/731205301247803413/1295518127974776885.

This issue is caused because when applying presets, after we determine the true value of the NamedRange from the preset, we try to set the `namedRangeSelect` to that value. If the value doesn't exist, trying to do so unsets the `select` element. This change detects if it was flipped to unselected (`.selectedIndex == -1`) and changes it to `"custom"` instead.

## How was this tested?
Ran the WebHost locally, loaded up the Stardew Valley player option page, applied the available presets.