### PR TITLE
Core: An attempt at fixing the new connect_entrances bug

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -68,6 +68,8 @@ class MultiWorld():
     precollected_items: Dict[int, List[Item]]
     state: CollectionState
 
+    completed_world_stages: List[str]
+
     plando_options: PlandoOptions
     early_items: Dict[int, Dict[str, int]]
     local_early_items: Dict[int, Dict[str, int]]
@@ -173,6 +175,7 @@ class MultiWorld():
         self.per_slot_randoms = Utils.DeprecateDict("Using per_slot_randoms is now deprecated. Please use the "
                                                     "world's random object instead (usually self.random)")
         self.plando_options = PlandoOptions.none
+        self.completed_world_stages = []
 
     def get_all_ids(self) -> Tuple[int, ...]:
         return self.player_ids + tuple(self.groups)
@@ -428,6 +431,11 @@ class MultiWorld():
         return self.regions.location_cache[player][location_name]
 
     def get_all_state(self, use_cache: bool, allow_partial_entrances: bool = False) -> CollectionState:
+        assert allow_partial_entrances or "connect_entrances" in self.completed_world_stages, (
+            "Before the end of connect_entrances, get_all_state must be called with allow_partial_entrances = True. "
+            "This is because other worlds may still have dangling entrances."
+        )
+
         cached = getattr(self, "_all_state", None)
         if use_cache and cached:
             return cached.copy()

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -431,7 +431,12 @@ class MultiWorld():
         return self.regions.location_cache[player][location_name]
 
     def get_all_state(self, use_cache: bool, allow_partial_entrances: bool = False) -> CollectionState:
-        assert allow_partial_entrances or "connect_entrances" in self.completed_world_stages, (
+        assert (
+            allow_partial_entrances
+            or "connect_entrances" in self.completed_world_stages
+            or "generate_basic" in self.completed_world_stages
+            # Worlds have unit tests that don't call connect_entrances because they were written before it was added
+        ), (
             "Before the end of connect_entrances, get_all_state must be called with allow_partial_entrances = True. "
             "This is because other worlds may still have dangling entrances."
         )

--- a/test/multiworld/test_multiworlds.py
+++ b/test/multiworld/test_multiworlds.py
@@ -46,6 +46,7 @@ class MultiworldTestBase(TestCase):
                     stage_callable = getattr(world_type, f"stage_{step}", None)
                     if stage_callable:
                         stage_callable(self.multiworld)
+                self.multiworld.completed_world_stages.append(step)
 
 
 @unittest.skip("too slow for main")

--- a/test/multiworld/test_multiworlds.py
+++ b/test/multiworld/test_multiworlds.py
@@ -46,7 +46,7 @@ class MultiworldTestBase(TestCase):
                     stage_callable = getattr(world_type, f"stage_{step}", None)
                     if stage_callable:
                         stage_callable(self.multiworld)
-                self.multiworld.completed_world_stages.append(step)
+            self.multiworld.completed_world_stages.append(step)
 
 
 @unittest.skip("too slow for main")

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -192,6 +192,8 @@ def call_all(multiworld: "MultiWorld", method_name: str, *args: Any) -> None:
 
     call_stage(multiworld, method_name, *args)
 
+    multiworld.completed_world_stages.append(method_name)
+
 
 def call_stage(multiworld: "MultiWorld", method_name: str, *args: Any) -> None:
     world_types = {multiworld.worlds[player].__class__ for player in multiworld.player_ids}

--- a/worlds/alttp/Rules.py
+++ b/worlds/alttp/Rules.py
@@ -1125,7 +1125,7 @@ def set_trock_key_rules(world, player):
     for entrance in ['Turtle Rock Dark Room Staircase', 'Turtle Rock (Chain Chomp Room) (North)', 'Turtle Rock (Chain Chomp Room) (South)', 'Turtle Rock Entrance to Pokey Room', 'Turtle Rock (Pokey Room) (South)', 'Turtle Rock (Pokey Room) (North)', 'Turtle Rock Big Key Door']:
         set_rule(world.get_entrance(entrance, player), lambda state: False)
 
-    all_state = world.get_all_state(use_cache=False)
+    all_state = world.get_all_state(use_cache=False, allow_partial_entrances=True)
     all_state.reachable_regions[player] = set()  # wipe reachable regions so that the locked doors actually work
     all_state.stale[player] = True
 

--- a/worlds/factorio/__init__.py
+++ b/worlds/factorio/__init__.py
@@ -281,7 +281,7 @@ class Factorio(World):
                                                                            for technology in
                                                                            victory_tech_names)
         for tech_name in victory_tech_names:
-            if not self.multiworld.get_all_state(True).has(tech_name, player):
+            if not self.multiworld.get_all_state(True, allow_partial_entrances=True).has(tech_name, player):
                 print(tech_name)
         self.multiworld.completion_condition[player] = lambda state: state.has('Victory', player)
 


### PR DESCRIPTION
In https://github.com/ArchipelagoMW/Archipelago/pull/4420, we added a new step called `connect_entrances`.
The description of this step reads: "By the end of this step, all Entrances must be connected".

However, there are some worlds that are relying on *other* worlds not having any dangling entrances in `set_rules` (which is before connect_entrances).
The culprit here is `get_all_state`, which does region sweeps on all worlds.

This is my attempt at a fix. Only 1 line needs to be changed in Factorio and ALTTP each, but I also wanted to add protection against this happening to unsupported worlds.

**This PR also serves as the "release blocker" PR, but this label does not mean this particular implementation is what we want to go with**

Other options:
1. Don't do this with an assert, do it with a unit test (Counter argument: This would only catch default options)
2. Change the documentation of connect_entrances to say that Entrances must be connected *somehow* after create_items, but their *final* connection must be done by connect_entrances
3. Revert the connect_entrances PR for now? But it's very necessary for GER and plando rewrite