### PR TITLE
Launcher: launch without delay on URI without choice

### DIFF
--- a/Launcher.py
+++ b/Launcher.py
@@ -126,12 +126,13 @@ def handle_uri(path: str, launch_args: Tuple[str, ...]) -> None:
         elif component.display_name == "Text Client":
             text_client_component = component
 
-    from kvui import App, Button, BoxLayout, Label, Clock, Window
+    if client_component is None:
+        run_component(text_client_component, *launch_args)
+        return
+
+    from kvui import App, Button, BoxLayout, Label, Window
 
     class Popup(App):
-        timer_label: Label
-        remaining_time: Optional[int]
-
         def __init__(self):
             self.title = "Connect to Multiworld"
             self.icon = r"data/icon.png"
@@ -139,47 +140,24 @@ def handle_uri(path: str, launch_args: Tuple[str, ...]) -> None:
 
         def build(self):
             layout = BoxLayout(orientation="vertical")
+            layout.add_widget(Label(text="Select client to open and connect with."))
+            button_row = BoxLayout(orientation="horizontal", size_hint=(1, 0.4))
 
-            if client_component is None:
-                self.remaining_time = 7
-                label_text = (f"A game client able to parse URIs was not detected for {game}.\n"
-                              f"Launching Text Client in 7 seconds...")
-                self.timer_label = Label(text=label_text)
-                layout.add_widget(self.timer_label)
-                Clock.schedule_interval(self.update_label, 1)
-            else:
-                layout.add_widget(Label(text="Select client to open and connect with."))
-                button_row = BoxLayout(orientation="horizontal", size_hint=(1, 0.4))
+            text_client_button = Button(
+                text=text_client_component.display_name,
+                on_release=lambda *args: run_component(text_client_component, *launch_args)
+            )
+            button_row.add_widget(text_client_button)
 
-                text_client_button = Button(
-                    text=text_client_component.display_name,
-                    on_release=lambda *args: run_component(text_client_component, *launch_args)
-                )
-                button_row.add_widget(text_client_button)
+            game_client_button = Button(
+                text=client_component.display_name,
+                on_release=lambda *args: run_component(client_component, *launch_args)
+            )
+            button_row.add_widget(game_client_button)
 
-                game_client_button = Button(
-                    text=client_component.display_name,
-                    on_release=lambda *args: run_component(client_component, *launch_args)
-                )
-                button_row.add_widget(game_client_button)
-
-                layout.add_widget(button_row)
+            layout.add_widget(button_row)
 
             return layout
-
-        def update_label(self, dt):
-            if self.remaining_time > 1:
-                # countdown the timer and string replace the number
-                self.remaining_time -= 1
-                self.timer_label.text = self.timer_label.text.replace(
-                    str(self.remaining_time + 1), str(self.remaining_time)
-                )
-            else:
-                # our timer is finished so launch text client and close down
-                run_component(text_client_component, *launch_args)
-                Clock.unschedule(self.update_label)
-                App.get_running_app().stop()
-                Window.close()
 
         def _stop(self, *largs):
             # see run_gui Launcher _stop comment for details


### PR DESCRIPTION
## What is this fixing or adding?
When handling a uri to launch it now instantly launches Text Client if nothing else is registered

## How was this tested?
I only tested Launcher.py archipelago://localhost
