### PR TITLE
DLC Quest: Update tests to use bases.py

### DIFF
--- a/worlds/dlcquest/test/__init__.py
+++ b/worlds/dlcquest/test/__init__.py
@@ -4,7 +4,7 @@ from typing import Dict, FrozenSet, Tuple, Any
 from argparse import Namespace
 
 from BaseClasses import MultiWorld
-from test.TestBase import WorldTestBase
+from test.bases import WorldTestBase
 from .. import DLCqworld
 from test.general import gen_steps, setup_solo_multiworld as setup_base_solo_multiworld
 from worlds.AutoWorld import call_all


### PR DESCRIPTION
## What is this fixing or adding?
Updates import to bases.py rather than TestBase.py since the latter is deprecated

## How was this tested?
Running unit tests