### PR TITLE
DLC Quest Bug Fix 50+ coin bundle basic Campaign

### DIFF
--- a/worlds/dlcquest/__init__.py
+++ b/worlds/dlcquest/__init__.py
@@ -74,6 +74,8 @@ class DLCqworld(World):
 
         if self.options.campaign == Options.Campaign.option_basic or self.options.campaign == Options.Campaign.option_both:
             self.multiworld.early_items[self.player]["Movement Pack"] = 1
+            if self.options.campaign == Options.Campaign.option_both and self.options.coinsanity and self.options.coinbundlequantity > 50:
+                self.multiworld.local_early_items[self.player]["Live Freemium or Die: Coin Bundle"] = 1
 
         for item in items_to_exclude:
             if item in self.multiworld.itempool:
@@ -82,7 +84,7 @@ class DLCqworld(World):
     def precollect_coinsanity(self):
         if self.options.campaign == Options.Campaign.option_basic:
             if self.options.coinsanity == Options.CoinSanity.option_coin and self.options.coinbundlequantity >= 5:
-                self.multiworld.push_precollected(self.create_item("Movement Pack"))
+                self.multiworld.push_precollected(self.create_item("DLC Quest: Coin Bundle"))
 
     def create_item(self, item: Union[str, ItemData], classification: ItemClassification = None) -> DLCQuestItem:
         if isinstance(item, str):

--- a/worlds/dlcquest/__init__.py
+++ b/worlds/dlcquest/__init__.py
@@ -72,10 +72,16 @@ class DLCqworld(World):
 
         self.multiworld.itempool += created_items
 
-        if self.options.campaign == Options.Campaign.option_basic or self.options.campaign == Options.Campaign.option_both:
-            self.multiworld.early_items[self.player]["Movement Pack"] = 1
-            if self.options.campaign == Options.Campaign.option_both and self.options.coinsanity and self.options.coinbundlequantity > 50:
-                self.multiworld.local_early_items[self.player]["Live Freemium or Die: Coin Bundle"] = 1
+        campaign = self.options.campaign
+        has_both = campaign == Options.Campaign.option_both
+        has_base = campaign == Options.Campaign.option_basic or has_both
+        has_big_bundles = self.options.coinsanity and self.options.coinbundlequantity > 50
+        early_items = self.multiworld.early_items
+        if has_base:
+            if has_both and has_big_bundles:
+                early_items[self.player]["Incredibly Important Pack"] = 1
+            else:
+                early_items[self.player]["Movement Pack"] = 1
 
         for item in items_to_exclude:
             if item in self.multiworld.itempool:


### PR DESCRIPTION
Fixing a generation bug

## What is this fixing or adding?
if you are playing either both or basic campaign and you have coinsanity above 50 and you are alone in the multiworld the generation crash

## How was this tested?
unit test and some game generation that failed before

## If this makes graphical changes, please attach screenshots.
