### PR TITLE
ALttP: Use auto indirect conditions

### DIFF
--- a/worlds/alttp/EntranceShuffle.py
+++ b/worlds/alttp/EntranceShuffle.py
@@ -3338,25 +3338,6 @@ inverted_default_dungeon_connections = [('Desert Palace Entrance (South)', 'Dese
                                         ('Turtle Rock Exit (Front)', 'Dark Death Mountain'),
                                         ('Ice Palace Exit', 'Dark Lake Hylia')]
 
-# Regions that can be required to access entrances through rules, not paths
-indirect_connections = {
-    "Turtle Rock (Top)": "Turtle Rock",
-    "East Dark World": "Pyramid Fairy",
-    "Dark Desert": "Pyramid Fairy",
-    "West Dark World": "Pyramid Fairy",
-    "South Dark World": "Pyramid Fairy",
-    "Light World": "Pyramid Fairy",
-    "Old Man Cave": "Old Man S&Q"
-}
-
-indirect_connections_inverted = {
-    "Inverted Big Bomb Shop": "Pyramid Fairy",
-}
-
-indirect_connections_not_inverted = {
-    "Big Bomb Shop": "Pyramid Fairy",
-}
-
 # format:
 # Key=Name
 # addr = (door_index, exitdata) # multiexit

--- a/worlds/alttp/__init__.py
+++ b/worlds/alttp/__init__.py
@@ -8,8 +8,7 @@ import typing
 import Utils
 from BaseClasses import Item, CollectionState, Tutorial, MultiWorld
 from .Dungeons import create_dungeons, Dungeon
-from .EntranceShuffle import link_entrances, link_inverted_entrances, plando_connect, \
-    indirect_connections, indirect_connections_inverted, indirect_connections_not_inverted
+from .EntranceShuffle import link_entrances, link_inverted_entrances, plando_connect
 from .InvertedRegions import create_inverted_regions, mark_dark_world_regions
 from .ItemPool import generate_itempool, difficulties
 from .Items import item_init_table, item_name_groups, item_table, GetBeemizerItem
@@ -137,6 +136,7 @@ class ALTTPWorld(World):
     settings_key = "lttp_options"
     settings: typing.ClassVar[ALTTPSettings]
     topology_present = True
+    explicit_indirect_conditions = False
     item_name_groups = item_name_groups
     location_name_groups = {
         "Blind's Hideout": {"Blind's Hideout - Top", "Blind's Hideout - Left", "Blind's Hideout - Right",
@@ -394,22 +394,12 @@ class ALTTPWorld(World):
         if multiworld.mode[player] != 'inverted':
             link_entrances(multiworld, player)
             mark_light_world_regions(multiworld, player)
-            for region_name, entrance_name in indirect_connections_not_inverted.items():
-                multiworld.register_indirect_condition(multiworld.get_region(region_name, player),
-                                                  multiworld.get_entrance(entrance_name, player))
         else:
             link_inverted_entrances(multiworld, player)
             mark_dark_world_regions(multiworld, player)
-            for region_name, entrance_name in indirect_connections_inverted.items():
-                multiworld.register_indirect_condition(multiworld.get_region(region_name, player),
-                                                  multiworld.get_entrance(entrance_name, player))
 
         multiworld.random = old_random
         plando_connect(multiworld, player)
-
-        for region_name, entrance_name in indirect_connections.items():
-            multiworld.register_indirect_condition(multiworld.get_region(region_name, player),
-                                              multiworld.get_entrance(entrance_name, player))
 
     def collect_item(self, state: CollectionState, item: Item, remove=False):
         item_name = item.name


### PR DESCRIPTION
## What is this fixing or adding?

ALttP makes common use of entrances with access rules that require another entrance to be accessible. This results in requiring an indirect condition to be registered for the other entrance's `.parent_region`, but this indirect condition is often missing. Additionally, if that other entrance also requires indirect conditions, those same indirect conditions would also need to be registered on the original entrance.

There are so many missing indirect conditions, and due to the complexity of some of the chained rules, it is simply not realistic to add all the missing indirect conditions.

This patch changes ALttP to use automatic indirect conditions instead of explicit indirect conditions and removes the places that were registering indirect conditions.

Without this patch, the missing indirect conditions almost never have an effect on generating with default options, but enabling certain options, such as `glitches_required` or `entrance_shuffle` can result in frequently checking entrances that are missing indirect conditions.

Examples of complex chained rules:
`get_rule_to_add()` in `Rules.set_bunny_rules()` can create rules on entrances that require access to any of a number of different other entrances, which should require the parent regions of all of those other entrances to be registered as indirect conditions as well as any indirect conditions that those other entrances require.

There are entrance access rules that check
`StateHelpers.can_kill_most_things()` (e.g. `Turtle Rock Second Section Bomb Wall`), which can check `can_extend_magic()`, which checks for being able to buy unlimited `Blue Potion`, which checks for being able to reach a shop that sells unlimited `Blue Potion`. This is usually `Potion Shop`, but there is a yaml option that shuffles shop inventories, so the shop that sells unlimited `Blue Potion` can be randomized, meaning that the region that should be registered as an indirect condition can also be randomized.

Example of many missing indirect conditions:
With `small_key_shuffle: universal`, every single
`ALttPLogic._lttp_has_key()` checks for being able to reach shops that sell an unlimited number of universal Small Keys. Meaning that every entrance access rule that uses `_lttp_has_key()` should register all shop regions that sell unlimited universal small keys as indirect conditions.

## How was this tested?

I ran generations with mostly random options with [Violet's missing indirect condition checker](https://github.com/NewSoupVi/Archipelago/tree/indirect_condition_checker) (after merging main into it locally) as well as [my own implementation](https://github.com/Mysteryem/Archipelago-ahit/tree/missing_indirect_condition_checker_mysteryem_version). I started trying to add the missing indirect conditions as they came up, but gave up.