### PR TITLE
Blasphemous: Fix starting_location: random affecting all Blasphemous worlds

### DIFF
--- a/worlds/blasphemous/Options.py
+++ b/worlds/blasphemous/Options.py
@@ -4,14 +4,17 @@ import random
 
 
 class ChoiceIsRandom(Choice):
-    randomized: bool = False
+    randomized: bool
+
+    def __init__(self, value: int, randomized: bool = False):
+        super().__init__(value)
+        self.randomized = randomized
 
     @classmethod
     def from_text(cls, text: str) -> Choice:
         text = text.lower()
         if text == "random":
-            cls.randomized = True
-            return cls(random.choice(list(cls.name_lookup)))
+            return cls(random.choice(list(cls.name_lookup)), True)
         for option_name, value in cls.options.items():
             if option_name == text:
                 return cls(value)


### PR DESCRIPTION
## What is this fixing or adding?

Option resolution for the `StartingLocation` option (the only `ChoiceIsRandom` subclass) was writing to the `randomized` attribute on the class instead of on the instance, meaning that `self.options.starting_location.randomized` would be `True` for all Blasphemous players in the multiworld if any one of the players set their `StartingLocation` option to `"random"`.

This patch fixes the issue by writing to the `randomized` attribute on the new instance instead of on the class.

## How was this tested?

I ran a generation with two template Blasphemous yamls, but with one yaml changed to use `starting_location: random`.
I put breakpoints in both conditional branches at the start of `generate_early`:
https://github.com/ArchipelagoMW/Archipelago/blob/a7b483e4b72e8a983875e660a2d92762baedbf62/worlds/blasphemous/__init__.py#L68-L83
Before this PR, both worlds would act as if `self.options.starting_location.randomized` was `True`, even though only one world had `starting_location: random`. After this PR, each world enters the correct conditional branch depending on whether it chooses a specific choice or `random` as its starting location.