### PR TITLE
CI: cap pytest-subtest version

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest pytest-subtests pytest-xdist
+        pip install pytest "pytest-subtests<0.14.0" pytest-xdist
         python ModuleUpdate.py --yes --force --append "WebHostLib/requirements.txt"
         python Launcher.py --update_settings  # make sure host.yaml exists for tests
     - name: Unittests


### PR DESCRIPTION
## What is this fixing or adding?
puts a cap on pytest-subtest in pipeline unittests to not run into a new bug
https://github.com/pytest-dev/pytest-subtests/issues/173

hopefully can be reverted when pytest-subtests fixes the bug or py3.10 gets dropped

## How was this tested?
ran pytest on local with the same pip command and let them complete successfully on my branch

## If this makes graphical changes, please attach screenshots.
