### PR TITLE
id Tech 1: Clean up difficulty options

### DIFF
--- a/worlds/doom_1993/Options.py
+++ b/worlds/doom_1993/Options.py
@@ -16,9 +16,9 @@ class Goal(Choice):
 
 class Difficulty(Choice):
     """
-    Choose the difficulty option. Those match DOOM's difficulty options.
-    baby (I'm too young to die.) double ammos, half damage, less monsters or strength.
-    easy (Hey, not too rough.) less monsters or strength.
+    Choose the game difficulty. These options match DOOM's skill levels.
+    baby (I'm too young to die.) Same as easy, with double ammo pickups and half damage taken.
+    easy (Hey, not too rough.) Less monsters or strength.
     medium (Hurt me plenty.) Default.
     hard (Ultra-Violence.) More monsters or strength.
     nightmare (Nightmare!) Monsters attack more rapidly and respawn.
@@ -29,6 +29,11 @@ class Difficulty(Choice):
     option_medium = 2
     option_hard = 3
     option_nightmare = 4
+    alias_itytd = 0
+    alias_hntr = 1
+    alias_hmp = 2
+    alias_uv = 3
+    alias_nm = 4
     default = 2
 
 

--- a/worlds/doom_ii/Options.py
+++ b/worlds/doom_ii/Options.py
@@ -6,9 +6,9 @@ from dataclasses import dataclass
 
 class Difficulty(Choice):
     """
-    Choose the difficulty option. Those match DOOM's difficulty options.
-    baby (I'm too young to die.) double ammos, half damage, less monsters or strength.
-    easy (Hey, not too rough.) less monsters or strength.
+    Choose the game difficulty. These options match DOOM's skill levels.
+    baby (I'm too young to die.) Same as easy, with double ammo pickups and half damage taken.
+    easy (Hey, not too rough.) Less monsters or strength.
     medium (Hurt me plenty.) Default.
     hard (Ultra-Violence.) More monsters or strength.
     nightmare (Nightmare!) Monsters attack more rapidly and respawn.
@@ -19,6 +19,11 @@ class Difficulty(Choice):
     option_medium = 2
     option_hard = 3
     option_nightmare = 4
+    alias_itytd = 0
+    alias_hntr = 1
+    alias_hmp = 2
+    alias_uv = 3
+    alias_nm = 4
     default = 2
 
 

--- a/worlds/heretic/Options.py
+++ b/worlds/heretic/Options.py
@@ -16,14 +16,8 @@ class Goal(Choice):
 
 class Difficulty(Choice):
     """
-    Choose the difficulty option. Those match DOOM's difficulty options.
-    baby (I'm too young to die.) double ammos, half damage, less monsters or strength.
-    easy (Hey, not too rough.) less monsters or strength.
-    medium (Hurt me plenty.) Default.
-    hard (Ultra-Violence.) More monsters or strength.
-    nightmare (Nightmare!) Monsters attack more rapidly and respawn.
-
-    wet nurse (hou needeth a wet-nurse) - Fewer monsters and more items than medium. Damage taken is halved, and ammo pickups carry twice as much ammo. Any Quartz Flasks and Mystic Urns are automatically used when the player nears death.
+    Choose the game difficulty. These options match Heretic's skill levels.
+    wet nurse (Thou needeth a wet-nurse) - Fewer monsters and more items than medium. Damage taken is halved, and ammo pickups carry twice as much ammo. Any Quartz Flasks and Mystic Urns are automatically used when the player nears death.
     easy (Yellowbellies-r-us) - Fewer monsters and more items than medium.
     medium (Bringest them oneth) - Completely balanced, this is the standard difficulty level.
     hard (Thou art a smite-meister) - More monsters and fewer items than medium.
@@ -35,6 +29,11 @@ class Difficulty(Choice):
     option_medium = 2
     option_hard = 3
     option_black_plague = 4
+    alias_wn = 0
+    alias_yru = 1
+    alias_bto = 2
+    alias_sm = 3
+    alias_bp = 4
     default = 2
 
 


### PR DESCRIPTION
## What is this fixing or adding?

Cleans up the difficulty options for each of the three games. (Especially Heretic, looks like there was a bit of overzealous copy-pasting there...) Also adds aliases, allowing the use of community standard skill level abbreviations (e.g. `itytd`, `hmp`, `uv`, etc.) instead of the more generic ones.

## How was this tested?

Test generations to make sure new aliases mapped to correct difficulty settings.