### PR TITLE
Shivers: Stop using get_all_state cache to fix timing issue

### DIFF
--- a/worlds/factorio/__init__.py
+++ b/worlds/factorio/__init__.py
@@ -280,9 +280,6 @@ class Factorio(World):
         self.get_location("Rocket Launch").access_rule = lambda state: all(state.has(technology, player)
                                                                            for technology in
                                                                            victory_tech_names)
-        for tech_name in victory_tech_names:
-            if not self.multiworld.get_all_state(True).has(tech_name, player):
-                print(tech_name)
         self.multiworld.completion_condition[player] = lambda state: state.has('Victory', player)
 
     def get_recipe(self, name: str) -> Recipe:

--- a/worlds/shivers/__init__.py
+++ b/worlds/shivers/__init__.py
@@ -245,7 +245,7 @@ class ShiversWorld(World):
 
         storage_items += [self.create_item("Empty") for _ in range(3)]
 
-        state = self.multiworld.get_all_state(True)
+        state = self.multiworld.get_all_state(False)
 
         self.random.shuffle(storage_locs)
         self.random.shuffle(storage_items)


### PR DESCRIPTION
## What is this fixing or adding?
#4519 notes an issue where factorio is forcing a cache save on CollectionState before set_rules finishes and shivers uses cached state in pre_fill, so if factorio's slot runs before shivers's the shivers indirect connections are not registered for the state used in prefill which makes regions unreachable and fails to fill

this is not the only approach that fixes the problem, but both of these changes independently make sense to me

## How was this tested?
tested each of these changes individually with default yamls for both games, also confirmed slot order matters by moving the shivers yaml before the factorio yaml by renaming

## If this makes graphical changes, please attach screenshots.
