### PR TITLE
Yacht Dice: Proguseful items: Dice and 100 Points

### DIFF
--- a/worlds/yachtdice/Items.py
+++ b/worlds/yachtdice/Items.py
@@ -16,7 +16,7 @@ class YachtDiceItem(Item):
 
 
 item_table = {
-    "Dice": ItemData(16871244000, ItemClassification.progression),
+    "Dice": ItemData(16871244000, ItemClassification.progression | ItemClassification.useful),
     "Dice Fragment": ItemData(16871244001, ItemClassification.progression),
     "Roll": ItemData(16871244002, ItemClassification.progression),
     "Roll Fragment": ItemData(16871244003, ItemClassification.progression),
@@ -64,7 +64,7 @@ item_table = {
     # These points are included in the logic and might be necessary to progress.
     "1 Point": ItemData(16871244301, ItemClassification.progression_skip_balancing),
     "10 Points": ItemData(16871244302, ItemClassification.progression),
-    "100 Points": ItemData(16871244303, ItemClassification.progression),
+    "100 Points": ItemData(16871244303, ItemClassification.progression | ItemClassification.useful),
 }
 
 # item groups for better hinting


### PR DESCRIPTION
## What is this fixing or adding?
This marks Dice and 100 Points as useful, in addition to progression.

## How was this tested?
Checked Text Client and Yacht Dice Client. Also did 100 test gens.
![image](https://github.com/user-attachments/assets/6d2ba8f6-df64-49d0-99be-83a98896f59a)
