### PR TITLE
CommonClient: implement check_locations to send missing locations only

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -461,8 +461,7 @@ class CommonContext:
 
     async def check_locations(self, locations: typing.Collection[int]) -> set[int]:
         """Send new location checks to the server. Returns set of actually new locations that were send."""
-        locations = set(locations)
-        locations.update(self.missing_locations)
+        locations = set(locations) & self.missing_locations
         if locations:
             await self.send_msgs([{"cmd": 'LocationChecks', "locations": tuple(locations)}])
         return locations

--- a/CommonClient.py
+++ b/CommonClient.py
@@ -459,6 +459,14 @@ class CommonContext:
         await self.send_msgs([payload])
         await self.send_msgs([{"cmd": "Get", "keys": ["_read_race_mode"]}])
 
+    async def check_locations(self, locations: typing.Collection[int]) -> set[int]:
+        """Send new location checks to the server. Returns set of actually new locations that were send."""
+        locations = set(locations)
+        locations.update(self.missing_locations)
+        if locations:
+            await self.send_msgs([{"cmd": 'LocationChecks', "locations": tuple(locations)}])
+        return locations
+
     async def console_input(self) -> str:
         if self.ui:
             self.ui.focus_textinput()

--- a/CommonClient.py
+++ b/CommonClient.py
@@ -460,7 +460,7 @@ class CommonContext:
         await self.send_msgs([{"cmd": "Get", "keys": ["_read_race_mode"]}])
 
     async def check_locations(self, locations: typing.Collection[int]) -> set[int]:
-        """Send new location checks to the server. Returns set of actually new locations that were send."""
+        """Send new location checks to the server. Returns the set of actually new locations that were sent."""
         locations = set(locations) & self.missing_locations
         if locations:
             await self.send_msgs([{"cmd": 'LocationChecks', "locations": tuple(locations)}])

--- a/worlds/alttp/Client.py
+++ b/worlds/alttp/Client.py
@@ -464,7 +464,7 @@ async def track_locations(ctx, roomid, roomdata) -> bool:
             snes_logger.info(f"Discarding recent {len(new_locations)} checks as ROM Status has changed.")
             return False
         else:
-            await ctx.send_msgs([{"cmd": 'LocationChecks', "locations": new_locations}])
+            await ctx.check_locations(new_locations)
     await snes_flush_writes(ctx)
     return True
 

--- a/worlds/factorio/Client.py
+++ b/worlds/factorio/Client.py
@@ -234,8 +234,7 @@ async def game_watcher(ctx: FactorioContext):
                         f"Connected Multiworld is not the expected one {data['seed_name']} != {ctx.seed_name}")
                 else:
                     data = data["info"]
-                    research_data = data["research_done"]
-                    research_data = {int(tech_name.split("-")[1]) for tech_name in research_data}
+                    research_data: set[int] = {int(tech_name.split("-")[1]) for tech_name in data["research_done"]}
                     victory = data["victory"]
                     await ctx.update_death_link(data["death_link"])
                     ctx.multiplayer = data.get("multiplayer", False)
@@ -249,7 +248,7 @@ async def game_watcher(ctx: FactorioContext):
                             f"New researches done: "
                             f"{[ctx.location_names.lookup_in_game(rid) for rid in research_data - ctx.locations_checked]}")
                         ctx.locations_checked = research_data
-                        await ctx.send_msgs([{"cmd": 'LocationChecks', "locations": tuple(research_data)}])
+                        await ctx.check_locations(research_data)
                     death_link_tick = data.get("death_link_tick", 0)
                     if death_link_tick != ctx.death_link_tick:
                         ctx.death_link_tick = death_link_tick


### PR DESCRIPTION
## What is this fixing or adding?
check_locations, a method that filters location checks before potentially bothering to send stuff over the wire

## How was this tested?
once with Factorio.

Also included is LttP which hopefully someone tests at some point, though it should be fairly safe if Factorio worked.
