### PR TITLE
Pokemon Emerald: Clarify death link and start inventory descriptions

### DIFF
--- a/worlds/pokemon_emerald/__init__.py
+++ b/worlds/pokemon_emerald/__init__.py
@@ -22,7 +22,7 @@ from .locations import (PokemonEmeraldLocation, create_location_label_to_id_map,
                         set_free_fly, set_legendary_cave_entrances)
 from .opponents import randomize_opponent_parties
 from .options import (Goal, DarkCavesRequireFlash, HmRequirements, ItemPoolType, PokemonEmeraldOptions,
-                      RandomizeWildPokemon, RandomizeBadges, RandomizeHms, NormanRequirement)
+                      RandomizeWildPokemon, RandomizeBadges, RandomizeHms, NormanRequirement, OPTION_GROUPS)
 from .pokemon import (get_random_move, get_species_id_by_label, randomize_abilities, randomize_learnsets,
                       randomize_legendary_encounters, randomize_misc_pokemon, randomize_starters,
                       randomize_tm_hm_compatibility,randomize_types, randomize_wild_encounters)
@@ -63,6 +63,7 @@ class PokemonEmeraldWebWorld(WebWorld):
     )
 
     tutorials = [setup_en, setup_es, setup_sv]
+    option_groups = OPTION_GROUPS
 
 
 class PokemonEmeraldSettings(settings.Group):

--- a/worlds/pokemon_emerald/options.py
+++ b/worlds/pokemon_emerald/options.py
@@ -4,7 +4,7 @@ Option definitions for Pokemon Emerald
 from dataclasses import dataclass
 
 from Options import (Choice, DeathLink, DefaultOnToggle, OptionSet, NamedRange, Range, Toggle, FreeText,
-                     PerGameCommonOptions)
+                     PerGameCommonOptions, OptionGroup, StartInventory)
 
 from .data import data
 
@@ -785,6 +785,14 @@ class RandomizeFanfares(Toggle):
     display_name = "Randomize Fanfares"
 
 
+class PokemonEmeraldDeathLink(DeathLink):
+    """
+    When you die, everyone who enabled death link dies. Of course, the reverse is true too.
+
+    In Pokemon Emerald, whiting out sends a death and receiving a death causes you to white out.
+    """
+
+
 class WonderTrading(DefaultOnToggle):
     """
     Allows participation in wonder trading with other players in your current multiworld. Speak with the center receptionist on the second floor of any pokecenter.
@@ -808,6 +816,14 @@ class EasterEgg(FreeText):
     """
     display_name = "Easter Egg"
     default = "EMERALD SECRET"
+
+
+class PokemonEmeraldStartInventory(StartInventory):
+    """
+    Start with these items.
+
+    They will be in your PC, which you can access from your home or a pokemon center.
+    """
 
 
 @dataclass
@@ -885,7 +901,18 @@ class PokemonEmeraldOptions(PerGameCommonOptions):
     music: RandomizeMusic
     fanfares: RandomizeFanfares
 
-    death_link: DeathLink
+    death_link: PokemonEmeraldDeathLink
 
     enable_wonder_trading: WonderTrading
     easter_egg: EasterEgg
+
+    start_inventory: PokemonEmeraldStartInventory
+
+
+OPTION_GROUPS = [
+    OptionGroup(
+        "Item & Location Options", [
+            PokemonEmeraldStartInventory,
+        ], True,
+    ),
+]


### PR DESCRIPTION
## What is this fixing or adding?

Adds a couple clarifying lines to the death link and start inventory descriptions, since these questions get asked a lot.

This does change the order of the start inventory option within the option group by putting it at the top, but I'm fine with that.

## How was this tested?

Launched the webhost, read the descriptions
