### PR TITLE
Pokemon RB - Fix Incorrect Item Location in Victory Road 2F

### DIFF
--- a/worlds/pokemon_rb/locations.py
+++ b/worlds/pokemon_rb/locations.py
@@ -223,7 +223,7 @@ location_data = [
                  Missable(92)),
     LocationData("Victory Road 2F-C", "East Item", "Full Heal", rom_addresses["Missable_Victory_Road_2F_Item_2"],
                  Missable(93)),
-    LocationData("Victory Road 2F-W", "West Item", "TM05 Mega Kick", rom_addresses["Missable_Victory_Road_2F_Item_3"],
+    LocationData("Victory Road 2F-C", "West Item", "TM05 Mega Kick", rom_addresses["Missable_Victory_Road_2F_Item_3"],
                  Missable(94)),
     LocationData("Victory Road 2F-NW", "North Item Near Moltres", "Guard Spec", rom_addresses["Missable_Victory_Road_2F_Item_4"],
                  Missable(95)),


### PR DESCRIPTION
## What is this fixing or adding?
Corrects the location of an item pointed out in #4202 (and also on the Discord)

## How was this tested?
You can visually see the TM05 (Mega Kick) item should belong in "Victory Road 2F-C" and not "Victory Road 2F-W".
![image](https://github.com/user-attachments/assets/26aa045d-02b9-4d6a-b951-fcc5917452bf)
