### PR TITLE
TUNIC: Add clarifying comment to item links handling

### DIFF
--- a/worlds/tunic/__init__.py
+++ b/worlds/tunic/__init__.py
@@ -432,6 +432,7 @@ class TunicWorld(World):
         # this would be in a stage if there was an appropriate stage for it
         self.player_item_link_locations = {}
         groups = self.multiworld.get_player_groups(self.player)
+        # checking if groups so that this doesn't run if the player isn't in a group
         if groups:
             if not self.item_link_locations:
                 tunic_worlds: Tuple[TunicWorld] = self.multiworld.get_game_worlds("TUNIC")


### PR DESCRIPTION
## What is this fixing or adding?
Was effectively requested to add a clarifying comment for the item link handling code, to make it clear that it's not looping over every location in the multiworld for slots that aren't in an item link in a world that contains item links.