### PR TITLE
id Tech: Standardizing ResetLevelOnDeath display

### DIFF
--- a/worlds/doom_1993/Options.py
+++ b/worlds/doom_1993/Options.py
@@ -112,7 +112,7 @@ class StartWithComputerAreaMaps(Toggle):
 class ResetLevelOnDeath(DefaultOnToggle):
     """When dying, levels are reset and monsters respawned. But inventory and checks are kept.
     Turning this setting off is considered easy mode. Good for new players that don't know the levels well."""
-    display_name="Reset Level on Death"
+    display_name = "Reset Level on Death"
 
 
 class Episode1(DefaultOnToggle):

--- a/worlds/doom_ii/Options.py
+++ b/worlds/doom_ii/Options.py
@@ -102,7 +102,7 @@ class StartWithComputerAreaMaps(Toggle):
 class ResetLevelOnDeath(DefaultOnToggle):
     """When dying, levels are reset and monsters respawned. But inventory and checks are kept.
     Turning this setting off is considered easy mode. Good for new players that don't know the levels well."""
-    display_message="Reset level on death"
+    display_name = "Reset Level on Death"
 
 
 class Episode1(DefaultOnToggle):

--- a/worlds/heretic/Options.py
+++ b/worlds/heretic/Options.py
@@ -104,7 +104,7 @@ class StartWithMapScrolls(Toggle):
 class ResetLevelOnDeath(DefaultOnToggle):
     """When dying, levels are reset and monsters respawned. But inventory and checks are kept.
     Turning this setting off is considered easy mode. Good for new players that don't know the levels well."""
-    display_message="Reset level on death"
+    display_name = "Reset Level on Death"
 
     
 class CheckSanity(Toggle):


### PR DESCRIPTION
## What is this fixing or adding?

Changes the capitalization of "Reset Level on Death" to be the same for all three games and also changes DOOM II and Heretic to actually use `display_name` now.

## How was this tested?

Locally run webhost and a custom unit test to find visible options without a display_name.

## If this makes graphical changes, please attach screenshots.

![OLD](https://github.com/user-attachments/assets/a0aa8ce8-9ae1-4f80-bc9b-0f72288d486a)

![NEW](https://github.com/user-attachments/assets/8a591b5a-4ac8-46e8-8ea1-f0fa7a03468e)
