### PR TITLE
Docs: SC2 - Add a description of mission order and the impact of collect on a SC2 world

### DIFF
--- a/worlds/sc2/docs/en_Starcraft 2.md
+++ b/worlds/sc2/docs/en_Starcraft 2.md
@@ -5,6 +5,7 @@
 
 ## What does randomization do to this game?
 
+### Items and locations
 The following unlocks are randomized as items:
 1. Your ability to build any non-worker unit.
 2. Unit specific upgrades including some combinations not available in the vanilla campaigns, such as both strain 
@@ -34,18 +35,28 @@ When you receive items, they will immediately become available, even during a mi
 notified via a text box in the top-right corner of the game screen. 
 Item unlocks are also logged in the Archipelago client.
 
+### Mission order
+
+The missions and the order in which they need to be completed, referred to as the mission order, can also be randomized.
+The four StarCraft 2 campaigns can be used to populate the mission order. 
+Note that the evolution missions from Heart of the Swarm are not included in the randomizer.
+The default mission order follows the structure of the selected campaigns but several other options are available, 
+e.g., blitz, grid, etc.
+
 Missions are launched through the StarCraft 2 Archipelago client, through the StarCraft 2 Launcher tab. 
 The between mission segments on the Hyperion, the Leviathan, and the Spear of Adun are not included. 
 Additionally, metaprogression currencies such as credits and Solarite are not used.
+Missions that are available have their names in blue and those where all locations were collected are shown in white.
+If you move your mouse over a mission, the uncollected locations will be displayed, categorized by type.
+If the mission is not available, its requirements will also be shown there.
 
 ## What is the goal of this game when randomized?
 
 The goal is to beat the final mission in the mission order. 
-The yaml configuration file controls the mission order (e.g. blitz, grid, etc.), which combination of the four 
-StarCraft 2 campaigns can be used to populate the mission order and how missions are shuffled. 
+The yaml configuration file controls the mission order, which combination of the four StarCraft 2 campaigns can be 
+used and how missions are shuffled. 
 Since the first two options determine the number of missions in a StarCraft 2 world, they can be used to customize the 
 expected time to complete the world. 
-Note that the evolution missions from Heart of the Swarm are not included in the randomizer.
 
 ## What non-randomized changes are there from vanilla StarCraft 2?
 
@@ -100,6 +111,18 @@ Additionally, upgrades are grouped beneath their corresponding units or building
 A filter parameter can be provided, e.g., `/received Thor`, to limit the number of items shown.
 Every item whose name, race, or group name contains the provided parameter will be shown.
 
+## Particularities in a multiworld
+
+### Collect on goal completion
+
+One of the default options of multiworlds is that once a world has achieved its goal, it collects its items from all 
+other worlds. 
+This is set when the multiworld is generated and it cannot be modified afterward. 
+If you do not want this to happen, you should ask the person generating the multiworld to set the `Collect Permission` 
+option to something else, e.g., manual. 
+If the generation is not done via the website, the person that does the generation should modify the corresponding 
+option in their `host.yaml` file prior to generation. 
+
 ## Known issues
 
 - StarCraft 2 Archipelago does not support loading a saved game. 
@@ -108,3 +131,7 @@ For this reason, it is recommended to play on a difficulty level lower than what
 To restart a mission, use the StarCraft 2 Client.
 - A crash report is often generated when a mission is closed. 
 This does not affect the game and can be ignored.
+- Currently, the StarCraft 2 client uses the Victory locations to determine which missions have been completed. 
+As a result, the Archipelago collect feature can sometime grant access to missions that are connected to a mission that 
+you did not complete.
+

--- a/worlds/sc2/docs/en_Starcraft 2.md
+++ b/worlds/sc2/docs/en_Starcraft 2.md
@@ -46,15 +46,15 @@ e.g., blitz, grid, etc.
 Missions are launched through the StarCraft 2 Archipelago client, through the StarCraft 2 Launcher tab. 
 The between mission segments on the Hyperion, the Leviathan, and the Spear of Adun are not included. 
 Additionally, metaprogression currencies such as credits and Solarite are not used.
