### PR TITLE
AHIT: Fix broken link in setup guide

### DIFF
--- a/worlds/ahit/docs/setup_en.md
+++ b/worlds/ahit/docs/setup_en.md
@@ -21,7 +21,7 @@
 
 
 3. Click the **Betas** tab. In the **Beta Participation** dropdown, select `tcplink`.  
-   While it downloads, you can subscribe to the [Archipelago workshop mod.](https://steamcommunity.com/sharedfiles/filedetails/?id=3026842601)
+   While it downloads, you can subscribe to the [Archipelago workshop mod](https://steamcommunity.com/sharedfiles/filedetails/?id=3026842601).
 
 
 4. Once the game finishes downloading, start it up.  

--- a/worlds/ahit/docs/setup_en.md
+++ b/worlds/ahit/docs/setup_en.md
@@ -21,7 +21,7 @@
 
 
 3. Click the **Betas** tab. In the **Beta Participation** dropdown, select `tcplink`.  
-   While it downloads, you can subscribe to the [Archipelago workshop mod.]((https://steamcommunity.com/sharedfiles/filedetails/?id=3026842601))
+   While it downloads, you can subscribe to the [Archipelago workshop mod.](https://steamcommunity.com/sharedfiles/filedetails/?id=3026842601)
 
 
 4. Once the game finishes downloading, start it up.  


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?
Fixes a broken link to the AHIT Steam workshop mod that had double parentheses for some reason

## How was this tested?
By clicking the link

## If this makes graphical changes, please attach screenshots.
