### PR TITLE
Core: use patch extension register directly

### DIFF
--- a/worlds/Files.py
+++ b/worlds/Files.py
@@ -14,7 +14,6 @@ import bsdiff4
 semaphore = threading.Semaphore(os.cpu_count() or 4)
 
 del threading
-del os
 
 
 class AutoPatchRegister(abc.ABCMeta):
@@ -33,6 +32,9 @@ class AutoPatchRegister(abc.ABCMeta):
 
     @staticmethod
     def get_handler(file: str) -> Optional[AutoPatchRegister]:
+        _, suffix = os.path.splitext(file)
+        if suffix in AutoPatchRegister.file_endings:
+            return AutoPatchRegister.file_endings[suffix]
         for file_ending, handler in AutoPatchRegister.file_endings.items():
             if file.endswith(file_ending):
                 return handler


### PR DESCRIPTION
## What is this fixing or adding?
use existing patch extension register instead of iterating over potentials

could use something like `"".join(file.rpartition(".")[1:])` if we still don't want os loaded also i left in the iteration option in case there's an edge case I don't know about, tested a bizhawk game without it and had no issue

## How was this tested?
opened up a bizhawk game by patch

## If this makes graphical changes, please attach screenshots.
