### PR TITLE
Landstalker: Fix issues on generation

### DIFF
--- a/worlds/landstalker/Constants.py
+++ b/worlds/landstalker/Constants.py
@@ -1,0 +1,28 @@
+
+BASE_ITEM_ID = 4000
+
+BASE_LOCATION_ID = 4000
+BASE_GROUND_LOCATION_ID = BASE_LOCATION_ID + 256
+BASE_SHOP_LOCATION_ID = BASE_GROUND_LOCATION_ID + 30
+BASE_REWARD_LOCATION_ID = BASE_SHOP_LOCATION_ID + 50
+
+ENDGAME_REGIONS = [
+    "kazalt",
+    "king_nole_labyrinth_pre_door",
+    "king_nole_labyrinth_post_door",
+    "king_nole_labyrinth_exterior",
+    "king_nole_labyrinth_fall_from_exterior",
+    "king_nole_labyrinth_path_to_palace",
+    "king_nole_labyrinth_raft_entrance",
+    "king_nole_labyrinth_raft",
+    "king_nole_labyrinth_sacred_tree",
+    "king_nole_palace"
+]
+
+ENDGAME_PROGRESSION_ITEMS = [
+    "Gola's Nail",
+    "Gola's Fang",
+    "Gola's Horn",
+    "Logs",
+    "Snow Spikes"
+]

--- a/worlds/landstalker/Hints.py
+++ b/worlds/landstalker/Hints.py
@@ -45,7 +45,7 @@ def generate_lithograph_hint(world: "LandstalkerWorld"):
             words.append(item.name.split(" ")[0].upper())
         if item.location.player != world.player:
             # Add player name if it's not in our own world
-            player_name = world.multiworld.get_player_name(world.player)
+            player_name = world.multiworld.get_player_name(item.location.player)
             words.append(player_name.upper())
         world.random.shuffle(words)
         hint_text += " ".join(words) + "\n"

--- a/worlds/landstalker/Items.py
+++ b/worlds/landstalker/Items.py
@@ -1,8 +1,7 @@
 from typing import Dict, List, NamedTuple
 
 from BaseClasses import Item, ItemClassification
-
-BASE_ITEM_ID = 4000
+from .Constants import BASE_ITEM_ID
 
 
 class LandstalkerItem(Item):

--- a/worlds/landstalker/data/world_node.py
+++ b/worlds/landstalker/data/world_node.py
@@ -223,6 +223,13 @@ WORLD_NODES_JSON = {
             "in the infamous Greenmaze"
         ]
     },
