### PR TITLE
HK: fix grubhunt required grubs count

### DIFF
--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -511,9 +511,12 @@ class HKWorld(World):
                 if grub.location and grub.location.player in group_lookup.keys():
                     # will count the item linked grub instead
                     pass
-                else:
+                elif player in group_lookup:
                     for real_player in group_lookup[player]:
                         grub_count_per_player[real_player] += 1
+                else:
+                    # for worlds not linking grubs but in a group
+                    grub_count_per_player[player] += 1
 
             for player, count in grub_count_per_player.items():
                 multiworld.worlds[player].grub_count = count

--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -509,10 +509,11 @@ class HKWorld(World):
                     per_player_grubs_per_player[player][player] += 1
 
                 if grub.location and grub.location.player in group_lookup.keys():
-                    for real_player in group_lookup[grub.location.player]:
-                        grub_count_per_player[real_player] += 1
+                    # will count the item linked grub instead
+                    pass
                 else:
-                    grub_count_per_player[player] += 1
+                    for real_player in group_lookup[player]:
+                        grub_count_per_player[real_player] += 1
 
             for player, count in grub_count_per_player.items():
                 multiworld.worlds[player].grub_count = count

--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -515,7 +515,7 @@ class HKWorld(World):
                     for real_player in group_lookup[player]:
                         grub_count_per_player[real_player] += 1
                 else:
-                    # for worlds not linking grubs but in a group
+                    # for non-linked grubs
                     grub_count_per_player[player] += 1
 
             for player, count in grub_count_per_player.items():

--- a/worlds/hk/test/__init__.py
+++ b/worlds/hk/test/__init__.py
@@ -1,0 +1,62 @@
+import typing
+from argparse import Namespace
+from BaseClasses import CollectionState, MultiWorld
+from Options import ItemLinks
+from test.bases import WorldTestBase
+from worlds.AutoWorld import AutoWorldRegister, call_all
+from .. import HKWorld
+
+
+class linkedTestHK():
+    run_default_tests = False
+    game = "Hollow Knight"
+    world: HKWorld
+    expected_grubs: int
+    item_link_group: typing.List[typing.Dict[str, typing.Any]]
+
+    def setup_item_links(self, args):
+        setattr(args, "item_links",
+                {
+                    1: ItemLinks.from_any(self.item_link_group),
+                    2: ItemLinks.from_any([{
+                        "name": "ItemLinkTest",
+                        "item_pool": ["Grub"],
+                        "link_replacement": False,
+                        "replacement_item": "One_Geo",
+                    }])
+                })
+        return args
+
+    def world_setup(self) -> None:
+        """
+        Create a multiworld with two players that share an itemlink
+        """
+        self.multiworld = MultiWorld(2)
+        self.multiworld.game = {1: self.game, 2: self.game}
+        self.multiworld.player_name = {1: "Linker 1", 2: "Linker 2"}
+        self.multiworld.set_seed()
+        args = Namespace()
+        options_dataclass = AutoWorldRegister.world_types[self.game].options_dataclass
+        for name, option in options_dataclass.type_hints.items():
+            setattr(args, name, {
+                1: option.from_any(self.options.get(name, option.default)),
+                2: option.from_any(self.options.get(name, option.default))
+            })
+        args = self.setup_item_links(args)
+        self.multiworld.set_options(args)
+        self.multiworld.set_item_links()
+        # groups get added to state during its constructor so this has to be after item links are set
+        self.multiworld.state = CollectionState(self.multiworld)
+        gen_steps = ("generate_early", "create_regions", "create_items", "set_rules", "generate_basic")
+        for step in gen_steps:
+            call_all(self.multiworld, step)
+        # link the items together and stop at prefill
+        self.multiworld.link_items()
+        self.multiworld._all_state = None
+        call_all(self.multiworld, "pre_fill")
+
+        self.world = self.multiworld.worlds[self.player]
+
+    def test_grub_count(self) -> None:
+        assert self.world.grub_count == self.expected_grubs, \
+               f"Expected {self.expected_grubs} but found {self.world.grub_count}"

