### PR TITLE
Core/Webhost: Add a unit test that games don't have presets with illegal randoms

### DIFF
--- a/test/webhost/test_option_presets.py
+++ b/test/webhost/test_option_presets.py
@@ -63,9 +63,7 @@ class TestOptionPresets(unittest.TestCase):
                                 )
 
     def test_option_preset_dont_have_unsupported_randoms(self):
-        """Test that option preset values are not a special flavor of 'random' or use from_text to resolve another
-        value.
-        """
+        """Test that option presets are not using 'random' on option types that do not support random."""
         option_types_that_dont_support_random = (OptionSet, OptionDict, OptionList)
         for game_name, world_type in AutoWorldRegister.world_types.items():
             presets = world_type.web.options_presets


### PR DESCRIPTION
## What is this fixing or adding?
Some option types do not support "random" as a value, but they are currently allowed in presets. Picking such a preset causes some under-the-hood problems on the webhost page that makes all presets not work anymore until a reload.

Related conversation: https://discord.com/channels/731205301247803413/731214280439103580/1306366651771388038

This PR does not fix any related problems, but it introduces a unit test that should catch these cases.

Currently, the only offender is Stardew Valley, maintained by @agilbert1412 , so it will need to get fixed before this PR can be merged

Waiting on https://github.com/ArchipelagoMW/Archipelago/pull/4206

## How was this tested?
Ran the test, looked at the failing worlds, they match the observed behavior