### PR TITLE
MultiServer Hints: Fix !hint-ing a multi-copy item creating every already found copy as a persistent hint

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -743,16 +743,19 @@ class Context:
                 concerns[player].append(data)
             if not hint.local and data not in concerns[hint.finding_player]:
                 concerns[hint.finding_player].append(data)
-            # remember hints in all cases
 
-            # since hints are bidirectional, finding player and receiving player,
-            # we can check once if hint already exists
-            if hint not in self.hints[team, hint.finding_player]:
-                self.hints[team, hint.finding_player].add(hint)
-                new_hint_events.add(hint.finding_player)
-                for player in self.slot_set(hint.receiving_player):
-                    self.hints[team, player].add(hint)
-                    new_hint_events.add(player)
+            # For !hint use cases, only hints that were not already found at the time of creation should be remembered
+            # For "scouting" use cases (LocationScouts with only_new), all hints should be remembered
+            if not hint.found or only_new:
+                # since hints are bidirectional, finding player and receiving player,
+                # we can check once if hint already exists
+
+                if hint not in self.hints[team, hint.finding_player]:
+                    self.hints[team, hint.finding_player].add(hint)
+                    new_hint_events.add(hint.finding_player)
+                    for player in self.slot_set(hint.receiving_player):
+                        self.hints[team, player].add(hint)
+                        new_hint_events.add(player)
 
             self.logger.info("Notice (Team #%d): %s" % (team + 1, format_hint(self, team, hint)))
         for slot in new_hint_events:


### PR DESCRIPTION
In https://github.com/ArchipelagoMW/Archipelago/pull/4214, we changed the behavior of LocationScouts with create_as_hint=2 to fix an issue where already found locations would still broadcast every time they were scouted.

However, this had the unintended consequence of making `!hint Power Star` not just broadcast every previously found Power Star, but also make all of those hints persist.

This PR fixes that issue while retaining the new, "better" behavior for LocationScouts create_as_hint 2.
