### PR TITLE
Pokémon R/B: Fix Route 11-E to Route-12-W logic

### DIFF
--- a/worlds/pokemon_rb/regions.py
+++ b/worlds/pokemon_rb/regions.py
@@ -1718,7 +1718,7 @@ def create_regions(world):
     connect(multiworld, player, "Vermilion City", "Vermilion City-Dock", lambda state: state.has("S.S. Ticket", player))
     connect(multiworld, player, "Vermilion City", "Route 11")
     connect(multiworld, player, "Route 12-N", "Route 12-S", lambda state: logic.can_surf(state, world, player))
-    connect(multiworld, player, "Route 12-W", "Route 11-E", lambda state: state.has("Poke Flute", player))
+    connect(multiworld, player, "Route 12-W", "Route 11-E")
     connect(multiworld, player, "Route 12-W", "Route 12-N", lambda state: state.has("Poke Flute", player))
     connect(multiworld, player, "Route 12-W", "Route 12-S", lambda state: state.has("Poke Flute", player))
     connect(multiworld, player, "Route 12-S", "Route 12-Grass", lambda state: logic.can_cut(state, world, player), one_way=True)


### PR DESCRIPTION
## What is this fixing or adding?
Removes an erroneous logical requirement to have the Poké Flute to reach Route 12-W from Route 11-E. The actual spot you need the Poké Flute is in Route 12 just beyond a hidden item location, so this location was logically requiring Poké Flute. The Sleeping Pokémon location (in Route 12-W) as well as the connections to Route 12-N and Route 12-S all require Poké Flute, so everything else should work as expected without this rule here.


## How was this tested?
I have not tested this yet