### PR TITLE
LADX: correct in-game check counter

### DIFF
--- a/worlds/ladx/LADXR/patches/bank3e.py
+++ b/worlds/ladx/LADXR/patches/bank3e.py
@@ -96,7 +96,9 @@ StartGameMarinMessage:
         ldi  [hl], a ;hour counter
 
         ld   hl, $B010
+        ld   a, $01  ;tarin's gift gets skipped for some reason, so inflate count by 1
         ldi  [hl], a ;check counter low
+        xor  a
         ldi  [hl], a ;check counter high
 
         ; Show the normal message


### PR DESCRIPTION
## What is this fixing or adding?
The in-game check counter that displays at the end of the game isn't counting the mandatory first check (Tarin's Gift) and so it is off by one. This inflates the check count by one at the start to correct.

## How was this tested?
It has been in the rolling ladx beta since Nov 14, waiting for a confirmation that it does what it is meant to do before undrafting.