### PR TITLE
Stardew Valley - Update documentation 5.x.x links into 6.x.x links

### DIFF
--- a/worlds/stardew_valley/docs/en_Stardew Valley.md
+++ b/worlds/stardew_valley/docs/en_Stardew Valley.md
@@ -138,7 +138,7 @@ This means that, for these specific mods, if you decide to include them in your 
 with the assumption that you will install and play with these mods. The multiworld will contain related items and locations
 for these mods, the specifics will vary from mod to mod
 
-[Supported Mods Documentation](https://github.com/agilbert1412/StardewArchipelago/blob/5.x.x/Documentation/Supported%20Mods.md)
+[Supported Mods Documentation](https://github.com/agilbert1412/StardewArchipelago/blob/6.x.x/Documentation/Supported%20Mods.md)
 
 List of supported mods:
 

--- a/worlds/stardew_valley/docs/setup_en.md
+++ b/worlds/stardew_valley/docs/setup_en.md
@@ -12,7 +12,7 @@
 - Archipelago from the [Archipelago Releases Page](https://github.com/ArchipelagoMW/Archipelago/releases)
     * (Only for the TextClient)
 - Other Stardew Valley Mods [Nexus Mods](https://www.nexusmods.com/stardewvalley)
-    * There are [supported mods](https://github.com/agilbert1412/StardewArchipelago/blob/5.x.x/Documentation/Supported%20Mods.md) 
+    * There are [supported mods](https://github.com/agilbert1412/StardewArchipelago/blob/6.x.x/Documentation/Supported%20Mods.md) 
   that you can add to your yaml to include them with the Archipelago randomization
 
     * It is **not** recommended to further mod Stardew Valley with unsupported mods, although it is possible to do so. 


### PR DESCRIPTION
## What is this fixing or adding?
A couple links were missed during the transition. Discord user CelestialBlade found this bug about 3 hours after the release, so here's the fix

## How was this tested?
It's documentation