-Missions that are available have their names in blue and those where all locations were collected are shown in white.
+Available missions are in blue; missions where all locations were collected are in white.
 If you move your mouse over a mission, the uncollected locations will be displayed, categorized by type.
-If the mission is not available, its requirements will also be shown there.
+Unavailable missions are in grey; their requirements will also be shown there.
 
 ## What is the goal of this game when randomized?
 
 The goal is to beat the final mission in the mission order. 
 The yaml configuration file controls the mission order, which combination of the four StarCraft 2 campaigns can be 
-used and how missions are shuffled. 
+used, and how missions are shuffled. 
 Since the first two options determine the number of missions in a StarCraft 2 world, they can be used to customize the 
 expected time to complete the world. 
 

--- a/worlds/sc2/docs/en_Starcraft 2.md
+++ b/worlds/sc2/docs/en_Starcraft 2.md
@@ -117,11 +117,12 @@ Every item whose name, race, or group name contains the provided parameter will 
 
 One of the default options of multiworlds is that once a world has achieved its goal, it collects its items from all 
 other worlds. 
-This is set when the multiworld is generated and it cannot be modified afterward. 
 If you do not want this to happen, you should ask the person generating the multiworld to set the `Collect Permission` 
 option to something else, e.g., manual. 
 If the generation is not done via the website, the person that does the generation should modify the corresponding 
 option in their `host.yaml` file prior to generation. 
+If the multiworld has already been generated, the host can use the command `/option collect_mode [value]` to change 
+this option.
 
 ## Known issues
 

--- a/worlds/sc2/docs/en_Starcraft 2.md
+++ b/worlds/sc2/docs/en_Starcraft 2.md
@@ -50,7 +50,7 @@ The between mission segments on the Hyperion, the Leviathan, and the Spear of Ad
 Additionally, metaprogression currencies such as credits and Solarite are not used.
 Available missions are in blue; missions where all locations were collected are in white.
 If you move your mouse over a mission, the uncollected locations will be displayed, categorized by type.
-Unavailable missions are in gray; their requirements will also be shown there.
+Unavailable missions are in grey; their requirements will also be shown there.
 
 ## What is the goal of this game when randomized?
 
@@ -92,8 +92,8 @@ Will overwrite existing files
     * Options: default, slower, slow, normal, fast, faster
 * `/color [faction] [color]` Changes your color for one of your playable factions.
     * Faction options: raynor, kerrigan, primal, protoss, nova
-    * Color options: white, red, blue, teal, purple, yellow, orange, green, lightpink, violet, lightgray, darkgreen, 
-    brown, lightgreen, darkgray, pink, rainbow, random, default
+    * Color options: white, red, blue, teal, purple, yellow, orange, green, light pink, violet, light grey, dark green, 
+    brown, light green, dark grey, pink, rainbow, random, default
 * `/option [option_name] [option_value]` Sets an option normally controlled by your yaml after generation.
     * Run without arguments to list all options.
     * Options pertain to automatic cutscene skipping, Kerrigan presence, Spear of Adun presence, starting resource 

--- a/worlds/sc2/docs/en_Starcraft 2.md
+++ b/worlds/sc2/docs/en_Starcraft 2.md
@@ -1,11 +1,13 @@
 # StarCraft 2
 
 ## Game page in other languages:
+
 * [Français](/games/Starcraft%202/info/fr)
 
 ## What does randomization do to this game?
 
 ### Items and locations
+
 The following unlocks are randomized as items:
 1. Your ability to build any non-worker unit.
 2. Unit specific upgrades including some combinations not available in the vanilla campaigns, such as both strain 
@@ -48,7 +50,7 @@ The between mission segments on the Hyperion, the Leviathan, and the Spear of Ad
 Additionally, metaprogression currencies such as credits and Solarite are not used.
 Available missions are in blue; missions where all locations were collected are in white.
 If you move your mouse over a mission, the uncollected locations will be displayed, categorized by type.
