### PR TITLE
Core: Clear single player local/non-local items earlier

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -84,6 +84,11 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
     if not args.skip_output:
         AutoWorld.call_stage(multiworld, "assert_generate")
 
+    # Clear non-applicable local and non-local items.
+    if multiworld.players == 1:
+        multiworld.worlds[1].options.non_local_items.value = set()
+        multiworld.worlds[1].options.local_items.value = set()
+
     AutoWorld.call_all(multiworld, "generate_early")
 
     logger.info('')
@@ -145,10 +150,7 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
     # Set local and non-local item rules.
     if multiworld.players > 1:
         locality_rules(multiworld)
-    else:
-        multiworld.worlds[1].options.non_local_items.value = set()
-        multiworld.worlds[1].options.local_items.value = set()
-    
+
     AutoWorld.call_all(multiworld, "generate_basic")
 
     # remove starting inventory from pool items.

--- a/Main.py
+++ b/Main.py
@@ -150,6 +150,9 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
     # Set local and non-local item rules.
     if multiworld.players > 1:
         locality_rules(multiworld)
+    else:  # Done before generate_early and again here to satisfy impossible non-local can_fill requirements
+        multiworld.worlds[1].options.non_local_items.value = set()
+        multiworld.worlds[1].options.local_items.value = set()
 
     AutoWorld.call_all(multiworld, "generate_basic")
 

--- a/Main.py
+++ b/Main.py
@@ -150,7 +150,7 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
     # Set local and non-local item rules.
     if multiworld.players > 1:
         locality_rules(multiworld)
-    else:  # Done before generate_early and again here to satisfy impossible non-local can_fill requirements
+    else:  # Already did before generate_early. Done again here to satisfy impossible non-local can_fill requirements.
         multiworld.worlds[1].options.non_local_items.value = set()
         multiworld.worlds[1].options.local_items.value = set()
 


### PR DESCRIPTION
## What is this fixing or adding?

Adds a check before `generate_early` to clear local/non-local items with single player generations.
The motivation behind this is that some worlds check local/non-local items and warnings or exceptions can occur from these even though they do not make sense for a solo-generation.
The previous behavior of clearing them after `set_rules` is kept in in case worlds modify `non_local_items` before then so that [`can_fill`](https://github.com/ArchipelagoMW/Archipelago/blob/78637c96a747dd15584fb85a281d447b8307ebe0/BaseClasses.py#L1208C17-L1208C94) can still be correct.

## How was this tested?

Unit tests and checking the value of local/non-local items in single player generations at various stages of generation. The `can_fill` necessity was tested using Shivers which adds to `non_local_items`.