### PR TITLE
MultiServer/CommonClient: We forgot about Item Links again (Hint Priority)

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1914,7 +1914,7 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
             hint = ctx.get_hint(client.team, player, location)
             if not hint:
                 return  # Ignored safely
-            if hint.receiving_player != client.slot:
+            if client.slot not in ctx.slot_set(hint.receiving_player):
                 await ctx.send_msgs(client,
                                     [{'cmd': 'InvalidPacket', "type": "arguments", "text": 'UpdateHint: No Permission',
                                       "original_cmd": cmd}])

--- a/NetUtils.py
+++ b/NetUtils.py
@@ -232,7 +232,7 @@ class JSONtoTextParser(metaclass=HandlerMeta):
 
     def _handle_player_id(self, node: JSONMessagePart):
         player = int(node["text"])
-        node["color"] = 'magenta' if player == self.ctx.slot else 'yellow'
+        node["color"] = 'magenta' if self.ctx.slot_concerns_self(player) else 'yellow'
         node["text"] = self.ctx.player_names[player]
         return self._handle_color(node)
 

--- a/kvui.py
+++ b/kvui.py
@@ -371,7 +371,7 @@ class HintLabel(RecycleDataViewBehavior, BoxLayout):
                     if self.hint["status"] == HintStatus.HINT_FOUND:
                         return
                     ctx = App.get_running_app().ctx
-                    if ctx.slot == self.hint["receiving_player"]:  # If this player owns this hint
+                    if ctx.slot_concerns_self(self.hint["receiving_player"]):  # If this player owns this hint
                         # open a dropdown
                         self.dropdown.open(self.ids["status"])
                 elif self.selected:
@@ -800,7 +800,7 @@ class HintLog(RecycleView):
             hint_status_node = self.parser.handle_node({"type": "color",
                                                         "color": status_colors.get(hint["status"], "red"),
                                                         "text": status_names.get(hint["status"], "Unknown")})
-            if hint["status"] != HintStatus.HINT_FOUND and hint["receiving_player"] == ctx.slot:
+            if hint["status"] != HintStatus.HINT_FOUND and ctx.slot_concerns_self(hint["receiving_player"]):
                 hint_status_node = f"[u]{hint_status_node}[/u]"
             data.append({
                 "receiving": {"text": self.parser.handle_node({"type": "player_id", "text": hint["receiving_player"]})},


### PR DESCRIPTION
When testing https://github.com/ArchipelagoMW/Archipelago/pull/3506, we all forgot to test itemlinks again, lol

Basically, noone can update the priority of an item links hint.

Also included: Color item links players that concern this slot pink, just like when it's the slot itself

Before:
![image](https://github.com/user-attachments/assets/dd37c9df-a2b6-46d6-a2c4-b5dd69a90260)
After:
![image](https://github.com/user-attachments/assets/a0fde623-7950-4086-8d0f-9c0f0bef264c)