### PR TITLE
SMZ3: Move non_local_items Changes Earlier

### DIFF
--- a/worlds/smz3/__init__.py
+++ b/worlds/smz3/__init__.py
@@ -202,6 +202,10 @@ class SMZ3World(World):
         SMZ3World.location_names = frozenset(self.smz3World.locationLookup.keys())
 
         self.multiworld.state.smz3state[self.player] = TotalSMZ3Item.Progression([])
+
+        if not self.smz3World.Config.Keysanity:
+            # Dungeons items here are not in the itempool and will be prefilled locally so they must stay local
+            self.options.non_local_items.value -= frozenset(item_name for item_name in self.item_names if TotalSMZ3Item.Item.IsNameDungeonItem(item_name))
     
     def create_items(self):
         self.dungeon = TotalSMZ3Item.Item.CreateDungeonPool(self.smz3World)
@@ -218,8 +222,6 @@ class SMZ3World(World):
             progressionItems = self.progression + self.dungeon + self.keyCardsItems + self.SmMapsItems
         else:
             progressionItems = self.progression
-            # Dungeons items here are not in the itempool and will be prefilled locally so they must stay local
-            self.options.non_local_items.value -= frozenset(item_name for item_name in self.item_names if TotalSMZ3Item.Item.IsNameDungeonItem(item_name))
             for item in self.keyCardsItems:
                 self.multiworld.push_precollected(SMZ3Item(item.Type.name, ItemClassification.filler, item.Type, self.item_name_to_id[item.Type.name], self.player, item))
 


### PR DESCRIPTION
## What is this fixing or adding?

Moves the changes to `non_local_items` from `create_items` to `generate_early`. The primary motivation for this is a future PR requiring that local/non_local options not be changed after `generate_early`, which helps to cleanup some of the code in `Main.py`

## How was this tested?

Local generations with items in non_local_items with and without Keysanity enabled to see that items were properly removed. Also just printing the frozenset in `generate_early` and `create_items` to see that they were identical with various random yamls