### PR TITLE
Super Metroid: Replace random module with world random in variaRandomizer

### DIFF
--- a/worlds/sm/__init__.py
+++ b/worlds/sm/__init__.py
@@ -130,7 +130,7 @@ class SMWorld(World):
         Logic.factory('vanilla')
 
         dummy_rom_file = Utils.user_path(SMSettings.RomFile.copy_to)  # actual rom set in generate_output
-        self.variaRando = VariaRandomizer(self.options, dummy_rom_file, self.player)
+        self.variaRando = VariaRandomizer(self.options, dummy_rom_file, self.player, self.multiworld.seed, self.random)
         self.multiworld.state.smbm[self.player] = SMBoolManager(self.player, self.variaRando.maxDifficulty)
 
         # keeps Nothing items local so no player will ever pickup Nothing

--- a/worlds/sm/variaRandomizer/graph/graph_utils.py
+++ b/worlds/sm/variaRandomizer/graph/graph_utils.py
@@ -1,5 +1,4 @@
 import copy
-import random
 from ..logic.logic import Logic
 from ..utils.parameters import Knows
 from ..graph.location import locationsDict
@@ -136,7 +135,8 @@ class GraphUtils:
                 refused[apName] = cause
         return ret, refused
 
-    def updateLocClassesStart(startGraphArea, split, possibleMajLocs, preserveMajLocs, nLocs):
+    @staticmethod
+    def updateLocClassesStart(startGraphArea, split, possibleMajLocs, preserveMajLocs, nLocs, random):
         locs = locationsDict
         preserveMajLocs = [locs[locName] for locName in preserveMajLocs if locs[locName].isClass(split)]
         possLocs = [locs[locName] for locName in possibleMajLocs][:nLocs]
@@ -160,7 +160,8 @@ class GraphUtils:
         ap = getAccessPoint(startApName)
         return ap.Start['patches'] if 'patches' in ap.Start else []
 
-    def createBossesTransitions():
+    @staticmethod
+    def createBossesTransitions(random):
         transitions = vanillaBossesTransitions
         def isVanilla():
             for t in vanillaBossesTransitions:
@@ -180,13 +181,15 @@ class GraphUtils:
                 transitions.append((src,dst))
         return transitions
 
-    def createAreaTransitions(lightAreaRando=False):
+    @staticmethod
+    def createAreaTransitions(lightAreaRando=False, *, random):
         if lightAreaRando:
-            return GraphUtils.createLightAreaTransitions()
+            return GraphUtils.createLightAreaTransitions(random=random)
         else:
-            return GraphUtils.createRegularAreaTransitions()
+            return GraphUtils.createRegularAreaTransitions(random=random)
 
-    def createRegularAreaTransitions(apList=None, apPred=None):
+    @staticmethod
+    def createRegularAreaTransitions(apList=None, apPred=None, *, random):
         if apList is None:
             apList = Logic.accessPoints
         if apPred is None:
@@ -239,7 +242,8 @@ class GraphUtils:
             transitions.append((ap.Name, ap.Name))
 
     # crateria can be forced in corner cases
-    def createMinimizerTransitions(startApName, locLimit, forcedAreas=None):
+    @staticmethod
+    def createMinimizerTransitions(startApName, locLimit, forcedAreas=None, *, random):
         if forcedAreas is None:
             forcedAreas = []
         if startApName == 'Ceres':
@@ -316,7 +320,8 @@ class GraphUtils:
         GraphUtils.log.debug("FINAL MINIMIZER areas: "+str(areas))
         return transitions
 
-    def createLightAreaTransitions():
+    @staticmethod
+    def createLightAreaTransitions(random):
         # group APs by area
         aps = {}
         totalCount = 0
@@ -407,7 +412,8 @@ class GraphUtils:
 
         return rooms
 
-    def escapeAnimalsTransitions(graph, possibleTargets, firstEscape):
+    @staticmethod
+    def escapeAnimalsTransitions(graph, possibleTargets, firstEscape, random):
         n = len(possibleTargets)
         assert (n < 4 and firstEscape is not None) or (n <= 4 and firstEscape is None), "Invalid possibleTargets list: " + str(possibleTargets)
         GraphUtils.log.debug("escapeAnimalsTransitions. possibleTargets="+str(possibleTargets)+", firstEscape="+str(firstEscape))

