### PR TITLE
AHiT: Fix reconnecting rift access regions for starting and plando acts

### DIFF
--- a/worlds/ahit/Regions.py
+++ b/worlds/ahit/Regions.py
@@ -740,17 +740,20 @@ def is_valid_first_act(world: "HatInTimeWorld", act: Region) -> bool:
 
 
 def connect_time_rift(world: "HatInTimeWorld", time_rift: Region, exit_region: Region):
-    i = 1
-    while i <= len(rift_access_regions[time_rift.name]):
+    for i, access_region in enumerate(rift_access_regions[time_rift.name], start=1):
+        # Matches the naming convention and iteration order in `create_rift_connections()`.
         name = f"{time_rift.name} Portal - Entrance {i}"
         entrance: Entrance
         try:
-            entrance = world.multiworld.get_entrance(name, world.player)
+            entrance = world.get_entrance(name)
+            # Reconnect the rift access region to the new exit region.
             reconnect_regions(entrance, entrance.parent_region, exit_region)
         except KeyError:
-            time_rift.connect(exit_region, name)
-
-        i += 1
+            # The original entrance to the time rift has been deleted by already reconnecting a telescope act to the
+            # time rift, so create a new entrance from the original rift access region to the new exit region.
+            # Normally, acts and time rifts are sorted such that time rifts are reconnected to acts/rifts first, but
+            # starting acts/rifts and act-plando can reconnect acts to time rifts before this happens.
+            world.get_region(access_region).connect(exit_region, name)
 
 
 def get_shuffleable_act_regions(world: "HatInTimeWorld") -> List[Region]:


### PR DESCRIPTION
## What is this fixing or adding?

Reconnecting an act in a telescope to a time rift removes the entrances to the time rift from its access regions because it will be accessible from the telescope instead.

By doing so early on, as a starting act with insanity act randomizer or as a plando-ed act, this can happen before the time rift itself has been reconnected to an act or other time rift. In which case, when later attempting to connect that time rift to an act or other time rift, the entrances from the rift access regions will no longer exist, so must be re-created. The original code was mistakenly re-creating the entrances from the time rift being reconnected, instead of from the rift access regions.

I'm not sure the entrances need to be removed in the first place and I think a better fix would be to not create the entrances until after act randomization is completed so that all the entrance reconnecting can be entirely avoided, but these changes would be larger, so I have made the simple fix for now.

## How was this tested?
I have been writing logic tests as well as a fixing a number of minor/inconsequential logic issues that are not yet ready for review. The tests were what initially identified this issue.

To reproduce this issue with random seeds, either play with insanity act randomizer and a Chapter 1 or 2 start until a purple Time Rift gets chosen as one of the starting acts, or use act-plando to place Time Rifts on telescope acts, e.g.
```yaml
  ActPlando:
    # Plando acts onto other acts. For example, "Train Rush": "Alpine Free Roam" will place Alpine Free Roam
    # at Train Rush.
    "Alpine Free Roam": "Time Rift - Rumbi Factory"
    "The Illness has Spread": "Time Rift - Sewers"
    "Down with the Mafia!": "Time Rift - Bazaar"
```

The playthrough from fully generating the same seed that failed the test contained a nonsensical path to reach `Time Rift - Deep Sea` because Time Rift levels do not contain Time Rift entrances (indicated by the entrance using the word "Portal"):
```
Deep Sea - Page: Urchin Ledge
        Menu -> Save File -> Spaceship
   =>   Spaceship -> Telescope -> Mafia Town
   =>   Mafia Town -> Mafia Town - Act 1
   =>   Time Rift - Dead Bird Studio -> Time Rift - Dead Bird Studio Portal - Entrance 2
   =>   Time Rift - Deep Sea
```

By visualising the regions, it could be seen that `Time Rift - Dead Bird Studio` (placed at Chapter 1 Act 1) had two unexpected connections to `Time Rift - Deep Sea`, which was actually placed where `Time Rift - Dead Bird Studio` would be in vanilla.

![image](https://github.com/user-attachments/assets/c0b54cc7-6235-452d-abff-45cb78baba06)

---

After this PR, the visualised regions show that `Time Rift - Dead Bird Studio` correctly connects to only the acts placed at Chapter 1 Act 2 and Chapter 1 Act 3, with `Time Rift - Deep Sea` being connected from `Dead Bird Studio` and `Dead Bird Studio Basement` as expected.
![image](https://github.com/user-attachments/assets/59b57f6c-fda6-4647-8dbd-557a4f54e929)
![image](https://github.com/user-attachments/assets/e4fbb204-3f6f-4f5e-9049-120dce5e863c)
