### PR TITLE
Core: Log warnings at call site, not Utils itself

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -875,8 +875,7 @@ class DeprecateDict(dict):
         if self.should_error:
             deprecate(self.log_message)
         elif __debug__:
-            import warnings
-            warnings.warn(self.log_message)
+            warnings.warn(self.log_message, stacklevel=2)
         return super().__getitem__(item)
 
 

--- a/Utils.py
+++ b/Utils.py
@@ -855,11 +855,10 @@ def async_start(co: Coroutine[None, None, typing.Any], name: Optional[str] = Non
     task.add_done_callback(_faf_tasks.discard)
 
 
-def deprecate(message: str):
+def deprecate(message: str, add_stacklevels: int = 0):
     if __debug__:
         raise Exception(message)
-    import warnings
-    warnings.warn(message)
+    warnings.warn(message, stacklevel=2 + add_stacklevels)
 
 
 class DeprecateDict(dict):
@@ -873,7 +872,7 @@ class DeprecateDict(dict):
 
     def __getitem__(self, item: Any) -> Any:
         if self.should_error:
-            deprecate(self.log_message)
+            deprecate(self.log_message, add_stacklevels=1)
         elif __debug__:
             warnings.warn(self.log_message, stacklevel=2)
         return super().__getitem__(item)


### PR DESCRIPTION
## What is this fixing or adding?

When I run tests to generate all supported games, I get a lot of warnings like this:

```
Utils.py:879: UserWarning: Getting options from multiworld is now deprecated. Please use `self.options.enemy_shuffle` instead.
  warnings.warn(self.log_message)
Utils.py:879: UserWarning: Getting options from multiworld is now deprecated. Please use `self.options.enemy_health` instead.     
  warnings.warn(self.log_message)
Utils.py:879: UserWarning: Getting options from multiworld is now deprecated. Please use `self.options.accessibility` instead.    
  warnings.warn(self.log_message)
```

Adding in the appropriate keyword argument to the `warnings` library produces the actual code that needs to be updated:

```
worlds\alttp\__init__.py:844: UserWarning: Getting options from multiworld is now deprecated. Please use `self.options.glitches_required` instead.
  if self.multiworld.glitches_required[player] == 'no_logic':
worlds\alttp\__init__.py:846: UserWarning: Getting options from multiworld is now deprecated. Please use `self.options.small_key_shuffle` instead.
  if self.multiworld.small_key_shuffle[player] == small_key_shuffle.option_universal:
worlds\alttp\StateHelpers.py:27: UserWarning: Getting options from multiworld is now deprecated. Please use `self.options.retro_bow` instead.
  if state.multiworld.retro_bow[player]:
```

## How was this tested?
`python Generate.py --seed=42 --skip_output` before and after, and then with deliberate usage of `sweep_for_events` and setting `should_error` to True for options access (in order to cover `add_stacklevels`).
