### PR TITLE
PKMN R/B: Don't change classification of items from other worlds

### DIFF
--- a/worlds/pokemon_rb/__init__.py
+++ b/worlds/pokemon_rb/__init__.py
@@ -528,8 +528,8 @@ class PokemonRedBlueWorld(World):
         for sphere in multiworld.get_spheres():
             mon_locations_in_sphere = {}
             for location in sphere:
-                if (location.game == "Pokemon Red and Blue" and (location.item.name in poke_data.pokemon_data.keys()
-                                                                 or "Static " in location.item.name)
+                if (location.game == location.item.game == "Pokemon Red and Blue"
+                        and (location.item.name in poke_data.pokemon_data.keys() or "Static " in location.item.name)
                         and location.item.advancement):
                     key = (location.player, location.item.name)
                     if key in found_mons:


### PR DESCRIPTION
## What is this fixing or adding?
Previously the game only checked if the location was for Pokemon R/B and if the item name contained "Static " which would include items from other worlds. Now it only modifies R/B items.

## How was this tested?

Running generations with a modified ChecksFinder to include an item named "MapStatic Item" (replacing Map Bombs).
This previously caused generations to fail because progression items were made Useful, with this change, those generations now succeeded. Print debugging was used to check if any off-world items were being made Useful, they were not after these changes and were before them.