### PR TITLE
WebHost: Fix 500 server errors for hints involving ItemLink slots on tracker pages

### DIFF
--- a/WebHostLib/templates/genericTracker.html
+++ b/WebHostLib/templates/genericTracker.html
@@ -98,6 +98,8 @@
                             <td>
                                 {% if hint.finding_player == player %}
                                     <b>{{ player_names_with_alias[(team, hint.finding_player)] }}</b>
+                                {% elif get_slot_info(team, hint.finding_player).type == 2 %}
+                                    <i>{{ player_names_with_alias[(team, hint.finding_player)] }}</i>
                                 {% else %}
                                     <a href="{{ url_for("get_player_tracker", tracker=room.tracker, tracked_team=team, tracked_player=hint.finding_player) }}">
                                         {{ player_names_with_alias[(team, hint.finding_player)] }}
@@ -107,6 +109,8 @@
                             <td>
                                 {% if hint.receiving_player == player %}
                                     <b>{{ player_names_with_alias[(team, hint.receiving_player)] }}</b>
+                                {% elif get_slot_info(team, hint.receiving_player).type == 2 %}
+                                    <i>{{ player_names_with_alias[(team, hint.receiving_player)] }}</i>
                                 {% else %}
                                     <a href="{{ url_for("get_player_tracker", tracker=room.tracker, tracked_team=team, tracked_player=hint.receiving_player) }}">
                                         {{ player_names_with_alias[(team, hint.receiving_player)] }}

--- a/WebHostLib/templates/multitrackerHintTable.html
+++ b/WebHostLib/templates/multitrackerHintTable.html
@@ -21,8 +21,20 @@
                     )
                 -%}
                     <tr>
-                        <td>{{ player_names_with_alias[(team, hint.finding_player)] }}</td>
-                        <td>{{ player_names_with_alias[(team, hint.receiving_player)] }}</td>
+                        <td>
+                            {% if get_slot_info(team, hint.finding_player).type == 2 %}
+                                <i>{{ player_names_with_alias[(team, hint.finding_player)] }}</i>
+                            {% else %}
+                                {{ player_names_with_alias[(team, hint.finding_player)] }}
+                            {% endif %}
+                        </td>
+                        <td>
+                            {% if get_slot_info(team, hint.receiving_player).type == 2 %}
+                                <i>{{ player_names_with_alias[(team, hint.receiving_player)] }}</i>
+                            {% else %}
+                                {{ player_names_with_alias[(team, hint.receiving_player)] }}
+                            {% endif %}
+                        </td>
                         <td>{{ item_id_to_name[games[(team, hint.receiving_player)]][hint.item] }}</td>
                         <td>{{ location_id_to_name[games[(team, hint.finding_player)]][hint.location] }}</td>
                         <td>{{ games[(team, hint.finding_player)] }}</td>

--- a/WebHostLib/tracker.py
+++ b/WebHostLib/tracker.py
@@ -423,6 +423,7 @@ def render_generic_tracker(tracker_data: TrackerData, team: int, player: int) ->
         template_name_or_list="genericTracker.html",
         game_specific_tracker=game in _player_trackers,
         room=tracker_data.room,
+        get_slot_info=tracker_data.get_slot_info,
         team=team,
         player=player,
         player_name=tracker_data.get_room_long_player_names()[team, player],
@@ -446,6 +447,7 @@ def render_generic_multiworld_tracker(tracker_data: TrackerData, enabled_tracker
         enabled_trackers=enabled_trackers,
         current_tracker="Generic",
         room=tracker_data.room,
+        get_slot_info=tracker_data.get_slot_info,
         all_slots=tracker_data.get_all_slots(),
         room_players=tracker_data.get_all_players(),
         locations=tracker_data.get_room_locations(),
@@ -497,7 +499,7 @@ if "Factorio" in network_data_package["games"]:
             (team, player): collections.Counter({
                 tracker_data.item_id_to_name["Factorio"][item_id]: count
                 for item_id, count in tracker_data.get_player_inventory_counts(team, player).items()
-            }) for team, players in tracker_data.get_all_slots().items() for player in players
+            }) for team, players in tracker_data.get_all_players().items() for player in players
             if tracker_data.get_player_game(team, player) == "Factorio"
         }
 
@@ -506,6 +508,7 @@ if "Factorio" in network_data_package["games"]:
             enabled_trackers=enabled_trackers,
             current_tracker="Factorio",
             room=tracker_data.room,
+            get_slot_info=tracker_data.get_slot_info,
             all_slots=tracker_data.get_all_slots(),
             room_players=tracker_data.get_all_players(),
             locations=tracker_data.get_room_locations(),
@@ -638,6 +641,7 @@ if "A Link to the Past" in network_data_package["games"]:
             enabled_trackers=enabled_trackers,
             current_tracker="A Link to the Past",
             room=tracker_data.room,
+            get_slot_info=tracker_data.get_slot_info,
             all_slots=tracker_data.get_all_slots(),
             room_players=tracker_data.get_all_players(),
             locations=tracker_data.get_room_locations(),


### PR DESCRIPTION
## What is this fixing or adding?

* Prevent player-specific trackers from attempting to link to an ItemLink player tracker (they do not exist, which is what caused a 500 error).
  * Caused by #3569 not taking item links into account.
* Fixes a 500 server error on the Factorio multi-tracker when item links exist.
* Also makes adjustments to the style for these slots by italicizing its names (including multi-tracker).

## How was this tested?
Tested before/after effects with a game containing item linked players and hints involving said players. Server returns a 500 error before, but no longer does after.

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/user-attachments/assets/94e76f95-ff08-4a98-b58b-eef537b4fec9)
![image](https://github.com/user-attachments/assets/2e8aa055-8566-41c1-84a0-8e2a3b888bdc)