--- a/worlds/sm/variaRandomizer/rando/Filler.py
+++ b/worlds/sm/variaRandomizer/rando/Filler.py
@@ -1,5 +1,5 @@
 
-import copy, time, random
+import copy, time
 from ..utils import log
 from ..logic.cache import RequestCache
 from ..rando.RandoServices import RandoServices
@@ -15,11 +15,11 @@ from ..graph.graph_utils import GraphUtils
 # item pool is not empty).
 # entry point is generateItems
 class Filler(object):
-    def __init__(self, startAP, graph, restrictions, emptyContainer, endDate=infinity):
+    def __init__(self, startAP, graph, restrictions, emptyContainer, endDate=infinity, *, random):
         self.startAP = startAP
         self.cache = RequestCache()
         self.graph = graph
-        self.services = RandoServices(graph, restrictions, self.cache)
+        self.services = RandoServices(graph, restrictions, self.cache, random=random)
         self.restrictions = restrictions
         self.settings = restrictions.settings
         self.endDate = endDate
@@ -108,9 +108,9 @@ class Filler(object):
 
 # very simple front fill algorithm with no rollback and no "softlock checks" (== dessy algorithm)
 class FrontFiller(Filler):
-    def __init__(self, startAP, graph, restrictions, emptyContainer, endDate=infinity):
-        super(FrontFiller, self).__init__(startAP, graph, restrictions, emptyContainer, endDate)
-        self.choice = ItemThenLocChoice(restrictions)
+    def __init__(self, startAP, graph, restrictions, emptyContainer, endDate=infinity, *, random):
+        super(FrontFiller, self).__init__(startAP, graph, restrictions, emptyContainer, endDate, random=random)
+        self.choice = ItemThenLocChoice(restrictions, random)
         self.stdStart = GraphUtils.isStandardStart(self.startAP)
 
     def isEarlyGame(self):

--- a/worlds/sm/variaRandomizer/rando/GraphBuilder.py
+++ b/worlds/sm/variaRandomizer/rando/GraphBuilder.py
@@ -1,5 +1,5 @@
 
-import random, copy
+import copy
 from ..utils import log
 from ..graph.graph_utils import GraphUtils, vanillaTransitions, vanillaBossesTransitions, escapeSource, escapeTargets, graphAreas, getAccessPoint
 from ..logic.logic import Logic
@@ -11,13 +11,14 @@ from collections import defaultdict
 
 # creates graph and handles randomized escape
 class GraphBuilder(object):
-    def __init__(self, graphSettings):
+    def __init__(self, graphSettings, random):
         self.graphSettings = graphSettings
         self.areaRando = graphSettings.areaRando
         self.bossRando = graphSettings.bossRando
         self.escapeRando = graphSettings.escapeRando
         self.minimizerN = graphSettings.minimizerN
         self.log = log.get('GraphBuilder')
+        self.random = random
 
     # builds everything but escape transitions
     def createGraph(self, maxDiff):
@@ -48,18 +49,18 @@ class GraphBuilder(object):
                             objForced = forcedAreas.intersection(escAreas)
                             escAreasList = sorted(list(escAreas))
                             while len(objForced) < n and len(escAreasList) > 0:
-                                objForced.add(escAreasList.pop(random.randint(0, len(escAreasList)-1)))
+                                objForced.add(escAreasList.pop(self.random.randint(0, len(escAreasList)-1)))
                             forcedAreas = forcedAreas.union(objForced)
-                transitions = GraphUtils.createMinimizerTransitions(self.graphSettings.startAP, self.minimizerN, sorted(list(forcedAreas)))
+                transitions = GraphUtils.createMinimizerTransitions(self.graphSettings.startAP, self.minimizerN, sorted(list(forcedAreas)), random=self.random)
             else:
                 if not self.bossRando:
                     transitions += vanillaBossesTransitions
                 else:
