### PR TITLE
OoT: Allow Crowd Control support for Ocarina of Time (Bizhawk)

### DIFF
--- a/data/lua/connector_oot.lua
+++ b/data/lua/connector_oot.lua
@@ -1816,7 +1816,7 @@ end
 
 -- Main control handling: main loop and socket receive
 
-function receive()
+function APreceive()
     l, e = ootSocket:receive()
     -- Handle incoming message
     if e == 'closed' then
@@ -1874,7 +1874,7 @@ function main()
         end
         if (curstate == STATE_OK) or (curstate == STATE_INITIAL_CONNECTION_MADE) or (curstate == STATE_TENTATIVELY_CONNECTED) then
             if (frame % 30 == 0) then
-                receive()
+                APreceive()
             end
         elseif (curstate == STATE_UNINITIALIZED) then
             if  (frame % 60 == 0) then


### PR DESCRIPTION
## What is this fixing or adding?

It changes the name of the "receive" function in order to have compatibility with other scripts using the same name (in this particular instance, it was tested with Crowd Control).

## How was this tested?

Created a run with at least 2 worlds, added both CC's and AP's scripts to Bizhawk (patching the script with AP's .apz5 file, then adding the resulting .z64 to CC).

Released one of the worlds and got the items in game properly.
Sent an effect through CC, and also got the effect properly.
