### PR TITLE
ALttP: Fix Itemlinks

### DIFF
--- a/worlds/alttp/Items.py
+++ b/worlds/alttp/Items.py
@@ -7,7 +7,7 @@ from worlds.AutoWorld import World
 def GetBeemizerItem(world, player: int, item):
     item_name = item if isinstance(item, str) else item.name
 
-    if item_name not in trap_replaceable:
+    if item_name not in trap_replaceable or player in world.groups:
         return item
 
     # first roll - replaceable item should be replaced, within beemizer_total_chance


### PR DESCRIPTION
## What is this fixing or adding?

Itemlinks could call `create_filler` with a dummy/itemlinking world, which calls `GetBeemizerItem` and checks `world.beemizer_total_chance[player]`, throwing a KeyError. This makes it so that itemlink worlds never replace items with traps. This made sense to me as a default behavior and it allows itemlinks to work.

## How was this tested?

Generated some itemlinking multiworlds and ran the itemlinking test.