### PR TITLE
TUNIC: Make the local_fill option load in a specific number of locations

### DIFF
--- a/worlds/tunic/__init__.py
+++ b/worlds/tunic/__init__.py
@@ -394,8 +394,6 @@ class TunicWorld(World):
         self.multiworld.itempool += tunic_items
 
     def pre_fill(self) -> None:
-        self.fill_locations = []
-
         if self.options.local_fill > 0 and self.multiworld.players > 1:
             # we need to reserve a couple locations so that we don't fill up every sphere 1 location
             reserved_locations: Set[str] = set(self.random.sample(sphere_one, 2))
@@ -406,8 +404,8 @@ class TunicWorld(World):
             if len(viable_locations) < self.amount_to_local_fill:
                 raise OptionError(f"TUNIC: Not enough locations for local_fill option for {self.player_name}. "
                                   f"This is likely due to excess plando or priority locations.")
-
-            self.fill_locations += viable_locations
+            self.fill_locations = []
+            self.fill_locations += viable_locations[:self.amount_to_local_fill]
 
     @classmethod
     def stage_pre_fill(cls, multiworld: MultiWorld) -> None:

--- a/worlds/tunic/__init__.py
+++ b/worlds/tunic/__init__.py
@@ -404,6 +404,7 @@ class TunicWorld(World):
             if len(viable_locations) < self.amount_to_local_fill:
                 raise OptionError(f"TUNIC: Not enough locations for local_fill option for {self.player_name}. "
                                   f"This is likely due to excess plando or priority locations.")
+            self.random.shuffle(viable_locations)
             self.fill_locations = viable_locations[:self.amount_to_local_fill]
 
     @classmethod

--- a/worlds/tunic/__init__.py
+++ b/worlds/tunic/__init__.py
@@ -95,7 +95,7 @@ class TunicWorld(World):
 
     # for the local_fill option
     fill_items: List[TunicItem]
-    fill_locations: List[TunicLocation]
+    fill_locations: List[Location]
     amount_to_local_fill: int
 
     # so we only loop the multiworld locations once
@@ -404,8 +404,7 @@ class TunicWorld(World):
             if len(viable_locations) < self.amount_to_local_fill:
                 raise OptionError(f"TUNIC: Not enough locations for local_fill option for {self.player_name}. "
                                   f"This is likely due to excess plando or priority locations.")
-            self.fill_locations = []
-            self.fill_locations += viable_locations[:self.amount_to_local_fill]
+            self.fill_locations = viable_locations[:self.amount_to_local_fill]
 
     @classmethod
     def stage_pre_fill(cls, multiworld: MultiWorld) -> None:


### PR DESCRIPTION
## What is this fixing or adding?
Currently, if one player chooses 1% local fill and another chooses 99% local fill, it'll take 1% of the first player's filler and 99% of the second player's filler and fill them equally across both games. That's dumb, so now it'll take the same number of locations as items, so they get as many filler locations as they put in filler.

## How was this tested?
Test gens.