### PR TITLE
LTTP: Update tests to use bases.py

### DIFF
--- a/worlds/alttp/test/items/TestDifficulty.py
+++ b/worlds/alttp/test/items/TestDifficulty.py
@@ -1,5 +1,5 @@
 from worlds.alttp.ItemPool import difficulties
-from test.TestBase import TestBase
+from test.bases import TestBase
 
 base_items = 41
 extra_counts = (15, 15, 10, 5, 25)

--- a/worlds/alttp/test/items/TestPrizes.py
+++ b/worlds/alttp/test/items/TestPrizes.py
@@ -1,7 +1,7 @@
 from typing import List
 
 from BaseClasses import Item, Location
-from test.TestBase import WorldTestBase
+from test.bases import WorldTestBase
 
 
 class TestPrizes(WorldTestBase):

--- a/worlds/alttp/test/minor_glitches/TestMinor.py
+++ b/worlds/alttp/test/minor_glitches/TestMinor.py
@@ -2,7 +2,7 @@ from worlds.alttp.Dungeons import get_dungeon_item_pool
 from worlds.alttp.InvertedRegions import mark_dark_world_regions
 from worlds.alttp.ItemPool import difficulties
 from worlds.alttp.Items import item_factory
-from test.TestBase import TestBase
+from test.bases import TestBase
 from worlds.alttp.Options import GlitchesRequired
 
 from worlds.alttp.test import LTTPTestBase

--- a/worlds/alttp/test/owg/TestVanillaOWG.py
+++ b/worlds/alttp/test/owg/TestVanillaOWG.py
@@ -2,7 +2,7 @@ from worlds.alttp.Dungeons import get_dungeon_item_pool
 from worlds.alttp.InvertedRegions import mark_dark_world_regions
 from worlds.alttp.ItemPool import difficulties
 from worlds.alttp.Items import item_factory
-from test.TestBase import TestBase
+from test.bases import TestBase
 from worlds.alttp.Options import GlitchesRequired
 
 from worlds.alttp.test import LTTPTestBase

--- a/worlds/alttp/test/shops/TestSram.py
+++ b/worlds/alttp/test/shops/TestSram.py
@@ -1,5 +1,5 @@
 from worlds.alttp.Shops import shop_table
-from test.TestBase import TestBase
+from test.bases import TestBase
 
 
 class TestSram(TestBase):

--- a/worlds/alttp/test/vanilla/TestVanilla.py
+++ b/worlds/alttp/test/vanilla/TestVanilla.py
@@ -2,7 +2,7 @@ from worlds.alttp.Dungeons import get_dungeon_item_pool
 from worlds.alttp.InvertedRegions import mark_dark_world_regions
 from worlds.alttp.ItemPool import difficulties
 from worlds.alttp.Items import item_factory
-from test.TestBase import TestBase
+from test.bases import TestBase
 from worlds.alttp.Options import GlitchesRequired
 from worlds.alttp.test import LTTPTestBase
 


### PR DESCRIPTION
## What is this fixing or adding?
Updates import to bases.py rather than TestBase.py since the latter is deprecated

## How was this tested?
Running unit tests