### PR TITLE
Core: Add JSONMessagePart for Hint Status (Hint Priority)

### DIFF
--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -554,7 +554,7 @@ class JSONMessagePart(TypedDict):
     color: Optional[str] # only available if type is a color
     flags: Optional[int] # only available if type is an item_id or item_name
     player: Optional[int] # only available if type is either item or location
-    hint_status: Optional[int] # only available if type is hint_status
+    hint_status: Optional[[HintStatus](#HintStatus)] # only available if type is hint_status
 ```
 
 `type` is used to denote the intent of the message part. This can be used to indicate special information which may be rendered differently depending on client. How these types are displayed in Archipelago's ALttP client is not the end-all be-all. Other clients may choose to interpret and display these messages differently.

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -554,7 +554,7 @@ class JSONMessagePart(TypedDict):
     color: Optional[str] # only available if type is a color
     flags: Optional[int] # only available if type is an item_id or item_name
     player: Optional[int] # only available if type is either item or location
-    hint_status: Optional[[HintStatus](#HintStatus)] # only available if type is hint_status
+    hint_status: Optional[HintStatus] # only available if type is hint_status
 ```
 
 `type` is used to denote the intent of the message part. This can be used to indicate special information which may be rendered differently depending on client. How these types are displayed in Archipelago's ALttP client is not the end-all be-all. Other clients may choose to interpret and display these messages differently.
@@ -570,7 +570,7 @@ Possible values for `type` include:
 | location_id | Location ID, should be resolved to Location Name |
 | location_name | Location Name, not currently used over network, but supported by reference Clients. |
 | entrance_name | Entrance Name. No ID mapping exists. |
-| hint_status | The status of the hint (i.e. found, priority). Both `text` and `hint_status` are given. |
+| hint_status | The [HintStatus](#HintStatus) of the hint. Both `text` and `hint_status` are given. |
 | color | Regular text that should be colored. Only `type` that will contain `color` data. |
 
 

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -570,7 +570,7 @@ Possible values for `type` include:
 | location_id | Location ID, should be resolved to Location Name |
 | location_name | Location Name, not currently used over network, but supported by reference Clients. |
 | entrance_name | Entrance Name. No ID mapping exists. |
-| hint_status | The status of the hint (i.e. found, priority). See [HintStatus](#HintStatus) for details. Both `text` and `hint_status` are given. |
+| hint_status | The status of the hint (i.e. found, priority). Both `text` and `hint_status` are given. |
 | color | Regular text that should be colored. Only `type` that will contain `color` data. |
 
 

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -554,6 +554,7 @@ class JSONMessagePart(TypedDict):
     color: Optional[str] # only available if type is a color
     flags: Optional[int] # only available if type is an item_id or item_name
     player: Optional[int] # only available if type is either item or location
+    hint_status: Optional[int] # only available if type is hint_status
 ```
 
 `type` is used to denote the intent of the message part. This can be used to indicate special information which may be rendered differently depending on client. How these types are displayed in Archipelago's ALttP client is not the end-all be-all. Other clients may choose to interpret and display these messages differently.
@@ -569,6 +570,7 @@ Possible values for `type` include:
 | location_id | Location ID, should be resolved to Location Name |
 | location_name | Location Name, not currently used over network, but supported by reference Clients. |
 | entrance_name | Entrance Name. No ID mapping exists. |
+| hint_status | The status of the hint (i.e. found, priority). See (HintStatus)[#HintStatus] for details. Both `text` and `hint_status` are given. |
 | color | Regular text that should be colored. Only `type` that will contain `color` data. |
 
 

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -570,7 +570,7 @@ Possible values for `type` include:
 | location_id | Location ID, should be resolved to Location Name |
 | location_name | Location Name, not currently used over network, but supported by reference Clients. |
 | entrance_name | Entrance Name. No ID mapping exists. |
-| hint_status | The status of the hint (i.e. found, priority). See (HintStatus)[#HintStatus] for details. Both `text` and `hint_status` are given. |
+| hint_status | The status of the hint (i.e. found, priority). See [HintStatus](#HintStatus) for details. Both `text` and `hint_status` are given. |
 | color | Regular text that should be colored. Only `type` that will contain `color` data. |
 
 


### PR DESCRIPTION
## What is this fixing or adding?

Added a new JSONMessagePart type (`hint_status`) for displaying hint status/hint priority, pursuant to [my suggestion here](https://discord.com/channels/731205301247803413/731214280439103580/1320078772199882864) to fix [this issue](https://discord.com/channels/731205301247803413/731214280439103580/1320009008156901449).

This sets up correct handlers throughout the code to display hint priority in the correct coloration and to send abstract styling hints to clients.

### Some design notes

A correctly formatted hint_status JSONMessagePart appears as:

```json
{"text": "(unspecified)", "hint_status": 1, "type": "hint_status"}
```

In contrast to `item_id` and `player_id`, I elected to store hint status and text separately as there will not be one canonical visual representation of the text. I could be convinced that this system should be changed. 

## How was this tested?

Poked around in CommonClient and tested different values of hint priority.

## If this makes graphical changes, please attach screenshots.

This is a more versatile means to the same visual end as #3506 added. I believe parity has been achieved. 