### PR TITLE
Various Worlds: use / explicitly for pkgutil

### DIFF
--- a/worlds/kdl3/regions.py
+++ b/worlds/kdl3/regions.py
@@ -57,7 +57,7 @@ def generate_valid_level(world: "KDL3World", level: int, stage: int,
 
 def generate_rooms(world: "KDL3World", level_regions: Dict[int, Region]) -> None:
     level_names = {location_name.level_names[level]: level for level in location_name.level_names}
-    room_data = orjson.loads(get_data(__name__, os.path.join("data", "Rooms.json")))
+    room_data = orjson.loads(get_data(__name__, "data/Rooms.json"))
     rooms: Dict[str, KDL3Room] = dict()
     for room_entry in room_data:
         room = KDL3Room(room_entry["name"], world.player, world.multiworld, None, room_entry["level"],

--- a/worlds/kdl3/rom.py
+++ b/worlds/kdl3/rom.py
@@ -313,7 +313,7 @@ def handle_level_sprites(stages: List[Tuple[int, ...]], sprites: List[bytearray]
 def write_heart_star_sprites(rom: RomData) -> None:
     compressed = rom.read_bytes(heart_star_address, heart_star_size)
     decompressed = hal_decompress(compressed)
-    patch = get_data(__name__, os.path.join("data", "APHeartStar.bsdiff4"))
+    patch = get_data(__name__, "data/APHeartStar.bsdiff4")
     patched = bytearray(bsdiff4.patch(decompressed, patch))
     rom.write_bytes(0x1AF7DF, patched)
     patched[0:0] = [0xE3, 0xFF]
@@ -327,10 +327,10 @@ def write_consumable_sprites(rom: RomData, consumables: bool, stars: bool) -> No
     decompressed = hal_decompress(compressed)
     patched = bytearray(decompressed)
     if consumables:
-        patch = get_data(__name__, os.path.join("data", "APConsumable.bsdiff4"))
+        patch = get_data(__name__, "data/APConsumable.bsdiff4")
         patched = bytearray(bsdiff4.patch(bytes(patched), patch))
     if stars:
-        patch = get_data(__name__, os.path.join("data", "APStars.bsdiff4"))
+        patch = get_data(__name__, "data/APStars.bsdiff4")
         patched = bytearray(bsdiff4.patch(bytes(patched), patch))
     patched[0:0] = [0xE3, 0xFF]
     patched.append(0xFF)
@@ -380,7 +380,7 @@ class KDL3ProcedurePatch(APProcedurePatch, APTokenMixin):
 
 def patch_rom(world: "KDL3World", patch: KDL3ProcedurePatch) -> None:
     patch.write_file("kdl3_basepatch.bsdiff4",
-                     get_data(__name__, os.path.join("data", "kdl3_basepatch.bsdiff4")))
+                     get_data(__name__, "data/kdl3_basepatch.bsdiff4"))
 
     # Write open world patch
     if world.options.open_world:

--- a/worlds/ladx/LADXR/patches/bank34.py
+++ b/worlds/ladx/LADXR/patches/bank34.py
@@ -75,7 +75,7 @@ def addBank34(rom, item_list):
     .notCavesA:
         add  hl, de
         ret
-    """ + pkgutil.get_data(__name__, os.path.join("bank3e.asm", "message.asm")).decode().replace("\r", ""), 0x4000), fill_nop=True)
+    """ + pkgutil.get_data(__name__, "bank3e.asm/message.asm").decode().replace("\r", ""), 0x4000), fill_nop=True)
 
     nextItemLookup = ItemNameStringBufferStart
     nameLookup = {

--- a/worlds/ladx/LADXR/patches/bank3e.py
+++ b/worlds/ladx/LADXR/patches/bank3e.py
@@ -56,7 +56,7 @@ def addBank3E(rom, seed, player_id, player_name_list):
     """))
 
     def get_asm(name):
-        return pkgutil.get_data(__name__, os.path.join("bank3e.asm", name)).decode().replace("\r", "")
+        return pkgutil.get_data(__name__, "bank3e.asm/" + name).decode().replace("\r", "")
 
     rom.patch(0x3E, 0x0000, 0x2F00, ASM("""
         call MainJumpTable

--- a/worlds/lingo/static_logic.py
+++ b/worlds/lingo/static_logic.py
@@ -107,7 +107,7 @@ def load_static_data_from_file():
                 return getattr(safe_builtins, name)
             raise pickle.UnpicklingError(f"global '{module}.{name}' is forbidden")
 
-    file = pkgutil.get_data(__name__, os.path.join("data", "generated.dat"))
+    file = pkgutil.get_data(__name__, "data/generated.dat")
     pickdata = RenameUnpickler(BytesIO(file)).load()
         
     HASHES.update(pickdata["HASHES"])

--- a/worlds/minecraft/Constants.py
+++ b/worlds/minecraft/Constants.py
@@ -3,7 +3,7 @@ import json
 import pkgutil
 
 def load_data_file(*args) -> dict:
-    fname = os.path.join("data", *args)
+    fname = "/".join("data", *args)
     return json.loads(pkgutil.get_data(__name__, fname).decode())
 
 # For historical reasons, these values are different.

--- a/worlds/minecraft/Constants.py
+++ b/worlds/minecraft/Constants.py
@@ -3,7 +3,7 @@ import json
 import pkgutil
 
 def load_data_file(*args) -> dict:
-    fname = "/".join("data", *args)
+    fname = "/".join(["data", *args])
     return json.loads(pkgutil.get_data(__name__, fname).decode())
 
 # For historical reasons, these values are different.

--- a/worlds/mm2/rom.py
+++ b/worlds/mm2/rom.py
@@ -126,7 +126,7 @@ class MM2ProcedurePatch(APProcedurePatch, APTokenMixin):
 
 
 def patch_rom(world: "MM2World", patch: MM2ProcedurePatch) -> None:
-    patch.write_file("mm2_basepatch.bsdiff4", pkgutil.get_data(__name__, os.path.join("data", "mm2_basepatch.bsdiff4")))
+    patch.write_file("mm2_basepatch.bsdiff4", pkgutil.get_data(__name__, "data/mm2_basepatch.bsdiff4"))
     # text writing
     patch.write_bytes(0x37E2A, MM2TextEntry("FOR           ", 0xCB).resolve())
     patch.write_bytes(0x37EAA, MM2TextEntry("GET EQUIPPED  ", 0x0B).resolve())

--- a/worlds/shivers/Constants.py
+++ b/worlds/shivers/Constants.py
@@ -3,7 +3,7 @@ import json
 import pkgutil
 
 def load_data_file(*args) -> dict:
-    fname = os.path.join("data", *args)
+    fname = "/".join("data", *args)
     return json.loads(pkgutil.get_data(__name__, fname).decode())
 
 location_id_offset: int = 27000

--- a/worlds/shivers/Constants.py
+++ b/worlds/shivers/Constants.py
@@ -3,7 +3,7 @@ import json
 import pkgutil
 
 def load_data_file(*args) -> dict:
-    fname = "/".join("data", *args)
+    fname = "/".join(["data", *args])
     return json.loads(pkgutil.get_data(__name__, fname).decode())
 
 location_id_offset: int = 27000


### PR DESCRIPTION
## What is this fixing or adding?
patches various worlds to use "/" explicitly instead of os.path.join for pkgutil

to any world dev who wants to pr this change yourself just suggest removing your world's change / say so and I will remove

## How was this tested?
wasn't

## If this makes graphical changes, please attach screenshots.
