### PR TITLE
[FFMQ] Fix all checks sending on hard reset + stronger read validation check

### DIFF
--- a/worlds/ffmq/Client.py
+++ b/worlds/ffmq/Client.py
@@ -52,10 +52,9 @@ def validate_read_state(data1, data2):
 
     if data1 is None or data2 is None:
         return False
-    else:
-        for i in range(6):
-            if data1[i] != validation_array[i] or data2[i] != validation_array[i]:
-                return False;
+    for i in range(6):
+        if data1[i] != validation_array[i] or data2[i] != validation_array[i]:
+            return False;
     return True
     
    

--- a/worlds/ffmq/Client.py
+++ b/worlds/ffmq/Client.py
@@ -47,6 +47,18 @@ def get_flag(data, flag):
     bit = int(0x80 / (2 ** (flag % 8)))
     return (data[byte] & bit) > 0
 
+def validate_read_state(data1, data2):
+    validation_aray = bytes([0x01, 0x46, 0x46, 0x4D, 0x51, 0x52])
+
+    if data1 is None or data2 is None:
+        return False
+    else:
+        for i in range(6):
+            if data1[i] != validation_aray[i] or data2[i] != validation_aray[i]:
+                return False;
+    return True
+    
+   
 
 class FFMQClient(SNIClient):
     game = "Final Fantasy Mystic Quest"
@@ -67,11 +79,11 @@ class FFMQClient(SNIClient):
     async def game_watcher(self, ctx):
         from SNIClient import snes_buffered_write, snes_flush_writes, snes_read
 
-        check_1 = await snes_read(ctx, 0xF53749, 1)
+        check_1 = await snes_read(ctx, 0xF53749, 6)
         received = await snes_read(ctx, RECEIVED_DATA[0], RECEIVED_DATA[1])
         data = await snes_read(ctx, READ_DATA_START, READ_DATA_END - READ_DATA_START)
-        check_2 = await snes_read(ctx, 0xF53749, 1)
-        if (check_1 is None or check_2 is None) or (check_1 != b'\x01' or check_2 != b'\x01'):
+        check_2 = await snes_read(ctx, 0xF53749, 6)
+        if validate_read_state(check_1, check_2) == False:
             return
 
         def get_range(data_range):

--- a/worlds/ffmq/Client.py
+++ b/worlds/ffmq/Client.py
@@ -71,7 +71,7 @@ class FFMQClient(SNIClient):
         received = await snes_read(ctx, RECEIVED_DATA[0], RECEIVED_DATA[1])
         data = await snes_read(ctx, READ_DATA_START, READ_DATA_END - READ_DATA_START)
         check_2 = await snes_read(ctx, 0xF53749, 1)
-        if check_1 != b'\x01' or check_2 != b'\x01':
+        if (check_1 is None or check_2 is None) or (check_1 != b'\x01' or check_2 != b'\x01'):
             return
 
         def get_range(data_range):

--- a/worlds/ffmq/Client.py
+++ b/worlds/ffmq/Client.py
@@ -82,7 +82,7 @@ class FFMQClient(SNIClient):
         received = await snes_read(ctx, RECEIVED_DATA[0], RECEIVED_DATA[1])
         data = await snes_read(ctx, READ_DATA_START, READ_DATA_END - READ_DATA_START)
         check_2 = await snes_read(ctx, 0xF53749, 6)
-        if validate_read_state(check_1, check_2) == False:
+        if not validate_read_state(check_1, check_2):
             return
 
         def get_range(data_range):

--- a/worlds/ffmq/Client.py
+++ b/worlds/ffmq/Client.py
@@ -48,13 +48,13 @@ def get_flag(data, flag):
     return (data[byte] & bit) > 0
 
 def validate_read_state(data1, data2):
-    validation_aray = bytes([0x01, 0x46, 0x46, 0x4D, 0x51, 0x52])
+    validation_array = bytes([0x01, 0x46, 0x46, 0x4D, 0x51, 0x52])
 
     if data1 is None or data2 is None:
         return False
     else:
         for i in range(6):
-            if data1[i] != validation_aray[i] or data2[i] != validation_aray[i]:
+            if data1[i] != validation_array[i] or data2[i] != validation_array[i]:
                 return False;
     return True
     


### PR DESCRIPTION
## What is this fixing or adding?

SNIClient's task will die sometime (like on hard resets) and FFMQ's client will pass the validation check when it's not supposed to on some emulator. This fix the issue by checking None type and adding a stronger validation check.

## How was this tested?
Test was done on a known seed that would reliably trigger the behaviour on hard reset.
