### PR TITLE
[KH2] Add new Poptracker Pack to the KH2 Setup Guide

### DIFF
--- a/worlds/kh2/docs/setup_en.md
+++ b/worlds/kh2/docs/setup_en.md
@@ -83,9 +83,9 @@ Enter `The room's port number` into the top box <b> where the x's are</b> and pr
 
 Have any questions on what's in logic? This spreadsheet made by Bulcon has the answer [Requirements/logic sheet](https://docs.google.com/spreadsheets/d/1nNi8ohEs1fv-sDQQRaP45o6NoRcMlLJsGckBonweDMY/edit?usp=sharing)
 
-Alternatively you can use the Kingdom Hearts 2 Poptracker Pack that is based off of the logic sheet above and does all the work for you.
+Alternatively you can use the Kingdom Hearts 2 PopTracker Pack that is based off of the logic sheet above and does all the work for you.
 
-<h3 style="text-transform:none";>Poptracker Pack</h3>
+<h3 style="text-transform:none";>PopTracker Pack</h3>
 
 1. Download [Kingdom Hearts 2 AP Tracker](https://github.com/palex00/kh2-ap-tracker/releases/latest/) and
 [PopTracker](https://github.com/black-sliver/PopTracker/releases).

--- a/worlds/kh2/docs/setup_en.md
+++ b/worlds/kh2/docs/setup_en.md
@@ -36,9 +36,15 @@ When you generate a game you will see a download link for a KH2 .zip seed on the
 Make sure the seed is on the top of the list (Highest Priority)<br>
 After Installing the seed click `Mod Loader -> Build/Build and Run`. Every slot is a unique mod to install and will be needed be repatched for different slots/rooms.
 
+<h2 style="text-transform:none";>Optional Software:</h2>
+
+- [Kingdom Hearts 2 AP Tracker](https://github.com/palex00/kh2-ap-tracker/releases/latest/), for use with
+[PopTracker](https://github.com/black-sliver/PopTracker/releases)
+
 <h2 style="text-transform:none";>What the Mod Manager Should Look Like.</h2>
 
 ![image](https://i.imgur.com/Si4oZ8w.png)
+
 
 <h2 style="text-transform:none";>Using the KH2 Client</h2>
 
@@ -73,9 +79,23 @@ Enter `The room's port number` into the top box <b> where the x's are</b> and pr
 - Run the game in windows/borderless windowed mode. Fullscreen is stable but the game can crash if you alt-tab out.
 - Make sure to save in a different save slot when playing in an async or disconnecting from the server to play a different seed
 
-<h2 style="text-transform:none";>Logic Sheet</h2>
+<h2 style="text-transform:none";>Poptracker Autotracking & Logic Sheet</h2>
 
 Have any questions on what's in logic? This spreadsheet made by Bulcon has the answer [Requirements/logic sheet](https://docs.google.com/spreadsheets/d/1nNi8ohEs1fv-sDQQRaP45o6NoRcMlLJsGckBonweDMY/edit?usp=sharing)
+
+Alternatively you can use the Kingdom Hearts 2 Poptracker Pack that is based off of the logic sheet above and does all the work for you.
+
+<h3 style="text-transform:none";>Poptracker Pack</h3>
+
+1. Download [Kingdom Hearts 2 AP Tracker](https://github.com/palex00/kh2-ap-tracker/releases/latest/) and
+[PopTracker](https://github.com/black-sliver/PopTracker/releases).
+2. Put the tracker pack into packs/ in your PopTracker install.
+3. Open PopTracker, and load the Kingdom Hearts 2 pack.
+4. For autotracking, click on the "AP" symbol at the top.
+5. Enter the Archipelago server address (the one you connected your client to), slot name, and password.
+
+This pack will handle logic, received items, checked locations and autotabbing for you!
+
 
 <h2 style="text-transform:none";>F.A.Q.</h2>
 

--- a/worlds/kh2/docs/setup_en.md
+++ b/worlds/kh2/docs/setup_en.md
@@ -79,7 +79,7 @@ Enter `The room's port number` into the top box <b> where the x's are</b> and pr
 - Run the game in windows/borderless windowed mode. Fullscreen is stable but the game can crash if you alt-tab out.
 - Make sure to save in a different save slot when playing in an async or disconnecting from the server to play a different seed
 
-<h2 style="text-transform:none";>Poptracker Autotracking & Logic Sheet</h2>
+<h2 style="text-transform:none";>Logic Sheet & PopTracker Autotracking</h2>
 
 Have any questions on what's in logic? This spreadsheet made by Bulcon has the answer [Requirements/logic sheet](https://docs.google.com/spreadsheets/d/1nNi8ohEs1fv-sDQQRaP45o6NoRcMlLJsGckBonweDMY/edit?usp=sharing)
 


### PR DESCRIPTION
## What is this fixing or adding?
Adding the new Poptracker Pack developed by @Ugh-Sunlight and me. Both have full access to the repository and can continue the work if the other dies.

The pack is based on the logic sheet and is still being tested thoroughly but it already extremly accurate. The maintainer of KH2 is aware of the pack and it is pinned in the channel.

The pack is currently not yet fully done (1.0.0) because some Icons are still placeholder but before 0.5.1 drops that will be done.

## How was this tested?
Visual look at the Setup Guide. Pack itself is being tested [here](https://discord.com/channels/731205301247803413/1295193435418005554)

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/user-attachments/assets/e9d6acd7-5711-457f-8eab-e35488f462aa)
![image-1](https://github.com/user-attachments/assets/af1979fc-311a-48a6-9fcb-a5b8b58f81aa)
