### PR TITLE
Landstalker: Fix paths Lantern logic affecting other Landstalker worlds

### DIFF
--- a/worlds/landstalker/Rules.py
+++ b/worlds/landstalker/Rules.py
@@ -37,7 +37,8 @@ def add_path_requirements(world: "LandstalkerWorld"):
         name = data["fromId"] + " -> " + data["toId"]
 
         # Determine required items to reach this region
-        required_items = data["requiredItems"] if "requiredItems" in data else []
+        # WORLD_PATHS_JSON is shared by all Landstalker worlds, so a copy is made to prevent modifying the original
+        required_items = data["requiredItems"].copy() if "requiredItems" in data else []
         if "itemsPlacedWhenCrossing" in data:
             required_items += data["itemsPlacedWhenCrossing"]
 


### PR DESCRIPTION
## What is this fixing or adding?

The data from `WORLD_PATHS_JSON` is supposed to be constant logic data shared by all Landstalker worlds, but `add_path_requirements()` was modifying this data such that after adding a `Lantern` requirement for a dark region, subsequent Landstalker worlds to have their logic set could also be affected by this `Lantern` requirement and previous Landstalker worlds without damage boosting logic could also be affected by this `Lantern` requirement because they could all end up using the same list instances. This issue would only occur for paths that have `"requiredItems"` because all paths without required items would create a new empty list, avoiding the problem.

The items in `data["itemsPlacedWhenCrossing"]` were also getting added once for each Landstalker player, but there are no paths that have both `"itemsPlacedWhenCrossing"` and `"requiredItems"`, so all such cases would start from a new empty list of required items and avoid modifying `WORLD_PATHS_JSON`.

## How was this tested?

I have been working on a test for deterministic generation that spawns a secondary Python process. This secondary Python process freshly imports all the modules again when it is created. When running the test on its own, no problems appear, but when running the entirety of Archipelago's unit tests, Landstalker almost always fails the test. This only happens when running all the tests because various Landstalker generations have already occurred and modified the contents of `WORLD_PATHS_JSON`. The secondary Python process loads the `worlds.landstalker.data.world_path` module anew, so its `WORLD_PATHS_JSON` has not been modified in any way and when it generates the same seed as the main process, it produces different results and the test fails.

I also generated with many template Landstalker yamls and added a breakpoint with the condition of `len(set(required_items)) != len(required_items)` to look for `required_items` containing `"Lantern"` multiple times, which should not happen because `WORLD_PATHS_JSON` does not contain any paths that require `"Lantern"`.

With this patch, the test no longer fails and the conditional breakpoint is never hit.