### PR TITLE
WebHost: add a page to manage session cookie

### DIFF
--- a/WebHostLib/__init__.py
+++ b/WebHostLib/__init__.py
@@ -84,6 +84,6 @@ def register():
 
     from WebHostLib.customserver import run_server_process
     # to trigger app routing picking up on it
-    from . import tracker, upload, landing, check, generate, downloads, api, stats, misc, robots, options
+    from . import tracker, upload, landing, check, generate, downloads, api, stats, misc, robots, options, session
 
     app.register_blueprint(api.api_endpoints)

--- a/WebHostLib/misc.py
+++ b/WebHostLib/misc.py
@@ -18,13 +18,6 @@ def get_world_theme(game_name: str):
     return 'grass'
 
 
-@app.before_request
-def register_session():
-    session.permanent = True  # technically 31 days after the last visit
-    if not session.get("_id", None):
-        session["_id"] = uuid4()  # uniquely identify each session without needing a login
-
-
 @app.errorhandler(404)
 @app.errorhandler(jinja2.exceptions.TemplateNotFound)
 def page_not_found(err):

--- a/WebHostLib/session.py
+++ b/WebHostLib/session.py
@@ -1,0 +1,31 @@
+from uuid import uuid4, UUID
+
+from flask import session, render_template
+
+from WebHostLib import app
+
+
+@app.before_request
+def register_session():
+    session.permanent = True  # technically 31 days after the last visit
+    if not session.get("_id", None):
+        session["_id"] = uuid4()  # uniquely identify each session without needing a login
+
+
+@app.route('/session')
+def show_session():
+    return render_template(
+        "session.html",
+    )
+
+
+@app.route('/session/<string:_id>')
+def set_session(_id: str):
+    new_id: UUID = UUID(_id, version=4)
+    old_id: UUID = session["_id"]
+    if old_id != new_id:
+        session["_id"] = new_id
+    return render_template(
+        "session.html",
+        old_id=old_id,
+    )

--- a/WebHostLib/templates/session.html
+++ b/WebHostLib/templates/session.html
@@ -1,0 +1,30 @@
+{% extends 'pageWrapper.html' %}
+
+{% block head %}
+    {% include 'header/stoneHeader.html' %}
+    <title>Session</title>
+    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename="styles/markdown.css") }}" />
+{% endblock %}
+
+{% block body %}
+    <div class="markdown">
+        {% if old_id is defined %}
+            <p>Your old code was:</p>
+            <code>{{ old_id }}</code>
+            <br>
+        {% endif %}
+        <p>The following code is your unique identifier, it binds your uploaded content, such as rooms and seeds to you.
+            Treat it like a combined login name and password.
+            You should save this securely if you ever need to restore access.
+            You can also paste it into another device to access your content from multiple devices / browsers.
+            Some browsers, such as Brave, will delete your identifier cookie on a timer.</p>
+        <code>{{ session["_id"] }}</code>
+        <br>
+        <p>
+            The following link can be used to set the identifier. Do not share the code or link with others. <br>
+            <a href="{{ url_for('set_session', _id=session['_id']) }}">
+                {{ url_for('set_session', _id=session['_id'], _external=True) }}
+            </a>
+        </p>
+    </div>
+{%  endblock %}

--- a/WebHostLib/templates/siteMap.html
+++ b/WebHostLib/templates/siteMap.html
@@ -26,6 +26,7 @@
             <li><a href="/user-content">User Content</a></li>
             <li><a href="{{url_for('stats')}}">Game Statistics</a></li>
             <li><a href="/glossary/en">Glossary</a></li>
+            <li><a href="{{url_for("show_session")}}">Session / Login</a></li>
         </ul>
 
         <h2>Tutorials</h2>


### PR DESCRIPTION
## What is this fixing or adding?
Some basic session save / load. It will probably be discovered by most users after they lost their identifier, but at least there is now a remedy available.

## How was this tested?
locally with Chrome and Vivaldi, settings cookies back and forth.
