### PR TITLE
Settings: crash worlds with an empty settings definition early

### DIFF
--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -8,7 +8,7 @@ import time
 from random import Random
 from dataclasses import make_dataclass
 from typing import (Any, Callable, ClassVar, Dict, FrozenSet, Iterable, List, Mapping, Optional, Set, TextIO, Tuple,
-                    TYPE_CHECKING, Type, Union)
+                    TYPE_CHECKING, Type, Union, get_args)
 
 from Options import item_and_loc_options, ItemsAccessibility, OptionGroup, PerGameCommonOptions
 from BaseClasses import CollectionState
@@ -83,6 +83,13 @@ class AutoWorldRegister(type):
 
         # construct class
         new_class = super().__new__(mcs, name, bases, dct)
+
+        if "settings" in new_class.__annotations__:
+            settings_cls = get_args(new_class.__annotations__["settings"])
+            if settings_cls and not settings_cls[0].__annotations__:
+                raise Exception(f"{name} has defined an empty settings.Group which is not appropritate, "
+                                "leave as default if no settings are required")
+
         if "game" in dct:
             if dct["game"] in AutoWorldRegister.world_types:
                 raise RuntimeError(f"""Game {dct["game"]} already registered.""")


### PR DESCRIPTION
## What is this fixing or adding?
currently settings groups with an empty `__annotations__` crash in saving, this moves the crash to world creation so devs will be aware sooner and it won't impede other worlds trying to save

this probably has to go the extra mile to implement more of the same cls_or_name code here
https://github.com/ArchipelagoMW/Archipelago/blob/main/settings.py#L757
so open to any and all suggestions on that end

## How was this tested?
made emerald's settings into just `pass` and saw it fail to load but 'open host.yaml' button on launcher succeed to open without error

## If this makes graphical changes, please attach screenshots.
