### PR TITLE
TUNIC: Add Shop indirect condition

### DIFF
--- a/worlds/tunic/er_rules.py
+++ b/worlds/tunic/er_rules.py
@@ -344,9 +344,10 @@ def set_er_region_rules(world: "TunicWorld", regions: Dict[str, Region], portal_
         connecting_region=regions["Overworld"],
         rule=lambda state: state.has_any({grapple, laurels}, player))
 
-    regions["Overworld"].connect(
+    entrance = regions["Overworld"].connect(
         connecting_region=regions["Cube Cave Entrance Region"],
         rule=lambda state: state.has(gun, player) or can_shop(state, world))
+    world.multiworld.register_indirect_condition(regions["Shop"], entrance)
     regions["Cube Cave Entrance Region"].connect(
         connecting_region=regions["Overworld"])
 

--- a/worlds/tunic/er_rules.py
+++ b/worlds/tunic/er_rules.py
@@ -344,10 +344,10 @@ def set_er_region_rules(world: "TunicWorld", regions: Dict[str, Region], portal_
         connecting_region=regions["Overworld"],
         rule=lambda state: state.has_any({grapple, laurels}, player))
 
-    entrance = regions["Overworld"].connect(
+    cube_entrance = regions["Overworld"].connect(
         connecting_region=regions["Cube Cave Entrance Region"],
         rule=lambda state: state.has(gun, player) or can_shop(state, world))
-    world.multiworld.register_indirect_condition(regions["Shop"], entrance)
+    world.multiworld.register_indirect_condition(regions["Shop"], cube_entrance)
     regions["Cube Cave Entrance Region"].connect(
         connecting_region=regions["Overworld"])
 


### PR DESCRIPTION
## What is this fixing or adding?

The `Overworld -> Cube Cave Entrance Region` Entrance checks `can_shop()` which checks for being able to reach the "Shop" Region, so the Entrance requires an indirect condition of reaching the "Shop" Region.

## How was this tested?
I ran multiple generations with the template yaml modified to enable entrance rando, before and after this patch, with both Violet's and my indirect condition checker.

Without entrance rando being enabled, it seems that either `state.has(gun, player)` always ends up `True` or `has_sword(state, world.player)` (part of `can_shop()`) always ends up `False` meaning that the `state.can_reach_region("Shop", world.player)` part of `can_shop()` does not get called, making it appear as if there are no missing indirect conditions.

For reference, `can_shop()` is:
```py
def can_shop(state: CollectionState, world: "TunicWorld") -> bool:
    return has_sword(state, world.player) and state.can_reach_region("Shop", world.player)
```