### PR TITLE
WIP: AHiT: Add logic tests

### DIFF
--- a/worlds/ahit/Regions.py
+++ b/worlds/ahit/Regions.py
@@ -947,6 +947,16 @@ def get_shuffled_region(world: "HatInTimeWorld", region: str) -> str:
                     return name
 
 
+def get_region_shuffled_to(world: "HatInTimeWorld", region: str) -> str:
+    if world.options.ActRandomizer:
+        original_ci: str = chapter_act_info[region]
+        shuffled_ci = world.act_connections[original_ci]
+        return next(act_name for act_name, ci in chapter_act_info.items()
+                    if ci == shuffled_ci)
+    else:
+        return region
+
+
 def get_region_location_count(world: "HatInTimeWorld", region_name: str, included_only: bool = True) -> int:
     count = 0
     region = world.multiworld.get_region(region_name, world.player)

--- a/worlds/ahit/test/logic_test_data.py
+++ b/worlds/ahit/test/logic_test_data.py
@@ -1,9 +1,18 @@
-from typing import Dict, Tuple, List, Hashable, Iterable, TypeVar
+from typing import Dict, Tuple, List, Hashable, TypeVar
 
 from .. import Items
 from ..Types import ChapterIndex
 
 from .logic_test_helpers import TestConditions, TestData, SpotType
