### PR TITLE
Bumper Stickers: Update tests to bases.py

### DIFF
--- a/worlds/bumpstik/test/__init__.py
+++ b/worlds/bumpstik/test/__init__.py
@@ -1,4 +1,4 @@
-from test.TestBase import WorldTestBase
+from test.bases import WorldTestBase
 
 
 class BumpStikTestBase(WorldTestBase):


### PR DESCRIPTION
## What is this fixing or adding?
Updates import to bases.py rather than TestBase.py since the latter is deprecated

## How was this tested?
Running unit tests