### PR TITLE
core:  Load folders from custom_worlds folder

### DIFF
--- a/worlds/__init__.py
+++ b/worlds/__init__.py
@@ -79,6 +79,15 @@ class WorldSource:
                     # Found no equivalent for < 3.10
                     if hasattr(importer, "exec_module"):
                         importer.exec_module(mod)
+            elif not self.relative:
+                basename = os.path.basename(self.path)
+                spec = importlib.util.spec_from_file_location('worlds.' + basename, os.path.join(self.resolved_path, "__init__.py"))
+                mod = importlib.util.module_from_spec(spec)
+                sys.modules[mod.__name__] = mod
+
+                importer = mod.__loader__
+                if hasattr(importer, "exec_module"):
+                    importer.exec_module(mod)
             else:
                 importlib.import_module(f".{self.path}", "worlds")
             self.time_taken = time.perf_counter()-start


### PR DESCRIPTION
## What is this fixing or adding?
Currently, if you have an unpacked folder in custom_worlds, it crashes with a `ModuleNotFoundError: No module named 'worlds./Users/silasary/repos/Archipelago/custom_worlds/tracker'

This PR uses `importlib.util.spec_from_file_location` to correctly 

## How was this tested?
Put a folder in custom_worlds and ran the Launcher 

## If this makes graphical changes, please attach screenshots.
