### PR TITLE
Muse Dash: Remove bad option defaults.

### DIFF
--- a/worlds/musedash/Options.py
+++ b/worlds/musedash/Options.py
@@ -11,7 +11,6 @@ class DLCMusicPacks(OptionSet):
     Note: The [Just As Planned] DLC contains all [Muse Plus] songs.
     """
     display_name = "DLC Packs"
-    default = {}
     valid_keys = [dlc for dlc in MuseDashCollections.DLC]
 
 
@@ -142,7 +141,6 @@ class ChosenTraps(OptionSet):
     Note: SFX traps are only available if [Just as Planned] DLC songs are enabled.
     """
     display_name = "Chosen Traps"
-    default = {}
     valid_keys = {trap for trap in MuseDashCollections.trap_items.keys()}
 
 


### PR DESCRIPTION
## What is this fixing or adding?
Some options used a dict as their default option, even though they were sets.

## How was this tested?
Generated a template yaml and double checked website.