### PR TITLE
Core: downgrade websockets and minor fixes

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -89,4 +89,4 @@ jobs:
       run: |
         source venv/bin/activate
         export PYTHONPATH=$(pwd)
-        python test/hosting/__main__.py
+        timeout 300 python test/hosting/__main__.py

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -89,4 +89,4 @@ jobs:
       run: |
         source venv/bin/activate
         export PYTHONPATH=$(pwd)
-        timeout 300 python test/hosting/__main__.py
+        timeout 600 python test/hosting/__main__.py

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1960,8 +1960,10 @@ class ServerCommandProcessor(CommonCommandProcessor):
 
     def _cmd_exit(self) -> bool:
         """Shutdown the server"""
-        self.ctx.server.ws_server.close()
-        self.ctx.exit_event.set()
+        try:
+            self.ctx.server.ws_server.close()
+        finally:
+            self.ctx.exit_event.set()
         return True
 
     @mark_raw

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 colorama>=0.4.6
-websockets>=13.0.1
+websockets>=13.0.1,<14
 PyYAML>=6.0.2
 jellyfish>=1.1.0
 jinja2>=3.1.4


### PR DESCRIPTION
## What is this fixing or adding?

* Downgrades websockets to 13.x, because
  * some API changed in 14.x, which is incompatible with current code
  * 14.x is incompatible with py3.8, making it unsuitable for AP 0.5.x
* Add a timeout to hosting CI to make sure it fails if MultiProcessing MultiServer doesn't stop
* Make cmd_exit set the exit_event on error (otherwise the process wouldn't stop) 

## How was this tested?

CI