### PR TITLE
SMZ3: Fix minimal logic considering SM boss tokens unnecessary

### DIFF
--- a/worlds/smz3/TotalSMZ3/Regions/Zelda/GanonsTower.py
+++ b/worlds/smz3/TotalSMZ3/Regions/Zelda/GanonsTower.py
@@ -140,7 +140,8 @@ class GanonsTower(Z3Region):
 
     # added for AP completion_condition when TowerCrystals is lower than GanonCrystals
     def CanComplete(self, items: Progression):
-        return self.world.CanAcquireAtLeast(self.world.GanonCrystals, items, RewardType.AnyCrystal)
+        return self.world.CanAcquireAtLeast(self.world.GanonCrystals, items, RewardType.AnyCrystal) and \
+            self.world.CanAcquireAtLeast(self.world.TourianBossTokens, items, RewardType.AnyBossToken)
 
     def CanFill(self, item: Item):
         if (self.Config.Multiworld):

--- a/worlds/smz3/__init__.py
+++ b/worlds/smz3/__init__.py
@@ -230,7 +230,7 @@ class SMZ3World(World):
         self.multiworld.itempool += itemPool
 
     def set_rules(self):
-        # SM G4 is logically required to access Ganon's Tower in SMZ3
+        # SM G4 is logically required to complete Ganon's Tower
         self.multiworld.completion_condition[self.player] = lambda state: \
             self.smz3World.GetRegion("Ganon's Tower").CanEnter(state.smz3state[self.player]) and \
             self.smz3World.GetRegion("Ganon's Tower").TowerAscend(state.smz3state[self.player]) and \


### PR DESCRIPTION
## What is this fixing or adding?

SMZ3 used to rely on the fact that entering GT logically required all SM boss tokens as part of its victory condition, but SMZ3 version 11.3 actually changed that logic so that the number of required SM boss tokens to logically enter GT scales with its crystal entry cost. This means that some boss tokens were being considered unnecessary for game completion, which means minimal accessibility wouldn't ensure that the correct number of boss tokens could actually be reached, resulting in an impossible seed sometimes being generated. (Well, as "impossible" as anything is in LTTP, anyway.)

## How was this tested?

Test generations with 0/7/4 minimal accessibility seeds.