### PR TITLE
ALTTP: add dungeon->boss/prize mapping into slotdata

### DIFF
--- a/worlds/alttp/__init__.py
+++ b/worlds/alttp/__init__.py
@@ -815,9 +815,9 @@ class ALTTPWorld(World):
         if not self.multiworld.is_race:
             prizes = {}
             bosses = {
-                'Ganons Tower - bottom': self.dungeons['Ganons Tower'].bosses['bottom'].name,
-                'Ganons Tower - middle': self.dungeons['Ganons Tower'].bosses['middle'].name,
-                'Ganons Tower - top': self.dungeons['Ganons Tower'].bosses['top'].name
+                "Ganons Tower - bottom": self.dungeons["Ganons Tower"].bosses["bottom"].name,
+                "Ganons Tower - middle": self.dungeons["Ganons Tower"].bosses["middle"].name,
+                "Ganons Tower - top": self.dungeons["Ganons Tower"].bosses["top"].name
             }
             # all of these option are NOT used by the SNI- or Text-Client.
             # they are used by the alttp-poptracker pack (https://github.com/StripesOO7/alttp-ap-poptracker-pack)
@@ -834,20 +834,20 @@ class ALTTPWorld(World):
             ]
 
             for dungeon in self.dungeons.keys():
-                if dungeon not in ['Hyrule Castle', 'Ganons Tower', "Agahnims Tower"]:
+                if dungeon not in ["Hyrule Castle", "Ganons Tower", "Agahnims Tower"]:
                     bosses[dungeon] = self.dungeons[dungeon].boss.name
 
                     if dungeon == "Thieves Town":
                         dungeon = "Thieves\' Town"
-                    prizes[dungeon] = self.get_location(location_name=dungeon+" - Prize").item.name
+                    prizes[dungeon] = self.get_location(f"{dungeon} - Prize").item.name
 
             slot_data = {option_name: getattr(self.multiworld, option_name)[self.player].value for option_name in
                          slot_options}
             slot_data.update({
-                'mm_medalion': self.required_medallions[0],
-                'tr_medalion': self.required_medallions[1],
+                "mm_medalion": self.required_medallions[0],
+                "tr_medalion": self.required_medallions[1],
                 "bosses": bosses,
-                "prizes": prizes
+                "prizes": prizes,
                 }
             )
         return slot_data

--- a/worlds/alttp/__init__.py
+++ b/worlds/alttp/__init__.py
@@ -813,6 +813,12 @@ class ALTTPWorld(World):
     def fill_slot_data(self):
         slot_data = {}
         if not self.multiworld.is_race:
+            prizes = {}
+            bosses = {
+                'Ganons Tower - bottom': self.dungeons['Ganons Tower'].bosses['bottom'].name,
+                'Ganons Tower - middle': self.dungeons['Ganons Tower'].bosses['middle'].name,
+                'Ganons Tower - top': self.dungeons['Ganons Tower'].bosses['top'].name
+            }
             # all of these option are NOT used by the SNI- or Text-Client.
             # they are used by the alttp-poptracker pack (https://github.com/StripesOO7/alttp-ap-poptracker-pack)
             # for convenient auto-tracking of the generated settings and adjusting the tracker accordingly
@@ -827,11 +833,21 @@ class ALTTPWorld(World):
                             "triforce_pieces_available", "triforce_pieces_extra",
             ]
 
-            slot_data = {option_name: getattr(self.multiworld, option_name)[self.player].value for option_name in slot_options}
+            for dungeon in self.dungeons.keys():
+                if dungeon not in ['Hyrule Castle', 'Ganons Tower', "Agahnims Tower"]:
+                    bosses[dungeon] = self.dungeons[dungeon].boss.name
 
+                    if dungeon == "Thieves Town":
+                        dungeon = "Thieves\' Town"
+                    prizes[dungeon] = self.get_location(location_name=dungeon+" - Prize").item.name
+
+            slot_data = {option_name: getattr(self.multiworld, option_name)[self.player].value for option_name in
+                         slot_options}
             slot_data.update({
                 'mm_medalion': self.required_medallions[0],
                 'tr_medalion': self.required_medallions[1],
+                "bosses": bosses,
+                "prizes": prizes
                 }
             )
         return slot_data

--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -1188,10 +1188,34 @@ class OOTWorld(World):
 
     def fill_slot_data(self):
         self.collectible_flags_available.wait()
