### PR TITLE
BizHawkClient: Fix version warning not falling through to regular execution

### DIFF
--- a/data/lua/connector_bizhawk_generic.lua
+++ b/data/lua/connector_bizhawk_generic.lua
@@ -613,9 +613,11 @@ end)
 
 if bizhawk_major < 2 or (bizhawk_major == 2 and bizhawk_minor < 7) then
     print("Must use BizHawk 2.7.0 or newer")
-elseif bizhawk_major > 2 or (bizhawk_major == 2 and bizhawk_minor > 9) then
-    print("Warning: This version of BizHawk is newer than this script. If it doesn't work, consider downgrading to 2.9.")
 else
+    if bizhawk_major > 2 or (bizhawk_major == 2 and bizhawk_minor > 10) then
+        print("Warning: This version of BizHawk is newer than this script. If it doesn't work, consider downgrading to 2.10.")
+    end
+
     if emu.getsystemid() == "NULL" then
         print("No ROM is loaded. Please load a ROM.")
         while emu.getsystemid() == "NULL" do


### PR DESCRIPTION
## What is this fixing or adding?

The script is supposed to print a warning for new bizhawk versions and then proceed, but it got mistakenly put in an incorrect `elseif`.

## How was this tested?

Ran the script on BizHawk 2.10 (before changing the version it checks) to see the warning and see it start working.

There's nothing in the 2.10 patch notes to suggest any sort of breaking change with this script as far as I can tell. It worked fine for a quick test. I'll continue to use 2.10 to make sure it works.
