### PR TITLE
CV64: Fix the first Waterway 3HB ledge setting the flag of one of the Nitro room item locations.

### DIFF
--- a/worlds/cv64/rom.py
+++ b/worlds/cv64/rom.py
@@ -684,38 +684,37 @@ class CV64PatchExtensions(APPatchExtension):
 
         # Disable the 3HBs checking and setting flags when breaking them and enable their individual items checking and
         # setting flags instead.
-        if options["multi_hit_breakables"]:
-            rom_data.write_int32(0xE87F8, 0x00000000)  # NOP
-            rom_data.write_int16(0xE836C, 0x1000)
-            rom_data.write_int32(0xE8B40, 0x0C0FF3CD)  # JAL 0x803FCF34
-            rom_data.write_int32s(0xBFCF34, patches.three_hit_item_flags_setter)
-            # Villa foyer chandelier-specific functions (yeah, IDK why KCEK made different functions for this one)
-            rom_data.write_int32(0xE7D54, 0x00000000)  # NOP
-            rom_data.write_int16(0xE7908, 0x1000)
-            rom_data.write_byte(0xE7A5C, 0x10)
-            rom_data.write_int32(0xE7F08, 0x0C0FF3DF)  # JAL 0x803FCF7C
-            rom_data.write_int32s(0xBFCF7C, patches.chandelier_item_flags_setter)
+        rom_data.write_int32(0xE87F8, 0x00000000)  # NOP
+        rom_data.write_int16(0xE836C, 0x1000)
+        rom_data.write_int32(0xE8B40, 0x0C0FF3CD)  # JAL 0x803FCF34
+        rom_data.write_int32s(0xBFCF34, patches.three_hit_item_flags_setter)
+        # Villa foyer chandelier-specific functions (yeah, IDK why KCEK made different functions for this one)
+        rom_data.write_int32(0xE7D54, 0x00000000)  # NOP
+        rom_data.write_int16(0xE7908, 0x1000)
+        rom_data.write_byte(0xE7A5C, 0x10)
+        rom_data.write_int32(0xE7F08, 0x0C0FF3DF)  # JAL 0x803FCF7C
+        rom_data.write_int32s(0xBFCF7C, patches.chandelier_item_flags_setter)
 
