### PR TITLE
Core: Fix playthrough only checking half of the sphere 0 items

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1385,18 +1385,20 @@ class Spoiler:
         # second phase, sphere 0
         removed_precollected: List[Item] = []
 
-        # The lists of precollected items are going to be mutated by removing one item at a time to determine if each
-        # item is required to beat the game, and re-adding that item if it was required, so copies of the lists need to
-        # be made before iterating.
-        for item in (i for i in chain.from_iterable(items.copy() for items in multiworld.precollected_items.values())
-                     if i.advancement):
-            logging.debug('Checking if %s (Player %d) is required to beat the game.', item.name, item.player)
-            multiworld.precollected_items[item.player].remove(item)
-            multiworld.state.remove(item)
-            if not multiworld.can_beat_game():
-                multiworld.push_precollected(item)
-            else:
-                removed_precollected.append(item)
+        for precollected_items in multiworld.precollected_items.values():
+            # The list of items is mutated by removing one item at a time to determine if each item is required to beat
+            # the game, and re-adding that item if it was required, so a copy needs to be made before iterating.
+            for item in precollected_items.copy():
+                if not item.advancement:
+                    continue
+                logging.debug('Checking if %s (Player %d) is required to beat the game.', item.name, item.player)
+                precollected_items.remove(item)
+                multiworld.state.remove(item)
+                if not multiworld.can_beat_game():
+                    # Add the item back into `precollected_items` and collect it into `multiworld.state`.
+                    multiworld.push_precollected(item)
+                else:
+                    removed_precollected.append(item)
 
         # we are now down to just the required progress items in collection_spheres. Unfortunately
         # the previous pruning stage could potentially have made certain items dependant on others

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1384,7 +1384,12 @@ class Spoiler:
 
         # second phase, sphere 0
         removed_precollected: List[Item] = []
-        for item in (i for i in chain.from_iterable(multiworld.precollected_items.values()) if i.advancement):
+
+        # The lists of precollected items are going to be mutated by removing one item at a time to determine if each
+        # item is required to beat the game, and re-adding that item if it was required, so copies of the lists need to
+        # be made before iterating.
+        for item in (i for i in chain.from_iterable(items.copy() for items in multiworld.precollected_items.values())
+                     if i.advancement):
             logging.debug('Checking if %s (Player %d) is required to beat the game.', item.name, item.player)
             multiworld.precollected_items[item.player].remove(item)
             multiworld.state.remove(item)


### PR DESCRIPTION
## What is this fixing or adding?

The lists of precollected items were being mutated while iterating those same lists, causing playthrough to skip checking half of the sphere 0 advancement items.

This patch ensures the lists are copied before they are iterated.

## How was this tested?
I generated a playthrough before and after this patch, using a Witness yaml with `start_inventory: {Black/White Squares: 10}` and a Hat in Time yaml with `start_inventory: {Time Piece: 200}`, comparing the sphere 0 in the spoiler playthroughs afterwards.

Generating with `--log_level debug` can also show the issue clearly (generated with only the Witness yaml):
Before:
```
[...]
Checking if +1 Laser (Player 1) is required to beat the game.
Checking if Black/White Squares (Player 1) is required to beat the game.
Checking if Black/White Squares (Player 1) is required to beat the game.
Checking if Black/White Squares (Player 1) is required to beat the game.
Checking if Black/White Squares (Player 1) is required to beat the game.
Checking if Black/White Squares (Player 1) is required to beat the game.
Checking if Black/White Squares (Player 1) is required to beat the game.
Calculated final sphere 1, containing 6 of 23 progress items.
[...]
```
After:
```
[...]
Checking if Desert Laser Redirection (Player 1) is required to beat the game.
Checking if Black/White Squares (Player 1) is required to beat the game.
Checking if Black/White Squares (Player 1) is required to beat the game.
Checking if Black/White Squares (Player 1) is required to beat the game.
Checking if Black/White Squares (Player 1) is required to beat the game.
Checking if Black/White Squares (Player 1) is required to beat the game.
Checking if Black/White Squares (Player 1) is required to beat the game.
Checking if Black/White Squares (Player 1) is required to beat the game.
Checking if Black/White Squares (Player 1) is required to beat the game.
Checking if Black/White Squares (Player 1) is required to beat the game.
Checking if Black/White Squares (Player 1) is required to beat the game.
Calculated final sphere 1, containing 6 of 23 progress items.
[...]
```