### PR TITLE
Core: log process ID

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -556,7 +556,7 @@ def init_logging(name: str, loglevel: typing.Union[str, int] = logging.INFO, wri
     import platform
     logging.info(
         f"Archipelago ({__version__}) logging initialized"
-        f" on {platform.platform()}"
+        f" on {platform.platform()} process {os.getpid()}"
         f" running Python {sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
         f"{' (frozen)' if is_frozen() else ''}"
     )


### PR DESCRIPTION
## What is this fixing or adding?
logs process ID in cases where it might matter.

## How was this tested?
`[2024-11-29 23:18:30] Archipelago (0.6.0) logging initialized on Windows-10-10.0.19045-SP0 process 20648 running Python 3.12.6`

## If this makes graphical changes, please attach screenshots.
