### PR TITLE
LADX: Move Locality Changes Earlier

### DIFF
--- a/worlds/ladx/__init__.py
+++ b/worlds/ladx/__init__.py
@@ -140,6 +140,26 @@ class LinksAwakeningWorld(World):
         self.ladxr_logic = LADXRLogic(configuration_options=self.ladxr_settings, world_setup=world_setup)
         self.ladxr_itempool = LADXRItemPool(self.ladxr_logic, self.ladxr_settings, self.random).toDict()
 
+    def generate_early(self) -> None:
+        for dungeon_item_type in ["maps", "compasses", "small_keys", "nightmare_keys", "stone_beaks", "instruments"]:
+            option_name = "shuffle_" + dungeon_item_type
+            option: DungeonItemShuffle = getattr(self.options, option_name)
+
+            self.dungeon_item_types[option.ladxr_item] = option.value
+
+            # The color dungeon does not contain an instrument
+            num_items = 8 if dungeon_item_type == "instruments" else 9
+
+            # For any and different world, set item rule instead
+            if option.value == DungeonItemShuffle.option_own_world:
+                self.options.local_items.value |= {
+                    ladxr_item_to_la_item_name[f"{option.ladxr_item}{i}"] for i in range(1, num_items + 1)
+                }
+            elif option.value == DungeonItemShuffle.option_different_world:
+                self.options.non_local_items.value |= {
+                    ladxr_item_to_la_item_name[f"{option.ladxr_item}{i}"] for i in range(1, num_items + 1)
+                }
+
     def create_regions(self) -> None:
         # Initialize
         self.convert_ap_options_to_ladxr_logic()
@@ -185,32 +205,9 @@ class LinksAwakeningWorld(World):
     def create_items(self) -> None:
         exclude = [item.name for item in self.multiworld.precollected_items[self.player]]
 
-        dungeon_item_types = {
-
-        }
-
         self.prefill_original_dungeon = [ [], [], [], [], [], [], [], [], [] ]
         self.prefill_own_dungeons = []
         self.pre_fill_items = []
-        # For any and different world, set item rule instead
-        
-        for dungeon_item_type in ["maps", "compasses", "small_keys", "nightmare_keys", "stone_beaks", "instruments"]:
-            option_name = "shuffle_" + dungeon_item_type
-            option: DungeonItemShuffle = getattr(self.options, option_name)
-
-            dungeon_item_types[option.ladxr_item] = option.value
-
-            # The color dungeon does not contain an instrument
-            num_items = 8 if dungeon_item_type == "instruments" else 9
-
-            if option.value == DungeonItemShuffle.option_own_world:
-                self.options.local_items.value |= {
-                    ladxr_item_to_la_item_name[f"{option.ladxr_item}{i}"] for i in range(1, num_items + 1)
-                }
-            elif option.value == DungeonItemShuffle.option_different_world:
-                self.options.non_local_items.value |= {
-                    ladxr_item_to_la_item_name[f"{option.ladxr_item}{i}"] for i in range(1, num_items + 1)
-                }
         # option_original_dungeon = 0
         # option_own_dungeons = 1
         # option_own_world = 2
@@ -238,7 +235,7 @@ class LinksAwakeningWorld(World):
 
                     if isinstance(item.item_data, DungeonItemData):
                         item_type = item.item_data.ladxr_id[:-1]
-                        shuffle_type = dungeon_item_types[item_type]
+                        shuffle_type = self.dungeon_item_types[item_type]
 
                         if item.item_data.dungeon_item_type == DungeonItemType.INSTRUMENT and shuffle_type == ShuffleInstruments.option_vanilla:
                             # Find instrument, lock

--- a/worlds/ladx/__init__.py
+++ b/worlds/ladx/__init__.py
@@ -141,6 +141,8 @@ class LinksAwakeningWorld(World):
         self.ladxr_itempool = LADXRItemPool(self.ladxr_logic, self.ladxr_settings, self.random).toDict()
 
     def generate_early(self) -> None:
+        self.dungeon_item_types = {
+        }
         for dungeon_item_type in ["maps", "compasses", "small_keys", "nightmare_keys", "stone_beaks", "instruments"]:
             option_name = "shuffle_" + dungeon_item_type
             option: DungeonItemShuffle = getattr(self.options, option_name)


### PR DESCRIPTION
## What is this fixing or adding?

Moves the LADX changes to local/non-local items into `generate_early`. This moves the whole block of code and just adds a variable to the world for later use. The main motivation here is to move locality code earlier and simplify some of the code in `main.py`

## How was this tested?

Generations (with checking spoiler logs that hit these code paths) and unit tests.