### PR TITLE
Blasphemous: Add start_inventory_from_pool

### DIFF
--- a/worlds/blasphemous/Options.py
+++ b/worlds/blasphemous/Options.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from Options import Choice, Toggle, DefaultOnToggle, DeathLink, PerGameCommonOptions, OptionGroup
+from Options import Choice, Toggle, DefaultOnToggle, DeathLink, PerGameCommonOptions, StartInventoryPool, OptionGroup
 import random
 
 
@@ -213,6 +213,7 @@ class BlasphemousDeathLink(DeathLink):
 
 @dataclass
 class BlasphemousOptions(PerGameCommonOptions):
+    start_inventory_from_pool: StartInventoryPool
     prie_dieu_warp: PrieDieuWarp
     skip_cutscenes: SkipCutscenes
     corpse_hints: CorpseHints

--- a/worlds/blasphemous/__init__.py
+++ b/worlds/blasphemous/__init__.py
@@ -137,7 +137,6 @@ class BlasphemousWorld(World):
         ]
 
         skipped_items = []
-        junk: int = 0
 
         skipped_items.extend(unrandomized_dict.values())
 
@@ -188,9 +187,6 @@ class BlasphemousWorld(World):
             else:
                 for _ in range(count):
                     pool.append(self.create_item(item["name"]))
-
-        for _ in range(junk):
-            pool.append(self.create_item(self.get_filler_item_name()))
 
         self.multiworld.itempool += pool
 

--- a/worlds/blasphemous/__init__.py
+++ b/worlds/blasphemous/__init__.py
@@ -139,11 +139,6 @@ class BlasphemousWorld(World):
         skipped_items = []
         junk: int = 0
 
-        for item, count in self.options.start_inventory.value.items():
-            for _ in range(count):
-                skipped_items.append(item)
-                junk += 1
-
         skipped_items.extend(unrandomized_dict.values())
 
         if self.options.thorn_shuffle == "vanilla":


### PR DESCRIPTION
## What is this fixing or adding?

Adds `start_inventory_from_pool` and removes the code that made `start_inventory` act like `from_pool`.
The items are now automatically "skipped" and replacement junk items are automatically added. So all the code could be removed.

## How was this tested?

Yamls using both `start_inventory` and `start_inventory_from_pool` with numbers of items in the pool and in excess of the pool.