### PR TITLE
Core: Crass less on loading settings with invalid apworlds

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -746,7 +746,12 @@ class Settings(Group):
                 return super().__getattribute__(key)
             # directly import world and grab settings class
             world_mod, world_cls_name = _world_settings_name_cache[key].rsplit(".", 1)
-            world = cast(type, getattr(__import__(world_mod, fromlist=[world_cls_name]), world_cls_name))
+            try:
+                world = cast(type, getattr(__import__(world_mod, fromlist=[world_cls_name]), world_cls_name))
+            except AttributeError:
+                import warnings
+                warnings.warn(f"World {world_cls_name} failed to initialize properly.")
+                return super().__getattribute__(key)
             assert getattr(world, "settings_key") == key
             try:
                 cls_or_name = world.__annotations__["settings"]


### PR DESCRIPTION
## What is this fixing or adding?
handle nicer when a single world using settings api fails to load (like duplicate apworlds)

note: i swear the issue was an importerror but i could only get attributeerrors on the getattr() call, maybe we want to check for both?

## How was this tested?
added an apworld that uses Settings to both custom_worlds and lib/worlds and saw it not crash on open host.yaml after the change 

## If this makes graphical changes, please attach screenshots.
