### PR TITLE
Pokemon Emerald: Fix invalid escape sequence warnings

### DIFF
--- a/worlds/pokemon_emerald/data.py
+++ b/worlds/pokemon_emerald/data.py
@@ -397,13 +397,13 @@ def _init() -> None:
         label = []
         for word in map_name[4:].split("_"):
             # 1F, B1F, 2R, etc.
-            re_match = re.match("^B?\d+[FRP]$", word)
+            re_match = re.match(r"^B?\d+[FRP]$", word)
             if re_match:
                 label.append(word)
                 continue
 
             # Route 103, Hall 1, House 5, etc.
-            re_match = re.match("^([A-Z]+)(\d+)$", word)
+            re_match = re.match(r"^([A-Z]+)(\d+)$", word)
             if re_match:
                 label.append(re_match.group(1).capitalize())
                 label.append(re_match.group(2).lstrip("0"))


### PR DESCRIPTION
## What is this fixing or adding?
Generation (of any game) on Python 3.12 would print SyntaxWarnings due to invalid '\d' escape sequences added in #3832.

Use raw strings to avoid `\` being used to escape characters.

## How was this tested?
I tested running generation of emerald and non-emerald.

Before:
```
G:\git_Repos_other\Archipelago\worlds\pokemon_emerald\data.py:400: SyntaxWarning: invalid escape sequence '\d'
  re_match = re.match("^B?\d+[FRP]$", word)
G:\git_Repos_other\Archipelago\worlds\pokemon_emerald\data.py:406: SyntaxWarning: invalid escape sequence '\d'
  re_match = re.match("^([A-Z]+)(\d+)$", word)
```