### PR TITLE
Various: Allow for --nogui client launches from the Launcher

### DIFF
--- a/worlds/_bizhawk/client.py
+++ b/worlds/_bizhawk/client.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import abc
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from worlds.LauncherComponents import Component, SuffixIdentifier, Type, components, launch_subprocess
+from worlds.LauncherComponents import Component, SuffixIdentifier, Type, components, launch as launch_component
 
 if TYPE_CHECKING:
     from .context import BizHawkClientContext
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 def launch_client(*args) -> None:
     from .context import launch
-    launch_subprocess(launch, name="BizHawkClient", args=args)
+    launch_component(launch, name="BizHawkClient", args=args)
 
 
 component = Component("BizHawk Client", "BizHawkClient", component_type=Type.CLIENT, func=launch_client,

--- a/worlds/ahit/__init__.py
+++ b/worlds/ahit/__init__.py
@@ -12,13 +12,13 @@ from .DeathWishRules import set_dw_rules, create_enemy_events, hit_list, bosses
 from worlds.AutoWorld import World, WebWorld, CollectionState
 from worlds.generic.Rules import add_rule
 from typing import List, Dict, TextIO
-from worlds.LauncherComponents import Component, components, icon_paths, launch_subprocess, Type
+from worlds.LauncherComponents import Component, components, icon_paths, launch as launch_component, Type
 from Utils import local_path
 
 
 def launch_client():
     from .Client import launch
-    launch_subprocess(launch, name="AHITClient")
+    launch_component(launch, name="AHITClient")
 
 
 components.append(Component("A Hat in Time Client", "AHITClient", func=launch_client,

--- a/worlds/factorio/__init__.py
+++ b/worlds/factorio/__init__.py
@@ -8,7 +8,7 @@ import Utils
 import settings
 from BaseClasses import Region, Location, Item, Tutorial, ItemClassification
 from worlds.AutoWorld import World, WebWorld
-from worlds.LauncherComponents import Component, components, Type, launch_subprocess
+from worlds.LauncherComponents import Component, components, Type, launch as launch_component
 from worlds.generic import Rules
 from .Locations import location_pools, location_table
 from .Mod import generate_mod
@@ -24,7 +24,7 @@ from .Technologies import base_tech_table, recipe_sources, base_technology_table
 
 def launch_client():
     from .Client import launch
-    launch_subprocess(launch, name="FactorioClient")
+    launch_component(launch, name="FactorioClient")
 
 
 components.append(Component("Factorio Client", "FactorioClient", func=launch_client, component_type=Type.CLIENT))

--- a/worlds/kh1/__init__.py
+++ b/worlds/kh1/__init__.py
@@ -9,12 +9,12 @@ from .Options import KH1Options, kh1_option_groups
 from .Regions import connect_entrances, create_regions
 from .Rules import set_rules
 from .Presets import kh1_option_presets
-from worlds.LauncherComponents import Component, components, Type, launch_subprocess
+from worlds.LauncherComponents import Component, components, Type, launch as launch_component
 
 
 def launch_client():
     from .Client import launch
-    launch_subprocess(launch, name="KH1 Client")
+    launch_component(launch, name="KH1 Client")
 
 
 components.append(Component("KH1 Client", "KH1Client", func=launch_client, component_type=Type.CLIENT))

--- a/worlds/kh2/__init__.py
+++ b/worlds/kh2/__init__.py
@@ -3,7 +3,7 @@ from typing import List
 
 from BaseClasses import Tutorial, ItemClassification
 from Fill import fast_fill
-from worlds.LauncherComponents import Component, components, Type, launch_subprocess
+from worlds.LauncherComponents import Component, components, Type, launch as launch_component
 from worlds.AutoWorld import World, WebWorld
 from .Items import *
 from .Locations import *
@@ -17,7 +17,7 @@ from .Subclasses import KH2Item
 
 def launch_client():
     from .Client import launch
-    launch_subprocess(launch, name="KH2Client")
+    launch_component(launch, name="KH2Client")
 
 
 components.append(Component("KH2 Client", "KH2Client", func=launch_client, component_type=Type.CLIENT))

--- a/worlds/zork_grand_inquisitor/__init__.py
+++ b/worlds/zork_grand_inquisitor/__init__.py
@@ -5,7 +5,7 @@ from .world import ZorkGrandInquisitorWorld
 
 def launch_client() -> None:
     from .client import main
-    LauncherComponents.launch_subprocess(main, name="ZorkGrandInquisitorClient")
+    LauncherComponents.launch(main, name="ZorkGrandInquisitorClient")
 
 
 LauncherComponents.components.append(


### PR DESCRIPTION
## What is this fixing or adding?
Mostly using the PR as a way to itemize the clients who have the ability to use --nogui but will currently fail to accept further user input if that arg is used from the launcher

update various components to use the new launch() if their client code checks for nogui

if any of these clients aren't actually expected to work with --nogui they don't need these changes but then they have unused/unneeded codepaths in their clients

## How was this tested?
tested the functionality of LauncherComponents.launch in the PR that added it and with a unsupported client not in the PR but did not test all of the affected clients in the PR

## If this makes graphical changes, please attach screenshots.
