### PR TITLE
MultiServer: CreateHints command (Allows clients to hint own items in other worlds)

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1900,6 +1900,43 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
             if locs and create_as_hint:
                 ctx.save()
             await ctx.send_msgs(client, [{'cmd': 'LocationInfo', 'locations': locs}])
+
+        elif cmd == 'CreateHint':
+            location_player = args.get("player", client.slot)
+            locations = args["locations"]
+            status = args.get("status", HintStatus.HINT_UNSPECIFIED)
+
+            hints = []
+
+            for location in locations:
+                if location_player != client.slot and location not in ctx.locations[location_player]:
+                    error_text = (
+                        "UpdateHint: One or more of the locations do not exist for the specified off-world player. "
+                        "Please refrain from hinting other slot's locations that you don't know contain your items."
+                    )
+                    await ctx.send_msgs(client, [{"cmd": "InvalidPacket", "type": "arguments",
+                                                  "text": error_text, "original_cmd": cmd}])
+                    return
+
+                target_item, item_player, flags = ctx.locations[location_player][location]
+
+                if client.slot not in ctx.slot_set(item_player):
+                    if status != HintStatus.HINT_UNSPECIFIED:
+                        error_text = 'UpdateHint: Must use "unspecified"/None status for items for other players.'
+                        await ctx.send_msgs(client, [{"cmd": "InvalidPacket", "type": "arguments",
+                                                      "text": error_text, "original_cmd": cmd}])
+                        return
+
+                    if client.slot != location_player:
+                        error_text = "UpdateHint: Can only create hints for own items or own locations."
+                        await ctx.send_msgs(client, [{"cmd": "InvalidPacket", "type": "arguments",
+                                                      "text": error_text, "original_cmd": cmd}])
+                        return
+
+                hints += collect_hint_location_id(ctx, client.team, location_player, location, status)
+
+            ctx.notify_hints(client.team, hints, only_new=True)
+            ctx.save()
         
         elif cmd == 'UpdateHint':
             location = args["location"]

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1939,7 +1939,7 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
 
                 hints += collect_hint_location_id(ctx, client.team, location_player, location, status)
 
-            # As of writing this code, only_new=True does not update status, so existing hints will always be skipped
+            # As of writing this code, only_new=True does not update status for existing hints
             ctx.notify_hints(client.team, hints, only_new=True)
             ctx.save()
         

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1906,6 +1906,10 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
             locations = args["locations"]
             status = args.get("status", HintStatus.HINT_UNSPECIFIED)
 
+            if not locations:
+                await ctx.send_msgs(client, [{"cmd": "InvalidPacket", "type": "arguments",
+                                              "text": "CreateHints: No locations specified.", "original_cmd": cmd}])
+
             hints = []
 
             for location in locations:

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1901,7 +1901,7 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
                 ctx.save()
             await ctx.send_msgs(client, [{'cmd': 'LocationInfo', 'locations': locs}])
 
-        elif cmd == 'CreateHint':
+        elif cmd == 'CreateHints':
             location_player = args.get("player", client.slot)
             locations = args["locations"]
             status = args.get("status", HintStatus.HINT_UNSPECIFIED)
