### PR TITLE
Launcher: fix detection of valid .apworld

### DIFF
--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -103,7 +103,7 @@ def _install_apworld(apworld_src: str = "") -> Optional[Tuple[pathlib.Path, path
     try:
         import zipfile
         zip = zipfile.ZipFile(apworld_path)
-        directories = [f.filename.strip('/') for f in zip.filelist if f.CRC == 0 and f.file_size == 0 and f.filename.count('/') == 1]
+        directories = [f.name for f in zipfile.Path(zip).iterdir() if f.is_dir()]
         if len(directories) == 1 and directories[0] in apworld_path.stem:
             module_name = directories[0]
             apworld_name = module_name + ".apworld"


### PR DESCRIPTION
## What is this fixing or adding?

Cherry-pick of https://github.com/ArchipelagoMW/Archipelago/pull/4267 for main

## How was this tested?

In the other PR