### PR TITLE
Pokemon Emerald: Prevent evolution fanfare from being replaced with flute

### DIFF
--- a/worlds/pokemon_emerald/CHANGELOG.md
+++ b/worlds/pokemon_emerald/CHANGELOG.md
@@ -18,6 +18,8 @@ the player randomized NPC gifts.
 with another NPC was moved to an unoccupied space.
 - Fixed a problem where the client would crash on certain operating systems while using certain python versions if the
 player tried to wonder trade.
+- Prevent the poke flute sound from replacing the evolution fanfare, which would cause the game to wait in silence for
+a long time during the evolution scene.
 
 # 2.2.0
 

--- a/worlds/pokemon_emerald/rom.py
+++ b/worlds/pokemon_emerald/rom.py
@@ -73,6 +73,7 @@ _FANFARES: Dict[str, int] = {
     "MUS_OBTAIN_SYMBOL":       318,
     "MUS_REGISTER_MATCH_CALL": 135,
 }
+_EVOLUTION_FANFARE_INDEX = list(_FANFARES.keys()).index("MUS_EVOLVED")
 
 CAVE_EVENT_NAME_TO_ID = {
     "TERRA_CAVE_ROUTE_114_1": 1,
@@ -661,6 +662,15 @@ def write_tokens(world: "PokemonEmeraldWorld", patch: PokemonEmeraldProcedurePat
         # Shuffle the lists, pair new tracks with original tracks, set the new track ids, and set new fanfare durations
         randomized_fanfares = [fanfare_name for fanfare_name in _FANFARES]
         world.random.shuffle(randomized_fanfares)
+
+        # Prevent the evolution fanfare from receiving the poke flute by swapping it with something else.
+        # The poke flute sound causes the evolution scene to get stuck for like 40 seconds
+        if randomized_fanfares[_EVOLUTION_FANFARE_INDEX] == "MUS_RG_POKE_FLUTE":
+            swap_index = (_EVOLUTION_FANFARE_INDEX + 1) % len(_FANFARES)
+            temp = randomized_fanfares[_EVOLUTION_FANFARE_INDEX]
+            randomized_fanfares[_EVOLUTION_FANFARE_INDEX] = randomized_fanfares[swap_index]
+            randomized_fanfares[swap_index] = temp
+
         for i, fanfare_pair in enumerate(zip(_FANFARES.keys(), randomized_fanfares)):
             patch.write_token(
                 APTokenTypes.WRITE,


### PR DESCRIPTION
## What is this fixing or adding?

If the `MUS_EVOLVED` sound is replaced with `MUS_RG_POKE_FLUTE`, when a pokemon finishes evolving, it pauses and goes silent for like 40 seconds. I'm not entirely sure why; the same sound is happy to play for the correct duration in other scenarios, and other sounds don't have this problem.

This just swaps the sound for something else if it ever gets randomized into this matchup. Perhaps slightly overengineered to future proof it in case the `_FANFARES` dict gets modified for some reason.

## How was this tested?

Inspected `randomized_fanfares` after the condition to make sure it swapped correctly and breakpointed inside the condition to make sure it ran. Also modified `_FANFARES` to be sure it generalized.
