### PR TITLE
The Messenger: reduce strictness of output path check

### DIFF
--- a/worlds/messenger/__init__.py
+++ b/worlds/messenger/__init__.py
@@ -381,7 +381,7 @@ class MessengerWorld(World):
             return
         # the messenger client calls into AP with specific args, so check the out path matches what the client sends
         out_path = output_path(multiworld.get_out_file_name_base(1) + ".aptm")
-        if "The Messenger\\Archipelago\\output" not in out_path:
+        if "Messenger\\Archipelago\\output" not in out_path:
             return
         import orjson
         data = {


### PR DESCRIPTION
## What is this fixing or adding?
Turns out the steam version puts the game in a folder called "The Messenger", but the epic version puts the game in a folder called "TheMessenger". Fun.

## How was this tested?
Generated a seed with the expected args and checked it still works.