### PR TITLE
Core: Replace item link locations with modified collect/remove

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -379,15 +379,15 @@ class MultiWorld():
                 continue
 
             new_itempool: List[Item] = []
-            for item_name, item_count in next(iter(common_item_count.values())).items():
+            # The common item counts are the same for each player to start with, so get the counts for the first player.
+            first_player_counts: Dict[str, int] = next(iter(common_item_count.values()))
+            for item_name, item_count in first_player_counts.items():
                 for _ in range(item_count):
                     new_item = group["world"].create_item(item_name)
                     # mangle together all original classification bits
                     new_item.classification |= classifications[item_name]
                     new_itempool.append(new_item)
 
-            # The common item counts are the same for each player to start with, so get the counts for the first player.
-            first_player_counts: Dict[str, int] = next(iter(common_item_count.values()))
             linked_items: Dict[str, List[List[Item]]] = {item_name: [[] for _ in range(item_count)]
                                                          for item_name, item_count in first_player_counts.items()}
 

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -396,6 +396,10 @@ class MultiWorld():
             for item in self.itempool:
                 count = common_item_count.get(item.player, {}).get(item.name, 0)
                 if count:
+                    # Only linked advancement items are relevant to logic, so non-advancement copies do not need to be
+                    # appended to a list within `linked_items`. This avoids attempting to collect non-advancement items
+                    # when a group item is collected, which slightly increases performance when some of the linked items
+                    # are advancement and some are not.
                     if item.advancement:
                         linked_items_tuple = linked_items[item.name]
                         index = len(linked_items_tuple) - count

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -401,9 +401,12 @@ class MultiWorld():
                     # when a group item is collected, which slightly increases performance when some of the linked items
                     # are advancement and some are not.
                     if item.advancement:
-                        linked_items_tuple = linked_items[item.name]
-                        index = len(linked_items_tuple) - count
-                        linked_items_for_count = linked_items_tuple[index]
+                        linked_items_for_name = linked_items[item.name]
+                        # Put the first item found for `item.player` with name `item.name` in the first list and put the
+                        # second item found in the second list etc. This way, the earlier lists get filled with one item
+                        # per player first.
+                        index = len(linked_items_for_name) - count
+                        linked_items_for_count = linked_items_for_name[index]
                         linked_items_for_count.append(item)
 
                     common_item_count[item.player][item.name] -= 1

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -401,12 +401,12 @@ class MultiWorld():
                     # when a group item is collected, which slightly increases performance when some of the linked items
                     # are advancement and some are not.
                     if item.advancement:
-                        linked_items_for_name = linked_items[item.name]
+                        linked_items_for_name: List[List[Item]] = linked_items[item.name]
                         # Put the first item found for `item.player` with name `item.name` in the first list and put the
                         # second item found in the second list etc. This way, the earlier lists get filled with one item
                         # per player first.
                         index = len(linked_items_for_name) - count
-                        linked_items_for_count = linked_items_for_name[index]
+                        linked_items_for_count: List[Item] = linked_items_for_name[index]
                         linked_items_for_count.append(item)
 
                     common_item_count[item.player][item.name] -= 1

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -387,7 +387,7 @@ class MultiWorld():
                     new_itempool.append(new_item)
 
             # The common item counts are the same for each player to start with, so get the counts for the first player.
-            first_player_counts = next(iter(common_item_count.values()))
+            first_player_counts: Dict[str, int] = next(iter(common_item_count.values()))
             linked_items: Dict[str, List[List[Item]]] = {item_name: [[] for _ in range(item_count)]
                                                          for item_name, item_count in first_player_counts.items()}
 

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -448,7 +448,17 @@ class MultiWorld():
                      player not in self.groups and self.game[player] == game_name)
 
     def get_name_string_for_object(self, obj: HasNameAndPlayer) -> str:
-        return obj.name if self.players == 1 else f'{obj.name} ({self.get_player_name(obj.player)})'
+        if self.players == 1:
+            return obj.name
+
+        player = obj.player
+        if player in self.groups:
+            # Include all the players in the group.
+            group_players = self.groups[player]["players"]
+            group_players_str = ", ".join(map(self.get_player_name, group_players))
+            return f"{obj.name} ({self.get_player_name(player)} ({group_players_str}))"
+        else:
+            return obj.name if self.players == 1 else f'{obj.name} ({self.get_player_name(player)})'
 
     def get_player_name(self, player: int) -> str:
         return self.player_name[player]


### PR DESCRIPTION
## What is this fixing or adding?

This patch removes the locations from item links, fixing a couple of issues with item links:
1) By removing the locations, there are no longer any concerns about unreachable item link locations failing location accessibility requirements.
2) Because the linked items are no longer placed at locations and are collected with the group unlocker items simultaneously, additional spheres are no longer required to pick up the linked items.

However, there are some downsides:
1) In a spoiler, it is no longer immediately clear which players have an item locked behind a group unlocker item.
    - This has been resolved by changing the conversion to a string representation for group items/locations to also include the names of the players that belong to the group.
2) In a spoiler playthrough, it is no longer clear which of the linked items unlocked by collecting a group unlocker item are required to beat the game. Previously, each linked item would be placed and locked at a unique location, so only each individual linked item that was required to beat the game would be present in the spoiler playthrough. With this patch, if a group unlocker item unlocks linked items for 10 players, but only 1 of those linked items is needed to beat the game, there is no way to tell that this is the case because only the group unlocker item will show in the playthrough.
3) Because the linked items are no longer placed at locations, they will not be found by worlds that use `multiworld.get_spheres()` or similar.

## How was this tested?

I generated seeds with Bumper Stickers with `Everything` item linked, as well as A Hat in Time with linked Time Pieces, Hookshot Badge and Scooter Badge.


## If this makes graphical changes, please attach screenshots.
In a spoiler, a location/item belonging to a group will now also write the names of the players within that group:
```
Treasure Bumper 28 (Player5): 100 Pons (Player3)
Treasure Bumper 29 (Player5): Treasure Bumper (link_test (Player8, Player5, Player6, Player7))
Treasure Bumper 30 (Player5): Yarn (Player2)
```
