### PR TITLE
Zork Grand Inquisitor: Precollect Start with Hotspot Items in deterministic order

### DIFF
--- a/worlds/zork_grand_inquisitor/world.py
+++ b/worlds/zork_grand_inquisitor/world.py
@@ -176,7 +176,7 @@ class ZorkGrandInquisitorWorld(World):
 
         if start_with_hotspot_items:
             item: ZorkGrandInquisitorItems
-            for item in items_with_tag(ZorkGrandInquisitorTags.HOTSPOT):
+            for item in sorted(items_with_tag(ZorkGrandInquisitorTags.HOTSPOT), key=lambda item: item.name):
                 self.multiworld.push_precollected(self.create_item(item.value))
 
     def create_item(self, name: str) -> ZorkGrandInquisitorItem:


### PR DESCRIPTION
## What is this fixing or adding?

The order the items are created and collected generally should not matter for start inventory (`push_precollected`) currently, but could be relevant in the future.

This patch sorts the set of item enum members by name before creating and precollecting the items.

## How was this tested?
I ran the tests in https://github.com/ArchipelagoMW/Archipelago/pull/4410 with these changes.
