### PR TITLE
LADX: Swap out invalid characters in item names

### DIFF
--- a/worlds/ladx/LADXR/locations/itemInfo.py
+++ b/worlds/ladx/LADXR/locations/itemInfo.py
@@ -2,6 +2,10 @@ import typing
 from ..checkMetadata import checkMetadataTable
 from .constants import *
 
+custom_name_replacements = {
+    '"':"'",
+    '_':' ',
+}
 
 class ItemInfo:
     MULTIWORLD = True
@@ -22,6 +26,11 @@ class ItemInfo:
 
     def setLocation(self, location):
         self._location = location
+
+    def setCustomItemName(self, name):
+        for key, val in custom_name_replacements.items():
+            name = name.replace(key, val)
+        self.custom_item_name = name
 
     def getOptions(self):
         return self.OPTIONS

--- a/worlds/ladx/__init__.py
+++ b/worlds/ladx/__init__.py
@@ -439,7 +439,7 @@ class LinksAwakeningWorld(World):
                     # Otherwise, use a cute letter as the icon
                     elif self.options.foreign_item_icons == 'guess_by_name':
                         loc.ladxr_item.item = self.guess_icon_for_other_world(loc.item)
-                        loc.ladxr_item.custom_item_name = loc.item.name
+                        loc.ladxr_item.setCustomItemName(loc.item.name)
 
                     else:
                         if loc.item.advancement:


### PR DESCRIPTION
## What is this fixing or adding?
Items with a `"` break the LADX patching, `_` doesn't display well.
`"` issue reported here: https://discord.com/channels/731205301247803413/1316960757526695997/1329539545250664488

## How was this tested?
generates, will go in beta
