### PR TITLE
LADX: avoid connector sni issues

### DIFF
--- a/LinksAwakeningClient.py
+++ b/LinksAwakeningClient.py
@@ -235,8 +235,7 @@ class RAGameboy():
 
     def check_command_response(self, command: str, response: bytes):
         if command == "VERSION":
-            resp = response.decode('ascii')
-            ok = ("bizhawk connector" in resp) or (re.match("\d+\.\d+\.\d+", resp) is not None)
+            ok = re.match("\d+\.\d+\.\d+", response.decode('ascii')) is not None
         else:
             ok = response.startswith(command.encode())
         if not ok:

--- a/LinksAwakeningClient.py
+++ b/LinksAwakeningClient.py
@@ -235,7 +235,8 @@ class RAGameboy():
 
     def check_command_response(self, command: str, response: bytes):
         if command == "VERSION":
-            ok = re.match("\d+\.\d+\.\d+", response.decode('ascii')) is not None
+            resp = response.decode('ascii')
+            ok = ("bizhawk connector" in resp) or (re.match("\d+\.\d+\.\d+", resp) is not None)
         else:
             ok = response.startswith(command.encode())
         if not ok:

--- a/data/lua/connector_ladx_bizhawk.lua
+++ b/data/lua/connector_ladx_bizhawk.lua
@@ -68,8 +68,9 @@ function on_vblank()
         -- "data" format is "COMMAND [PARAMETERS] [...]"
         local command = string.match(data, "%S+")
         if command == "VERSION" then
-            -- sending a bad version string keeps other things (SNI) from connecting
-            udp:sendto("bizhawk connector\n", msg_or_ip, port_or_nil)
+            -- 1.14 is the latest RetroArch release at the time of writing this, no other reason
+            -- for choosing this here.
+            udp:sendto("1.14.0\n", msg_or_ip, port_or_nil)
         elseif command == "GET_STATUS" then
             local status = "PLAYING"
             if client.ispaused() then

--- a/data/lua/connector_ladx_bizhawk.lua
+++ b/data/lua/connector_ladx_bizhawk.lua
@@ -46,8 +46,16 @@ local socket = require("socket")
 udp = socket.socket.udp()
 require('common')
 
-udp:setsockname('127.0.0.1', 55355)
-udp:settimeout(0)
+-- SNI interacts poorly with this connector and looks for ports 55355+
+-- We'll start from 55354 and go down looking for an open port, allowing for multiple concurrent instances
+
+port = 55355
+LOWEST_PORT = 55344
+isbound = nil
+while not isbound and port > LOWEST_PORT do
+    port = port - 1
+    isbound = udp:setsockname('127.0.0.1', port)
+end
 
 function on_vblank()
     -- Attempt to lessen the CPU load by only polling the UDP socket every x frames.
@@ -68,9 +76,8 @@ function on_vblank()
         -- "data" format is "COMMAND [PARAMETERS] [...]"
         local command = string.match(data, "%S+")
         if command == "VERSION" then
-            -- 1.14 is the latest RetroArch release at the time of writing this, no other reason
-            -- for choosing this here.
-            udp:sendto("1.14.0\n", msg_or_ip, port_or_nil)
+            -- Invalid retroarch version string but its probably better not to pretend this is normal retroarch
+            udp:sendto("bizhawk connector\n", msg_or_ip, port_or_nil)
         elseif command == "GET_STATUS" then
             local status = "PLAYING"
             if client.ispaused() then
@@ -138,7 +145,13 @@ function on_vblank()
     end
 end
 
-event.onmemoryexecute(on_vblank, 0x40, "ap_connector_vblank")
+if isbound then
+    udp:settimeout(0)
+    console.log(string.format("Connector is running on port %s", port))
+    event.onmemoryexecute(on_vblank, 0x40, "ap_connector_vblank")
+else
+    console.log("No available port was found")
+end
 
 while true do
     emu.yield()

--- a/data/lua/connector_ladx_bizhawk.lua
+++ b/data/lua/connector_ladx_bizhawk.lua
@@ -68,9 +68,8 @@ function on_vblank()
         -- "data" format is "COMMAND [PARAMETERS] [...]"
         local command = string.match(data, "%S+")
         if command == "VERSION" then
-            -- 1.14 is the latest RetroArch release at the time of writing this, no other reason
-            -- for choosing this here.
-            udp:sendto("1.14.0\n", msg_or_ip, port_or_nil)
+            -- sending a bad version string keeps other things (SNI) from connecting
+            udp:sendto("bizhawk connector\n", msg_or_ip, port_or_nil)
         elseif command == "GET_STATUS" then
             local status = "PLAYING"
             if client.ispaused() then

--- a/data/lua/connector_ladx_bizhawk.lua
+++ b/data/lua/connector_ladx_bizhawk.lua
@@ -50,7 +50,7 @@ require('common')
 -- We'll start from 55354 and go down looking for an open port, allowing for multiple concurrent instances
 
 port = 55355
-LOWEST_PORT = 55344
+LOWEST_PORT = 55350
 isbound = nil
 while not isbound and port > LOWEST_PORT do
     port = port - 1


### PR DESCRIPTION
## What is this fixing or adding?
The LADX Bizhawk connector mimics Retroarch, but only enough to do what we need. SNI tries to connect with it and bogs the system down with rapid reconnect attempts, which is a commonly encountered issue. Maybe something should be done on the SNI side, but I think it's also in our benefit to not actually pretend to be Retroarch in the connector.

This changes the connector to identify itself in response to a version request and has it use a range of ports below the standard Retroarch port. The client is modified to accept this behavior.


## How was this tested?
Will put it out for beta testing.