### PR TITLE
Core: Handle integer arguments in player names gracefully

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -270,22 +270,30 @@ def get_choice(option, root, value=None) -> Any:
     raise RuntimeError(f"All options specified in \"{option}\" are weighted as zero.")
 
 
-class SafeDict(dict):
-    def __missing__(self, key):
-        return '{' + key + '}'
+class SafeFormatter(string.Formatter):
+    def get_value(self, key, args, kwargs):
+        if isinstance(key, int):
+            if key < len(args):
+                return args[key]
+            else:
+                return "{" + str(key) + "}"
+        else:
+            return kwargs.get(key, "{" + key + "}")
 
 
 def handle_name(name: str, player: int, name_counter: Counter):
     name_counter[name.lower()] += 1
     number = name_counter[name.lower()]
     new_name = "%".join([x.replace("%number%", "{number}").replace("%player%", "{player}") for x in name.split("%%")])
-    new_name = string.Formatter().vformat(new_name, (), SafeDict(number=number,
-                                                                 NUMBER=(number if number > 1 else ''),
-                                                                 player=player,
-                                                                 PLAYER=(player if player > 1 else '')))
+
+    new_name = SafeFormatter().vformat(new_name, (), {"number": number,
+                                                      "NUMBER": (number if number > 1 else ''),
+                                                      "player": player,
+                                                      "PLAYER": (player if player > 1 else '')})
     # Run .strip twice for edge case where after the initial .slice new_name has a leading whitespace.
     # Could cause issues for some clients that cannot handle the additional whitespace.
     new_name = new_name.strip()[:16].strip()
+
     if new_name == "Archipelago":
         raise Exception(f"You cannot name yourself \"{new_name}\"")
     return new_name


### PR DESCRIPTION
## What is this fixing or adding?

If a player's name includes a sequence like `{1}`, with any number, this would crash the generator with a standard library error that is confusing for some players. Sequences like `{a}`, with any string, would work fine due to a clever subclassing of `dict`, which would dynamically insert the key surrounded by curly braces into the dict for any unknown key.

This PR subclasses `string.Formatter` as opposed to `dict` and overrides the default behavior by making the value fall back to the key or index surrounded by curly braces. This solution handles more cases more directly.

## How was this tested?

Generate with the following YAML before and after applying this commit:

```yaml﻿
name: Player{1}

description: nonexistent integer

game: A Link to the Past
requires:
  version: 0.5.0 # Version of Archipelago required for this yaml to work as expected.

A Link to the Past: {}

---
name: Player{a}

description: nonexistent string key

game: A Link to the Past
requires:
  version: 0.5.0 # Version of Archipelago required for this yaml to work as expected.

A Link to the Past: {}
```

Feel free to change the game; the options other than the name are immaterial.

## If this makes graphical changes, please attach screenshots.

It does not.