### PR TITLE
[PKMN RB] Fixes faulty logic in Victory Road 1

### DIFF
--- a/worlds/pokemon_rb/rules.py
+++ b/worlds/pokemon_rb/rules.py
@@ -94,6 +94,9 @@ def set_rules(multiworld, world, player):
 
         "Route 22 - Trainer Parties": lambda state: state.has("Oak's Parcel", player),
 
+        "Victory Road 1F - Top Item": lambda state: logic.can_strength(state, world, player),
+        "Victory Road 1F - Left Item": lambda state: logic.can_strength(state, world, player),
+
         # # Rock Tunnel
         "Rock Tunnel 1F - PokeManiac": lambda state: logic.rock_tunnel(state, world, player),
         "Rock Tunnel 1F - Hiker 1": lambda state: logic.rock_tunnel(state, world, player),


### PR DESCRIPTION
## What is this fixing or adding?
https://discord.com/channels/731205301247803413/1306419629115314257
The checks "Victory Road 1F - Left Item" and "Victory Road 1F - Top Item" were missing their strength requirements.

## How was this tested?
It wasn't

## If this makes graphical changes, please attach screenshots.
N/A