### PR TITLE
SC2: Fix wrongly classified location type

### DIFF
--- a/worlds/sc2/Locations.py
+++ b/worlds/sc2/Locations.py
@@ -1387,7 +1387,7 @@ def get_locations(world: Optional[World]) -> Tuple[LocationData, ...]:
                      lambda state: logic.templars_return_requirement(state)),
         LocationData("The Host", "The Host: Victory", SC2LOTV_LOC_ID_OFFSET + 2100, LocationType.VICTORY,
                      lambda state: logic.the_host_requirement(state)),
-        LocationData("The Host", "The Host: Southeast Void Shard", SC2LOTV_LOC_ID_OFFSET + 2101, LocationType.VICTORY,
+        LocationData("The Host", "The Host: Southeast Void Shard", SC2LOTV_LOC_ID_OFFSET + 2101, LocationType.EXTRA,
                      lambda state: logic.the_host_requirement(state)),
         LocationData("The Host", "The Host: South Void Shard", SC2LOTV_LOC_ID_OFFSET + 2102, LocationType.EXTRA,
                      lambda state: logic.the_host_requirement(state)),


### PR DESCRIPTION
## What is this fixing or adding?
Fixes location classification. This location isn't a victory one.

## How was this tested?
Generated a YAML where the bug triggered (only victory locations were allowed) and the offending location is gone

## If this makes graphical changes, please attach screenshots.
No