### PR TITLE
OoT: fix plando/item links (again)

### DIFF
--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -1348,22 +1348,8 @@ class OOTWorld(World):
     def get_locations(self):
         return self.multiworld.get_locations(self.player)
 
-    def get_location(self, location):
-        return self.multiworld.get_location(location, self.player)
-
-    def get_region(self, region_name):
-        try:
-            return self._regions_cache[region_name]
-        except KeyError:
-            ret = self.multiworld.get_region(region_name, self.player)
-            self._regions_cache[region_name] = ret
-            return ret
-
     def get_entrances(self):
         return self.multiworld.get_entrances(self.player)
-
-    def get_entrance(self, entrance):
-        return self.multiworld.get_entrance(entrance, self.player)
 
     def is_major_item(self, item: OOTItem):
         if item.type == 'Token':


### PR DESCRIPTION
## What is this fixing or adding?
Start region name PR changed from using the multiworld get_region to the world get_region, which broke OoT which still had its own get_region before the helpers existed. We just remove the functions that are now replaced by the helpers.

This has apparently existed for a while, but went untested from lack of plando/item links tests.

## How was this tested?
Tried genning OoT before making the fix, unable to gen.
Tried genning OoT with item links after the fix, gen succeeds.

## If this makes graphical changes, please attach screenshots.
