### PR TITLE
Docs: Clarify !alias commands in commands_en.md

### DIFF
--- a/worlds/generic/docs/commands_en.md
+++ b/worlds/generic/docs/commands_en.md
@@ -26,7 +26,7 @@ including the exclamation point.
 ### Utilities
 - `!countdown <number of seconds>` Starts a countdown using the given seconds value. Useful for synchronizing starts.
   Defaults to 10 seconds if no argument is provided.
-- `!alias <alias>` Sets your alias, which allows you to use commands with the alias rather than your provided name.
+- `!alias <alias>` Sets your alias, which allows you to use commands with the alias rather than your provided name. `!alias` on it's own will reset the alias to the player's original name.
 - `!admin <command>` Executes a command as if you typed it into the server console. Remote administration must be
   enabled.
 
@@ -64,7 +64,7 @@ including the exclamation point.
 - `/countdown <number of seconds>` Starts a countdown sent to all players via text chat. Defaults to 10 seconds if no
   argument is provided.
 - `/option <option name> <option value>` Set a server option. For a list of options, use the `/options` command.
-- `/alias <player name> <alias name>` Assign a player an alias, allowing you to reference the player by the alias in commands.
+- `/alias <player name> <alias name>` Assign a player an alias, allowing you to reference the player by the alias in commands. `!alias <player name>` on it's own will reset the alias to the player's original name.
 
 
 ### Collect/Release

--- a/worlds/generic/docs/commands_en.md
+++ b/worlds/generic/docs/commands_en.md
@@ -66,7 +66,7 @@ including the exclamation point.
   argument is provided.
 - `/option <option name> <option value>` Set a server option. For a list of options, use the `/options` command.
 - `/alias <player name> <alias name>` Assign a player an alias, allowing you to reference the player by the alias in commands.
-  `!alias <player name>` on it's own will reset the alias to the player's original name.
+  `!alias <player name>` on its own will reset the alias to the player's original name.
 
 
 ### Collect/Release

--- a/worlds/generic/docs/commands_en.md
+++ b/worlds/generic/docs/commands_en.md
@@ -65,7 +65,8 @@ including the exclamation point.
 - `/countdown <number of seconds>` Starts a countdown sent to all players via text chat. Defaults to 10 seconds if no
   argument is provided.
 - `/option <option name> <option value>` Set a server option. For a list of options, use the `/options` command.
-- `/alias <player name> <alias name>` Assign a player an alias, allowing you to reference the player by the alias in commands. `!alias <player name>` on it's own will reset the alias to the player's original name.
+- `/alias <player name> <alias name>` Assign a player an alias, allowing you to reference the player by the alias in commands.
+  `!alias <player name>` on it's own will reset the alias to the player's original name.
 
 
 ### Collect/Release

--- a/worlds/generic/docs/commands_en.md
+++ b/worlds/generic/docs/commands_en.md
@@ -26,7 +26,8 @@ including the exclamation point.
 ### Utilities
 - `!countdown <number of seconds>` Starts a countdown using the given seconds value. Useful for synchronizing starts.
   Defaults to 10 seconds if no argument is provided.
-- `!alias <alias>` Sets your alias, which allows you to use commands with the alias rather than your provided name. `!alias` on it's own will reset the alias to the player's original name.
+- `!alias <alias>` Sets your alias, which allows you to use commands with the alias rather than your provided name.
+  `!alias` on its own will reset the alias to the player's original name.
 - `!admin <command>` Executes a command as if you typed it into the server console. Remote administration must be
   enabled.
 


### PR DESCRIPTION
Really simple doc change.  Users (myself included until recently) are generally unaware that you can reset an alias using an empty argument.  This clarifies that function for both the client and host commands.

## What is this fixing or adding?

Slight confusion regarding the full use of the !alias command

## How was this tested?

By aliasing and unaliasing a player slot.  Also, GitHub Preview seems good 'nuff for visual testing.

## If this makes graphical changes, please attach screenshots.

It's two lines of text.