### PR TITLE
Settings: add error message to identify host.yaml parsing failures

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -787,7 +787,17 @@ class Settings(Group):
         if location:
             from Utils import parse_yaml
             with open(location, encoding="utf-8-sig") as f:
-                options = parse_yaml(f.read())
+                from yaml.error import MarkedYAMLError
+                try:
+                    options = parse_yaml(f.read())
+                except MarkedYAMLError as ex:
+                    if ex.problem_mark:
+                        f.seek(0)
+                        lines = f.readlines()
+                        problem_line = lines[ex.problem_mark.line]
+                        error_line = " " * ex.problem_mark.column + "^"
+                        raise Exception(f"{ex.context} {ex.problem}\n{problem_line}{error_line}")
+                    raise ex
                 # TODO: detect if upgrade is required
                 # TODO: once we have a cache for _world_settings_name_cache, detect if any game section is missing
                 self.update(options or {})


### PR DESCRIPTION
## What is this fixing or adding?
Add custom exception text for host.yaml failing parsing because 1) it's hard for people without the knowledge to notice host.yaml is the problem 2) it's very often unescaped \ characters from copy/pasting explorer paths on windows causing this exception to be thrown

by all means suggest a better import scheme and/or error text, I just wanted something down because i've had to handle this support question too many times

## How was this tested?
mucked up my host.yaml and ran get_settings()

## If this makes graphical changes, please attach screenshots.