-                    transitions += GraphUtils.createBossesTransitions()
+                    transitions += GraphUtils.createBossesTransitions(self.random)
                 if not self.areaRando:
                     transitions += vanillaTransitions
                 else:
-                    transitions += GraphUtils.createAreaTransitions(self.graphSettings.lightAreaRando)
+                    transitions += GraphUtils.createAreaTransitions(self.graphSettings.lightAreaRando, random=self.random)
         ret = AccessGraph(Logic.accessPoints, transitions, self.graphSettings.dotFile)
         Objectives.objDict[self.graphSettings.player].setGraph(ret, maxDiff)
         return ret
@@ -100,7 +101,7 @@ class GraphBuilder(object):
         self.escapeTimer(graph, paths, self.areaRando or escapeTrigger is not None)
         self.log.debug("escapeGraph: ({}, {}) timer: {}".format(escapeSource, dst, graph.EscapeAttributes['Timer']))
         # animals
-        GraphUtils.escapeAnimalsTransitions(graph, possibleTargets, dst)
+        GraphUtils.escapeAnimalsTransitions(graph, possibleTargets, dst, self.random)
         return True
 
     def _getTargets(self, sm, graph, maxDiff):
@@ -110,7 +111,7 @@ class GraphBuilder(object):
         if len(possibleTargets) == 0:
             self.log.debug("Can't randomize escape, fallback to vanilla")
             possibleTargets.append('Climb Bottom Left')
-        random.shuffle(possibleTargets)
+        self.random.shuffle(possibleTargets)
         return possibleTargets
 
     def getPossibleEscapeTargets(self, emptyContainer, graph, maxDiff):

--- a/worlds/sm/variaRandomizer/rando/RandoServices.py
+++ b/worlds/sm/variaRandomizer/rando/RandoServices.py
@@ -1,5 +1,4 @@
-
-import copy, random, sys, logging, os
+import copy, sys, logging, os
 from enum import Enum, unique
 from ..utils import log
 from ..utils.parameters import infinity
@@ -19,12 +18,13 @@ class ComebackCheckType(Enum):
 
 # collection of stateless services to be used mainly by fillers
 class RandoServices(object):
-    def __init__(self, graph, restrictions, cache=None):
+    def __init__(self, graph, restrictions, cache=None, *, random):
         self.restrictions = restrictions
         self.settings = restrictions.settings
         self.areaGraph = graph
         self.cache = cache
         self.log = log.get('RandoServices')
+        self.random = random
 
     @staticmethod
     def printProgress(s):
@@ -217,7 +217,7 @@ class RandoServices(object):
                     # choose a morph item location in that context
                     morphItemLoc = ItemLocation(
                         morph,
-                        random.choice(morphLocs)
+                        self.random.choice(morphLocs)
                     )
                     # acquire morph in new context and see if we can still open new locs
                     newAP = self.collect(ap, containerCpy, morphItemLoc)
@@ -232,7 +232,7 @@ class RandoServices(object):
         if morphLocItem is None or len(itemLocDict) == 1:
             # no morph, or it is the only possibility: nothing to do
             return
-        morphLocs = self.restrictions.lateMorphCheck(container, itemLocDict[morphLocItem])
+        morphLocs = self.restrictions.lateMorphCheck(container, itemLocDict[morphLocItem], self.random)
         if morphLocs is not None:
             itemLocDict[morphLocItem] = morphLocs
         else:
@@ -380,10 +380,10 @@ class RandoServices(object):
         (itemLocDict, isProg) = self.getPossiblePlacements(ap, container, ComebackCheckType.NoCheck)
         assert not isProg
         items = list(itemLocDict.keys())
-        random.shuffle(items)
+        self.random.shuffle(items)
         for item in items:
             cont = copy.copy(container)
-            loc = random.choice(itemLocDict[item])
+            loc = self.random.choice(itemLocDict[item])
             itemLoc1 = ItemLocation(item, loc)
             self.log.debug("itemLoc1 attempt: "+getItemLocStr(itemLoc1))
             newAP = self.collect(ap, cont, itemLoc1)
