### PR TITLE
Factorio: hide hidden vanilla techs in factoriopedia too

### DIFF
--- a/worlds/factorio/data/mod_template/data-final-fixes.lua
+++ b/worlds/factorio/data/mod_template/data-final-fixes.lua
@@ -162,6 +162,7 @@ data.raw["ammo"]["artillery-shell"].stack_size = 10
 {# each randomized tech gets set to be invisible, with new nodes added that trigger those #}
 {%- for original_tech_name in base_tech_table -%}
 technologies["{{ original_tech_name }}"].hidden = true
+technologies["{{ original_tech_name }}"].hidden_in_factoriopedia = true
 {% endfor %}
 {%- for location, item in locations %}
 {#- the tech researched by the local player #}


### PR DESCRIPTION
## What is this fixing or adding?
hides technologies that are meant to be hidden in factoriopedia too. The attribute is new in 2.0 and if not set completely circumvents the main hidden variable as factoriopedia allows you to jump to the original.  This may end up being considered a vanilla bug and fixed, but for now, it is what it is.

## How was this tested?
It loaded ingame.
