### PR TITLE
CV64: Fix DeathLink Nitro explosions hitting you at times they shouldn't

### DIFF
--- a/worlds/cv64/data/patches.py
+++ b/worlds/cv64/data/patches.py
@@ -197,6 +197,23 @@ deathlink_nitro_edition = [
     0xA168FFFD,  # SB    T0, 0xFFFD (T3)
 ]
 
+deathlink_nitro_state_checker = [
+    # Checks to see if the player is in an alright state before exploding them. If not, then the Nitro explosion spawn
+    # code will be aborted, and they should eventually explode after getting out of that state.
+    #
+    # Invalid states so far include: interacting/going through a door, being grabbed by a vampire.
+    0x90880009,  # LBU   T0, 0x0009 (A0)
+    0x24090005,  # ADDIU T1, R0, 0x0005
+    0x11090005,  # BEQ   T0, T1, [forward 0x05]
+    0x24090002,  # ADDIU T1, R0, 0x0002
+    0x11090003,  # BEQ   T0, T1, [forward 0x03]
+    0x00000000,  # NOP
+    0x08000660,  # J     0x80001980
+    0x00000000,  # NOP
+    0x03E00008,  # JR    RA
+    0xAC400048   # SW    R0, 0x0048 (V0)
+]
+
 launch_fall_killer = [
     # Custom code to force the instant fall death if at a high enough falling speed after getting killed by something
     # that launches you (whether it be the Nitro explosion or a Big Toss hit). The game doesn't normally run the check

--- a/worlds/cv64/rom.py
+++ b/worlds/cv64/rom.py
@@ -357,8 +357,12 @@ class CV64PatchExtensions(APPatchExtension):
 
         # Make received DeathLinks blow you to smithereens instead of kill you normally.
         if options["death_link"] == DeathLink.option_explosive:
-            rom_data.write_int32(0x27A70, 0x10000008)  # B [forward 0x08]
             rom_data.write_int32s(0xBFC0D0, patches.deathlink_nitro_edition)
+            rom_data.write_int32(0x27A70, 0x10000008)  # B [forward 0x08]
+            rom_data.write_int32(0x27AA0, 0x0C0FFA78)  # JAL	0x803FE9E0
+            rom_data.write_int32s(0xBFE9E0, patches.deathlink_nitro_state_checker)
+            # NOP the function call to subtract Nitro from the inventory after exploding, just in case.
+            rom_data.write_int32(0x32DBC, 0x00000000)
 
         # Set the DeathLink ROM flag if it's on at all.
         if options["death_link"] != DeathLink.option_off:


### PR DESCRIPTION
## What is this fixing or adding?
With the Explosive DeathLink option on, prevents receiving Nitro explosions while going through doors and being grabbed by vampires. Blowing up while in these states is problematic because they will put you in the "Nitro Flash" state (as seen in speedruns) that will prevent you from taking damage or blowing up again until the next time you load into a map, so a hack has been added to wait until you come out of these states before triggering it.

In addition, the explosion normally subtracts a Nitro from your inventory (which is pretty funny considering you are normally not supposed to be able to open the pause menu between when you explode and when you Game Over), so this is now prevented *juuuuuuuuust* in case.

## How was this tested?
By getting Carrie blown up at just the right moments thanks to Lunais's heroic sacrifices!