### PR TITLE
Webhost: Make YGO 06 setup title match page

### DIFF
--- a/worlds/yugioh06/__init__.py
+++ b/worlds/yugioh06/__init__.py
@@ -50,7 +50,7 @@ from .client_bh import YuGiOh2006Client
 class Yugioh06Web(WebWorld):
     theme = "stone"
     setup = Tutorial(
-        "Multiworld Setup Tutorial",
+        "Multiworld Setup Guide",
         "A guide to setting up Yu-Gi-Oh! - Ultimate Masters Edition - World Championship Tournament 2006 "
         "for Archipelago on your computer.",
         "English",


### PR DESCRIPTION
## What is this fixing or adding?
Make Guide title match the rest of the set up guides on the webhost


## How was this tested?
I looked at the changes

## If this makes graphical changes, please attach screenshots.
