### PR TITLE
Core: clear cached all_state after connect_entrances

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -150,6 +150,8 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
         multiworld.worlds[1].options.local_items.value = set()
 
     AutoWorld.call_all(multiworld, "connect_entrances")
+    if hasattr(multiworld, "_all_state"):
+        del multiworld._all_state
     AutoWorld.call_all(multiworld, "generate_basic")
 
     # remove starting inventory from pool items.


### PR DESCRIPTION
## What is this fixing or adding?
#4519 revealed that it is possible for one world to create an invalid all state cache and another world using all state cache to use that invalid state
this is one solution of a couple offered to reduce the chances that that could happen

other options include:
* removing caching from get_all_state altogether (because there's so few timings where it makes sense)
* making get_all_state(True) check a flag set by Main denoting that a particular step (probably set_rules?) has finished so caching is sensible, and have all calls to get_all_state(True) before that flag is set not save a cache

## How was this tested?
reverted the changes to factorio and shivers that got around this problem and seeing that the new code alone also fixes that particular issue

## If this makes graphical changes, please attach screenshots.
