### PR TITLE
Linux: move the user home Archipelago dir to $XDG_DATA_HOME

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -152,8 +152,15 @@ def home_path(*path: str) -> str:
     if hasattr(home_path, 'cached_path'):
         pass
     elif sys.platform.startswith('linux'):
-        home_path.cached_path = os.path.expanduser('~/Archipelago')
-        os.makedirs(home_path.cached_path, 0o700, exist_ok=True)
+        xdg_data_home = os.getenv('XDG_DATA_HOME', os.path.expanduser('~/.local/share'))
+        home_path.cached_path = xdg_data_home + '/Archipelago'
+        if not os.path.isdir(home_path.cached_path):
+            legacy_home_path = os.path.expanduser('~/Archipelago')
+            if os.path.isdir(legacy_home_path):
+                os.renames(legacy_home_path, home_path.cached_path)
+                os.symlink(home_path.cached_path, legacy_home_path)
+            else:
+                os.makedirs(home_path.cached_path, 0o700, exist_ok=True)
     else:
         # not implemented
         home_path.cached_path = local_path()  # this will generate the same exceptions we got previously


### PR DESCRIPTION
Closes #4337.

This affects builds with non-writable installation directories. Instead of saving data in `~/Archipelago` we now use `$XDG_DATA_HOME/Archipelago` (defaulting to `~/.local/share/Archipelago`).
If ~/Archipelago still exists we move it to the new location and link `~/Archipelago` to it.

Motivation: This follows the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/) to at least some degree and doesn't clutter the user's home directory.

## How was this tested?

I ran the AppImage once while still having a `~/Archipelago` dir and it moved it correctly and put a working symlink at `~/Archipelago`.