### PR TITLE
sm64ex: Make the Randomize 1Up !-Blocks option a Toggle

### DIFF
--- a/worlds/sm64ex/Options.py
+++ b/worlds/sm64ex/Options.py
@@ -91,12 +91,11 @@ class BuddyChecks(Toggle):
     display_name = "Bob-omb Buddy Checks"
 
 
-class ExclamationBoxes(Choice):
+class ExclamationBoxes(Toggle):
     """Include 1Up Exclamation Boxes during randomization.
     Adds 29 locations to the pool."""
     display_name = "Randomize 1Up !-Blocks"
-    option_Off = 0
-    option_1Ups_Only = 1
+    alias_1Ups_Only = 1
 
 
 class CompletionType(Choice):

--- a/worlds/sm64ex/__init__.py
+++ b/worlds/sm64ex/__init__.py
@@ -55,7 +55,7 @@ class SM64World(World):
             for action in self.options.move_rando_actions.value:
                 max_stars -= 1
                 self.move_rando_bitvec |= (1 << (action_item_table[action] - action_item_table['Double Jump']))
-        if (self.options.exclamation_boxes > 0):
+        if self.options.exclamation_boxes:
             max_stars += 29
         self.number_of_stars = min(self.options.amount_of_stars, max_stars)
         self.filler_count = max_stars - self.number_of_stars
@@ -133,7 +133,7 @@ class SM64World(World):
             self.multiworld.get_location("THI: Bob-omb Buddy", self.player).place_locked_item(self.create_item("Cannon Unlock THI"))
             self.multiworld.get_location("RR: Bob-omb Buddy", self.player).place_locked_item(self.create_item("Cannon Unlock RR"))
 
-        if (self.options.exclamation_boxes == 0):
+        if not self.options.exclamation_boxes:
             self.multiworld.get_location("CCM: 1Up Block Near Snowman", self.player).place_locked_item(self.create_item("1Up Mushroom"))
             self.multiworld.get_location("CCM: 1Up Block Ice Pillar", self.player).place_locked_item(self.create_item("1Up Mushroom"))
             self.multiworld.get_location("CCM: 1Up Block Secret Slide", self.player).place_locked_item(self.create_item("1Up Mushroom"))


### PR DESCRIPTION
## What is this fixing or adding?

The "Off" vs "1Ups Only" options for the "Randomize 1Up !-Blocks" option is a frequent source of confusion to new players. Here's two separate questions about it in #super-mario-64 on the discord in just the past month:

https://discord.com/channels/731205301247803413/937206798014898186/1303553542900023358
https://discord.com/channels/731205301247803413/937206798014898186/1296220828555546705

The "1Ups Only" name makes it seem as if it will just put 1Ups in those locations, when it actually means that it will "only" randomize the 1-Up blocks. But given that the display name is _already_ "Randomize 1Up !-Blocks", the expectation is already that only 1ups will be confused. The docstring/tooltip reinforces that, stating "Include 1Up Exclamation Boxes during randomization". So, to clear up that confusion, this PR changes it to a simple `Toggle`.

## How was this tested?

Generated with it off, with it on, and with an old YAML that still used the option `1ups_only`.

## If this makes graphical changes, please attach screenshots.

![image](https://github.com/user-attachments/assets/33c1de84-e531-4bc1-a5bc-0362f29af925)

