### PR TITLE
DLCQuest: Use options API for campaign and remove unused imports in tests

### DIFF
--- a/worlds/dlcquest/test/TestOptionsLong.py
+++ b/worlds/dlcquest/test/TestOptionsLong.py
@@ -5,7 +5,6 @@ from Options import NamedRange
 from .option_names import options_to_include
 from .checks.world_checks import assert_can_win, assert_same_number_items_locations
 from . import DLCQuestTestBase, setup_dlc_quest_solo_multiworld
-from ... import AutoWorldRegister
 
 
 def basic_checks(tester: DLCQuestTestBase, multiworld: MultiWorld):

--- a/worlds/dlcquest/test/checks/world_checks.py
+++ b/worlds/dlcquest/test/checks/world_checks.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from BaseClasses import MultiWorld, ItemClassification
+from BaseClasses import MultiWorld
 from .. import DLCQuestTestBase
 from ... import Options
 
@@ -14,7 +14,7 @@ def get_all_location_names(multiworld: MultiWorld) -> List[str]:
 
 
 def assert_victory_exists(tester: DLCQuestTestBase, multiworld: MultiWorld):
-    campaign = multiworld.campaign[1]
+    campaign = multiworld.worlds[1].options.campaign
     all_items = [item.name for item in multiworld.get_items()]
     if campaign == Options.Campaign.option_basic or campaign == Options.Campaign.option_both:
         tester.assertIn("Victory Basic", all_items)
@@ -25,7 +25,7 @@ def assert_victory_exists(tester: DLCQuestTestBase, multiworld: MultiWorld):
 def collect_all_then_assert_can_win(tester: DLCQuestTestBase, multiworld: MultiWorld):
     for item in multiworld.get_items():
         multiworld.state.collect(item)
-    campaign = multiworld.campaign[1]
+    campaign = multiworld.worlds[1].options.campaign
     if campaign == Options.Campaign.option_basic or campaign == Options.Campaign.option_both:
         tester.assertTrue(multiworld.find_item("Victory Basic", 1).can_reach(multiworld.state))
     if campaign == Options.Campaign.option_live_freemium_or_die or campaign == Options.Campaign.option_both:


### PR DESCRIPTION
## What is this fixing or adding?
Removes unused imports in DLCQuest world tests and uses Options API for checking the value of campaign

## How was this tested?
Running unittests
