### PR TITLE
Timespinner: Re-added missing enmemy rando option

### DIFF
--- a/worlds/timespinner/Options.py
+++ b/worlds/timespinner/Options.py
@@ -379,6 +379,7 @@ class TimespinnerOptions(PerGameCommonOptions, DeathLinkMixin):
     cantoran: Cantoran
     lore_checks: LoreChecks
     boss_rando: BossRando
+    enemy_rando: EnemyRando
     damage_rando: DamageRando
     damage_rando_overrides: DamageRandoOverrides
     hp_cap: HpCap
@@ -445,6 +446,7 @@ class BackwardsCompatiableTimespinnerOptions(TimespinnerOptions):
     Cantoran: hidden(Cantoran) # type: ignore
     LoreChecks: hidden(LoreChecks) # type: ignore
     BossRando: hidden(BossRando) # type: ignore
+    EnemyRando: hidden(EnemyRando) # type: ignore
     DamageRando: hidden(DamageRando) # type: ignore
     DamageRandoOverrides: HiddenDamageRandoOverrides
     HpCap: hidden(HpCap) # type: ignore
@@ -515,6 +517,10 @@ class BackwardsCompatiableTimespinnerOptions(TimespinnerOptions):
         if self.BossRando != BossRando.default and \
             self.boss_rando == BossRando.default:
             self.boss_rando.value = self.BossRando.value
+            self.has_replaced_options.value = Toggle.option_true
+        if self.EnemyRando != EnemyRando.default and \
+            self.enemy_rando == EnemyRando.default:
+            self.enemy_rando.value = self.EnemyRando.value
             self.has_replaced_options.value = Toggle.option_true
         if self.DamageRando != DamageRando.default and \
             self.damage_rando == DamageRando.default:

--- a/worlds/timespinner/__init__.py
+++ b/worlds/timespinner/__init__.py
@@ -98,6 +98,7 @@ class TimespinnerWorld(World):
             "Cantoran": self.options.cantoran.value,
             "LoreChecks": self.options.lore_checks.value,
             "BossRando": self.options.boss_rando.value,
+            "EnemyRando": self.options.enemy_rando.value,
             "DamageRando": self.options.damage_rando.value,
             "DamageRandoOverrides": self.options.damage_rando_overrides.value,
             "HpCap": self.options.hp_cap.value,


### PR DESCRIPTION
This is found on RC2/3 for 5.1, i am not sure if this is a major enough issue to delay an RC, but its also quite a low impacting change so maybe it can get in it dunno

## What is this fixing or adding?

During option migration to snake_case #2485 , the enemy rando option was missed

## How was this tested?

a few local generation and verified in spoiler that the value was correctly taken over
