### PR TITLE
Core: adds a custom KeyError for invalid item names

### DIFF
--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -21,6 +21,10 @@ if TYPE_CHECKING:
 perf_logger = logging.getLogger("performance")
 
 
+class InvalidItemError(KeyError):
+    pass
+
+
 class AutoWorldRegister(type):
     world_types: Dict[str, Type[World]] = {}
     __file__: str


### PR DESCRIPTION
## What is this fixing or adding?
adds a custom KeyError for raising on world.create_item() if the passed in name is invalid

Note: I will restate here as well I'm on the camp of core should be validating item names in plando blocks (like other item names from user input), but if the want to make plando or similar generic is enough that core cannot do that due diligence and we want a way to signal up from create_item that the inputs are invalid, it should be explicit, hence the need for an explicit exception

## How was this tested?
added heavy handed error checking to musedash then plando'd `thingy_mc_bobber`
saw `worlds.AutoWorld.InvalidItemError: 'Invalid item thingy_mc_bobber'` in the generate log


## If this makes graphical changes, please attach screenshots.
