### PR TITLE
Launcher: warn if there is no file browser

### DIFF
--- a/Launcher.py
+++ b/Launcher.py
@@ -85,12 +85,16 @@ def browse_files():
 def open_folder(folder_path):
     if is_linux:
         exe = which('xdg-open') or which('gnome-open') or which('kde-open')
-        subprocess.Popen([exe, folder_path])
     elif is_macos:
         exe = which("open")
-        subprocess.Popen([exe, folder_path])
     else:
         webbrowser.open(folder_path)
+        return
+
+    if exe:
+        subprocess.Popen([exe, folder_path])
+    else:
+        logging.warning(f"No file browser available to open {folder_path}")
 
 
 def update_settings():


### PR DESCRIPTION
## What is this fixing or adding?

Clicking "Generate Template Options" generates template options (yay) and then tries to open a file browser. When I did this in WSL to simplify some testing it threw an exception. Ideally when we don't have a file browser we just get back the path to the folder.

## How was this tested?

`python3 Launcher.py` and click "Generate Template Options" in WSL, i.e. a linux environment, without xdg-open, gnome-open, or kde-open.