### PR TITLE
AHiT: Various logic fixes

### DIFF
--- a/worlds/ahit/DeathWishRules.py
+++ b/worlds/ahit/DeathWishRules.py
@@ -343,6 +343,7 @@ def create_enemy_events(world: "HatInTimeWorld"):
 
 def set_enemy_rules(world: "HatInTimeWorld"):
     no_tourist = "Camera Tourist" in world.excluded_dws or "Camera Tourist" in world.excluded_bonuses
+    difficulty: Difficulty = Difficulty(world.options.LogicDifficulty)
 
     for enemy, regions in hit_list.items():
         if no_tourist and enemy in bosses:
@@ -371,6 +372,14 @@ def set_enemy_rules(world: "HatInTimeWorld"):
                              state.has("Zipline Unlock - The Birdhouse Path", world.player)
                              or state.has("Zipline Unlock - The Lava Cake Path", world.player)
                              or state.has("Zipline Unlock - The Windmill Path", world.player))
+
+            elif enemy == "Toilet":
+                if area == "Toilet of Doom":
+                    # The boss firewall is in the way and can only be skipped on Expert logic using a cherry hover.
+                    add_rule(event, lambda state: has_paintings(state, world, 1, allow_skip=difficulty == Difficulty.EXPERT))
+                    if difficulty < Difficulty.HARD:
+                        # Hard logic and above can cross the boss arena gap with a cherry bridge.
+                        add_rule(event, lambda state: can_use_hookshot(state, world))
 
             elif enemy == "Director":
                 if area == "Dead Bird Studio Basement":

--- a/worlds/ahit/DeathWishRules.py
+++ b/worlds/ahit/DeathWishRules.py
@@ -346,7 +346,7 @@ def create_enemy_events(world: "HatInTimeWorld"):
 
 def set_enemy_rules(world: "HatInTimeWorld"):
     no_tourist = "Camera Tourist" in world.excluded_dws or "Camera Tourist" in world.excluded_bonuses
-    difficulty: Difficulty = Difficulty(world.options.LogicDifficulty)
+    difficulty = get_difficulty(world)
 
     for enemy, regions in hit_list.items():
         if no_tourist and enemy in bosses:

