### PR TITLE
HK: Fix Nondeterministic Behavior

### DIFF
--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -231,7 +231,7 @@ class HKWorld(World):
             all_event_names.update(set(godhome_event_names))
 
         # Link regions
-        for event_name in all_event_names:
+        for event_name in sorted(all_event_names):
             #if event_name in wp_exclusions:
             #    continue
             loc = HKLocation(self.player, event_name, None, menu_region)


### PR DESCRIPTION
## What is this fixing or adding?

`all_event_names` is a set and iterating over a set is nondeterministic. This sorts the set.
Yes, they're events, so it doesn't _really_ matter, I hope, but it's an easy change.

## How was this tested?

Generations and the [Determinism Test PR](https://github.com/ArchipelagoMW/Archipelago/pull/2819)

@qwint @BadMagic100 
