### PR TITLE
Core: Fix nondeterministic option resolution in some tests

### DIFF
--- a/test/general/__init__.py
+++ b/test/general/__init__.py
@@ -1,7 +1,9 @@
 from argparse import Namespace
+import random
 from typing import List, Optional, Tuple, Type, Union
 
 from BaseClasses import CollectionState, Item, ItemClassification, Location, MultiWorld, Region
+from Generate import get_seed_name
 from worlds import network_data_package
 from worlds.AutoWorld import World, call_all
 
@@ -42,6 +44,8 @@ def setup_multiworld(worlds: Union[List[Type[World]], Type[World]], steps: Tuple
     multiworld.player_name = {player: f"Tester{player}" for player in multiworld.player_ids}
     multiworld.set_seed(seed)
     multiworld.state = CollectionState(multiworld)
+    random.seed(multiworld.seed)
+    multiworld.seed_name = get_seed_name(random)  # only called to get the same RNG progression as Generate.py
     args = Namespace()
     for player, world_type in enumerate(worlds, 1):
         for key, option in world_type.options_dataclass.type_hints.items():


### PR DESCRIPTION
## What is this fixing or adding?

Option resolution uses the `random` module directly, so `random` needs its seed to be set to produce deterministic generation.

To produce the same RNG progression as Generate.py, `Generate.get_seed_name` is also called once before option resolution. This means that if a specific seed deterministically fails one of the tests, developers should be able to reproduce the issue using Generate.py.

The patch makes that same changes as #2471, but to `setup_multiworld`.

## How was this tested?

I was working on a possible new test and was finding that MM2's and FFMQ's start inventory would end up different in tests with the same seed. This behaviour could not be reproduced with Generate.py running with the same seeds used in the test. Since there is an option controlling MM2's start inventory that is set to `"random"` by default, option resolution seemed to be the issue, and making this change fixed the problem.

Seeing that this problem was already fixed for `WorldTestBase.world_setup()` in #2471 makes it seem likely that this fix is correct.