--- a/worlds/hk/test/test_grub_count.py
+++ b/worlds/hk/test/test_grub_count.py
@@ -1,0 +1,110 @@
+from . import linkedTestHK, WorldTestBase
+from Options import ItemLinks
+
+
+class test_grubcount_limited(linkedTestHK, WorldTestBase):
+    options = {
+        "RandomizeGrubs": True,
+        "GrubHuntGoal": 20,
+        "Goal": "any",
+    }
+    item_link_group = [{
+        "name": "ItemLinkTest",
+        "item_pool": ["Grub"],
+        "link_replacement": True,
+        "replacement_item": "Grub",
+    }]
+    expected_grubs = 20
+
+
+class test_grubcount_default(linkedTestHK, WorldTestBase):
+    options = {
+        "RandomizeGrubs": True,
+        "Goal": "any",
+    }
+    item_link_group = [{
+        "name": "ItemLinkTest",
+        "item_pool": ["Grub"],
+        "link_replacement": True,
+        "replacement_item": "Grub",
+    }]
+    expected_grubs = 46
+
+
+class test_grubcount_all_unlinked(linkedTestHK, WorldTestBase):
+    options = {
+        "RandomizeGrubs": True,
+        "GrubHuntGoal": "all",
+        "Goal": "any",
+    }
+    item_link_group = []
+    expected_grubs = 46
+
+
+class test_grubcount_all_linked(linkedTestHK, WorldTestBase):
+    options = {
+        "RandomizeGrubs": True,
+        "GrubHuntGoal": "all",
+        "Goal": "any",
+    }
+    item_link_group = [{
+        "name": "ItemLinkTest",
+        "item_pool": ["Grub"],
+        "link_replacement": True,
+        "replacement_item": "Grub",
+    }]
+    expected_grubs = 46 + 23
+
+
+class test_replacement_only(linkedTestHK, WorldTestBase):
+    options = {
+        "RandomizeGrubs": True,
+        "GrubHuntGoal": "all",
+        "Goal": "any",
+    }
+    expected_grubs = 46 + 18  # the count of grubs + skills removed from item links
+
+    def setup_item_links(self, args):
+        setattr(args, "item_links",
+                {
+                    1: ItemLinks.from_any([{
+                        "name": "ItemLinkTest",
+                        "item_pool": ["Skills"],
+                        "link_replacement": True,
+                        "replacement_item": "Grub",
+                    }]),
+                    2: ItemLinks.from_any([{
+                        "name": "ItemLinkTest",
+                        "item_pool": ["Skills"],
+                        "link_replacement": True,
+                        "replacement_item": "Grub",
+                    }])
+                })
+        return args
+
+
+class test_replacement_only_unlinked(linkedTestHK, WorldTestBase):
+    options = {
+        "RandomizeGrubs": True,
+        "GrubHuntGoal": "all",
+        "Goal": "any",
+    }
+    expected_grubs = 46 + 9  # the count of grubs + half skills removed from item links
+
+    def setup_item_links(self, args):
+        setattr(args, "item_links",
+                {
+                    1: ItemLinks.from_any([{
+                        "name": "ItemLinkTest",
+                        "item_pool": ["Skills"],
+                        "link_replacement": False,
+                        "replacement_item": "Grub",
+                    }]),
+                    2: ItemLinks.from_any([{
+                        "name": "ItemLinkTest",
+                        "item_pool": ["Skills"],
+                        "link_replacement": False,
+                        "replacement_item": "Grub",
+                    }])
+                })
+        return args

--- a/worlds/hk/test/test_grub_count.py
+++ b/worlds/hk/test/test_grub_count.py
@@ -89,7 +89,7 @@ class test_replacement_only_unlinked(linkedTestHK, WorldTestBase):
         "GrubHuntGoal": "all",
         "Goal": "any",
     }
-    expected_grubs = 46 + 9  # the count of grubs + half skills removed from item links
+    expected_grubs = 46 + 9  # Player1s replacement Grubs
 
     def setup_item_links(self, args):
         setattr(args, "item_links",
@@ -108,3 +108,59 @@ class test_replacement_only_unlinked(linkedTestHK, WorldTestBase):
                     }])
                 })
         return args
+
+
+class test_ignore_others(linkedTestHK, WorldTestBase):
+    options = {
+        "RandomizeGrubs": True,
+        "GrubHuntGoal": "all",
+        "Goal": "any",
+    }
+    # player2 has more than 46 grubs but they are unlinked so player1s grubs are vanilla
+    expected_grubs = 46
+
+    def setup_item_links(self, args):
+        setattr(args, "item_links",
+                {
+                    1: ItemLinks.from_any([{
+                        "name": "ItemLinkTest",
+                        "item_pool": ["Skills"],
+                        "link_replacement": False,
+                        "replacement_item": "One_Geo",
+                    }]),
+                    2: ItemLinks.from_any([{
+                        "name": "ItemLinkTest",
+                        "item_pool": ["Skills"],
+                        "link_replacement": False,
+                        "replacement_item": "Grub",
+                    }])
+                })
+        return args
+
+
+class test_ignore_others(linkedTestHK, WorldTestBase):
+    options = {
+        "RandomizeGrubs": True,
+        "GrubHuntGoal": "all",
+        "Goal": "any",
+    }
+    expected_grubs = 46 + 9  # Player2s linkreplacement grubs
+
+    def setup_item_links(self, args):
+        setattr(args, "item_links",
+                {
+                    1: ItemLinks.from_any([{
+                        "name": "ItemLinkTest",
+                        "item_pool": ["Skills"],
+                        "link_replacement": True,
+                        "replacement_item": "One_Geo",
+                    }]),
+                    2: ItemLinks.from_any([{
+                        "name": "ItemLinkTest",
+                        "item_pool": ["Skills"],
+                        "link_replacement": True,
+                        "replacement_item": "Grub",
+                    }])
+                })
+        return args
+

--- a/worlds/hk/test/test_grub_count.py
+++ b/worlds/hk/test/test_grub_count.py
@@ -138,7 +138,7 @@ class test_ignore_others(linkedTestHK, WorldTestBase):
         return args
 
 
-class test_ignore_others(linkedTestHK, WorldTestBase):
+class test_replacement_only_linked(linkedTestHK, WorldTestBase):
     options = {
         "RandomizeGrubs": True,
         "GrubHuntGoal": "all",
@@ -163,4 +163,3 @@ class test_ignore_others(linkedTestHK, WorldTestBase):
                     }])
                 })
         return args
-


### PR DESCRIPTION
## What is this fixing or adding?
somehow this mixup got into the final grubhunt PR

the original code that somehow got mixed up in the final grubhunt PR (in a per player loop, which is why we need the loop in the new code)
```
if grub.location and grub.location.player in relevant_groups:
    # not counting our grubs stuck in item links because we also will count the group's copy
    pass
else:
    world.grub_count += 1
```
## How was this tested?
gen'd with a breakpoint to confirm world.grub_count with 4 grubhunt: all players using both replacement grubs and null, and confirmed that the number gets honored when not using all still

## If this makes graphical changes, please attach screenshots.