-            # New flag values to put in each 3HB vanilla flag's spot
-            rom_data.write_int32(0x10C7C8, 0x8000FF48)  # FoS dirge maiden rock
-            rom_data.write_int32(0x10C7B0, 0x0200FF48)  # FoS S1 bridge rock
-            rom_data.write_int32(0x10C86C, 0x0010FF48)  # CW upper rampart save nub
-            rom_data.write_int32(0x10C878, 0x4000FF49)  # CW Dracula switch slab
-            rom_data.write_int32(0x10CAD8, 0x0100FF49)  # Tunnel twin arrows slab
-            rom_data.write_int32(0x10CAE4, 0x0004FF49)  # Tunnel lonesome bucket pit rock
-            rom_data.write_int32(0x10CB54, 0x4000FF4A)  # UW poison parkour ledge
-            rom_data.write_int32(0x10CB60, 0x0080FF4A)  # UW skeleton crusher ledge
-            rom_data.write_int32(0x10CBF0, 0x0008FF4A)  # CC Behemoth crate
-            rom_data.write_int32(0x10CC2C, 0x2000FF4B)  # CC elevator pedestal
-            rom_data.write_int32(0x10CC70, 0x0200FF4B)  # CC lizard locker slab
-            rom_data.write_int32(0x10CD88, 0x0010FF4B)  # ToE pre-midsavepoint platforms ledge
-            rom_data.write_int32(0x10CE6C, 0x4000FF4C)  # ToSci invisible bridge crate
-            rom_data.write_int32(0x10CF20, 0x0080FF4C)  # CT inverted battery slab
-            rom_data.write_int32(0x10CF2C, 0x0008FF4C)  # CT inverted door slab
-            rom_data.write_int32(0x10CF38, 0x8000FF4D)  # CT final room door slab
-            rom_data.write_int32(0x10CF44, 0x1000FF4D)  # CT Renon slab
-            rom_data.write_int32(0x10C908, 0x0008FF4D)  # Villa foyer chandelier
-            rom_data.write_byte(0x10CF37, 0x04)  # pointer for CT final room door slab item data
+        # New flag values to put in each 3HB vanilla flag's spot
+        rom_data.write_int32(0x10C7C8, 0x8000FF48)  # FoS dirge maiden rock
+        rom_data.write_int32(0x10C7B0, 0x0200FF48)  # FoS S1 bridge rock
+        rom_data.write_int32(0x10C86C, 0x0010FF48)  # CW upper rampart save nub
+        rom_data.write_int32(0x10C878, 0x4000FF49)  # CW Dracula switch slab
+        rom_data.write_int32(0x10CAD8, 0x0100FF49)  # Tunnel twin arrows slab
+        rom_data.write_int32(0x10CAE4, 0x0004FF49)  # Tunnel lonesome bucket pit rock
+        rom_data.write_int32(0x10CB54, 0x4000FF4A)  # UW poison parkour ledge
+        rom_data.write_int32(0x10CB60, 0x0080FF4A)  # UW skeleton crusher ledge
+        rom_data.write_int32(0x10CBF0, 0x0008FF4A)  # CC Behemoth crate
+        rom_data.write_int32(0x10CC2C, 0x2000FF4B)  # CC elevator pedestal
+        rom_data.write_int32(0x10CC70, 0x0200FF4B)  # CC lizard locker slab
+        rom_data.write_int32(0x10CD88, 0x0010FF4B)  # ToE pre-midsavepoint platforms ledge
+        rom_data.write_int32(0x10CE6C, 0x4000FF4C)  # ToSci invisible bridge crate
+        rom_data.write_int32(0x10CF20, 0x0080FF4C)  # CT inverted battery slab
+        rom_data.write_int32(0x10CF2C, 0x0008FF4C)  # CT inverted door slab
+        rom_data.write_int32(0x10CF38, 0x8000FF4D)  # CT final room door slab
+        rom_data.write_int32(0x10CF44, 0x1000FF4D)  # CT Renon slab
+        rom_data.write_int32(0x10C908, 0x0008FF4D)  # Villa foyer chandelier
+        rom_data.write_byte(0x10CF37, 0x04)  # pointer for CT final room door slab item data
 
         # Once-per-frame gameplay checks
         rom_data.write_int32(0x6C848, 0x080FF40D)  # J 0x803FD034


### PR DESCRIPTION
## What is this fixing or adding?
Breaking the "First poison parkour ledge" 3-hit breakable (3HB) in Underground Waterway when the option to randomize the 3HB items was turned off would cause the flag for the item location known as "Castle Center: Magical Nitro shelf - Heinrich side" to be set, both causing the location check to send out when it wasn't supposed to and the item later not spawning when it should be. When I added the two extra item actors in the Nitro room and put flags on them, I evidently chose to put one of them on a flag that I didn't realize at the time was already being used by something else (for whatever reason I didn't record it on my big list of the game's flags). And because I don't ever bother breaking the 3HBs when they are turned off, it wasn't until someone else recently brought it to my attention that I found out.

This fixes the issue by just always applying the 3HB flag hacks regardless of whether the 3HBs are randomized or not, meaning none of them will set flags upon being broken and each item that drops from them are tracked by their own individual flags. I could change what flag the Nitro room item sets, but that would require changing the AP location ID as well due to how the item flags and location IDs correlate to each other, and changing IDs tends to muck things up when it comes to backwards compatibility, so I didn't think it'd be worth opening that can of worms over this.

## How was this tested?
Generated a game with the 3HBs not randomized, broke the "First poison parkour ledge" 3HB and picked up its items to make sure the Nitro shelf location did not send, and then checked on that location to make sure the item spawned correctly.