+        prizes = {}
+        bosses = {}
+        for location in [
+            'Links Pocket',
+            'Queen Gohma',
+            'King Dodongo',
+            'Barinade',
+            'Phantom Ganon',
+            'Volvagia',
+            'Morpha',
+            'Bongo Bongo',
+            'Twinrova',
+            # 'Ganon',
+        ]:
+            if not location == 'Links Pocket':
+                entrance = self.get_region(region_name=location+" Boss Room").entrances
+                entrance = entrance[0].name
+                dungeon = entrance[:str(entrance).index(" Boss Door")]
+            else:
+                dungeon = "Start"
+            prizes[self.get_location(location_name=location).item.name] = dungeon
+            bosses[dungeon] = location
 
         slot_data = {
             'collectible_override_flags': self.collectible_override_flags,
-            'collectible_flag_offsets': self.collectible_flag_offsets
+            'collectible_flag_offsets': self.collectible_flag_offsets,
+            'prizes': prizes,
+            'bosses': bosses
         }
         slot_data.update(self.options.as_dict(
             "open_forest", "open_kakariko", "open_door_of_time", "zora_fountain", "gerudo_fortress",

--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -1191,31 +1191,31 @@ class OOTWorld(World):
         prizes = {}
         bosses = {}
         for location in [
-            'Links Pocket',
-            'Queen Gohma',
-            'King Dodongo',
-            'Barinade',
-            'Phantom Ganon',
-            'Volvagia',
-            'Morpha',
-            'Bongo Bongo',
-            'Twinrova',
+            "Links Pocket",
+            "Queen Gohma",
+            "King Dodongo",
+            "Barinade",
+            "Phantom Ganon",
+            "Volvagia",
+            "Morpha",
+            "Bongo Bongo",
+            "Twinrova",
             # 'Ganon',
         ]:
-            if not location == 'Links Pocket':
-                entrance = self.get_region(region_name=location+" Boss Room").entrances
+            if location != "Links Pocket":
+                entrance = self.get_region(f"{location} Boss Room").entrances
                 entrance = entrance[0].name
                 dungeon = entrance[:str(entrance).index(" Boss Door")]
             else:
                 dungeon = "Start"
-            prizes[self.get_location(location_name=location).item.name] = dungeon
+            prizes[self.get_location(location).item.name] = dungeon
             bosses[dungeon] = location
 
         slot_data = {
-            'collectible_override_flags': self.collectible_override_flags,
-            'collectible_flag_offsets': self.collectible_flag_offsets,
-            'prizes': prizes,
-            'bosses': bosses
+            "collectible_override_flags": self.collectible_override_flags,
+            "collectible_flag_offsets": self.collectible_flag_offsets,
+            "prizes": prizes,
+            "bosses": bosses,
         }
         slot_data.update(self.options.as_dict(
             "open_forest", "open_kakariko", "open_door_of_time", "zora_fountain", "gerudo_fortress",

--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -1188,34 +1188,10 @@ class OOTWorld(World):
 
     def fill_slot_data(self):
         self.collectible_flags_available.wait()
-        prizes = {}
-        bosses = {}
-        for location in [
-            "Links Pocket",
-            "Queen Gohma",
-            "King Dodongo",
-            "Barinade",
-            "Phantom Ganon",
-            "Volvagia",
-            "Morpha",
-            "Bongo Bongo",
-            "Twinrova",
-            # 'Ganon',
-        ]:
-            if location != "Links Pocket":
-                entrance = self.get_region(f"{location} Boss Room").entrances
-                entrance = entrance[0].name
-                dungeon = entrance[:str(entrance).index(" Boss Door")]
-            else:
-                dungeon = "Start"
-            prizes[self.get_location(location).item.name] = dungeon
-            bosses[dungeon] = location
 
         slot_data = {
-            "collectible_override_flags": self.collectible_override_flags,
-            "collectible_flag_offsets": self.collectible_flag_offsets,
-            "prizes": prizes,
-            "bosses": bosses,
+            'collectible_override_flags': self.collectible_override_flags,
+            'collectible_flag_offsets': self.collectible_flag_offsets
         }
         slot_data.update(self.options.as_dict(
             "open_forest", "open_kakariko", "open_door_of_time", "zora_fountain", "gerudo_fortress",


### PR DESCRIPTION
## What is this fixing or adding?
Add a new mapping for dungeon->boss and dungeon->prize into slotdata so the Poptracker packs can read it


## How was this tested?
Generated multiple seeds with the changes and read/confirmed the newly created slotdata with Poptracker console output.
