### PR TITLE
Core: Add settings module to RestrictedUnpickler

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -17,6 +17,8 @@ import logging
 import warnings
 
 from argparse import Namespace
+from operator import attrgetter
+
 from settings import Settings, get_settings
 from time import sleep
 from typing import BinaryIO, Coroutine, Optional, Set, Dict, Any, Union, TypeGuard
@@ -414,6 +416,7 @@ class RestrictedUnpickler(pickle.Unpickler):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super(RestrictedUnpickler, self).__init__(*args, **kwargs)
         self.options_module = importlib.import_module("Options")
+        self.settings_module = importlib.import_module("settings")
         self.net_utils_module = importlib.import_module("NetUtils")
         self.generic_properties_module = None
 
@@ -438,6 +441,9 @@ class RestrictedUnpickler(pickle.Unpickler):
             obj = getattr(mod, name)
             if issubclass(obj, (self.options_module.Option, self.options_module.PlandoConnection)):
                 return obj
+        if module == "settings":
+            return attrgetter(name)(self.settings_module)
+
         # Forbid everything else.
         raise pickle.UnpicklingError(f"global '{module}.{name}' is forbidden")
 


### PR DESCRIPTION
`JOB_THRESHOLD: 2` currently breaks singleplayer generations on WebHost.

This is because our RestrictedUnpickler can't unpickle settings objects.

This fixes that. Alternative to https://github.com/ArchipelagoMW/Archipelago/pull/4362

`attrgetter` is used here because it supports inputs like `a.b` and will recursively getattr, which is necessary in this case as we're getting `ServerOptions.ReleaseMode` from `settings`.