### PR TITLE
Core: Make the error for a missing option display the player name

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -500,7 +500,8 @@ def roll_settings(weights: dict, plando_options: PlandoOptions = PlandoOptions.b
     for option_key in game_weights:
         if option_key in {"triggers", *valid_keys}:
             continue
-        logging.warning(f"{option_key} is not a valid option name for {ret.game} and is not present in triggers.")
+        logging.warning(f"{option_key} is not a valid option name for {ret.game} and is not present in triggers "
+                        f"for player {ret.name}.")
     if PlandoOptions.items in plando_options:
         ret.plando_items = copy.deepcopy(game_weights.get("plando_items", []))
     if ret.game == "A Link to the Past":


### PR DESCRIPTION
## What is this fixing or adding?
Makes the error when you have an option in a yaml that does not match an option in the apworld display the name chosen in the yaml, to make it easier to tell which one has the issue when you have many players in a generation.

Not fully attached to the wording of it.

## How was this tested?
Test gen.

Before:
`achievements is not a valid option name for Terraria and is not present in triggers.`

After:
`achievements is not a valid option name for Terraria and is not present in triggers for player PlayerName.`