### PR TITLE
Core: Properly fall back to a world's `rich_text_options_doc`

### DIFF
--- a/WebHostLib/templates/playerOptions/macros.html
+++ b/WebHostLib/templates/playerOptions/macros.html
@@ -196,13 +196,14 @@
 {% macro OptionTitle(option_name, option) %}
     <label for="{{ option_name }}">
         {{ option.display_name|default(option_name) }}:
+        {% set rich_text = option.rich_text_doc or (option.rich_text_doc is none and world.web.rich_text_options_doc) %}
         <span
             class="interactive tooltip-container"
-            {% if not (option.rich_text_doc | default(world.web.rich_text_options_doc, true)) %}
+            {% if not rich_text %}
               data-tooltip="{{(option.__doc__ | default("Please document me!"))|replace('\n    ', '\n')|escape|trim}}"
             {% endif %}>
           (?)
-          {% if option.rich_text_doc | default(world.web.rich_text_options_doc, true) %}
+          {% if rich_text %}
             <div class="tooltip">
               {{ option.__doc__ | default("**Please document me!**") | rst_to_html | safe }}
             </div>


### PR DESCRIPTION
## What is this fixing or adding?

Previously, because `default(..., true)` only checks if the left-hand-side is falsey, not just `None`, this always forced options to render in non-rich mode if they were explicitly set to `rich_text_doc = None`. Now it matches the intended and documented behavior, where `None` falls back to the world's
`rich_text_options_doc` setting.

## How was this tested?

I modified a world's `Option.rich_text_doc` value locally.