### PR TITLE
Pokemon Emerald: Clean up free fly blacklist

### DIFF
--- a/worlds/pokemon_emerald/locations.py
+++ b/worlds/pokemon_emerald/locations.py
@@ -34,6 +34,11 @@ VISITED_EVENT_NAME_TO_ID = {
 }
 
 BLACKLIST_OPTION_TO_VISITED_EVENT = {
+    "Littleroot Town": "EVENT_VISITED_LITTLEROOT_TOWN",
+    "Oldale Town": "EVENT_VISITED_OLDALE_TOWN",
+    "Petalburg City": "EVENT_VISITED_PETALBURG_CITY",
+    "Rustboro City": "EVENT_VISITED_RUSTBORO_CITY",
+    "Dewford Town": "EVENT_VISITED_DEWFORD_TOWN",
     "Slateport City": "EVENT_VISITED_SLATEPORT_CITY",
     "Mauville City": "EVENT_VISITED_MAUVILLE_CITY",
     "Verdanturf Town": "EVENT_VISITED_VERDANTURF_TOWN",
@@ -45,6 +50,9 @@ BLACKLIST_OPTION_TO_VISITED_EVENT = {
     "Sootopolis City": "EVENT_VISITED_SOOTOPOLIS_CITY",
     "Ever Grande City": "EVENT_VISITED_EVER_GRANDE_CITY",
 }
+
+VISITED_EVENTS = frozenset(BLACKLIST_OPTION_TO_VISITED_EVENT.values())
+
 
 class PokemonEmeraldLocation(Location):
     game: str = "Pokemon Emerald"
@@ -142,7 +150,7 @@ def set_free_fly(world: "PokemonEmeraldWorld") -> None:
     fly_location_name = "EVENT_VISITED_LITTLEROOT_TOWN"
     if world.options.free_fly_location:
         blacklisted_locations = set(BLACKLIST_OPTION_TO_VISITED_EVENT[city] for city in world.options.free_fly_blacklist.value)
-        free_fly_locations = sorted(set(BLACKLIST_OPTION_TO_VISITED_EVENT.values()) - blacklisted_locations)
+        free_fly_locations = sorted(VISITED_EVENTS - blacklisted_locations)
         if free_fly_locations:
             fly_location_name = world.random.choice(free_fly_locations)
 

--- a/worlds/pokemon_emerald/options.py
+++ b/worlds/pokemon_emerald/options.py
@@ -725,13 +725,20 @@ class FreeFlyLocation(Toggle):
     """
     display_name = "Free Fly Location"
 
+
 class FreeFlyBlacklist(OptionSet):
     """
     Disables specific locations as valid free fly locations.
+
     Has no effect if Free Fly Location is disabled.
     """
     display_name = "Free Fly Blacklist"
     valid_keys = [
+        "Littleroot Town",
+        "Oldale Town",
+        "Petalburg City",
+        "Rustboro City",
+        "Dewford Town",
         "Slateport City",
         "Mauville City",
         "Verdanturf Town",
@@ -743,6 +750,14 @@ class FreeFlyBlacklist(OptionSet):
         "Sootopolis City",
         "Ever Grande City",
     ]
+    default = [
+        "Littleroot Town",
+        "Oldale Town",
+        "Petalburg City",
+        "Rustboro City",
+        "Dewford Town",
+    ]
+
 
 class HmRequirements(Choice):
     """


### PR DESCRIPTION
## What is this fixing or adding?

Cleans up what was added in #4165 and adds sphere 1 fly locations as default-blacklisted options.

## How was this tested?

Generated and checked the free fly location in the debugger.