-Unavailable missions are in grey; their requirements will also be shown there.
+Unavailable missions are in gray; their requirements will also be shown there.
 
 ## What is the goal of this game when randomized?
 
@@ -90,8 +92,8 @@ Will overwrite existing files
     * Options: default, slower, slow, normal, fast, faster
 * `/color [faction] [color]` Changes your color for one of your playable factions.
     * Faction options: raynor, kerrigan, primal, protoss, nova
-    * Color options: white, red, blue, teal, purple, yellow, orange, green, lightpink, violet, lightgrey, darkgreen, 
-    brown, lightgreen, darkgrey, pink, rainbow, random, default
+    * Color options: white, red, blue, teal, purple, yellow, orange, green, lightpink, violet, lightgray, darkgreen, 
+    brown, lightgreen, darkgray, pink, rainbow, random, default
 * `/option [option_name] [option_value]` Sets an option normally controlled by your yaml after generation.
     * Run without arguments to list all options.
     * Options pertain to automatic cutscene skipping, Kerrigan presence, Spear of Adun presence, starting resource 
@@ -119,7 +121,7 @@ One of the default options of multiworlds is that once a world has achieved its 
 other worlds. 
 If you do not want this to happen, you should ask the person generating the multiworld to set the `Collect Permission` 
 option to something else, e.g., manual. 
-If the generation is not done via the website, the person that does the generation should modify the corresponding 
+If the generation is not done via the website, the person that does the generation should modify the `collect_mode` 
 option in their `host.yaml` file prior to generation. 
 If the multiworld has already been generated, the host can use the command `/option collect_mode [value]` to change 
 this option.

--- a/worlds/sc2/docs/en_Starcraft 2.md
+++ b/worlds/sc2/docs/en_Starcraft 2.md
@@ -91,9 +91,7 @@ Will overwrite existing files
 * `/game_speed [game_speed]` Overrides the game speed for the world
     * Options: default, slower, slow, normal, fast, faster
 * `/color [faction] [color]` Changes your color for one of your playable factions.
-    * Faction options: raynor, kerrigan, primal, protoss, nova
-    * Color options: white, red, blue, teal, purple, yellow, orange, green, light pink, violet, light grey, dark green, 
-    brown, light green, dark grey, pink, rainbow, random, default
+    * Run without arguments to list all factions and colors that are available.
 * `/option [option_name] [option_value]` Sets an option normally controlled by your yaml after generation.
     * Run without arguments to list all options.
     * Options pertain to automatic cutscene skipping, Kerrigan presence, Spear of Adun presence, starting resource 

--- a/worlds/sc2/docs/fr_Starcraft 2.md
+++ b/worlds/sc2/docs/fr_Starcraft 2.md
@@ -55,7 +55,7 @@ Archipelago*.
 Les missions accessibles ont leur nom en bleu, tandis que celles où toutes les *locations* ont été collectées 
 apparaissent en blanc.
 En plaçant votre souris sur une mission, les *locations* non collectées s’affichent, classées par catégorie.
-Si la mission n'est pas disponible, ses prérequis seront également affichés à cet endroit.
+Les missions qui ne sont pas accessibles ont leur nom en gris et leurs prérequis seront également affichés à cet endroit.
 
 
 ## Quel est le but de ce jeu quand il est *randomized*?

--- a/worlds/sc2/docs/fr_Starcraft 2.md
+++ b/worlds/sc2/docs/fr_Starcraft 2.md
@@ -131,13 +131,14 @@ Tous les *items* dont le nom, la race ou le nom de groupe contient le paramètre
 
 ### *Collect on goal completion*
 
-L'une des options par défaut des *multiworlds* est qu'une fois qu'un monde a atteint son objectif final, il collecte  
+L'une des options par défaut des *multiworlds* est qu'une fois qu'un monde a atteint son objectif final, il collecte 
 tous ses *items*, incluant ceux dans les autres mondes.
