### PR TITLE
core: persist hints even if previously found

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -727,14 +727,16 @@ class Context:
             if not hint.local and data not in concerns[hint.finding_player]:
                 concerns[hint.finding_player].append(data)
             # remember hints in all cases
-            if not hint.found:
-                # since hints are bidirectional, finding player and receiving player,
-                # we can check once if hint already exists
-                if hint not in self.hints[team, hint.finding_player]:
-                    self.hints[team, hint.finding_player].add(hint)
+
+            # since hints are bidirectional, finding player and receiving player,
+            # we can check once if hint already exists
+            if hint not in self.hints[team, hint.finding_player]:
+                self.hints[team, hint.finding_player].add(hint)
+                if not hint.found:
                     new_hint_events.add(hint.finding_player)
-                    for player in self.slot_set(hint.receiving_player):
-                        self.hints[team, player].add(hint)
+                for player in self.slot_set(hint.receiving_player):
+                    self.hints[team, player].add(hint)
+                    if not hint.found:
                         new_hint_events.add(player)
 
             self.logger.info("Notice (Team #%d): %s" % (team + 1, format_hint(self, team, hint)))

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -732,12 +732,10 @@ class Context:
             # we can check once if hint already exists
             if hint not in self.hints[team, hint.finding_player]:
                 self.hints[team, hint.finding_player].add(hint)
-                if not hint.found:
-                    new_hint_events.add(hint.finding_player)
+                new_hint_events.add(hint.finding_player)
                 for player in self.slot_set(hint.receiving_player):
                     self.hints[team, player].add(hint)
-                    if not hint.found:
-                        new_hint_events.add(player)
+                    new_hint_events.add(player)
 
             self.logger.info("Notice (Team #%d): %s" % (team + 1, format_hint(self, team, hint)))
         for slot in new_hint_events:


### PR DESCRIPTION
## What is this fixing or adding?
adding already found hints to ctx.hints so create_as_hint=2 knows they were previously hinted and doesn't send the message in chat about them

## How was this tested?
wasn't; vi test it for me please :)

## If this makes graphical changes, please attach screenshots.
