### PR TITLE
Core: Make log time an optional arg & setting for Generate.py as well

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -42,7 +42,9 @@ def mystery_argparse():
                         help="Path to output folder. Absolute or relative to cwd.")  # absolute or relative to cwd
     parser.add_argument('--race', action='store_true', default=defaults.race)
     parser.add_argument('--meta_file_path', default=defaults.meta_file_path)
-    parser.add_argument('--log_level', default='info', help='Sets log level')
+    parser.add_argument('--log_level', default=defaults.loglevel, help='Sets log level')
+    parser.add_argument('--log_time', help="Add timestamps to STDOUT",
+                        default=defaults.logtime, action='store_true')
     parser.add_argument("--csv_output", action="store_true",
                         help="Output rolled player options to csv (made for async multiworld).")
     parser.add_argument("--plando", default=defaults.plando_options,
@@ -75,7 +77,7 @@ def main(args=None) -> Tuple[argparse.Namespace, int]:
 
     seed = get_seed(args.seed)
 
-    Utils.init_logging(f"Generate_{seed}", loglevel=args.log_level)
+    Utils.init_logging(f"Generate_{seed}", loglevel=args.log_level, add_timestamp=args.log_time)
     random.seed(seed)
     seed_name = get_seed_name(random)
 

--- a/settings.py
+++ b/settings.py
@@ -678,6 +678,8 @@ class GeneratorOptions(Group):
     race: Race = Race(0)
     plando_options: PlandoOptions = PlandoOptions("bosses, connections, texts")
     panic_method: PanicMethod = PanicMethod("swap")
+    loglevel: str = "info"
+    logtime: bool = False
 
 
 class SNIOptions(Group):


### PR DESCRIPTION
https://github.com/ArchipelagoMW/Archipelago/pull/3028 added timestamps to all logging output.
Then, https://github.com/ArchipelagoMW/Archipelago/pull/4266 made this optional via an arg and added a setting for it for MultiServer.py. This effectively *turned off* timestamping for Generate.py again, because the default for the new arg is `False`.

This PR now aims to do the same thing 4266 did but for Generate.py, adding a CLI arg & setting to GeneratorOptions that allows turning on timestamps.

Also, adds `log_level` as a setting to GeneratorOptions, for parity with MultiServer.