### PR TITLE
CV64: Fix some textbox message truncation issues

### DIFF
--- a/worlds/cv64/rom.py
+++ b/worlds/cv64/rom.py
@@ -944,13 +944,19 @@ def write_patch(world: "CV64World", patch: CV64ProcedurePatch, offset_data: Dict
     for loc in active_locations:
         if loc.address is None or get_location_info(loc.name, "type") == "shop" or loc.item.player == world.player:
             continue
-        if len(loc.item.name) > 67:
-            item_name = loc.item.name[0x00:0x68]
+        # If the Item's name is longer than 104 characters, truncate the name to inject at 104.
+        if len(loc.item.name) > 104:
+            item_name = loc.item.name[0:104]
         else:
             item_name = loc.item.name
+        # Get the item's player's name. If it's longer than 16 characters (which can happen if it's an ItemLinked item),
+        # truncate it at 16.
+        player_name = world.multiworld.get_player_name(loc.item.player)
+        if len(player_name) > 16:
+            player_name = player_name[0:16]
+
         inject_address = 0xBB7164 + (256 * (loc.address & 0xFFF))
-        wrapped_name, num_lines = cv64_text_wrap(item_name + "\nfor " +
-                                                 world.multiworld.get_player_name(loc.item.player), 96)
+        wrapped_name, num_lines = cv64_text_wrap(item_name + "\nfor " + player_name, 96)
         patch.write_token(APTokenTypes.WRITE, inject_address, bytes(get_item_text_color(loc) +
                                                                     cv64_string_to_bytearray(wrapped_name)))
         patch.write_token(APTokenTypes.WRITE, inject_address + 255, bytes([num_lines]))


### PR DESCRIPTION
## What is this fixing or adding?
Properly truncates injected player names when they should be; before they were not. 

There is no limit on ItemLink group names, so any of those that are longer than 16 characters being injected for each of the game's Locations at patch time has potential to cause weird unintended behavior depending on how long the player and item name is. This PR fixes that by truncating these player names at 16.

For the server player names injected into the game during runtime whenever an item is received, from what I can tell, the max number of characters those names can have is 35 (16 for the original slot name + 16 for the alias + 3 for the added space and parenthesis around the original name). Still, they are now being truncated at 40 characters just to be on the safe side. CV64's item names shouldn't need to be truncated because none of them even come close to the imposed character limit for the game's textbox messaging system.

Also fixed are a couple of oversights with the patched-in item names and the DeathLink cause messages being truncated using hexadecimal numbers when the length check was being done using regular decimal numbers. Whoops!

## How was this tested?
Forced everyone's favorite FFXIV Free Trial item ItemLinked with a reallllllllllllllly long group name into CV64 and picked it up to make sure the ensuring textbox was working properly. Also aliased a player with the max slot name with the max slot alias and had them send an item to the CV64 player to check that textbox and then made sure DeathLink cause messages were still working.

## If this makes graphical changes, please attach screenshots.
![Screenshot 2024-11-07 140314](https://github.com/user-attachments/assets/dd134153-2cc3-4b34-ac81-c9e9f169e4fb)
