### PR TITLE
LADX: specific instruments goal

### DIFF
--- a/worlds/ladx/LADXR/generator.py
+++ b/worlds/ladx/LADXR/generator.py
@@ -308,6 +308,8 @@ def generateRom(args, world: "LinksAwakeningWorld"):
         patches.bingo.setBingoGoal(rom, world_setup.bingo_goals, world_setup.goal)
     elif world_setup.goal == "seashells":
         patches.goal.setSeashellGoal(rom, 20)
+    elif isinstance(world_setup.goal, str) and world_setup.goal.startswith("="):
+        patches.goal.setSpecificInstruments(rom, [int(c) for c in world_setup.goal[1:]])
     else:
         patches.goal.setRequiredInstrumentCount(rom, world_setup.goal)
 

--- a/worlds/ladx/LADXR/logic/__init__.py
+++ b/worlds/ladx/LADXR/logic/__init__.py
@@ -73,6 +73,8 @@ class Logic:
             world.nightmare.connect(world.egg, COUNT(SEASHELL, 20))
         elif world_setup.goal in ("raft", "bingo", "bingo-full"):
             world.nightmare.connect(world.egg, egg_trigger)
+        elif isinstance(world_setup.goal, str) and world_setup.goal.startswith("="):
+            world.nightmare.connect(world.egg, AND(egg_trigger, *["INSTRUMENT%s" % c for c in world_setup.goal[1:]]))
         else:
             goal = int(world_setup.goal)
             if goal < 0:

--- a/worlds/ladx/LADXR/patches/goal.py
+++ b/worlds/ladx/LADXR/patches/goal.py
@@ -62,6 +62,18 @@ noinc:
     """), fill_nop=True)
 
 
+def setSpecificInstruments(rom, instruments):
+    rom.texts[0x1A3] = formatText("You need:\n" + "\n".join(["{INSTRUMENT%s}" % (c) for c in instruments]))
+
+    rom.patch(0x19, 0x0BF9, ASM("cp 7"), ASM("cp %d" % (instruments[0] - 1)))
+    code = f"ld hl, $DB65 + {instruments[1] - 1}\nld a, [hl]\n"
+    for n in range(2, len(instruments)):
+        code += f"ld l, $65 + {instruments[n] - 1}\nand [hl]\n"
+    code += "and $02\njp z, $4C1A\njp $4C0B"
+    rom.patch(0x19, 0x3F2B, "00" * 26, ASM(code), fill_nop=True)
+    rom.patch(0x19, 0x0BFE, 0x0C0B, ASM("jp $7F2B"), fill_nop=True)
+
+
 def setSeashellGoal(rom, count):
     rom.texts[0x1A3] = formatText("You need %d {SEASHELL}s" % (count))
 

--- a/worlds/ladx/LADXR/settings.py
+++ b/worlds/ladx/LADXR/settings.py
@@ -135,7 +135,8 @@ Note, some entrances can lead into water, use the warp-to-home from the save&qui
                                                          ('open', 'O', 'Egg already open'), ('random', 'R', 'Random instrument count'),
                                                          ('open-4', '<', 'Random short game (0-4)'), ('5-8', '>', 'Random long game (5-8)'),
                                                          ('seashells', 'S', 'Seashell hunt (20)'), ('bingo', 'b', 'Bingo!'),
-                                                         ('bingo-full', 'B', 'Bingo-25!')], default='8',
+                                                         ('bingo-full', 'B', 'Bingo-25!'),
+                                                         ('specific', 's', '4 specific instruments')], default='8',
                 description="""Changes the goal of the game.
 [1-8 instruments], number of instruments required to open the egg.
 [No instruments] open the egg without instruments, still requires the ocarina with the balled of the windfish

--- a/worlds/ladx/LADXR/worldSetup.py
+++ b/worlds/ladx/LADXR/worldSetup.py
@@ -112,6 +112,10 @@ class WorldSetup:
             self.goal = -1
         elif settings.goal in {"seashells", "bingo", "bingo-full"}:
             self.goal = settings.goal
