### PR TITLE
Pokemon Emerald: Add Mr Briney's House indirect conditions

### DIFF
--- a/worlds/pokemon_emerald/rules.py
+++ b/worlds/pokemon_emerald/rules.py
@@ -415,13 +415,16 @@ def set_rules(world: "PokemonEmeraldWorld") -> None:
     )
 
     # Dewford Town
+    entrance = get_entrance("REGION_DEWFORD_TOWN/MAIN -> REGION_ROUTE109/BEACH")
     set_rule(
-        get_entrance("REGION_DEWFORD_TOWN/MAIN -> REGION_ROUTE109/BEACH"),
+        entrance,
         lambda state:
             state.can_reach("REGION_ROUTE104_MR_BRINEYS_HOUSE/MAIN -> REGION_DEWFORD_TOWN/MAIN", "Entrance", world.player)
             and state.has("EVENT_TALK_TO_MR_STONE", world.player)
             and state.has("EVENT_DELIVER_LETTER", world.player)
     )
+    world.multiworld.register_indirect_condition(
+        get_entrance("REGION_ROUTE104_MR_BRINEYS_HOUSE/MAIN -> REGION_DEWFORD_TOWN/MAIN").parent_region, entrance)
     set_rule(
         get_entrance("REGION_DEWFORD_TOWN/MAIN -> REGION_ROUTE104_MR_BRINEYS_HOUSE/MAIN"),
         lambda state:
@@ -450,14 +453,17 @@ def set_rules(world: "PokemonEmeraldWorld") -> None:
     )
 
     # Route 109
+    entrance = get_entrance("REGION_ROUTE109/BEACH -> REGION_DEWFORD_TOWN/MAIN")
     set_rule(
-        get_entrance("REGION_ROUTE109/BEACH -> REGION_DEWFORD_TOWN/MAIN"),
+        entrance,
         lambda state:
             state.can_reach("REGION_ROUTE104_MR_BRINEYS_HOUSE/MAIN -> REGION_DEWFORD_TOWN/MAIN", "Entrance", world.player)
             and state.can_reach("REGION_DEWFORD_TOWN/MAIN -> REGION_ROUTE109/BEACH", "Entrance", world.player)
             and state.has("EVENT_TALK_TO_MR_STONE", world.player)
             and state.has("EVENT_DELIVER_LETTER", world.player)
     )
+    world.multiworld.register_indirect_condition(
+        get_entrance("REGION_ROUTE104_MR_BRINEYS_HOUSE/MAIN -> REGION_DEWFORD_TOWN/MAIN").parent_region, entrance)
     set_rule(
         get_entrance("REGION_ROUTE109/BEACH -> REGION_ROUTE109/SEA"),
         hm_rules["HM03 Surf"]


### PR DESCRIPTION
## What is this fixing or adding?

The `REGION_DEWFORD_TOWN/MAIN -> REGION_ROUTE109/BEACH` and `REGION_ROUTE109/BEACH -> REGION_DEWFORD_TOWN/MAIN` entrances require access to the
`REGION_ROUTE104_MR_BRINEYS_HOUSE/MAIN -> REGION_DEWFORD_TOWN/MAIN` entrance in their access rules, so require indirect conditions for the parent_region of the entrance: `REGION_ROUTE104_MR_BRINEYS_HOUSE/MAIN`.

## How was this tested?

I ran generations with the template yaml without the changes in this PR with both Violet's missing indirect condition checker and my own implementation and both found these missing indirect conditions.

After applying the changes in this PR, both indirect condition checkers do not report any issues when generating with the template yaml.