### PR TITLE
[Factorio] Make it possible to use rocket part in blueprint parameterization.

### DIFF
--- a/worlds/factorio/data/mod_template/data-final-fixes.lua
+++ b/worlds/factorio/data/mod_template/data-final-fixes.lua
@@ -1,6 +1,7 @@
 {% from "macros.lua" import dict_to_recipe, variable_to_lua %}
 -- this file gets written automatically by the Archipelago Randomizer and is in its raw form a Jinja2 Template
 require('lib')
+data.raw["item"]["rocket-part"].hidden = false
 data.raw["rocket-silo"]["rocket-silo"].fluid_boxes = {
     {
         production_type = "input",


### PR DESCRIPTION
This allows for example, making a blueprint of your rocket silo with requester chests specifying a request for the 2-8 rocket part ingredients needed to build the rocket.

Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?
Unhiding the rocket part item from blueprint parameterization. 

## How was this tested?
Made a standalone mod to test this.

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/user-attachments/assets/06a53219-49c7-4b44-b0a7-d92de3c5105d)
![image](https://github.com/user-attachments/assets/33f4dc80-b46c-48b4-8337-f38fbe033a01)
![image](https://github.com/user-attachments/assets/e7f57130-c258-4073-9384-a680e33ec351)


