### PR TITLE
FFMQ: Create itempool in deterministic order

### DIFF
--- a/worlds/ffmq/Items.py
+++ b/worlds/ffmq/Items.py
@@ -260,7 +260,8 @@ def create_items(self) -> None:
         items.append(i)
 
     for item_group in ("Key Items", "Spells", "Armors", "Helms", "Shields", "Accessories", "Weapons"):
-        for item in self.item_name_groups[item_group]:
+        # Sort for deterministic order
+        for item in sorted(self.item_name_groups[item_group]):
             add_item(item)
 
     if self.options.brown_boxes == "include":


### PR DESCRIPTION
## What is this fixing or adding?

Worlds should not modify the item pool after `create_items`, but some of them do anyway. If the multiworld's item pool has not been created in a deterministic order, and a world breaks the rules and removes an item from or inserts an item into the item pool after `create_items`, then it can result in nondeterministic generation.

FFMQ was iterating values from `item_name_groups` which are sets, which have nondeterministic iteration order, resulting in the order of the items in the item pool being nondeterministic.

This patch makes the order deterministic by sorting the sets before iterating them.

## How was this tested?
I ran the tests in #4410 with these changes.
