### PR TITLE
Core: fix item links for alternate menu regions

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -341,7 +341,7 @@ class MultiWorld():
                     new_item.classification |= classifications[item_name]
                     new_itempool.append(new_item)
 
-            region = Region("Menu", group_id, self, "ItemLink")
+            region = Region(group["world"].origin_region_name, group_id, self, "ItemLink")
             self.regions.append(region)
             locations = region.locations
             # ensure that progression items are linked first, then non-progression


### PR DESCRIPTION
## What is this fixing or adding?
not assume origin is Menu in Groups
vi made me do it

## How was this tested?
two link everything factorios

## If this makes graphical changes, please attach screenshots.
