### PR TITLE
Core: Hint Priority fixes

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1929,6 +1929,11 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
                                     [{'cmd': 'InvalidPacket', "type": "arguments",
                                       "text": 'UpdateHint: Invalid Status', "original_cmd": cmd}])
                 return
+            if status == HintStatus.HINT_FOUND:
+                await ctx.send_msgs(client,
+                                    [{'cmd': 'InvalidPacket', "type": "arguments",
+                                      "text": 'UpdateHint: Cannot manually update status to "HINT_FOUND"', "original_cmd": cmd}])
+                return
             new_hint = new_hint.re_prioritize(ctx, status)
             if hint == new_hint:
                 return

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -351,7 +351,7 @@ Sent to the server to update the status of a Hint. The client must be the 'recei
 | ---- | ---- | ----- |
 | player | int | The ID of the player whose location is being hinted for. |
 | location | int | The ID of the location to update the hint for. If no hint exists for this location, the packet is ignored. |
-| status | [HintStatus](#HintStatus) | Optional. If included, sets the status of the hint to this status. Fails if the status is already `Found`. |
+| status | [HintStatus](#HintStatus) | Optional. If included, sets the status of the hint to this status. Cannot set `HINT_FOUND`, or change the status from `HINT_FOUND`. |
 
 #### HintStatus
 An enumeration containing the possible hint states.

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -351,7 +351,7 @@ Sent to the server to update the status of a Hint. The client must be the 'recei
 | ---- | ---- | ----- |
 | player | int | The ID of the player whose location is being hinted for. |
 | location | int | The ID of the location to update the hint for. If no hint exists for this location, the packet is ignored. |
-| status | [HintStatus](#HintStatus) | Optional. If included, sets the status of the hint to this status. |
+| status | [HintStatus](#HintStatus) | Optional. If included, sets the status of the hint to this status. Fails if the status is already `Found`. |
 
 #### HintStatus
 An enumeration containing the possible hint states.
@@ -359,12 +359,15 @@ An enumeration containing the possible hint states.
 ```python
 import enum
 class HintStatus(enum.IntEnum):
-    HINT_FOUND = 0
-    HINT_UNSPECIFIED = 1
-    HINT_NO_PRIORITY = 10
-    HINT_AVOID = 20
-    HINT_PRIORITY = 30
+    HINT_FOUND = 0        # The location has been collected. Status cannot be changed once found.
+    HINT_UNSPECIFIED = 1  # The receiving player has not specified any status
+    HINT_NO_PRIORITY = 10 # The receiving player has specified that the item is unneeded
+    HINT_AVOID = 20       # The receiving player has specified that the item is detrimental
+    HINT_PRIORITY = 30    # The receiving player has specified that the item is needed
 ```
+- Hints created with `LocationScouts`, `!hint_location`, or similar (hinting a location) default to `HINT_UNSPECIFIED`.
+- Hints created with `!hint` or similar (hinting an item for yourself) default to `HINT_PRIORITY`.
+- Once a hint is collected, its' status is updated to `HINT_FOUND` automatically, and can no longer be changed.
 
 ### StatusUpdate
 Sent to the server to update on the sender's status. Examples include readiness or goal completion. (Example: defeated Ganon in A Link to the Past)
@@ -668,6 +671,7 @@ class Hint(typing.NamedTuple):
     found: bool
     entrance: str = ""
     item_flags: int = 0
+    status: HintStatus = HintStatus.HINT_UNSPECIFIED
 ```
 
 ### Data Package Contents

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -365,6 +365,7 @@ class HintStatus(enum.IntEnum):
     HINT_AVOID = 20       # The receiving player has specified that the item is detrimental
     HINT_PRIORITY = 30    # The receiving player has specified that the item is needed
 ```
+- Hints for items with `ItemClassification.trap` default to `HINT_AVOID`.
 - Hints created with `LocationScouts`, `!hint_location`, or similar (hinting a location) default to `HINT_UNSPECIFIED`.
 - Hints created with `!hint` or similar (hinting an item for yourself) default to `HINT_PRIORITY`.
 - Once a hint is collected, its' status is updated to `HINT_FOUND` automatically, and can no longer be changed.


### PR DESCRIPTION
## What is this fixing or adding?
Some documentation missed in the hint priority PR
Also fixed a missing check to prevent `UpdateHint` packets from setting the status to `HINT_FOUND`
Fix precollected hints not being handled at all

## How was this tested?
Read the changed docs.
Modified TextClient to send a faulty `UpdateHint` packet with `HINT_FOUND` as the status, which gave `WARNING:Client:Invalid Packet of arguments: UpdateHint: Cannot manually update status to "HINT_FOUND"` (the correct new error message)
Tested `start_hints`, `start_location_hints`

## If this makes graphical changes, please attach screenshots.
`start_hints`,`start_location_hints` test:
![image](https://github.com/user-attachments/assets/0bc0e02c-3154-4435-8ef7-391487039bc9)
(`Progressive Movie Theater` is properly marked `Avoid` due to being `Progression + Trap` classification, `Progressive Pickaxe` is properly `Priority` via `start_hints`, and the `Return Scepter` is properly `Unspecified` via `start_location_hints`)