### PR TITLE
The Witness: Fix bridge/elevator items being progression when they shouldn't be

### DIFF
--- a/worlds/witness/player_logic.py
+++ b/worlds/witness/player_logic.py
@@ -927,7 +927,6 @@ class WitnessPlayerLogic:
 
         # Gather quick references to relevant options
         eps_shuffled = world.options.shuffle_EPs
-        come_to_you = world.options.elevators_come_to_you
         difficulty = world.options.puzzle_randomization
         discards_shuffled = world.options.shuffle_discarded_panels
         boat_shuffled = world.options.shuffle_boat
@@ -938,6 +937,9 @@ class WitnessPlayerLogic:
         doors = world.options.shuffle_doors
         shortbox_req = world.options.mountain_lasers
         longbox_req = world.options.challenge_lasers
+
+        swamp_bridge_comes_to_you = "Swamp Long Bridge" in world.options.elevators_come_to_you
+        quarry_elevator_comes_to_you = "Quarry Elevator" in world.options.elevators_come_to_you
 
         # Make some helper booleans so it is easier to follow what's going on
         mountain_upper_is_in_postgame = (
@@ -956,8 +958,8 @@ class WitnessPlayerLogic:
             "0x17D02": eps_shuffled,  # Windmill Turn Control
             "0x0368A": symbols_shuffled or door_panels,  # Quarry Stoneworks Stairs Door
             "0x3865F": symbols_shuffled or door_panels or eps_shuffled,  # Quarry Boathouse 2nd Barrier
-            "0x17CC4": come_to_you or eps_shuffled,  # Quarry Elevator Panel
-            "0x17E2B": come_to_you and boat_shuffled or eps_shuffled,  # Swamp Long Bridge
+            "0x17CC4": quarry_elevator_comes_to_you or eps_shuffled,  # Quarry Elevator Panel
+            "0x17E2B": swamp_bridge_comes_to_you and boat_shuffled or eps_shuffled,  # Swamp Long Bridge
             "0x0CF2A": False,  # Jungle Monastery Garden Shortcut
             "0x0364E": False,  # Monastery Laser Shortcut Door
             "0x03713": remote_doors,  # Monastery Laser Shortcut Panel


### PR DESCRIPTION
In https://github.com/ArchipelagoMW/Archipelago/pull/4000, which changed a single Toggle to a granular OptionSet, I forgot to update a minor part of the code to check for the individual OptionSet values, so right now it just checks for truthiness of the set.

This leads to some items being progression when they shouldn't.