### PR TITLE
Factorio: improve error message for config validation

### DIFF
--- a/worlds/factorio/Options.py
+++ b/worlds/factorio/Options.py
@@ -3,13 +3,23 @@ from __future__ import annotations
 from dataclasses import dataclass
 import typing
 
-from schema import Schema, Optional, And, Or
+from schema import Schema, Optional, And, Or, SchemaError
 
 from Options import Choice, OptionDict, OptionSet, DefaultOnToggle, Range, DeathLink, Toggle, \
     StartInventoryPool, PerGameCommonOptions, OptionGroup
 
 # schema helpers
-FloatRange = lambda low, high: And(Or(int, float), lambda f: low <= f <= high)
+class FloatRange:
+    def __init__(self, low, high):
+        self._low = low
+        self._high = high
+
+    def validate(self, value):
+        if not isinstance(value, (float, int)):
+            raise SchemaError(f"should be instance of float or int, but was {value!r}")
+        if not self._low <= value <= self._high:
+            raise SchemaError(f"{value} is not between {self._low} and {self._high}")
+
 LuaBool = Or(bool, And(int, lambda n: n in (0, 1)))
 
 

--- a/worlds/factorio/test_file_validation.py
+++ b/worlds/factorio/test_file_validation.py
@@ -1,0 +1,39 @@
+"""Tests for error messages from YAML validation."""
+
+import os
+import unittest
+
+import WebHostLib.check
+
+FACTORIO_YAML="""
+game: Factorio
+Factorio:
+  world_gen:
+    autoplace_controls:
+      coal:
+        richness: 1
+        frequency: {}
+        size: 1
+"""
+
+def yamlWithFrequency(f):
+    return FACTORIO_YAML.format(f)
+
+
+class TestFileValidation(unittest.TestCase):
+    def test_out_of_range(self):
+        results, _ = WebHostLib.check.roll_options({"bob.yaml": yamlWithFrequency(1000)})
+        self.assertIn("between 0 and 6", results["bob.yaml"])
+
+    def test_bad_non_numeric(self):
+        results, _ = WebHostLib.check.roll_options({"bob.yaml": yamlWithFrequency("not numeric")})
+        self.assertIn("float", results["bob.yaml"])
+        self.assertIn("int", results["bob.yaml"])
+
+    def test_good_float(self):
+        results, _ = WebHostLib.check.roll_options({"bob.yaml": yamlWithFrequency(1.0)})
+        self.assertIs(results["bob.yaml"], True)
+
+    def test_good_int(self):
+        results, _ = WebHostLib.check.roll_options({"bob.yaml": yamlWithFrequency(1)})
+        self.assertIs(results["bob.yaml"], True)


### PR DESCRIPTION
For a Factorio game, I hand-modified a YAML file in an attempt to increase the richness of ore patches. This is a subset of the YAML:

---
name: <me>
game: Factorio
Factorio:
  world_gen:
    autoplace_controls:
      iron-ore:
        richness: 20
---

This is invalid because it is required that 0.166 <= richness <= 6. The YAML-checker tool (archipelago.gg/check) showed that there was an error, but it could have been more helpful:

[...] Key 'iron-ore' error: Key 'richness' error: <lambda>(20) should evaluate to True

That does identify the unacceptable value, but it doesn't really tell me what's wrong.

This commit improves the error message; now it will say "20 is not between 0.166 and 6" instead of "<lambda>(20) should evaluate to True".

## What is this fixing or adding?

This only improves error messages for invalid Factorio world-generation settings. Configs with valid settings are unaffected.

## How was this tested?

I wrote a unit test that got the old error message and failed, then improved the validator to emit better errors and saw the unit test start passing.

## If this makes graphical changes, please attach screenshots.

No graphical changes. 