### PR TITLE
WebHost: disable abbreviations for argparse

### DIFF
--- a/WebHost.py
+++ b/WebHost.py
@@ -34,7 +34,7 @@ def get_app() -> "Flask":
         app.config.from_file(configpath, yaml.safe_load)
         logging.info(f"Updated config from {configpath}")
     # inside get_app() so it's usable in systems like gunicorn, which do not run WebHost.py, but import it.
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
     parser.add_argument('--config_override', default=None,
                         help="Path to yaml config file that overrules config.yaml.")
     args = parser.parse_known_args()[0]


### PR DESCRIPTION
## What is this fixing or adding?
Alternative for https://github.com/ArchipelagoMW/Archipelago/pull/4351

## How was this tested?
This one wasn't.
