### PR TITLE
The Witness: Fix unreachable locations on Longbox + Postgame

### DIFF
--- a/worlds/witness/player_logic.py
+++ b/worlds/witness/player_logic.py
@@ -984,7 +984,7 @@ class WitnessPlayerLogic:
         Makes event-item pairs for entities with associated events, unless these entities are disabled.
         """
 
-        self.ALWAYS_EVENT_NAMES_BY_HEX[self.VICTORY_LOCATION] = "Victory"
+        self.USED_EVENT_NAMES_BY_HEX[self.VICTORY_LOCATION].append("Victory")
 
         for event_hex, event_name in self.ALWAYS_EVENT_NAMES_BY_HEX.items():
             self.USED_EVENT_NAMES_BY_HEX[event_hex].append(event_name)

--- a/worlds/witness/test/test_roll_other_options.py
+++ b/worlds/witness/test/test_roll_other_options.py
@@ -62,3 +62,10 @@ class TestPostgameGroupedDoors(WitnessTestBase):
         "door_groupings": "regional",
         "victory_condition": "elevator",
     }
+
+
+class TestPostgamePanels(WitnessTestBase):
+    options = {
+        "victory_condition": "mountain_box_long",
+        "shuffle_postgame": True
+    }


### PR DESCRIPTION
A little snag that was missed with the most recent event system revamp. These options just accessibility fail 100% of the time right now.

Essentially, `PlayerLogic.ALWAYS_EVENTS_BY_HEX` had a vital event being overwritten with the Victory event. This change assures that both events exist:
```
Mountaintop Box Long Solved: Victory
Mountaintop Box Long Solved (Effect 2): Bottom Floor Discard Turns On
```

Also add a basic regression test that just rolls these options.