### PR TITLE
WebHost: custom proc title for Generator and MultiHoster

### DIFF
--- a/WebHostLib/autolauncher.py
+++ b/WebHostLib/autolauncher.py
@@ -6,9 +6,10 @@ import multiprocessing
 import typing
 from datetime import timedelta, datetime
 from threading import Event, Thread
+from typing import Any
 from uuid import UUID
 
-from pony.orm import db_session, select, commit
+from pony.orm import db_session, select, commit, PrimaryKey
 
 from Utils import restricted_loads
 from .locker import Locker, AlreadyRunningException
@@ -35,12 +36,21 @@ def handle_generation_failure(result: BaseException):
         logging.exception(e)
 
 
+def _mp_gen_game(gen_options: dict, meta: dict[str, Any] | None = None, owner=None, sid=None) -> PrimaryKey | None:
+    from setproctitle import setproctitle
+
+    setproctitle(f"Generator ({sid})")
+    res = gen_game(gen_options, meta=meta, owner=owner, sid=sid)
+    setproctitle(f"Generator (idle)")
+    return res
+
+
 def launch_generator(pool: multiprocessing.pool.Pool, generation: Generation):
     try:
         meta = json.loads(generation.meta)
         options = restricted_loads(generation.options)
         logging.info(f"Generating {generation.id} for {len(options)} players")
-        pool.apply_async(gen_game, (options,),
+        pool.apply_async(_mp_gen_game, (options,),
                          {"meta": meta,
                           "sid": generation.id,
                           "owner": generation.owner},
@@ -53,7 +63,10 @@ def launch_generator(pool: multiprocessing.pool.Pool, generation: Generation):
         generation.state = STATE_STARTED
 
 
-def init_db(pony_config: dict):
+def init_generator(pony_config: dict):
+    from setproctitle import setproctitle
+
+    setproctitle("Generator (idle)")
     db.bind(**pony_config)
     db.generate_mapping()
 
@@ -105,7 +118,7 @@ def autogen(config: dict):
         try:
             with Locker("autogen"):
 
-                with multiprocessing.Pool(config["GENERATORS"], initializer=init_db,
+                with multiprocessing.Pool(config["GENERATORS"], initializer=init_generator,
                                           initargs=(config["PONY"],), maxtasksperchild=10) as generator_pool:
                     with db_session:
                         to_start = select(generation for generation in Generation if generation.state == STATE_STARTED)

--- a/WebHostLib/customserver.py
+++ b/WebHostLib/customserver.py
@@ -224,6 +224,9 @@ def set_up_logging(room_id) -> logging.Logger:
 def run_server_process(name: str, ponyconfig: dict, static_server_data: dict,
                        cert_file: typing.Optional[str], cert_key_file: typing.Optional[str],
                        host: str, rooms_to_run: multiprocessing.Queue, rooms_shutting_down: multiprocessing.Queue):
+    from setproctitle import setproctitle
+
+    setproctitle(name)
     Utils.init_logging(name)
     try:
         import resource

--- a/WebHostLib/requirements.txt
+++ b/WebHostLib/requirements.txt
@@ -9,3 +9,4 @@ bokeh>=3.5.2
 markupsafe>=2.1.5
 Markdown>=3.7
 mdx-breakless-lists>=1.0.1
+setproctitle>=1.3.4


### PR DESCRIPTION
## What is this fixing or adding?

Sets process name / title for Generator and MultiHoster multiprocesses

Small caveat: htop, etc. may cache the display name, so if the name changes while already shown, htop, etc. needs to be restarted,

## How was this tested?

by looking at htop

## If this makes graphical changes, please attach screenshots.

```bash
htop --filter "Host|Generator"
```
![htop](https://github.com/user-attachments/assets/aa2ecea7-498b-4d42-a83a-b97f4ed2a862)
