### PR TITLE
Core: Fix worlds that rely on other worlds having their Entrances connected before connect_entrances, add unit test

### DIFF
--- a/test/general/test_entrances.py
+++ b/test/general/test_entrances.py
@@ -55,7 +55,7 @@ class TestBase(unittest.TestCase):
                         "As such, any call to get_all_state must use allow_partial_entrances = True."
                     ))
 
-                    original_get_all_state(use_cache, allow_partial_entrances)
+                    return original_get_all_state(use_cache, allow_partial_entrances)
 
                 multiworld.get_all_state = patched_get_all_state
 

--- a/test/general/test_entrances.py
+++ b/test/general/test_entrances.py
@@ -1,5 +1,4 @@
 import unittest
-
 from worlds.AutoWorld import AutoWorldRegister, call_all, World
 from . import setup_solo_multiworld
 
@@ -38,7 +37,8 @@ class TestBase(unittest.TestCase):
 
     def test_all_state_before_connect_entrances(self):
         """Before connect_entrances, Entrance objects may be unconnected.
-        Thus, we test that get_all_state is performed with allow_partial_entrances if used before connect_entrances."""
+        Thus, we test that get_all_state is performed with allow_partial_entrances if used before or during
+        connect_entrances."""
 
         gen_steps = ("generate_early", "create_regions", "create_items", "set_rules", "connect_entrances")
 

--- a/test/general/test_entrances.py
+++ b/test/general/test_entrances.py
@@ -1,4 +1,6 @@
 import unittest
+
+from BaseClasses import MultiWorld
 from worlds.AutoWorld import AutoWorldRegister, call_all, World
 from . import setup_solo_multiworld
 
@@ -34,3 +36,29 @@ class TestBase(unittest.TestCase):
                         self.assertEqual(
                             original_entrances, step_entrances, f"{game_name} modified entrances during {step}"
                         )
+
+    def test_all_state_before_connect_entrances(self):
+        """Before connect_entrances, Entrance objects may be unconnected.
+        Thus, we test that get_all_state is performed with allow_partial_entrances if used before connect_entrances."""
+
+        gen_steps = ("generate_early", "create_regions", "create_items", "set_rules", "connect_entrances")
+
+        for game_name, world_type in AutoWorldRegister.world_types.items():
+            with self.subTest("Game", game_name=game_name):
+                multiworld = setup_solo_multiworld(world_type, ())
+
+                original_get_all_state = multiworld.get_all_state
+
+                def patched_get_all_state(use_cache: bool, allow_partial_entrances: bool = False):
+                    self.assertTrue(allow_partial_entrances, (
+                        "Before the connect_entrances step, other worlds might still have partial entrances. "
+                        "As such, any call to get_all_state must use allow_partial_entrances = True."
+                    ))
+
+                    original_get_all_state(use_cache, allow_partial_entrances)
+
+                multiworld.get_all_state = patched_get_all_state
+
+                for step in gen_steps:
+                    with self.subTest("Step", step=step):
+                        call_all(multiworld, step)

--- a/test/general/test_entrances.py
+++ b/test/general/test_entrances.py
@@ -50,7 +50,7 @@ class TestBase(unittest.TestCase):
 
                 def patched_get_all_state(use_cache: bool, allow_partial_entrances: bool = False):
                     self.assertTrue(allow_partial_entrances, (
-                        "Before the connect_entrances step, other worlds might still have partial entrances. "
+                        "Before the connect_entrances step finishes, other worlds might still have partial entrances. "
                         "As such, any call to get_all_state must use allow_partial_entrances = True."
                     ))
 

--- a/test/general/test_entrances.py
+++ b/test/general/test_entrances.py
@@ -1,6 +1,5 @@
 import unittest
 
-from BaseClasses import MultiWorld
 from worlds.AutoWorld import AutoWorldRegister, call_all, World
 from . import setup_solo_multiworld
 

--- a/worlds/alttp/Rules.py
+++ b/worlds/alttp/Rules.py
@@ -1125,7 +1125,7 @@ def set_trock_key_rules(world, player):
     for entrance in ['Turtle Rock Dark Room Staircase', 'Turtle Rock (Chain Chomp Room) (North)', 'Turtle Rock (Chain Chomp Room) (South)', 'Turtle Rock Entrance to Pokey Room', 'Turtle Rock (Pokey Room) (South)', 'Turtle Rock (Pokey Room) (North)', 'Turtle Rock Big Key Door']:
         set_rule(world.get_entrance(entrance, player), lambda state: False)
 
-    all_state = world.get_all_state(use_cache=False)
+    all_state = world.get_all_state(use_cache=False, allow_partial_entrances=True)
     all_state.reachable_regions[player] = set()  # wipe reachable regions so that the locked doors actually work
     all_state.stale[player] = True
 

--- a/worlds/factorio/__init__.py
+++ b/worlds/factorio/__init__.py
@@ -281,7 +281,7 @@ class Factorio(World):
                                                                            for technology in
                                                                            victory_tech_names)
         for tech_name in victory_tech_names:
-            if not self.multiworld.get_all_state(True).has(tech_name, player):
+            if not self.multiworld.get_all_state(True, allow_partial_entrances=True).has(tech_name, player):
                 print(tech_name)
         self.multiworld.completion_condition[player] = lambda state: state.has('Victory', player)
 


### PR DESCRIPTION
Fixes https://github.com/ArchipelagoMW/Archipelago/issues/4527.

In https://github.com/ArchipelagoMW/Archipelago/pull/4420, we added a new step called connect_entrances.
The description of this step reads: "By the end of this step, all Entrances must be connected".

However, there are some worlds that are relying on other worlds not having any dangling entrances in set_rules (which is before connect_entrances).
The culprit here is get_all_state, which does region sweeps on all worlds.

Conveniently, get_all_state has an `allow_partial_entrances` kwarg.
So, this PR adds that arg to the two "offending" worlds, and adds a unit test to ensure that it is used.