### PR TITLE
Setup: exclude zstandard

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -632,7 +632,7 @@ cx_Freeze.setup(
             "packages": ["worlds", "kivy", "cymem", "websockets"],
             "includes": [],
             "excludes": ["numpy", "Cython", "PySide2", "PIL",
-                         "pandas"],
+                         "pandas", "zstandard"],
             "zip_include_packages": ["*"],
             "zip_exclude_packages": ["worlds", "sc2", "orjson"],  # TODO: remove orjson here once we drop py3.8 support
             "include_files": [],  # broken in cx 6.14.0, we use more special sauce now


### PR DESCRIPTION
This is quite the big dependency (~20MB) that is unused.
For non-webhost it is an optional dependency to requests.