### PR TITLE
HK: Save GrubHuntGoal by value

### DIFF
--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -209,7 +209,7 @@ class HKWorld(World):
         # defaulting so completion condition isn't incorrect before pre_fill
         self.grub_count = (
             46 if options.GrubHuntGoal == GrubHuntGoal.special_range_names["all"]
-            else options.GrubHuntGoal
+            else options.GrubHuntGoal.value
             )
         self.grub_player_count = {self.player: self.grub_count}
 


### PR DESCRIPTION
## What is this fixing or adding?
adds a .value to potentially fix a codepath where this value persists to slot data

reported by user
```
Traceback (most recent call last):
  File "/Projects/APBeta/MultiServer.py", line 836, in server
    await process_client_cmd(ctx, client, msg)
  File "/Projects/APBeta/MultiServer.py", line 1984, in process_client_cmd
    await ctx.send_msgs(client, [args])
  File "/Projects/APBeta/MultiServer.py", line 325, in send_msgs
    msg = self.dumper(msgs)
          ^^^^^^^^^^^^^^^^^
  File "/Projects/APBeta/NetUtils.py", line 116, in encode
    return _encode(_scan_for_TypedTuples(obj))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/encoder.py", line 258, in iterencode
    return _iterencode(o, 0)
           ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type GrubHuntGoal is not JSON serializable
```

hoping to get more info back on exactly how/why this was still in multidata because pre_fill should overwrite it in every case where the option was set directly, but this probably fixes whatever weird case they found

## How was this tested?
commented out the line that overwrites the attribute in pre_fill and ran `pytest test/general/test_implemented.py::TestImplemented::test_slot_data`, saw them failing before the change and passing after

theoretically there could be something else that needs to be tested with multiserver/webhost directly, but would require more debugging info from the user to track down

## If this makes graphical changes, please attach screenshots.
