### PR TITLE
Core: Add Item.excludable helper function

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1265,6 +1265,10 @@ class Item:
         return ItemClassification.trap in self.classification
 
     @property
+    def excludable(self) -> bool:
+        return not (self.advancement or self.useful)
+
+    @property
     def flags(self) -> int:
         return self.classification.as_flag()
 


### PR DESCRIPTION
Some worlds might want to check for "Item is junk", i.e. an excludable item.

Because this is both `filler` and `trap`, and because `filler` is `0`, there are many "wrong ways" to do this. So I think we should provide a helper function for it.

I believe the only one that covers all cases and is somewhat future proof is to just list out the things that are **not** excludable, and then check that the classification isn't any of those.