### PR TITLE
Core: cast LogRecord.msg to string to not crash on crashes

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -515,7 +515,7 @@ def init_logging(name: str, loglevel: typing.Union[str, int] = logging.INFO,
             return self.condition(record)
 
     file_handler.addFilter(Filter("NoStream", lambda record: not getattr(record,  "NoFile", False)))
-    file_handler.addFilter(Filter("NoCarriageReturn", lambda record: '\r' not in record.msg))
+    file_handler.addFilter(Filter("NoCarriageReturn", lambda record: '\r' not in str(record.msg)))
     root_logger.addHandler(file_handler)
     if sys.stdout:
         formatter = logging.Formatter(fmt='[%(asctime)s] %(message)s', datefmt='%Y-%m-%d %H:%M:%S')


### PR DESCRIPTION
## What is this fixing or adding?
casts the LogRecord.msg (typed as Any) to a string before we check its contents as if it was a string


## How was this tested?
```py
import logging
from Utils import init_logging

init_logging("test")
l = logging.getLogger("test")
l.exception(Exception("Hello World"))
```
it doesn't crash now

## If this makes graphical changes, please attach screenshots.