--- a/worlds/ahit/DeathWishRules.py
+++ b/worlds/ahit/DeathWishRules.py
@@ -430,7 +430,7 @@ hit_list = {
     # Bosses
     "Mafia Boss":       ["Down with the Mafia!", "Encore! Encore!", "Boss Rush"],
 
-    "Conductor":        ["Dead Bird Studio Basement", "Killing Two Birds", "Boss Rush"],
+    "Director":        ["Dead Bird Studio Basement", "Killing Two Birds", "Boss Rush"],
     "Toilet":           ["Toilet of Doom", "Boss Rush"],
 
     "Snatcher":         ["Your Contract has Expired", "Breaching the Contract", "Boss Rush",
@@ -454,7 +454,7 @@ triple_enemy_locations = [
 
 bosses = [
     "Mafia Boss",
-    "Conductor",
+    "Director",
     "Toilet",
     "Snatcher",
     "Toxic Flower",

--- a/worlds/ahit/DeathWishRules.py
+++ b/worlds/ahit/DeathWishRules.py
@@ -141,9 +141,12 @@ def set_dw_rules(world: "HatInTimeWorld"):
         add_dw_rules(world, all_clear)
         add_rule(main_stamp, main_objective.access_rule)
         add_rule(all_clear, main_objective.access_rule)
-        # Only set bonus stamp rules if we don't auto complete bonuses
+        # Only set bonus stamp rules to require All Clear if we don't auto complete bonuses
         if not world.options.DWAutoCompleteBonuses and not world.is_bonus_excluded(all_clear.name):
             add_rule(bonus_stamps, all_clear.access_rule)
+        else:
+            # As soon as the Main Objective is completed, the bonuses auto-complete.
+            add_rule(bonus_stamps, main_objective.access_rule)
 
     if world.options.DWShuffle:
         for i in range(len(world.dw_shuffle)-1):

--- a/worlds/ahit/Locations.py
+++ b/worlds/ahit/Locations.py
@@ -323,7 +323,7 @@ ahit_locations = {
     "Alpine Skyline - The Twilight Path": LocData(2000334434, "Alpine Skyline Area", required_hats=[HatType.DWELLER]),
     "Alpine Skyline - The Twilight Bell: Wide Purple Platform": LocData(2000336478, "The Twilight Bell"),
     "Alpine Skyline - The Twilight Bell: Ice Platform": LocData(2000335826, "The Twilight Bell"),
-    "Alpine Skyline - Goat Outpost Horn": LocData(2000334760, "Alpine Skyline Area"),
+    "Alpine Skyline - Goat Outpost Horn": LocData(2000334760, "Alpine Skyline Area (TIHS)", hookshot=True),
     "Alpine Skyline - Windy Passage": LocData(2000334776, "Alpine Skyline Area (TIHS)", hookshot=True),
     "Alpine Skyline - The Windmill: Inside Pon Cluster": LocData(2000336395, "The Windmill"),
     "Alpine Skyline - The Windmill: Entrance": LocData(2000335783, "The Windmill"),

--- a/worlds/ahit/Locations.py
+++ b/worlds/ahit/Locations.py
@@ -878,7 +878,7 @@ snatcher_coins = {
                                                dlc_flags=HatDLC.death_wish),
 
     "Snatcher Coin - Top of HQ (DW: BTH)": LocData(0, "Beat the Heat", snatcher_coin="Snatcher Coin - Top of HQ",
-                                                   dlc_flags=HatDLC.death_wish),
+                                                   hit_type=HitType.umbrella, dlc_flags=HatDLC.death_wish),
 
     "Snatcher Coin - Top of Tower": LocData(0, "Mafia Town Area (HUMT)", snatcher_coin="Snatcher Coin - Top of Tower",
                                             dlc_flags=HatDLC.death_wish),

--- a/worlds/ahit/Locations.py
+++ b/worlds/ahit/Locations.py
@@ -407,7 +407,7 @@ act_completions = {
                                                hit_type=HitType.umbrella_or_brewing, hookshot=True, paintings=1),
 
     "Act Completion (Queen Vanessa's Manor)": LocData(2000312017, "Queen Vanessa's Manor",
-                                                      hit_type=HitType.umbrella, paintings=1),
+                                                      hit_type=HitType.dweller_bell, paintings=1),
 
     "Act Completion (Mail Delivery Service)": LocData(2000312032, "Mail Delivery Service",
                                                       required_hats=[HatType.SPRINT]),

--- a/worlds/ahit/Locations.py
+++ b/worlds/ahit/Locations.py
@@ -264,7 +264,6 @@ ahit_locations = {
                                              required_hats=[HatType.DWELLER], paintings=3),
 
     "Subcon Forest - Tall Tree Hookshot Swing": LocData(2000324766, "Subcon Forest Area",
-                                                        required_hats=[HatType.DWELLER],
                                                         hookshot=True,
                                                         paintings=3),
 

--- a/worlds/ahit/Rules.py
+++ b/worlds/ahit/Rules.py
@@ -590,7 +590,7 @@ def set_expert_rules(world: "HatInTimeWorld"):
 
     if world.is_dlc2():
         # Expert: clear Rush Hour with nothing
-        if not world.options.NoTicketSkips:
+        if world.options.NoTicketSkips != NoTicketSkips.option_true:
             set_rule(world.multiworld.get_location("Act Completion (Rush Hour)", world.player), lambda state: True)
         else:
             set_rule(world.multiworld.get_location("Act Completion (Rush Hour)", world.player),

--- a/worlds/ahit/Rules.py
+++ b/worlds/ahit/Rules.py
@@ -493,9 +493,6 @@ def set_hard_rules(world: "HatInTimeWorld"):
              lambda state: has_paintings(state, world, 3, True))
 
     # SDJ
-    add_rule(world.multiworld.get_location("Subcon Forest - Long Tree Climb Chest", world.player),
-             lambda state: can_use_hat(state, world, HatType.SPRINT) and has_paintings(state, world, 2), "or")
-
     add_rule(world.multiworld.get_location("Act Completion (Time Rift - Curly Tail Trail)", world.player),
              lambda state: can_use_hat(state, world, HatType.SPRINT), "or")
 

--- a/worlds/ahit/Rules.py
+++ b/worlds/ahit/Rules.py
@@ -530,7 +530,10 @@ def set_expert_rules(world: "HatInTimeWorld"):
     # Expert: Mafia Town - Above Boats, Top of Lighthouse, and Hot Air Balloon with nothing
     set_rule(world.multiworld.get_location("Mafia Town - Above Boats", world.player), lambda state: True)
     set_rule(world.multiworld.get_location("Mafia Town - Top of Lighthouse", world.player), lambda state: True)
-    set_rule(world.multiworld.get_location("Mafia Town - Hot Air Balloon", world.player), lambda state: True)
+    # There are not enough buckets/beach balls to bucket/ball hover in Heating Up Mafia Town, so any other Mafia Town
+    # act is required.
+    add_rule(world.multiworld.get_location("Mafia Town - Hot Air Balloon", world.player),
+             lambda state: state.can_reach_region("Mafia Town Area", world.player), "or")
 
     # Expert: Clear Dead Bird Studio with nothing
     for loc in world.multiworld.get_region("Dead Bird Studio - Post Elevator Area", world.player).locations:

--- a/worlds/ahit/Rules.py
+++ b/worlds/ahit/Rules.py
@@ -739,7 +739,7 @@ def set_dlc1_rules(world: "HatInTimeWorld"):
 
     # This particular item isn't present in Act 3 for some reason, yes in vanilla too
     add_rule(world.multiworld.get_location("The Arctic Cruise - Toilet", world.player),
-             lambda state: state.can_reach("Bon Voyage!", "Region", world.player)
+             lambda state: (state.can_reach("Bon Voyage!", "Region", world.player) and can_use_hookshot(state, world))
              or state.can_reach("Ship Shape", "Region", world.player))
 
 

--- a/worlds/ahit/Rules.py
+++ b/worlds/ahit/Rules.py
@@ -414,7 +414,7 @@ def set_moderate_rules(world: "HatInTimeWorld"):
 
     # Moderate: Mystifying Time Mesa time trial without hats
     set_rule(world.multiworld.get_location("Alpine Skyline - Mystifying Time Mesa: Zipline", world.player),
-             lambda state: can_use_hookshot(state, world))
+             lambda state: True)
 
     # Moderate: Goat Refinery from TIHS with Sprint only
     add_rule(world.multiworld.get_location("Alpine Skyline - Goat Refinery", world.player),


### PR DESCRIPTION
## What is this fixing or adding?

Fixes various logic issues in A Hat in Time. Most are where logic was overly restrictive, but a few are where logic was too lenient and could have rarely created impossible seeds.

The most notable fix is for the missing Hookshot logic for `The Arctic Cruise - Toilet` from `Bon Voyage!` with existing access to `Cruise Ship` only through `Rock the Boat`, which has resulted in impossible seeds being reported a couple of times.

### Missing Hookshot logic for `Director` boss photo
The rules were being added to for the "Director" boss in `set_enemy_rules()`, which didn't exist because the boss created was called "Conductor" instead.

The name of the boss has been changed to "Director", to match, because it is more accurate due to DJ Grooves possibly being the boss instead of The Conductor.

The missing logic was the `Hookshot Badge` requirement, however, the boss events are only used as part of the `Camera Tourist - All Clear` location, which requires every boss event to be reachable, and the `Toxic Flower` boss also has a `Hookshot Badge` requirement, so the missing `Hookshot Badge` for the `Director` boss had no effect on logic.

### Missing Hookshot + Painting logic for `Toilet` boss picture
These rules were absent and have been added. The new rules include the Hard logic of crossing the gap with a cherry bridge instead of Hookshot and the expert logic of being able to skip the boss firewall with a cherry hover.

Because boss events are only used as part of the `Camera Tourist - All Clear` location, the missing Hookshot logic had no effect on the multiworld logic, but the missing Painting logic technically could have resulted in impossible seeds if all 3 Progressive Painting Unlock were locked behind `Camera Tourist - All Clear`, though this would have been incredibly rare.

### `Alpine Skyline - Goat Outpost Horn` being inaccessible from `The Illness has Spread`
`Alpine Skyline - Goat Outpost Horn` is accessible from `The Illness has Spread`, but was being added to the region that is only accessible from `Alpine Free Roam`. `Alpine Skyline - Goat Outpost Horn` has been moved to the region that is accessible from both `The Illness has Spread` and `Alpine Free Roam`.

This was a case of logic being overly restrictive, so could not have created impossible seeds.

### Missing `HitType.umbrella` logic for Top of HQ Snatcher Coin in `Beat the Heat`
Like `Heating Up Mafia Town`, the cannon to the Mafia HQ area only opens once all the faucets have been turned off by hitting them. This requires the Umbrella when umbrella logic is enabled, but the Snatcher Coin on top of Mafia HQ was missing this requirement when accessed from `Beat the Heat`.

This could have resulted in impossible seeds if `Umbrella` was locked behind `Snatcher Coins in Mafia Town - All Clear` and there was no access to the acts that can get to Mafia HQ without `Umbrella`.

### Missing Main Objective requirement for auto-completed Bonus Stamps

When a Main Objective is not excluded, but the bonuses are excluded, the bonuses auto-complete once the Main Objective is completed. The requirement to complete the Main Objective was missing, so the logic was incorrectly awarding bonus stamps as soon as a Contract was unlocked, even when it was not possible to complete the Main Objective of that Contract.

There's probably some way this could have created impossible seeds by having the logic think a Death Wish Contracts is unlocked despite the player not having enough Stamps to unlock it, but trying to come up with a specific scenario where this would happen is complicated.

### Missing Hookshot logic for `The Arctic Cruise - Toilet` from `Bon Voyage!` with access to `Cruise Ship` through `Rock the Boat`
`The Arctic Cruise - Toilet` is accessed from the `Cruise Ship` region, but it is only present in the `Ship Shape` and `Bon Voyage!` acts.

`Ship Shape` and `Rock the Boat` can access `Cruise Ship` without any items, but `Bon Voyage!` requires the `Hookshot Badge` to reach `Cruise Ship`.

With how the logic was set up, it was incorrectly giving access to `The Arctic Cruise - Toilet` if the player had access to `Bon Voyage!` but only had access to `Cruise Ship` through `Rock the Boat` (where the location is not present).

This has resulted in a couple of reported impossible seeds over discord.

### Expert logic Rush Hour-only ticket skips acting like No Ticket Skips
The code was checking `if not world.options.NoTicketSkips:`, but that would only be `True` for `"false"`. For `"rush_hour"` (for Rush Hour-only ticket skips), it would be `False`, causing Rush Hour-only ticket skips to act as if ticket skips were disabled.

This was a case of logic being overly restrictive, so could not have created impossible seeds.

### Clean up `Mystifying Time Mesa: Zipline` Moderate logic
The Moderate logic was gaining the Hookshot requirement, despite Normal logic not requiring it because the region the location is in requires Hookshot to be reached. This extraneous Hookshot requirement has been removed.

This change has no effect on logic.

### `Act Completion (Queen Vanessa's Manor)` not allowing Brewing Hat/Dweller Mask for hitting the initial Dweller Bell
It was logically requiring the Umbrella hit type only, whereas all the other locations in Queen Vanessa's Manor require the Dweller Bell hit type which additionally allows Dweller Mask or Brewing Hat.

This was a case of logic being overly restrictive, so could not have created impossible seeds.

### `Subcon Forest - Tall Tree Hookshot Swing` requiring Dweller Mask
The Dweller Mask is not used in the intended vanilla route to get this item, so this requirement seems to have been a mistake and has been removed.

This was a case of logic being overly restrictive, so could not have created impossible seeds.

### Clean up `Subcon Forest - Long Tree Climb Chest` Hard logic
Hard logic can already reach this location with nothing (other than paintings), so the "or" logic of being able to perform an SDJ was unused.

This change has no effect on logic.

### `Mafia Town - Hot Air Balloon` with nothing (Expert logic) being accessible in `Heating Up Mafia Town`
Two buckets/beach balls are required to bucket/ball hover, but there is only a single beach ball accessible in `Heating Up Mafia Town`, and no accessible buckets.

There is an alternative strategy for `Mafia Town - Top of Lighthouse` that only requires a single beach ball, so that location can still be reached with nothing from `Heating Up Mafia Town`, so its logic has not been modified.

This could have resulted in impossible seeds if an item required to progress was placed at Hot Air Balloon, HUMT was the only accessible Mafia Town act and the player did not have Ice Hat.

## How was this tested?

Plando as well as comparing where locations get collected in a playthrough has been used to confirm most of the changes. WIP local-only logic tests have been used to confirm the others.