### PR TITLE
Faxanadu: Fix generations with itemlinks

### DIFF
--- a/worlds/faxanadu/__init__.py
+++ b/worlds/faxanadu/__init__.py
@@ -169,7 +169,7 @@ class FaxanaduWorld(World):
         # If red potions are locked in shops, remove the count from the ratio.
         self.filler_ratios["Red Potion"] -= red_potion_in_shop_count
 
-        # Remove poisons if not desired
+        # Add poisons if desired
         if self.options.include_poisons:
             self.filler_ratios["Poison"] = self.item_name_to_item["Poison"].count
 

--- a/worlds/faxanadu/__init__.py
+++ b/worlds/faxanadu/__init__.py
@@ -44,8 +44,13 @@ class FaxanaduWorld(World):
     location_name_to_id = {loc.name: loc.id for loc in Locations.locations if loc.id is not None}
 
     def __init__(self, world: MultiWorld, player: int):
-        self.filler_ratios: Dict[str, int] = {}
-        
+        self.filler_ratios: Dict[str, int] = {
+            item.name: item.count
+            for item in Items.items
+            if item.classification in [ItemClassification.filler, ItemClassification.trap]
+        }
+        # Remove poison by default to respect itemlinking
+        self.filler_ratios["Poison"] = 0
         super().__init__(world, player)
 
     def create_regions(self):
@@ -160,19 +165,13 @@ class FaxanaduWorld(World):
                 for i in range(item.progression_count):
                     itempool.append(FaxanaduItem(item.name, ItemClassification.progression, item.id, self.player))
 
-        # Set up filler ratios
-        self.filler_ratios = {
-            item.name: item.count
-            for item in Items.items
-            if item.classification in [ItemClassification.filler, ItemClassification.trap]
-        }
-
+        # Adjust filler ratios
         # If red potions are locked in shops, remove the count from the ratio.
         self.filler_ratios["Red Potion"] -= red_potion_in_shop_count
 
         # Remove poisons if not desired
-        if not self.options.include_poisons:
-            self.filler_ratios["Poison"] = 0
+        if self.options.include_poisons:
+            self.filler_ratios["Poison"] = 13
 
         # Randomly add fillers to the pool with ratios based on og game occurrence counts.
         filler_count = len(Locations.locations) - len(itempool) - prefilled_count

--- a/worlds/faxanadu/__init__.py
+++ b/worlds/faxanadu/__init__.py
@@ -171,7 +171,7 @@ class FaxanaduWorld(World):
 
         # Remove poisons if not desired
         if self.options.include_poisons:
-            self.filler_ratios["Poison"] = 13
+            self.filler_ratios["Poison"] = self.item_name_to_item["Poison"].count
 
         # Randomly add fillers to the pool with ratios based on og game occurrence counts.
         filler_count = len(Locations.locations) - len(itempool) - prefilled_count


### PR DESCRIPTION
## What is this fixing or adding?

Because itemlinks can call `create_filler` using the linking world and Faxanadu created `filler_ratios` in `create_items`, which is not called for linking worlds, it would be empty and couldn't be used. This creates an initial `filler_ratios` in `__init__` instead.

This sets the weight for Poison to be a default of 0 and then modifies it to the regular value of 13 if poisons are included. This is done so that itemlinking worlds don't get poison added when they didn't want it.

## How was this tested?

Generations and the itemlinking test PR.