@@ -391,8 +391,8 @@ class RandoServices(object):
                 self.cache.reset()
             (ild, isProg) = self.getPossiblePlacements(newAP, cont, ComebackCheckType.NoCheck)
             if isProg:
-                item2 = random.choice(list(ild.keys()))
-                itemLoc2 = ItemLocation(item2, random.choice(ild[item2]))
+                item2 = self.random.choice(list(ild.keys()))
+                itemLoc2 = ItemLocation(item2, self.random.choice(ild[item2]))
                 self.log.debug("itemLoc2: "+getItemLocStr(itemLoc2))
                 return (itemLoc1, itemLoc2)
         return None

--- a/worlds/sm/variaRandomizer/rando/RandoSettings.py
+++ b/worlds/sm/variaRandomizer/rando/RandoSettings.py
@@ -1,5 +1,4 @@
-
-import sys, random
+import sys
 from collections import defaultdict
 from ..rando.Items import ItemManager
 from ..utils.utils import getRangeDict, chooseFromRange
@@ -32,11 +31,11 @@ class RandoSettings(object):
     def isPlandoRando(self):
         return self.PlandoOptions is not None
 
-    def getItemManager(self, smbm, nLocs, bossesItems):
+    def getItemManager(self, smbm, nLocs, bossesItems, random):
         if not self.isPlandoRando():
-            return ItemManager(self.restrictions['MajorMinor'], self.qty, smbm, nLocs, bossesItems, self.maxDiff)
+            return ItemManager(self.restrictions['MajorMinor'], self.qty, smbm, nLocs, bossesItems, self.maxDiff, random)
         else:
-            return ItemManager('Plando', self.qty, smbm, nLocs, bossesItems, self.maxDiff)
+            return ItemManager('Plando', self.qty, smbm, nLocs, bossesItems, self.maxDiff, random)
 
     def getExcludeItems(self, locations):
         if not self.isPlandoRando():
@@ -94,7 +93,7 @@ class ProgSpeedParameters(object):
         self.restrictions = restrictions
         self.nLocs = nLocs
 
-    def getVariableSpeed(self):
+    def getVariableSpeed(self, random):
         ranges = getRangeDict({
             'slowest':7,
             'slow':20,
@@ -102,7 +101,7 @@ class ProgSpeedParameters(object):
             'fast':27,
             'fastest':11
         })
-        return chooseFromRange(ranges)
+        return chooseFromRange(ranges, random)
 
     def getMinorHelpProb(self, progSpeed):
         if self.restrictions.split != 'Major':
@@ -134,7 +133,7 @@ class ProgSpeedParameters(object):
     def isSlow(self, progSpeed):
         return progSpeed == "slow" or (progSpeed == "slowest" and self.restrictions.split == "Chozo")
 
-    def getItemLimit(self, progSpeed):
+    def getItemLimit(self, progSpeed, random):
         itemLimit = self.nLocs
         if self.isSlow(progSpeed):
             itemLimit = int(self.nLocs*0.209) # 21 for 105

--- a/worlds/sm/variaRandomizer/rando/RandoSetup.py
+++ b/worlds/sm/variaRandomizer/rando/RandoSetup.py
@@ -1,4 +1,4 @@
-import copy, random
+import copy
 
 from ..utils import log
 from ..utils.utils import randGaussBounds
@@ -16,8 +16,9 @@ from ..rom.rom_patches import RomPatches
 # checks init conditions for the randomizer: processes super fun settings, graph, start location, special restrictions
 # the entry point is createItemLocContainer
 class RandoSetup(object):
-    def __init__(self, graphSettings, locations, services, player):
+    def __init__(self, graphSettings, locations, services, player, random):
         self.sm = SMBoolManager(player, services.settings.maxDiff)
+        self.random = random
         self.settings = services.settings
         self.graphSettings = graphSettings
         self.startAP = graphSettings.startAP
@@ -31,7 +32,7 @@ class RandoSetup(object):
 #        print("nLocs Setup: "+str(len(self.locations)))
         # in minimizer we can have some missing boss locs
         bossesItems = [loc.BossItemType for loc in self.locations if loc.isBoss()]
