### PR TITLE
Core: Pass maximum exploration states in distribute_items_restrictive

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -500,13 +500,15 @@ def distribute_items_restrictive(multiworld: MultiWorld,
 
     if prioritylocations:
         # "priority fill"
-        fill_restrictive(multiworld, multiworld.state, prioritylocations, progitempool,
+        maximum_exploration_state = sweep_from_pool(multiworld.state)
+        fill_restrictive(multiworld, maximum_exploration_state, prioritylocations, progitempool,
                          single_player_placement=single_player, swap=False, on_place=mark_for_locking,
                          name="Priority", one_item_per_player=True, allow_partial=True)
 
         if prioritylocations:
             # retry with one_item_per_player off because some priority fills can fail to fill with that optimization
-            fill_restrictive(multiworld, multiworld.state, prioritylocations, progitempool,
+            maximum_exploration_state = sweep_from_pool(multiworld.state)
+            fill_restrictive(multiworld, maximum_exploration_state, prioritylocations, progitempool,
                             single_player_placement=single_player, swap=False, on_place=mark_for_locking,
                             name="Priority Retry", one_item_per_player=False)
         accessibility_corrections(multiworld, multiworld.state, prioritylocations, progitempool)
@@ -514,14 +516,15 @@ def distribute_items_restrictive(multiworld: MultiWorld,
 
     if progitempool:
         # "advancement/progression fill"
+        maximum_exploration_state = sweep_from_pool(multiworld.state)
         if panic_method == "swap":
-            fill_restrictive(multiworld, multiworld.state, defaultlocations, progitempool, swap=True,
+            fill_restrictive(multiworld, maximum_exploration_state, defaultlocations, progitempool, swap=True,
                              name="Progression", single_player_placement=single_player)
         elif panic_method == "raise":
-            fill_restrictive(multiworld, multiworld.state, defaultlocations, progitempool, swap=False,
+            fill_restrictive(multiworld, maximum_exploration_state, defaultlocations, progitempool, swap=False,
                              name="Progression", single_player_placement=single_player)
         elif panic_method == "start_inventory":
-            fill_restrictive(multiworld, multiworld.state, defaultlocations, progitempool, swap=False,
+            fill_restrictive(multiworld, maximum_exploration_state, defaultlocations, progitempool, swap=False,
                              allow_partial=True, name="Progression", single_player_placement=single_player)
             if progitempool:
                 for item in progitempool:


### PR DESCRIPTION
## What is this fixing or adding?
The base state passed to fill_restrictive should be as maximal as possible otherwise fill_restrictive has to repeatedly re-sweep and collect from advancement locations that were reachable from before fill_restrictive has placed a single item.

This is not added within fill_restrictive itself because it is common for fills to be performed using a partial 'all_state', which is already a maximum exploration state.

With --skip_output generation of every template yaml with no progression balancing, except FF, KH and Shivers, this prevented repeatedly re-sweeping 576 advancement locations in every sweep within progression fill, reducing the generation time from 124s to 113s for me (8.8% reduction, averaged over 5 generations each).

## How was this tested?

Generated seeds with `python -O .\Generate.py --skip_output --seed 1` before and after and compared that the output produced identical results.

The count of advancement locations saved from being re-swept and collected over and over was taken by comparing the lengths of `multiworld.state.advancements` and `maximum_exploration_state.advancements`.