### PR TITLE
KDL3: Fix world access on non-strict open world

### DIFF
--- a/worlds/kdl3/rules.py
+++ b/worlds/kdl3/rules.py
@@ -334,8 +334,8 @@ def set_rules(world: "KDL3World") -> None:
                                      "Level 4 Boss - Defeated", "Level 5 Boss - Defeated"],
                                     location_name.level_names.keys()):
             set_rule(world.get_location(boss_flag),
-                     lambda state: state.has(f"{level} - Stage Completion", world.player,
-                                             world.options.ow_boss_requirement.value))
+                     lambda state, lvl=level: state.has(f"{lvl} - Stage Completion", world.player,
+                                                        world.options.ow_boss_requirement.value))
 
     set_rule(world.multiworld.get_entrance("To Level 6", world.player),
              lambda state: state.has("Heart Star", world.player, world.required_heart_stars))

--- a/worlds/kdl3/rules.py
+++ b/worlds/kdl3/rules.py
@@ -206,19 +206,19 @@ def set_rules(world: "KDL3World") -> None:
                  lambda state: can_reach_needle(state, world.player))
         set_rule(world.multiworld.get_location(location_name.sand_canyon_5_u2, world.player),
                  lambda state: can_reach_ice(state, world.player) and
-                 (can_reach_rick(state, world.player) or can_reach_coo(state, world.player)
-                  or can_reach_chuchu(state, world.player) or can_reach_pitch(state, world.player)
-                  or can_reach_nago(state, world.player)))
+                               (can_reach_rick(state, world.player) or can_reach_coo(state, world.player)
+                                or can_reach_chuchu(state, world.player) or can_reach_pitch(state, world.player)
+                                or can_reach_nago(state, world.player)))
         set_rule(world.multiworld.get_location(location_name.sand_canyon_5_u3, world.player),
                  lambda state: can_reach_ice(state, world.player) and
-                 (can_reach_rick(state, world.player) or can_reach_coo(state, world.player)
-                  or can_reach_chuchu(state, world.player) or can_reach_pitch(state, world.player)
-                  or can_reach_nago(state, world.player)))
+                               (can_reach_rick(state, world.player) or can_reach_coo(state, world.player)
+                                or can_reach_chuchu(state, world.player) or can_reach_pitch(state, world.player)
+                                or can_reach_nago(state, world.player)))
         set_rule(world.multiworld.get_location(location_name.sand_canyon_5_u4, world.player),
                  lambda state: can_reach_ice(state, world.player) and
-                 (can_reach_rick(state, world.player) or can_reach_coo(state, world.player)
-                  or can_reach_chuchu(state, world.player) or can_reach_pitch(state, world.player)
-                  or can_reach_nago(state, world.player)))
+                               (can_reach_rick(state, world.player) or can_reach_coo(state, world.player)
+                                or can_reach_chuchu(state, world.player) or can_reach_pitch(state, world.player)
+                                or can_reach_nago(state, world.player)))
         set_rule(world.multiworld.get_location(location_name.cloudy_park_6_u1, world.player),
                  lambda state: can_reach_cutter(state, world.player))
 
@@ -248,9 +248,9 @@ def set_rules(world: "KDL3World") -> None:
         for i in range(12, 18):
             set_rule(world.multiworld.get_location(f"Sand Canyon 5 - Star {i}", world.player),
                      lambda state: can_reach_ice(state, world.player) and
-                     (can_reach_rick(state, world.player) or can_reach_coo(state, world.player)
-                      or can_reach_chuchu(state, world.player) or can_reach_pitch(state, world.player)
-                      or can_reach_nago(state, world.player)))
+                                   (can_reach_rick(state, world.player) or can_reach_coo(state, world.player)
+                                    or can_reach_chuchu(state, world.player) or can_reach_pitch(state, world.player)
+                                    or can_reach_nago(state, world.player)))
         for i in range(21, 23):
             set_rule(world.multiworld.get_location(f"Sand Canyon 5 - Star {i}", world.player),
                      lambda state: can_reach_chuchu(state, world.player))
@@ -307,7 +307,7 @@ def set_rules(world: "KDL3World") -> None:
              lambda state: can_reach_coo(state, world.player) and can_reach_burning(state, world.player))
     set_rule(world.multiworld.get_location(animal_friend_spawns.iceberg_4_a3, world.player),
              lambda state: can_reach_chuchu(state, world.player) and can_reach_coo(state, world.player)
-             and can_reach_burning(state, world.player))
+                           and can_reach_burning(state, world.player))
 
     for boss_flag, purification, i in zip(["Level 1 Boss - Purified", "Level 2 Boss - Purified",
                                            "Level 3 Boss - Purified", "Level 4 Boss - Purified",
@@ -328,6 +328,14 @@ def set_rules(world: "KDL3World") -> None:
                                                         world.options.open_world.value,
                                                         world.options.ow_boss_requirement.value,
                                                         world.player_levels)))
+
+    if world.options.open_world:
+        for boss_flag, level in zip(["Level 1 Boss - Defeated", "Level 2 Boss - Defeated", "Level 3 Boss - Defeated",
+                                     "Level 4 Boss - Defeated", "Level 5 Boss - Defeated"],
+                                    location_name.level_names.keys()):
+            set_rule(world.get_location(boss_flag),
+                     lambda state: state.has(f"{level} - Stage Completion", world.player,
+                                             world.options.ow_boss_requirement.value))
 
     set_rule(world.multiworld.get_entrance("To Level 6", world.player),
              lambda state: state.has("Heart Star", world.player, world.required_heart_stars))


### PR DESCRIPTION
## What is this fixing or adding?
There's just been an entire set of rules missing since the initial merge of KDL3 that only causes an issue on a single settings combination. This creates unbeatable worlds by not accounting for logical requirements for stage completion, which would block access to the level's boss.

## How was this tested?
```yaml
Kirby's Dream Land 3:
    strict_bosses: "false"
    open_world: "true"
    ow_boss_requirement: 6
```
Watched the generated spheres no longer contain all 5 levels by sphere 5.

## If this makes graphical changes, please attach screenshots.
