### PR TITLE
WebHost: allow lists without leading blank line in markdown

### DIFF
--- a/WebHostLib/misc.py
+++ b/WebHostLib/misc.py
@@ -77,7 +77,7 @@ def faq(lang: str):
     return render_template(
         "markdown_document.html",
         title="Frequently Asked Questions",
-        html_from_markdown=markdown.markdown(document,  extensions=['mdx_truly_sane_lists']),
+        html_from_markdown=markdown.markdown(document,  extensions=["mdx_truly_sane_lists", "mdx_breakless_lists"]),
     )
 
 
@@ -90,7 +90,7 @@ def glossary(lang: str):
     return render_template(
         "markdown_document.html",
         title="Glossary",
-        html_from_markdown=markdown.markdown(document,  extensions=['mdx_truly_sane_lists']),
+        html_from_markdown=markdown.markdown(document,  extensions=["mdx_truly_sane_lists", "mdx_breakless_lists"]),
     )
 
 

--- a/WebHostLib/requirements.txt
+++ b/WebHostLib/requirements.txt
@@ -11,3 +11,4 @@ bokeh>=3.5.2; python_version >= '3.10'
 markupsafe>=2.1.5
 Markdown>=3.7
 mdx_truly_sane_lists>=1.3
+mdx-breakless-lists>=1.0.1


### PR DESCRIPTION
Sane lists do not fix the billets now showing with missing blank line before the list. This does.

The render on WebHost looks basically identical to github with this.