+        elif settings.goal == "specific":
+            instruments = [c for c in "12345678"]
+            rnd.shuffle(instruments)
+            self.goal = "=" + "".join(instruments[:4])
         elif "-" in settings.goal:
             a, b = settings.goal.split("-")
             if a == "open":

--- a/worlds/ladx/LADXR/worldSetup.py
+++ b/worlds/ladx/LADXR/worldSetup.py
@@ -67,7 +67,7 @@ class WorldSetup:
 
         return entrances
 
-    def randomize(self, settings, rnd):
+    def randomize(self, settings, rnd, ap_options):
         if settings.overworld == "dungeondive":
             self.entrance_mapping = {"d%d" % (n): "d%d" % (n) for n in range(9)}
         if settings.randomstartlocation and settings.entranceshuffle == "none":
@@ -115,7 +115,7 @@ class WorldSetup:
         elif settings.goal == "specific":
             instruments = [c for c in "12345678"]
             rnd.shuffle(instruments)
-            self.goal = "=" + "".join(instruments[:4])
+            self.goal = "=" + "".join(instruments[:ap_options.instrument_count.value])
         elif "-" in settings.goal:
             a, b = settings.goal.split("-")
             if a == "open":

--- a/worlds/ladx/Options.py
+++ b/worlds/ladx/Options.py
@@ -224,7 +224,7 @@ class Goal(Choice, LADXROption):
     [Instruments] The Wind Fish's Egg will only open if you have the required number of Instruments of the Sirens, and play the Ballad of the Wind Fish.
     [Seashells] The Egg will open when you bring 20 seashells. The Ballad and Ocarina are not needed.
     [Open] The Egg will start pre-opened.  
-    [Specific] The Wind Fish's Egg will open with 4 specific instruments, check the sign at the egg to see which.
+    [Specific] The Wind Fish's Egg will open with specific instruments, check the sign at the egg to see which.
     """
     display_name = "Goal"
     ladxr_name = "goal"

--- a/worlds/ladx/Options.py
+++ b/worlds/ladx/Options.py
@@ -224,12 +224,14 @@ class Goal(Choice, LADXROption):
     [Instruments] The Wind Fish's Egg will only open if you have the required number of Instruments of the Sirens, and play the Ballad of the Wind Fish.
     [Seashells] The Egg will open when you bring 20 seashells. The Ballad and Ocarina are not needed.
     [Open] The Egg will start pre-opened.  
+    [Specific] The Wind Fish's Egg will open with 4 specific instruments, check the sign at the egg to see which.
     """
     display_name = "Goal"
     ladxr_name = "goal"
     option_instruments = 1
     option_seashells = 2
     option_open = 3
+    option_specific = 4
 
     default = option_instruments
 

--- a/worlds/ladx/__init__.py
+++ b/worlds/ladx/__init__.py
@@ -126,7 +126,7 @@ class LinksAwakeningWorld(World):
 
         self.ladxr_settings.validate()
         world_setup = LADXRWorldSetup()
-        world_setup.randomize(self.ladxr_settings, self.random)
+        world_setup.randomize(self.ladxr_settings, self.random, self.options)
         self.ladxr_logic = LADXRLogic(configuration_options=self.ladxr_settings, world_setup=world_setup)
         self.ladxr_itempool = LADXRItemPool(self.ladxr_logic, self.ladxr_settings, self.random).toDict()
 

--- a/worlds/ladx/__init__.py
+++ b/worlds/ladx/__init__.py
@@ -444,6 +444,10 @@ class LinksAwakeningWorld(World):
         if not os.path.exists(rom_file):
             raise FileNotFoundError(rom_file)
 
+    def generate_early(self):
+        if self.options.goal == "specific":
+            assert self.options.instrument_count.value > 0, "Specific instrument count cannnot be zero."
+
     def generate_output(self, output_directory: str):
         # copy items back to locations
         for r in self.multiworld.get_regions(self.player):


### PR DESCRIPTION
## What is this fixing or adding?
Adds the specific instruments goal from upstream, where a specific set of instruments are needed to open the egg. The instruments are posted on the sign at the base of the egg. Unlike upstream, the instrument count is variable, and uses the instrument_count option.

## How was this tested?
Light playtesting, needs more

