### PR TITLE
Stardew Valley: Force deactivation of Mr. Qi's special orders when ginger island is deactivated

### DIFF
--- a/worlds/stardew_valley/options/forced_options.py
+++ b/worlds/stardew_valley/options/forced_options.py
@@ -41,9 +41,10 @@ def force_qi_special_orders_deactivation_when_ginger_island_is_excluded(world_op
     qi_board_is_active = world_options.special_order_locations.value & options.SpecialOrderLocations.value_qi
 
     if ginger_island_is_excluded and qi_board_is_active:
+        original_option_name = world_options.special_order_locations.current_option_name
         world_options.special_order_locations.value -= options.SpecialOrderLocations.value_qi
         logger.warning(f"Mr. Qi's Special Orders requires Ginger Island. "
-                       f"Ginger Island was excluded from {player} ({player_name})'s world, so Mr. Qi's Special Orders were force disabled")
+                       f"Ginger Island was excluded from {player} ({player_name})'s world, so Special Order Locations was changed from {original_option_name} to {world_options.special_order_locations.current_option_name}")
 
 
 def force_accessibility_to_full_when_goal_requires_all_locations(player, player_name, world_options):

--- a/worlds/stardew_valley/options/forced_options.py
+++ b/worlds/stardew_valley/options/forced_options.py
@@ -9,6 +9,7 @@ logger = logging.getLogger(__name__)
 def force_change_options_if_incompatible(world_options: options.StardewValleyOptions, player: int, player_name: str) -> None:
     force_ginger_island_inclusion_when_goal_is_ginger_island_related(world_options, player, player_name)
     force_walnutsanity_deactivation_when_ginger_island_is_excluded(world_options, player, player_name)
+    force_qi_special_orders_deactivation_when_ginger_island_is_excluded(world_options, player, player_name)
     force_accessibility_to_full_when_goal_requires_all_locations(player, player_name, world_options)
 
 
