### PR TITLE
WebHost: Update UTC calls

### DIFF
--- a/WebHostLib/autolauncher.py
+++ b/WebHostLib/autolauncher.py
@@ -4,7 +4,7 @@ import json
 import logging
 import multiprocessing
 import typing
-from datetime import timedelta, datetime
+from datetime import timedelta, datetime, timezone
 from threading import Event, Thread
 from uuid import UUID
 
@@ -87,10 +87,10 @@ def autohost(config: dict):
                     with db_session:
                         rooms = select(
                             room for room in Room if
-                            room.last_activity >= datetime.utcnow() - timedelta(days=3))
+                            room.last_activity >= datetime.now(timezone.utc) - timedelta(days=3))
                         for room in rooms:
                             # we have to filter twice, as the per-room timeout can't currently be PonyORM transpiled.
-                            if room.last_activity >= datetime.utcnow() - timedelta(seconds=room.timeout + 5):
+                            if room.last_activity >= datetime.now(timezone.utc) - timedelta(seconds=room.timeout + 5):
                                 hosters[room.id.int % len(hosters)].start_room(room.id)
 
         except AlreadyRunningException:

--- a/WebHostLib/customserver.py
+++ b/WebHostLib/customserver.py
@@ -159,7 +159,7 @@ class WebHostContext(Context):
         room.multisave = pickle.dumps(self.get_save())
         # saving only occurs on activity, so we can "abuse" this information to mark this as last_activity
         if not exit_save:  # we don't want to count a shutdown as activity, which would restart the server again
-            room.last_activity = datetime.datetime.utcnow()
+            room.last_activity = datetime.datetime.now(datetime.timezone.utc)
         return True
 
     def get_save(self) -> dict:
@@ -314,7 +314,7 @@ def run_server_process(name: str, ponyconfig: dict, static_server_data: dict,
                     with (db_session):
                         # ensure the Room does not spin up again on its own, minute of safety buffer
                         room = Room.get(id=room_id)
-                        room.last_activity = datetime.datetime.utcnow() - \
+                        room.last_activity = datetime.datetime.now(datetime.timezone.utc) - \
                                              datetime.timedelta(minutes=1, seconds=room.timeout)
                     logging.info(f"Shutting down room {room_id} on {name}.")
                 finally:

--- a/WebHostLib/landing.py
+++ b/WebHostLib/landing.py
@@ -1,4 +1,4 @@
-from datetime import timedelta, datetime
+from datetime import timedelta, datetime, timezone
 
 from flask import render_template
 from pony.orm import count
@@ -10,6 +10,6 @@ from .models import Room, Seed
 @app.route('/', methods=['GET', 'POST'])
 @cache.cached(timeout=300)  # cache has to appear under app route for caching to work
 def landing():
-    rooms = count(room for room in Room if room.creation_time >= datetime.utcnow() - timedelta(days=7))
-    seeds = count(seed for seed in Seed if seed.creation_time >= datetime.utcnow() - timedelta(days=7))
+    rooms = count(room for room in Room if room.creation_time >= datetime.now(timezone.utc) - timedelta(days=7))
+    seeds = count(seed for seed in Seed if seed.creation_time >= datetime.now(timezone.utc) - timedelta(days=7))
     return render_template("landing.html", rooms=rooms, seeds=seeds)

--- a/WebHostLib/misc.py
+++ b/WebHostLib/misc.py
@@ -172,7 +172,7 @@ def host_room(room: UUID):
     if room is None:
         return abort(404)
 
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     # indicate that the page should reload to get the assigned port
     should_refresh = ((not room.last_port and now - room.creation_time < datetime.timedelta(seconds=3))
                       or room.last_activity < now - datetime.timedelta(seconds=room.timeout))

--- a/WebHostLib/models.py
+++ b/WebHostLib/models.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from uuid import UUID, uuid4
 from pony.orm import Database, PrimaryKey, Required, Set, Optional, buffer, LongStr
 
@@ -20,8 +20,8 @@ class Slot(db.Entity):
 
 class Room(db.Entity):
     id = PrimaryKey(UUID, default=uuid4)
-    last_activity = Required(datetime, default=lambda: datetime.utcnow(), index=True)
-    creation_time = Required(datetime, default=lambda: datetime.utcnow(), index=True)  # index used by landing page
+    last_activity = Required(datetime, default=lambda: datetime.now(timezone.utc), index=True)
+    creation_time = Required(datetime, default=lambda: datetime.now(timezone.utc), index=True)  # index used by landing page
     owner = Required(UUID, index=True)
     commands = Set('Command')
     seed = Required('Seed', index=True)
@@ -38,7 +38,7 @@ class Seed(db.Entity):
     rooms = Set(Room)
     multidata = Required(bytes, lazy=True)
     owner = Required(UUID, index=True)
-    creation_time = Required(datetime, default=lambda: datetime.utcnow(), index=True)  # index used by landing page
+    creation_time = Required(datetime, default=lambda: datetime.now(timezone.utc), index=True)  # index used by landing page
     slots = Set(Slot)
     spoiler = Optional(LongStr, lazy=True)
     meta = Required(LongStr, default=lambda: "{\"race\": false}")  # additional meta information/tags

--- a/WebHostLib/tracker.py
+++ b/WebHostLib/tracker.py
@@ -274,9 +274,9 @@ class TrackerData:
         Does not include players who have no activity recorded.
         """
         last_activity: Dict[TeamPlayer, datetime.timedelta] = {}
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
         for (team, player), timestamp in self._multisave.get("client_activity_timers", []):
-            last_activity[team, player] = now - datetime.datetime.utcfromtimestamp(timestamp)
+            last_activity[team, player] = now - datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc)
 
         return last_activity
 
@@ -307,7 +307,6 @@ def _process_if_request_valid(incoming_request: Request, room: Optional[Room]) -
         if_modified = parsedate_to_datetime(if_modified_str)
         if if_modified.tzinfo is None:
             abort(400)  # standard requires "GMT" timezone
-        # database may use datetime.utcnow(), which is timezone-naive. convert to timezone-aware.
         last_activity = room.last_activity
         if last_activity.tzinfo is None:
             last_activity = room.last_activity.replace(tzinfo=datetime.timezone.utc)


### PR DESCRIPTION
## What is this fixing or adding?
Similar to #4170 , WebHost was using `datetime.utcnow()` for timestamps, which is deprecated. This updates the various deprecated calls for utc time stamps.

## How was this tested?
Unittests and a sample room