### PR TITLE
Aquaria: Fixing itemlink not working

### DIFF
--- a/worlds/aquaria/__init__.py
+++ b/worlds/aquaria/__init__.py
@@ -105,6 +105,13 @@ class AquariaWorld(World):
         self.ingredients_substitution = []
         self.exclude = []
 
+    def generate_early(self) -> None:
+        """
+        Run before any general steps of the MultiWorld other than options. Useful for getting and adjusting option
+        results and determining layouts for entrance rando etc. start inventory gets pushed after this step.
+        """
+        self.regions = AquariaRegions(self.multiworld, self.player)
+
     def create_regions(self) -> None:
         """
         Create every Region in `regions`
@@ -127,13 +134,6 @@ class AquariaWorld(World):
         result = AquariaItem(name, classification, data.id, self.player)
 
         return result
-
-    def generate_early(self) -> None:
-        """
-        Run before any general steps of the MultiWorld other than options. Useful for getting and adjusting option
-        results and determining layouts for entrance rando etc. start inventory gets pushed after this step.
-        """
-        self.regions = AquariaRegions(self.multiworld, self.player)
 
     def __pre_fill_item(self, item_name: str, location_name: str, precollected,
                         itemClassification: ItemClassification = ItemClassification.useful) -> None:

--- a/worlds/aquaria/__init__.py
+++ b/worlds/aquaria/__init__.py
@@ -93,7 +93,7 @@ class AquariaWorld(World):
     options: AquariaOptions
     "Every options of the world"
 
-    regions: AquariaRegions
+    regions: AquariaRegions | None
     "Used to manage Regions"
 
     exclude: List[str]
@@ -101,7 +101,7 @@ class AquariaWorld(World):
     def __init__(self, multiworld: MultiWorld, player: int):
         """Initialisation of the Aquaria World"""
         super(AquariaWorld, self).__init__(multiworld, player)
-        self.regions = AquariaRegions(multiworld, player)
+        self.regions = None
         self.ingredients_substitution = []
         self.exclude = []
 
@@ -127,6 +127,13 @@ class AquariaWorld(World):
         result = AquariaItem(name, classification, data.id, self.player)
 
         return result
+
+    def generate_early(self) -> None:
+        """
+        Run before any general steps of the MultiWorld other than options. Useful for getting and adjusting option
+        results and determining layouts for entrance rando etc. start inventory gets pushed after this step.
+        """
+        self.regions = AquariaRegions(self.multiworld, self.player)
 
     def __pre_fill_item(self, item_name: str, location_name: str, precollected,
                         itemClassification: ItemClassification = ItemClassification.useful) -> None:


### PR DESCRIPTION
## What is this fixing or adding?

Moving the Regions initialization from the module `__init__` to the `generate_early` method so that item link can work.

## How was this tested?

I generate 100 single player and multiplayer multiworlds.
