### PR TITLE
WebHost: Fix crash on advanced options when a Range option uses "random" as its default

### DIFF
--- a/WebHostLib/templates/weightedOptions/macros.html
+++ b/WebHostLib/templates/weightedOptions/macros.html
@@ -53,7 +53,7 @@
     <table class="range-rows" data-option="{{ option_name }}">
         <tbody>
             {{ RangeRow(option_name, option, option.range_start, option.range_start, True) }}
-            {% if option.range_start < option.default < option.range_end %}
+            {% if option.default is number and option.range_start < option.default < option.range_end %}
                 {{ RangeRow(option_name, option, option.default, option.default, True) }}
             {% endif %}
             {{ RangeRow(option_name, option, option.range_end, option.range_end, True) }}


### PR DESCRIPTION
This whole code looks a bit jank to me, but I don't think I'm capable of improving it.
Anyway, this problem means that you currently cannot access https://archipelago.gg/games/The%20Witness/weighted-options

Tested: Mostly just checked whether it works after