-Cette option est définie lors de la génération du *multiworld* et ne peut pas être modifiée par la suite.
 Si vous ne souhaitez pas que cela se produise, vous devez demander à la personne générant le *multiworld* de changer 
 l'option *Collect Permission*.
 Si la génération n'est pas effectuée via le site web, la personne qui effectue la génération doit modifier l'option 
 correspondante dans son fichier *host.yaml* avant la génération.
+Si le *multiworld* a déjà été généré, l'hôte peut utiliser la commande `/option collect_mode [valeur]` pour modifier 
+cette option.
 
 ## Problèmes connus
 

--- a/worlds/sc2/docs/fr_Starcraft 2.md
+++ b/worlds/sc2/docs/fr_Starcraft 2.md
@@ -2,6 +2,7 @@
 
 ## Quel est l'effet de la *randomization* sur ce jeu ?
 
+### *Items* et *locations*
 Les éléments qui suivent sont les *items* qui sont *randomized* et qui doivent être débloqués pour être utilisés dans 
 le jeu:
 1. La capacité de produire des unités, excepté les drones/probes/scv.
@@ -37,21 +38,33 @@ Quand vous recevez un *item*, il devient immédiatement disponible, même pendan
 la boîte de texte situé dans le coin en haut à droite de *StarCraft 2*.
 L'acquisition d'un *item* est aussi indiquée dans le client d'Archipelago.
 
+### *Mission order*
+
+Les missions et l'ordre dans lequel elles doivent être complétées, dénoté *mission order*, peuvent également être 
+*randomized*.
+Les quatre campagnes de *StarCraft 2* peuvent être utilisées pour remplir le *mission order*.
+Notez que les missions d'évolution de *Heart of the Swarm* ne sont pas incluses dans le *randomizer*.
+Par défaut, le *mission order* suit la structure des campagnes sélectionnées, mais plusieurs autres options sont 
+disponibles, comme *blitz*, *grid*, etc.
+
 Les missions peuvent être lancées par le client *StarCraft 2 Archipelago*, via l'interface graphique de l'onglet 
 *StarCraft 2 Launcher*.
 Les segments qui se passent sur l'*Hyperion*, un Léviathan et la *Spear of Adun* ne sont pas inclus.
-De plus, les points de progression tels que les crédits ou la Solarite ne sont pas utilisés dans *StarCraft 2 
+De plus, les points de progression, tels que les crédits ou la Solarite, ne sont pas utilisés dans *StarCraft 2 
 Archipelago*.
+Les missions accessibles ont leur nom en bleu, tandis que celles où toutes les *locations* ont été collectées 
+apparaissent en blanc.
+En plaçant votre souris sur une mission, les *locations* non collectées s’affichent, classées par catégorie.
+Si la mission n'est pas disponible, ses prérequis seront également affichés à cet endroit.
+
 
 ## Quel est le but de ce jeu quand il est *randomized*?
 
 Le but est de réussir la mission finale du *mission order* (e.g. *blitz*, *grid*, etc.).
-Le fichier de configuration yaml permet de spécifier le *mission order*, lesquelles des quatre campagnes de 
-*StarCraft 2* peuvent être utilisées pour remplir le *mission order* et comment les missions sont distribuées dans le 
-*mission order*. 
+Le fichier de configuration yaml permet de spécifier le *mission order*, quelle combinaison des quatre campagnes de 
+*StarCraft 2* peuvent être utilisée et comment les missions sont distribuées dans le *mission order*. 
 Étant donné que les deux premières options déterminent le nombre de missions dans un monde de *StarCraft 2*, elles 
 peuvent être utilisées pour moduler le temps nécessaire pour terminer le monde. 
-Notez que les missions d'évolution de Heart of the Swarm ne sont pas incluses dans le *randomizer*.
 
 ## Quelles sont les modifications non aléatoires comparativement à la version de base de *StarCraft 2*
 
@@ -114,6 +127,18 @@ De plus, les améliorations sont regroupées sous leurs unités/bâtiments corre
 Un paramètre de filtrage peut aussi être fourni, e.g., `/received Thor`, pour limiter le nombre d'*items* affichés.
 Tous les *items* dont le nom, la race ou le nom de groupe contient le paramètre fourni seront affichés.
 
