### PR TITLE
Utils: Visualize Regions showing the reachable regions in color

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -933,7 +933,7 @@ def freeze_support() -> None:
 
 def visualize_regions(root_region: Region, file_name: str, *,
                       show_entrance_names: bool = False, show_locations: bool = True, show_other_regions: bool = True,
-                      linetype_ortho: bool = True) -> None:
+                      linetype_ortho: bool = True, regions_to_highlight: set[Region] = None) -> None:
     """Visualize the layout of a world as a PlantUML diagram.
 
     :param root_region: The region from which to start the diagram from. (Usually the "Menu" region of your world.)
@@ -949,6 +949,7 @@ def visualize_regions(root_region: Region, file_name: str, *,
             Items without ID will be shown in italics.
     :param show_other_regions: (default True) If enabled, regions that can't be reached by traversing exits are shown.
     :param linetype_ortho: (default True) If enabled, orthogonal straight line parts will be used; otherwise polylines.
+    :param regions_to_highlight: Regions that will be highlighted in green if they are reachable.
 
     Example usage in World code:
     from Utils import visualize_regions
@@ -959,6 +960,8 @@ def visualize_regions(root_region: Region, file_name: str, *,
     for player in multiworld.player_ids:
         visualize_regions(multiworld.get_region("Menu", player), f"{multiworld.get_out_file_name_base(player)}.puml")
     """
+    if regions_to_highlight is None:
+        regions_to_highlight = set()
     assert root_region.multiworld, "The multiworld attribute of root_region has to be filled"
     from BaseClasses import Entrance, Item, Location, LocationProgressType, MultiWorld, Region
     from collections import deque
@@ -1011,7 +1014,7 @@ def visualize_regions(root_region: Region, file_name: str, *,
                 uml.append(f"\"{fmt(region)}\" : {{field}} {lock}{fmt(location)}")
 
     def visualize_region(region: Region) -> None:
-        uml.append(f"class \"{fmt(region)}\"")
+        uml.append(f"class \"{fmt(region)}\" {'#00FF00' if region in regions_to_highlight else ''}")
         if show_locations:
             visualize_locations(region)
         visualize_exits(region)

--- a/Utils.py
+++ b/Utils.py
@@ -953,7 +953,10 @@ def visualize_regions(root_region: Region, file_name: str, *,
 
     Example usage in World code:
     from Utils import visualize_regions
-    visualize_regions(self.multiworld.get_region("Menu", self.player), "my_world.puml")
+    state = self.multiworld.get_all_state(False)
+    state.update_reachable_regions(self.player)
+    visualize_regions(self.get_region("Menu"), "my_world.puml", show_entrance_names=True,
+                      regions_to_highlight=state.reachable_regions[self.player])
 
     Example usage in Main code:
     from Utils import visualize_regions

--- a/Utils.py
+++ b/Utils.py
@@ -933,7 +933,7 @@ def freeze_support() -> None:
 
 def visualize_regions(root_region: Region, file_name: str, *,
                       show_entrance_names: bool = False, show_locations: bool = True, show_other_regions: bool = True,
-                      linetype_ortho: bool = True, regions_to_highlight: set[Region] = None) -> None:
+                      linetype_ortho: bool = True, regions_to_highlight: set[Region] | None = None) -> None:
     """Visualize the layout of a world as a PlantUML diagram.
 
     :param root_region: The region from which to start the diagram from. (Usually the "Menu" region of your world.)


### PR DESCRIPTION
## What is this fixing or adding?
Originally written by Zunawe, I figured this should be in core since it's very useful for newer devs to be able to see which regions are reachable.

## How was this tested?
Test gen with the example code.

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/user-attachments/assets/c2520094-ab71-44cb-9324-d0db1ddb6ac1)
woe be upon thee, for I have too many regions