### PR TITLE
HK: add random handling to plandocharmcosts

### DIFF
--- a/worlds/hk/Options.py
+++ b/worlds/hk/Options.py
@@ -6,7 +6,7 @@ from .ExtractedData import logic_options, starts, pool_options
 from .Rules import cost_terms
 from schema import And, Or, Schema, Optional
 
-from Options import Option, DefaultOnToggle, Toggle, Choice, Range, OptionDict, NamedRange, DeathLink, PerGameCommonOptions, OptionError
+from Options import Option, DefaultOnToggle, Toggle, Choice, Range, OptionDict, NamedRange, DeathLink, PerGameCommonOptions
 from .Charms import vanilla_costs, names as charm_names
 
 if typing.TYPE_CHECKING:

--- a/worlds/hk/Options.py
+++ b/worlds/hk/Options.py
@@ -293,6 +293,7 @@ class RandomCharmCosts(NamedRange):
                 charms[index] += 1
             return charms
 
+
 class CharmCost(Range):
     range_end = 6
 
@@ -319,7 +320,6 @@ class PlandoCharmCosts(OptionDict):
             except ValueError as ex:
                 # will fail schema afterwords
                 self.value[key] = data
-
 
     def get_costs(self, charm_costs: typing.List[int]) -> typing.List[int]:
         for name, cost in self.value.items():

--- a/worlds/hk/Options.py
+++ b/worlds/hk/Options.py
@@ -310,6 +310,14 @@ class PlandoCharmCosts(OptionDict):
     def __init__(self, value):
         self.value = {}
         for key, data in value.items():
+            if isinstance(data, str):
+                if data.lower() == "vanilla" and key in self.valid_keys:
+                    self.value[key] = vanilla_costs[charm_names.index(key)]
+                    continue
+                elif data.lower() == "default":
+                    # default is too easily confused with vanilla but actually 0
+                    self.value[key] = data
+                    continue
             try:
                 self.value[key] = CharmCost.from_any(data).value
             except ValueError as ex:

--- a/worlds/hk/Options.py
+++ b/worlds/hk/Options.py
@@ -308,6 +308,9 @@ class PlandoCharmCosts(OptionDict):
         })
 
     def __init__(self, value):
+        # To handle keys of random like other options, create an option instance from their values
+        # Additionally a vanilla keyword is added to plando individual charms to vanilla costs
+        # and default is disabled so as to not cause confusion
         self.value = {}
         for key, data in value.items():
             if isinstance(data, str):
@@ -316,6 +319,7 @@ class PlandoCharmCosts(OptionDict):
                     continue
                 elif data.lower() == "default":
                     # default is too easily confused with vanilla but actually 0
+                    # skip CharmCost resolution to fail schema afterwords
                     self.value[key] = data
                     continue
             try:

--- a/worlds/hk/Options.py
+++ b/worlds/hk/Options.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, make_dataclass
 
 from .ExtractedData import logic_options, starts, pool_options
 from .Rules import cost_terms
-from schema import And, Or, Schema, Optional
+from schema import And, Schema, Optional
 
 from Options import Option, DefaultOnToggle, Toggle, Choice, Range, OptionDict, NamedRange, DeathLink, PerGameCommonOptions
 from .Charms import vanilla_costs, names as charm_names
@@ -304,12 +304,7 @@ class PlandoCharmCosts(OptionDict):
     display_name = "Charm Notch Cost Plando"
     valid_keys = frozenset(charm_names)
     schema = Schema({
-        Optional(name): Or(
-            And(str, lambda n: n.startswith("random")),
-            And(int, lambda n: 6 >= n >= 0),
-            error="Charm costs must be integers in the range 0-6 or use a random prefixed string."
-            )
-        for name in charm_names
+        Optional(name): And(int, lambda n: 6 >= n >= 0, error="Charm costs must be integers in the range 0-6.") for name in charm_names
         })
 
     def __init__(self, value):


### PR DESCRIPTION
## What is this fixing or adding?
adds random handling to charm cost plando by using a Range option class's from_any

## How was this tested?
used a plando charm cost block with "random", "random-range-0-3", normal ints, and some invalid keys including dicts and invalid strings and saw everything resolve as expected in the spoiler log

## If this makes graphical changes, please attach screenshots.
