### PR TITLE
Core: Remove Location.__hash__ for faster generation

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1181,9 +1181,6 @@ class Location:
         multiworld = self.parent_region.multiworld if self.parent_region and self.parent_region.multiworld else None
         return multiworld.get_name_string_for_object(self) if multiworld else f'{self.name} (Player {self.player})'
 
-    def __hash__(self):
-        return hash((self.name, self.player))
-
     def __lt__(self, other: Location):
         return (self.player, self.name) < (other.player, other.name)
 


### PR DESCRIPTION
## What is this fixing or adding?
`Location` does not override `__eq__` so should not override `__hash__` to begin with.

With this patch, this makes operations on sets of locations slightly faster because they will use `object.__hash__` rather than `Location.__hash__`.

`object.__hash__` is about 4 to 5 times faster than `Location.__hash__` for me. Generation often uses sets of locations, so this slightly speeds up generation.

The only place I could find that was hashing locations directly was `WitnessLocationHint.__hash__`, but it has implemented a matching `__eq__`, so is fine.

For security reasons, Python randomizes its hash seed each time it is started, so the result of the `hash()` function is nondeterministic and can't have been used by worlds for anything that needed to be deterministic and can't have been used to compare information hashed at generation time to information hashed by a client.

## How was this tested?
I generated multiworlds with a fixed seed and one of each ROM-less template yaml alphabetically from A Hat in Time to Meritous (29 worlds, though one is an empty Final Fantasy world and another is Clique, so more like 27 worlds). The placement of all items were seen to match in seeds generated before and after this patch.
Generated with `python -O .\Generate.py --seed 1` and averaged over 5 generations:
| Step | Before/s | After/s | Reduction/s | Reduction |
| --- | --- | --- | --- | --- |
| Main Fill + Post-Fill | 20.5 | 18.5 | 1.9 | 9.4% |
| Balancing | 4.6 | 4.2 | 0.4 | 8.5% |
| Playthrough | 81.2 | 76.2 | 5.7 | 7.0% |
| Total | 107.5 | 99.4 | 8.1 | 7.5% |

The individual performance of `Location.__hash__` and `object.__hash__` was compared by creating a list of 10,000 Location instances and using `timeit` to `"for loc in loc_list:\n\thash(loc)"`, as well as using `timeit` to `"hash(first_loc)", setup="first_loc=loc_list[0]"`.

I know that `CollectionState.sweep_for_advancements` uses sets in a few places where it could use lists instead, but I was honestly not expecting this much of a difference, I was thinking it would have been a reduction of maybe 1-2% at most.