### PR TITLE
pytest: fix typo in pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,5 +3,5 @@ python_files = test_*.py Test*.py  # TODO: remove Test* once all worlds have bee
 python_classes = Test
 python_functions = test
 testpaths =
-    tests
+    test
     worlds


### PR DESCRIPTION
Fixes mistake introduced in #4500 

The typo disabled a bunch of tests :S

![pytest](https://github.com/user-attachments/assets/c0814fba-f7fb-456b-87db-95e80ea6a8c5)