+## Particularités dans un multiworld
+
+### *Collect on goal completion*
+
+L'une des options par défaut des *multiworlds* est qu'une fois qu'un monde a atteint son objectif final, il collecte  
+tous ses *items*, incluant ceux dans les autres mondes.
+Cette option est définie lors de la génération du *multiworld* et ne peut pas être modifiée par la suite.
+Si vous ne souhaitez pas que cela se produise, vous devez demander à la personne générant le *multiworld* de changer 
+l'option *Collect Permission*.
+Si la génération n'est pas effectuée via le site web, la personne qui effectue la génération doit modifier l'option 
+correspondante dans son fichier *host.yaml* avant la génération.
+
 ## Problèmes connus
 
 - *StarCraft 2 Archipelago* ne supporte pas le chargement d'une sauvegarde. 
@@ -123,3 +148,7 @@ normalement à l'aise.
 Pour redémarrer une mission, utilisez le client de *StarCraft 2 Archipelago*.
 - Un rapport d'erreur est souvent généré lorsqu'une mission est fermée. 
 Cela n'affecte pas le jeu et peut être ignoré.
+- Actuellement, le client de *StarCraft 2* utilise la *location* associée à la victoire d'une mission pour déterminer 
+si celle-ci a été complétée.
+En conséquence, la fonctionnalité *collect* d'*Archipelago* peut rendre accessible des missions connectées à une 
+mission que vous n'avez pas terminée.

--- a/worlds/sc2/docs/fr_Starcraft 2.md
+++ b/worlds/sc2/docs/fr_Starcraft 2.md
@@ -104,8 +104,8 @@ Les fichiers existants vont être écrasés.
     * Les options sont *default*, *slower*, *slow*, *normal*, *fast*, and *faster*.
 * `/color [faction] [color]` Remplace la couleur d'une des *factions* qui est jouable. 
     * Les options de *faction*: raynor, kerrigan, primal, protoss, nova.
-    * Les options de couleur: *white*, *red*, *blue*, *teal*, *purple*, *yellow*, *orange*, *green*, *lightpink*, 
-*violet*, *lightgrey*, *darkgreen*, *brown*, *lightgreen*, *darkgrey*, *pink*, *rainbow*, *random*, *default*.
+    * Les options de couleur: *white*, *red*, *blue*, *teal*, *purple*, *yellow*, *orange*, *green*, *light pink*, 
+*violet*, *light grey*, *dark green*, *brown*, *light green*, *dark grey*, *pink*, *rainbow*, *random*, *default*.
 * `/option [option_name] [option_value]` Permet de changer un option normalement définit dans le *yaml*. 
     * Si la commande est lancée sans option, la liste des options qui sont modifiables va être affichée.
     * Les options qui peuvent être changées avec cette commande incluent sauter les cinématiques  automatiquement, la 

--- a/worlds/sc2/docs/fr_Starcraft 2.md
+++ b/worlds/sc2/docs/fr_Starcraft 2.md
@@ -3,6 +3,7 @@
 ## Quel est l'effet de la *randomization* sur ce jeu ?
 
 ### *Items* et *locations*
+
 Les éléments qui suivent sont les *items* qui sont *randomized* et qui doivent être débloqués pour être utilisés dans 
 le jeu:
 1. La capacité de produire des unités, excepté les drones/probes/scv.
@@ -136,7 +137,7 @@ tous ses *items*, incluant ceux dans les autres mondes.
 Si vous ne souhaitez pas que cela se produise, vous devez demander à la personne générant le *multiworld* de changer 
 l'option *Collect Permission*.
 Si la génération n'est pas effectuée via le site web, la personne qui effectue la génération doit modifier l'option 
-correspondante dans son fichier *host.yaml* avant la génération.
+`collect_mode` dans son fichier *host.yaml* avant la génération.
 Si le *multiworld* a déjà été généré, l'hôte peut utiliser la commande `/option collect_mode [valeur]` pour modifier 
 cette option.
 

