### PR TITLE
TLOZ: Assorted Logic Fixes

### DIFF
--- a/worlds/tloz/Locations.py
+++ b/worlds/tloz/Locations.py
@@ -108,9 +108,13 @@ sword_cave_locations = [
 ]
 
 food_locations = [
-    "Level 7 Map", "Level 7 Boss", "Level 7 Triforce", "Level 7 Key Drop (Goriyas)",
+    "Level 7 Item (Red Candle)", "Level 7 Map", "Level 7 Boss", "Level 7 Triforce", "Level 7 Key Drop (Goriyas)",
     "Level 7 Bomb Drop (Moldorms North)", "Level 7 Bomb Drop (Goriyas North)",
     "Level 7 Bomb Drop (Dodongos)", "Level 7 Rupee Drop (Goriyas North)"
+]
+
+gohma_locations = [
+    "Level 6 Boss", "Level 6 Triforce", "Level 8 Item (Magical Key)", "Level 8 Bomb Drop (Darknuts North)"
 ]
 
 gleeok_locations = [

--- a/worlds/tloz/Rules.py
+++ b/worlds/tloz/Rules.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import add_rule
-from .Locations import food_locations, shop_locations, gleeok_locations
+from .Locations import food_locations, shop_locations, gleeok_locations, gohma_locations
 from .ItemPool import dangerous_weapon_locations
 from .Options import StartingPosition
 
@@ -38,7 +38,8 @@ def set_rules(tloz_world: "TLoZWorld"):
                                         state.has("Heart Container", player, int(hearts / 4))))
             if "Pols Voice" in location.name:  # This enemy needs specific weapons
                 add_rule(world.get_location(location.name, player),
-                         lambda state: state.has_group("swords", player) or state.has("Bow", player))
+                         lambda state: state.has_group("swords", player) or
+                                       (state.has("Bow", player) and state.has_group("arrows", player)))
 
     # No requiring anything in a shop until we can farm for money
     for location in shop_locations:
@@ -58,22 +59,25 @@ def set_rules(tloz_world: "TLoZWorld"):
             add_rule(world.get_location(location.name, player),
                      lambda state: state.has("Stepladder", player))
 
+    # Level 4 Access
+    for location in tloz_world.levels[4].locations:
+        add_rule(world.get_location(location.name, player),
+                 lambda state: state.has("Raft", player) or state.has("Recorder", player))
+
+    # Digdogger boss. Rework this once ER happens
     add_rule(world.get_location("Level 5 Boss", player),
              lambda state: state.has("Recorder", player))
-
-    add_rule(world.get_location("Level 6 Boss", player),
-             lambda state: state.has("Bow", player) and state.has_group("arrows", player))
-
-    add_rule(world.get_location("Level 7 Item (Red Candle)", player),
+    add_rule(world.get_location("Level 5 Triforce", player),
              lambda state: state.has("Recorder", player))
-    add_rule(world.get_location("Level 7 Boss", player),
-             lambda state: state.has("Recorder", player))
-    if options.ExpandedPool:
-        add_rule(world.get_location("Level 7 Key Drop (Stalfos)", player),
-                 lambda state: state.has("Recorder", player))
-        add_rule(world.get_location("Level 7 Bomb Drop (Digdogger)", player),
-                 lambda state: state.has("Recorder", player))
-        add_rule(world.get_location("Level 7 Rupee Drop (Dodongos)", player),
+
+    for location in gohma_locations:
+        if options.ExpandedPool or "Drop" not in location:
+            add_rule(world.get_location(location, player),
+                     lambda state: state.has("Bow", player) and state.has_group("arrows", player))
+
+    # Recorder Access for Level 7
+    for location in tloz_world.levels[7].locations:
+        add_rule(world.get_location(location.name, player),
                  lambda state: state.has("Recorder", player))
 
     for location in food_locations:
@@ -133,15 +137,6 @@ def set_rules(tloz_world: "TLoZWorld"):
         add_rule(world.get_location("Take Any Item Right", player),
                  lambda state: state.has_group("candles", player) or
                                state.has("Raft", player))
-    for location in tloz_world.levels[4].locations:
-        add_rule(world.get_location(location.name, player),
-                 lambda state: state.has("Raft", player) or state.has("Recorder", player))
-    for location in tloz_world.levels[7].locations:
-        add_rule(world.get_location(location.name, player),
-                 lambda state: state.has("Recorder", player))
-    for location in tloz_world.levels[8].locations:
-        add_rule(world.get_location(location.name, player),
-                 lambda state: state.has("Bow", player))
 
     add_rule(world.get_location("Potion Shop Item Left", player),
              lambda state: state.has("Letter", player))

--- a/worlds/tloz/Rules.py
+++ b/worlds/tloz/Rules.py
@@ -62,7 +62,7 @@ def set_rules(tloz_world: "TLoZWorld"):
     # Level 4 Access
     for location in tloz_world.levels[4].locations:
         add_rule(world.get_location(location.name, player),
-                 lambda state: state.has("Raft", player) or state.has("Recorder", player))
+                 lambda state: state.has_any(("Raft", "Recorder"), player))
 
     # Digdogger boss. Rework this once ER happens
     add_rule(world.get_location("Level 5 Boss", player),


### PR DESCRIPTION
## What is this fixing or adding?
- Add needing arrows for Pols Voice rule. Not super necessary at the moment since wooden arrows are always accessible in one of the opening shops, but future proofing for future plans

- Create Gohma Locations and make sure all Gohma blocked locations have the required rule (was missing at least one location before)

- Remove the rule requiring Bow for all locations of level 8 (not sure why that was there, it's theoretically redundant now that Gohma and Pols Voice are properly marked)

- Make sure Digdogger locations properly require Recorder, and clean up redundant Level 7 rules as level 7 currently requires Recorder to access the entrance

- Add a missing Food required location to food_locations

## How was this tested?
ran unit tests (note: was a failed world load for KDL3? haven't been in the loop if that is known or not)

## If this makes graphical changes, please attach screenshots.
N/A