### PR TITLE
Docs: Fix typo in Rich Text Options flag documentation

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -137,7 +137,7 @@ class Option(typing.Generic[T], metaclass=AssembleOptions):
     If this is False, the docstring is instead interpreted as plain text, and
     displayed as-is on the WebHost with whitespace preserved.
 
-    If this is None, it inherits the value of `World.rich_text_options_doc`. For
+    If this is None, it inherits the value of `WebWorld.rich_text_options_doc`. For
     backwards compatibility, this defaults to False, but worlds are encouraged to
     set it to True and use reStructuredText for their Option documentation.
 

--- a/docs/options api.md
+++ b/docs/options api.md
@@ -95,7 +95,7 @@ user hovers over the yellow "(?)" icon, and included in the YAML templates gener
 The WebHost can display Option documentation either as plain text with all whitespace preserved (other than the base
 indentation), or as HTML generated from the standard Python [reStructuredText] format. Although plain text is the
 default for backwards compatibility, world authors are encouraged to write their Option documentation as
-reStructuredText and enable rich text rendering by setting `World.rich_text_options_doc = True`.
+reStructuredText and enable rich text rendering by setting `WebWorld.rich_text_options_doc = True`.
 
 [reStructuredText]: https://docutils.sourceforge.io/rst.html
 


### PR DESCRIPTION
## What is this fixing or adding?
fix a typo in which class rich_text_options_doc is set on

addressed #4461

## How was this tested?
I used the bool in #4079

## If this makes graphical changes, please attach screenshots.
