### PR TITLE
[Docs] Update the macOS guide to match changes in core

### DIFF
--- a/worlds/generic/docs/mac_en.md
+++ b/worlds/generic/docs/mac_en.md
@@ -3,6 +3,7 @@ Archipelago does not have a compiled release on macOS. However, it is possible t
 ## Prerequisite Software
 Here is a list of software to install and source code to download.
 1. Python 3.10 "universal2" or newer from the [macOS Python downloads page](https://www.python.org/downloads/macos/).
+   **Python 3.13 is not supported yet.**
 2. Xcode from the [macOS App Store](https://apps.apple.com/us/app/xcode/id497799835).
 3. The source code from the [Archipelago releases page](https://github.com/ArchipelagoMW/Archipelago/releases).
 4. The asset with darwin in the name from the [SNI Github releases page](https://github.com/alttpo/sni/releases).

--- a/worlds/generic/docs/mac_en.md
+++ b/worlds/generic/docs/mac_en.md
@@ -2,8 +2,7 @@
 Archipelago does not have a compiled release on macOS. However, it is possible to run from source code on macOS. This guide expects you to have some experience with running software from the terminal.
 ## Prerequisite Software
 Here is a list of software to install and source code to download.
-1. Python 3.9 "universal2" or newer from the [macOS Python downloads page](https://www.python.org/downloads/macos/).
-   **Python 3.11 is not supported yet.**
+1. Python 3.10 "universal2" or newer from the [macOS Python downloads page](https://www.python.org/downloads/macos/).
 2. Xcode from the [macOS App Store](https://apps.apple.com/us/app/xcode/id497799835).
 3. The source code from the [Archipelago releases page](https://github.com/ArchipelagoMW/Archipelago/releases).
 4. The asset with darwin in the name from the [SNI Github releases page](https://github.com/alttpo/sni/releases).


### PR DESCRIPTION
Updated the minimum version recommended to the minimum version actually supported by AP ( as of #3973 ). I've not followed other changes too closely, so if anything else in this guide is out of date, please let me know and I'll adjust it. Also, depending on the state of 3.13 support, I can be easily convinced to add the 'not supported' version warning we previously had for 3.11 back in for 3.13.

## How was this tested?
I felt lazy this time and didn't use anything to test it, not even my eyes.

