### PR TITLE
TUNIC: Fix missing ladder rule for library fuse

### DIFF
--- a/worlds/tunic/er_rules.py
+++ b/worlds/tunic/er_rules.py
@@ -1446,7 +1446,7 @@ def set_er_location_rules(world: "TunicWorld") -> None:
     set_rule(world.get_location("West Garden Fuse"),
              lambda state: has_ability(prayer, state, world))
     set_rule(world.get_location("Library Fuse"),
-             lambda state: has_ability(prayer, state, world))
+             lambda state: has_ability(prayer, state, world) and has_ladder("Ladders in Library", state, world))
 
     # Bombable Walls
     for location_name in bomb_walls:


### PR DESCRIPTION
## What is this fixing or adding?
Library fuse was missing the ladder requirement, it is now there.

## How was this tested?
It wasn't, just it's very clear it won't fail.