### PR TITLE
Aquaria: Remove BaseException handling from create_item

### DIFF
--- a/worlds/aquaria/__init__.py
+++ b/worlds/aquaria/__init__.py
@@ -119,14 +119,15 @@ class AquariaWorld(World):
         result: AquariaItem
         try:
             data = item_table[name]
-            classification: ItemClassification = ItemClassification.useful
-            if data.type == ItemType.JUNK:
-                classification = ItemClassification.filler
-            elif data.type == ItemType.PROGRESSION:
-                classification = ItemClassification.progression
-            result = AquariaItem(name, classification, data.id, self.player)
-        except BaseException:
-            raise Exception('The item ' + name + ' is not valid.')
+        except KeyError as e:
+            raise Exception('The item ' + name + ' is not valid.') from e
+
+        classification: ItemClassification = ItemClassification.useful
+        if data.type == ItemType.JUNK:
+            classification = ItemClassification.filler
+        elif data.type == ItemType.PROGRESSION:
+            classification = ItemClassification.progression
+        result = AquariaItem(name, classification, data.id, self.player)
 
         return result
 

--- a/worlds/aquaria/__init__.py
+++ b/worlds/aquaria/__init__.py
@@ -118,7 +118,6 @@ class AquariaWorld(World):
         """
         result: AquariaItem
         data = item_table[name]
-
         classification: ItemClassification = ItemClassification.useful
         if data.type == ItemType.JUNK:
             classification = ItemClassification.filler

--- a/worlds/aquaria/__init__.py
+++ b/worlds/aquaria/__init__.py
@@ -117,10 +117,7 @@ class AquariaWorld(World):
         Create an AquariaItem using 'name' as item name.
         """
         result: AquariaItem
-        try:
-            data = item_table[name]
-        except KeyError as e:
-            raise Exception('The item ' + name + ' is not valid.') from e
+        data = item_table[name]
 
         classification: ItemClassification = ItemClassification.useful
         if data.type == ItemType.JUNK:


### PR DESCRIPTION
## What is this fixing or adding?
Catching `BaseException` without re-raising the exception should almost never be done because `BaseException` includes exit exceptions, such as `SystemExit` and `KeyboardInterrupt`.

Ideally, the caught exception types should be as narrow as possible to not mask bugs from catching unexpected exceptions. Having narrow exception types can also help indicate to other developers what exceptions are expected to be raisable by the code within the `try` clause.

Similarly, the `try` clause should ideally contain the minimum code necessary, to avoid masking bugs in the case that code within the `try` clause that is not expected to raise an exception does so.

In this case, the only expected exception that can occur appears to be `item_table[name]` that can raise a `KeyError` when `create_item()` is passed an unexpected `name` argument. This patch removes the try-except in favour of letting the `KeyError` be propagated as is.

## How was this tested?
I modified the world's code to force the world to try to create an item from a non-existent item name and observed the raised exception.
