### PR TITLE
Docs: Update outdated info in World API docs

### DIFF
--- a/docs/world api.md
+++ b/docs/world api.md
@@ -243,7 +243,9 @@ progression. Progression items will be assigned to locations with higher priorit
 and satisfy progression balancing.
 
 The name needs to be unique within each game, meaning if you need to create multiple items with the same name, they
-will all have the same ID. Name must not be numeric (must contain at least 1 letter or symbol).
+will all have the same ID. Name must not be numeric (must contain at least 1 letter or symbol). 
+The ID thus also needs to be unique across all items with different names within the game. 
+Items and locations can share IDs, and items can share IDs with other games' items.
 
 Other classifications include:
 

--- a/docs/world api.md
+++ b/docs/world api.md
@@ -222,8 +222,8 @@ could also be progress in a research tree, or even something more abstract like 
 
 Each location has a `name` and an `address` (hereafter referred to as an `id`), is placed in a Region, has access rules,
 and has a classification. The name needs to be unique within each game and must not be numeric (must contain least 1
-letter or symbol). The ID needs to be unique across all games, and is best kept in the same range as the item IDs.
-Locations and items can share IDs, so typically a game's locations and items start at the same ID.
+letter or symbol). The ID needs to be unique across all locations within the game. 
+Locations and items can share IDs, and locations can share IDs with other games' locations.
 
 World-specific IDs must be in the range 1 to 2<sup>53</sup>-1; IDs ≤ 0 are global and reserved.
 


### PR DESCRIPTION
Docs: Correct outdated documentation in world api.md about location ID uniqueness

## What is this fixing or adding?

Previously the docs stated that location IDs must be unique across all games, which is no longer the case

## How was this tested?

Discussion on Discord

## If this makes graphical changes, please attach screenshots.
