### PR TITLE
Tests: have option preset validation test do full validation

### DIFF
--- a/test/webhost/test_option_presets.py
+++ b/test/webhost/test_option_presets.py
@@ -1,5 +1,6 @@
 import unittest
 
+from BaseClasses import PlandoOptions
 from worlds import AutoWorldRegister
 from Options import ItemDict, NamedRange, NumericOption, OptionList, OptionSet
 
@@ -14,6 +15,10 @@ class TestOptionPresets(unittest.TestCase):
                     with self.subTest(game=game_name, preset=preset_name, option=option_name):
                         try:
                             option = world_type.options_dataclass.type_hints[option_name].from_any(option_value)
+                            # some options may need verification to ensure the provided option is actually valid
+                            # pass in all plando options in case a preset wants to require certain plando options
+                            # for some reason
+                            option.verify(world_type, "Test Player", PlandoOptions(0b1111))
                             supported_types = [NumericOption, OptionSet, OptionList, ItemDict]
                             if not any([issubclass(option.__class__, t) for t in supported_types]):
                                 self.fail(f"'{option_name}' in preset '{preset_name}' for game '{game_name}' "


### PR DESCRIPTION
## What is this fixing or adding?
The option preset validation test checks that an option class can be created, but some options technically allow invalid creation and do the actual validation separately. This just adds the extra validation to the existing test.

## How was this tested?
Ran before and after commit 4b80b786, failing before it.
