### PR TITLE
Super Mario 64: Option groups

### DIFF
--- a/worlds/sm64ex/Options.py
+++ b/worlds/sm64ex/Options.py
@@ -1,6 +1,6 @@
 import typing
 from dataclasses import dataclass
-from Options import DefaultOnToggle, Range, Toggle, DeathLink, Choice, PerGameCommonOptions, OptionSet
+from Options import DefaultOnToggle, Range, Toggle, DeathLink, Choice, PerGameCommonOptions, OptionSet, OptionGroup
 from .Items import action_item_table
 
 class EnableCoinStars(DefaultOnToggle):
@@ -126,6 +126,30 @@ class MoveRandomizerActions(OptionSet):
     # HACK: Disable randomization for double jump
     valid_keys = [action for action in action_item_table if action != 'Double Jump']
     default = valid_keys
+
+sm64_options_groups = [
+    OptionGroup("Sanity Options", [
+        BuddyChecks,
+        ExclamationBoxes,
+        ProgressiveKeys,
+        EnableCoinStars,
+        EnableMoveRandomizer,
+        MoveRandomizerActions,
+        StrictCapRequirements,
+        StrictCannonRequirements,
+        StrictMoveRequirements,
+    ]),
+    OptionGroup("Goal Options", [
+        AmountOfStars,
+        FirstBowserStarDoorCost,
+        BasementStarDoorCost,
+        SecondFloorStarDoorCost,
+        MIPS1Cost,
+        MIPS2Cost,
+        StarsToFinish,
+        CompletionType,
+    ]),
+]
 
 @dataclass
 class SM64Options(PerGameCommonOptions):

--- a/worlds/sm64ex/Options.py
+++ b/worlds/sm64ex/Options.py
@@ -128,7 +128,7 @@ class MoveRandomizerActions(OptionSet):
     default = valid_keys
 
 sm64_options_groups = [
-    OptionGroup("Item Options", [
+    OptionGroup("Logic Options", [
         BuddyChecks,
         ExclamationBoxes,
         ProgressiveKeys,

--- a/worlds/sm64ex/Options.py
+++ b/worlds/sm64ex/Options.py
@@ -129,6 +129,7 @@ class MoveRandomizerActions(OptionSet):
 
 sm64_options_groups = [
     OptionGroup("Logic Options", [
+        AreaRandomizer,
         BuddyChecks,
         ExclamationBoxes,
         ProgressiveKeys,
@@ -139,7 +140,7 @@ sm64_options_groups = [
         StrictCannonRequirements,
         StrictMoveRequirements,
     ]),
-    OptionGroup("Goal Options", [
+    OptionGroup("Star Options", [
         AmountOfStars,
         FirstBowserStarDoorCost,
         BasementStarDoorCost,
@@ -147,6 +148,8 @@ sm64_options_groups = [
         MIPS1Cost,
         MIPS2Cost,
         StarsToFinish,
+    ]),
+OptionGroup("Goal Options", [
         CompletionType,
     ]),
 ]

--- a/worlds/sm64ex/Options.py
+++ b/worlds/sm64ex/Options.py
@@ -128,7 +128,7 @@ class MoveRandomizerActions(OptionSet):
     default = valid_keys
 
 sm64_options_groups = [
-    OptionGroup("Sanity Options", [
+    OptionGroup("Item Options", [
         BuddyChecks,
         ExclamationBoxes,
         ProgressiveKeys,

--- a/worlds/sm64ex/Options.py
+++ b/worlds/sm64ex/Options.py
@@ -134,10 +134,12 @@ sm64_options_groups = [
         ExclamationBoxes,
         ProgressiveKeys,
         EnableCoinStars,
-        EnableMoveRandomizer,
-        MoveRandomizerActions,
         StrictCapRequirements,
         StrictCannonRequirements,
+    ]),
+    OptionGroup("Ability Options", [
+        EnableMoveRandomizer,
+        MoveRandomizerActions,
         StrictMoveRequirements,
     ]),
     OptionGroup("Star Options", [
@@ -148,9 +150,6 @@ sm64_options_groups = [
         MIPS1Cost,
         MIPS2Cost,
         StarsToFinish,
-    ]),
-OptionGroup("Goal Options", [
-        CompletionType,
     ]),
 ]
 

--- a/worlds/sm64ex/__init__.py
+++ b/worlds/sm64ex/__init__.py
@@ -3,7 +3,7 @@ import os
 import json
 from .Items import item_table, action_item_table, cannon_item_table, SM64Item
 from .Locations import location_table, SM64Location
-from .Options import SM64Options
+from .Options import SM64Options, sm64_options_groups
 from .Rules import set_rules
 from .Regions import create_regions, sm64_level_to_entrances, SM64Levels
 from BaseClasses import Item, Tutorial, ItemClassification, Region
@@ -19,6 +19,8 @@ class SM64Web(WebWorld):
         "setup/en",
         ["N00byKing"]
     )]
+
+    option_groups = sm64_options_groups
 
 
 class SM64World(World):

--- a/worlds/sm64ex/__init__.py
+++ b/worlds/sm64ex/__init__.py
@@ -3,7 +3,7 @@ import os
 import json
 from .Items import item_table, action_item_table, cannon_item_table, SM64Item
 from .Locations import location_table, SM64Location
-from .Options import SM64Options, sm64_options_groups
+from .Options import sm64_options_groups, SM64Options
 from .Rules import set_rules
 from .Regions import create_regions, sm64_level_to_entrances, SM64Levels
 from BaseClasses import Item, Tutorial, ItemClassification, Region


### PR DESCRIPTION
## What is this fixing or adding?
Adds option groups to to options page for SM64.
Initially modelled after the option groups for SMW.

## How was this tested?
Unit tests, and generating a YAML.

## If this makes graphical changes, please attach screenshots.
![ArchipelagoMW-SM64OptionGroups](https://github.com/user-attachments/assets/d02b3d7a-2717-4aac-9990-57d2031af57d)
