### PR TITLE
Adventure: `create_item` AttributeError -> KeyError

### DIFF
--- a/worlds/adventure/__init__.py
+++ b/worlds/adventure/__init__.py
@@ -446,7 +446,7 @@ class AdventureWorld(World):
     # end of ordered Main.py calls
 
     def create_item(self, name: str) -> Item:
-        item_data: ItemData = item_table.get(name)
+        item_data: ItemData = item_table[name]
         return AdventureItem(name, item_data.classification, item_data.id, self.player)
 
     def create_event(self, name: str, classification: ItemClassification) -> Item:


### PR DESCRIPTION
## What is this fixing or adding?

Changes the error from an invalid item name (such as from plando) to KeyError instead of causing an AttributeError on the next line from the `get` default of `None`

## How was this tested?

Generations and using plando