### PR TITLE
Aquaria: Replacing the release link to the latest link

### DIFF
--- a/worlds/aquaria/docs/setup_en.md
+++ b/worlds/aquaria/docs/setup_en.md
@@ -3,11 +3,11 @@
 ## Required Software
 
 - The original Aquaria Game (purchasable from most online game stores)
-- The [Aquaria randomizer](https://github.com/tioui/Aquaria_Randomizer/releases)
+- The [Aquaria randomizer](https://github.com/tioui/Aquaria_Randomizer/releases/latest)
 
 ## Optional Software
  
-- For sending [commands](/tutorial/Archipelago/commands/en) like `!hint`: the TextClient from [the most recent Archipelago release](https://github.com/ArchipelagoMW/Archipelago/releases)
+- For sending [commands](/tutorial/Archipelago/commands/en) like `!hint`: the TextClient from [the most recent Archipelago release](https://github.com/ArchipelagoMW/Archipelago/releases/latest)
 - [Aquaria AP Tracker](https://github.com/palex00/aquaria-ap-tracker/releases/latest), for use with
 [PopTracker](https://github.com/black-sliver/PopTracker/releases/latest)
 

--- a/worlds/aquaria/docs/setup_fr.md
+++ b/worlds/aquaria/docs/setup_fr.md
@@ -3,8 +3,7 @@
 ## Logiciels nécessaires
 
 - Une copie du jeu Aquaria non-modifiée (disponible sur la majorité des sites de ventes de jeux vidéos en ligne)
-- Le client du Randomizer d'Aquaria [Aquaria randomizer]
-(https://github.com/tioui/Aquaria_Randomizer/releases/latest)
+- Le client du Randomizer d'Aquaria [Aquaria randomizer](https://github.com/tioui/Aquaria_Randomizer/releases/latest)
 
 ## Logiciels optionnels
 

--- a/worlds/aquaria/docs/setup_fr.md
+++ b/worlds/aquaria/docs/setup_fr.md
@@ -4,11 +4,11 @@
 
 - Une copie du jeu Aquaria non-modifiée (disponible sur la majorité des sites de ventes de jeux vidéos en ligne)
 - Le client du Randomizer d'Aquaria [Aquaria randomizer]
-(https://github.com/tioui/Aquaria_Randomizer/releases)
+(https://github.com/tioui/Aquaria_Randomizer/releases/latest)
 
 ## Logiciels optionnels
 
-- De manière optionnel, pour pouvoir envoyer des [commandes](/tutorial/Archipelago/commands/en) comme `!hint`: utilisez le client texte de [la version la plus récente d'Archipelago](https://github.com/ArchipelagoMW/Archipelago/releases)
+- De manière optionnel, pour pouvoir envoyer des [commandes](/tutorial/Archipelago/commands/en) comme `!hint`: utilisez le client texte de [la version la plus récente d'Archipelago](https://github.com/ArchipelagoMW/Archipelago/releases/latest)
 - [Aquaria AP Tracker](https://github.com/palex00/aquaria-ap-tracker/releases/latest), pour utiliser avec [PopTracker](https://github.com/black-sliver/PopTracker/releases/latest)
 
 ## Procédures d'installation et d'exécution


### PR DESCRIPTION
## What is this fixing or adding?

Many times, the setup documentation link in the setup guide make users download the beta client instead of the latest one. So, I change the link so that is it point to the latest release page instead of the releases page.

## How was this tested?

I started the Webhost locally to test if the links was working.