### PR TITLE
FFMQ: Fix collect_item

### DIFF
--- a/worlds/ffmq/__init__.py
+++ b/worlds/ffmq/__init__.py
@@ -152,14 +152,23 @@ class FFMQWorld(World):
         return FFMQItem(name, self.player)
 
     def collect_item(self, state, item, remove=False):
+        if not item.advancement:
+            return None
         if "Progressive" in item.name:
             i = item.code - 256
-            if state.has(self.item_id_to_name[i], self.player):
-                if state.has(self.item_id_to_name[i+1], self.player):
-                    return self.item_id_to_name[i+2]
-                return self.item_id_to_name[i+1]
-            return self.item_id_to_name[i]
-        return item.name if item.advancement else None
+            if not remove:
+                if state.has(self.item_id_to_name[i], self.player):
+                    if state.has(self.item_id_to_name[i + 1], self.player):
+                        return self.item_id_to_name[i + 2]
+                    return self.item_id_to_name[i + 1]
+                return self.item_id_to_name[i]
+            else:
+                if state.has(self.item_id_to_name[i + 1], self.player):
+                    if state.has(self.item_id_to_name[i + 2], self.player):
+                        return self.item_id_to_name[i + 2]
+                    return self.item_id_to_name[i + 1]
+                return self.item_id_to_name[i]
+        return item.name
 
     def modify_multidata(self, multidata):
         # wait for self.rom_name to be available.

--- a/worlds/ffmq/__init__.py
+++ b/worlds/ffmq/__init__.py
@@ -156,18 +156,18 @@ class FFMQWorld(World):
             return None
         if "Progressive" in item.name:
             i = item.code - 256
-            if not remove:
-                if state.has(self.item_id_to_name[i], self.player):
-                    if state.has(self.item_id_to_name[i + 1], self.player):
-                        return self.item_id_to_name[i + 2]
-                    return self.item_id_to_name[i + 1]
+            if remove:
+                if state.has(self.item_id_to_name[i+1], self.player):
+                    if state.has(self.item_id_to_name[i+2], self.player):
+                        return self.item_id_to_name[i+2]
+                    return self.item_id_to_name[i+1]
                 return self.item_id_to_name[i]
-            else:
-                if state.has(self.item_id_to_name[i + 1], self.player):
-                    if state.has(self.item_id_to_name[i + 2], self.player):
-                        return self.item_id_to_name[i + 2]
-                    return self.item_id_to_name[i + 1]
-                return self.item_id_to_name[i]
+
+            if state.has(self.item_id_to_name[i], self.player):
+                if state.has(self.item_id_to_name[i+1], self.player):
+                    return self.item_id_to_name[i+2]
+                return self.item_id_to_name[i+1]
+            return self.item_id_to_name[i]
         return item.name
 
     def modify_multidata(self, multidata):


### PR DESCRIPTION
## What is this fixing or adding?

FFMQ's `collect_item` previously returned names (modified state) for non-progression items and did not handle `remove` properly. This fixes both of these things.

## How was this tested?

This was tested using a fixed version of https://github.com/ArchipelagoMW/Archipelago/pull/2062 following Qwint's deepcopy comment. FFMQ failed the tests before these changes and succeeds after them.