### PR TITLE
Core: warn if a yaml is empty

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -123,6 +123,9 @@ def main(args=None) -> Tuple[argparse.Namespace, int]:
     for filename, yaml_data in weights_cache.items():
         if filename not in {args.meta_file_path, args.weights_file_path}:
             for yaml in yaml_data:
+                if yaml is None:
+                    logging.warning(f"Ignoring empty yaml block in {filename}")
+                    continue
                 logging.info(f"P{player_id} Weights: {filename} >> "
                              f"{get_choice('description', yaml, 'No description specified')}")
                 player_files[player_id] = filename

--- a/Generate.py
+++ b/Generate.py
@@ -122,9 +122,9 @@ def main(args=None) -> Tuple[argparse.Namespace, int]:
     weights_cache = {key: value for key, value in sorted(weights_cache.items(), key=lambda k: k[0].casefold())}
     for filename, yaml_data in weights_cache.items():
         if filename not in {args.meta_file_path, args.weights_file_path}:
-            for yaml in yaml_data:
+            for doc_idx, yaml in enumerate(yaml_data):
                 if yaml is None:
-                    logging.warning(f"Ignoring empty yaml block in {filename}")
+                    logging.warning(f"Ignoring empty yaml document #{doc_idx + 1} in {filename}")
                     continue
                 logging.info(f"P{player_id} Weights: {filename} >> "
                              f"{get_choice('description', yaml, 'No description specified')}")

--- a/Generate.py
+++ b/Generate.py
@@ -114,13 +114,13 @@ def main(args=None) -> Tuple[argparse.Namespace, int]:
                 os.path.join(args.player_files_path, fname) not in {args.meta_file_path, args.weights_file_path}:
             path = os.path.join(args.player_files_path, fname)
             try:
-                wcache = []
+                weights_for_file = []
                 for doc_idx, yaml in enumerate(read_weights_yamls(path)):
                     if yaml is None:
                         logging.warning(f"Ignoring empty yaml document #{doc_idx + 1} in {fname}")
                     else:
-                        wcache.append(yaml)
-                weights_cache[fname] = tuple(wcache)
+                        weights_for_file.append(yaml)
+                weights_cache[fname] = tuple(weights_for_file)
                         
             except Exception as e:
                 raise ValueError(f"File {fname} is invalid. Please fix your yaml.") from e

--- a/WebHostLib/check.py
+++ b/WebHostLib/check.py
@@ -105,8 +105,9 @@ def roll_options(options: Dict[str, Union[dict, str]],
                                                              plando_options=plando_options)
                 else:
                     for i, yaml_data in enumerate(yaml_datas):
-                        rolled_results[f"{filename}/{i + 1}"] = roll_settings(yaml_data,
-                                                                              plando_options=plando_options)
+                        if yaml_data is not None:
+                            rolled_results[f"{filename}/{i + 1}"] = roll_settings(yaml_data,
+                                                                                  plando_options=plando_options)
             except Exception as e:
                 if e.__cause__:
                     results[filename] = f"Failed to generate options in {filename}: {e} - {e.__cause__}"


### PR DESCRIPTION
## What is this fixing or adding?

`---` marks the start of a yaml document which lets us put multiple yamls in one file, but if it's accidentally put at the end of the file (or twice in a row or anything), that yaml document will be empty, aka `None`. This throws an exception that doesn't clearly identify the file:

```
Uncaught exception
Traceback (most recent call last):
  File "c:\Users\bswolf\Documents\GitHub\Archipelago\Generate.py", line 529, in <module>
    erargs, seed = main()
                   ^^^^^^
  File "c:\Users\bswolf\Documents\GitHub\Archipelago\Generate.py", line 127, in main
    f"{get_choice('description', yaml, 'No description specified')}")
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\Users\bswolf\Documents\GitHub\Archipelago\Generate.py", line 260, in get_choice
    if option not in root:
       ^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable
```

Rather than write a new exception to specify the file, we can simply issue a warning and continue:

```
P72 Weights: Zannick Psy.yaml >> Plain Psychonauts
Ignoring empty yaml block in Zannick Psy.yaml
P73 Weights: Zillion.yaml >> Default Zillion Template
```

## How was this tested?

Manually.