### PR TITLE
Limit ItemLink Name to 16 Characters

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -1389,7 +1389,8 @@ class ItemLinks(OptionList):
         for link in self.value:
             link["name"] = link["name"].strip()[:16].strip()
             if link["name"] in existing_links:
-                raise Exception(f"You cannot have more than one link named {link['name']}.")
+                raise Exception(f"Item link names are limited to their first 16 characters and must be unique. "
+                                f"You have more than one link named '{link['name']}'.")
             existing_links.add(link["name"])
 
             pool = self.verify_items(link["item_pool"], link["name"], "item_pool", world)


### PR DESCRIPTION
## What is this fixing or adding?

Aliases and player names are both limited to 16 characters, however, ItemLink names are not. This truncates them to sixteen characters as well.

Also changes the error message to be more specific about the conditions for identical item link names and adds quotation marks around the name itself.

## How was this tested?

Not all that much, generating an itemlink with the name "Just A Really Long Name" and both generating and uploading a world on a local webhost using the same itemlink group. Checked that the name everywhere had been shortened and connected to the multiworld to get some checks.