### PR TITLE
TUNIC: Reduce range end for local_fill option

### DIFF
--- a/worlds/tunic/options.py
+++ b/worlds/tunic/options.py
@@ -173,7 +173,7 @@ class LocalFill(NamedRange):
     internal_name = "local_fill"
     display_name = "Local Fill Percent"
     range_start = 0
-    range_end = 100
+    range_end = 98
     special_range_names = {
         "default": -1
     }


### PR DESCRIPTION
## What is this fixing or adding?
Setting it too high can sometimes lead to a late gen failure due to not enough spots left for progression items. This can be reverted once fill can swap out swaps prefilled with filler.

## How was this tested?
I changed a number.