### PR TITLE
LADX: combine warp options

### DIFF
--- a/worlds/ladx/LADXR/generator.py
+++ b/worlds/ladx/LADXR/generator.py
@@ -58,7 +58,7 @@ from . import hints
 
 from .patches import bank34
 from .utils import formatText
-from ..Options import TrendyGame, Palette
+from ..Options import TrendyGame, Palette, Warps
 from .roomEditor import RoomEditor, Object
 from .patches.aesthetics import rgb_to_bin, bin_to_rgb
 
@@ -418,8 +418,8 @@ def generateRom(args, world: "LinksAwakeningWorld"):
             for channel in range(3):
                 color[channel] = color[channel] * 31 // 0xbc
 
-    if world.options.warp_improvements:
-        patches.core.addWarpImprovements(rom, world.options.additional_warp_points)
+    if world.options.warps != Warps.options_vanilla:
+        patches.core.addWarpImprovements(rom, world.options.warps == Warps.options_improved_additional)
 
     palette = world.options.palette
     if palette != Palette.option_normal:

--- a/worlds/ladx/LADXR/generator.py
+++ b/worlds/ladx/LADXR/generator.py
@@ -418,8 +418,8 @@ def generateRom(args, world: "LinksAwakeningWorld"):
             for channel in range(3):
                 color[channel] = color[channel] * 31 // 0xbc
 
-    if world.options.warps != Warps.options_vanilla:
-        patches.core.addWarpImprovements(rom, world.options.warps == Warps.options_improved_additional)
+    if world.options.warps != Warps.option_vanilla:
+        patches.core.addWarpImprovements(rom, world.options.warps == Warps.option_improved_additional)
 
     palette = world.options.palette
     if palette != Palette.option_normal:

--- a/worlds/ladx/Options.py
+++ b/worlds/ladx/Options.py
@@ -486,20 +486,17 @@ class Music(Choice, LADXROption):
         return self.ladxr_name, s
 
 
-class WarpImprovements(DefaultOffToggle):
+class Warps(Choice):
     """
-    [On] Adds remake style warp screen to the game. Choose your warp destination on the map after jumping in a portal and press B to select.
-    [Off] No change
+    [Improved] Adds remake style warp screen to the game. Choose your warp destination on the map after jumping in a portal and press B to select.
+    [Improved Additonal] Improved warps, and adds a warp point at Crazy Tracy's house (the Mambo teleport spot) and Eagle's Tower.
     """
-    display_name = "Warp Improvements"
+    display_name = "Warps"
+    option_vanilla = 0
+    option_improved = 1
+    option_improved_additional = 2
+    default = option_vanilla
 
-
-class AdditionalWarpPoints(DefaultOffToggle):
-    """
-    [On] (requires warp improvements) Adds a warp point at Crazy Tracy's house (the Mambo teleport spot) and Eagle's Tower
-    [Off] No change
-    """
-    display_name = "Additional Warp Points"
 
 ladx_option_groups = [
     OptionGroup("Goal Options", [
@@ -515,8 +512,7 @@ ladx_option_groups = [
         ShuffleStoneBeaks
     ]),
     OptionGroup("Warp Points", [
-        WarpImprovements,
-        AdditionalWarpPoints,
+        Warps,
     ]),
     OptionGroup("Miscellaneous", [
         TradeQuest,
@@ -562,8 +558,7 @@ class LinksAwakeningOptions(PerGameCommonOptions):
     # 'bowwow': Bowwow,
     # 'overworld': Overworld,
     link_palette: LinkPalette
-    warp_improvements: WarpImprovements
-    additional_warp_points: AdditionalWarpPoints
+    warps: Warps,
     trendy_game: TrendyGame
     gfxmod: GfxMod
     palette: Palette

--- a/worlds/ladx/Options.py
+++ b/worlds/ladx/Options.py
@@ -489,7 +489,7 @@ class Music(Choice, LADXROption):
 class Warps(Choice):
     """
     [Improved] Adds remake style warp screen to the game. Choose your warp destination on the map after jumping in a portal and press B to select.
-    [Improved Additonal] Improved warps, and adds a warp point at Crazy Tracy's house (the Mambo teleport spot) and Eagle's Tower.
+    [Improved Additional] Improved warps, and adds a warp point at Crazy Tracy's house (the Mambo teleport spot) and Eagle's Tower.
     """
     display_name = "Warps"
     option_vanilla = 0

--- a/worlds/ladx/Options.py
+++ b/worlds/ladx/Options.py
@@ -558,7 +558,7 @@ class LinksAwakeningOptions(PerGameCommonOptions):
     # 'bowwow': Bowwow,
     # 'overworld': Overworld,
     link_palette: LinkPalette
-    warps: Warps,
+    warps: Warps
     trendy_game: TrendyGame
     gfxmod: GfxMod
     palette: Palette

--- a/worlds/ladx/Options.py
+++ b/worlds/ladx/Options.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import os.path
 import typing
 import logging
-from Options import Choice, Toggle, DefaultOnToggle, Range, FreeText, PerGameCommonOptions, OptionGroup
+from Options import Choice, Toggle, DefaultOnToggle, Range, FreeText, PerGameCommonOptions, OptionGroup, Removed
 from collections import defaultdict
 import Utils
 
@@ -574,3 +574,6 @@ class LinksAwakeningOptions(PerGameCommonOptions):
     nag_messages: NagMessages
     ap_title_screen: APTitleScreen
     boots_controls: BootsControls
+
+    warp_improvements: Removed
+    additional_warp_points: Removed


### PR DESCRIPTION
## What is this fixing or adding?
LADX has two QoL warp options as toggles, but one only works if the other is enabled. This makes a single option combining both.

## How was this tested?
Was added very early in the ladx beta process, has had a lot of playtesting.