### PR TITLE
Launcher: fix detection of valid .apworld (0.5.1-hotfix1)

### DIFF
--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -103,7 +103,7 @@ def _install_apworld(apworld_src: str = "") -> Optional[Tuple[pathlib.Path, path
     try:
         import zipfile
         zip = zipfile.ZipFile(apworld_path)
-        directories = [f.filename.strip('/') for f in zip.filelist if f.CRC == 0 and f.file_size == 0 and f.filename.count('/') == 1]
+        directories = [f.name for f in zipfile.Path(zip).iterdir() if f.is_dir()]
         if len(directories) == 1 and directories[0] in apworld_path.stem:
             module_name = directories[0]
             apworld_name = module_name + ".apworld"


### PR DESCRIPTION
## What is this fixing or adding?

https://discord.com/channels/731205301247803413/731214280439103580/1311410300809117717

Should now properly detect folders in the zip root even if they are missing from the zipinfo list.

## How was this tested?

![success](https://github.com/user-attachments/assets/5ee90f33-0b6a-4a32-b222-2a6835c0cfd8)