### PR TITLE
Docs: Move A Short Hike to the unmaintained list in CODEOWNERS

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -142,9 +142,6 @@
 # Shivers
 /worlds/shivers/ @GodlFire
 
-# A Short Hike
-/worlds/shorthike/ @chandler05
-
 # Sonic Adventure 2 Battle
 /worlds/sa2b/ @PoryGone @RaspberrySpace
 
@@ -229,6 +226,9 @@
 
 # Ocarina of Time
 # /worlds/oot/
+
+# A Short Hike
+# /worlds/shorthike/
 
 ## Disabled Unmaintained Worlds
 


### PR DESCRIPTION
## What is this fixing or adding?
![image](https://github.com/user-attachments/assets/1a77decb-ba12-4d02-8e46-edd1418de123)
Moving it to unmaintained since there was only the one maintainer listed in Codeowners.

## How was this tested?
Reading

## If this makes graphical changes, please attach screenshots.
N/A