+    "greenmaze_post_whistle_tree": {
+        "name": "Greenmaze (post-whistle tree)",
+        "hints": [
+            "among the trees",
+            "in the infamous Greenmaze"
+        ]
+    },
     "verla_shore": {
         "name": "Verla shore",
         "hints": [

--- a/worlds/landstalker/data/world_node.py
+++ b/worlds/landstalker/data/world_node.py
@@ -73,6 +73,22 @@ WORLD_NODES_JSON = {
             "between Gumi and Ryuma"
         ]
     },
+    "tibor_tree": {
+        "name": "Route from Gumi to Ryuma (Tibor tree)",
+        "hints": [
+            "on a route",
+            "in a region inhabited by bears",
+            "between Gumi and Ryuma"
+        ]
+    },
+    "mercator_gate_tree": {
+        "name": "Route from Gumi to Ryuma (Mercator gate tree)",
+        "hints": [
+            "on a route",
+            "in a region inhabited by bears",
+            "between Gumi and Ryuma"
+        ]
+    },
     "tibor": {
         "name": "Tibor",
         "hints": [
@@ -237,6 +253,13 @@ WORLD_NODES_JSON = {
             "near the town of Verla"
         ]
     },
+    "verla_shore_tree": {
+        "name": "Verla shore tree",
+        "hints": [
+            "on a route",
+            "near the town of Verla"
+        ]
+    },
     "verla_shore_cliff": {
         "name": "Verla shore cliff (accessible from Verla Mines)",
         "hints": [
@@ -329,6 +352,12 @@ WORLD_NODES_JSON = {
     },
     "mountainous_area": {
         "name": "Mountainous Area",
+        "hints": [
+            "in a mountainous area"
+        ]
+    },
+    "mountainous_area_tree": {
+        "name": "Mountainous Area tree",
         "hints": [
             "in a mountainous area"
         ]

--- a/worlds/landstalker/data/world_path.py
+++ b/worlds/landstalker/data/world_path.py
@@ -55,6 +55,16 @@ WORLD_PATHS_JSON = [
         "twoWay": True
     },
     {
+        "fromId": "route_gumi_ryuma",
+        "toId": "tibor_tree",
+        "twoWay": True
+    },
+    {
+        "fromId": "route_gumi_ryuma",
+        "toId": "mercator_gate_tree",
+        "twoWay": True
+    },
+    {
         "fromId": "ryuma",
         "toId": "ryuma_after_thieves_hideout",
         "requiredNodes": [
@@ -260,6 +270,11 @@ WORLD_PATHS_JSON = [
     },
     {
         "fromId": "verla_shore",
+        "toId": "verla_shore_tree",
+        "twoWay": True
+    },
+    {
+        "fromId": "verla_shore",
         "toId": "mir_tower_sector",
         "requiredNodes": [
             "verla_mines"
@@ -320,6 +335,11 @@ WORLD_PATHS_JSON = [
         "requiredItems": [
             "Axe Magic"
         ]
+    },
+    {
+        "fromId": "mountainous_area",
+        "toId": "mountainous_area_tree",
+        "twoWay": True
     },
     {
         "fromId": "mountainous_area",

--- a/worlds/landstalker/data/world_path.py
+++ b/worlds/landstalker/data/world_path.py
@@ -213,6 +213,11 @@ WORLD_PATHS_JSON = [
     },
     {
         "fromId": "greenmaze_post_whistle",
+        "toId": "greenmaze_post_whistle_tree",
+        "twoWay": True
+    },
+    {
+        "fromId": "greenmaze_post_whistle",
         "toId": "route_massan_gumi"
     },
     {

--- a/worlds/landstalker/data/world_region.py
+++ b/worlds/landstalker/data/world_region.py
@@ -57,7 +57,9 @@ WORLD_REGIONS_JSON = [
         "name": "Route between Gumi and Ryuma",
         "canBeHintedAsRequired": False,
         "nodeIds": [
-            "route_gumi_ryuma"
+            "route_gumi_ryuma",
+            "tibor_tree",
+            "mercator_gate_tree"
         ]
     },
     {
@@ -166,7 +168,8 @@ WORLD_REGIONS_JSON = [
         "canBeHintedAsRequired": False,
         "nodeIds": [
             "verla_shore",
-            "verla_shore_cliff"
+            "verla_shore_cliff",
+            "verla_shore_tree"
         ]
     },
     {
@@ -245,7 +248,8 @@ WORLD_REGIONS_JSON = [
         "name": "Mountainous Area",
         "hintName": "in the mountainous area",
         "nodeIds": [
-            "mountainous_area"
+            "mountainous_area",
+            "mountainous_area_tree"
         ]
     },
     {

--- a/worlds/landstalker/data/world_region.py
+++ b/worlds/landstalker/data/world_region.py
@@ -157,7 +157,8 @@ WORLD_REGIONS_JSON = [
         "hintName": "in Greenmaze",
         "nodeIds": [
             "greenmaze_pre_whistle",
-            "greenmaze_post_whistle"
+            "greenmaze_post_whistle",
+            "greenmaze_post_whistle_tree"
         ]
     },
     {

--- a/worlds/landstalker/data/world_teleport_tree.py
+++ b/worlds/landstalker/data/world_teleport_tree.py
@@ -8,19 +8,19 @@ WORLD_TELEPORT_TREES_JSON = [
         {
             "name": "Tibor tree",
             "treeMapId": 534,
-            "nodeId": "route_gumi_ryuma"
+            "nodeId": "tibor_tree"
         }
     ],
     [
         {
             "name": "Mercator front gate tree",
             "treeMapId": 539,
-            "nodeId": "route_gumi_ryuma"
+            "nodeId": "mercator_gate_tree"
         },
         {
             "name": "Verla shore tree",
             "treeMapId": 537,
-            "nodeId": "verla_shore"
+            "nodeId": "verla_shore_tree"
         }
     ],
     [
@@ -44,7 +44,7 @@ WORLD_TELEPORT_TREES_JSON = [
         {
             "name": "Mountainous area tree",
             "treeMapId": 535,
-            "nodeId": "mountainous_area"
+            "nodeId": "mountainous_area_tree"
         }
     ],
     [

--- a/worlds/landstalker/data/world_teleport_tree.py
+++ b/worlds/landstalker/data/world_teleport_tree.py
@@ -56,7 +56,7 @@ WORLD_TELEPORT_TREES_JSON = [
         {
             "name": "Greenmaze end tree",
             "treeMapId": 511,
-            "nodeId": "greenmaze_post_whistle"
+            "nodeId": "greenmaze_post_whistle_tree"
         }
     ]
 ]


### PR DESCRIPTION
## What is this fixing or adding?

This bundles a few fixes for Landstalker world generation:
- Several entrances were ending up with the same name in specific conditions, causing a generation failure (https://discord.com/channels/731205301247803413/1314864280256122880)
- When using a specific short goal ("Reach Kazalt"), endgame locations were excluded but still present and causing accessibility issues (https://discord.com/channels/731205301247803413/1313260966439419965)
- The hint provided by the Lithograph was giving current player name instead of the name of the player whose location contains the hinted item

## How was this tested?

This was tested by manually generating ~100 seeds with the previously problematic options set to ensure it was fixed.
