### PR TITLE
TUNIC: Add relics and abilities to the item pool in deterministic order

### DIFF
--- a/worlds/tunic/__init__.py
+++ b/worlds/tunic/__init__.py
@@ -284,12 +284,14 @@ class TunicWorld(World):
 
             remove_filler(items_to_create[gold_hexagon])
 
-            for hero_relic in item_name_groups["Hero Relics"]:
+            # Sort for deterministic order
+            for hero_relic in sorted(item_name_groups["Hero Relics"]):
                 tunic_items.append(self.create_item(hero_relic, ItemClassification.useful))
                 items_to_create[hero_relic] = 0
 
         if not self.options.ability_shuffling:
-            for page in item_name_groups["Abilities"]:
+            # Sort for deterministic order
+            for page in sorted(item_name_groups["Abilities"]):
                 if items_to_create[page] > 0:
                     tunic_items.append(self.create_item(page, ItemClassification.useful))
                     items_to_create[page] = 0


### PR DESCRIPTION
## What is this fixing or adding?

Worlds should not modify the item pool after `create_items`, but some of them do anyway. If the multiworld's item pool has not been created in a deterministic order, and a world breaks the rules and removes an item from or inserts an item into the item pool after `create_items`, then it can result in nondeterministic generation.

TUNIC was iterating values from `item_name_groups` which are sets, which have nondeterministic iteration order, resulting in the order of the items in the item pool being nondeterministic.

This patch makes the order deterministic by sorting the sets before iterating them.

## How was this tested?
I ran the tests in #4410 with these changes.
