### PR TITLE
CV64: Remove multiworld random usage

### DIFF
--- a/worlds/cv64/__init__.py
+++ b/worlds/cv64/__init__.py
@@ -89,7 +89,7 @@ class CV64World(World):
 
     def generate_early(self) -> None:
         # Generate the player's unique authentication
-        self.auth = bytearray(self.multiworld.random.getrandbits(8) for _ in range(16))
+        self.auth = bytearray(self.random.getrandbits(8) for _ in range(16))
 
         self.total_s1s = self.options.total_special1s.value
         self.s1s_per_warp = self.options.special1s_per_warp.value


### PR DESCRIPTION
## What is this fixing or adding?
Changes the multiworld random used to generate the player's slot authentication into a world random instead, bringing it more in-line with other worlds. Unless someone finds any others that I missed, CV64 should be free of multiworld random usages now.

## How was this tested?
Generated the same seed twice, made sure the auth did not change.

