### PR TITLE
LADX: Closing the client window closes the window

### DIFF
--- a/LinksAwakeningClient.py
+++ b/LinksAwakeningClient.py
@@ -560,6 +560,10 @@ class LinksAwakeningContext(CommonContext):
 
         while self.client.auth == None:
             await asyncio.sleep(0.1)
+
+            # Just return if we're closing
+            if self.exit_event.is_set():
+                return
         self.auth = self.client.auth
         await self.send_connect()
 


### PR DESCRIPTION
## What is this fixing or adding?
The bug is the following: if you launch the ladx client, connect to the server then attempt to close without connecting the client to retroarch/bizhawk, the client will just hang.
I put a bandaid there so that it stopped happening since it has been at least a year since I submitted this bug report. A proper sync like the other clients would be cleaner in the future

## How was this tested?
By opening, connecting then closing

## If this makes graphical changes, please attach screenshots.
Before:
![image](https://github.com/user-attachments/assets/221dedda-ef72-4999-868e-bac5b304136d)
After: