### PR TITLE
Factorio: Fix skins factored not giving starting items

### DIFF
--- a/worlds/factorio/data/mod_template/control.lua
+++ b/worlds/factorio/data/mod_template/control.lua
@@ -445,6 +445,10 @@ end
 
 script.on_event(defines.events.on_player_main_inventory_changed, update_player_event)
 
+-- Update players when the cutscene is cancelled or finished.  (needed for skins_factored)
+script.on_event(defines.events.on_cutscene_cancelled, update_player_event)
+script.on_event(defines.events.on_cutscene_finished, update_player_event)
+
 function add_samples(force, name, count)
     local function add_to_table(t)
         if count <= 0 then


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?

Starting items not being given when skins factored is selected, during the cutscene phase of starting the map.  Addresses issue #4399 

## How was this tested?

loaded into games with the fix in place.

## If this makes graphical changes, please attach screenshots.
