### PR TITLE
SM64ex: Add links to documentation for makeflags and patches

### DIFF
--- a/worlds/sm64ex/docs/setup_en.md
+++ b/worlds/sm64ex/docs/setup_en.md
@@ -36,6 +36,8 @@ Then continue to `Using the Launcher`
     - Windows: If you did not use the default install directory for MSYS, close this window, check `Show advanced options` and reopen using `Re-check Requirements`. You can then set the path manually.
 5. When finished, use `Compile default SM64AP build` to continue
     - Advanced user can use `Show advanced options` to build with custom makeflags (`BETTERCAMERA`, `NODRAWINGDISTANCE`, ...), different repos and branches, and game patches such as 60FPS, Enhanced Moveset and others.
+      - [Available Makeflags](https://github.com/sm64pc/sm64ex/wiki/Build-options)
+      - [Included Game Patches](https://github.com/N00byKing/sm64ex/blob/archipelago/enhancements/README.md)
 6. Press `Download Files` to prepare the build, afterwards `Create Build`.
 7. SM64EX will now be compiled. This can take a while.
 


### PR DESCRIPTION
## What is this fixing or adding?
Adds links for the appropriate documentation for makeflags and patches. #3300 will be fully resolved once N00byKing/sm64ex#11
is merged

## How was this tested?
Looking at render and clicking links

Resolves #3300 