-        self.itemManager = self.settings.getItemManager(self.sm, len(self.locations), bossesItems)
+        self.itemManager = self.settings.getItemManager(self.sm, len(self.locations), bossesItems, random)
         self.forbiddenItems = []
         self.restrictedLocs = []
         self.lastRestricted = []
@@ -165,7 +166,7 @@ class RandoSetup(object):
             return True
         self.log.debug("********* PRE RANDO START")
         container = copy.copy(self.container)
-        filler = FrontFiller(self.startAP, self.areaGraph, self.restrictions, container)
+        filler = FrontFiller(self.startAP, self.areaGraph, self.restrictions, container, random=self.random)
         condition = filler.createStepCountCondition(4)
         (isStuck, itemLocations, progItems) = filler.generateItems(condition)
         self.log.debug("********* PRE RANDO END")
@@ -345,9 +346,9 @@ class RandoSetup(object):
     def getForbiddenItemsFromList(self, itemList):
         self.log.debug('getForbiddenItemsFromList: ' + str(itemList))
         remove = []
-        n = randGaussBounds(len(itemList))
+        n = randGaussBounds(self.random, len(itemList))
         for i in range(n):
-            idx = random.randint(0, len(itemList) - 1)
+            idx = self.random.randint(0, len(itemList) - 1)
             item = itemList.pop(idx)
             if item is not None:
                 remove.append(item)

--- a/worlds/sm/variaRandomizer/rando/Restrictions.py
+++ b/worlds/sm/variaRandomizer/rando/Restrictions.py
@@ -1,4 +1,4 @@
-import copy, random
+import copy
 from ..utils import log
 from ..graph.graph_utils import getAccessPoint
 from ..rando.ItemLocContainer import getLocListStr
@@ -112,7 +112,7 @@ class Restrictions(object):
             return item.Class == "Minor"
 
     # return True if we can keep morph as a possibility
-    def lateMorphCheck(self, container, possibleLocs):
+    def lateMorphCheck(self, container, possibleLocs, random):
         # the closer we get to the limit the higher the chances of allowing morph
         proba = random.randint(0, self.lateMorphLimit)
         if self.split == 'Full':

--- a/worlds/sm/variaRandomizer/randomizer.py
+++ b/worlds/sm/variaRandomizer/randomizer.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 from Utils import output_path
-import argparse, os.path, json, sys, shutil, random, copy, requests
+import argparse, os.path, json, sys, shutil, copy, requests
 
 from .rando.RandoSettings import RandoSettings, GraphSettings
 from .rando.RandoExec import RandoExec
@@ -39,7 +39,7 @@ objectives = defaultMultiValues['objective']
 tourians = defaultMultiValues['tourian']
 areaRandomizations = defaultMultiValues['areaRandomization']
 
-def randomMulti(args, param, defaultMultiValues):
+def randomMulti(args, param, defaultMultiValues, random):
     value = args[param]
 
     isRandom = False
@@ -250,10 +250,11 @@ class VariaRandomizer:
     parser.add_argument('--tourianList', help="list to choose from when random",
                         dest='tourianList', nargs='?', default=None)
 
-    def __init__(self, options, rom, player):
+    def __init__(self, options, rom, player, seed, random):
         # parse args       
         self.args = copy.deepcopy(VariaRandomizer.parser.parse_args(["--logic", "varia"])) #dummy custom args to skip parsing _sys.argv while still get default values
         self.player = player
+        self.random = random
         args = self.args
         args.rom = rom
         # args.startLocation = to_pascal_case_with_space(options.startLocation.current_key)
@@ -323,11 +324,13 @@ class VariaRandomizer:
 
         logger.debug("preset: {}".format(preset))
 
-        # if no seed given, choose one
-        if args.seed == 0:
-            self.seed = random.randrange(sys.maxsize)
-        else:
-            self.seed = args.seed
+        # Archipelago provides a seed for the multiworld.
+        self.seed = seed
+        # # if no seed given, choose one
+        # if args.seed == 0:
+        #     self.seed = random.randrange(sys.maxsize)
+        # else:
+        #     self.seed = args.seed
         logger.debug("seed: {}".format(self.seed))
 
         if args.raceMagic is not None:
