### PR TITLE
FFMQ: No Longer Allow Inaccessible Useful Items

### DIFF
--- a/worlds/ffmq/Options.py
+++ b/worlds/ffmq/Options.py
@@ -1,4 +1,4 @@
-from Options import Choice, FreeText, Toggle, Range, PerGameCommonOptions
+from Options import Choice, FreeText, ItemsAccessibility, Toggle, Range, PerGameCommonOptions
 from dataclasses import dataclass
 
 
@@ -324,6 +324,7 @@ class KaelisMomFightsMinotaur(Toggle):
 
 @dataclass
 class FFMQOptions(PerGameCommonOptions):
+    accessibility: ItemsAccessibility
     logic: Logic
     brown_boxes: BrownBoxes
     sky_coin_mode: SkyCoinMode

--- a/worlds/ffmq/Options.py
+++ b/worlds/ffmq/Options.py
@@ -1,4 +1,4 @@
-from Options import Choice, FreeText, ItemsAccessibility, Toggle, Range, PerGameCommonOptions
+from Options import Choice, FreeText, Toggle, Range, PerGameCommonOptions
 from dataclasses import dataclass
 
 
@@ -324,7 +324,6 @@ class KaelisMomFightsMinotaur(Toggle):
 
 @dataclass
 class FFMQOptions(PerGameCommonOptions):
-    accessibility: ItemsAccessibility
     logic: Logic
     brown_boxes: BrownBoxes
     sky_coin_mode: SkyCoinMode

--- a/worlds/ffmq/Regions.py
+++ b/worlds/ffmq/Regions.py
@@ -221,7 +221,7 @@ def stage_set_rules(multiworld):
                 else:
                     multiworld.get_location(location, player).access_rule = lambda state: False
     else:
-        raise Exception(f"Not enough filler/trap items for full and items accessibility players. "
+        raise Exception(f"Not enough filler/trap items for FFMQ players with full and items accessibility. "
                         f"Add more items or change the 'Enemies Density' option to something besides 'none'")
 
 

--- a/worlds/ffmq/Regions.py
+++ b/worlds/ffmq/Regions.py
@@ -213,7 +213,7 @@ def stage_set_rules(multiworld):
                           if multiworld.worlds[player].options.enemies_density == "none"]
     if (len([item for item in multiworld.itempool if item.excludable
             ]) > len([player for player in no_enemies_players if
-                                              multiworld.worlds[player].options.accessibility == "minimal"]) * 3):
+                                              multiworld.worlds[player].options.accessibility != "minimal"]) * 3):
         for player in no_enemies_players:
             for location in vendor_locations:
                 if multiworld.worlds[player].options.accessibility == "full":

--- a/worlds/ffmq/Regions.py
+++ b/worlds/ffmq/Regions.py
@@ -211,8 +211,8 @@ def stage_set_rules(multiworld):
     # If there's no enemies, there's no repeatable income sources
     no_enemies_players = [player for player in multiworld.get_game_players("Final Fantasy Mystic Quest")
                           if multiworld.worlds[player].options.enemies_density == "none"]
-    if (len([item for item in multiworld.itempool if item.classification in (ItemClassification.filler,
-            ItemClassification.trap)]) > len([player for player in no_enemies_players if
+    if (len([item for item in multiworld.itempool if item.excludable
+            ]) > len([player for player in no_enemies_players if
                                               multiworld.worlds[player].options.accessibility == "minimal"]) * 3):
         for player in no_enemies_players:
             for location in vendor_locations:
@@ -225,7 +225,7 @@ def stage_set_rules(multiworld):
         # advancement items so that useful items can be placed.
         for player in no_enemies_players:
             for location in vendor_locations:
-                multiworld.get_location(location, player).item_rule = lambda item: not item.advancement
+                multiworld.get_location(location, player).item_rule = lambda item: item.excludable
 
 
 class FFMQLocation(Location):

--- a/worlds/ffmq/Regions.py
+++ b/worlds/ffmq/Regions.py
@@ -221,11 +221,8 @@ def stage_set_rules(multiworld):
                 else:
                     multiworld.get_location(location, player).access_rule = lambda state: False
     else:
-        # There are not enough junk items to fill non-minimal players' vendors. Just set an item rule not allowing
-        # advancement items so that useful items can be placed.
-        for player in no_enemies_players:
-            for location in vendor_locations:
-                multiworld.get_location(location, player).item_rule = lambda item: item.excludable
+        raise Exception(f"Not enough filler/trap items for full and items accessibility players. "
+                        f"Add more items or change the 'Enemies Density' option to something besides 'none'")
 
 
 class FFMQLocation(Location):


### PR DESCRIPTION
## What is this fixing or adding?

Previously, if the entire multiworld did not have enough filler/trap items to place on inaccessible vendor locations, these locations would be modified to allow useful items to be placed. [Useful items are not allowed on inaccessible locations](https://github.com/ArchipelagoMW/Archipelago/blob/main/Fill.py#L353-L354). This changes the code to now raise an exception instead of allowing Useful items.

Changes the accessibility check to look for `!= "minimal"` because it's non-minimal player's whose locations are relevant here, not the minimal ones.

Uses the new `item.excludable` since it's technically safer.

Alternatively, the `if/else` and iteration over the multiworld itempool could be removed entirely. This would make it crash later, but that's what other worlds do too.
```py
def stage_set_rules(multiworld):
    # If there's no enemies, there's no repeatable income sources
    no_enemies_players = [player for player in multiworld.get_game_players("Final Fantasy Mystic Quest")
                          if multiworld.worlds[player].options.enemies_density == "none"]
    for player in no_enemies_players:
        for location in vendor_locations:
            if multiworld.worlds[player].options.accessibility == "full":
                multiworld.get_location(location, player).progress_type = LocationProgressType.EXCLUDED
            else:
                multiworld.get_location(location, player).access_rule = lambda state: False
```

## How was this tested?

Generations using FFMQ and Witness where Useful items were plando'ed into the inaccessible vendor locations.
