### PR TITLE
Core: The Item Links fix to end them all (for now, hopefully)

### DIFF
--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -10,7 +10,7 @@ from dataclasses import make_dataclass
 from typing import (Any, Callable, ClassVar, Dict, FrozenSet, List, Mapping, Optional, Set, TextIO, Tuple,
                     TYPE_CHECKING, Type, Union)
 
-from Options import item_and_loc_options, OptionGroup, PerGameCommonOptions
+from Options import item_and_loc_options, ItemsAccessibility, OptionGroup, PerGameCommonOptions
 from BaseClasses import CollectionState
 
 if TYPE_CHECKING:

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -480,6 +480,7 @@ class World(metaclass=AutoWorldRegister):
         group = cls(multiworld, new_player_id)
         group.options = cls.options_dataclass(**{option_key: option.from_any(option.default)
                                                  for option_key, option in cls.options_dataclass.type_hints.items()})
+        group.options.accessibility = ItemsAccessibility(ItemsAccessibility.option_items)
 
         return group
 


### PR DESCRIPTION
This puts the bandaid that was holding Item Links together for years back on. It's called "Items accessibility by default" (but only for groups this time)

It's a bad solution
But it's what we had previously, and the change away from this is what originally "broke" item links. Apparently item links were considered fine with this in place.

So in the interest of 0.5.1 releasing this century, maybe we should just go with this.

Ran it with two identical everything-linked Bumper Stickers yamls.
Idk, does this break Webhost or something?

```
name: Player{number}
description: Default Bumper Stickers Template
game: Bumper Stickers
Bumper Stickers:
  item_links:
    # Share part of your item pool with other players.
    - name: BSLink
      item_pool:
        - Everything
      replacement_item: null
      link_replacement: true
```