### PR TITLE
Shivers: Adds ixupi captures priority option

### DIFF
--- a/worlds/shivers/Options.py
+++ b/worlds/shivers/Options.py
@@ -110,6 +110,13 @@ class FullPots(Choice):
     option_mixed = 2
 
 
+class IxupiCapturesPriority(DefaultOnToggle):
+    """
+    Ixupi captures are set to priority locations. This forces a progression item into these locations if possible.
+    """
+    display_name = "Ixupi Captures are Priority"
+
+
 class PuzzleCollectBehavior(Choice):
     """
     Defines what happens to puzzles on collect.
@@ -177,6 +184,7 @@ class ShiversOptions(PerGameCommonOptions):
     early_lightning: EarlyLightning
     location_pot_pieces: LocationPotPieces
     full_pots: FullPots
+    ixupi_captures_priority: IxupiCapturesPriority
     puzzle_collect_behavior: PuzzleCollectBehavior
     local_items: ShiversLocalItems
     non_local_items: ShiversNonLocalItems

--- a/worlds/shivers/__init__.py
+++ b/worlds/shivers/__init__.py
@@ -16,7 +16,7 @@ class ShiversWeb(WebWorld):
         "English",
         "setup_en.md",
         "setup/en",
-        ["GodlFire", "Mathx2"]
+        ["GodlFire", "Cynbel_Terreus"]
     )]
     option_groups = shivers_option_groups
 
@@ -40,6 +40,20 @@ class ShiversWorld(World):
 
     def generate_early(self):
         self.pot_completed_list = []
+
+        # Pot piece shuffle location:
+        if self.options.location_pot_pieces == "own_world":
+            self.options.local_items.value |= {name for name, data in item_table.items() if
+                                               data.type in [ItemType.POT, ItemType.POT_COMPLETE]}
+        elif self.options.location_pot_pieces == "different_world":
+            self.options.non_local_items.value |= {name for name, data in item_table.items() if
+                                                   data.type in [ItemType.POT, ItemType.POT_COMPLETE]}
+
+        # Ixupi captures priority locations:
+        if self.options.ixupi_captures_priority:
+            self.options.priority_locations.value |= (
+                {name for name in self.location_names if name.startswith('Ixupi Captured')}
+            )
 
     def create_item(self, name: str) -> Item:
         data = item_table[name]
@@ -193,20 +207,6 @@ class ShiversWorld(World):
         item_pool += map(self.create_item, self.random.choices(
             ["Heal", "Easier Lyre"], weights=[95, 5], k=filler_needed
         ))
-
-        # Pot piece shuffle location:
-        if self.options.location_pot_pieces == "own_world":
-            self.options.local_items.value |= {name for name, data in item_table.items() if
-                                               data.type in [ItemType.POT, ItemType.POT_COMPLETE]}
-        elif self.options.location_pot_pieces == "different_world":
-            self.options.non_local_items.value |= {name for name, data in item_table.items() if
-                                                   data.type in [ItemType.POT, ItemType.POT_COMPLETE]}
-
-        # Ixupi captures priority locations:
-        if self.options.ixupi_captures_priority:
-            self.options.priority_locations.value |= (
-                {name for name in self.location_names if name.startswith('Ixupi Captured')}
-            )
 
         self.multiworld.itempool += item_pool
 

--- a/worlds/shivers/__init__.py
+++ b/worlds/shivers/__init__.py
@@ -202,6 +202,12 @@ class ShiversWorld(World):
             self.options.non_local_items.value |= {name for name, data in item_table.items() if
                                                    data.type in [ItemType.POT, ItemType.POT_COMPLETE]}
 
+        # Ixupi captures priority locations:
+        if self.options.ixupi_captures_priority == 1:
+            self.options.priority_locations.value |= (
+                {name for name in self.location_names if name.startswith('Ixupi Captured')}
+            )
+
         self.multiworld.itempool += item_pool
 
     def pre_fill(self) -> None:

--- a/worlds/shivers/__init__.py
+++ b/worlds/shivers/__init__.py
@@ -203,7 +203,7 @@ class ShiversWorld(World):
                                                    data.type in [ItemType.POT, ItemType.POT_COMPLETE]}
 
         # Ixupi captures priority locations:
-        if self.options.ixupi_captures_priority == 1:
+        if self.options.ixupi_captures_priority:
             self.options.priority_locations.value |= (
                 {name for name in self.location_names if name.startswith('Ixupi Captured')}
             )

--- a/worlds/shivers/docs/setup_en.md
+++ b/worlds/shivers/docs/setup_en.md
@@ -7,6 +7,11 @@
 - [ScummVM](https://www.scummvm.org/downloads/) version 2.7.0 or later
 - [Shivers Randomizer](https://github.com/GodlFire/Shivers-Randomizer-CSharp/releases/latest) Latest release version
 
+## Optional Software
+
+- [PopTracker](https://github.com/black-sliver/PopTracker/releases/)
+  - [Jax's Shivers PopTracker pack](https://github.com/blazik-barth/Shivers-Tracker/releases/)
+
 ## Setup ScummVM for Shivers
 
 ### GOG version of Shivers
@@ -57,4 +62,4 @@ validator page: [YAML Validation page](/mysterycheck)
 - Every puzzle
 - Every puzzle hint/solution
 - Every document that is considered a Flashback
-- Optionally information plaques.
+- Optionally information plaques


### PR DESCRIPTION
## What is this fixing or adding?
Adds new option to make ixupi captures priority
This had been in a [previous PR](https://github.com/ArchipelagoMW/Archipelago/pull/3287#issuecomment-2159566855) but was removed because of generation failures, that was until this PR got merged in https://github.com/ArchipelagoMW/Archipelago/pull/3592

Note this option is basically just a shorthand for behavior that can be achieved through plando / item location options.
But this will be SUPER useful for big asyncs or similar that use filler games. Makes Shivers more important as a game.

## How was this tested?
Generation of a single world and a generation of 100 worlds all with this option on (they also included puzzle hints required which is a more complex rule set)
