### PR TITLE
Core: Pickle hints by value

### DIFF
--- a/NetUtils.py
+++ b/NetUtils.py
@@ -10,7 +10,7 @@ import websockets
 from Utils import ByValue, Version
 
 
-class HintStatus(enum.IntEnum):
+class HintStatus(ByValue, enum.IntEnum):
     HINT_FOUND = 0
     HINT_UNSPECIFIED = 1
     HINT_NO_PRIORITY = 10


### PR DESCRIPTION
## What is this fixing or adding?
add the pickle by value mixin to HintStatus so it works on a weird subset of python where enums don't do that by default

## How was this tested?
```py
from NetUtils import HintStatus
import pickle
from Utils import restricted_loads
x = {"thing1": HintStatus(1), "thing2": HintStatus.HINT_UNSPECIFIED}
y = pickle.dumps(x)
restricted_loads(y)
```
crashes on 3.11.4 without this change, doesn't crash with the change

## If this makes graphical changes, please attach screenshots.
