### PR TITLE
Core: cast all the settings values so they don't try to get pickled later

### DIFF
--- a/WebHostLib/generate.py
+++ b/WebHostLib/generate.py
@@ -31,11 +31,11 @@ def get_meta(options_source: dict, race: bool = False) -> Dict[str, Union[List[s
 
     server_options = {
         "hint_cost": int(options_source.get("hint_cost", ServerOptions.hint_cost)),
-        "release_mode": options_source.get("release_mode", ServerOptions.release_mode),
-        "remaining_mode": options_source.get("remaining_mode", ServerOptions.remaining_mode),
-        "collect_mode": options_source.get("collect_mode", ServerOptions.collect_mode),
+        "release_mode": str(options_source.get("release_mode", ServerOptions.release_mode)),
+        "remaining_mode": str(options_source.get("remaining_mode", ServerOptions.remaining_mode)),
+        "collect_mode": str(options_source.get("collect_mode", ServerOptions.collect_mode)),
         "item_cheat": bool(int(options_source.get("item_cheat", not ServerOptions.disable_item_cheat))),
-        "server_password": options_source.get("server_password", None),
+        "server_password": str(options_source.get("server_password", None)),
     }
     generator_options = {
         "spoiler": int(options_source.get("spoiler", GeneratorOptions.spoiler)),


### PR DESCRIPTION
## What is this fixing or adding?
cast all the settings values so they don't try to get pickled later

## How was this tested?
ran webhost with forcing the `elif len(gen_options) >= app.config["JOB_THRESHOLD"]:` line to resolve false to trigger the else clause and didn't see unpickling errors

## If this makes graphical changes, please attach screenshots.
