### PR TITLE
Subnautica: compose DeathLink custom text instead of overwriting

### DIFF
--- a/worlds/subnautica/options.py
+++ b/worlds/subnautica/options.py
@@ -112,7 +112,7 @@ class AggressiveScanLogic(Choice):
 
 
 class SubnauticaDeathLink(DeathLink):
-    __doc__ = DeathLink.__doc__ + "\n    Note: can be toggled via in-game console command \"deathlink\"."
+    __doc__ = DeathLink.__doc__ + "\n\n    Note: can be toggled via in-game console command \"deathlink\"."
 
 
 class FillerItemsDistribution(ItemDict):

--- a/worlds/subnautica/options.py
+++ b/worlds/subnautica/options.py
@@ -112,8 +112,7 @@ class AggressiveScanLogic(Choice):
 
 
 class SubnauticaDeathLink(DeathLink):
-    """When you die, everyone dies. Of course the reverse is true too.
-    Note: can be toggled via in-game console command "deathlink"."""
+    __doc__ = DeathLink.__doc__ + "\n    Note: can be toggled via in-game console command \"deathlink\"."
 
 
 class FillerItemsDistribution(ItemDict):


### PR DESCRIPTION
## What is this fixing or adding?
Prevents divergence if core text is updated. (Which it was.)

## How was this tested?
![image](https://github.com/user-attachments/assets/4c9ead48-e597-47d0-9226-77700a85d90a)