@@ -360,12 +363,12 @@ class VariaRandomizer:
         logger.debug("maxDifficulty: {}".format(self.maxDifficulty))
 
         # handle random parameters with dynamic pool of values
-        (_, progSpeed) = randomMulti(args.__dict__, "progressionSpeed", speeds)
-        (_, progDiff) = randomMulti(args.__dict__, "progressionDifficulty", progDiffs)
-        (majorsSplitRandom, args.majorsSplit) = randomMulti(args.__dict__, "majorsSplit", majorsSplits)
-        (_, self.gravityBehaviour) = randomMulti(args.__dict__, "gravityBehaviour", gravityBehaviours)
-        (_, args.tourian) = randomMulti(args.__dict__, "tourian", tourians)
-        (areaRandom, args.area) = randomMulti(args.__dict__, "area", areaRandomizations)
+        (_, progSpeed) = randomMulti(args.__dict__, "progressionSpeed", speeds, random)
+        (_, progDiff) = randomMulti(args.__dict__, "progressionDifficulty", progDiffs, random)
+        (majorsSplitRandom, args.majorsSplit) = randomMulti(args.__dict__, "majorsSplit", majorsSplits, random)
+        (_, self.gravityBehaviour) = randomMulti(args.__dict__, "gravityBehaviour", gravityBehaviours, random)
+        (_, args.tourian) = randomMulti(args.__dict__, "tourian", tourians, random)
+        (areaRandom, args.area) = randomMulti(args.__dict__, "area", areaRandomizations, random)
         areaRandomization = args.area in ['light', 'full']
         lightArea = args.area == 'light'
     
@@ -626,7 +629,7 @@ class VariaRandomizer:
             if args.objective:
                 if (args.objectiveRandom):
                     availableObjectives = [goal for goal in objectives if goal != "collect 100% items"] if "random" in args.objectiveList else args.objectiveList
-                    self.objectivesManager.setRandom(args.nbObjective, availableObjectives)
+                    self.objectivesManager.setRandom(args.nbObjective, availableObjectives, self.random)
                 else:
                     maxActiveGoals = Objectives.maxActiveGoals - addedObjectives
                     if len(args.objective) > maxActiveGoals:
@@ -660,7 +663,7 @@ class VariaRandomizer:
         #    print("energyQty:{}".format(energyQty))
 
         #try:
-        self.randoExec = RandoExec(seedName, args.vcr, randoSettings, graphSettings, self.player)
+        self.randoExec = RandoExec(seedName, args.vcr, randoSettings, graphSettings, self.player, self.random)
         self.container = self.randoExec.randomize()
         # if we couldn't find an area layout then the escape graph is not created either
         # and getDoorConnections will crash if random escape is activated.
@@ -690,7 +693,7 @@ class VariaRandomizer:
                             'gameend.ips', 'grey_door_animals.ips', 'low_timer.ips', 'metalimals.ips',
                             'phantoonimals.ips', 'ridleyimals.ips']
             if args.escapeRando == False:
-                args.patches.append(random.choice(animalsPatches))
+                args.patches.append(self.random.choice(animalsPatches))
                 args.patches.append("Escape_Animals_Change_Event")
             else:
                 optErrMsgs.append("Ignored animals surprise because of escape randomization")
@@ -760,9 +763,9 @@ class VariaRandomizer:
                 # patch local rom
                 romFileName = args.rom
                 shutil.copyfile(romFileName, outputFilename)
-                romPatcher = RomPatcher(settings=patcherSettings, romFileName=outputFilename, magic=args.raceMagic, player=self.player)
+                romPatcher = RomPatcher(settings=patcherSettings, romFileName=outputFilename, magic=args.raceMagic, player=self.player, random=self.random)
             else:
-                romPatcher = RomPatcher(settings=patcherSettings, magic=args.raceMagic)
+                romPatcher = RomPatcher(settings=patcherSettings, magic=args.raceMagic, random=self.random)
 
             if customPrePatchApply != None:
                 customPrePatchApply(romPatcher)

