### PR TITLE
WebHost: update werkzeug

### DIFF
--- a/WebHostLib/requirements.txt
+++ b/WebHostLib/requirements.txt
@@ -1,5 +1,5 @@
 flask>=3.0.3
-werkzeug>=3.0.4
+werkzeug>=3.0.6
 pony>=0.7.19
 waitress>=3.0.0
 Flask-Caching>=2.3.0


### PR DESCRIPTION
## What is this fixing or adding?

Update werkzeug dependency. The old min requirement has a known bug.

## How was this tested?

Running webhost locally, loading a couple of pages, rolling and hosting a game.