### PR TITLE
Core: make `get_filler_item_name` abstract

### DIFF
--- a/test/general/__init__.py
+++ b/test/general/__init__.py
@@ -60,6 +60,9 @@ class TestWorld(World):
     location_name_to_id = {}
     hidden = True
 
+    def get_filler_item_name(self) -> str:
+        return "Nothing"
+
 
 # add our test world to the data package, so we can test it later
 network_data_package["games"][TestWorld.game] = TestWorld.get_data_package_data()

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -5,7 +5,7 @@ import logging
 import pathlib
 import sys
 import time
-from abc import abstractmethod
+from abc import ABCMeta, abstractmethod
 from random import Random
 from dataclasses import make_dataclass
 from typing import (Any, Callable, ClassVar, Dict, FrozenSet, List, Mapping, Optional, Set, TextIO, Tuple,
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 perf_logger = logging.getLogger("performance")
 
 
-class AutoWorldRegister(type):
+class AutoWorldRegister(ABCMeta):
     world_types: Dict[str, Type[World]] = {}
     __file__: str
     zip_path: Optional[str]
@@ -470,7 +470,7 @@ class World(metaclass=AutoWorldRegister):
     @abstractmethod
     def get_filler_item_name(self) -> str:
         """Called when the item pool needs to be filled with additional items to match location count."""
-        return self.multiworld.random.choice(tuple(self.item_name_to_id.keys()))
+        return self.random.choice(tuple(self.item_name_to_id.keys()))
 
     @classmethod
     def create_group(cls, multiworld: "MultiWorld", new_player_id: int, players: Set[int]) -> World:

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -5,6 +5,7 @@ import logging
 import pathlib
 import sys
 import time
+from abc import abstractmethod
 from random import Random
 from dataclasses import make_dataclass
 from typing import (Any, Callable, ClassVar, Dict, FrozenSet, List, Mapping, Optional, Set, TextIO, Tuple,
@@ -466,9 +467,9 @@ class World(metaclass=AutoWorldRegister):
         """
         raise NotImplementedError
 
+    @abstractmethod
     def get_filler_item_name(self) -> str:
         """Called when the item pool needs to be filled with additional items to match location count."""
-        logging.warning(f"World {self} is generating a filler item without custom filler pool.")
         return self.multiworld.random.choice(tuple(self.item_name_to_id.keys()))
 
     @classmethod

--- a/worlds/factorio/__init__.py
+++ b/worlds/factorio/__init__.py
@@ -537,6 +537,9 @@ class Factorio(World):
                             all_items[name], self.player)
         return item
 
+    def get_filler_item_name(self) -> str:
+        return super().get_filler_item_name()
+
 
 class FactorioLocation(Location):
     game: str = Factorio.game

--- a/worlds/generic/__init__.py
+++ b/worlds/generic/__init__.py
@@ -49,6 +49,9 @@ class GenericWorld(World):
             return Item(name, ItemClassification.filler, -1, self.player)
         raise KeyError(name)
 
+    def get_filler_item_name(self) -> str:
+        return "Nothing"
+
 
 class PlandoItem(NamedTuple):
     item: str

--- a/worlds/overcooked2/__init__.py
+++ b/worlds/overcooked2/__init__.py
@@ -591,6 +591,9 @@ class Overcooked2World(World):
             kitchen_name = world.level_mapping[overworld_id].shortname
             spoiler_handle.write(f'{overworld_name} | {kitchen_name}\n')
 
+    def get_filler_item_name(self) -> str:
+        return "Bonus Star"
+
 
 def level_unlock_requirement_factory(stars_to_win: int) -> Dict[int, int]:
     level_unlock_counts = dict()

--- a/worlds/raft/__init__.py
+++ b/worlds/raft/__init__.py
@@ -224,6 +224,10 @@ class RaftWorld(World):
             "DeathLink": bool(self.options.death_link)
         }
 
+    def get_filler_item_name(self) -> str:
+        return super().get_filler_item_name()
+
+
 def create_region(world: MultiWorld, player: int, name: str, locations=None, exits=None):
     ret = Region(name, player, world)
     if locations:


### PR DESCRIPTION
## What is this fixing or adding?
Makes the get_filler_item_name implementation an abstract method, forcing worlds to implement it. Provides a default implementation that can be used if desired.

## How was this tested?
Generated successfully with factorio. Tests all fail for worlds that can't be created with this.