+
+"""
+All the different logic tests to check.
+
+Tests try to avoid testing the logic of the internal structure of the world, focusing on a starting point (region) and
+what items should be required to reach specific locations from that starting point. For that reason, there are few tests
+for individual entrances and no tests specifically checking event items used for logic, such as `TOD Access` and
+`AFR Access`.
+"""
 
 BASE_WORLD_OPTIONS = {
     # Disable entrance randomization for simplicity.

--- a/worlds/ahit/test/logic_test_data.py
+++ b/worlds/ahit/test/logic_test_data.py
@@ -1,0 +1,1078 @@
+from typing import Dict, Tuple, List, Hashable, Iterable, TypeVar
+
+from .. import Items
+from ..Types import ChapterIndex
+
+from .logic_test_helpers import TestConditions, TestData, SpotType
+
+BASE_WORLD_OPTIONS = {
+    # Disable entrance randomization for simplicity.
+    "ActRandomizer": False,
+    # With no act randomization, starts other than Chapter 1 can put items into start inventory.
+    # The time piece costs for each chapter are overwritten in world_setup() to fixed values.
+    "StartingChapter": 1,
+    # DLCs and Death Wish are disabled by default to reduce world setup times.
+    "EnableDLC1": False,
+    "EnableDLC2": False,
+    "EnableDeathWish": False,
+    # Default to no painting skips.
+    "NoPaintingSkips": True,
+    # Default to no ticket skips.
+    "NoTicketSkips": True,
+    # Force the maximum number of thug shop locations.
+    "NyakuzaThugMinShopItems": 5,
+    "NyakuzaThugMaxShopItems": 5,
+    # Enable so that "Progressive Painting Unlock" items are in the pool by default.
+    "ShuffleSubconPaintings": True,
+    # Enable so that zipline unlock items are in the pool by default.
+    "ShuffleAlpineZiplines": True,
+    "LogicDifficulty": "normal",
+    # Enable so that Umbrella is more logically relevant by default.
+    "UmbrellaLogic": True,
+    # Due to randomized Hat stitching order, Yarn is difficult to add tests for, so HatItems are enabled by default.
+    "HatItems": True,
+}
+
+# Each chapter is specifically set to a non-zero time piece requirement so that the first act in a chapter without a
+# timepiece requirement does not become accessible with nothing when there is access to Spaceship.
+TEST_CHAPTER_TIMEPIECE_COSTS: Dict[ChapterIndex, int] = {
+    ChapterIndex.MAFIA: 1,
+    ChapterIndex.BIRDS: 2,
+    ChapterIndex.SUBCON: 3,
+    ChapterIndex.ALPINE: 4,
+    ChapterIndex.FINALE: 5,
+    ChapterIndex.CRUISE: 6,
+    ChapterIndex.METRO: 7,
+}
+
+TEST_CHAPTER_TIMEPIECES: Dict[ChapterIndex, Tuple[str, ...]] = {
+    chapter_index: ("Time Piece",) * cost for chapter_index, cost in TEST_CHAPTER_TIMEPIECE_COSTS.items()
+}
+
+
+MAIN_SUBCON_ACTS = {
+    "Contractual Obligations",
+    "The Subcon Well",
+    "Toilet of Doom",
+    "Queen Vanessa's Manor",
+    "Mail Delivery Service",
+}
+
+ALL_SUBCON_ACTS = {
+    *MAIN_SUBCON_ACTS,
+    "Your Contract has Expired",
+}
+
+MAFIA_TOWN_ACTS = {
+    "Welcome to Mafia Town",
+    "Barrel Battle",
+    "She Came from Outer Space",
+    "Down with the Mafia!",
+    "Cheating the Race",
+    "Heating Up Mafia Town",
+    "The Golden Vault",
+}
+
+RUSH_HOUR_TICKETS = {
+    "Metro Ticket - Yellow",
+    "Metro Ticket - Blue",
+    "Metro Ticket - Pink"
+}
+
+# Shorten test code by putting the TestConditions classmethods into the module globals.
+always = TestConditions.always
+always_all_difficulties = TestConditions.always_all_difficulties
+never = TestConditions.never
+never_all_difficulties = TestConditions.never_all_difficulties
+
+T = TypeVar("T", TestData, List[TestConditions])
+
+
+def add_options(to: T, **options: Hashable) -> T:
+    """Helper to add options to a group of Conditions or an entire TestData dict."""
+    if isinstance(to, dict):
+        for conditions_list in to.values():
+            for conditions in conditions_list:
+                conditions.options.update(options)
+    elif isinstance(to, list):
+        for conditions in to:
+            conditions.options.update(options)
+    else:
+        raise TypeError(f"Could not add options to: {to}")
+    return to
+
+
+LOCATION_TEST_DATA: TestData = {
+    # Spaceship
+    "Act Completion (Time Rift - Gallery)": [
+        always("Time Rift - Gallery", "Brewing Hat"),
+        *always_all_difficulties("Time Rift - Gallery", min_difficulty="moderate"),
+    ],
+
+    # Chapter 1 - Mafia Town
+    # The Mafia HQ platform is only reachable in acts that are chronologically after the start of Down with the Mafia!.
+    "Mafia Town - Behind HQ Chest": [
+        # todo: Expert logic could probably bucket hover up to the Mafia HQ platform.
+        *always_all_difficulties(["Down with the Mafia!", "Cheating the Race", "The Golden Vault"]),
+        # The cannon to the platform is only activated once all the faucets have been turned off.
+        *always_all_difficulties("Heating Up Mafia Town", "Umbrella"),
+        *always_all_difficulties("Heating Up Mafia Town", UmbrellaLogic=False),
+        *never_all_difficulties(["Welcome to Mafia Town", "Barrel Battle", "She Came from Outer Space"]),
+    ],
+    # The Old Men are not present in She Came from Outer Space or Heating Up Mafia Town.
+    ("Mafia Town - Old Man (Steel Beams)",
+     "Mafia Town - Old Man (Seaside Spaghetti)"): [
+        *always_all_difficulties(MAFIA_TOWN_ACTS - {"She Came from Outer Space", "Heating Up Mafia Town"}),
+        *never_all_difficulties(["She Came from Outer Space", "Heating Up Mafia Town"]),
+    ],
+    # This location is not present in She Came from Outer Space because the Time Piece is there instead.
+    "Mafia Town - Mafia Geek Platform": [
+        *always_all_difficulties(MAFIA_TOWN_ACTS - {"She Came from Outer Space"}),
+        *never_all_difficulties("She Came from Outer Space"),
+    ],
+    # This location is not present in Down with the Mafia! for some unknown reason.
+    "Mafia Town - On Scaffolding": [
+        *always_all_difficulties(MAFIA_TOWN_ACTS - {"Down with the Mafia!"}),
+        *never_all_difficulties("Down with the Mafia!"),
+    ],
+    # The brewing crate in the way is removed in Heating Up Mafia Town.
+    "Mafia Town - Secret Cave": [
+        *always_all_difficulties(MAFIA_TOWN_ACTS - {"Heating Up Mafia Town"}, "Brewing Hat"),
+        *always_all_difficulties("Heating Up Mafia Town"),
+    ],
+    # The lava is above sea level, so the player can bounce across the lava (and die) to reach this in Heating Up Mafia
+    # Town.
+    "Mafia Town - Above Boats": [
+        always(MAFIA_TOWN_ACTS - {"Heating Up Mafia Town"}, "Hookshot Badge"),
+        # Moderate logic can Ice Hat slide.
+        *always_all_difficulties(MAFIA_TOWN_ACTS - {"Heating Up Mafia Town"}, ["Hookshot Badge", "Ice Hat"], min_difficulty="moderate", max_difficulty="hard"),
+        # Expert can dive boost off a descending sloped roof to gain incredible speed, launching themselves to this
+        # location from far away.
+        always(MAFIA_TOWN_ACTS - {"Heating Up Mafia Town"}, LogicDifficulty="expert"),
+        *always_all_difficulties("Heating Up Mafia Town"),
+    ],
+    # This location was previously mistakenly not possible to access with Sprint Hat + Scooter Badge on Normal logic
+    # difficulty with CTRLogic: scooter because the Scooter Badge was not being set to ItemClassification.progression.
+    "Act Completion (Cheating the Race)": [
+        *always_all_difficulties("Cheating the Race", "Time Stop Hat"),
+        *always_all_difficulties("Cheating the Race", ["Time Stop Hat", ("Sprint Hat", "Scooter Badge")], CTRLogic="scooter"),
+        *always_all_difficulties("Cheating the Race", ["Time Stop Hat", "Sprint Hat"], CTRLogic="sprint"),
+        *always_all_difficulties("Cheating the Race", CTRLogic="nothing"),
+    ],
+    # This location was previously mistakenly not having its moderate logic set.
+    "Mafia Town - Clock Tower Chest": [
+        always(MAFIA_TOWN_ACTS, "Hookshot Badge"),
+        *always_all_difficulties(MAFIA_TOWN_ACTS, min_difficulty="moderate"),
+    ],
+    # This location was previously mistakenly not having its moderate logic set.
+    "Mafia Town - Top of Ruined Tower": [
+        always(MAFIA_TOWN_ACTS, "Ice Hat"),
+        *always_all_difficulties(MAFIA_TOWN_ACTS, min_difficulty="moderate"),
+    ],
+    "Mafia Town - Top of Lighthouse": [
+        *always_all_difficulties(MAFIA_TOWN_ACTS, "Hookshot Badge", max_difficulty="hard"),
+        always(MAFIA_TOWN_ACTS, LogicDifficulty="expert"),
+    ],
+    "Mafia Town - Hot Air Balloon": [
+        *always_all_difficulties(MAFIA_TOWN_ACTS, "Ice Hat", max_difficulty="hard"),
+        always(MAFIA_TOWN_ACTS - {"Heating Up Mafia Town"}, LogicDifficulty="expert"),
+        always("Heating Up Mafia Town", "Ice Hat", LogicDifficulty="expert"),
+    ],
+
+    # Chapter 2 - Battle of the Birds
+    # Reaching the Post Elevator Area has a mix of requirements depending on UmbrellaLogic and LogicDifficulty.
+    "Dead Bird Studio - Tightrope Chest": [
+        *always_all_difficulties("Dead Bird Studio", UmbrellaLogic=False),
+        *always_all_difficulties("Dead Bird Studio", ["Umbrella", "Brewing Hat"], max_difficulty="hard"),
+        always("Dead Bird Studio Basement", LogicDifficulty="expert", UmbrellaLogic=False),
+        always(["Dead Bird Studio", "Dead Bird Studio Basement"], LogicDifficulty="expert"),
+        # Access from Dead Bird Studio Basement is expert-only.
+        *never_all_difficulties("Dead Bird Studio Basement", max_difficulty="hard"),
+    ],
+    # These locations are in the Post Elevator Area, but are after a fast moving platform controlled by a lever, which
+    # results in slightly different requirements.
+    ("Dead Bird Studio - DJ Grooves Sign Chest",
+     "Dead Bird Studio - Tepee Chest",
+     "Dead Bird Studio - Conductor Chest"): [
+        *add_options(UmbrellaLogic=False, to=[
+            # Umbrella/Brewing Hat is still required on Normal logic even with UmbrellaLogic=False because the platform
+            # starts moving away before Hat Kid is finished recoiling in pain from punching the lever.
+            always("Dead Bird Studio", ["Umbrella", "Brewing Hat"]),
+            *always_all_difficulties("Dead Bird Studio", min_difficulty="moderate"),
+            always("Dead Bird Studio Basement", LogicDifficulty="expert"),
+            # Access from Dead Bird Studio Basement is expert-only.
+            *never_all_difficulties("Dead Bird Studio Basement", max_difficulty="hard"),
+        ]),
+        *always_all_difficulties("Dead Bird Studio", ["Umbrella", "Brewing Hat"], max_difficulty="hard"),
+        # Expert can climb on top of the walls of the level to get past the gaps with moving platforms.
+        always(["Dead Bird Studio", "Dead Bird Studio Basement"], LogicDifficulty="expert"),
+        # Access from Dead Bird Studio Basement is expert-only.
+        *never_all_difficulties("Dead Bird Studio Basement", max_difficulty="hard"),
+    ],
+    # This location is in the same area as above, but is only accessible in Dead Bird Studio, so must be tested
+    # separately.
+    "Act Completion (Dead Bird Studio)": [
+        always("Dead Bird Studio", ["Umbrella", "Brewing Hat"], UmbrellaLogic=False),
+        *always_all_difficulties("Dead Bird Studio", min_difficulty="moderate", UmbrellaLogic=False),
+        always("Dead Bird Studio", ["Umbrella", "Brewing Hat"]),
+        *always_all_difficulties("Dead Bird Studio", ["Umbrella", "Brewing Hat"], min_difficulty="moderate", max_difficulty="hard"),
+        always("Dead Bird Studio", LogicDifficulty="expert"),
+        *never_all_difficulties("Dead Bird Studio Basement"),
+    ],
+    # Expert logic can clear Dead Bird Studio Basement without hookshot.
+    ("Dead Bird Studio Basement - Window Platform",
+     "Dead Bird Studio Basement - Cardboard Conductor",
+     "Dead Bird Studio Basement - Above Conductor Sign",
+     "Dead Bird Studio Basement - Disco Room",
+     "Dead Bird Studio Basement - Tightrope",
+     "Dead Bird Studio Basement - Cameras",
+     "Dead Bird Studio Basement - Locked Room",
+     "Act Completion (Dead Bird Studio Basement)"): [
+        *always_all_difficulties("Dead Bird Studio Basement", "Hookshot Badge", max_difficulty="hard"),
+        always("Dead Bird Studio Basement", LogicDifficulty="expert"),
+    ],
+
+    # Chapter 3 - Subcon Forest
+    # This location was previously missing accessibility from Your Contract has Expired with no items.
+    "Subcon Forest - Boss Arena Chest": [
+        # Accessible with nothing from YCHE.
+        *always_all_difficulties("Your Contract has Expired"),
+        # Normal logic can only access from YCHE and TOD.
+        *always_all_difficulties("Toilet of Doom", [("Hookshot Badge", "Progressive Painting Unlock")], max_difficulty="moderate"),
+        # Moderate logic and below can only access from YCHE and TOD.
+        *never_all_difficulties(MAIN_SUBCON_ACTS - {"Toilet of Doom"}, max_difficulty="moderate"),
+
+        # Cherry bridge across the boss arena gap instead of needing to use Hookshot Badge in Toilet of Doom.
+        *always_all_difficulties(MAIN_SUBCON_ACTS, "Progressive Painting Unlock", min_difficulty="hard"),
+        # Hard logic cannot skip the boss firewall.
+        always(MAIN_SUBCON_ACTS, "Progressive Painting Unlock", LogicDifficulty="hard", NoPaintingSkips=False),
+
+        # Only expert can skip the boss firewall, so the painting unlock is still required.
+        always(MAIN_SUBCON_ACTS, "Progressive Painting Unlock", LogicDifficulty="expert"),
+        always(MAIN_SUBCON_ACTS, LogicDifficulty="expert", NoPaintingSkips=False),
+        # Expert can Snatcher Hover to reach the act completion of YCHE, but this does not grant access to the boss
+        # arena itself if logic does not allow painting skips.
+        *never_all_difficulties(MAIN_SUBCON_ACTS, "Progressive Painting Unlock"),
+    ],
+    "Act Completion (Your Contract has Expired)": [
+        *always_all_difficulties("Your Contract has Expired", UmbrellaLogic=False),
+        *always_all_difficulties("Your Contract has Expired", "Umbrella", max_difficulty="hard"),
+        # Expert can 'Snatcher Hover', skipping directly to the post-fight cutscene area.
+        always("Your Contract has Expired", LogicDifficulty="expert"),
+        # 'Snatcher Hover' also works from other Subcon Forest acts.
+        always(MAIN_SUBCON_ACTS, LogicDifficulty="expert")
+    ],
+    "Act Completion (Toilet of Doom)": [
+        *always_all_difficulties("Toilet of Doom", [
+            ("Hookshot Badge", "Umbrella", "Progressive Painting Unlock"),
+            ("Hookshot Badge", "Brewing Hat", "Progressive Painting Unlock")
+        ]),
+        always("Toilet of Doom", [
+            ("Hookshot Badge", "Umbrella"),
+            ("Hookshot Badge", "Brewing Hat")
+        ], LogicDifficulty="expert", NoPaintingSkips=False),
+        # Expert logic is required to skip the boss firewall.
+        *never_all_difficulties("Toilet of Doom", "Progressive Painting Unlock", max_difficulty="hard", NoPaintingSkips=False)
+    ],
+    # This location was previously missing the requirement to get past the boss firewall.
+    "Subcon Village - Snatcher Statue Chest": [
+        *always_all_difficulties(MAIN_SUBCON_ACTS, "Progressive Painting Unlock"),
+        # Only expert logic can skip the boss firewall.
+        *always_all_difficulties(MAIN_SUBCON_ACTS, "Progressive Painting Unlock", max_difficulty="hard", NoPaintingSkips=False),
+        always(MAIN_SUBCON_ACTS, LogicDifficulty="expert", NoPaintingSkips=False),
+        # Expert can cherry hover across the boss arena gap in reverse. No paintings are needed because YCHE enters from
+        # the boss arena, which is already behind the boss firewall.
+        always("Your Contract has Expired", LogicDifficulty="expert"),
+        # todo: Hard could probably cherry bridge across the boss arena gap in reverse.
+        *never_all_difficulties("Your Contract has Expired", max_difficulty="hard")
+    ],
+    # Paintings can never be skipped for Contractual Obligations.
+    "Act Completion (Contractual Obligations)": [
+        *never_all_difficulties("Contractual Obligations", "Progressive Painting Unlock", NoPaintingSkips=False),
+    ],
+    # Moderate logic can reach all locations within Subcon Well with nothing.
+    ("Subcon Well - Hookshot Badge Chest",
+     "Subcon Well - Above Chest",
+     "Subcon Well - Mushroom"): [
+        always("The Subcon Well", [
+            ("Progressive Painting Unlock", "Umbrella"),
+            ("Progressive Painting Unlock", "Brewing Hat"),
+        ]),
+        always("The Subcon Well", [
+            ("Progressive Painting Unlock", "Umbrella"),
+            ("Progressive Painting Unlock", "Brewing Hat"),
+        ], NoPaintingSkips=False),
+        *always_all_difficulties("The Subcon Well", "Progressive Painting Unlock", UmbrellaLogic=False),
+        *always_all_difficulties("The Subcon Well", "Progressive Painting Unlock", min_difficulty="moderate"),
+        *always_all_difficulties("The Subcon Well", min_difficulty="moderate", NoPaintingSkips=False),
+    ],
+    ("Subcon Well - On Pipe",
+     "Act Completion (The Subcon Well)"): [
+        always("The Subcon Well", [
+            ("Progressive Painting Unlock", "Hookshot Badge", "Umbrella"),
+            ("Progressive Painting Unlock", "Hookshot Badge", "Brewing Hat"),
+        ]),
+        always("The Subcon Well", [
+            ("Progressive Painting Unlock", "Hookshot Badge", "Umbrella"),
+            ("Progressive Painting Unlock", "Hookshot Badge", "Brewing Hat"),
+        ], NoPaintingSkips=False),
+        always("The Subcon Well", [
+            ("Progressive Painting Unlock", "Hookshot Badge"),
+        ], UmbrellaLogic=False),
+        *always_all_difficulties("The Subcon Well", "Progressive Painting Unlock", min_difficulty="moderate"),
+        *always_all_difficulties("The Subcon Well", min_difficulty="moderate", NoPaintingSkips=False),
+    ],
+    # Moderate logic can reach all locations within Queen Vanessa's Manor with nothing.
+    ("Queen Vanessa's Manor - Cellar",
+     "Queen Vanessa's Manor - Bedroom Chest",
+     "Queen Vanessa's Manor - Hall Chest",
+     "Queen Vanessa's Manor - Chandelier",
+     "Act Completion (Queen Vanessa's Manor)"): [
+        # Normal logic needs to be able to hit a Dweller Bell or use their Dweller Mask.
+        always("Queen Vanessa's Manor", "Progressive Painting Unlock", UmbrellaLogic=False),
+        # Painting skips require at least Moderate logic.
+        always("Queen Vanessa's Manor", "Progressive Painting Unlock", UmbrellaLogic=False, NoPaintingSkips=False),
+        always("Queen Vanessa's Manor", [
+            ("Umbrella", "Progressive Painting Unlock"),
+            ("Brewing Hat", "Progressive Painting Unlock"),
+            ("Dweller Mask", "Progressive Painting Unlock")
+        ], UmbrellaLogic=True),
+        *always_all_difficulties("Queen Vanessa's Manor", min_difficulty="moderate", UmbrellaLogic=True, NoPaintingSkips=False),
+        *always_all_difficulties("Queen Vanessa's Manor", "Progressive Painting Unlock", min_difficulty="moderate", UmbrellaLogic=True),
+    ],
+    # Like the locations within Queen Vanessa's Manor, moderate logic can reach this location with nothing.
+    "Subcon Forest - Manor Rooftop": [
+        always(MAIN_SUBCON_ACTS, "Progressive Painting Unlock", UmbrellaLogic=False),
+        # Painting skips require at least Moderate logic.
+        always(MAIN_SUBCON_ACTS, "Progressive Painting Unlock", UmbrellaLogic=False, NoPaintingSkips=False),
+        always(MAIN_SUBCON_ACTS, [
+            ("Umbrella", "Progressive Painting Unlock"),
+            ("Brewing Hat", "Progressive Painting Unlock"),
+            ("Dweller Mask", "Progressive Painting Unlock")
+        ], UmbrellaLogic=True),
+        *always_all_difficulties(MAIN_SUBCON_ACTS, min_difficulty="moderate", UmbrellaLogic=False, NoPaintingSkips=False),
+        *always_all_difficulties(MAIN_SUBCON_ACTS, "Progressive Painting Unlock", min_difficulty="moderate", UmbrellaLogic=True),
+        # Expert can Cherry Hover over the boss arena gap from YCHE to reach the main Subcon Forest area.
+        always("Your Contract has Expired", LogicDifficulty="expert", UmbrellaLogic=False, NoPaintingSkips=False),
+        *never_all_difficulties("Your Contract has Expired", max_difficulty="hard"),
+    ],
+    "Act Completion (Time Rift - Village)": [
+        *always_all_difficulties("Time Rift - Village", ["Brewing Hat", "Umbrella", "Dweller Mask"], max_difficulty="hard"),
+        always("Time Rift - Village", ["Brewing Hat", "Umbrella", "Dweller Mask"], UmbrellaLogic=False),
+        # Moderate logic can punch the first dweller bell in the time rift and then, at the final area, jump from the
+        # top of the first dweller bell in that area, to the Time Piece.
+        *always_all_difficulties("Time Rift - Village", UmbrellaLogic=False, min_difficulty="moderate", max_difficulty="hard"),
+        # Expert logic can skip needing to hit the first dweller bell in the time rift with a slingshot.
+        always("Time Rift - Village", LogicDifficulty="expert"),
+        always("Time Rift - Village", UmbrellaLogic=False, LogicDifficulty="expert"),
+    ],
+    ("Subcon Forest - Dweller Floating Rocks",
+     "Subcon Forest - Dweller Platforming Tree B"): [
+        *always_all_difficulties(MAIN_SUBCON_ACTS, [("Dweller Mask",) + (("Progressive Painting Unlock",) * 3)], max_difficulty="moderate"),
+        # No Dweller Mask needed for Hard.
+        *always_all_difficulties(MAIN_SUBCON_ACTS, [("Progressive Painting Unlock",) * 3], min_difficulty="hard"),
+        *never_all_difficulties("Your Contract has Expired"),
+        *add_options(NoPaintingSkips=False, to=[
+            always(MAIN_SUBCON_ACTS, [("Dweller Mask",) + (("Progressive Painting Unlock",) * 3)]),
+            # Moderate can skip paintings.
+            always(MAIN_SUBCON_ACTS, "Dweller Mask", LogicDifficulty="moderate"),
+            # No Dweller Mask needed for Hard.
+            *always_all_difficulties(MAIN_SUBCON_ACTS, min_difficulty="hard"),
+            # Only Expert can access from YCHE.
+            always("Your Contract has Expired", LogicDifficulty="expert"),
+            *never_all_difficulties("Your Contract has Expired", max_difficulty="hard"),
+        ]),
+    ],
+    "Subcon Forest - Noose Treehouse": [
+        *always_all_difficulties(MAIN_SUBCON_ACTS, [("Hookshot Badge",) + (("Progressive Painting Unlock",) * 2)], max_difficulty="moderate"),
+        *always_all_difficulties(MAIN_SUBCON_ACTS, [("Progressive Painting Unlock",) * 2], min_difficulty="hard"),
+        *never_all_difficulties("Your Contract has Expired"),
+        *add_options(NoPaintingSkips=False, to=[
+            always(MAIN_SUBCON_ACTS, [("Hookshot Badge",) + (("Progressive Painting Unlock",) * 2)]),
+            always(MAIN_SUBCON_ACTS, "Hookshot Badge", LogicDifficulty="moderate"),
+            *always_all_difficulties(MAIN_SUBCON_ACTS, min_difficulty="hard"),
+            always("Your Contract has Expired", LogicDifficulty="expert"),
+            *never_all_difficulties("Your Contract has Expired", max_difficulty="hard"),
+        ]),
+    ],
+    "Subcon Forest - Tall Tree Hookshot Swing": [
+        *always_all_difficulties(MAIN_SUBCON_ACTS, [("Hookshot Badge",) + (("Progressive Painting Unlock",) * 3)], max_difficulty="moderate"),
+        *always_all_difficulties(MAIN_SUBCON_ACTS, [("Progressive Painting Unlock",) * 3], min_difficulty="hard"),
+        *never_all_difficulties("Your Contract has Expired"),
+        *add_options(NoPaintingSkips=False, to=[
+            always(MAIN_SUBCON_ACTS, [("Hookshot Badge",) + (("Progressive Painting Unlock",) * 3)]),
+            always(MAIN_SUBCON_ACTS, "Hookshot Badge", LogicDifficulty="moderate"),
+            *always_all_difficulties(MAIN_SUBCON_ACTS, min_difficulty="hard"),
+            always("Your Contract has Expired", LogicDifficulty="expert"),
+            *never_all_difficulties("Your Contract has Expired", max_difficulty="hard"),
+        ]),
+    ],
+    "Subcon Forest - Long Tree Climb Chest": [
+        *always_all_difficulties(MAIN_SUBCON_ACTS, [("Dweller Mask",) + (("Progressive Painting Unlock",) * 2)], max_difficulty="moderate"),
+        *always_all_difficulties(MAIN_SUBCON_ACTS, [("Progressive Painting Unlock",) * 2], min_difficulty="hard"),
+        *never_all_difficulties("Your Contract has Expired"),
+        *add_options(NoPaintingSkips=False, to=[
+            always(MAIN_SUBCON_ACTS, [("Dweller Mask",) + (("Progressive Painting Unlock",) * 2)]),
+            always(MAIN_SUBCON_ACTS, "Dweller Mask", LogicDifficulty="moderate"),
+            *always_all_difficulties(MAIN_SUBCON_ACTS, min_difficulty="hard"),
+            always("Your Contract has Expired", LogicDifficulty="expert"),
+            *never_all_difficulties("Your Contract has Expired", max_difficulty="hard"),
+        ]),
+    ],
+    "Subcon Forest - Magnet Badge Bush": [
+        *always_all_difficulties(MAIN_SUBCON_ACTS, [("Brewing Hat",) + (("Progressive Painting Unlock",) * 3)], max_difficulty="hard"),
+        always(MAIN_SUBCON_ACTS, [("Progressive Painting Unlock",) * 3], LogicDifficulty="expert"),
+        *never_all_difficulties("Your Contract has Expired"),
+        *add_options(NoPaintingSkips=False, to=[
+            always(MAIN_SUBCON_ACTS, [("Brewing Hat",) + (("Progressive Painting Unlock",) * 3)]),
+            *always_all_difficulties(MAIN_SUBCON_ACTS, "Brewing Hat", max_difficulty="hard"),
+            always(MAIN_SUBCON_ACTS, LogicDifficulty="expert"),
+            always("Your Contract has Expired", LogicDifficulty="expert"),
+            *never_all_difficulties("Your Contract has Expired", max_difficulty="hard"),
+        ])
+    ],
+    # These locations were previous missing the requirement to get past the first firewall. The locations can be
+    # collected in any order, but only two are accessible without a Progressive Painting Unlock, so all three must
+    # logically require a painting unlock.
+    ("Snatcher's Contract - Toilet of Doom",
+     "Snatcher's Contract - Queen Vanessa's Manor",
+     "Snatcher's Contract - Mail Delivery Service"): [
+        *always_all_difficulties("Subcon Forest Area", "Progressive Painting Unlock"),
+        *always_all_difficulties("Subcon Forest Area", min_difficulty="moderate", NoPaintingSkips=False),
+    ],
+    # This location looks similar to the above Contract locations, but should have separate rules.
+    "Snatcher's Contract - The Subcon Well": [
+        *always_all_difficulties("Contractual Obligations"),
+        # This contract is only reachable from Contractual Obligations.
+        *never_all_difficulties(MAIN_SUBCON_ACTS - {"Contractual Obligations"}),
+    ],
+
+    # Chapter 4 - Alpine Skyline
+    # No Brewing Hat needed for Moderate logic.
+    "Alpine Skyline - Yellow Band Hills": [
+        always("Alpine Free Roam", [("Umbrella", "Hookshot Badge", "Zipline Unlock - The Birdhouse Path", "Brewing Hat")]),
+        *always_all_difficulties("Alpine Free Roam", [("Umbrella", "Hookshot Badge", "Zipline Unlock - The Birdhouse Path")], min_difficulty="moderate"),
+        always("The Illness has Spread", [("Hookshot Badge", "Zipline Unlock - The Birdhouse Path", "Brewing Hat")]),
+        *always_all_difficulties("The Illness has Spread", [("Hookshot Badge", "Zipline Unlock - The Birdhouse Path")], min_difficulty="moderate"),
+        *add_options(UmbrellaLogic=False, to=[
+            always(["Alpine Free Roam", "The Illness has Spread"], [("Hookshot Badge", "Zipline Unlock - The Birdhouse Path", "Brewing Hat")]),
+            *always_all_difficulties(["Alpine Free Roam", "The Illness has Spread"], [("Hookshot Badge", "Zipline Unlock - The Birdhouse Path")], min_difficulty="moderate"),
+        ]),
+        *add_options(ShuffleAlpineZiplines=False, to=[
+            always("Alpine Free Roam", [("Umbrella", "Hookshot Badge", "Brewing Hat")]),
+            *always_all_difficulties("Alpine Free Roam", [("Umbrella", "Hookshot Badge")], min_difficulty="moderate"),
+            always("The Illness has Spread", [("Hookshot Badge", "Brewing Hat")]),
+            *always_all_difficulties("The Illness has Spread", "Hookshot Badge", min_difficulty="moderate"),
+            *add_options(UmbrellaLogic=False, to=[
+                always(["Alpine Free Roam", "The Illness has Spread"], [("Hookshot Badge", "Brewing Hat")]),
+                *always_all_difficulties(["Alpine Free Roam", "The Illness has Spread"], "Hookshot Badge", min_difficulty="moderate"),
+            ]),
+        ]),
+    ],
+    "Alpine Skyline - The Birdhouse: Dweller Platforms Relic": [
+        always("The Birdhouse", "Dweller Mask"),
+        *always_all_difficulties("The Birdhouse", min_difficulty="moderate"),
+    ],
+    # Moderate and above can void out to warp past the section that would otherwise require the Dweller Mask.
+    "Alpine Skyline - The Twilight Path": [
+        always("Alpine Free Roam", [("Umbrella", "Hookshot Badge", "Dweller Mask", "Zipline Unlock - The Twilight Bell Path")]),
+        *always_all_difficulties("Alpine Free Roam", [("Umbrella", "Hookshot Badge", "Zipline Unlock - The Twilight Bell Path")], min_difficulty="moderate"),
+        *add_options(UmbrellaLogic=False, to=[
+            always("Alpine Free Roam", [("Hookshot Badge", "Dweller Mask", "Zipline Unlock - The Twilight Bell Path")]),
+            *always_all_difficulties("Alpine Free Roam", [("Hookshot Badge", "Zipline Unlock - The Twilight Bell Path")], min_difficulty="moderate"),
+        ]),
+        *never_all_difficulties("The Illness has Spread"),
+        *add_options(ShuffleAlpineZiplines=False, to=[
+            always("Alpine Free Roam", [("Umbrella", "Hookshot Badge", "Dweller Mask")]),
+            *always_all_difficulties("Alpine Free Roam", [("Umbrella", "Hookshot Badge")], min_difficulty="moderate"),
+            *add_options(UmbrellaLogic=False, to=[
+                always("Alpine Free Roam", [("Hookshot Badge", "Dweller Mask")]),
+                *always_all_difficulties("Alpine Free Roam", "Hookshot Badge", min_difficulty="moderate"),
+            ]),
+        ]),
+    ],
+    # Moderate can reach without Sprint Hat or Time Stop Hat.
+    "Alpine Skyline - Mystifying Time Mesa: Zipline": [
+        always("Alpine Free Roam", [
+            ("Umbrella", "Hookshot Badge", "Sprint Hat", "Zipline Unlock - The Lava Cake Path"),
+            ("Umbrella", "Hookshot Badge", "Time Stop Hat", "Zipline Unlock - The Lava Cake Path")]),
+        # No hats needed for moderate logic.
+        *always_all_difficulties("Alpine Free Roam", [("Umbrella", "Hookshot Badge", "Zipline Unlock - The Lava Cake Path")], min_difficulty="moderate"),
+        *add_options(UmbrellaLogic=False, to=[
+            always("Alpine Free Roam", [
+                ("Hookshot Badge", "Sprint Hat", "Zipline Unlock - The Lava Cake Path"),
+                ("Hookshot Badge", "Time Stop Hat", "Zipline Unlock - The Lava Cake Path")
+            ]),
+            *always_all_difficulties("Alpine Free Roam", [("Hookshot Badge", "Zipline Unlock - The Lava Cake Path")], min_difficulty="moderate"),
+        ]),
+        # The Zipline is blocked off in TIHS.
+        *never_all_difficulties("The Illness has Spread"),
+    ],
+    "Alpine Skyline - Goat Refinery": [
+        # There is no way to get past the Alpine Free Roam intro without these items, which provides enough to reach
+        # the location once past the intro.
+        *always_all_difficulties("Alpine Free Roam", [("Hookshot Badge", "Umbrella")]),
+        *always_all_difficulties("Alpine Free Roam", "Hookshot Badge", UmbrellaLogic=False),
+        # Normal logic cannot get this item from The Illness has Spread because the hookpoint is blocked and Normal
+        # logic has no trick to reach the location without using the hookpoint.
+        never("The Illness has Spread"),
+        # Moderate logic can use Sprint Hat to cross the gap to Goat Refinery.
+        always("The Illness has Spread", "Sprint Hat", LogicDifficulty="moderate"),
+        # Hard logic can cross the gap with nothing.
+        *always_all_difficulties("The Illness has Spread", min_difficulty="hard"),
+    ],
+    "Act Completion (Time Rift - The Twilight Bell)": [
+        *always_all_difficulties("Time Rift - The Twilight Bell", "Dweller Mask", max_difficulty="moderate"),
+        # Hard can jump around the Dweller wall with the Scooter.
+        always("Time Rift - The Twilight Bell", ["Dweller Mask", ("Sprint Hat", "Scooter Badge")], LogicDifficulty="hard"),
+        # Expert can jump around the Dweller wall with nothing.
+        always("Time Rift - The Twilight Bell", LogicDifficulty="expert"),
+    ],
+    "Act Completion (Time Rift - Curly Tail Trail)": [
+        *always_all_difficulties("Time Rift - Curly Tail Trail", "Ice Hat", max_difficulty="moderate"),
+        # SDJ.
+        always("Time Rift - Curly Tail Trail", ["Ice Hat", "Sprint Hat"], LogicDifficulty="hard"),
+        # Slingshot.
+        always("Time Rift - Curly Tail Trail", LogicDifficulty="expert"),
+    ],
+    # Goat Outpost Horn was previously missing accessibility from The Illness has Spread.
+    ("Alpine Skyline - Goat Outpost Horn",
+     "Alpine Skyline - Windy Passage"): [
+        *add_options(UmbrellaLogic=False, ShuffleAlpineZiplines=False, to=[
+            *always_all_difficulties("Alpine Free Roam", "Hookshot Badge"),
+            *always_all_difficulties("The Illness has Spread", "Hookshot Badge"),
+        ]),
+        *never_all_difficulties("Alpine Free Roam", ["Zipline Unlock - The Windmill Path", "Umbrella"]),
+        *never_all_difficulties("The Illness has Spread", "Zipline Unlock - The Windmill Path"),
+        *never_all_difficulties(["Alpine Free Roam", "The Illness has Spread"], "Zipline Unlock - The Windmill Path", UmbrellaLogic=False),
+        *never_all_difficulties("Alpine Free Roam", "Umbrella", ShuffleAlpineZiplines=False),
+    ],
+    "Act Completion (The Twilight Bell)": [
+        *add_options(UmbrellaLogic=False, ShuffleAlpineZiplines=False, to=[
+            *always_all_difficulties("Alpine Free Roam", [("Hookshot Badge", "Dweller Mask")], max_difficulty="moderate"),
+            always("Alpine Free Roam", [("Hookshot Badge", "Dweller Mask")], LogicDifficulty="hard"),
+            always("Alpine Free Roam", [
+                ("Hookshot Badge", "Brewing Hat"),
+                ("Hookshot Badge", "Dweller Mask"),
+                ("Hookshot Badge", "Sprint Hat"),
+                # The Time Stop Hat + Umbrella option still requires Umbrella with Umbrella logic not enabled.
+                ("Hookshot Badge", "Umbrella", "Time Stop Hat"),
+            ], LogicDifficulty="expert"),
+        ]),
+        *never_all_difficulties("Alpine Free Roam", ["Zipline Unlock - The Twilight Bell Path", "Umbrella"]),
+        *never_all_difficulties("Alpine Free Roam", "Zipline Unlock - The Twilight Bell Path", UmbrellaLogic=False),
+        *never_all_difficulties("Alpine Free Roam", "Umbrella", ShuffleAlpineZiplines=False),
+        *never_all_difficulties("The Illness has Spread"),
+    ],
+
+    # Chapter 5 - The Finale
+    "Act Completion (The Finale)": [
+        # No difficulties need Ice Hat.
+        always("The Finale", [("Hookshot Badge", "Dweller Mask")]),
+        # Moderate does not need Hookshot Badge.
+        *always_all_difficulties("The Finale", "Dweller Mask", min_difficulty="moderate"),
+    ],
+}
+
+
+DLC1_LOCATION_TEST_DATA: TestData = add_options(EnableDLC1=True, to={
+    # Chapter 6 - The Arctic Cruise
+    # This location does not exist in Rock the Boat, so can only be accessed from Bon Voyage! or Ship Shape.
+    # This location was previously missing the Hookshot Badge requirement to reach the Cruise Ship region from
+    # Bon Voyage!.
+    # Rock the Boat gives access to the Cruise Ship region with no items required, but this location is not present in
+    # Rock the Boat, so access to either Ship Shape or Bon Voyage! is required.
+    "The Arctic Cruise - Toilet": [
+        *always_all_difficulties("Ship Shape"),
+        *always_all_difficulties("Bon Voyage!", "Hookshot Badge"),
+        # Neither of these combinations of accessible regions can give access to the location without Hookshot Badge.
+        *never_all_difficulties([("Cruise Ship", "Bon Voyage!"), ("Rock the Boat", "Bon Voyage!")], "Hookshot Badge"),
+        # With all items, neither of these regions are enough to reach the location.
+        *never_all_difficulties(["Cruise Ship", "Rock the Boat"]),
+    ],
+    # These locations were previously mistakenly not having their moderate logic set, due to using the wrong rule
+    # function.
+    ("Rock the Boat - Post Captain Rescue",
+     "Act Completion (Rock the Boat)"): [
+        always("Rock the Boat", "Ice Hat"),
+        # Moderate can jump across the freezing water while taking damage.
+        *always_all_difficulties("Rock the Boat", min_difficulty="moderate"),
+    ],
+    "Act Completion (Time Rift - Deep Sea)": [
+        always("Time Rift - Deep Sea", [("Hookshot Badge", "Dweller Mask", "Ice Hat")]),
+        # Moderate can reach enough Rift Pons without Ice Hat.
+        always("Time Rift - Deep Sea", [("Hookshot Badge", "Dweller Mask")], LogicDifficulty="moderate"),
+        # Hard can reach enough Rift Pons without either Ice Hat or Dweller Mask.
+        *always_all_difficulties("Time Rift - Deep Sea", "Hookshot Badge", min_difficulty="hard"),
+    ],
+})
+
+
+DLC2_LOCATION_TEST_DATA: TestData = add_options(EnableDLC2=True, to={
+    # Chapter 7 - Nyakuza Metro
+    "Act Completion (Yellow Overpass Station)": [
+        always(["Nyakuza Free Roam", "Yellow Overpass Station"], "Hookshot Badge"),
+        *always_all_difficulties(["Nyakuza Free Roam", "Yellow Overpass Station"], min_difficulty="moderate"),
+    ],
+    "Pink Paw Station - Behind Fan": [
+        # Tickets are always required with NoTicketSkips=True
+        always("Nyakuza Free Roam", [
+            ("Metro Ticket - Blue", "Metro Ticket - Yellow", "Hookshot Badge", "Time Stop Hat", "Dweller Mask"),
+            ("Metro Ticket - Pink", "Hookshot Badge", "Time Stop Hat", "Dweller Mask")]),
+        # Only tickets required on moderate logic.
+        *always_all_difficulties("Nyakuza Free Roam", [
+            ("Metro Ticket - Blue", "Metro Ticket - Yellow"),
+            "Metro Ticket - Pink"
+        ], min_difficulty="moderate"),
+        # Rush Hour ticket skips only allows ticket skips in Rush Hour, and not in Nyakuza Free Roam.
+        *add_options(NoTicketSkips="rush_hour", to=[
+            always("Nyakuza Free Roam", [
+                ("Metro Ticket - Blue", "Metro Ticket - Yellow", "Hookshot Badge", "Time Stop Hat", "Dweller Mask"),
+                ("Metro Ticket - Pink", "Hookshot Badge", "Time Stop Hat", "Dweller Mask")]),
+            # Only tickets required on moderate logic.
+            *always_all_difficulties("Nyakuza Free Roam", [
+                ("Metro Ticket - Blue", "Metro Ticket - Yellow"),
+                "Metro Ticket - Pink"
+            ], min_difficulty="moderate"),
+        ]),
+        *add_options(NoTicketSkips=False, to=[
+            # Normal logic cannot perform ticket skips, so still needs the tickets.
+            always("Nyakuza Free Roam", [
+                ("Metro Ticket - Blue", "Metro Ticket - Yellow", "Hookshot Badge", "Time Stop Hat", "Dweller Mask"),
+                ("Metro Ticket - Pink", "Hookshot Badge", "Time Stop Hat", "Dweller Mask")]),
+            # Moderate can wrongwarp into Pink Paw Station from Yellow Overpass Station, so requires nothing.
+            *always_all_difficulties("Nyakuza Free Roam", min_difficulty="moderate"),
+        ]),
+    ],
+    # This location was previously mistakenly not setting its ticket skips logic in Hard logic, so was acting as if
+    # ticket skips were always disabled.
+    # This location was previously mistakenly not setting its Rush Hour-only ticket skips logic in Expert logic.
+    "Act Completion (Rush Hour)": [
+        # Rush Hour ticket skips are only in logic on Hard LogicDifficulty and above.
+        always("Rush Hour", [("Brewing Hat", "Dweller Mask", "Ice Hat", "Hookshot Badge", *RUSH_HOUR_TICKETS)]),
+        always("Rush Hour", [("Brewing Hat", "Dweller Mask", "Ice Hat", "Hookshot Badge", *RUSH_HOUR_TICKETS)], NoTicketSkips=False),
+        always("Rush Hour", [("Brewing Hat", "Dweller Mask", "Ice Hat", "Hookshot Badge", *RUSH_HOUR_TICKETS)], NoTicketSkips="rush_hour"),
+        # Moderate logic can do wall jumps to skip needing Hookshot Badge and can make precise jumps and go under
+        # Dweller signs to skip needing Dweller Mask.
+        *add_options(LogicDifficulty="moderate", to=[
+            always("Rush Hour", [("Brewing Hat", "Ice Hat", *RUSH_HOUR_TICKETS)]),
+            always("Rush Hour", [("Brewing Hat", "Ice Hat", *RUSH_HOUR_TICKETS)], NoTicketSkips=False),
+            always("Rush Hour", [("Brewing Hat", "Ice Hat", *RUSH_HOUR_TICKETS)], NoTicketSkips="rush_hour"),
+        ]),
+        # Hard logic can perform the ticket skip when ticket skips are in logic and can skip Ice Hat by jumping directly
+        # from Green Clean Station to Yellow Overpass Station while avoiding the kill plane under most of Green Clean.
+        *add_options(LogicDifficulty="hard", to=[
+            always("Rush Hour", [("Brewing Hat", *RUSH_HOUR_TICKETS)]),
+            always("Rush Hour", "Brewing Hat", NoTicketSkips=False),
+            always("Rush Hour", "Brewing Hat", NoTicketSkips="rush_hour"),
+        ]),
+        # Expert logic can go out-of-bounds to bypass the brewing obstacle.
+        *add_options(LogicDifficulty="expert", to=[
+            always("Rush Hour", [tuple(RUSH_HOUR_TICKETS)]),
+            always("Rush Hour", NoTicketSkips=False),
+            always("Rush Hour", NoTicketSkips="rush_hour"),
+        ]),
+    ],
+    # This thug shop has unique logical requirements.
+    ("Green Clean Station Thug B - Item 1",
+     "Green Clean Station Thug B - Item 2",
+     "Green Clean Station Thug B - Item 3",
+     "Green Clean Station Thug B - Item 4",
+     "Green Clean Station Thug B - Item 5"): [
+        *always_all_difficulties("Nyakuza Free Roam", ["Ice Hat", "Metro Ticket - Yellow"])
+    ],
+    # In the upper section of Pink Paw Station, so additionally requires Hookshot Badge + Dweller Mask.
+    "Act Completion (Pink Paw Station)": [
+        always("Nyakuza Free Roam", [
+            ("Metro Ticket - Pink", "Hookshot Badge", "Dweller Mask"),
+            ("Metro Ticket - Yellow", "Metro Ticket - Blue", "Hookshot Badge", "Dweller Mask"),
+        ]),
+        # Hookshot Badge + Dweller Mask can be skipped using either wall jumps or the wrongwarp from Yellow Overpass.
+        *always_all_difficulties("Nyakuza Free Roam", [
+            "Metro Ticket - Pink",
+            ("Metro Ticket - Yellow", "Metro Ticket - Blue"),
+        ], min_difficulty="moderate"),
+        *always_all_difficulties("Nyakuza Free Roam", min_difficulty="moderate", NoTicketSkips=False),
+    ],
+    "Act Completion (Green Clean Manhole)": [
+        *always_all_difficulties("Nyakuza Free Roam", [("Ice Hat", "Dweller Mask")], max_difficulty="moderate"),
+        # Hard can jump from the sign below the Dweller roof and wall jump to get on top of the Dweller roof.
+        always("Nyakuza Free Roam", "Ice Hat", LogicDifficulty="hard"),
+        # Boop Clip to get into the manhole area without entering the manhole.
+        always("Nyakuza Free Roam", LogicDifficulty="expert"),
+    ],
+    "Act Completion (Yellow Overpass Manhole)": [
+        *always_all_difficulties("Nyakuza Free Roam", "Ice Hat", max_difficulty="hard"),
+        # Boop Clip to get into the manhole area without entering the manhole.
+        always("Nyakuza Free Roam", LogicDifficulty="expert"),
+    ],
+})
+
+
+DEATH_WISH_OPTIONS: Dict[str, Hashable] = dict(
+    # Fully enable Death Wish locations.
+    EnableDeathWish=True,
+    DWEnableBonus=True,
+    DWAutoCompleteBonuses=False,
+    DWExcludeAnnoyingContracts=False,
+    DWExcludeAnnoyingBonuses=False,
+    DWExcludeCandles=False,
+)
+
+
+DEATH_WISH_LOCATION_TEST_DATA: TestData = add_options(**DEATH_WISH_OPTIONS, to={
+    # Death Wish
+    # Auto-completed Bonus Stamp locations were previously missing the requirement to complete the contract's Main
+    # Objective, which would incorrectly grant Bonus Stamps as soon as the Death Wish contract was unlocked.
+    "Bonus Stamps - Beat the Heat": [
+        # With Umbrella logic enabled, Umbrella is required to complete the Main Objective of Beat the Heat.
+        *always_all_difficulties("Beat the Heat", "Umbrella"),
+        *always_all_difficulties("Beat the Heat", "Umbrella", DWAutoCompleteBonuses=True),
+        *always_all_difficulties("Beat the Heat", "Umbrella", DWEnableBonus=False),
+        *always_all_difficulties("Beat the Heat", "Umbrella", DWEnableBonus=False, DWAutoCompleteBonuses=True),
+        # With Umbrella logic disabled, no items are required to complete the Main Objective of Beat the Heat.
+        *add_options(UmbrellaLogic=False, to=[
+            *always_all_difficulties("Beat the Heat"),
+            *always_all_difficulties("Beat the Heat", DWAutoCompleteBonuses=True),
+            *always_all_difficulties("Beat the Heat", DWEnableBonus=False),
+            *always_all_difficulties("Beat the Heat", DWEnableBonus=False, DWAutoCompleteBonuses=True),
+        ]),
+    ],
+    # Camera Tourist
+    # There was previously a mismatch between the locations and logic, where one used the name "Director" and the other
+    # used the name "Conductor", so the Hookshot Badge logic requirement for this location was not being set.
+    "Director - Dead Bird Studio Basement": [
+        always("Dead Bird Studio Basement", "Hookshot Badge"),
+        # todo: There is currently no expert logic set for reaching this location without Hookshot Badge.
+        # always("Dead Bird Studio Basement", LogicDifficulty="expert"),
+    ],
+    # This location was previously missing all item requirements.
+    "Toilet - Toilet of Doom": [
+        # The boss is behind the boss firewall, so Expert is the only difficulty that does not need the Progressive
+        # Painting Unlock with NoPaitningSkips=False.
+        *always_all_difficulties("Toilet of Doom", [("Progressive Painting Unlock", "Hookshot Badge")], max_difficulty="moderate"),
+        # Hard logic can cherry bridge across the boss arena gap.
+        *always_all_difficulties("Toilet of Doom", "Progressive Painting Unlock", min_difficulty="hard"),
+        always("Toilet of Doom", "Progressive Painting Unlock", LogicDifficulty="hard", NoPaintingSkips=False),
+        always("Toilet of Doom", LogicDifficulty="expert", NoPaintingSkips=False),
+    ],
+    # Snatcher Coins
+    # This location was previously missing the requirement to be able to complete Beat the Heat. The cannon to the HQ
+    # platform only opens once all faucets have been turned off.
+    "Snatcher Coin - Top of HQ (DW: BTH)": [
+        *always_all_difficulties("Beat the Heat", "Umbrella"),
+        *always_all_difficulties("Beat the Heat", UmbrellaLogic=False),
+    ],
+    # todo: Snatcher Coin - Swamp Tree and Snatcher Coin - Swamp Tree (Speedrun Well) should not need Hookshot on higher
+    #  logic difficulties.
+    # todo: Snatcher Coin - Manor Roof is missing moderate logic
+})
+
+
+ENTRANCE_TEST_DATA: TestData = {
+    # Chapter 3 - Subcon Forest
+    # "Subcon Forest" is the name for the Chapter 3 telescope Region, it is not related to "Subcon Forest Area".
+    "Subcon Forest - Act 2": [
+        *always_all_difficulties("Spaceship", [("Snatcher's Contract - The Subcon Well", *TEST_CHAPTER_TIMEPIECES[ChapterIndex.SUBCON])]),
+        *always_all_difficulties("Subcon Forest", "Snatcher's Contract - The Subcon Well"),
+    ],
+    "Subcon Forest - Act 3": [
+        *always_all_difficulties("Spaceship", [("Snatcher's Contract - Toilet of Doom", *TEST_CHAPTER_TIMEPIECES[ChapterIndex.SUBCON])]),
+        *always_all_difficulties("Subcon Forest", "Snatcher's Contract - Toilet of Doom"),
+    ],
+    "Subcon Forest - Act 4": [
+        *always_all_difficulties("Spaceship", [("Snatcher's Contract - Queen Vanessa's Manor", *TEST_CHAPTER_TIMEPIECES[ChapterIndex.SUBCON])]),
+        *always_all_difficulties("Subcon Forest", "Snatcher's Contract - Queen Vanessa's Manor"),
+    ],
+    "Subcon Forest - Act 5": [
+        *always_all_difficulties("Spaceship", [("Snatcher's Contract - Mail Delivery Service", *TEST_CHAPTER_TIMEPIECES[ChapterIndex.SUBCON])]),
+        *always_all_difficulties("Subcon Forest", "Snatcher's Contract - Mail Delivery Service"),
+    ],
+
+    # Chapter 4 - Alpine Skyline
+    "Alpine Skyline - Finale": [
+        *never_all_difficulties("Alpine Skyline", [
+            "Zipline Unlock - The Birdhouse Path",
+            "Zipline Unlock - The Lava Cake Path",
+            "Zipline Unlock - The Windmill Path",
+            "Zipline Unlock - The Twilight Bell Path",
+            "Umbrella",
+            "Hookshot Badge",
+        ]),
+        *never_all_difficulties("Alpine Skyline", [
+            "Zipline Unlock - The Birdhouse Path",
+            "Zipline Unlock - The Lava Cake Path",
+            "Zipline Unlock - The Windmill Path",
+            "Zipline Unlock - The Twilight Bell Path",
+            "Hookshot Badge",
+        ], UmbrellaLogic=False),
+        *add_options(ShuffleAlpineZiplines=False, UmbrellaLogic=False, to=[
+            always("Alpine Skyline", [
+                ("Hookshot Badge", "Brewing Hat", "Dweller Mask")
+            ]),
+            # Moderate does not need Brewing Hat for completing The Birdhouse.
+            *always_all_difficulties("Alpine Skyline", [
+                ("Hookshot Badge", "Dweller Mask")
+            ], min_difficulty="moderate", max_difficulty="hard"),
+            # Expert has alternatives to Dweller Mask for completing The Twilight Bell.
+            # See also: Act Completion (The Twilight Bell).
+            always("Alpine Skyline", [
+                ("Hookshot Badge", "Brewing Hat"),
+                ("Hookshot Badge", "Dweller Mask"),
+                ("Hookshot Badge", "Sprint Hat"),
+                ("Hookshot Badge", "Umbrella", "Time Stop Hat"),
+            ], LogicDifficulty="expert"),
+        ]),
+    ],
+}
+
+REGION_TEST_DATA: TestData = {
+    # Spaceship
+    "Mafia Town": [
+        *always_all_difficulties("Spaceship", [tuple(TEST_CHAPTER_TIMEPIECES[ChapterIndex.MAFIA])]),
+    ],
+    "Battle of the Birds": [
+        *always_all_difficulties("Spaceship", [tuple(TEST_CHAPTER_TIMEPIECES[ChapterIndex.BIRDS])]),
+    ],
+    "Subcon Forest": [
+        *always_all_difficulties("Spaceship", [tuple(TEST_CHAPTER_TIMEPIECES[ChapterIndex.SUBCON])]),
+    ],
+    "Alpine Skyline": [
+        *always_all_difficulties("Spaceship", [tuple(TEST_CHAPTER_TIMEPIECES[ChapterIndex.ALPINE])]),
+    ],
+    "Time's End": [
+        # No difficulties need Ice Hat because the ceiling button can be reached by jumping from the top of the Dweller
+        # block.
+        always("Spaceship", [("Dweller Mask", "Brewing Hat", *TEST_CHAPTER_TIMEPIECES[ChapterIndex.FINALE])]),
+        # Moderate can alternatively bounce on a beach ball with the Ice Hat to get over the iron bars blocking access
+        # to the telescope.
+        *always_all_difficulties("Spaceship", [
+            ("Dweller Mask", "Brewing Hat", *TEST_CHAPTER_TIMEPIECES[ChapterIndex.FINALE]),
+            ("Ice Hat", *TEST_CHAPTER_TIMEPIECES[ChapterIndex.FINALE])
+        ], min_difficulty="moderate", max_difficulty="hard"),
+        always("Spaceship", [tuple(TEST_CHAPTER_TIMEPIECES[ChapterIndex.FINALE])], LogicDifficulty="expert"),
+    ],
+    # The Chapter 6 and 7 doors are behind the Chapter 4 door.
+    "The Arctic Cruise": [
+        *always_all_difficulties("Spaceship", [
+            ("Time Piece",) * max(TEST_CHAPTER_TIMEPIECE_COSTS[ChapterIndex.ALPINE], TEST_CHAPTER_TIMEPIECE_COSTS[ChapterIndex.CRUISE]),
+        ], EnableDLC1=True),
+    ],
+    "Nyakuza Metro": [
+        *always_all_difficulties("Spaceship", [
+            (
+                "Dweller Mask",
+                "Ice Hat",
+                *(["Time Piece"] * max(TEST_CHAPTER_TIMEPIECE_COSTS[ChapterIndex.ALPINE], TEST_CHAPTER_TIMEPIECE_COSTS[ChapterIndex.METRO]))
+             )
+        ], EnableDLC2=True),
+    ],
+
+    # Chapter 3 - Subcon Forest
+    "Subcon Forest Area": [
+        *always_all_difficulties(MAIN_SUBCON_ACTS),
+        # Expert can cherry hover from YCHE to the Subcon Forest Area.
+        always("Your Contract has Expired", LogicDifficulty="expert", NoPaintingSkips=False),
+        # Without painting skips, it is not possible to go from the Boss Arena to the Subcon Forest Area because the
+        # paintings are on the other side of the boss firewall.
+        *never_all_difficulties("Your Contract has Expired"),
+    ],
+    "Your Contract has Expired - Post Fight": [
+        # The entrance from YCHE must never have any requirements because its logic is not inherited by act connections.
+        *always_all_difficulties("Your Contract has Expired"),
+        # Snatcher Hover.
+        always(MAIN_SUBCON_ACTS, LogicDifficulty="expert"),
+    ],
+
+    "Alpine Skyline Area (TIHS)": [
+        *always_all_difficulties("Alpine Free Roam", [("Umbrella", "Hookshot Badge")]),
+        *always_all_difficulties("Alpine Free Roam", "Hookshot Badge", UmbrellaLogic=False),
+        *always_all_difficulties("The Illness has Spread"),
+    ],
+    "The Birdhouse": [
+        always("Alpine Skyline Area", [("Hookshot Badge", "Brewing Hat", "Zipline Unlock - The Birdhouse Path")]),
+        *always_all_difficulties("Alpine Skyline Area", [("Hookshot Badge", "Zipline Unlock - The Birdhouse Path")], min_difficulty="moderate"),
+        always("Alpine Skyline Area", [("Hookshot Badge", "Brewing Hat")], ShuffleAlpineZiplines=False),
+        *always_all_difficulties("Alpine Skyline Area", "Hookshot Badge", min_difficulty="moderate", ShuffleAlpineZiplines=False),
+        *never_all_difficulties("The Illness has Spread"),
+    ],
+    "The Lava Cake": [
+        *always_all_difficulties("Alpine Skyline Area", [("Hookshot Badge", "Zipline Unlock - The Lava Cake Path")]),
+        *always_all_difficulties("Alpine Skyline Area", "Hookshot Badge", ShuffleAlpineZiplines=False),
+        *never_all_difficulties("The Illness has Spread"),
+    ],
+    "The Windmill": [
+        *always_all_difficulties("Alpine Skyline Area", [("Hookshot Badge", "Zipline Unlock - The Windmill Path")]),
+        *always_all_difficulties("Alpine Skyline Area", "Hookshot Badge", ShuffleAlpineZiplines=False),
+        *never_all_difficulties("The Illness has Spread"),
+    ],
+    "The Twilight Bell": [
+        *always_all_difficulties("Alpine Skyline Area", [("Hookshot Badge", "Dweller Mask", "Zipline Unlock - The Twilight Bell Path")], max_difficulty="hard"),
+        *always_all_difficulties("Alpine Skyline Area", [("Hookshot Badge", "Dweller Mask")], max_difficulty="hard", ShuffleAlpineZiplines=False),
+        always("Alpine Skyline Area", [("Hookshot Badge", "Zipline Unlock - The Twilight Bell Path")], LogicDifficulty="expert"),
+        always("Alpine Skyline Area", "Hookshot Badge", LogicDifficulty="expert", ShuffleAlpineZiplines=False),
+        *never_all_difficulties("The Illness has Spread"),
+    ],
+
+    # Chapter 6 - The Arctic Cruise
+    "Cruise Ship": add_options(EnableDLC1=True, to=[
+        *always_all_difficulties("Bon Voyage!", "Hookshot Badge"),
+        *always_all_difficulties(["Ship Shape", "Rock the Boat"]),
+    ]),
+
+    # Other
+    "Badge Seller": [
+        # todo: Also accessible from some Death Wish contracts, e.g. Collect-a-thon, though this is rather obscure
+        #  knowledge.
+        *always_all_difficulties([
+            *MAFIA_TOWN_ACTS,
+            "Dead Bird Studio",
+            "Picture Perfect",
+            "Train Rush",
+            *MAIN_SUBCON_ACTS,
+            "The Illness has Spread",
+            "Ship Shape",
+            "Rock the Boat",
+        ], EnableDLC1=True),
+        *always_all_difficulties("Bon Voyage!", "Hookshot Badge", EnableDLC1=True),
+        *always_all_difficulties("Alpine Free Roam", [("Hookshot Badge", "Umbrella")]),
+        *always_all_difficulties("Alpine Free Roam", "Hookshot Badge", UmbrellaLogic=False),
+        # Needs painting skips because the boss firewall cannot be removed from the YCHE side.
+        always("Your Contract has Expired", LogicDifficulty="expert", NoPaintingSkips=False),
+        *never_all_difficulties("Your Contract has Expired", NoPaintingSkips=True),
+    ],
+}
+
+DLC2_REGION_TEST_DATA: TestData = add_options(EnableDLC2=True, to={
+    # Chapter 7 - Nyakuza Metro
+    "Yellow Overpass Station": [
+        *always_all_difficulties("Nyakuza Free Roam")
+    ],
+    "Green Clean Station": [
+        *always_all_difficulties("Nyakuza Free Roam")
+    ],
+    "Pink Paw Station": [
+        *always_all_difficulties("Nyakuza Free Roam", [
+            "Metro Ticket - Pink",
+            ("Metro Ticket - Yellow", "Metro Ticket - Blue"),
+        ]),
+        # Wrongwarp from Yellow Overpass Station into Pink Paw Station.
+        *always_all_difficulties("Nyakuza Free Roam", min_difficulty="moderate", NoTicketSkips=False),
+    ],
+    "Bluefin Tunnel": [
+        *always_all_difficulties("Nyakuza Free Roam", ["Metro Ticket - Green", "Metro Ticket - Blue"]),
+        # Ticket skips require Moderate logic, so tickets are still required with Normal logic.
+        always("Nyakuza Free Roam", ["Metro Ticket - Green", "Metro Ticket - Blue"], NoTicketSkips=False),
+        # Dive under the kill plane/box from the entrance to Yellow Overpass Station.
+        *always_all_difficulties("Nyakuza Free Roam", min_difficulty="moderate", NoTicketSkips=False),
+    ],
+})
+
+# Separated from region tests because these regions can be shuffled when act randomization is enabled.
+RANDOMIZED_REGION_TEST_DATA: TestData = {
+    "Time Rift - Gallery": [
+        *always_all_difficulties("Spaceship", [("Brewing Hat", *TEST_CHAPTER_TIMEPIECES[ChapterIndex.BIRDS])]),
+    ],
+    "Time Rift - The Lab": [
+        *always_all_difficulties("Spaceship", [("Dweller Mask", *TEST_CHAPTER_TIMEPIECES[ChapterIndex.ALPINE])]),
+    ],
+    "Time Rift - Sewers": [
+        *always_all_difficulties(MAFIA_TOWN_ACTS, None, "Mafia Town - Act 4"),
+    ],
+    "Time Rift - Bazaar": [
+        *always_all_difficulties(MAFIA_TOWN_ACTS, None, "Mafia Town - Act 6"),
+    ],
+    "Time Rift - Mafia of Cooks": [
+        *always_all_difficulties(MAFIA_TOWN_ACTS - {"Heating Up Mafia Town"}, [Items.relic_groups["Burger"]]),
+        *never_all_difficulties("Heating Up Mafia Town"),
+    ],
+    "Time Rift - The Owl Express": [
+        *always_all_difficulties("Murder on the Owl Express", None, ["Battle of the Birds - Act 2", "Battle of the Birds - Act 3"]),
+    ],
+    "Time Rift - The Moon": [
+        *always_all_difficulties(["Picture Perfect", "The Big Parade"], None, ["Battle of the Birds - Act 4", "Battle of the Birds - Act 5"]),
+    ],
+    "Time Rift - Dead Bird Studio": [
+        *always_all_difficulties(["Dead Bird Studio", "Dead Bird Studio Basement"], [Items.relic_groups["Train"]]),
+    ],
+    "Time Rift - Pipe": [
+        *always_all_difficulties(MAIN_SUBCON_ACTS, [("Progressive Painting Unlock", "Progressive Painting Unlock")], "Subcon Forest - Act 2"),
+        *always_all_difficulties(MAIN_SUBCON_ACTS, None, "Subcon Forest - Act 2", min_difficulty="moderate", NoPaintingSkips=False),
+        always("Your Contract has Expired", None, "Subcon Forest - Act 2", LogicDifficulty="expert", NoPaintingSkips=False),
+    ],
+    "Time Rift - Village": [
+        *always_all_difficulties(MAIN_SUBCON_ACTS, [("Progressive Painting Unlock", "Progressive Painting Unlock")], "Subcon Forest - Act 4"),
+        *always_all_difficulties(MAIN_SUBCON_ACTS, None, "Subcon Forest - Act 4", min_difficulty="moderate", NoPaintingSkips=False),
+        always("Your Contract has Expired", None, "Subcon Forest - Act 4", LogicDifficulty="expert", NoPaintingSkips=False),
+    ],
+    "Time Rift - Sleepy Subcon": [
+        *always_all_difficulties(MAIN_SUBCON_ACTS, [(
+            "Progressive Painting Unlock",
+            "Progressive Painting Unlock",
+            "Progressive Painting Unlock",
+            *Items.relic_groups["UFO"],
+        )]),
+        *always_all_difficulties(MAIN_SUBCON_ACTS, [Items.relic_groups["UFO"]], min_difficulty="moderate", NoPaintingSkips=False),
+        always("Your Contract has Expired", [Items.relic_groups["UFO"]], LogicDifficulty="expert", NoPaintingSkips=False),
+    ],
+    # Access to the time rift is unlocked by completing The Windmill.
+    "Time Rift - Curly Tail Trail": [
+        *always_all_difficulties("Alpine Free Roam", [("Hookshot Badge", "Umbrella", "Zipline Unlock - The Windmill Path")]),
+        *always_all_difficulties("Alpine Free Roam", [("Hookshot Badge", "Zipline Unlock - The Windmill Path")], UmbrellaLogic=False),
+        *always_all_difficulties("Alpine Free Roam", [("Hookshot Badge", "Umbrella")], ShuffleAlpineZiplines=False),
+        *always_all_difficulties("Alpine Free Roam", "Hookshot Badge", UmbrellaLogic=False, ShuffleAlpineZiplines=False),
+        *never_all_difficulties("The Illness has Spread"),
+    ],
+    # Access to the time rift is unlocked by completing The Twilight Bell.
+    # The tests for "-> The Twilight Bell" and "Act Completion (The Twilight Bell)" go over more of the combinations of
+    # conditions that can reach the Act Completion.
+    "Time Rift - The Twilight Bell": [
+        # Copied from the "Act Completion (The Twilight Bell)" test:
+        *add_options(UmbrellaLogic=False, ShuffleAlpineZiplines=False, to=[
+            *always_all_difficulties("Alpine Free Roam", [("Hookshot Badge", "Dweller Mask")], max_difficulty="moderate"),
+            always("Alpine Free Roam", [("Hookshot Badge", "Dweller Mask")], LogicDifficulty="hard"),
+            always("Alpine Free Roam", [
+                ("Hookshot Badge", "Brewing Hat"),
+                ("Hookshot Badge", "Dweller Mask"),
+                ("Hookshot Badge", "Sprint Hat"),
+                # The Time Stop Hat + Umbrella option still requires Umbrella with Umbrella logic not enabled.
+                ("Hookshot Badge", "Umbrella", "Time Stop Hat"),
+            ], LogicDifficulty="expert"),
+        ]),
+        *never_all_difficulties("Alpine Free Roam", ["Zipline Unlock - The Twilight Bell Path", "Umbrella"]),
+        *never_all_difficulties("Alpine Free Roam", "Zipline Unlock - The Twilight Bell Path", UmbrellaLogic=False),
+        *never_all_difficulties("Alpine Free Roam", "Umbrella", ShuffleAlpineZiplines=False),
+        *never_all_difficulties("The Illness has Spread"),
+    ],
+    # The entrance to this Purple Time Rift was previously missing the Hookshot Badge and Umbrella (with umbrella logic)
+    # requirements when accessed from Alpine Free Roam.
+    "Time Rift - Alpine Skyline": [
+        *always_all_difficulties("Alpine Free Roam", [("Umbrella", "Hookshot Badge", *Items.relic_groups["Crayon"])]),
+        *always_all_difficulties("Alpine Free Roam", [("Hookshot Badge", *Items.relic_groups["Crayon"])], UmbrellaLogic=False),
+        *always_all_difficulties("The Illness has Spread", [Items.relic_groups["Crayon"]]),
+    ],
+    "Time Rift - Balcony": add_options(EnableDLC1=True, to=[
+        *always_all_difficulties("Cruise Ship", None, "The Arctic Cruise - Finale"),
+        *always_all_difficulties("Bon Voyage!", "Hookshot Badge", "The Arctic Cruise - Finale"),
+        *always_all_difficulties(["Ship Shape", "Rock the Boat"], None, "The Arctic Cruise - Finale"),
+    ]),
+    "Time Rift - Deep Sea": add_options(EnableDLC1=True, to=[
+        *always_all_difficulties("Bon Voyage!", [Items.relic_groups["Cake"]]),
+        *never_all_difficulties(["Ship Shape", "Rock the Boat"]),
+    ]),
+    "Time Rift - Rumbi Factory": add_options(EnableDLC2=True, to=[
+        *always_all_difficulties("Nyakuza Free Roam", [Items.relic_groups["Necklace"]]),
+        *never_all_difficulties("Rush Hour"),
+    ]),
+}
+
+ALL_TESTS: List[Tuple[SpotType, TestData]] = [
+    ("Location", LOCATION_TEST_DATA),
+    ("Location", DLC1_LOCATION_TEST_DATA),
+    ("Location", DLC2_LOCATION_TEST_DATA),
+    ("Location", DEATH_WISH_LOCATION_TEST_DATA),
+    ("Entrance", ENTRANCE_TEST_DATA),
+    ("Region", REGION_TEST_DATA),
+    ("Region", DLC2_REGION_TEST_DATA),
+    ("RandomizedRegion", RANDOMIZED_REGION_TEST_DATA),
+]

--- a/worlds/ahit/test/logic_test_data.py
+++ b/worlds/ahit/test/logic_test_data.py
@@ -81,9 +81,9 @@ RUSH_HOUR_TICKETS = {
 
 # Shorten test code by putting the TestConditions classmethods into the module globals.
 always = TestConditions.always
-always_all_difficulties = TestConditions.always_all_difficulties
+always_on_difficulties = TestConditions.always_on_difficulties
 never = TestConditions.never
-never_all_difficulties = TestConditions.never_all_difficulties
+never_on_difficulties = TestConditions.never_on_difficulties
 
 T = TypeVar("T", TestData, List[TestConditions])
 
@@ -106,75 +106,75 @@ LOCATION_TEST_DATA: TestData = {
     # Spaceship
     "Act Completion (Time Rift - Gallery)": [
         always("Time Rift - Gallery", "Brewing Hat"),
-        *always_all_difficulties("Time Rift - Gallery", min_difficulty="moderate"),
+        *always_on_difficulties("Time Rift - Gallery", min_difficulty="moderate"),
     ],
 
     # Chapter 1 - Mafia Town
     # The Mafia HQ platform is only reachable in acts that are chronologically after the start of Down with the Mafia!.
     "Mafia Town - Behind HQ Chest": [
         # todo: Expert logic could probably bucket hover up to the Mafia HQ platform.
-        *always_all_difficulties(["Down with the Mafia!", "Cheating the Race", "The Golden Vault"]),
+        *always_on_difficulties(["Down with the Mafia!", "Cheating the Race", "The Golden Vault"]),
         # The cannon to the platform is only activated once all the faucets have been turned off.
-        *always_all_difficulties("Heating Up Mafia Town", "Umbrella"),
-        *always_all_difficulties("Heating Up Mafia Town", UmbrellaLogic=False),
-        *never_all_difficulties(["Welcome to Mafia Town", "Barrel Battle", "She Came from Outer Space"]),
+        *always_on_difficulties("Heating Up Mafia Town", "Umbrella"),
+        *always_on_difficulties("Heating Up Mafia Town", UmbrellaLogic=False),
+        *never_on_difficulties(["Welcome to Mafia Town", "Barrel Battle", "She Came from Outer Space"]),
     ],
     # The Old Men are not present in She Came from Outer Space or Heating Up Mafia Town.
     ("Mafia Town - Old Man (Steel Beams)",
      "Mafia Town - Old Man (Seaside Spaghetti)"): [
-        *always_all_difficulties(MAFIA_TOWN_ACTS - {"She Came from Outer Space", "Heating Up Mafia Town"}),
-        *never_all_difficulties(["She Came from Outer Space", "Heating Up Mafia Town"]),
+        *always_on_difficulties(MAFIA_TOWN_ACTS - {"She Came from Outer Space", "Heating Up Mafia Town"}),
+        *never_on_difficulties(["She Came from Outer Space", "Heating Up Mafia Town"]),
     ],
     # This location is not present in She Came from Outer Space because the Time Piece is there instead.
     "Mafia Town - Mafia Geek Platform": [
-        *always_all_difficulties(MAFIA_TOWN_ACTS - {"She Came from Outer Space"}),
-        *never_all_difficulties("She Came from Outer Space"),
+        *always_on_difficulties(MAFIA_TOWN_ACTS - {"She Came from Outer Space"}),
+        *never_on_difficulties("She Came from Outer Space"),
     ],
     # This location is not present in Down with the Mafia! for some unknown reason.
     "Mafia Town - On Scaffolding": [
-        *always_all_difficulties(MAFIA_TOWN_ACTS - {"Down with the Mafia!"}),
-        *never_all_difficulties("Down with the Mafia!"),
+        *always_on_difficulties(MAFIA_TOWN_ACTS - {"Down with the Mafia!"}),
+        *never_on_difficulties("Down with the Mafia!"),
     ],
     # The brewing crate in the way is removed in Heating Up Mafia Town.
     "Mafia Town - Secret Cave": [
-        *always_all_difficulties(MAFIA_TOWN_ACTS - {"Heating Up Mafia Town"}, "Brewing Hat"),
-        *always_all_difficulties("Heating Up Mafia Town"),
+        *always_on_difficulties(MAFIA_TOWN_ACTS - {"Heating Up Mafia Town"}, "Brewing Hat"),
+        *always_on_difficulties("Heating Up Mafia Town"),
     ],
     # The lava is above sea level, so the player can bounce across the lava (and die) to reach this in Heating Up Mafia
     # Town.
     "Mafia Town - Above Boats": [
         always(MAFIA_TOWN_ACTS - {"Heating Up Mafia Town"}, "Hookshot Badge"),
         # Moderate logic can Ice Hat slide.
-        *always_all_difficulties(MAFIA_TOWN_ACTS - {"Heating Up Mafia Town"}, ["Hookshot Badge", "Ice Hat"], min_difficulty="moderate", max_difficulty="hard"),
+        *always_on_difficulties(MAFIA_TOWN_ACTS - {"Heating Up Mafia Town"}, ["Hookshot Badge", "Ice Hat"], min_difficulty="moderate", max_difficulty="hard"),
         # Expert can dive boost off a descending sloped roof to gain incredible speed, launching themselves to this
         # location from far away.
         always(MAFIA_TOWN_ACTS - {"Heating Up Mafia Town"}, LogicDifficulty="expert"),
-        *always_all_difficulties("Heating Up Mafia Town"),
+        *always_on_difficulties("Heating Up Mafia Town"),
     ],
     # This location was previously mistakenly not possible to access with Sprint Hat + Scooter Badge on Normal logic
     # difficulty with CTRLogic: scooter because the Scooter Badge was not being set to ItemClassification.progression.
     "Act Completion (Cheating the Race)": [
-        *always_all_difficulties("Cheating the Race", "Time Stop Hat"),
-        *always_all_difficulties("Cheating the Race", ["Time Stop Hat", ("Sprint Hat", "Scooter Badge")], CTRLogic="scooter"),
-        *always_all_difficulties("Cheating the Race", ["Time Stop Hat", "Sprint Hat"], CTRLogic="sprint"),
-        *always_all_difficulties("Cheating the Race", CTRLogic="nothing"),
+        *always_on_difficulties("Cheating the Race", "Time Stop Hat"),
+        *always_on_difficulties("Cheating the Race", ["Time Stop Hat", ("Sprint Hat", "Scooter Badge")], CTRLogic="scooter"),
+        *always_on_difficulties("Cheating the Race", ["Time Stop Hat", "Sprint Hat"], CTRLogic="sprint"),
+        *always_on_difficulties("Cheating the Race", CTRLogic="nothing"),
     ],
     # This location was previously mistakenly not having its moderate logic set.
     "Mafia Town - Clock Tower Chest": [
         always(MAFIA_TOWN_ACTS, "Hookshot Badge"),
-        *always_all_difficulties(MAFIA_TOWN_ACTS, min_difficulty="moderate"),
+        *always_on_difficulties(MAFIA_TOWN_ACTS, min_difficulty="moderate"),
     ],
     # This location was previously mistakenly not having its moderate logic set.
     "Mafia Town - Top of Ruined Tower": [
         always(MAFIA_TOWN_ACTS, "Ice Hat"),
-        *always_all_difficulties(MAFIA_TOWN_ACTS, min_difficulty="moderate"),
+        *always_on_difficulties(MAFIA_TOWN_ACTS, min_difficulty="moderate"),
     ],
     "Mafia Town - Top of Lighthouse": [
-        *always_all_difficulties(MAFIA_TOWN_ACTS, "Hookshot Badge", max_difficulty="hard"),
+        *always_on_difficulties(MAFIA_TOWN_ACTS, "Hookshot Badge", max_difficulty="hard"),
         always(MAFIA_TOWN_ACTS, LogicDifficulty="expert"),
     ],
     "Mafia Town - Hot Air Balloon": [
-        *always_all_difficulties(MAFIA_TOWN_ACTS, "Ice Hat", max_difficulty="hard"),
+        *always_on_difficulties(MAFIA_TOWN_ACTS, "Ice Hat", max_difficulty="hard"),
         always(MAFIA_TOWN_ACTS - {"Heating Up Mafia Town"}, LogicDifficulty="expert"),
         always("Heating Up Mafia Town", "Ice Hat", LogicDifficulty="expert"),
     ],
@@ -182,12 +182,12 @@ LOCATION_TEST_DATA: TestData = {
     # Chapter 2 - Battle of the Birds
     # Reaching the Post Elevator Area has a mix of requirements depending on UmbrellaLogic and LogicDifficulty.
     "Dead Bird Studio - Tightrope Chest": [
-        *always_all_difficulties("Dead Bird Studio", UmbrellaLogic=False),
-        *always_all_difficulties("Dead Bird Studio", ["Umbrella", "Brewing Hat"], max_difficulty="hard"),
+        *always_on_difficulties("Dead Bird Studio", UmbrellaLogic=False),
+        *always_on_difficulties("Dead Bird Studio", ["Umbrella", "Brewing Hat"], max_difficulty="hard"),
         always("Dead Bird Studio Basement", LogicDifficulty="expert", UmbrellaLogic=False),
         always(["Dead Bird Studio", "Dead Bird Studio Basement"], LogicDifficulty="expert"),
         # Access from Dead Bird Studio Basement is expert-only.
-        *never_all_difficulties("Dead Bird Studio Basement", max_difficulty="hard"),
+        *never_on_difficulties("Dead Bird Studio Basement", max_difficulty="hard"),
     ],
     # These locations are in the Post Elevator Area, but are after a fast moving platform controlled by a lever, which
     # results in slightly different requirements.
@@ -198,26 +198,26 @@ LOCATION_TEST_DATA: TestData = {
             # Umbrella/Brewing Hat is still required on Normal logic even with UmbrellaLogic=False because the platform
             # starts moving away before Hat Kid is finished recoiling in pain from punching the lever.
             always("Dead Bird Studio", ["Umbrella", "Brewing Hat"]),
-            *always_all_difficulties("Dead Bird Studio", min_difficulty="moderate"),
+            *always_on_difficulties("Dead Bird Studio", min_difficulty="moderate"),
             always("Dead Bird Studio Basement", LogicDifficulty="expert"),
             # Access from Dead Bird Studio Basement is expert-only.
-            *never_all_difficulties("Dead Bird Studio Basement", max_difficulty="hard"),
+            *never_on_difficulties("Dead Bird Studio Basement", max_difficulty="hard"),
         ]),
-        *always_all_difficulties("Dead Bird Studio", ["Umbrella", "Brewing Hat"], max_difficulty="hard"),
+        *always_on_difficulties("Dead Bird Studio", ["Umbrella", "Brewing Hat"], max_difficulty="hard"),
         # Expert can climb on top of the walls of the level to get past the gaps with moving platforms.
         always(["Dead Bird Studio", "Dead Bird Studio Basement"], LogicDifficulty="expert"),
         # Access from Dead Bird Studio Basement is expert-only.
-        *never_all_difficulties("Dead Bird Studio Basement", max_difficulty="hard"),
+        *never_on_difficulties("Dead Bird Studio Basement", max_difficulty="hard"),
     ],
     # This location is in the same area as above, but is only accessible in Dead Bird Studio, so must be tested
     # separately.
     "Act Completion (Dead Bird Studio)": [
         always("Dead Bird Studio", ["Umbrella", "Brewing Hat"], UmbrellaLogic=False),
-        *always_all_difficulties("Dead Bird Studio", min_difficulty="moderate", UmbrellaLogic=False),
+        *always_on_difficulties("Dead Bird Studio", min_difficulty="moderate", UmbrellaLogic=False),
         always("Dead Bird Studio", ["Umbrella", "Brewing Hat"]),
-        *always_all_difficulties("Dead Bird Studio", ["Umbrella", "Brewing Hat"], min_difficulty="moderate", max_difficulty="hard"),
+        *always_on_difficulties("Dead Bird Studio", ["Umbrella", "Brewing Hat"], min_difficulty="moderate", max_difficulty="hard"),
         always("Dead Bird Studio", LogicDifficulty="expert"),
-        *never_all_difficulties("Dead Bird Studio Basement"),
+        *never_on_difficulties("Dead Bird Studio Basement"),
     ],
     # Expert logic can clear Dead Bird Studio Basement without hookshot.
     ("Dead Bird Studio Basement - Window Platform",
@@ -228,7 +228,7 @@ LOCATION_TEST_DATA: TestData = {
      "Dead Bird Studio Basement - Cameras",
      "Dead Bird Studio Basement - Locked Room",
      "Act Completion (Dead Bird Studio Basement)"): [
-        *always_all_difficulties("Dead Bird Studio Basement", "Hookshot Badge", max_difficulty="hard"),
+        *always_on_difficulties("Dead Bird Studio Basement", "Hookshot Badge", max_difficulty="hard"),
         always("Dead Bird Studio Basement", LogicDifficulty="expert"),
     ],
 
@@ -236,14 +236,14 @@ LOCATION_TEST_DATA: TestData = {
     # This location was previously missing accessibility from Your Contract has Expired with no items.
     "Subcon Forest - Boss Arena Chest": [
         # Accessible with nothing from YCHE.
-        *always_all_difficulties("Your Contract has Expired"),
+        *always_on_difficulties("Your Contract has Expired"),
         # Normal logic can only access from YCHE and TOD.
-        *always_all_difficulties("Toilet of Doom", [("Hookshot Badge", "Progressive Painting Unlock")], max_difficulty="moderate"),
+        *always_on_difficulties("Toilet of Doom", [("Hookshot Badge", "Progressive Painting Unlock")], max_difficulty="moderate"),
         # Moderate logic and below can only access from YCHE and TOD.
-        *never_all_difficulties(MAIN_SUBCON_ACTS - {"Toilet of Doom"}, max_difficulty="moderate"),
+        *never_on_difficulties(MAIN_SUBCON_ACTS - {"Toilet of Doom"}, max_difficulty="moderate"),
 
         # Cherry bridge across the boss arena gap instead of needing to use Hookshot Badge in Toilet of Doom.
-        *always_all_difficulties(MAIN_SUBCON_ACTS, "Progressive Painting Unlock", min_difficulty="hard"),
+        *always_on_difficulties(MAIN_SUBCON_ACTS, "Progressive Painting Unlock", min_difficulty="hard"),
         # Hard logic cannot skip the boss firewall.
         always(MAIN_SUBCON_ACTS, "Progressive Painting Unlock", LogicDifficulty="hard", NoPaintingSkips=False),
 
@@ -252,18 +252,18 @@ LOCATION_TEST_DATA: TestData = {
         always(MAIN_SUBCON_ACTS, LogicDifficulty="expert", NoPaintingSkips=False),
         # Expert can Snatcher Hover to reach the act completion of YCHE, but this does not grant access to the boss
         # arena itself if logic does not allow painting skips.
-        *never_all_difficulties(MAIN_SUBCON_ACTS, "Progressive Painting Unlock"),
+        *never_on_difficulties(MAIN_SUBCON_ACTS, "Progressive Painting Unlock"),
     ],
     "Act Completion (Your Contract has Expired)": [
-        *always_all_difficulties("Your Contract has Expired", UmbrellaLogic=False),
-        *always_all_difficulties("Your Contract has Expired", "Umbrella", max_difficulty="hard"),
+        *always_on_difficulties("Your Contract has Expired", UmbrellaLogic=False),
+        *always_on_difficulties("Your Contract has Expired", "Umbrella", max_difficulty="hard"),
         # Expert can 'Snatcher Hover', skipping directly to the post-fight cutscene area.
         always("Your Contract has Expired", LogicDifficulty="expert"),
         # 'Snatcher Hover' also works from other Subcon Forest acts.
         always(MAIN_SUBCON_ACTS, LogicDifficulty="expert")
     ],
     "Act Completion (Toilet of Doom)": [
-        *always_all_difficulties("Toilet of Doom", [
+        *always_on_difficulties("Toilet of Doom", [
             ("Hookshot Badge", "Umbrella", "Progressive Painting Unlock"),
             ("Hookshot Badge", "Brewing Hat", "Progressive Painting Unlock")
         ]),
@@ -272,23 +272,23 @@ LOCATION_TEST_DATA: TestData = {
             ("Hookshot Badge", "Brewing Hat")
         ], LogicDifficulty="expert", NoPaintingSkips=False),
         # Expert logic is required to skip the boss firewall.
-        *never_all_difficulties("Toilet of Doom", "Progressive Painting Unlock", max_difficulty="hard", NoPaintingSkips=False)
+        *never_on_difficulties("Toilet of Doom", "Progressive Painting Unlock", max_difficulty="hard", NoPaintingSkips=False)
     ],
     # This location was previously missing the requirement to get past the boss firewall.
     "Subcon Village - Snatcher Statue Chest": [
-        *always_all_difficulties(MAIN_SUBCON_ACTS, "Progressive Painting Unlock"),
+        *always_on_difficulties(MAIN_SUBCON_ACTS, "Progressive Painting Unlock"),
         # Only expert logic can skip the boss firewall.
-        *always_all_difficulties(MAIN_SUBCON_ACTS, "Progressive Painting Unlock", max_difficulty="hard", NoPaintingSkips=False),
+        *always_on_difficulties(MAIN_SUBCON_ACTS, "Progressive Painting Unlock", max_difficulty="hard", NoPaintingSkips=False),
         always(MAIN_SUBCON_ACTS, LogicDifficulty="expert", NoPaintingSkips=False),
         # Expert can cherry hover across the boss arena gap in reverse. No paintings are needed because YCHE enters from
         # the boss arena, which is already behind the boss firewall.
         always("Your Contract has Expired", LogicDifficulty="expert"),
         # todo: Hard could probably cherry bridge across the boss arena gap in reverse.
-        *never_all_difficulties("Your Contract has Expired", max_difficulty="hard")
+        *never_on_difficulties("Your Contract has Expired", max_difficulty="hard")
     ],
     # Paintings can never be skipped for Contractual Obligations.
     "Act Completion (Contractual Obligations)": [
-        *never_all_difficulties("Contractual Obligations", "Progressive Painting Unlock", NoPaintingSkips=False),
+        *never_on_difficulties("Contractual Obligations", "Progressive Painting Unlock", NoPaintingSkips=False),
     ],
     # Moderate logic can reach all locations within Subcon Well with nothing.
     ("Subcon Well - Hookshot Badge Chest",
@@ -302,9 +302,9 @@ LOCATION_TEST_DATA: TestData = {
             ("Progressive Painting Unlock", "Umbrella"),
             ("Progressive Painting Unlock", "Brewing Hat"),
         ], NoPaintingSkips=False),
-        *always_all_difficulties("The Subcon Well", "Progressive Painting Unlock", UmbrellaLogic=False),
-        *always_all_difficulties("The Subcon Well", "Progressive Painting Unlock", min_difficulty="moderate"),
-        *always_all_difficulties("The Subcon Well", min_difficulty="moderate", NoPaintingSkips=False),
+        *always_on_difficulties("The Subcon Well", "Progressive Painting Unlock", UmbrellaLogic=False),
+        *always_on_difficulties("The Subcon Well", "Progressive Painting Unlock", min_difficulty="moderate"),
+        *always_on_difficulties("The Subcon Well", min_difficulty="moderate", NoPaintingSkips=False),
     ],
     ("Subcon Well - On Pipe",
      "Act Completion (The Subcon Well)"): [
@@ -319,8 +319,8 @@ LOCATION_TEST_DATA: TestData = {
         always("The Subcon Well", [
             ("Progressive Painting Unlock", "Hookshot Badge"),
         ], UmbrellaLogic=False),
-        *always_all_difficulties("The Subcon Well", "Progressive Painting Unlock", min_difficulty="moderate"),
-        *always_all_difficulties("The Subcon Well", min_difficulty="moderate", NoPaintingSkips=False),
+        *always_on_difficulties("The Subcon Well", "Progressive Painting Unlock", min_difficulty="moderate"),
+        *always_on_difficulties("The Subcon Well", min_difficulty="moderate", NoPaintingSkips=False),
     ],
     # Moderate logic can reach all locations within Queen Vanessa's Manor with nothing.
     ("Queen Vanessa's Manor - Cellar",
@@ -337,8 +337,8 @@ LOCATION_TEST_DATA: TestData = {
             ("Brewing Hat", "Progressive Painting Unlock"),
             ("Dweller Mask", "Progressive Painting Unlock")
         ], UmbrellaLogic=True),
-        *always_all_difficulties("Queen Vanessa's Manor", min_difficulty="moderate", UmbrellaLogic=True, NoPaintingSkips=False),
-        *always_all_difficulties("Queen Vanessa's Manor", "Progressive Painting Unlock", min_difficulty="moderate", UmbrellaLogic=True),
+        *always_on_difficulties("Queen Vanessa's Manor", min_difficulty="moderate", UmbrellaLogic=True, NoPaintingSkips=False),
+        *always_on_difficulties("Queen Vanessa's Manor", "Progressive Painting Unlock", min_difficulty="moderate", UmbrellaLogic=True),
     ],
     # Like the locations within Queen Vanessa's Manor, moderate logic can reach this location with nothing.
     "Subcon Forest - Manor Rooftop": [
@@ -350,85 +350,85 @@ LOCATION_TEST_DATA: TestData = {
             ("Brewing Hat", "Progressive Painting Unlock"),
             ("Dweller Mask", "Progressive Painting Unlock")
         ], UmbrellaLogic=True),
-        *always_all_difficulties(MAIN_SUBCON_ACTS, min_difficulty="moderate", UmbrellaLogic=False, NoPaintingSkips=False),
-        *always_all_difficulties(MAIN_SUBCON_ACTS, "Progressive Painting Unlock", min_difficulty="moderate", UmbrellaLogic=True),
+        *always_on_difficulties(MAIN_SUBCON_ACTS, min_difficulty="moderate", UmbrellaLogic=False, NoPaintingSkips=False),
+        *always_on_difficulties(MAIN_SUBCON_ACTS, "Progressive Painting Unlock", min_difficulty="moderate", UmbrellaLogic=True),
         # Expert can Cherry Hover over the boss arena gap from YCHE to reach the main Subcon Forest area.
         always("Your Contract has Expired", LogicDifficulty="expert", UmbrellaLogic=False, NoPaintingSkips=False),
-        *never_all_difficulties("Your Contract has Expired", max_difficulty="hard"),
+        *never_on_difficulties("Your Contract has Expired", max_difficulty="hard"),
     ],
     "Act Completion (Time Rift - Village)": [
-        *always_all_difficulties("Time Rift - Village", ["Brewing Hat", "Umbrella", "Dweller Mask"], max_difficulty="hard"),
+        *always_on_difficulties("Time Rift - Village", ["Brewing Hat", "Umbrella", "Dweller Mask"], max_difficulty="hard"),
         always("Time Rift - Village", ["Brewing Hat", "Umbrella", "Dweller Mask"], UmbrellaLogic=False),
         # Moderate logic can punch the first dweller bell in the time rift and then, at the final area, jump from the
         # top of the first dweller bell in that area, to the Time Piece.
-        *always_all_difficulties("Time Rift - Village", UmbrellaLogic=False, min_difficulty="moderate", max_difficulty="hard"),
+        *always_on_difficulties("Time Rift - Village", UmbrellaLogic=False, min_difficulty="moderate", max_difficulty="hard"),
         # Expert logic can skip needing to hit the first dweller bell in the time rift with a slingshot.
         always("Time Rift - Village", LogicDifficulty="expert"),
         always("Time Rift - Village", UmbrellaLogic=False, LogicDifficulty="expert"),
     ],
     ("Subcon Forest - Dweller Floating Rocks",
      "Subcon Forest - Dweller Platforming Tree B"): [
-        *always_all_difficulties(MAIN_SUBCON_ACTS, [("Dweller Mask",) + (("Progressive Painting Unlock",) * 3)], max_difficulty="moderate"),
+        *always_on_difficulties(MAIN_SUBCON_ACTS, [("Dweller Mask",) + (("Progressive Painting Unlock",) * 3)], max_difficulty="moderate"),
         # No Dweller Mask needed for Hard.
-        *always_all_difficulties(MAIN_SUBCON_ACTS, [("Progressive Painting Unlock",) * 3], min_difficulty="hard"),
-        *never_all_difficulties("Your Contract has Expired"),
+        *always_on_difficulties(MAIN_SUBCON_ACTS, [("Progressive Painting Unlock",) * 3], min_difficulty="hard"),
+        *never_on_difficulties("Your Contract has Expired"),
         *add_options(NoPaintingSkips=False, to=[
             always(MAIN_SUBCON_ACTS, [("Dweller Mask",) + (("Progressive Painting Unlock",) * 3)]),
             # Moderate can skip paintings.
             always(MAIN_SUBCON_ACTS, "Dweller Mask", LogicDifficulty="moderate"),
             # No Dweller Mask needed for Hard.
-            *always_all_difficulties(MAIN_SUBCON_ACTS, min_difficulty="hard"),
+            *always_on_difficulties(MAIN_SUBCON_ACTS, min_difficulty="hard"),
             # Only Expert can access from YCHE.
             always("Your Contract has Expired", LogicDifficulty="expert"),
-            *never_all_difficulties("Your Contract has Expired", max_difficulty="hard"),
+            *never_on_difficulties("Your Contract has Expired", max_difficulty="hard"),
         ]),
     ],
     "Subcon Forest - Noose Treehouse": [
-        *always_all_difficulties(MAIN_SUBCON_ACTS, [("Hookshot Badge",) + (("Progressive Painting Unlock",) * 2)], max_difficulty="moderate"),
-        *always_all_difficulties(MAIN_SUBCON_ACTS, [("Progressive Painting Unlock",) * 2], min_difficulty="hard"),
-        *never_all_difficulties("Your Contract has Expired"),
+        *always_on_difficulties(MAIN_SUBCON_ACTS, [("Hookshot Badge",) + (("Progressive Painting Unlock",) * 2)], max_difficulty="moderate"),
+        *always_on_difficulties(MAIN_SUBCON_ACTS, [("Progressive Painting Unlock",) * 2], min_difficulty="hard"),
+        *never_on_difficulties("Your Contract has Expired"),
         *add_options(NoPaintingSkips=False, to=[
             always(MAIN_SUBCON_ACTS, [("Hookshot Badge",) + (("Progressive Painting Unlock",) * 2)]),
             always(MAIN_SUBCON_ACTS, "Hookshot Badge", LogicDifficulty="moderate"),
-            *always_all_difficulties(MAIN_SUBCON_ACTS, min_difficulty="hard"),
+            *always_on_difficulties(MAIN_SUBCON_ACTS, min_difficulty="hard"),
             always("Your Contract has Expired", LogicDifficulty="expert"),
-            *never_all_difficulties("Your Contract has Expired", max_difficulty="hard"),
+            *never_on_difficulties("Your Contract has Expired", max_difficulty="hard"),
         ]),
     ],
     "Subcon Forest - Tall Tree Hookshot Swing": [
-        *always_all_difficulties(MAIN_SUBCON_ACTS, [("Hookshot Badge",) + (("Progressive Painting Unlock",) * 3)], max_difficulty="moderate"),
-        *always_all_difficulties(MAIN_SUBCON_ACTS, [("Progressive Painting Unlock",) * 3], min_difficulty="hard"),
-        *never_all_difficulties("Your Contract has Expired"),
+        *always_on_difficulties(MAIN_SUBCON_ACTS, [("Hookshot Badge",) + (("Progressive Painting Unlock",) * 3)], max_difficulty="moderate"),
+        *always_on_difficulties(MAIN_SUBCON_ACTS, [("Progressive Painting Unlock",) * 3], min_difficulty="hard"),
+        *never_on_difficulties("Your Contract has Expired"),
         *add_options(NoPaintingSkips=False, to=[
             always(MAIN_SUBCON_ACTS, [("Hookshot Badge",) + (("Progressive Painting Unlock",) * 3)]),
             always(MAIN_SUBCON_ACTS, "Hookshot Badge", LogicDifficulty="moderate"),
-            *always_all_difficulties(MAIN_SUBCON_ACTS, min_difficulty="hard"),
+            *always_on_difficulties(MAIN_SUBCON_ACTS, min_difficulty="hard"),
             always("Your Contract has Expired", LogicDifficulty="expert"),
-            *never_all_difficulties("Your Contract has Expired", max_difficulty="hard"),
+            *never_on_difficulties("Your Contract has Expired", max_difficulty="hard"),
         ]),
     ],
     "Subcon Forest - Long Tree Climb Chest": [
-        *always_all_difficulties(MAIN_SUBCON_ACTS, [("Dweller Mask",) + (("Progressive Painting Unlock",) * 2)], max_difficulty="moderate"),
-        *always_all_difficulties(MAIN_SUBCON_ACTS, [("Progressive Painting Unlock",) * 2], min_difficulty="hard"),
-        *never_all_difficulties("Your Contract has Expired"),
+        *always_on_difficulties(MAIN_SUBCON_ACTS, [("Dweller Mask",) + (("Progressive Painting Unlock",) * 2)], max_difficulty="moderate"),
+        *always_on_difficulties(MAIN_SUBCON_ACTS, [("Progressive Painting Unlock",) * 2], min_difficulty="hard"),
+        *never_on_difficulties("Your Contract has Expired"),
         *add_options(NoPaintingSkips=False, to=[
             always(MAIN_SUBCON_ACTS, [("Dweller Mask",) + (("Progressive Painting Unlock",) * 2)]),
             always(MAIN_SUBCON_ACTS, "Dweller Mask", LogicDifficulty="moderate"),
-            *always_all_difficulties(MAIN_SUBCON_ACTS, min_difficulty="hard"),
+            *always_on_difficulties(MAIN_SUBCON_ACTS, min_difficulty="hard"),
             always("Your Contract has Expired", LogicDifficulty="expert"),
-            *never_all_difficulties("Your Contract has Expired", max_difficulty="hard"),
+            *never_on_difficulties("Your Contract has Expired", max_difficulty="hard"),
         ]),
     ],
     "Subcon Forest - Magnet Badge Bush": [
-        *always_all_difficulties(MAIN_SUBCON_ACTS, [("Brewing Hat",) + (("Progressive Painting Unlock",) * 3)], max_difficulty="hard"),
+        *always_on_difficulties(MAIN_SUBCON_ACTS, [("Brewing Hat",) + (("Progressive Painting Unlock",) * 3)], max_difficulty="hard"),
         always(MAIN_SUBCON_ACTS, [("Progressive Painting Unlock",) * 3], LogicDifficulty="expert"),
-        *never_all_difficulties("Your Contract has Expired"),
+        *never_on_difficulties("Your Contract has Expired"),
         *add_options(NoPaintingSkips=False, to=[
             always(MAIN_SUBCON_ACTS, [("Brewing Hat",) + (("Progressive Painting Unlock",) * 3)]),
-            *always_all_difficulties(MAIN_SUBCON_ACTS, "Brewing Hat", max_difficulty="hard"),
+            *always_on_difficulties(MAIN_SUBCON_ACTS, "Brewing Hat", max_difficulty="hard"),
             always(MAIN_SUBCON_ACTS, LogicDifficulty="expert"),
             always("Your Contract has Expired", LogicDifficulty="expert"),
-            *never_all_difficulties("Your Contract has Expired", max_difficulty="hard"),
+            *never_on_difficulties("Your Contract has Expired", max_difficulty="hard"),
         ])
     ],
     # These locations were previous missing the requirement to get past the first firewall. The locations can be
@@ -437,57 +437,57 @@ LOCATION_TEST_DATA: TestData = {
     ("Snatcher's Contract - Toilet of Doom",
      "Snatcher's Contract - Queen Vanessa's Manor",
      "Snatcher's Contract - Mail Delivery Service"): [
-        *always_all_difficulties("Subcon Forest Area", "Progressive Painting Unlock"),
-        *always_all_difficulties("Subcon Forest Area", min_difficulty="moderate", NoPaintingSkips=False),
+        *always_on_difficulties("Subcon Forest Area", "Progressive Painting Unlock"),
+        *always_on_difficulties("Subcon Forest Area", min_difficulty="moderate", NoPaintingSkips=False),
     ],
     # This location looks similar to the above Contract locations, but should have separate rules.
     "Snatcher's Contract - The Subcon Well": [
-        *always_all_difficulties("Contractual Obligations"),
+        *always_on_difficulties("Contractual Obligations"),
         # This contract is only reachable from Contractual Obligations.
-        *never_all_difficulties(MAIN_SUBCON_ACTS - {"Contractual Obligations"}),
+        *never_on_difficulties(MAIN_SUBCON_ACTS - {"Contractual Obligations"}),
     ],
 
     # Chapter 4 - Alpine Skyline
     # No Brewing Hat needed for Moderate logic.
     "Alpine Skyline - Yellow Band Hills": [
         always("Alpine Free Roam", [("Umbrella", "Hookshot Badge", "Zipline Unlock - The Birdhouse Path", "Brewing Hat")]),
-        *always_all_difficulties("Alpine Free Roam", [("Umbrella", "Hookshot Badge", "Zipline Unlock - The Birdhouse Path")], min_difficulty="moderate"),
+        *always_on_difficulties("Alpine Free Roam", [("Umbrella", "Hookshot Badge", "Zipline Unlock - The Birdhouse Path")], min_difficulty="moderate"),
         always("The Illness has Spread", [("Hookshot Badge", "Zipline Unlock - The Birdhouse Path", "Brewing Hat")]),
-        *always_all_difficulties("The Illness has Spread", [("Hookshot Badge", "Zipline Unlock - The Birdhouse Path")], min_difficulty="moderate"),
+        *always_on_difficulties("The Illness has Spread", [("Hookshot Badge", "Zipline Unlock - The Birdhouse Path")], min_difficulty="moderate"),
         *add_options(UmbrellaLogic=False, to=[
             always(["Alpine Free Roam", "The Illness has Spread"], [("Hookshot Badge", "Zipline Unlock - The Birdhouse Path", "Brewing Hat")]),
-            *always_all_difficulties(["Alpine Free Roam", "The Illness has Spread"], [("Hookshot Badge", "Zipline Unlock - The Birdhouse Path")], min_difficulty="moderate"),
+            *always_on_difficulties(["Alpine Free Roam", "The Illness has Spread"], [("Hookshot Badge", "Zipline Unlock - The Birdhouse Path")], min_difficulty="moderate"),
         ]),
         *add_options(ShuffleAlpineZiplines=False, to=[
             always("Alpine Free Roam", [("Umbrella", "Hookshot Badge", "Brewing Hat")]),
-            *always_all_difficulties("Alpine Free Roam", [("Umbrella", "Hookshot Badge")], min_difficulty="moderate"),
+            *always_on_difficulties("Alpine Free Roam", [("Umbrella", "Hookshot Badge")], min_difficulty="moderate"),
             always("The Illness has Spread", [("Hookshot Badge", "Brewing Hat")]),
-            *always_all_difficulties("The Illness has Spread", "Hookshot Badge", min_difficulty="moderate"),
+            *always_on_difficulties("The Illness has Spread", "Hookshot Badge", min_difficulty="moderate"),
             *add_options(UmbrellaLogic=False, to=[
                 always(["Alpine Free Roam", "The Illness has Spread"], [("Hookshot Badge", "Brewing Hat")]),
-                *always_all_difficulties(["Alpine Free Roam", "The Illness has Spread"], "Hookshot Badge", min_difficulty="moderate"),
+                *always_on_difficulties(["Alpine Free Roam", "The Illness has Spread"], "Hookshot Badge", min_difficulty="moderate"),
             ]),
         ]),
     ],
     "Alpine Skyline - The Birdhouse: Dweller Platforms Relic": [
         always("The Birdhouse", "Dweller Mask"),
-        *always_all_difficulties("The Birdhouse", min_difficulty="moderate"),
+        *always_on_difficulties("The Birdhouse", min_difficulty="moderate"),
     ],
     # Moderate and above can void out to warp past the section that would otherwise require the Dweller Mask.
     "Alpine Skyline - The Twilight Path": [
         always("Alpine Free Roam", [("Umbrella", "Hookshot Badge", "Dweller Mask", "Zipline Unlock - The Twilight Bell Path")]),
-        *always_all_difficulties("Alpine Free Roam", [("Umbrella", "Hookshot Badge", "Zipline Unlock - The Twilight Bell Path")], min_difficulty="moderate"),
+        *always_on_difficulties("Alpine Free Roam", [("Umbrella", "Hookshot Badge", "Zipline Unlock - The Twilight Bell Path")], min_difficulty="moderate"),
         *add_options(UmbrellaLogic=False, to=[
             always("Alpine Free Roam", [("Hookshot Badge", "Dweller Mask", "Zipline Unlock - The Twilight Bell Path")]),
-            *always_all_difficulties("Alpine Free Roam", [("Hookshot Badge", "Zipline Unlock - The Twilight Bell Path")], min_difficulty="moderate"),
+            *always_on_difficulties("Alpine Free Roam", [("Hookshot Badge", "Zipline Unlock - The Twilight Bell Path")], min_difficulty="moderate"),
         ]),
-        *never_all_difficulties("The Illness has Spread"),
+        *never_on_difficulties("The Illness has Spread"),
         *add_options(ShuffleAlpineZiplines=False, to=[
             always("Alpine Free Roam", [("Umbrella", "Hookshot Badge", "Dweller Mask")]),
-            *always_all_difficulties("Alpine Free Roam", [("Umbrella", "Hookshot Badge")], min_difficulty="moderate"),
+            *always_on_difficulties("Alpine Free Roam", [("Umbrella", "Hookshot Badge")], min_difficulty="moderate"),
             *add_options(UmbrellaLogic=False, to=[
                 always("Alpine Free Roam", [("Hookshot Badge", "Dweller Mask")]),
-                *always_all_difficulties("Alpine Free Roam", "Hookshot Badge", min_difficulty="moderate"),
+                *always_on_difficulties("Alpine Free Roam", "Hookshot Badge", min_difficulty="moderate"),
             ]),
         ]),
     ],
@@ -497,39 +497,39 @@ LOCATION_TEST_DATA: TestData = {
             ("Umbrella", "Hookshot Badge", "Sprint Hat", "Zipline Unlock - The Lava Cake Path"),
             ("Umbrella", "Hookshot Badge", "Time Stop Hat", "Zipline Unlock - The Lava Cake Path")]),
         # No hats needed for moderate logic.
-        *always_all_difficulties("Alpine Free Roam", [("Umbrella", "Hookshot Badge", "Zipline Unlock - The Lava Cake Path")], min_difficulty="moderate"),
+        *always_on_difficulties("Alpine Free Roam", [("Umbrella", "Hookshot Badge", "Zipline Unlock - The Lava Cake Path")], min_difficulty="moderate"),
         *add_options(UmbrellaLogic=False, to=[
             always("Alpine Free Roam", [
                 ("Hookshot Badge", "Sprint Hat", "Zipline Unlock - The Lava Cake Path"),
                 ("Hookshot Badge", "Time Stop Hat", "Zipline Unlock - The Lava Cake Path")
             ]),
-            *always_all_difficulties("Alpine Free Roam", [("Hookshot Badge", "Zipline Unlock - The Lava Cake Path")], min_difficulty="moderate"),
+            *always_on_difficulties("Alpine Free Roam", [("Hookshot Badge", "Zipline Unlock - The Lava Cake Path")], min_difficulty="moderate"),
         ]),
         # The Zipline is blocked off in TIHS.
-        *never_all_difficulties("The Illness has Spread"),
+        *never_on_difficulties("The Illness has Spread"),
     ],
     "Alpine Skyline - Goat Refinery": [
         # There is no way to get past the Alpine Free Roam intro without these items, which provides enough to reach
         # the location once past the intro.
-        *always_all_difficulties("Alpine Free Roam", [("Hookshot Badge", "Umbrella")]),
-        *always_all_difficulties("Alpine Free Roam", "Hookshot Badge", UmbrellaLogic=False),
+        *always_on_difficulties("Alpine Free Roam", [("Hookshot Badge", "Umbrella")]),
+        *always_on_difficulties("Alpine Free Roam", "Hookshot Badge", UmbrellaLogic=False),
         # Normal logic cannot get this item from The Illness has Spread because the hookpoint is blocked and Normal
         # logic has no trick to reach the location without using the hookpoint.
         never("The Illness has Spread"),
         # Moderate logic can use Sprint Hat to cross the gap to Goat Refinery.
         always("The Illness has Spread", "Sprint Hat", LogicDifficulty="moderate"),
         # Hard logic can cross the gap with nothing.
-        *always_all_difficulties("The Illness has Spread", min_difficulty="hard"),
+        *always_on_difficulties("The Illness has Spread", min_difficulty="hard"),
     ],
     "Act Completion (Time Rift - The Twilight Bell)": [
-        *always_all_difficulties("Time Rift - The Twilight Bell", "Dweller Mask", max_difficulty="moderate"),
+        *always_on_difficulties("Time Rift - The Twilight Bell", "Dweller Mask", max_difficulty="moderate"),
         # Hard can jump around the Dweller wall with the Scooter.
         always("Time Rift - The Twilight Bell", ["Dweller Mask", ("Sprint Hat", "Scooter Badge")], LogicDifficulty="hard"),
         # Expert can jump around the Dweller wall with nothing.
         always("Time Rift - The Twilight Bell", LogicDifficulty="expert"),
     ],
     "Act Completion (Time Rift - Curly Tail Trail)": [
-        *always_all_difficulties("Time Rift - Curly Tail Trail", "Ice Hat", max_difficulty="moderate"),
+        *always_on_difficulties("Time Rift - Curly Tail Trail", "Ice Hat", max_difficulty="moderate"),
         # SDJ.
         always("Time Rift - Curly Tail Trail", ["Ice Hat", "Sprint Hat"], LogicDifficulty="hard"),
         # Slingshot.
@@ -539,17 +539,17 @@ LOCATION_TEST_DATA: TestData = {
     ("Alpine Skyline - Goat Outpost Horn",
      "Alpine Skyline - Windy Passage"): [
         *add_options(UmbrellaLogic=False, ShuffleAlpineZiplines=False, to=[
-            *always_all_difficulties("Alpine Free Roam", "Hookshot Badge"),
-            *always_all_difficulties("The Illness has Spread", "Hookshot Badge"),
+            *always_on_difficulties("Alpine Free Roam", "Hookshot Badge"),
+            *always_on_difficulties("The Illness has Spread", "Hookshot Badge"),
         ]),
-        *never_all_difficulties("Alpine Free Roam", ["Zipline Unlock - The Windmill Path", "Umbrella"]),
-        *never_all_difficulties("The Illness has Spread", "Zipline Unlock - The Windmill Path"),
-        *never_all_difficulties(["Alpine Free Roam", "The Illness has Spread"], "Zipline Unlock - The Windmill Path", UmbrellaLogic=False),
-        *never_all_difficulties("Alpine Free Roam", "Umbrella", ShuffleAlpineZiplines=False),
+        *never_on_difficulties("Alpine Free Roam", ["Zipline Unlock - The Windmill Path", "Umbrella"]),
+        *never_on_difficulties("The Illness has Spread", "Zipline Unlock - The Windmill Path"),
+        *never_on_difficulties(["Alpine Free Roam", "The Illness has Spread"], "Zipline Unlock - The Windmill Path", UmbrellaLogic=False),
+        *never_on_difficulties("Alpine Free Roam", "Umbrella", ShuffleAlpineZiplines=False),
     ],
     "Act Completion (The Twilight Bell)": [
         *add_options(UmbrellaLogic=False, ShuffleAlpineZiplines=False, to=[
-            *always_all_difficulties("Alpine Free Roam", [("Hookshot Badge", "Dweller Mask")], max_difficulty="moderate"),
+            *always_on_difficulties("Alpine Free Roam", [("Hookshot Badge", "Dweller Mask")], max_difficulty="moderate"),
             always("Alpine Free Roam", [("Hookshot Badge", "Dweller Mask")], LogicDifficulty="hard"),
             always("Alpine Free Roam", [
                 ("Hookshot Badge", "Brewing Hat"),
@@ -559,10 +559,10 @@ LOCATION_TEST_DATA: TestData = {
                 ("Hookshot Badge", "Umbrella", "Time Stop Hat"),
             ], LogicDifficulty="expert"),
         ]),
-        *never_all_difficulties("Alpine Free Roam", ["Zipline Unlock - The Twilight Bell Path", "Umbrella"]),
-        *never_all_difficulties("Alpine Free Roam", "Zipline Unlock - The Twilight Bell Path", UmbrellaLogic=False),
-        *never_all_difficulties("Alpine Free Roam", "Umbrella", ShuffleAlpineZiplines=False),
-        *never_all_difficulties("The Illness has Spread"),
+        *never_on_difficulties("Alpine Free Roam", ["Zipline Unlock - The Twilight Bell Path", "Umbrella"]),
+        *never_on_difficulties("Alpine Free Roam", "Zipline Unlock - The Twilight Bell Path", UmbrellaLogic=False),
+        *never_on_difficulties("Alpine Free Roam", "Umbrella", ShuffleAlpineZiplines=False),
+        *never_on_difficulties("The Illness has Spread"),
     ],
 
     # Chapter 5 - The Finale
@@ -570,7 +570,7 @@ LOCATION_TEST_DATA: TestData = {
         # No difficulties need Ice Hat.
         always("The Finale", [("Hookshot Badge", "Dweller Mask")]),
         # Moderate does not need Hookshot Badge.
-        *always_all_difficulties("The Finale", "Dweller Mask", min_difficulty="moderate"),
+        *always_on_difficulties("The Finale", "Dweller Mask", min_difficulty="moderate"),
     ],
 }
 
@@ -583,12 +583,12 @@ DLC1_LOCATION_TEST_DATA: TestData = add_options(EnableDLC1=True, to={
     # Rock the Boat gives access to the Cruise Ship region with no items required, but this location is not present in
     # Rock the Boat, so access to either Ship Shape or Bon Voyage! is required.
     "The Arctic Cruise - Toilet": [
-        *always_all_difficulties("Ship Shape"),
-        *always_all_difficulties("Bon Voyage!", "Hookshot Badge"),
+        *always_on_difficulties("Ship Shape"),
+        *always_on_difficulties("Bon Voyage!", "Hookshot Badge"),
         # Neither of these combinations of accessible regions can give access to the location without Hookshot Badge.
-        *never_all_difficulties([("Cruise Ship", "Bon Voyage!"), ("Rock the Boat", "Bon Voyage!")], "Hookshot Badge"),
+        *never_on_difficulties([("Cruise Ship", "Bon Voyage!"), ("Rock the Boat", "Bon Voyage!")], "Hookshot Badge"),
         # With all items, neither of these regions are enough to reach the location.
-        *never_all_difficulties(["Cruise Ship", "Rock the Boat"]),
+        *never_on_difficulties(["Cruise Ship", "Rock the Boat"]),
     ],
     # These locations were previously mistakenly not having their moderate logic set, due to using the wrong rule
     # function.
@@ -596,14 +596,14 @@ DLC1_LOCATION_TEST_DATA: TestData = add_options(EnableDLC1=True, to={
      "Act Completion (Rock the Boat)"): [
         always("Rock the Boat", "Ice Hat"),
         # Moderate can jump across the freezing water while taking damage.
-        *always_all_difficulties("Rock the Boat", min_difficulty="moderate"),
+        *always_on_difficulties("Rock the Boat", min_difficulty="moderate"),
     ],
     "Act Completion (Time Rift - Deep Sea)": [
         always("Time Rift - Deep Sea", [("Hookshot Badge", "Dweller Mask", "Ice Hat")]),
         # Moderate can reach enough Rift Pons without Ice Hat.
         always("Time Rift - Deep Sea", [("Hookshot Badge", "Dweller Mask")], LogicDifficulty="moderate"),
         # Hard can reach enough Rift Pons without either Ice Hat or Dweller Mask.
-        *always_all_difficulties("Time Rift - Deep Sea", "Hookshot Badge", min_difficulty="hard"),
+        *always_on_difficulties("Time Rift - Deep Sea", "Hookshot Badge", min_difficulty="hard"),
     ],
 })
 
@@ -612,7 +612,7 @@ DLC2_LOCATION_TEST_DATA: TestData = add_options(EnableDLC2=True, to={
     # Chapter 7 - Nyakuza Metro
     "Act Completion (Yellow Overpass Station)": [
         always(["Nyakuza Free Roam", "Yellow Overpass Station"], "Hookshot Badge"),
-        *always_all_difficulties(["Nyakuza Free Roam", "Yellow Overpass Station"], min_difficulty="moderate"),
+        *always_on_difficulties(["Nyakuza Free Roam", "Yellow Overpass Station"], min_difficulty="moderate"),
     ],
     "Pink Paw Station - Behind Fan": [
         # Tickets are always required with NoTicketSkips=True
@@ -620,7 +620,7 @@ DLC2_LOCATION_TEST_DATA: TestData = add_options(EnableDLC2=True, to={
             ("Metro Ticket - Blue", "Metro Ticket - Yellow", "Hookshot Badge", "Time Stop Hat", "Dweller Mask"),
             ("Metro Ticket - Pink", "Hookshot Badge", "Time Stop Hat", "Dweller Mask")]),
         # Only tickets required on moderate logic.
-        *always_all_difficulties("Nyakuza Free Roam", [
+        *always_on_difficulties("Nyakuza Free Roam", [
             ("Metro Ticket - Blue", "Metro Ticket - Yellow"),
             "Metro Ticket - Pink"
         ], min_difficulty="moderate"),
@@ -630,7 +630,7 @@ DLC2_LOCATION_TEST_DATA: TestData = add_options(EnableDLC2=True, to={
                 ("Metro Ticket - Blue", "Metro Ticket - Yellow", "Hookshot Badge", "Time Stop Hat", "Dweller Mask"),
                 ("Metro Ticket - Pink", "Hookshot Badge", "Time Stop Hat", "Dweller Mask")]),
             # Only tickets required on moderate logic.
-            *always_all_difficulties("Nyakuza Free Roam", [
+            *always_on_difficulties("Nyakuza Free Roam", [
                 ("Metro Ticket - Blue", "Metro Ticket - Yellow"),
                 "Metro Ticket - Pink"
             ], min_difficulty="moderate"),
@@ -641,7 +641,7 @@ DLC2_LOCATION_TEST_DATA: TestData = add_options(EnableDLC2=True, to={
                 ("Metro Ticket - Blue", "Metro Ticket - Yellow", "Hookshot Badge", "Time Stop Hat", "Dweller Mask"),
                 ("Metro Ticket - Pink", "Hookshot Badge", "Time Stop Hat", "Dweller Mask")]),
             # Moderate can wrongwarp into Pink Paw Station from Yellow Overpass Station, so requires nothing.
-            *always_all_difficulties("Nyakuza Free Roam", min_difficulty="moderate"),
+            *always_on_difficulties("Nyakuza Free Roam", min_difficulty="moderate"),
         ]),
     ],
     # This location was previously mistakenly not setting its ticket skips logic in Hard logic, so was acting as if
@@ -679,7 +679,7 @@ DLC2_LOCATION_TEST_DATA: TestData = add_options(EnableDLC2=True, to={
      "Green Clean Station Thug B - Item 3",
      "Green Clean Station Thug B - Item 4",
      "Green Clean Station Thug B - Item 5"): [
-        *always_all_difficulties("Nyakuza Free Roam", ["Ice Hat", "Metro Ticket - Yellow"])
+        *always_on_difficulties("Nyakuza Free Roam", ["Ice Hat", "Metro Ticket - Yellow"])
     ],
     # In the upper section of Pink Paw Station, so additionally requires Hookshot Badge + Dweller Mask.
     "Act Completion (Pink Paw Station)": [
@@ -688,21 +688,21 @@ DLC2_LOCATION_TEST_DATA: TestData = add_options(EnableDLC2=True, to={
             ("Metro Ticket - Yellow", "Metro Ticket - Blue", "Hookshot Badge", "Dweller Mask"),
         ]),
         # Hookshot Badge + Dweller Mask can be skipped using either wall jumps or the wrongwarp from Yellow Overpass.
-        *always_all_difficulties("Nyakuza Free Roam", [
+        *always_on_difficulties("Nyakuza Free Roam", [
             "Metro Ticket - Pink",
             ("Metro Ticket - Yellow", "Metro Ticket - Blue"),
         ], min_difficulty="moderate"),
-        *always_all_difficulties("Nyakuza Free Roam", min_difficulty="moderate", NoTicketSkips=False),
+        *always_on_difficulties("Nyakuza Free Roam", min_difficulty="moderate", NoTicketSkips=False),
     ],
     "Act Completion (Green Clean Manhole)": [
-        *always_all_difficulties("Nyakuza Free Roam", [("Ice Hat", "Dweller Mask")], max_difficulty="moderate"),
+        *always_on_difficulties("Nyakuza Free Roam", [("Ice Hat", "Dweller Mask")], max_difficulty="moderate"),
         # Hard can jump from the sign below the Dweller roof and wall jump to get on top of the Dweller roof.
         always("Nyakuza Free Roam", "Ice Hat", LogicDifficulty="hard"),
         # Boop Clip to get into the manhole area without entering the manhole.
         always("Nyakuza Free Roam", LogicDifficulty="expert"),
     ],
     "Act Completion (Yellow Overpass Manhole)": [
-        *always_all_difficulties("Nyakuza Free Roam", "Ice Hat", max_difficulty="hard"),
+        *always_on_difficulties("Nyakuza Free Roam", "Ice Hat", max_difficulty="hard"),
         # Boop Clip to get into the manhole area without entering the manhole.
         always("Nyakuza Free Roam", LogicDifficulty="expert"),
     ],
@@ -726,16 +726,16 @@ DEATH_WISH_LOCATION_TEST_DATA: TestData = add_options(**DEATH_WISH_OPTIONS, to={
     # Objective, which would incorrectly grant Bonus Stamps as soon as the Death Wish contract was unlocked.
     "Bonus Stamps - Beat the Heat": [
         # With Umbrella logic enabled, Umbrella is required to complete the Main Objective of Beat the Heat.
-        *always_all_difficulties("Beat the Heat", "Umbrella"),
-        *always_all_difficulties("Beat the Heat", "Umbrella", DWAutoCompleteBonuses=True),
-        *always_all_difficulties("Beat the Heat", "Umbrella", DWEnableBonus=False),
-        *always_all_difficulties("Beat the Heat", "Umbrella", DWEnableBonus=False, DWAutoCompleteBonuses=True),
+        *always_on_difficulties("Beat the Heat", "Umbrella"),
+        *always_on_difficulties("Beat the Heat", "Umbrella", DWAutoCompleteBonuses=True),
+        *always_on_difficulties("Beat the Heat", "Umbrella", DWEnableBonus=False),
+        *always_on_difficulties("Beat the Heat", "Umbrella", DWEnableBonus=False, DWAutoCompleteBonuses=True),
         # With Umbrella logic disabled, no items are required to complete the Main Objective of Beat the Heat.
         *add_options(UmbrellaLogic=False, to=[
-            *always_all_difficulties("Beat the Heat"),
-            *always_all_difficulties("Beat the Heat", DWAutoCompleteBonuses=True),
-            *always_all_difficulties("Beat the Heat", DWEnableBonus=False),
-            *always_all_difficulties("Beat the Heat", DWEnableBonus=False, DWAutoCompleteBonuses=True),
+            *always_on_difficulties("Beat the Heat"),
+            *always_on_difficulties("Beat the Heat", DWAutoCompleteBonuses=True),
+            *always_on_difficulties("Beat the Heat", DWEnableBonus=False),
+            *always_on_difficulties("Beat the Heat", DWEnableBonus=False, DWAutoCompleteBonuses=True),
         ]),
     ],
     # Camera Tourist
@@ -750,9 +750,9 @@ DEATH_WISH_LOCATION_TEST_DATA: TestData = add_options(**DEATH_WISH_OPTIONS, to={
     "Toilet - Toilet of Doom": [
         # The boss is behind the boss firewall, so Expert is the only difficulty that does not need the Progressive
         # Painting Unlock with NoPaitningSkips=False.
-        *always_all_difficulties("Toilet of Doom", [("Progressive Painting Unlock", "Hookshot Badge")], max_difficulty="moderate"),
+        *always_on_difficulties("Toilet of Doom", [("Progressive Painting Unlock", "Hookshot Badge")], max_difficulty="moderate"),
         # Hard logic can cherry bridge across the boss arena gap.
-        *always_all_difficulties("Toilet of Doom", "Progressive Painting Unlock", min_difficulty="hard"),
+        *always_on_difficulties("Toilet of Doom", "Progressive Painting Unlock", min_difficulty="hard"),
         always("Toilet of Doom", "Progressive Painting Unlock", LogicDifficulty="hard", NoPaintingSkips=False),
         always("Toilet of Doom", LogicDifficulty="expert", NoPaintingSkips=False),
     ],
@@ -760,8 +760,8 @@ DEATH_WISH_LOCATION_TEST_DATA: TestData = add_options(**DEATH_WISH_OPTIONS, to={
     # This location was previously missing the requirement to be able to complete Beat the Heat. The cannon to the HQ
     # platform only opens once all faucets have been turned off.
     "Snatcher Coin - Top of HQ (DW: BTH)": [
-        *always_all_difficulties("Beat the Heat", "Umbrella"),
-        *always_all_difficulties("Beat the Heat", UmbrellaLogic=False),
+        *always_on_difficulties("Beat the Heat", "Umbrella"),
+        *always_on_difficulties("Beat the Heat", UmbrellaLogic=False),
     ],
     # todo: Snatcher Coin - Swamp Tree and Snatcher Coin - Swamp Tree (Speedrun Well) should not need Hookshot on higher
     #  logic difficulties.
@@ -773,25 +773,25 @@ ENTRANCE_TEST_DATA: TestData = {
     # Chapter 3 - Subcon Forest
     # "Subcon Forest" is the name for the Chapter 3 telescope Region, it is not related to "Subcon Forest Area".
     "Subcon Forest - Act 2": [
-        *always_all_difficulties("Spaceship", [("Snatcher's Contract - The Subcon Well", *TEST_CHAPTER_TIMEPIECES[ChapterIndex.SUBCON])]),
-        *always_all_difficulties("Subcon Forest", "Snatcher's Contract - The Subcon Well"),
+        *always_on_difficulties("Spaceship", [("Snatcher's Contract - The Subcon Well", *TEST_CHAPTER_TIMEPIECES[ChapterIndex.SUBCON])]),
+        *always_on_difficulties("Subcon Forest", "Snatcher's Contract - The Subcon Well"),
     ],
     "Subcon Forest - Act 3": [
-        *always_all_difficulties("Spaceship", [("Snatcher's Contract - Toilet of Doom", *TEST_CHAPTER_TIMEPIECES[ChapterIndex.SUBCON])]),
-        *always_all_difficulties("Subcon Forest", "Snatcher's Contract - Toilet of Doom"),
+        *always_on_difficulties("Spaceship", [("Snatcher's Contract - Toilet of Doom", *TEST_CHAPTER_TIMEPIECES[ChapterIndex.SUBCON])]),
+        *always_on_difficulties("Subcon Forest", "Snatcher's Contract - Toilet of Doom"),
     ],
     "Subcon Forest - Act 4": [
-        *always_all_difficulties("Spaceship", [("Snatcher's Contract - Queen Vanessa's Manor", *TEST_CHAPTER_TIMEPIECES[ChapterIndex.SUBCON])]),
-        *always_all_difficulties("Subcon Forest", "Snatcher's Contract - Queen Vanessa's Manor"),
+        *always_on_difficulties("Spaceship", [("Snatcher's Contract - Queen Vanessa's Manor", *TEST_CHAPTER_TIMEPIECES[ChapterIndex.SUBCON])]),
+        *always_on_difficulties("Subcon Forest", "Snatcher's Contract - Queen Vanessa's Manor"),
     ],
     "Subcon Forest - Act 5": [
-        *always_all_difficulties("Spaceship", [("Snatcher's Contract - Mail Delivery Service", *TEST_CHAPTER_TIMEPIECES[ChapterIndex.SUBCON])]),
-        *always_all_difficulties("Subcon Forest", "Snatcher's Contract - Mail Delivery Service"),
+        *always_on_difficulties("Spaceship", [("Snatcher's Contract - Mail Delivery Service", *TEST_CHAPTER_TIMEPIECES[ChapterIndex.SUBCON])]),
+        *always_on_difficulties("Subcon Forest", "Snatcher's Contract - Mail Delivery Service"),
     ],
 
     # Chapter 4 - Alpine Skyline
     "Alpine Skyline - Finale": [
-        *never_all_difficulties("Alpine Skyline", [
+        *never_on_difficulties("Alpine Skyline", [
             "Zipline Unlock - The Birdhouse Path",
             "Zipline Unlock - The Lava Cake Path",
             "Zipline Unlock - The Windmill Path",
@@ -799,7 +799,7 @@ ENTRANCE_TEST_DATA: TestData = {
             "Umbrella",
             "Hookshot Badge",
         ]),
-        *never_all_difficulties("Alpine Skyline", [
+        *never_on_difficulties("Alpine Skyline", [
             "Zipline Unlock - The Birdhouse Path",
             "Zipline Unlock - The Lava Cake Path",
             "Zipline Unlock - The Windmill Path",
@@ -811,7 +811,7 @@ ENTRANCE_TEST_DATA: TestData = {
                 ("Hookshot Badge", "Brewing Hat", "Dweller Mask")
             ]),
             # Moderate does not need Brewing Hat for completing The Birdhouse.
-            *always_all_difficulties("Alpine Skyline", [
+            *always_on_difficulties("Alpine Skyline", [
                 ("Hookshot Badge", "Dweller Mask")
             ], min_difficulty="moderate", max_difficulty="hard"),
             # Expert has alternatives to Dweller Mask for completing The Twilight Bell.
@@ -829,16 +829,16 @@ ENTRANCE_TEST_DATA: TestData = {
 REGION_TEST_DATA: TestData = {
     # Spaceship
     "Mafia Town": [
-        *always_all_difficulties("Spaceship", [tuple(TEST_CHAPTER_TIMEPIECES[ChapterIndex.MAFIA])]),
+        *always_on_difficulties("Spaceship", [tuple(TEST_CHAPTER_TIMEPIECES[ChapterIndex.MAFIA])]),
     ],
     "Battle of the Birds": [
-        *always_all_difficulties("Spaceship", [tuple(TEST_CHAPTER_TIMEPIECES[ChapterIndex.BIRDS])]),
+        *always_on_difficulties("Spaceship", [tuple(TEST_CHAPTER_TIMEPIECES[ChapterIndex.BIRDS])]),
     ],
     "Subcon Forest": [
-        *always_all_difficulties("Spaceship", [tuple(TEST_CHAPTER_TIMEPIECES[ChapterIndex.SUBCON])]),
+        *always_on_difficulties("Spaceship", [tuple(TEST_CHAPTER_TIMEPIECES[ChapterIndex.SUBCON])]),
     ],
     "Alpine Skyline": [
-        *always_all_difficulties("Spaceship", [tuple(TEST_CHAPTER_TIMEPIECES[ChapterIndex.ALPINE])]),
+        *always_on_difficulties("Spaceship", [tuple(TEST_CHAPTER_TIMEPIECES[ChapterIndex.ALPINE])]),
     ],
     "Time's End": [
         # No difficulties need Ice Hat because the ceiling button can be reached by jumping from the top of the Dweller
@@ -846,7 +846,7 @@ REGION_TEST_DATA: TestData = {
         always("Spaceship", [("Dweller Mask", "Brewing Hat", *TEST_CHAPTER_TIMEPIECES[ChapterIndex.FINALE])]),
         # Moderate can alternatively bounce on a beach ball with the Ice Hat to get over the iron bars blocking access
         # to the telescope.
-        *always_all_difficulties("Spaceship", [
+        *always_on_difficulties("Spaceship", [
             ("Dweller Mask", "Brewing Hat", *TEST_CHAPTER_TIMEPIECES[ChapterIndex.FINALE]),
             ("Ice Hat", *TEST_CHAPTER_TIMEPIECES[ChapterIndex.FINALE])
         ], min_difficulty="moderate", max_difficulty="hard"),
@@ -854,12 +854,12 @@ REGION_TEST_DATA: TestData = {
     ],
     # The Chapter 6 and 7 doors are behind the Chapter 4 door.
     "The Arctic Cruise": [
-        *always_all_difficulties("Spaceship", [
+        *always_on_difficulties("Spaceship", [
             ("Time Piece",) * max(TEST_CHAPTER_TIMEPIECE_COSTS[ChapterIndex.ALPINE], TEST_CHAPTER_TIMEPIECE_COSTS[ChapterIndex.CRUISE]),
         ], EnableDLC1=True),
     ],
     "Nyakuza Metro": [
-        *always_all_difficulties("Spaceship", [
+        *always_on_difficulties("Spaceship", [
             (
                 "Dweller Mask",
                 "Ice Hat",
@@ -870,61 +870,61 @@ REGION_TEST_DATA: TestData = {
 
     # Chapter 3 - Subcon Forest
     "Subcon Forest Area": [
-        *always_all_difficulties(MAIN_SUBCON_ACTS),
+        *always_on_difficulties(MAIN_SUBCON_ACTS),
         # Expert can cherry hover from YCHE to the Subcon Forest Area.
         always("Your Contract has Expired", LogicDifficulty="expert", NoPaintingSkips=False),
         # Without painting skips, it is not possible to go from the Boss Arena to the Subcon Forest Area because the
         # paintings are on the other side of the boss firewall.
-        *never_all_difficulties("Your Contract has Expired"),
+        *never_on_difficulties("Your Contract has Expired"),
     ],
     "Your Contract has Expired - Post Fight": [
         # The entrance from YCHE must never have any requirements because its logic is not inherited by act connections.
-        *always_all_difficulties("Your Contract has Expired"),
+        *always_on_difficulties("Your Contract has Expired"),
         # Snatcher Hover.
         always(MAIN_SUBCON_ACTS, LogicDifficulty="expert"),
     ],
 
     "Alpine Skyline Area (TIHS)": [
-        *always_all_difficulties("Alpine Free Roam", [("Umbrella", "Hookshot Badge")]),
-        *always_all_difficulties("Alpine Free Roam", "Hookshot Badge", UmbrellaLogic=False),
-        *always_all_difficulties("The Illness has Spread"),
+        *always_on_difficulties("Alpine Free Roam", [("Umbrella", "Hookshot Badge")]),
+        *always_on_difficulties("Alpine Free Roam", "Hookshot Badge", UmbrellaLogic=False),
+        *always_on_difficulties("The Illness has Spread"),
     ],
     "The Birdhouse": [
         always("Alpine Skyline Area", [("Hookshot Badge", "Brewing Hat", "Zipline Unlock - The Birdhouse Path")]),
-        *always_all_difficulties("Alpine Skyline Area", [("Hookshot Badge", "Zipline Unlock - The Birdhouse Path")], min_difficulty="moderate"),
+        *always_on_difficulties("Alpine Skyline Area", [("Hookshot Badge", "Zipline Unlock - The Birdhouse Path")], min_difficulty="moderate"),
         always("Alpine Skyline Area", [("Hookshot Badge", "Brewing Hat")], ShuffleAlpineZiplines=False),
-        *always_all_difficulties("Alpine Skyline Area", "Hookshot Badge", min_difficulty="moderate", ShuffleAlpineZiplines=False),
-        *never_all_difficulties("The Illness has Spread"),
+        *always_on_difficulties("Alpine Skyline Area", "Hookshot Badge", min_difficulty="moderate", ShuffleAlpineZiplines=False),
+        *never_on_difficulties("The Illness has Spread"),
     ],
     "The Lava Cake": [
-        *always_all_difficulties("Alpine Skyline Area", [("Hookshot Badge", "Zipline Unlock - The Lava Cake Path")]),
-        *always_all_difficulties("Alpine Skyline Area", "Hookshot Badge", ShuffleAlpineZiplines=False),
-        *never_all_difficulties("The Illness has Spread"),
+        *always_on_difficulties("Alpine Skyline Area", [("Hookshot Badge", "Zipline Unlock - The Lava Cake Path")]),
+        *always_on_difficulties("Alpine Skyline Area", "Hookshot Badge", ShuffleAlpineZiplines=False),
+        *never_on_difficulties("The Illness has Spread"),
     ],
     "The Windmill": [
-        *always_all_difficulties("Alpine Skyline Area", [("Hookshot Badge", "Zipline Unlock - The Windmill Path")]),
-        *always_all_difficulties("Alpine Skyline Area", "Hookshot Badge", ShuffleAlpineZiplines=False),
-        *never_all_difficulties("The Illness has Spread"),
+        *always_on_difficulties("Alpine Skyline Area", [("Hookshot Badge", "Zipline Unlock - The Windmill Path")]),
+        *always_on_difficulties("Alpine Skyline Area", "Hookshot Badge", ShuffleAlpineZiplines=False),
+        *never_on_difficulties("The Illness has Spread"),
     ],
     "The Twilight Bell": [
-        *always_all_difficulties("Alpine Skyline Area", [("Hookshot Badge", "Dweller Mask", "Zipline Unlock - The Twilight Bell Path")], max_difficulty="hard"),
-        *always_all_difficulties("Alpine Skyline Area", [("Hookshot Badge", "Dweller Mask")], max_difficulty="hard", ShuffleAlpineZiplines=False),
+        *always_on_difficulties("Alpine Skyline Area", [("Hookshot Badge", "Dweller Mask", "Zipline Unlock - The Twilight Bell Path")], max_difficulty="hard"),
+        *always_on_difficulties("Alpine Skyline Area", [("Hookshot Badge", "Dweller Mask")], max_difficulty="hard", ShuffleAlpineZiplines=False),
         always("Alpine Skyline Area", [("Hookshot Badge", "Zipline Unlock - The Twilight Bell Path")], LogicDifficulty="expert"),
         always("Alpine Skyline Area", "Hookshot Badge", LogicDifficulty="expert", ShuffleAlpineZiplines=False),
-        *never_all_difficulties("The Illness has Spread"),
+        *never_on_difficulties("The Illness has Spread"),
     ],
 
     # Chapter 6 - The Arctic Cruise
     "Cruise Ship": add_options(EnableDLC1=True, to=[
-        *always_all_difficulties("Bon Voyage!", "Hookshot Badge"),
-        *always_all_difficulties(["Ship Shape", "Rock the Boat"]),
+        *always_on_difficulties("Bon Voyage!", "Hookshot Badge"),
+        *always_on_difficulties(["Ship Shape", "Rock the Boat"]),
     ]),
 
     # Other
     "Badge Seller": [
         # todo: Also accessible from some Death Wish contracts, e.g. Collect-a-thon, though this is rather obscure
         #  knowledge.
-        *always_all_difficulties([
+        *always_on_difficulties([
             *MAFIA_TOWN_ACTS,
             "Dead Bird Studio",
             "Picture Perfect",
@@ -934,94 +934,94 @@ REGION_TEST_DATA: TestData = {
             "Ship Shape",
             "Rock the Boat",
         ], EnableDLC1=True),
-        *always_all_difficulties("Bon Voyage!", "Hookshot Badge", EnableDLC1=True),
-        *always_all_difficulties("Alpine Free Roam", [("Hookshot Badge", "Umbrella")]),
-        *always_all_difficulties("Alpine Free Roam", "Hookshot Badge", UmbrellaLogic=False),
+        *always_on_difficulties("Bon Voyage!", "Hookshot Badge", EnableDLC1=True),
+        *always_on_difficulties("Alpine Free Roam", [("Hookshot Badge", "Umbrella")]),
+        *always_on_difficulties("Alpine Free Roam", "Hookshot Badge", UmbrellaLogic=False),
         # Needs painting skips because the boss firewall cannot be removed from the YCHE side.
         always("Your Contract has Expired", LogicDifficulty="expert", NoPaintingSkips=False),
-        *never_all_difficulties("Your Contract has Expired", NoPaintingSkips=True),
+        *never_on_difficulties("Your Contract has Expired", NoPaintingSkips=True),
     ],
 }
 
 DLC2_REGION_TEST_DATA: TestData = add_options(EnableDLC2=True, to={
     # Chapter 7 - Nyakuza Metro
     "Yellow Overpass Station": [
-        *always_all_difficulties("Nyakuza Free Roam")
+        *always_on_difficulties("Nyakuza Free Roam")
     ],
     "Green Clean Station": [
-        *always_all_difficulties("Nyakuza Free Roam")
+        *always_on_difficulties("Nyakuza Free Roam")
     ],
     "Pink Paw Station": [
-        *always_all_difficulties("Nyakuza Free Roam", [
+        *always_on_difficulties("Nyakuza Free Roam", [
             "Metro Ticket - Pink",
             ("Metro Ticket - Yellow", "Metro Ticket - Blue"),
         ]),
         # Wrongwarp from Yellow Overpass Station into Pink Paw Station.
-        *always_all_difficulties("Nyakuza Free Roam", min_difficulty="moderate", NoTicketSkips=False),
+        *always_on_difficulties("Nyakuza Free Roam", min_difficulty="moderate", NoTicketSkips=False),
     ],
     "Bluefin Tunnel": [
-        *always_all_difficulties("Nyakuza Free Roam", ["Metro Ticket - Green", "Metro Ticket - Blue"]),
+        *always_on_difficulties("Nyakuza Free Roam", ["Metro Ticket - Green", "Metro Ticket - Blue"]),
         # Ticket skips require Moderate logic, so tickets are still required with Normal logic.
         always("Nyakuza Free Roam", ["Metro Ticket - Green", "Metro Ticket - Blue"], NoTicketSkips=False),
         # Dive under the kill plane/box from the entrance to Yellow Overpass Station.
-        *always_all_difficulties("Nyakuza Free Roam", min_difficulty="moderate", NoTicketSkips=False),
+        *always_on_difficulties("Nyakuza Free Roam", min_difficulty="moderate", NoTicketSkips=False),
     ],
 })
 
 # Separated from region tests because these regions can be shuffled when act randomization is enabled.
 RANDOMIZED_REGION_TEST_DATA: TestData = {
     "Time Rift - Gallery": [
-        *always_all_difficulties("Spaceship", [("Brewing Hat", *TEST_CHAPTER_TIMEPIECES[ChapterIndex.BIRDS])]),
+        *always_on_difficulties("Spaceship", [("Brewing Hat", *TEST_CHAPTER_TIMEPIECES[ChapterIndex.BIRDS])]),
     ],
     "Time Rift - The Lab": [
-        *always_all_difficulties("Spaceship", [("Dweller Mask", *TEST_CHAPTER_TIMEPIECES[ChapterIndex.ALPINE])]),
+        *always_on_difficulties("Spaceship", [("Dweller Mask", *TEST_CHAPTER_TIMEPIECES[ChapterIndex.ALPINE])]),
     ],
     "Time Rift - Sewers": [
-        *always_all_difficulties(MAFIA_TOWN_ACTS, None, "Mafia Town - Act 4"),
+        *always_on_difficulties(MAFIA_TOWN_ACTS, None, "Mafia Town - Act 4"),
     ],
     "Time Rift - Bazaar": [
-        *always_all_difficulties(MAFIA_TOWN_ACTS, None, "Mafia Town - Act 6"),
+        *always_on_difficulties(MAFIA_TOWN_ACTS, None, "Mafia Town - Act 6"),
     ],
     "Time Rift - Mafia of Cooks": [
-        *always_all_difficulties(MAFIA_TOWN_ACTS - {"Heating Up Mafia Town"}, [Items.relic_groups["Burger"]]),
-        *never_all_difficulties("Heating Up Mafia Town"),
+        *always_on_difficulties(MAFIA_TOWN_ACTS - {"Heating Up Mafia Town"}, [Items.relic_groups["Burger"]]),
+        *never_on_difficulties("Heating Up Mafia Town"),
     ],
     "Time Rift - The Owl Express": [
-        *always_all_difficulties("Murder on the Owl Express", None, ["Battle of the Birds - Act 2", "Battle of the Birds - Act 3"]),
+        *always_on_difficulties("Murder on the Owl Express", None, ["Battle of the Birds - Act 2", "Battle of the Birds - Act 3"]),
     ],
     "Time Rift - The Moon": [
-        *always_all_difficulties(["Picture Perfect", "The Big Parade"], None, ["Battle of the Birds - Act 4", "Battle of the Birds - Act 5"]),
+        *always_on_difficulties(["Picture Perfect", "The Big Parade"], None, ["Battle of the Birds - Act 4", "Battle of the Birds - Act 5"]),
     ],
     "Time Rift - Dead Bird Studio": [
-        *always_all_difficulties(["Dead Bird Studio", "Dead Bird Studio Basement"], [Items.relic_groups["Train"]]),
+        *always_on_difficulties(["Dead Bird Studio", "Dead Bird Studio Basement"], [Items.relic_groups["Train"]]),
     ],
     "Time Rift - Pipe": [
-        *always_all_difficulties(MAIN_SUBCON_ACTS, [("Progressive Painting Unlock", "Progressive Painting Unlock")], "Subcon Forest - Act 2"),
-        *always_all_difficulties(MAIN_SUBCON_ACTS, None, "Subcon Forest - Act 2", min_difficulty="moderate", NoPaintingSkips=False),
+        *always_on_difficulties(MAIN_SUBCON_ACTS, [("Progressive Painting Unlock", "Progressive Painting Unlock")], "Subcon Forest - Act 2"),
+        *always_on_difficulties(MAIN_SUBCON_ACTS, None, "Subcon Forest - Act 2", min_difficulty="moderate", NoPaintingSkips=False),
         always("Your Contract has Expired", None, "Subcon Forest - Act 2", LogicDifficulty="expert", NoPaintingSkips=False),
     ],
     "Time Rift - Village": [
-        *always_all_difficulties(MAIN_SUBCON_ACTS, [("Progressive Painting Unlock", "Progressive Painting Unlock")], "Subcon Forest - Act 4"),
-        *always_all_difficulties(MAIN_SUBCON_ACTS, None, "Subcon Forest - Act 4", min_difficulty="moderate", NoPaintingSkips=False),
+        *always_on_difficulties(MAIN_SUBCON_ACTS, [("Progressive Painting Unlock", "Progressive Painting Unlock")], "Subcon Forest - Act 4"),
+        *always_on_difficulties(MAIN_SUBCON_ACTS, None, "Subcon Forest - Act 4", min_difficulty="moderate", NoPaintingSkips=False),
         always("Your Contract has Expired", None, "Subcon Forest - Act 4", LogicDifficulty="expert", NoPaintingSkips=False),
     ],
     "Time Rift - Sleepy Subcon": [
-        *always_all_difficulties(MAIN_SUBCON_ACTS, [(
+        *always_on_difficulties(MAIN_SUBCON_ACTS, [(
             "Progressive Painting Unlock",
             "Progressive Painting Unlock",
             "Progressive Painting Unlock",
             *Items.relic_groups["UFO"],
         )]),
-        *always_all_difficulties(MAIN_SUBCON_ACTS, [Items.relic_groups["UFO"]], min_difficulty="moderate", NoPaintingSkips=False),
+        *always_on_difficulties(MAIN_SUBCON_ACTS, [Items.relic_groups["UFO"]], min_difficulty="moderate", NoPaintingSkips=False),
         always("Your Contract has Expired", [Items.relic_groups["UFO"]], LogicDifficulty="expert", NoPaintingSkips=False),
     ],
     # Access to the time rift is unlocked by completing The Windmill.
     "Time Rift - Curly Tail Trail": [
-        *always_all_difficulties("Alpine Free Roam", [("Hookshot Badge", "Umbrella", "Zipline Unlock - The Windmill Path")]),
-        *always_all_difficulties("Alpine Free Roam", [("Hookshot Badge", "Zipline Unlock - The Windmill Path")], UmbrellaLogic=False),
-        *always_all_difficulties("Alpine Free Roam", [("Hookshot Badge", "Umbrella")], ShuffleAlpineZiplines=False),
-        *always_all_difficulties("Alpine Free Roam", "Hookshot Badge", UmbrellaLogic=False, ShuffleAlpineZiplines=False),
-        *never_all_difficulties("The Illness has Spread"),
+        *always_on_difficulties("Alpine Free Roam", [("Hookshot Badge", "Umbrella", "Zipline Unlock - The Windmill Path")]),
+        *always_on_difficulties("Alpine Free Roam", [("Hookshot Badge", "Zipline Unlock - The Windmill Path")], UmbrellaLogic=False),
+        *always_on_difficulties("Alpine Free Roam", [("Hookshot Badge", "Umbrella")], ShuffleAlpineZiplines=False),
+        *always_on_difficulties("Alpine Free Roam", "Hookshot Badge", UmbrellaLogic=False, ShuffleAlpineZiplines=False),
+        *never_on_difficulties("The Illness has Spread"),
     ],
     # Access to the time rift is unlocked by completing The Twilight Bell.
     # The tests for "-> The Twilight Bell" and "Act Completion (The Twilight Bell)" go over more of the combinations of
@@ -1029,7 +1029,7 @@ RANDOMIZED_REGION_TEST_DATA: TestData = {
     "Time Rift - The Twilight Bell": [
         # Copied from the "Act Completion (The Twilight Bell)" test:
         *add_options(UmbrellaLogic=False, ShuffleAlpineZiplines=False, to=[
-            *always_all_difficulties("Alpine Free Roam", [("Hookshot Badge", "Dweller Mask")], max_difficulty="moderate"),
+            *always_on_difficulties("Alpine Free Roam", [("Hookshot Badge", "Dweller Mask")], max_difficulty="moderate"),
             always("Alpine Free Roam", [("Hookshot Badge", "Dweller Mask")], LogicDifficulty="hard"),
             always("Alpine Free Roam", [
                 ("Hookshot Badge", "Brewing Hat"),
@@ -1039,30 +1039,30 @@ RANDOMIZED_REGION_TEST_DATA: TestData = {
                 ("Hookshot Badge", "Umbrella", "Time Stop Hat"),
             ], LogicDifficulty="expert"),
         ]),
-        *never_all_difficulties("Alpine Free Roam", ["Zipline Unlock - The Twilight Bell Path", "Umbrella"]),
-        *never_all_difficulties("Alpine Free Roam", "Zipline Unlock - The Twilight Bell Path", UmbrellaLogic=False),
-        *never_all_difficulties("Alpine Free Roam", "Umbrella", ShuffleAlpineZiplines=False),
-        *never_all_difficulties("The Illness has Spread"),
+        *never_on_difficulties("Alpine Free Roam", ["Zipline Unlock - The Twilight Bell Path", "Umbrella"]),
+        *never_on_difficulties("Alpine Free Roam", "Zipline Unlock - The Twilight Bell Path", UmbrellaLogic=False),
+        *never_on_difficulties("Alpine Free Roam", "Umbrella", ShuffleAlpineZiplines=False),
+        *never_on_difficulties("The Illness has Spread"),
     ],
     # The entrance to this Purple Time Rift was previously missing the Hookshot Badge and Umbrella (with umbrella logic)
     # requirements when accessed from Alpine Free Roam.
     "Time Rift - Alpine Skyline": [
-        *always_all_difficulties("Alpine Free Roam", [("Umbrella", "Hookshot Badge", *Items.relic_groups["Crayon"])]),
-        *always_all_difficulties("Alpine Free Roam", [("Hookshot Badge", *Items.relic_groups["Crayon"])], UmbrellaLogic=False),
-        *always_all_difficulties("The Illness has Spread", [Items.relic_groups["Crayon"]]),
+        *always_on_difficulties("Alpine Free Roam", [("Umbrella", "Hookshot Badge", *Items.relic_groups["Crayon"])]),
+        *always_on_difficulties("Alpine Free Roam", [("Hookshot Badge", *Items.relic_groups["Crayon"])], UmbrellaLogic=False),
+        *always_on_difficulties("The Illness has Spread", [Items.relic_groups["Crayon"]]),
     ],
     "Time Rift - Balcony": add_options(EnableDLC1=True, to=[
-        *always_all_difficulties("Cruise Ship", None, "The Arctic Cruise - Finale"),
-        *always_all_difficulties("Bon Voyage!", "Hookshot Badge", "The Arctic Cruise - Finale"),
-        *always_all_difficulties(["Ship Shape", "Rock the Boat"], None, "The Arctic Cruise - Finale"),
+        *always_on_difficulties("Cruise Ship", None, "The Arctic Cruise - Finale"),
+        *always_on_difficulties("Bon Voyage!", "Hookshot Badge", "The Arctic Cruise - Finale"),
+        *always_on_difficulties(["Ship Shape", "Rock the Boat"], None, "The Arctic Cruise - Finale"),
     ]),
     "Time Rift - Deep Sea": add_options(EnableDLC1=True, to=[
-        *always_all_difficulties("Bon Voyage!", [Items.relic_groups["Cake"]]),
-        *never_all_difficulties(["Ship Shape", "Rock the Boat"]),
+        *always_on_difficulties("Bon Voyage!", [Items.relic_groups["Cake"]]),
+        *never_on_difficulties(["Ship Shape", "Rock the Boat"]),
     ]),
     "Time Rift - Rumbi Factory": add_options(EnableDLC2=True, to=[
-        *always_all_difficulties("Nyakuza Free Roam", [Items.relic_groups["Necklace"]]),
-        *never_all_difficulties("Rush Hour"),
+        *always_on_difficulties("Nyakuza Free Roam", [Items.relic_groups["Necklace"]]),
+        *never_on_difficulties("Rush Hour"),
     ]),
 }
 

--- a/worlds/ahit/test/logic_test_helpers.py
+++ b/worlds/ahit/test/logic_test_helpers.py
@@ -143,13 +143,13 @@ class TestConditions(NamedTuple):
         return cls.new(False, access_regions, required_items, required_clearable_acts, options)
 
     @classmethod
-    def always_all_difficulties(cls,
-                                access_regions: Union[Iterable[Union[Iterable[str], str]], str, None],
-                                required_items: Union[Iterable[Union[Iterable[str], str]], str, None] = None,
-                                required_clearable_acts: Union[Iterable[str], str, None] = None,
-                                min_difficulty: Literal[None, "moderate", "hard", "expert"] = None,
-                                max_difficulty: Literal["normal", "moderate", "hard", None] = None,
-                                **options: Hashable) -> "List[TestConditions]":
+    def always_on_difficulties(cls,
+                               access_regions: Union[Iterable[Union[Iterable[str], str]], str, None],
+                               required_items: Union[Iterable[Union[Iterable[str], str]], str, None] = None,
+                               required_clearable_acts: Union[Iterable[str], str, None] = None,
+                               min_difficulty: Literal[None, "moderate", "hard", "expert"] = None,
+                               max_difficulty: Literal["normal", "moderate", "hard", None] = None,
+                               **options: Hashable) -> "List[TestConditions]":
         # Specifying a `min_difficulty` of "normal" or a `max_difficulty` of "expert" would be redundant, so they are
         # not present in the type hints and are chosen when no argument is provided.
         if min_difficulty is None:
@@ -163,7 +163,7 @@ class TestConditions(NamedTuple):
 
         conditions_list = []
         if "LogicDifficulty" in options:
-            raise RuntimeError("LogicDifficulty should not be provided when using always_all_difficulties, use the"
+            raise RuntimeError("LogicDifficulty should not be provided when using always_on_difficulties, use the"
                                " `min_difficulty` and `max_difficulty` arguments instead.")
         difficulties = ("normal", "moderate", "hard", "expert")
         start = difficulties.index(min_difficulty_)
@@ -183,15 +183,15 @@ class TestConditions(NamedTuple):
         return cls.new(True, access_regions, collect_all_but_items, required_clearable_acts, options)
 
     @classmethod
-    def never_all_difficulties(cls,
-                               access_regions: Union[Iterable[Union[Iterable[str], str]], str, None],
-                               collect_all_but_items: Union[Iterable[Union[Iterable[str], str]], str, None] = None,
-                               required_clearable_acts: Union[Iterable[str], str, None] = None,
-                               max_difficulty: Literal["normal", "moderate", "hard", "expert"] = "expert",
-                               **options: Hashable) -> "List[TestConditions]":
+    def never_on_difficulties(cls,
+                              access_regions: Union[Iterable[Union[Iterable[str], str]], str, None],
+                              collect_all_but_items: Union[Iterable[Union[Iterable[str], str]], str, None] = None,
+                              required_clearable_acts: Union[Iterable[str], str, None] = None,
+                              max_difficulty: Literal["normal", "moderate", "hard", "expert"] = "expert",
+                              **options: Hashable) -> "List[TestConditions]":
         conditions_list = []
         if "LogicDifficulty" in options:
-            raise RuntimeError("LogicDifficulty should not be provided when using never_all_difficulties, use the"
+            raise RuntimeError("LogicDifficulty should not be provided when using never_on_difficulties, use the"
                                "`max_difficulty` argument instead.")
         for difficulty in ("normal", "moderate", "hard", "expert"):
             conditions = cls.never(access_regions, collect_all_but_items, required_clearable_acts,

--- a/worlds/ahit/test/logic_test_helpers.py
+++ b/worlds/ahit/test/logic_test_helpers.py
@@ -1,0 +1,274 @@
+from contextlib import contextmanager
+from typing import Literal, Union, Dict, Hashable, NamedTuple, cast, Sequence, Iterable, Tuple, List
+
+from .. import HatInTimeWorld, Regions
+from .. import Rules as HatInTimeRules
+from BaseClasses import Location, Entrance, Region, CollectionState
+from worlds.generic import World
+from worlds.generic.Rules import set_rule
+
+from . import HatInTimeTestBase
+
+SpotType = Literal["Location", "Entrance", "Region", "RandomizedRegion"]
+"""String used to identify the type of a spot."""
+Spot = Union[Location, Entrance, Region]
+# For grouping purposes, all option values must currently be hashable.
+TestOptions = Dict[str, Hashable]
+
+
+class SpotData(NamedTuple):
+    """SpotType and the name of the spot."""
+    type: SpotType
+    name: str
+
+    def get_spot(self, world: HatInTimeWorld) -> Spot:
+        spot_type = self.type
+        if spot_type == "Location":
+            return world.get_location(self.name)
+        elif spot_type == "Entrance":
+            return world.get_entrance(self.name)
+        elif spot_type == "Region":
+            return world.get_region(self.name)
+        elif spot_type == "RandomizedRegion":
+            return world.get_region(Regions.get_region_shuffled_to(world, self.name))
+        else:
+            raise AssertionError(f"'{spot_type}' is not a valid spot type")
+
+    def unrandomize(self, test_base: HatInTimeTestBase) -> "SpotData":
+        if self.type != "RandomizedRegion":
+            raise TypeError(f"Only RandomizedRegion can be unrandomized, but got {self}")
+        world = cast(HatInTimeWorld, test_base.world)
+        return SpotData("Region", Regions.get_region_shuffled_to(world, self.name))
+
+
+def block_access_rule(state: CollectionState):
+    """
+    Simple access rule used to block access to locations and entrances and avoid creating lots of `lambda state: False`.
+    """
+    return False
+
+
+def block_access(spot: Union[Location, Entrance]):
+    """Small helper to block access to a location or entrance."""
+    set_rule(spot, block_access_rule)
+
+
+class TestConditions(NamedTuple):
+    """The test conditions to set up for a SpotTest"""
+
+    possible_items: Sequence[Sequence[str]]
+    """
+    The spot should be inaccessible without all of the required items, and accessible with any one subsequence of
+    required items.
+    """
+
+    access_regions: Sequence[Sequence[str]]
+    """
+    The spot should be accessible with any one of the subsequences of Regions, and all Regions within a subsequence
+    should be required.
+
+    This is slightly different from possible_items because there cannot be duplicate Regions. 
+    """
+
+    options: TestOptions
+    """
+    World options to use during the subtest.
+
+    Each unique dictionary of options results in a new test world being set up.
+
+    Non-hashable option values are not currently supported.
+    """
+
+    required_clearable_acts: Sequence[str]
+    """
+    The spot should be inaccessible without all of these required acts being clearable.
+
+    These requirements are only used for act entrances within telescopes and for time rift entrances.
+
+    There are no cases where there are multiple different sets of required clearable acts that would each give access,
+    so this is a flat sequence, unlike the other conditions.
+
+    See `Rules.act_connections` and `Rules.set_rift_rules()`/`Rules.set_default_rift_rules()`, or directly see use of
+    `Rules.can_clear_required_act()`.
+    """
+
+    negative: bool = False
+    """
+    When True, tests for a spot being unreachable with the given access regions and all items, except for each set of
+    items to collect.
+
+    Tests that check for spots being accessible already check that the spot is unreachable if one of the
+    required items is missing, so this bool is more useful for testing that specific region and/or option combinations
+    are insufficient to reach a spot even with all items.
+    """
+
+    @staticmethod
+    def parse_strings(strings: Union[Iterable[Union[Iterable[str], str]], str, None]) -> Sequence[Tuple[str, ...]]:
+        """
+        Helper that parses inputs strings in a mix of formats into a sequence of tuples of strings.
+        s1 -> [(s1,)]
+        [s1, s2, s3] -> [(s1,), (s2,), (s3,)]
+        [s1, [s2, s3]] ->  [(s1,), (s2, s3)]
+        [[s1, s2, s3]] -> [(s1, s2, s3)]
+        """
+        if strings is None:
+            return []
+        if isinstance(strings, str):
+            return [(strings,)]
+        return [(s,) if isinstance(s, str) else tuple(s) for s in strings]
+
+    @classmethod
+    def new(cls,
+            negative: bool,
+            access_regions: Union[Iterable[Union[Iterable[str], str]], str, None],
+            required_items: Union[Iterable[Union[Iterable[str], str]], str, None],
+            required_clearable_acts: Union[Iterable[str], str, None],
+            options: TestOptions) -> "TestConditions":
+        possible_items = cls.parse_strings(required_items)
+        access_regions = cls.parse_strings(access_regions)
+        if required_clearable_acts is None:
+            required_clearable_acts = ()
+        elif isinstance(required_clearable_acts, str):
+            required_clearable_acts = (required_clearable_acts,)
+        else:
+            required_clearable_acts = tuple(required_clearable_acts)
+        return cls(possible_items, access_regions, options, required_clearable_acts, negative)
+
+    @classmethod
+    def always(cls,
+               access_regions: Union[Iterable[Union[Iterable[str], str]], str, None],
+               required_items: Union[Iterable[Union[Iterable[str], str]], str, None] = None,
+               required_clearable_acts: Union[Iterable[str], str, None] = None,
+               **options: Hashable):
+        return cls.new(False, access_regions, required_items, required_clearable_acts, options)
+
+    @classmethod
+    def always_all_difficulties(cls,
+                                access_regions: Union[Iterable[Union[Iterable[str], str]], str, None],
+                                required_items: Union[Iterable[Union[Iterable[str], str]], str, None] = None,
+                                required_clearable_acts: Union[Iterable[str], str, None] = None,
+                                min_difficulty: Literal[None, "moderate", "hard", "expert"] = None,
+                                max_difficulty: Literal["normal", "moderate", "hard", None] = None,
+                                **options: Hashable) -> "List[TestConditions]":
+        # Specifying a `min_difficulty` of "normal" or a `max_difficulty` of "expert" would be redundant, so they are
+        # not present in the type hints and are chosen when no argument is provided.
+        if min_difficulty is None:
+            min_difficulty_ = "normal"
+        else:
+            min_difficulty_ = min_difficulty
+        if max_difficulty is None:
+            max_difficulty_ = "expert"
+        else:
+            max_difficulty_ = max_difficulty
+
+        conditions_list = []
+        if "LogicDifficulty" in options:
+            raise RuntimeError("LogicDifficulty should not be provided when using always_all_difficulties, use the"
+                               " `min_difficulty` and `max_difficulty` arguments instead.")
+        difficulties = ("normal", "moderate", "hard", "expert")
+        start = difficulties.index(min_difficulty_)
+        end = difficulties.index(max_difficulty_)
+        for difficulty in difficulties[start:end+1]:
+            conditions = cls.always(access_regions, required_items, required_clearable_acts, LogicDifficulty=difficulty,
+                                    **options)
+            conditions_list.append(conditions)
+        return conditions_list
+
+    @classmethod
+    def never(cls,
+              access_regions: Union[Iterable[Union[Iterable[str], str]], str, None],
+              collect_all_but_items: Union[Iterable[Union[Iterable[str], str]], str, None] = None,
+              required_clearable_acts: Union[Iterable[str], str, None] = None,
+              **options: Hashable):
+        return cls.new(True, access_regions, collect_all_but_items, required_clearable_acts, options)
+
+    @classmethod
+    def never_all_difficulties(cls,
+                               access_regions: Union[Iterable[Union[Iterable[str], str]], str, None],
+                               collect_all_but_items: Union[Iterable[Union[Iterable[str], str]], str, None] = None,
+                               required_clearable_acts: Union[Iterable[str], str, None] = None,
+                               max_difficulty: Literal["normal", "moderate", "hard", "expert"] = "expert",
+                               **options: Hashable) -> "List[TestConditions]":
+        conditions_list = []
+        if "LogicDifficulty" in options:
+            raise RuntimeError("LogicDifficulty should not be provided when using never_all_difficulties, use the"
+                               "`max_difficulty` argument instead.")
+        for difficulty in ("normal", "moderate", "hard", "expert"):
+            conditions = cls.never(access_regions, collect_all_but_items, required_clearable_acts,
+                                   LogicDifficulty=difficulty, **options)
+            conditions_list.append(conditions)
+            if difficulty == max_difficulty:
+                break
+        return conditions_list
+
+
+TestDataKey = Union[str, Tuple[str, ...]]
+TestDataValue = List[TestConditions]
+TestData = Dict[TestDataKey, TestDataValue]
+
+
+@contextmanager
+def mock_region_access(world: World, region_name: str):
+    """
+    Context manager that temporarily grants access to the given region and revokes access when exiting the context.
+    """
+    origin_region = world.get_region(world.origin_region_name)
+    target_region = world.get_region(region_name)
+    new_entrance = origin_region.connect(target_region)
+    try:
+        yield
+    finally:
+        origin_region.exits.remove(new_entrance)
+        target_region.entrances.remove(new_entrance)
+        # There should not be anything that can still use the entrance after is has been removed, but block access
+        # to be extra sure.
+        block_access(new_entrance)
+
+
+@contextmanager
+def mock_no_region_access(world: World, region_name: str):
+    """
+    Context manager that blocks all entrances to the given region and unblocks the entrances when exiting the
+    context.
+    """
+    target_region = world.get_region(region_name)
+    entrances = []
+    for entrance in target_region.entrances:
+        # Store the old access rule.
+        entrances.append((entrance, entrance.access_rule))
+        block_access(entrance)
+    try:
+        yield
+    finally:
+        # Restore the old access rules.
+        for entrance, access_rule in entrances:
+            entrance.access_rule = access_rule
+
+
+@contextmanager
+def mock_can_clear_acts(act_names: Iterable[str]):
+    original = HatInTimeRules.can_clear_required_act
+
+    act_names = set(act_names)
+
+    def replacement(state: CollectionState, world: HatInTimeWorld, act_entrance: str) -> bool:
+        return act_entrance in act_names
+
+    HatInTimeRules.can_clear_required_act = replacement
+    try:
+        yield
+    finally:
+        # Restore the old function.
+        HatInTimeRules.can_clear_required_act = original
+
+
+@contextmanager
+def mock_can_clear_all_acts():
+    original = HatInTimeRules.can_clear_required_act
+
+    HatInTimeRules.can_clear_required_act = lambda state, world, act_entrance: True
+    try:
+        yield
+    finally:
+        # Restore the old function.
+        HatInTimeRules.can_clear_required_act = original

--- a/worlds/ahit/test/test_logic.py
+++ b/worlds/ahit/test/test_logic.py
@@ -1,0 +1,457 @@
+from collections import Counter, defaultdict
+from functools import cache
+import logging
+from typing import (
+    Iterable, Dict, List, Tuple, Hashable, cast, Type, FrozenSet, NamedTuple, Optional, Union, Callable, Collection, Set
+)
+from contextlib import ExitStack
+
+from BaseClasses import CollectionState, Item, Location
+from Options import Option
+
+from . import HatInTimeTestBase
+from ..Rules import act_connections
+from .. import HatInTimeWorld
+
+from .logic_test_helpers import (
+    block_access, Spot, SpotData, TestOptions, TestConditions,
+    mock_region_access, mock_no_region_access, mock_can_clear_acts, mock_can_clear_all_acts
+)
+from . import logic_test_data
+
+
+UniqueTestOptionsKey = FrozenSet[Tuple[str, Hashable]]
+
+
+class SpotTest(NamedTuple):
+    """A list of spots to test reachability and the test conditions to set up."""
+    spots: List[SpotData]
+    conditions: TestConditions
+
+
+class TestSpotLogic(HatInTimeTestBase):
+    """
+    Tests the logic of various AHiT Locations/Entrances/Regions.
+
+    All kinds of spot are tested together to minimise the number of worlds that have to be set up to test all the
+    different option combinations.
+    """
+    # Do not run default tests.
+    run_default_tests = False
+    # Do not set up a default world.
+    auto_construct = False
+
+    # Some commonly looked up values are cached for better test performance.
+    _cached_item_from_pool_lookup: Optional[Dict[str, List[Item]]]
+    cached_spot_lookup: Callable[[SpotData], Spot]
+    cached_filled_advancements: List[Location]
+    cached_advancements_in_pool: List[Item]
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.cached_filled_advancements = []
+        self.cached_advancements_in_pool = []
+        del self.cached_item_pool_advancement_lookup
+
+        def dummy_cached_get_spot(spot_data: SpotData):
+            raise RuntimeError("cached_spot_lookup called before world_setup")
+
+        self.cached_spot_lookup = dummy_cached_get_spot
+
+    def tearDown(self) -> None:
+        # Must be cleared before `super().tearDown()` because `super().tearDown()` checks for not having leaked the
+        # world/multiworld. `cached_spot_lookup` stores Location/Entrance/Region instances, which reference the
+        # MultiWorld and `cached_item_pool_advancement_lookup` stores Item instances which can reference Location
+        # instances.
+        del self.cached_spot_lookup
+        del self.cached_item_pool_advancement_lookup
+        self.cached_advancements_in_pool = []
+        self.cached_filled_advancements = []
+        super().tearDown()
+
+    @property
+    def cached_item_pool_advancement_lookup(self):
+        """
+        Tests frequently need to collect advancement items from the item pool, so these are found from the pool in
+        advance and cached into a dictionary by item name.
+        """
+        from_pool_lookup = self._cached_item_from_pool_lookup
+        if from_pool_lookup is None:
+            from_pool_lookup = defaultdict(list)
+            from_pool_lookup.clear()
+            for item in self.cached_advancements_in_pool:
+                from_pool_lookup[item.name].append(item)
+            self._cached_item_from_pool_lookup = from_pool_lookup
+        return from_pool_lookup
+
+    @cached_item_pool_advancement_lookup.deleter
+    def cached_item_pool_advancement_lookup(self):
+        self._cached_item_from_pool_lookup = None
+
+    # TODO: Use special items in the tests that represent the time pieces for a specific chapter and swap them out the
+    #  special items for the correct number of time pieces during the test.
+    def world_setup(self, seed: Optional[int] = None) -> None:
+        """
+        In addition to the standard world setup:
+
+        Removes the usual accessibility to regions by blocking connections. This enables testing logic starting from a
+        specific region being accessible.
+        - Blocks all connections from the origin region.
+        - Blocks all connections to the origin region.
+        - Blocks all connections between telescope acts ('act connections').
+
+        Sets chapter costs to pre-determined values. This keeps the test data simpler because the test data can include
+        the pre-determined number of Time Pieces for chapter access instead of needing to set the Time Pieces in test
+        data dynamically after world setup is complete.
+
+        Sets/resets cached lookups that are specific to the newly created world.
+        """
+        super().world_setup(seed)
+
+        # The item pool lookup may not be needed, so is cached automatically when accessed. To ensure there is no old
+        # data in the cache, it is cleared here.
+        del self.cached_item_pool_advancement_lookup
+
+        world = cast(HatInTimeWorld, self.world)
+
+        # Cache filled locations so that there is no need to check all locations each time filled locations are needed.
+        self.cached_filled_advancements = [loc for loc in world.multiworld.get_locations(world.player)
+                                           if loc.advancement]
+        # Cache advancement items
+        self.cached_advancements_in_pool = [item for item in self.multiworld.itempool if item.advancement]
+
+        # Create a cached spot lookup for the current world instance. This particularly helps with looking up
+        # randomized regions because looking up randomized regions is an inefficient operation.
+        @cache
+        def get_spot(spot_data_: SpotData):
+            return spot_data_.get_spot(world)
+
+        self.cached_spot_lookup = get_spot
+
+        origin_region = world.get_region(world.origin_region_name)
+
+        # Block all connections from the origin region.
+        for entrance in list(origin_region.exits):
+            block_access(entrance)
+
+        # Remove all connections to the origin region.
+        for entrance in list(origin_region.entrances):
+            block_access(entrance)
+
+        # Remove all act connections to avoid gaining access to an act we are not testing, from an act we are testing.
+        # e.g. Chapter 1 Act 1 has a connection to Acts 2 and 3 because completing Act 1 unlocks Acts 2 and 3. If state
+        # is able to reach the Chapter 1 Act 1 entrance and is able to reach the Act Completion location of the act/rift
+        # placed at Chapter 1 Act 1, then the entrances to Act 2 and 3, from Act 1, are accessible.
+        # Note: This does not remove connections to Time Rifts, but with act randomization disabled, Time Rifts are
+        # always dead ends.
+        for key, acts in act_connections.items():
+            if key.startswith("The Arctic Cruise") and not world.options.EnableDLC1:
+                continue
+            for i, act in enumerate(acts, start=1):
+                entrance_name: str = f"{key}: Connection {i}"
+                entrance = world.get_entrance(entrance_name)
+                block_access(entrance)
+
+        # Overwrite chapter costs to fixed values so that TestData can contain pre-determined numbers of required Time
+        # Pieces when testing logic that requires entering a chapter door.
+        costs = world.chapter_timepiece_costs
+        for chapter_index, cost in logic_test_data.TEST_CHAPTER_TIMEPIECE_COSTS.items():
+            costs[chapter_index] = cost
+
+    def get_items_by_name_counts(self, item_names: Union[str, Iterable[str]]) -> List[Item]:
+        """
+        Returns actual items from the itempool that match the provided name(s), but only as many of each as are present
+        in `item_names`
+        """
+        if isinstance(item_names, str):
+            item_names = (item_names,)
+        names_counter = Counter(item_names)
+        items = []
+        from_pool_lookup = self.cached_item_pool_advancement_lookup
+        for name, count in names_counter.items():
+            items.extend(from_pool_lookup[name][:count])
+        return items
+
+    def assertAccessDependencyPoolOnlyExtended(self,
+                                               spot: Spot,
+                                               possible_items: Collection[Iterable[str]]) -> None:
+        """
+        Asserts that the provided location can only be reached with any one of the provided combinations of items.
+
+        Extended from WorldTestBase.assertAccessDependency to also check that any one item missing from a provided
+        combination should result in the location being unreachable.
+
+        Modified to only collect items from the item pool and then sweep, rather than collecting all items from both the
+        item pool and filled locations that are not in `possible_items`. Collecting all items from filled locations
+        would also pick up unreachable event items that AHiT uses to signify access to a specific region. Collecting
+        these event items when their locations are unreachable would make it impossible to test some conditions that
+        should be able to reach a provided location.
+        """
+        # Collect everything from the pool except the items being tested, and then sweep.
+        all_items = [item_name for item_names in possible_items for item_name in item_names]
+        all_items_set = set(all_items)
+        state = CollectionState(self.multiworld)
+        self.collect_all_from_pool_but_and_sweep(all_items_set, state)
+
+        # Assert that the location is unreachable without any of the sets of items that should be required to reach it.
+        self.assertFalse(spot.can_reach(state), f"{spot.name} should not be reachable without some of {all_items}")
+
+        for item_names in possible_items:
+            items = self.get_items_by_name_counts(item_names)
+            expected_item_counts = Counter(item_names)
+            actual_item_counts = Counter(item.name for item in items)
+            self.assertEqual(actual_item_counts, expected_item_counts,
+                             "Fewer items existed in the item pool than expected.")
+
+            # Collect all of these possible items into a state.
+            state_with_all = state.copy()
+            for item in items:
+                state_with_all.collect(item, prevent_sweep=True)
+
+            # Assert that the location is reachable with all of these items from the item pool.
+            test_state = state_with_all.copy()
+            # For better test performance, only sweep if needed.
+            if not spot.can_reach(test_state):
+                test_state.sweep_for_advancements(self.cached_filled_advancements)
+                self.assertTrue(spot.can_reach(test_state), f"{spot.name} should be reachable with {item_names}")
+
+            # Assert that the location is unreachable if any one of the items is missing.
+            for i in range(len(items)):
+                state_missing_one = state_with_all.copy()
+                skipped_item = items[i]
+                state_missing_one.remove(skipped_item)
+                state_missing_one.sweep_for_advancements(self.cached_filled_advancements)
+                self.assertFalse(spot.can_reach(state_missing_one), f"{spot.name} should not be reachable without"
+                                                                    f" {skipped_item.name}")
+
+    def collect_all_from_pool_but_and_sweep(self, item_names: Union[str, Iterable[str]],
+                                            state: CollectionState) -> None:
+        """
+        Collect all items from the item pool whose names are not in `item_names` and then sweep to pick up placed
+        locations.
+
+        The main purpose of this function is as a replacement for WorldTestBase.collect_all_but() that does not collect
+        unreachable event items for cases where logic checks for state having collected an event item placed in a region
+        rather than checking for access to that region.
+        """
+        if isinstance(item_names, str):
+            item_name: str = item_names
+            for item in self.cached_advancements_in_pool:
+                if item.name != item_name and item.advancement:
+                    state.collect(item, prevent_sweep=True)
+        else:
+            item_names = set(item_names)
+            if item_names:
+                for item in self.cached_advancements_in_pool:
+                    if item.name not in item_names and item.advancement:
+                        state.collect(item, prevent_sweep=True)
+            else:
+                # Collect every advancement item.
+                for item in self.cached_advancements_in_pool:
+                    if item.advancement:
+                        state.collect(item, prevent_sweep=True)
+        # Only sweep once at the end for performance.
+        state.sweep_for_advancements(self.cached_filled_advancements)
+
+    def inaccessible_spot_test(self, spot: Spot, possible_items: Collection[Iterable[str]],
+                               access_regions: Iterable[str], required_clearable_acts: Iterable[str] = ()) -> None:
+        """
+        Test that with access to the given regions, and any of the sets of possible items, the location is inaccessible.
+        """
+        with ExitStack() as exit_stack:
+            # Grant access to all the specified regions. Other regions that these regions connect to may indirectly
+            # become accessible.
+            for region in access_regions:
+                exit_stack.enter_context(mock_region_access(self.world, region))
+
+            # Mark all the specified acts as clearable.
+            exit_stack.enter_context(mock_can_clear_acts(required_clearable_acts))
+
+            if possible_items:
+                # For each set of items collected into a state, test that the location is unreachable.
+                for item_names in possible_items:
+                    state = CollectionState(self.multiworld)
+                    self.collect_all_from_pool_but_and_sweep(item_names, state)
+                    self.assertFalse(spot.can_reach(state), f"{spot.name} should not be reachable with everything but"
+                                                            f" {item_names}")
+            else:
+                # There are no sets of items, so test that the location in unreachable even with all items.
+                state = CollectionState(self.multiworld)
+                self.collect_all_from_pool_but_and_sweep((), state)
+                self.assertFalse(spot.can_reach(state), f"{spot.name} should not be reachable with no items")
+
+    def spot_test(self, spot: Spot, possible_items: Collection[Iterable[str]],
+                  required_regions: Iterable[str], required_clearable_acts: Iterable[str] = ()) -> None:
+        # Check that even with all items and all acts clearable, if any required region is inaccessible, the location is
+        # unreachable.
+        with mock_can_clear_all_acts():
+            required_regions = list(required_regions)
+            for i in range(len(required_regions)):
+                skipped_region = required_regions[i]
+                with ExitStack() as exit_stack:
+                    # Ensure the skipped region is inaccessible by temporarily blocking all entrances that connect to it.
+                    exit_stack.enter_context(mock_no_region_access(self.world, skipped_region))
+                    for j, region in enumerate(required_regions):
+                        if j != i:
+                            exit_stack.enter_context(mock_region_access(self.world, region))
+                    state = CollectionState(self.multiworld)
+                    self.collect_all_from_pool_but_and_sweep((), state)
+                    self.assertFalse(spot.can_reach(state), f"{spot.name} should not be reachable without access to"
+                                                            f" region {skipped_region}")
+
+        with ExitStack() as exit_stack:
+            for region in required_regions:
+                exit_stack.enter_context(mock_region_access(self.world, region))
+
+            # Check that with all required regions, that each of the required clearable acts are required
+            required_clearable_acts = list(required_clearable_acts)
+            if required_clearable_acts:
+                for i in range(len(required_clearable_acts)):
+                    skipped = required_clearable_acts[i]
+                    acts = required_clearable_acts.copy()
+                    del acts[i]
+                    with mock_can_clear_acts(acts):
+                        state = CollectionState(self.multiworld)
+                        self.collect_all_from_pool_but_and_sweep((), state)
+                        self.assertFalse(spot.can_reach(state), f"{spot.name} should not be reachable without being"
+                                                                f" able to complete act {skipped}")
+
+                # Now that it is confirmed that each required clearable act is indeed required, temporarily consider
+                # them all clearable while checking the items.
+                exit_stack.enter_context(mock_can_clear_acts(required_clearable_acts))
+
+            # Finally, now that it is confirmed that each of the required regions and required clearable acts are
+            # required, check that each sequence of possible items is required.
+            if possible_items:
+                self.assertAccessDependencyPoolOnlyExtended(spot, possible_items)
+            else:
+                # The location should be reachable with just access to the regions. No items from the item pool are
+                # required.
+                state = CollectionState(self.multiworld)
+                # For better test performance, only sweep if needed.
+                if not spot.can_reach(state):
+                    state.sweep_for_advancements(self.cached_filled_advancements)
+                    self.assertTrue(spot.can_reach(state), f"{spot.name} should be reachable without any items")
+
+        # The location should be inaccessible with all items, but no region access.
+        state = CollectionState(self.multiworld)
+        self.collect_all_from_pool_but_and_sweep((), state)
+        self.assertFalse(spot.can_reach(state))
+
+    def validate_options(self, options_tests_pairs: Iterable[Tuple[TestOptions, List[SpotTest]]]):
+        # Validate that each option exists and has a valid value.
+        ahit_options_type_hints: Dict[str, Type[Option]] = HatInTimeWorld.options_dataclass.type_hints
+        all_ahit_option_keys = ahit_options_type_hints.keys()
+        already_checked_options: Set[Tuple[str, Hashable]] = set()
+        for options, tests in options_tests_pairs:
+            option_keys = set(options.keys())
+            invalid_options = option_keys.difference(all_ahit_option_keys)
+            if invalid_options:
+                self.fail(f"No such options {sorted(invalid_options)} for tests {tests}")
+            failed_options = []
+            for option_pair in options.items():
+                if option_pair in already_checked_options:
+                    continue
+                option_key, option_value = option_pair
+                option_type = ahit_options_type_hints[option_key]
+                try:
+                    option_type.from_any(option_value)
+                except KeyError:
+                    failed_options.append(dict(option_key=option_key, option_value=option_value))
+                already_checked_options.add(option_pair)
+            if failed_options:
+                self.fail(f"Could not parse option values for {failed_options} for tests {tests}")
+
+    @staticmethod
+    def get_grouped_test_data() -> Iterable[Tuple[TestOptions, List[SpotTest]]]:
+        """
+        Group test data by unique sets of options.
+
+        Grouping by options reduces the number of worlds that must be set up to run the tests because each unique set of
+        options can share a single world.
+        """
+        options_key_to_options_tests_pairs: Dict[UniqueTestOptionsKey, Tuple[TestOptions, List[SpotTest]]] = {}
+        base_options = logic_test_data.BASE_WORLD_OPTIONS
+        test_spots: List[SpotData]
+        for spot_type, test_data in logic_test_data.ALL_TESTS:
+            for locations_raw, conditions_list in test_data.items():
+                if isinstance(locations_raw, str):
+                    test_spots = [SpotData(spot_type, locations_raw)]
+                else:
+                    test_spots = [SpotData(spot_type, loc) for loc in locations_raw]
+                for conditions in conditions_list:
+                    options = {k: v for k, v in conditions.options.items() if base_options.get(k) != v}
+                    if spot_type == "RandomizedRegion":
+                        # Run the test with each act randomization option.
+                        for act_rando in ("false", "light", "insanity"):
+                            if base_options.get("ActRandomizer") != act_rando:
+                                act_rando_options = options.copy()
+                                options.update(dict(ActRandomizer=act_rando))
+                            else:
+                                # Not going to modify, so no need to copy.
+                                act_rando_options = options
+                            options_key = frozenset(act_rando_options.items())
+                            spot_tests = options_key_to_options_tests_pairs.setdefault(options_key, (act_rando_options, []))[1]
+                            spot_tests.append(SpotTest(test_spots, conditions))
+                    else:
+                        options_key = frozenset(options.items())
+                        spot_tests = options_key_to_options_tests_pairs.setdefault(options_key, (options, []))[1]
+                        spot_tests.append(SpotTest(test_spots, conditions))
+        return options_key_to_options_tests_pairs.values()
+
+    def test_spot_logic(self) -> None:
+        tests_by_options = self.get_grouped_test_data()
+
+        # Validate that all the supplied options exist and have valid values.
+        self.validate_options(tests_by_options)
+
+        for options, tests in tests_by_options:
+            combined_options = logic_test_data.BASE_WORLD_OPTIONS.copy()
+            combined_options.update(options)
+
+            # Update the options that will be used when setting up the world.
+            # super().world_setup() creates the world using self.options.
+            self.options = combined_options
+            self.world_setup()
+            world = cast(HatInTimeWorld, self.world)
+
+            with self.subTest(seed=self.multiworld.seed, test_options=options):
+                for spot_test in tests:
+                    conditions = spot_test.conditions
+                    access_regions = conditions.access_regions
+                    required_clearable_acts = conditions.required_clearable_acts
+                    for spot_data in spot_test.spots:
+                        spot = self.cached_spot_lookup(spot_data)
+                        spot_type = spot_data.type
+                        spot_identifier: Union[str, Dict[str, str]]
+                        if spot_type == "RandomizedRegion":
+                            spot_identifier = dict(original=spot_data.name, randomized=spot.name)
+                        else:
+                            spot_identifier = spot_data.name
+                        spot_info = {spot_type: spot_identifier}
+                        with self.subTest(clearable_acts=required_clearable_acts, **spot_info):
+                            for access_region_list in access_regions:
+                                if (spot_type == "RandomizedRegion"
+                                        and world.options.ActRandomizer
+                                        and spot.name in access_region_list):
+                                    # Act rando placed a region, that we're intending to start with access to, at the
+                                    # randomized region, giving immediate or partial access.
+                                    # For example, when we want to test being able to go from "Welcome to Mafia Town" to
+                                    # what has been randomized at the "Time Rift - Bazaar" entrance, but when
+                                    # "Welcome to Mafia Town" is the act that has been randomized to that entrance.
+                                    #
+                                    # skipTest() within the subTest() skips the entire test with pytest, so just log
+                                    # this and continue.
+                                    logging.warning("Act randomization placed the entry point region '%s' at the"
+                                                    " randomized act/rift '%s' being tested, so the subtest has been"
+                                                    " skipped.", spot.name, spot_data.name)
+                                    continue
+                                with self.subTest(access_regions=access_region_list):
+                                    if conditions.negative:
+                                        collect_all_but_items = conditions.possible_items
+                                        self.inaccessible_spot_test(spot, collect_all_but_items, access_region_list,
+                                                                    required_clearable_acts)
+                                    else:
+                                        required_items = conditions.possible_items
+                                        self.spot_test(spot, required_items, access_region_list,
+                                                       required_clearable_acts)


### PR DESCRIPTION
## What is this fixing or adding?
Adds tests that check logic of locations, regions and entrances.

Locations and regions that change accessibility depending on the player's options have tests, except some Death Wish locations.

Many locations and regions that have had logic issues in the past have also been added to the tests.

## How was this tested?
By running them.

There are lots of failures currently because these tests expect logic to match given these PRs being merged:
Various logic fixes: https://github.com/ArchipelagoMW/Archipelago/pull/4492
YCHE and Boss Firewall logic rework: (PR TODO)
Add Dweller Mask requirement to normal logic Rush Hour: (PR TODO)