--- a/worlds/sm/variaRandomizer/rom/rompatcher.py
+++ b/worlds/sm/variaRandomizer/rom/rompatcher.py
@@ -49,7 +49,7 @@ class RomPatcher:
         'DoorsColors': ['beam_doors_plms.ips', 'beam_doors_gfx.ips', 'red_doors.ips']
     }
 
-    def __init__(self, settings=None, romFileName=None, magic=None, player=0):
+    def __init__(self, settings=None, romFileName=None, magic=None, player=0, *, random):
         self.log = log.get('RomPatcher')
         self.settings = settings
         self.romFileName = romFileName
@@ -76,6 +76,7 @@ class RomPatcher:
             0x93ea: self.forceRoomCRE
         }
         self.player = player
+        self.random = random
 
     def patchRom(self):
         self.applyIPSPatches()
@@ -495,9 +496,9 @@ class RomPatcher:
         self.romFile.ipsPatch(self.ipsPatches)
 
     def writeSeed(self, seed):
-        random.seed(seed)
-        seedInfo = random.randint(0, 0xFFFF)
-        seedInfo2 = random.randint(0, 0xFFFF)
+        r = random.Random(seed)
+        seedInfo = r.randint(0, 0xFFFF)
+        seedInfo2 = r.randint(0, 0xFFFF)
         self.romFile.writeWord(seedInfo, snes_to_pc(0xdfff00))
         self.romFile.writeWord(seedInfo2)
 
@@ -1065,7 +1066,7 @@ class RomPatcher:
 
     def writeObjectives(self, itemLocs, tourian):
         objectives = Objectives.objDict[self.player]
-        objectives.writeGoals(self.romFile)
+        objectives.writeGoals(self.romFile, self.random)
         objectives.writeIntroObjectives(self.romFile, tourian)
         self.writeItemsMasks(itemLocs)
         # hack bomb_torizo.ips to wake BT in all cases if necessary, ie chozo bots objective is on, and nothing at bombs

--- a/worlds/sm/variaRandomizer/utils/doorsmanager.py
+++ b/worlds/sm/variaRandomizer/utils/doorsmanager.py
@@ -1,4 +1,3 @@
-import random
 from enum import IntEnum,IntFlag
 import copy
 from ..logic.smbool import SMBool
@@ -123,7 +122,7 @@ class Door(object):
         else:
             return [color for color in colorsList if color not in self.forbiddenColors]
 
-    def randomize(self, allowGreyDoors):
+    def randomize(self, allowGreyDoors, random):
         if self.canRandomize():
             if self.canGrey and allowGreyDoors:
                 self.setColor(random.choice(self.filterColorList(colorsListGrey)))
@@ -347,9 +346,9 @@ class DoorsManager():
             currentDoors['CrabShaftRight'].forceBlue()
 
     @staticmethod
-    def randomize(allowGreyDoors, player):
+    def randomize(allowGreyDoors, player, random):
         for door in DoorsManager.doorsDict[player].values():
-            door.randomize(allowGreyDoors)
+            door.randomize(allowGreyDoors, random)
         # set both ends of toilet to the same color to avoid soft locking in area rando
         toiletTop = DoorsManager.doorsDict[player]['PlasmaSparkBottom']
         toiletBottom = DoorsManager.doorsDict[player]['OasisTop']

--- a/worlds/sm/variaRandomizer/utils/objectives.py
+++ b/worlds/sm/variaRandomizer/utils/objectives.py
@@ -1,5 +1,4 @@
 import copy
-import random
 from ..rom.addresses import Addresses
 from ..rom.rom import pc_to_snes
 from ..logic.helpers import Bosses
@@ -28,7 +27,7 @@ class Synonyms(object):
     ]
     alreadyUsed = []
     @staticmethod
-    def getVerb(): 
+    def getVerb(random):
         verb = random.choice(Synonyms.killSynonyms)
         while verb in Synonyms.alreadyUsed:
             verb = random.choice(Synonyms.killSynonyms)
