### PR TITLE
AHiT: Add Dweller Mask requirement to normal logic Rush Hour

### DIFF
--- a/worlds/ahit/Locations.py
+++ b/worlds/ahit/Locations.py
@@ -478,7 +478,7 @@ act_completions = {
     "Act Completion (Rush Hour)": LocData(2000311210, "Rush Hour",
                                           dlc_flags=HatDLC.dlc2,
                                           hookshot=True,
-                                          required_hats=[HatType.ICE, HatType.BREWING]),
+                                          required_hats=[HatType.ICE, HatType.BREWING, HatType.DWELLER]),
 
     "Act Completion (Time Rift - Rumbi Factory)": LocData(2000312736, "Time Rift - Rumbi Factory",
                                                           dlc_flags=HatDLC.dlc2),

--- a/worlds/ahit/Rules.py
+++ b/worlds/ahit/Rules.py
@@ -455,7 +455,7 @@ def set_moderate_rules(world: "HatInTimeWorld"):
             if "Pink Paw Station Thug" in key and is_location_valid(world, key):
                 set_rule(world.multiworld.get_location(key, world.player), lambda state: True)
 
-        # Moderate: clear Rush Hour without Hookshot
+        # Moderate: clear Rush Hour without Hookshot or Dweller Mask
         set_rule(world.multiworld.get_location("Act Completion (Rush Hour)", world.player),
                  lambda state: state.has("Metro Ticket - Pink", world.player)
                  and state.has("Metro Ticket - Yellow", world.player)


### PR DESCRIPTION
## What is this fixing or adding?

It's been brought up a few times now by different people that Rush Hour could probably logically require Dweller Mask by default.

This PR adds the Dweller Mask logic requirement for Normal Logic Difficulty only.

Skipping the need to use Dweller Mask is probably on about the same level as some Moderate Logic Difficulty tricks, so the Dweller Mask requirement has not been added to Moderate Logic or any higher difficulties.

Without Dweller Mask:
- Skipping the Dweller platforms in front of the generator in Pink Paw Station requires one of:
  a. Single jump + wall climb + double jump
  b. Double jump dive cancel from the top of a bench
  c. Double jump dive cancel from the top of the lamp
  d. The Empress sometimes shoots this generator without the player going all the way up to it, but I don't know how difficult this is to make consistent
- Skipping the Dweller block in Green Clean Station requires a near max height double jump + dive + cancel + wall climb (Hard logic an above can also just skip this section entirely).
- The Dweller signs above the trains in The Escape Tunnels cannot be passed through, which requires the player to go under the signs instead, between the trains.

## How was this tested?
Only with the tests in #4493