### PR TITLE
Webhost:  Sort Slot array in room API responses

### DIFF
--- a/WebHostLib/api/__init__.py
+++ b/WebHostLib/api/__init__.py
@@ -9,7 +9,7 @@ api_endpoints = Blueprint('api', __name__, url_prefix="/api")
 
 
 def get_players(seed: Seed) -> List[Tuple[str, str]]:
-    return [(slot.player_name, slot.game) for slot in seed.slots]
+    return [(slot.player_name, slot.game) for slot in sorted(seed.slots)]
 
 
 from . import datapackage, generate, room, user  # trigger registration


### PR DESCRIPTION
## What is this fixing or adding?
When accessing the /api/room_status/ api, the players key is currently unsorted (and appears to choose a random order each refresh).  

This makes it unusable for anyone trying to access things by slot number (most importantly, mapping Player Name to a download in the same API response).

This PR applies the same sorting used in the downloads key to the Players key.

## How was this tested?
Creating a room and comparing the API output to the expected order.  And refreshing a few times to be certain 😛 

## If this makes graphical changes, please attach screenshots.
