### PR TITLE
Stardew Valley: Hide the Mods from the simple options page

### DIFF
--- a/worlds/stardew_valley/options/options.py
+++ b/worlds/stardew_valley/options/options.py
@@ -772,6 +772,7 @@ if 'unittest' in sys.modules.keys() or 'pytest' in sys.modules.keys():
 
 class Mods(OptionSet):
     """List of mods that will be included in the shuffling."""
+    visibility = Visibility.all & ~Visibility.simple_ui
     internal_name = "mods"
     display_name = "Mods"
     valid_keys = {ModNames.deepwoods, ModNames.tractor, ModNames.big_backpack,


### PR DESCRIPTION
## What is this fixing or adding?
Short version: Hide the "Mods" option from the simple options page.

Long version: A long time ago, the first time modded content was discussed, I originally predicted that the average Stardew player would not be tech-savvy enough to figure out mods and that would drastically increase the amount of tech support we need to do. But back then, an OptionSet did not show up on the options page, so I figured it was fine, as the average player would not even realize the option exists.

Later, at some point, the website UI was improved and can now display OptionSets. This is generally good, but in this case, it has had the side effect of unleashing mod support upon the type of player that doesn't know what a screenshot is, let alone a file system. Furthermore, SVE itself (the most popular mod I imagine) has had a breaking update, which means we now provide a secondary patch for it, to make it work. This has lead to a **massive** amount of tech support request. Several people every single day end up needing assistance for the task of copying some files into their mod folder. I believe most of these players don't even know the mods documentation exist, and instead just check the box in the option page and blindly attempt at installing random versions and hope for the best.

So this PR restores the behavior, for this specific option, where the simple options page does not show it. It can be accessed in the advanced options page, the templates, the spoiler, and manual edits, which is where I suspect the power users will be. Plus, now, to even know there is mod support and attempt to use it, you must find the mods documentation, which greatly improves the chance that a user at least knows about the extra patches.

## How was this tested?
Ran the webhost locally and went through all the paths (simple, advanced, template). Things seemed fine

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/user-attachments/assets/eac39e5d-dd86-4aed-91d0-667663236af8)
