### PR TITLE
Pokemon Emerald: Remove unnecessary code

### DIFF
--- a/worlds/pokemon_emerald/data.py
+++ b/worlds/pokemon_emerald/data.py
@@ -1459,9 +1459,6 @@ def _init() -> None:
     for warp, destination in extracted_data["warps"].items():
         data.warp_map[warp] = None if destination == "" else destination
 
-        if encoded_warp not in data.warp_map:
-            data.warp_map[encoded_warp] = None
-
     # Create trainer data
     for i, trainer_json in enumerate(extracted_data["trainers"]):
         party_json = trainer_json["party"]


### PR DESCRIPTION
## What is this fixing or adding?

#4329

Checked in the debugger, the key that it sets is some warp in a regi cave. It gets set to `None` on the first loop and then overridden later. So this code is effectively dead and has no intended function anyway.

## How was this tested?

Generated after deleting the code.
