### PR TITLE
Muse Dash: Change AttributeError to KeyError when Create_Item receives an item name that doesn't exist in the world

### DIFF
--- a/worlds/musedash/__init__.py
+++ b/worlds/musedash/__init__.py
@@ -183,7 +183,7 @@ class MuseDashWorld(World):
         if album:
             return MuseDashSongItem(name, self.player, album)
 
-        song = self.md_collection.song_items.get(name)
+        song = self.md_collection.song_items[name]
         return MuseDashSongItem(name, self.player, song)
 
     def get_filler_item_name(self) -> str:

--- a/worlds/musedash/__init__.py
+++ b/worlds/musedash/__init__.py
@@ -183,10 +183,8 @@ class MuseDashWorld(World):
         if album:
             return MuseDashSongItem(name, self.player, album)
 
-        song = self.md_collection.song_items.get(name)
-        if song:
-            return MuseDashSongItem(name, self.player, song)
-        raise KeyError(name)
+        song = self.md_collection.song_items[name]
+        return MuseDashSongItem(name, self.player, song)
 
     def get_filler_item_name(self) -> str:
         return self.random.choices(self.filler_item_names, self.filler_item_weights)[0]

--- a/worlds/musedash/__init__.py
+++ b/worlds/musedash/__init__.py
@@ -183,8 +183,10 @@ class MuseDashWorld(World):
         if album:
             return MuseDashSongItem(name, self.player, album)
 
-        song = self.md_collection.song_items[name]
-        return MuseDashSongItem(name, self.player, song)
+        song = self.md_collection.song_items.get(name)
+        if song:
+            return MuseDashSongItem(name, self.player, song)
+        raise KeyError(name)
 
     def get_filler_item_name(self) -> str:
         return self.random.choices(self.filler_item_names, self.filler_item_weights)[0]


### PR DESCRIPTION
## What is this fixing or adding?
If a bad item exists in the item plando, Muse Dash would throw a `AttributeError` which does not explicitly point out the bad item. This change makes it an explicit `KeyError`, which makes the error similar to what other worlds would show.

## How was this tested?
With tests, and by running the following yaml:
```
name: MuseDash
description: aaaaa
game: Muse Dash
Muse Dash:
  plando_items: [{"items": {"Extra Life": true, "Great to Perfect (10 Pack)": true, "Miss to Great (5 Pack)": true}, "world": "DLC", "force": true, "from_pool": true}]

---
name: DLC
game: DLCQuest
DLCQuest:
  progression_balancing: 0
```
The casing of the items is slightly off which causes the error.
