### PR TITLE
Core: add HintStatus field to PrintJSON message

### DIFF
--- a/NetUtils.py
+++ b/NetUtils.py
@@ -382,7 +382,7 @@ class Hint(typing.NamedTuple):
         return {"cmd": "PrintJSON", "data": parts, "type": "Hint",
                 "receiving": self.receiving_player,
                 "item": NetworkItem(self.item, self.location, self.finding_player, self.item_flags),
-                "found": self.found}
+                "found": self.found, "hint_status": self.status}
 
     @property
     def local(self):

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -176,6 +176,7 @@ Sent to clients purely to display a message to the player. While various message
 | receiving | int | ItemSend, ItemCheat, Hint | Destination player's ID |
 | item | [NetworkItem](#NetworkItem) | ItemSend, ItemCheat, Hint | Source player's ID, location ID, item ID and item flags |
 | found | bool | Hint | Whether the location hinted for was checked |
+| hint_status | [HintStatus](#HintStatus) | The status of the hint. |
 | team | int | Join, Part, Chat, TagsChanged, Goal, Release, Collect, ItemCheat | Team of the triggering player |
 | slot | int | Join, Part, Chat, TagsChanged, Goal, Release, Collect | Slot of the triggering player |
 | message | str | Chat, ServerChat | Original chat message without sender prefix |


### PR DESCRIPTION
## What is this fixing or adding?

The `hint_status` field to the `PrintJSON` message type.

If we eventually want to cut out the `"found": "true"` part of the message, we could deprecate PrintJSON's `found` field to be fully removed in a future update.

## How was this tested?

Spun up `MultiServer.py` and then connected to it with archipelago.js in a node shell and logged incoming messages.

## If this makes graphical changes, please attach screenshots.