@@ -88,10 +87,10 @@ class Goal(object):
         # not all objectives require an ap (like limit objectives)
         return self.clearFunc(smbm, ap)
 
-    def getText(self):
+    def getText(self, random):
         out = "{}. ".format(self.rank)
         if self.useSynonym:
-            out += self.text.format(Synonyms.getVerb())
+            out += self.text.format(Synonyms.getVerb(random))
         else:
             out += self.text
         assert len(out) <= 28, "Goal text '{}' is too long: {}, max 28".format(out, len(out))
@@ -676,7 +675,7 @@ class Objectives(object):
         return [goal.name for goal in _goals.values() if goal.available and (not removeNothing or goal.name != "nothing")]
 
     # call from rando
-    def setRandom(self, nbGoals, availableGoals):
+    def setRandom(self, nbGoals, availableGoals, random):
         while self.nbActiveGoals < nbGoals and availableGoals:
             goalName = random.choice(availableGoals)
             self.addGoal(goalName)
@@ -702,7 +701,7 @@ class Objectives(object):
         LOG.debug("tourianRequired: {}".format(self.tourianRequired))
 
     # call from rando
-    def writeGoals(self, romFile):
+    def writeGoals(self, romFile, random):
         # write check functions
         romFile.seek(Addresses.getOne('objectivesList'))
         for goal in self.activeGoals:
@@ -736,7 +735,7 @@ class Objectives(object):
         space = 3 if self.nbActiveGoals == 5 else 4
         for i, goal in enumerate(self.activeGoals):
             addr = baseAddr + i * lineLength * space
-            text = goal.getText()
+            text = goal.getText(random)
             romFile.seek(addr)
             for c in text:
                 if c not in char2tile:

--- a/worlds/sm/variaRandomizer/utils/utils.py
+++ b/worlds/sm/variaRandomizer/utils/utils.py
@@ -1,5 +1,5 @@
 import io
-import os, json, re, random
+import os, json, re
 import pathlib
 import sys
 from typing import Any
@@ -88,7 +88,7 @@ def normalizeRounding(n):
 
 # gauss random in [0, r] range
 # the higher the slope, the less probable extreme values are.
-def randGaussBounds(r, slope=5):
+def randGaussBounds(random, r, slope=5):
     r = float(r)
     n = normalizeRounding(random.gauss(r/2, r/slope))
     if n < 0:
@@ -111,7 +111,7 @@ def getRangeDict(weightDict):
 
     return rangeDict
 
-def chooseFromRange(rangeDict):
+def chooseFromRange(rangeDict, random):
     r = random.random()
     val = None
     for v in sorted(rangeDict, key=rangeDict.get):


### PR DESCRIPTION
## What is this fixing or adding?
Replaces direct use of the `random` module with passing around the world's `.random` attribute instead.

Fixes different generation on webhost compared to local generation, assuming no yaml options are using random options because all random option resolution is currently nondeterministic on webhost.

The new arguments for passing self.random through to the various variaRandomizer classes and functions have been added to the end of the arguments for each relevant function, except `utils.randGaussBounds` where the `random` argument is more like a `self` argument in a method, so has been added as the first argument instead.

The multiworld seed is now passed through to variaRandomizer instead of it generating its own seed.

## How was this tested?

I started by removing all the `random` module imports and ran many generations with 5 almost fully random yamls, making adjustments to pass through the world's `.random` whenever generation crashed because it was trying to access the `random` module still. This helped me see the function calls through the code to determine what classes and functions I would have to pass the world's `.random` through.

Once generation was succeeding and I could not find any more direct use of the `random` module, I ran a generation of the template yaml on archipelago.gg (specifically the template yaml has no options set to random so should generate deterministically) and generated with the same seed locally and determined them to now produce the same results.

Additionally, I ran these changes along with the WIP test in https://github.com/ArchipelagoMW/Archipelago/pull/4410, and the failing test for Super Metroid would now pass.

I have not done any tests that go as far as connecting the client to a multiworld and patching the ROM, so I recommend more testing should be done by people more familiar with Super Metroid AP.