### PR TITLE
HK: Replace "hook" in Precise Movement description to "claw"

### DIFF
--- a/worlds/hk/Options.py
+++ b/worlds/hk/Options.py
@@ -77,7 +77,7 @@ option_docstrings = {
     "RandomizeLoreTablets": "Randomize Lore items into the itempool, one per Lore Tablet, and place randomized item "
                             "grants on the tablets themselves.\n    You must still read the tablet to get the item.",
     "PreciseMovement": "Places skips into logic which require extremely precise player movement, possibly without "
-                       "movement skills such as\n    dash or hook.",
+                       "movement skills such as\n    dash or claw.",
     "ProficientCombat": "Places skips into logic which require proficient combat, possibly with limited items.",
     "BackgroundObjectPogos": "Places skips into logic for locations which are reachable via pogoing off of "
                              "background objects.",


### PR DESCRIPTION
## What is this fixing or adding?

Change the "hook" in the "Precise Movement" option's description to "claw" to align with the "Mantis Claw" item in-game.

## How was this tested?

Inspect-elementing default HK options page to check if putting claw would change anything

## If this makes graphical changes, please attach screenshots.

![image](https://github.com/user-attachments/assets/5acc2923-1c04-4890-8f82-3edafdf421ba)
