### PR TITLE
SMW: Add Plando Text

### DIFF
--- a/worlds/smw/Names/TextBox.py
+++ b/worlds/smw/Names/TextBox.py
@@ -20,6 +20,10 @@ text_mapping = {
     "#": 0x5A, "(": 0x5B, ")": 0x5C, "'": 0x5D
 }
 
+text_table = {
+    "intro": [0x2A5D9, "Bowser has stolen all of Mario's abilities. Can you help Mario travel across Dinosaur land to get them back and save the Princess from him?"]
+}
+
 title_text_mapping = {
     "A": [0x0A, 0x38], "B": [0x0B, 0x38], "C": [0x0C, 0x38], "D": [0x0D, 0x38], "E": [0x0E, 0x38],
     "F": [0x0F, 0x38], "G": [0x10, 0x38], "H": [0x11, 0x38], "I": [0x12, 0x38], "J": [0x13, 0x38],

--- a/worlds/smw/Options.py
+++ b/worlds/smw/Options.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
-from Options import Choice, Range, Toggle, DeathLink, DefaultOnToggle, OptionGroup, PerGameCommonOptions
+from Options import Choice, Range, Toggle, DeathLink, DefaultOnToggle, OptionGroup, PerGameCommonOptions, PlandoTexts
+from worlds.smw.Names.TextBox import text_table
 
 
 class Goal(Choice):
@@ -397,6 +398,13 @@ class StartingLifeCount(Range):
     range_end = 99
     default = 5
 
+class SMWPlandoTexts(PlandoTexts):
+    """Text plando. Format is:
+    - text: 'This is your text'
+      at: text_key
+      percentage: 100
+    Percentage is an integer from 1 to 100, and defaults to 100 when omitted."""
+    valid_keys = list(text_table.keys())
 
 smw_option_groups = [
     OptionGroup("Goal Options", [
@@ -480,3 +488,4 @@ class SMWOptions(PerGameCommonOptions):
     level_palette_shuffle: LevelPaletteShuffle
     overworld_palette_shuffle: OverworldPaletteShuffle
     starting_life_count: StartingLifeCount
+    plando_texts: SMWPlandoTexts


### PR DESCRIPTION
## What is this fixing or adding?
Adds a plando text option for Super Mario World.

Gives players the ability to change the intro text.

## How was this tested?
Several seed and rom generations with a single SMW player.
- Stress tested by using very long strings. Decided to add trunc anyways.
- Regression tested by removing plando text option and observing vanilla text.

## If this makes graphical changes, please attach screenshots.
```yaml
game: Super Mario World
Super Mario World:
  # ...
  plando_texts:
    - text: "This isn't vanilla."
      at:
        intro: 1
      percent: 99
```
![ArchipelagoMW-SMWPlandoTextDemo](https://github.com/user-attachments/assets/399718ed-9f3f-4125-bb5e-0835b0123505)
