### PR TITLE
Core: IIS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,3 +200,6 @@ minecraft_versions.json
 .LSOverride
 Thumbs.db
 [Dd]esktop.ini
+
+# IIS hosting file
+web.config

--- a/WebHost.py
+++ b/WebHost.py
@@ -37,11 +37,16 @@ def get_app() -> "Flask":
     parser = argparse.ArgumentParser(allow_abbrev=False)
     parser.add_argument('--config_override', default=None,
                         help="Path to yaml config file that overrules config.yaml.")
+    parser.add_argument('--port'default=None,
+                        help="Port on which to host Archipelago website.")
     args = parser.parse_known_args()[0]
     if args.config_override:
         import yaml
         app.config.from_file(os.path.abspath(args.config_override), yaml.safe_load)
         logging.info(f"Updated config from {args.config_override}")
+    if args.port:
+        app.config["PORT"] = args.port
+        logging.info(f"PORT was set to {app.config['PORT']}")
     if not app.config["HOST_ADDRESS"]:
         logging.info("Getting public IP, as HOST_ADDRESS is empty.")
         app.config["HOST_ADDRESS"] = Utils.get_public_ipv4()


### PR DESCRIPTION
## What is this fixing or adding?

I'm adding some very small changes to support running the webhost under IIS using the HttpPlatformHandler. The HttpPlatformHandler works by running a child process targeting an arbitrary port and then forwarding that port to IIS. By making this small modification, I have been able to setup the web host under IIS on my personal server.

The main change is to allow a port to be passed in on the command line. This is necessary because in the web.config, a command for the child process is specified (in this case, `python.exe`). The other change is to ignore the web.config file used by IIS, so as not to clutter the repository any further.

## How was this tested?

I have setup Archipelago on a personal server and run multiple games through it, as well as tested most of the site's features (hosting, generation, etc.)

## If this makes graphical changes, please attach screenshots.

There are no graphical changes.