### PR TITLE
Zillion: Add display_name to ZillionSkill

### DIFF
--- a/worlds/zillion/options.py
+++ b/worlds/zillion/options.py
@@ -233,6 +233,7 @@ class ZillionSkill(Range):
     range_start = 0
     range_end = 5
     default = 2
+    display_name = "skill"
 
 
 class ZillionStartingCards(NamedRange):


### PR DESCRIPTION
## What is this fixing or adding?

Adds a display_name to the only option that didn't have one following the styling of other display names

## How was this tested?

Local webhost0

## If this makes graphical changes, please attach screenshots.

![OLD](https://github.com/user-attachments/assets/a3d32b08-2dfc-4b61-ad21-bfe2c36f8fbd)

![NEW](https://github.com/user-attachments/assets/60d485d6-a884-42cc-bffc-6b100e4d5395)

(Yes, they look the exact same)