### PR TITLE
Clients: fix high CPU usage when launcher via MultiProcessing

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -710,6 +710,11 @@ class CommonContext:
 
     def run_cli(self):
         if sys.stdin:
+            if sys.stdin.fileno() != 0:
+                from multiprocessing import parent_process
+                if parent_process():
+                    return  # ignore MultiProcessing pipe
+
             # steam overlay breaks when starting console_loop
             if 'gameoverlayrenderer' in os.environ.get('LD_PRELOAD', ''):
                 logger.info("Skipping terminal input, due to conflicting Steam Overlay detected. Please use GUI only.")

--- a/Utils.py
+++ b/Utils.py
@@ -18,6 +18,7 @@ import warnings
 
 from argparse import Namespace
 from settings import Settings, get_settings
+from time import sleep
 from typing import BinaryIO, Coroutine, Optional, Set, Dict, Any, Union
 from typing_extensions import TypeGuard
 from yaml import load, load_all, dump
@@ -568,6 +569,8 @@ def stream_input(stream: typing.TextIO, queue: "asyncio.Queue[str]"):
             else:
                 if text:
                     queue.put_nowait(text)
+                else:
+                    sleep(0.01)  # non-blocking stream
 
     from threading import Thread
     thread = Thread(target=queuer, name=f"Stream handler for {stream.name}", daemon=True)


### PR DESCRIPTION
## What is this fixing or adding?

* Fixes high CPU usage for clients launched via Launcher by not spawning the stream reader if stdin is likely a MultiProcessing pipe
* Also fixes our stream reader to not turn the CPU to 100% for non-blocking files (such as MP pipes)
  * Note: the 10ms sleep is not ideal; we could use blocking select() instead, but I am not sure how well that works cross platform.

## How was this tested?

Running TextClient via Launcher and via terminal