### PR TITLE
Tests: Ignore s2clientprotocol Deprecation Warnings

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -4,6 +4,7 @@ import warnings
 import settings
 
 warnings.simplefilter("always")
+warnings.filterwarnings(action="ignore", category=DeprecationWarning, module="s2clientprotocol")
 settings.no_gui = True
 settings.skip_autosave = True
 


### PR DESCRIPTION
## What is this fixing or adding?
Adds a filter to ignore Deprecation Warnings from the s2clientprotocol module.
s2clientprotocol is managed entirely by Blizzard, therefore seeing deprecation warnings from this module is unhelpful.
Currently, on Python 3.11+, multiple deprecation warnings are produced by this module. It is unclear if updating the module would remove these warnings since changelogs are not provided.

## How was this tested?
Running unittests and checking output