### PR TITLE
TUNIC: Make grass go in the regular location name group too

### DIFF
--- a/worlds/tunic/__init__.py
+++ b/worlds/tunic/__init__.py
@@ -78,7 +78,8 @@ class TunicWorld(World):
     settings: ClassVar[TunicSettings]
     item_name_groups = item_name_groups
     location_name_groups = location_name_groups
-    location_name_groups.update(grass_location_name_groups)
+    for group_name, members in grass_location_name_groups.items():
+        location_name_groups.setdefault(group_name, set()).update(members)
 
     item_name_to_id = item_name_to_id
     location_name_to_id = standard_location_name_to_id.copy()

--- a/worlds/tunic/grass.py
+++ b/worlds/tunic/grass.py
@@ -7767,8 +7767,10 @@ grass_location_name_to_id: Dict[str, int] = {name: location_base_id + 302 + inde
 
 grass_location_name_groups: Dict[str, Set[str]] = {}
 for loc_name, loc_data in grass_location_table.items():
-    loc_group_name = loc_name.split(" - ", 1)[0] + " Grass"
-    grass_location_name_groups.setdefault(loc_group_name, set()).add(loc_name)
+    area_name = loc_name.split(" - ", 1)[0]
+    # adding it to the normal location group and a grass-only one
+    grass_location_name_groups.setdefault(area_name, set()).add(loc_name)
+    grass_location_name_groups.setdefault(area_name + " Grass", set()).add(loc_name)
 
 
 def can_break_grass(state: CollectionState, world: "TunicWorld") -> bool:


### PR DESCRIPTION
## What is this fixing or adding?
Currently, grass has its own location name group. Someone brought up that if they excluded Guard House 1, they'd assume that it would exclude the grass in there too, but currently they'd have to also exclude Guard House 1 Grass.
So, the grass should probably go in the group too.

## How was this tested?
Unit tests, no test gens yet because I am at work and am a very good employee.