### PR TITLE
Core: rework python version check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,8 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '~3.12.7'
+          check-latest: true
       - name: Download run-time dependencies
         run: |
           Invoke-WebRequest -Uri https://github.com/Ijwu/Enemizer/releases/download/${Env:ENEMIZER_VERSION}/win-x64.zip -OutFile enemizer.zip
@@ -111,7 +112,8 @@ jobs:
       - name: Get a recent python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '~3.12.7'
+          check-latest: true
       - name: Install build-time dependencies
         run: |
           echo "PYTHON=python3.12" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,8 @@ jobs:
       - name: Get a recent python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '~3.12.7'
+          check-latest: true
       - name: Install build-time dependencies
         run: |
           echo "PYTHON=python3.12" >> $GITHUB_ENV

--- a/ModuleUpdate.py
+++ b/ModuleUpdate.py
@@ -5,8 +5,15 @@ import multiprocessing
 import warnings
 
 
-if sys.version_info < (3, 10, 11):
-    raise RuntimeError(f"Incompatible Python Version found: {sys.version_info}. 3.10.11+ is supported.")
+if sys.platform in ("win32", "darwin") and sys.version_info < (3, 10, 11):
+    # Official micro version updates. This should match the number in docs/running from source.md.
+    raise RuntimeError(f"Incompatible Python Version found: {sys.version_info}. Official 3.10.15+ is supported.")
+elif sys.platform in ("win32", "darwin") and sys.version_info < (3, 10, 15):
+    # There are known security issues, but no easy way to install fixed versions on Windows for testing.
+    warnings.warn(f"Python Version {sys.version_info} has security issues. Don't use in production.")
+elif sys.version_info < (3, 10, 1):
+    # Other platforms may get security backports instead of micro updates, so the number is unreliable.
+    raise RuntimeError(f"Incompatible Python Version found: {sys.version_info}. 3.10.1+ is supported.")
 
 # don't run update if environment is frozen/compiled or if not the parent process (skip in subprocess)
 _skip_update = bool(getattr(sys, "frozen", False) or multiprocessing.parent_process())

--- a/docs/running from source.md
+++ b/docs/running from source.md
@@ -7,7 +7,9 @@ use that version. These steps are for developers or platforms without compiled r
 ## General
 
 What you'll need:
- * [Python 3.10.15 or newer](https://www.python.org/downloads/), not the Windows Store version
+ * [Python 3.10.11 or newer](https://www.python.org/downloads/), not the Windows Store version
+   * On Windows, please consider only using the latest supported version in production environments since security
+     updates for older versions are not easily available.
    * Python 3.12.x is currently the newest supported version
  * pip: included in downloads from python.org, separate in many Linux distributions
  * Matching C compiler


### PR DESCRIPTION
## What is this fixing or adding?

* Makes version check for official distribution and docs match
* Add warning for 3.10.11 having known security issues
* Relaxes the check for micro updates on platforms that may not use the official distribution/versioning
* Sets min python version for build and release to current latest (with known security fixes)

## How was this tested?

* On Linux, Launcher fails on py3.9.x, but works on 3.10.14 *(updating to 3.10.15 now)*
* CI would probably fail if I got the versions wrong
* Seeing `UserWarning: Python Version sys.version_info(major=3, minor=10, micro=11, releaselevel='final', serial=0) has security issues. Don't use in production.` in CI