@@ -1911,7 +1911,7 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
             for location in locations:
                 if location_player != client.slot and location not in ctx.locations[location_player]:
                     error_text = (
-                        "UpdateHint: One or more of the locations do not exist for the specified off-world player. "
+                        "CreateHints: One or more of the locations do not exist for the specified off-world player. "
                         "Please refrain from hinting other slot's locations that you don't know contain your items."
                     )
                     await ctx.send_msgs(client, [{"cmd": "InvalidPacket", "type": "arguments",
@@ -1922,13 +1922,13 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
 
                 if client.slot not in ctx.slot_set(item_player):
                     if status != HintStatus.HINT_UNSPECIFIED:
-                        error_text = 'UpdateHint: Must use "unspecified"/None status for items for other players.'
+                        error_text = 'CreateHints: Must use "unspecified"/None status for items for other players.'
                         await ctx.send_msgs(client, [{"cmd": "InvalidPacket", "type": "arguments",
                                                       "text": error_text, "original_cmd": cmd}])
                         return
 
                     if client.slot != location_player:
-                        error_text = "UpdateHint: Can only create hints for own items or own locations."
+                        error_text = "CreateHints: Can only create hints for own items or own locations."
                         await ctx.send_msgs(client, [{"cmd": "InvalidPacket", "type": "arguments",
                                                       "text": error_text, "original_cmd": cmd}])
                         return

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1939,6 +1939,7 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
 
                 hints += collect_hint_location_id(ctx, client.team, location_player, location, status)
 
+            # As of writing this code, only_new=True does not update status, so existing hints will always be skipped
             ctx.notify_hints(client.team, hints, only_new=True)
             ctx.save()
         

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -272,6 +272,7 @@ These packets are sent purely from client to server. They are not accepted by cl
 * [Sync](#Sync)
 * [LocationChecks](#LocationChecks)
 * [LocationScouts](#LocationScouts)
+* [CreateHints](#CreateHints)
 * [UpdateHint](#UpdateHint)
 * [StatusUpdate](#StatusUpdate)
 * [Say](#Say)
@@ -342,6 +343,18 @@ This is useful in cases where an item appears in the game world, such as 'ledge 
 | ---- | ---- | ----- |
 | locations | list\[int\] | The ids of the locations seen by the client. May contain any number of locations, even ones sent before; duplicates do not cause issues with the Archipelago server. |
 | create_as_hint | int | If non-zero, the scouted locations get created and broadcasted as a player-visible hint. <br/>If 2 only new hints are broadcast, however this does not remove them from the LocationInfo reply. |
+
+### CreateHints
+
+Sent to the server to create hints for a specified list of locations.
+When creating hints for another slot's locations, the packet will fail if any of those locations don't contain items for the requesting slot.
+When creating hints for your own slot's locations, non-existing locations will silently be skipped.
+
+#### Arguments
+| Name | Type | Notes |
+| ---- | ---- | ----- |
+| locations | list\[int\] | The ids of the locations to create hints for. |
+| player | int | The ID of the player whose locations are being hinted for. Defaults to the requesting slot. |
 
 ### UpdateHint
 Sent to the server to update the status of a Hint. The client must be the 'receiving_player' of the Hint, or the update fails.

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -355,6 +355,7 @@ When creating hints for your own slot's locations, non-existing locations will s
 | ---- | ---- | ----- |
 | locations | list\[int\] | The ids of the locations to create hints for. |
 | player | int | The ID of the player whose locations are being hinted for. Defaults to the requesting slot. |
+| status | [HintStatus](#HintStatus) | If included, sets the status of the hint to this status. Defaults to `HINT_UNSPECIFIED`. Cannot set `HINT_FOUND`. |
 
 ### UpdateHint
 Sent to the server to update the status of a Hint. The client must be the 'receiving_player' of the Hint, or the update fails.

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -346,9 +346,11 @@ This is useful in cases where an item appears in the game world, such as 'ledge 
 
 ### CreateHints
 
-Sent to the server to create hints for a specified list of locations.
-When creating hints for another slot's locations, the packet will fail if any of those locations don't contain items for the requesting slot.
-When creating hints for your own slot's locations, non-existing locations will silently be skipped.
+Sent to the server to create hints for a specified list of locations.  
+Hints that already exist will be silently skipped and their status will not be updated.
+
+When creating hints for another slot's locations, the packet will fail if any of those locations don't contain items for the requesting slot.  
+When creating hints for your own slot's locations, non-existing locations will silently be skipped.  
 
 #### Arguments
 | Name | Type | Notes |


### PR DESCRIPTION
Supercedes https://github.com/ArchipelagoMW/Archipelago/pull/4316

Basically, this is supposed to supercede the concept of LocationScouts with create_as_hint in general, and have additional functionality.

Thanks to Jarno458 and EmilyV99 for their reviews on https://github.com/ArchipelagoMW/Archipelago/pull/4316, as well as Scipio's, alwaysintreble's and EmilyV99's (again) reviews on https://github.com/ArchipelagoMW/Archipelago/pull/3523. I apologize that your review work is lost, finding the right design is an iterative process that can only be done with reviewers' help :)

One question I anticipate is:
The code looks really similar to LocationScouts, so what was wrong with the original PR that allowed off-world LocationScouts?

The difference here is that this PR doesn't send back a LocationInfo packet, meaning that it can't be used to **find** your items in other slots. In fact, this packet will actually completely fail if any of the locations specified don't contain an item for the requestion slot, or the location doesn't even exist in the first place. Clients trying to find their remote items by scouting every slot one by one with their respective entire datapackage would've been **very bad**, but also very **appealing**.