### PR TITLE
Blasphemous: Move Locality Changes Earlier

### DIFF
--- a/worlds/blasphemous/__init__.py
+++ b/worlds/blasphemous/__init__.py
@@ -103,6 +103,9 @@ class BlasphemousWorld(World):
         if not self.options.wall_climb_shuffle:
             self.multiworld.push_precollected(self.create_item("Wall Climb Ability"))
 
+        if self.options.thorn_shuffle == "local_only":
+            self.options.local_items.value.add("Thorn Upgrade")
+
         if not self.options.boots_of_pleading:
             self.disabled_locations.append("RE401")
 
@@ -200,9 +203,6 @@ class BlasphemousWorld(World):
 
         if not self.options.skill_randomizer:
             self.place_items_from_dict(skill_dict)
-
-        if self.options.thorn_shuffle == "local_only":
-            self.options.local_items.value.add("Thorn Upgrade")
         
 
     def place_items_from_set(self, location_set: Set[str], name: str):


### PR DESCRIPTION
## What is this fixing or adding?

Technically nothing. This just moves changes to local/non-local items to be in `generate_early` instead of `create_items`

## How was this tested?

Generating a multiplayer game and seeing "Thorn Upgrade" added to local_items for the player that had thorn_shuffle set to local_only