### PR TITLE
TUNIC: Add link to logic tricks doc

### DIFF
--- a/worlds/tunic/docs/en_TUNIC.md
+++ b/worlds/tunic/docs/en_TUNIC.md
@@ -56,6 +56,7 @@ In general:
 - Bushes are not considered in logic. It is assumed that the player will find a way past them, whether it is with a sword, a bomb, fire, luring an enemy, etc. There is also an option in the in-game randomizer settings menu to clear some of the early bushes.
 - The Cathedral is accessible during the day by using the Hero's Laurels to reach the Overworld fuse near the Swamp entrance.
 - The Secret Legend chest at the Cathedral can be obtained during the day by opening the Holy Cross door from the outside.
+- For the Ice Grappling, Ladder Storage, and Laurels Zips options, there is a document showing the individual applications of these tricks in logic [here](https://docs.google.com/document/d/1SFZBfsqZWH1_EAV9zyZobvrBcvCd3_54JP3iVnJ8rUg/edit?usp=sharing).
 
 For the Entrance Randomizer:
 - Activating a fuse to turn on a yellow teleporter pad also activates its counterpart in the Far Shore.

--- a/worlds/tunic/docs/en_TUNIC.md
+++ b/worlds/tunic/docs/en_TUNIC.md
@@ -56,7 +56,7 @@ In general:
 - Bushes are not considered in logic. It is assumed that the player will find a way past them, whether it is with a sword, a bomb, fire, luring an enemy, etc. There is also an option in the in-game randomizer settings menu to clear some of the early bushes.
 - The Cathedral is accessible during the day by using the Hero's Laurels to reach the Overworld fuse near the Swamp entrance.
 - The Secret Legend chest at the Cathedral can be obtained during the day by opening the Holy Cross door from the outside.
-- For the Ice Grappling, Ladder Storage, and Laurels Zips options, there is a document showing the individual applications of these tricks in logic [here](https://docs.google.com/document/d/1SFZBfsqZWH1_EAV9zyZobvrBcvCd3_54JP3iVnJ8rUg/edit?usp=sharing).
+- For the Ice Grappling, Ladder Storage, and Laurels Zips options, there is [this document](https://docs.google.com/document/d/1SFZBfsqZWH1_EAV9zyZobvrBcvCd3_54JP3iVnJ8rUg/edit?usp=sharing) that shows the individual applications of these tricks in logic.
 
 For the Entrance Randomizer:
 - Activating a fuse to turn on a yellow teleporter pad also activates its counterpart in the Far Shore.


### PR DESCRIPTION
## What is this fixing or adding?
For the new logic options that have already been merged into main, I put together a doc detailing each of the individual instances of these tricks and which logic level they fall under.

I'm not attached to how I wrote the sentence describing this doc here, so please feel free to suggest an alternate.

## How was this tested?
Reading.

## If this makes graphical changes, please attach screenshots.
N/A