### PR TITLE
Tests: Use Option.from_any instead of Option() in test_pickle_dumps, which is currently preventing Range options from using default: "random"

### DIFF
--- a/test/general/test_options.py
+++ b/test/general/test_options.py
@@ -78,4 +78,4 @@ class TestOptions(unittest.TestCase):
             if not world_type.hidden:
                 for option_key, option in world_type.options_dataclass.type_hints.items():
                     with self.subTest(game=gamename, option=option_key):
-                        pickle.dumps(option(option.default))
+                        pickle.dumps(option.from_any(option.default))


### PR DESCRIPTION
A Range option using "random" as the default currently fails unit tests.

This is because `test_pickle_dumps` is doing `option(option.default)` when it should be doing `option.from_any(option.default)`, leading to unexpected values in the option constructor.