### PR TITLE
WebHost: restore fragment links for glossary and faq and make titles clickable

### DIFF
--- a/WebHostLib/misc.py
+++ b/WebHostLib/misc.py
@@ -77,7 +77,13 @@ def faq(lang: str):
     return render_template(
         "markdown_document.html",
         title="Frequently Asked Questions",
-        html_from_markdown=markdown.markdown(document,  extensions=["toc", "mdx_breakless_lists"]),
+        html_from_markdown=markdown.markdown(
+            document,
+            extensions=["toc", "mdx_breakless_lists"],
+            extension_configs={
+                "toc": {"anchorlink": True}
+            }
+        ),
     )
 
 
@@ -90,7 +96,13 @@ def glossary(lang: str):
     return render_template(
         "markdown_document.html",
         title="Glossary",
-        html_from_markdown=markdown.markdown(document,  extensions=["toc", "mdx_breakless_lists"]),
+        html_from_markdown=markdown.markdown(
+            document,
+            extensions=["toc", "mdx_breakless_lists"],
+            extension_configs={
+                "toc": {"anchorlink": True}
+            }
+        ),
     )
 
 

--- a/WebHostLib/misc.py
+++ b/WebHostLib/misc.py
@@ -77,7 +77,7 @@ def faq(lang: str):
     return render_template(
         "markdown_document.html",
         title="Frequently Asked Questions",
-        html_from_markdown=markdown.markdown(document,  extensions=["mdx_breakless_lists"]),
+        html_from_markdown=markdown.markdown(document,  extensions=["toc", "mdx_breakless_lists"]),
     )
 
 
@@ -90,7 +90,7 @@ def glossary(lang: str):
     return render_template(
         "markdown_document.html",
         title="Glossary",
-        html_from_markdown=markdown.markdown(document,  extensions=["mdx_breakless_lists"]),
+        html_from_markdown=markdown.markdown(document,  extensions=["toc", "mdx_breakless_lists"]),
     )
 
 

--- a/WebHostLib/static/styles/markdown.css
+++ b/WebHostLib/static/styles/markdown.css
@@ -28,7 +28,7 @@
     font-weight: normal;
     font-family: LondrinaSolid-Regular, sans-serif;
     text-transform: uppercase;
-    cursor: pointer;
+    cursor: pointer; /* TODO: remove once we drop showdown.js */
     width: 100%;
     text-shadow: 1px 1px 4px #000000;
 }
@@ -37,7 +37,7 @@
     font-size: 38px;
     font-weight: normal;
     font-family: LondrinaSolid-Light, sans-serif;
-    cursor: pointer;
+    cursor: pointer; /* TODO: remove once we drop showdown.js */
     width: 100%;
     margin-top: 20px;
     margin-bottom: 0.5rem;
@@ -50,7 +50,7 @@
     font-family: LexendDeca-Regular, sans-serif;
     text-transform: none;
     text-align: left;
-    cursor: pointer;
+    cursor: pointer; /* TODO: remove once we drop showdown.js */
     width: 100%;
     margin-bottom: 0.5rem;
 }
@@ -59,7 +59,7 @@
     font-family: LexendDeca-Regular, sans-serif;
     text-transform: none;
     font-size: 24px;
-    cursor: pointer;
+    cursor: pointer; /* TODO: remove once we drop showdown.js */
     margin-bottom: 24px;
 }
 
@@ -67,18 +67,27 @@
     font-family: LexendDeca-Regular, sans-serif;
     text-transform: none;
     font-size: 22px;
-    cursor: pointer;
+    cursor: pointer; /* TODO: remove once we drop showdown.js */
 }
 
 .markdown h6, .markdown details summary.h6{
     font-family: LexendDeca-Regular, sans-serif;
     text-transform: none;
     font-size: 20px;
-    cursor: pointer;;
+    cursor: pointer; /* TODO: remove once we drop showdown.js */
 }
 
 .markdown h4, .markdown h5, .markdown h6{
     margin-bottom: 0.5rem;
+}
+
+.markdown h1 > a,
+.markdown h2 > a,
+.markdown h3 > a,
+.markdown h4 > a,
+.markdown h5 > a,
+.markdown h6 > a {
+    color: inherit;
 }
 
 .markdown ul{


### PR DESCRIPTION
## What is this fixing or adding?

Fixes https://github.com/ArchipelagoMW/Archipelago/pull/4061#issuecomment-2417999195

see title,
such as /faq/en/#what-does-multi-game-mean

## How was this tested?

Looking at DOM and trying link shown above.