### PR TITLE
Stardew Valley: Fix a bug in equals between Or and And rules

### DIFF
--- a/worlds/stardew_valley/stardew_rule/base.py
+++ b/worlds/stardew_valley/stardew_rule/base.py
@@ -293,7 +293,7 @@ class AggregatingStardewRule(BaseStardewRule, ABC):
 
     def __eq__(self, other):
         return (isinstance(other, type(self)) and self.combinable_rules == other.combinable_rules and
-                self.simplification_state.original_simplifiable_rules == self.simplification_state.original_simplifiable_rules)
+                self.simplification_state.original_simplifiable_rules == other.simplification_state.original_simplifiable_rules)
 
     def __hash__(self):
         if len(self.combinable_rules) + len(self.simplification_state.original_simplifiable_rules) > 5:


### PR DESCRIPTION
## What is this fixing or adding?
So, I don't know how it went unnoticed for so long... Basically for `Or` and `And` rule, if two rules had the same combinable sub-rules, they would automatically be considered equals completely ignoring the other sub-rules. For example, a rule that require access to 5 regions would be considered equal to a different rule requiring 5 completely different regions. They would evaluate different, but be considered equal. 

I found this while writing tests in another branch. This bug has been merged for ~9 months and no one noticed, so I guess the `__eq__` is probably not used too often. At least the `__hash__` is correctly implemented, so that probably saved a lot of problems. 

## How was this tested?
Not really tested, but it's kind of obvious that the `__eq__` method should compare with `other` and not `self`. 

## If this makes graphical changes, please attach screenshots.
N/A