### PR TITLE
Generate: Prevent ini Files from Being Included in YAML Discovery

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -110,7 +110,7 @@ def main(args=None) -> Tuple[argparse.Namespace, int]:
     player_files = {}
     for file in os.scandir(args.player_files_path):
         fname = file.name
-        if file.is_file() and not fname.startswith(".") and \
+        if file.is_file() and not fname.startswith(".") and not fname.endswith(".ini") and \
                 os.path.join(args.player_files_path, fname) not in {args.meta_file_path, args.weights_file_path}:
             path = os.path.join(args.player_files_path, fname)
             try:

--- a/Generate.py
+++ b/Generate.py
@@ -110,7 +110,7 @@ def main(args=None) -> Tuple[argparse.Namespace, int]:
     player_files = {}
     for file in os.scandir(args.player_files_path):
         fname = file.name
-        if file.is_file() and not fname.startswith(".") and not fname.endswith(".ini") and \
+        if file.is_file() and not fname.startswith(".") and not fname.lower().endswith(".ini") and \
                 os.path.join(args.player_files_path, fname) not in {args.meta_file_path, args.weights_file_path}:
             path = os.path.join(args.player_files_path, fname)
             try:


### PR DESCRIPTION
## What is this fixing or adding?
Closes #4124 
Prevents ini files from being read into generation. This can be a problem if desktop.ini is created by Windows. This does not prevent any other file formats from being used.

## How was this tested?
Transplanting a desktop.ini file into the folder and running a generation with a valid yaml included