### PR TITLE
Factorio: require version that fixes a randomizer exploit

### DIFF
--- a/worlds/factorio/Mod.py
+++ b/worlds/factorio/Mod.py
@@ -37,8 +37,8 @@ base_info = {
     "description": "Integration client for the Archipelago Randomizer",
     "factorio_version": "2.0",
     "dependencies": [
-        "base >= 2.0.15",
-        "? quality >= 2.0.15",
+        "base >= 2.0.28",
+        "? quality >= 2.0.28",
         "! space-age",
         "? science-not-invited",
         "? factory-levels"


### PR DESCRIPTION
## What is this fixing or adding?
Works well in  conjunction with https://github.com/ArchipelagoMW/Archipelago/pull/4332
With this 4332 is technically not needed, as .hidden_in_factoriopedia is now defaulting to .hidden, instead of false, but I'd still prefer to have both to be more correct and explicit.

## How was this tested?
Just with Factorio, no server connection was made.

## If this makes graphical changes, please attach screenshots.
