### PR TITLE
Launcher: ports the _stop fix in the Launcher kivy App to handle_url Popup App

### DIFF
--- a/Launcher.py
+++ b/Launcher.py
@@ -421,7 +421,7 @@ if __name__ == '__main__':
     run_group.add_argument("args", nargs="*",
                            help="Arguments to pass to component.")
     main(parser.parse_args())
-    breakpoint()
+
     from worlds.LauncherComponents import processes
     for process in processes:
         # we await all child processes to close before we tear down the process host

--- a/Launcher.py
+++ b/Launcher.py
@@ -181,6 +181,11 @@ def handle_uri(path: str, launch_args: Tuple[str, ...]) -> None:
                 App.get_running_app().stop()
                 Window.close()
 
+        def _stop(self, *largs):
+            # see run_gui Launcher _stop comment for details
+            self.root_window.close()
+            super()._stop(*largs)
+
     Popup().run()
 
 
@@ -416,7 +421,7 @@ if __name__ == '__main__':
     run_group.add_argument("args", nargs="*",
                            help="Arguments to pass to component.")
     main(parser.parse_args())
-
+    breakpoint()
     from worlds.LauncherComponents import processes
     for process in processes:
         # we await all child processes to close before we tear down the process host


### PR DESCRIPTION
## What is this fixing or adding?
When handling a url for a game that has a url-handling component (ex. `launcher.py "archipelago://test:@localhost?game=The Messenger"`) the popup gives you an option between text client and game-specific component, staying open to allow the user to open both if desired
The issue is if you open a Kivy app (like text client) with that popup closing the popup window without closing all the spawned kivy apps will cause the popup to go unresponsive

This just ports the _stop override in the Launcher App definition to the Popup App definition which fixes the above issue.

## How was this tested?
by doing above steps and seeing it act like I expect it to

## If this makes graphical changes, please attach screenshots.
