### PR TITLE
HK: Fix charm cost when generating config from website

### DIFF
--- a/worlds/hk/Options.py
+++ b/worlds/hk/Options.py
@@ -266,7 +266,7 @@ class RandomCharmCosts(NamedRange):
     Set to -2 or shuffle to shuffle around the vanilla costs to different charms."""
 
     display_name = "Randomize Charm Notch Costs"
-    range_start = 0
+    range_start = -2
     range_end = 240
     default = -1
     vanilla_costs: typing.List[int] = vanilla_costs


### PR DESCRIPTION
In RandomCharmCosts, range_start and range_end don't cover -1 and -2 (0 to 240).

Because of the way the options webpage is generated, the range input in HTML is also limited to this range and wouldn't return a value below 0 in the generated YAML, even though it was showing a negative value.

Hence, turning every charm cost to 0, instead of the expected vanilla cost for -1 or shuffled for -2.