### PR TITLE
Stardew Valley: Fix potential incompletable seed when starting winter 

### DIFF
--- a/worlds/stardew_valley/logic/logic.py
+++ b/worlds/stardew_valley/logic/logic.py
@@ -281,7 +281,7 @@ class StardewLogic(ReceivedLogicMixin, HasLogicMixin, RegionLogicMixin, Travelin
             Material.coal: self.mine.can_mine_in_the_mines_floor_41_80() | self.tool.has_tool(Tool.pan),
             Material.fiber: True_(),
             Material.hardwood: self.tool.has_tool(Tool.axe, ToolMaterial.copper) & (self.region.can_reach(Region.secret_woods) | self.region.can_reach(Region.island_west)),
-            Material.moss: True_(),
+            Material.moss: self.season.has_any_not_winter(),
             Material.sap: self.ability.can_chop_trees(),
             Material.stone: self.tool.has_tool(Tool.pickaxe),
             Material.wood: self.tool.has_tool(Tool.axe),

--- a/worlds/stardew_valley/logic/logic.py
+++ b/worlds/stardew_valley/logic/logic.py
@@ -281,7 +281,7 @@ class StardewLogic(ReceivedLogicMixin, HasLogicMixin, RegionLogicMixin, Travelin
             Material.coal: self.mine.can_mine_in_the_mines_floor_41_80() | self.tool.has_tool(Tool.pan),
             Material.fiber: True_(),
             Material.hardwood: self.tool.has_tool(Tool.axe, ToolMaterial.copper) & (self.region.can_reach(Region.secret_woods) | self.region.can_reach(Region.island_west)),
-            Material.moss: self.season.has_any_not_winter(),
+            Material.moss: self.season.has_any_not_winter() & (self.tool.has_tool(Tool.scythe) | self.combat.has_any_weapon) & self.region.can_reach(Region.forest),
             Material.sap: self.ability.can_chop_trees(),
             Material.stone: self.tool.has_tool(Tool.pickaxe),
             Material.wood: self.tool.has_tool(Tool.axe),


### PR DESCRIPTION
## What is this fixing or adding?
This fixes an issue where a seed could be incompletable when starting winter, if other seasons were randomized behind stuff requiring moss. Namely, a bundle requiring moss, shipping moss and some crafting/cooking recipes if relevant option is enabled.

This bug was reported by a player here https://discord.com/channels/731205301247803413/1090823633099833464/1315132425210302606

## How was this tested?
Ran the tests

## If this makes graphical changes, please attach screenshots.
N/A