### PR TITLE
Tests: Make overlapping test actually print out the overlaps

### DIFF
--- a/test/general/test_ids.py
+++ b/test/general/test_ids.py
@@ -47,12 +47,38 @@ class TestIDs(unittest.TestCase):
         """Test that a game doesn't have item id overlap within its own datapackage"""
         for gamename, world_type in AutoWorldRegister.world_types.items():
             with self.subTest(game=gamename):
-                self.assertEqual(len(world_type.item_id_to_name), len(world_type.item_name_to_id))
+                len_item_id_to_name = len(world_type.item_id_to_name)
+                len_item_name_to_id = len(world_type.item_name_to_id)
+
+                if len_item_id_to_name != len_item_name_to_id:
+                    self.assertCountEqual(
+                        world_type.item_id_to_name.values(), 
+                        world_type.item_name_to_id.keys(),
+                        "\nThese items have an overlapping ids with other items its own world")
+                    self.assertCountEqual(
+                        world_type.item_id_to_name.keys(), 
+                        world_type.item_name_to_id.values(),
+                        "\nThese items have an overlapping names with other items its own world")
+                    
+                self.assertEqual(len_item_id_to_name, len_item_name_to_id)
 
     def test_duplicate_location_ids(self):
         """Test that a game doesn't have location id overlap within its own datapackage"""
         for gamename, world_type in AutoWorldRegister.world_types.items():
             with self.subTest(game=gamename):
+                len_location_id_to_name = len(world_type.location_id_to_name)
+                len_location_name_to_id = len(world_type.location_name_to_id)
+
+                if len_location_id_to_name != len_location_name_to_id:
+                    self.assertCountEqual(
+                        world_type.location_id_to_name.values(), 
+                        world_type.location_name_to_id.keys(),
+                        "\nThese locations have an overlapping ids with other locations its own world")
+                    self.assertCountEqual(
+                        world_type.location_id_to_name.keys(), 
+                        world_type.location_name_to_id.values(),
+                        "\nThese locations have an overlapping names with other locations its own world")
+
                 self.assertEqual(len(world_type.location_id_to_name), len(world_type.location_name_to_id))
 
     def test_postgen_datapackage(self):


### PR DESCRIPTION
## What is this fixing or adding?
Something iv ran into a couple of time myzelf, when the `test_duplicate_item_ids` fails it will say something like 600 != 602
This tell you nothing about which of those 600 items or locations are at fault, by changing these tests it will now print out the overlapping names or ids

example output:
```
AssertionError: Element counts were not equal:
First has 0, Second has 1:  'Bundle: Adequate Pioneering Statue'
First has 0, Second has 1:  'Bundle: Crystal Oscillator'
First has 0, Second has 1:  'Recipe: Tempered Caterium Ingot' : 
These items have an overlapping ids with other items its own world
self = <test.general.test_ids.TestIDs testMethod=test_duplicate_item_ids>

    def test_duplicate_item_ids(self):
        """Test that a game doesn't have item id overlap within its own datapackage"""
        for gamename, world_type in AutoWorldRegister.world_types.items():
            with self.subTest(game=gamename):
>               self.assertCountEqual(
                    world_type.item_id_to_name.values(),
                    world_type.item_name_to_id.keys(),
                    f"\nThese items have an overlapping ids with other items its own world")
E               AssertionError: Element counts were not equal:
E               First has 0, Second has 1:  'Bundle: Adequate Pioneering Statue'
E               First has 0, Second has 1:  'Bundle: Crystal Oscillator'
E               First has 0, Second has 1:  'Recipe: Tempered Caterium Ingot' : 
E               These items have an overlapping ids with other items its own world

test\general\test_ids.py:50: AssertionError
```

## How was this tested?
By introducing duplicates locally and running the tests
