### PR TITLE
Core: Add Retry to Priority Fill

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -502,7 +502,12 @@ def distribute_items_restrictive(multiworld: MultiWorld,
         # "priority fill"
         fill_restrictive(multiworld, multiworld.state, prioritylocations, progitempool,
                          single_player_placement=single_player, swap=False, on_place=mark_for_locking,
-                         name="Priority", one_item_per_player=False)
+                         name="Priority", one_item_per_player=True, allow_partial=True)
+
+        # retry with one_item_per_player off because some priority fills can fail to fill with that optimization
+        fill_restrictive(multiworld, multiworld.state, prioritylocations, progitempool,
+                         single_player_placement=single_player, swap=False, on_place=mark_for_locking,
+                         name="Priority Retry", one_item_per_player=False)
         accessibility_corrections(multiworld, multiworld.state, prioritylocations, progitempool)
         defaultlocations = prioritylocations + defaultlocations
 

--- a/Fill.py
+++ b/Fill.py
@@ -504,10 +504,11 @@ def distribute_items_restrictive(multiworld: MultiWorld,
                          single_player_placement=single_player, swap=False, on_place=mark_for_locking,
                          name="Priority", one_item_per_player=True, allow_partial=True)
 
-        # retry with one_item_per_player off because some priority fills can fail to fill with that optimization
-        fill_restrictive(multiworld, multiworld.state, prioritylocations, progitempool,
-                         single_player_placement=single_player, swap=False, on_place=mark_for_locking,
-                         name="Priority Retry", one_item_per_player=False)
+        if prioritylocations:
+            # retry with one_item_per_player off because some priority fills can fail to fill with that optimization
+            fill_restrictive(multiworld, multiworld.state, prioritylocations, progitempool,
+                            single_player_placement=single_player, swap=False, on_place=mark_for_locking,
+                            name="Priority Retry", one_item_per_player=False)
         accessibility_corrections(multiworld, multiworld.state, prioritylocations, progitempool)
         defaultlocations = prioritylocations + defaultlocations
 


### PR DESCRIPTION
## What is this fixing or adding?
adds a retry to priority fill in case the one item per player optimization would cause the priority fill to fail to find valid placements
this is beneficial over just current main's turn it fully off because other multis need the optimization to have a reasonable time to finish

## How was this tested?
gen'd with a bunch of copies of the witness yaml in #3467 (after confirming just turning one_item_per_player back on and not adding the retry step caused the failures), though more testing of other configurations would be appreciated 
did not test the large-multi usecase to notice the speedup

## If this makes graphical changes, please attach screenshots.
