### PR TITLE
Core: Add SaveInitialValueMixin for Options

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -194,12 +194,12 @@ class Option(typing.Generic[T], metaclass=AssembleOptions):
 class SaveInitialValueMixin:
     initial_value: typing.Any
 
-    def __init_subclass__(cls: type(Option), **kwargs):
+    def __init_subclass__(cls: typing.Type[Option], **kwargs) -> None:
         super().__init_subclass__(**kwargs)
 
         original_from_any = cls.from_any
 
-        def from_any_wrapped(_, data: typing.Any):
+        def from_any_wrapped(_, data: typing.Any) -> Option:
             ret = original_from_any(data)
             ret.initial_value = data
             return ret

--- a/Options.py
+++ b/Options.py
@@ -191,6 +191,22 @@ class Option(typing.Generic[T], metaclass=AssembleOptions):
             pass
 
 
+class SaveInitialValueMixin:
+    initial_value: typing.Any
+
+    def __init_subclass__(cls: type(Option), **kwargs):
+        super().__init_subclass__(**kwargs)
+
+        original_from_any = cls.from_any
+
+        def from_any_wrapped(_, data: typing.Any):
+            ret = original_from_any(data)
+            ret.initial_value = data
+            return ret
+
+        cls.from_any = classmethod(from_any_wrapped)
+
+
 class FreeText(Option[str]):
     """Text option that allows users to enter strings.
     Needs to be validated by the world or option definition."""


### PR DESCRIPTION
I mostly don't know what I'm doing, but it seems to work.

Please god help me with the typing.

Also, this probably doesn't actually make sense until https://github.com/ArchipelagoMW/Archipelago/pull/2169 is merged

Lots of applications, but for me the motivation of this is so that you can know whether an option was random, and then potentially even *reroll* by just calling from_any again.

## Tested

Changed Witness option `PuzzleRandomizationSeed` to this:

```py
class PuzzleRandomizationSeed(Range, SaveInitialValueMixin):
    range_start = 1
    range_end = 9999999
    default = "random"
```

And then printed out `self.options.puzzle_randomization_seed.initial_value` somewhere, and it correctly came up with "random".