### PR TITLE
CI: remove version restriction on pytest-subtests

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest "pytest-subtests<0.14.0" pytest-xdist
+        pip install pytest pytest-subtests pytest-xdist
         python ModuleUpdate.py --yes --force --append "WebHostLib/requirements.txt"
         python Launcher.py --update_settings  # make sure host.yaml exists for tests
     - name: Unittests


### PR DESCRIPTION
## What is this fixing or adding?
Reverts ArchipelagoMW/Archipelago#4344 since https://github.com/pytest-dev/pytest-subtests/issues/173 is fixed

## How was this tested?
Was not, but I guess the CI will in like 10 seconds

## If this makes graphical changes, please attach screenshots.
N/A