### PR TITLE
Core: Add new error message for item count when defined as a set instead of a dict

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -860,6 +860,8 @@ class ItemDict(OptionDict):
     verify_item_name = True
 
     def __init__(self, value: typing.Dict[str, int]):
+        if any(item_count is None for item_count in value.values()):
+            raise Exception("Item count option is a dictionary, not a set. Please provide integer values.")
         if any(item_count < 1 for item_count in value.values()):
             raise Exception("Cannot have non-positive item counts.")
         super(ItemDict, self).__init__(value)

--- a/Options.py
+++ b/Options.py
@@ -861,7 +861,7 @@ class ItemDict(OptionDict):
 
     def __init__(self, value: typing.Dict[str, int]):
         if any(item_count is None for item_count in value.values()):
-            raise Exception("Item count option is a dictionary, not a set. Please provide positive integer values.")
+            raise Exception("Items must have counts associated with them. Please provide positive integer values in the format \"item\": count .")
         if any(item_count < 1 for item_count in value.values()):
             raise Exception("Cannot have non-positive item counts.")
         super(ItemDict, self).__init__(value)

--- a/Options.py
+++ b/Options.py
@@ -861,7 +861,7 @@ class ItemDict(OptionDict):
 
     def __init__(self, value: typing.Dict[str, int]):
         if any(item_count is None for item_count in value.values()):
-            raise Exception("Item count option is a dictionary, not a set. Please provide integer values.")
+            raise Exception("Item count option is a dictionary, not a set. Please provide positive integer values.")
         if any(item_count < 1 for item_count in value.values()):
             raise Exception("Cannot have non-positive item counts.")
         super(ItemDict, self).__init__(value)


### PR DESCRIPTION
## What is this fixing or adding?

If you, like me, forget that items have counts and attempt to give yourself a unique starting item by writing in your yaml:
```yaml
    starting_items:
        {"Starting Item"}
```

You get an error `TypeError: '<' not supported between instances of 'NoneType' and 'int'`... because yaml interprets this as a dict with an implicit value of `None` and the original error message comes from checking whether any value is less than 1. This produces a better error message if any dict value is `None`.

## How was this tested?

Manually.