--- a/worlds/sc2/docs/fr_Starcraft 2.md
+++ b/worlds/sc2/docs/fr_Starcraft 2.md
@@ -103,9 +103,7 @@ Les fichiers existants vont être écrasés.
 * `/game_speed [game_speed]` Remplace la vitesse du jeu pour le monde.  
     * Les options sont *default*, *slower*, *slow*, *normal*, *fast*, and *faster*.
 * `/color [faction] [color]` Remplace la couleur d'une des *factions* qui est jouable. 
-    * Les options de *faction*: raynor, kerrigan, primal, protoss, nova.
-    * Les options de couleur: *white*, *red*, *blue*, *teal*, *purple*, *yellow*, *orange*, *green*, *light pink*, 
-*violet*, *light grey*, *dark green*, *brown*, *light green*, *dark grey*, *pink*, *rainbow*, *random*, *default*.
+    * Si la commande est lancée sans option, la liste des *factions* et des couleurs disponibles sera affichée.
 * `/option [option_name] [option_value]` Permet de changer un option normalement définit dans le *yaml*. 
     * Si la commande est lancée sans option, la liste des options qui sont modifiables va être affichée.
     * Les options qui peuvent être changées avec cette commande incluent sauter les cinématiques  automatiquement, la 

--- a/worlds/sc2/docs/setup_en.md
+++ b/worlds/sc2/docs/setup_en.md
@@ -41,6 +41,7 @@ Remember the name you enter in the options page or in the yaml file, you'll need
 Check out [Creating a YAML](/tutorial/Archipelago/setup/en#creating-a-yaml) for more game-agnostic information.
 
 ### Common yaml questions
+
 #### How do I know I set my yaml up correctly?
 
 The simplest way to check is to use the website [validator](/check). 
@@ -119,7 +120,7 @@ the mission in the 'StarCraft 2 Launcher' tab in the client.
 4. If the server has a password, enter that when prompted.
 5. Once connected, switch to the 'StarCraft 2 Launcher' tab in the client. There, you can see all the missions in your 
 world. 
-Unreachable missions will have greyed-out text. Just click on an available mission to start it!
+Unreachable missions will have grayed-out text. Just click on an available mission to start it!
 
 ## The game isn't launching when I try to start a mission.
 

--- a/worlds/sc2/docs/setup_en.md
+++ b/worlds/sc2/docs/setup_en.md
@@ -120,7 +120,7 @@ the mission in the 'StarCraft 2 Launcher' tab in the client.
 4. If the server has a password, enter that when prompted.
 5. Once connected, switch to the 'StarCraft 2 Launcher' tab in the client. There, you can see all the missions in your 
 world. 
-Unreachable missions will have grayed-out text. Just click on an available mission to start it!
+Unreachable missions will have greyed-out text. Just click on an available mission to start it!
 
 ## The game isn't launching when I try to start a mission.
 

--- a/worlds/sc2/docs/setup_fr.md
+++ b/worlds/sc2/docs/setup_fr.md
@@ -49,6 +49,7 @@ Si vous désirez des informations et/ou instructions générales sur l'utilisati
 veuillez consulter [*Creating a YAML*](/tutorial/Archipelago/setup/en#creating-a-yaml).
 
 ### Questions récurrentes à propos du fichier *yaml*
+
 #### Comment est-ce que je sais que mon *yaml* est bien défini?
 
 La manière la plus simple de valider votre *yaml* est d'utiliser le 


### PR DESCRIPTION
## What is this fixing or adding?
Added the following to SC2 documentation:
- Description that the order of the missions can also be randomized
- Explicit mention of AP collect and what it does. It is a recurring question in SC2 channel.
- Issue resulting from mission order progress being tied to Victory location. Mostly prevalent due to AP collect on goal. 

## How was this tested?
I used a writing assistant to check the text and hosted the website locally to make sure that the rendering was okay.

## If this makes graphical changes, please attach screenshots.
None