@@ -33,6 +34,16 @@ def force_walnutsanity_deactivation_when_ginger_island_is_excluded(world_options
         world_options.walnutsanity.value = options.Walnutsanity.preset_none
         logger.warning(f"Walnutsanity requires Ginger Island. "
                        f"Ginger Island was excluded from {player} ({player_name})'s world, so walnutsanity was force disabled")
+
+
+def force_qi_special_orders_deactivation_when_ginger_island_is_excluded(world_options: options.StardewValleyOptions, player: int, player_name: str):
+    ginger_island_is_excluded = world_options.exclude_ginger_island == options.ExcludeGingerIsland.option_true
+    qi_board_is_active = options.SpecialOrderLocations.value_qi & world_options.special_order_locations.value == options.SpecialOrderLocations.value_qi
+
+    if ginger_island_is_excluded and qi_board_is_active:
+        world_options.special_order_locations.value = world_options.special_order_locations.value ^ options.SpecialOrderLocations.value_qi
+        logger.warning(f"Mr. Qi's Special Orders requires Ginger Island. "
+                       f"Ginger Island was excluded from {player} ({player_name})'s world, so Mr. Qi's Special Orders were force disabled")
 
 
 def force_accessibility_to_full_when_goal_requires_all_locations(player, player_name, world_options):

--- a/worlds/stardew_valley/options/forced_options.py
+++ b/worlds/stardew_valley/options/forced_options.py
@@ -38,7 +38,7 @@ def force_walnutsanity_deactivation_when_ginger_island_is_excluded(world_options
 
 def force_qi_special_orders_deactivation_when_ginger_island_is_excluded(world_options: options.StardewValleyOptions, player: int, player_name: str):
     ginger_island_is_excluded = world_options.exclude_ginger_island == options.ExcludeGingerIsland.option_true
-    qi_board_is_active = options.SpecialOrderLocations.value_qi & world_options.special_order_locations.value == options.SpecialOrderLocations.value_qi
+    qi_board_is_active = world_options.special_order_locations.value & options.SpecialOrderLocations.value_qi
 
     if ginger_island_is_excluded and qi_board_is_active:
         world_options.special_order_locations.value = world_options.special_order_locations.value ^ options.SpecialOrderLocations.value_qi

--- a/worlds/stardew_valley/options/forced_options.py
+++ b/worlds/stardew_valley/options/forced_options.py
@@ -41,7 +41,7 @@ def force_qi_special_orders_deactivation_when_ginger_island_is_excluded(world_op
     qi_board_is_active = world_options.special_order_locations.value & options.SpecialOrderLocations.value_qi
 
     if ginger_island_is_excluded and qi_board_is_active:
-        world_options.special_order_locations.value = world_options.special_order_locations.value ^ options.SpecialOrderLocations.value_qi
+        world_options.special_order_locations.value -= options.SpecialOrderLocations.value_qi
         logger.warning(f"Mr. Qi's Special Orders requires Ginger Island. "
                        f"Ginger Island was excluded from {player} ({player_name})'s world, so Mr. Qi's Special Orders were force disabled")
 

--- a/worlds/stardew_valley/test/options/TestForcedOptions.py
+++ b/worlds/stardew_valley/test/options/TestForcedOptions.py
@@ -82,3 +82,34 @@ class TestGingerIslandExclusionOverridesWalnutsanity(unittest.TestCase):
                     force_change_options_if_incompatible(world_options, 1, "Tester")
 
                     self.assertEqual(world_options.walnutsanity.value, original_walnutsanity_choice)
+
+
+class TestGingerIslandExclusionOverridesQisSpecialOrders(unittest.TestCase):
+
+    def test_given_ginger_island_excluded_when_generate_then_qis_special_orders_are_forced_disabled(self):
+        special_order_options = options.SpecialOrderLocations.options
+        for special_order in special_order_options.keys():
+            with self.subTest(f"Special order: {special_order}"):
+                world_options = fill_dataclass_with_default({
+                    options.ExcludeGingerIsland: options.ExcludeGingerIsland.option_true,
+                    options.SpecialOrderLocations: special_order
+                })
+
+                force_change_options_if_incompatible(world_options, 1, "Tester")
+
+                self.assertEqual(world_options.special_order_locations.value & options.SpecialOrderLocations.value_qi, 0)
+
+    def test_given_ginger_island_related_goal_and_ginger_island_excluded_when_generate_then_special_orders_is_not_changed(self):
+        for goal in [options.Goal.option_greatest_walnut_hunter, options.Goal.option_perfection]:
+            special_order_options = options.SpecialOrderLocations.options
+            for special_order, original_special_order_value in special_order_options.items():
+                with self.subTest(f"Special order: {special_order}"):
+                    world_options = fill_dataclass_with_default({
+                        options.Goal: goal,
+                        options.ExcludeGingerIsland: options.ExcludeGingerIsland.option_true,
+                        options.SpecialOrderLocations: special_order
+                    })
+
+                    force_change_options_if_incompatible(world_options, 1, "Tester")
+
+                    self.assertEqual(world_options.special_order_locations.value, original_special_order_value)


### PR DESCRIPTION
## What is this fixing or adding?
This force the deactivation of Mr. Qi's special orders when ginger island is deactivated. Not force disabling this option was not a bug, because every time we check if Qi's special orders were enabled, we also check if ginger island is enabled (now this is unnecessary). The goal is more to handle incompatible option combination at the same place and log a warning to the person generating knows that some locations won't be included. This will also prevent future bug if we eventually forgot to check ginger island every time we also check if Qi's special orders are enabled.

![image](https://github.com/user-attachments/assets/b95045cb-7eef-4976-bd4b-fa79b1dae55d)


## How was this tested?

- Wrote some unit tests to validate specifically the function forcing options activation
- Generate games with qi's special orders settings and ginger island excluded/included. With those changes, is deactivated when ginger island is deactivated.


## If this makes graphical changes, please attach screenshots.
N/A