### PR TITLE
MultiServer: Correct tying of Context.groups, fixing a crash with hints

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -444,7 +444,7 @@ class Context:
 
         self.slot_info = decoded_obj["slot_info"]
         self.games = {slot: slot_info.game for slot, slot_info in self.slot_info.items()}
-        self.groups = {slot: slot_info.group_members for slot, slot_info in self.slot_info.items()
+        self.groups = {slot: set(slot_info.group_members) for slot, slot_info in self.slot_info.items()
                        if slot_info.type == SlotType.group}
 
         self.clients = {0: {}}


### PR DESCRIPTION
https://github.com/ArchipelagoMW/Archipelago/blob/main/MultiServer.py#L181 claims that Context.groups is a `dict[int, set[int]]`

However, in https://github.com/ArchipelagoMW/Archipelago/blob/main/MultiServer.py#L447-L448 it is assigned something that is a `dict[int, list[int] | tuple]`, because NetworkSlot.group_members is `list[int] | tuple`.

So far this went unnoticed, because we only used generic collection operations on the values of this dict.

However, in https://github.com/ArchipelagoMW/Archipelago/pull/3506, we introduced this line: https://github.com/ArchipelagoMW/Archipelago/blob/main/MultiServer.py#L677, which uses an actual set-exclusive operator `|`

This fixes the typing, and that crash, by actually converting to a set.

Tested:
Not really, just confirmed that PyCharm/mypy is happy now