### PR TITLE
Stardew Vallet Tests - Restructure the tests that validate Mods + ER together, improved performance

### DIFF
--- a/worlds/stardew_valley/test/mods/TestMods.py
+++ b/worlds/stardew_valley/test/mods/TestMods.py
@@ -1,4 +1,5 @@
 import random
+from typing import Union, Set
 
 from BaseClasses import get_seed
 from .. import SVTestBase, SVTestCase, allsanity_no_mods_6_x_x, allsanity_mods_6_x_x, solo_multiworld, \
@@ -7,7 +8,9 @@ from ..assertion import ModAssertMixin, WorldAssertMixin
 from ... import items, Group, ItemClassification, create_content
 from ... import options
 from ...items import items_by_group
+from ...mods.mod_data import ModNames
 from ...options import SkillProgression, Walnutsanity
+from ...options.options import all_mods
 from ...regions import RandomizationFlag, randomize_connections, create_final_connections_and_regions
 
 
@@ -20,17 +23,58 @@ class TestGenerateModsOptions(WorldAssertMixin, ModAssertMixin, SVTestCase):
                 self.assert_basic_checks(multi_world)
                 self.assert_stray_mod_items(mod, multi_world)
 
-    def test_given_mod_names_when_generate_paired_with_entrance_randomizer_then_basic_checks(self):
-        for option in options.EntranceRandomization.options:
-            for mod in options.Mods.valid_keys:
-                world_options = {
-                    options.EntranceRandomization: options.EntranceRandomization.options[option],
-                    options.Mods: mod,
-                    options.ExcludeGingerIsland: options.ExcludeGingerIsland.option_false
-                }
-                with self.solo_world_sub_test(f"entrance_randomization: {option}, Mod: {mod}", world_options) as (multi_world, _):
-                    self.assert_basic_checks(multi_world)
-                    self.assert_stray_mod_items(mod, multi_world)
+    # The following tests validate that ER still generates winnable and logically-sane games with given mods.
+    # Mods that do not interact with entrances are skipped
+    # Not all ER settings are tested, because 'buildings' is, essentially, a superset of all others
+    def test_deepwoods_entrance_randomization_buildings(self):
+        self.perform_basic_checks_on_mod_with_er(ModNames.deepwoods, options.EntranceRandomization.option_buildings)
+
+    def test_juna_entrance_randomization_buildings(self):
+        self.perform_basic_checks_on_mod_with_er(ModNames.juna, options.EntranceRandomization.option_buildings)
+
+    def test_jasper_entrance_randomization_buildings(self):
+        self.perform_basic_checks_on_mod_with_er(ModNames.jasper, options.EntranceRandomization.option_buildings)
+
+    def test_alec_entrance_randomization_buildings(self):
+        self.perform_basic_checks_on_mod_with_er(ModNames.alec, options.EntranceRandomization.option_buildings)
+
+    def test_yoba_entrance_randomization_buildings(self):
+        self.perform_basic_checks_on_mod_with_er(ModNames.yoba, options.EntranceRandomization.option_buildings)
+
+    def test_eugene_entrance_randomization_buildings(self):
+        self.perform_basic_checks_on_mod_with_er(ModNames.eugene, options.EntranceRandomization.option_buildings)
+
+    def test_ayeisha_entrance_randomization_buildings(self):
+        self.perform_basic_checks_on_mod_with_er(ModNames.ayeisha, options.EntranceRandomization.option_buildings)
+
+    def test_riley_entrance_randomization_buildings(self):
+        self.perform_basic_checks_on_mod_with_er(ModNames.riley, options.EntranceRandomization.option_buildings)
+
+    def test_sve_entrance_randomization_buildings(self):
+        self.perform_basic_checks_on_mod_with_er(ModNames.sve, options.EntranceRandomization.option_buildings)
+
+    def test_alecto_entrance_randomization_buildings(self):
+        self.perform_basic_checks_on_mod_with_er(ModNames.alecto, options.EntranceRandomization.option_buildings)
+
+    def test_lacey_entrance_randomization_buildings(self):
+        self.perform_basic_checks_on_mod_with_er(ModNames.lacey, options.EntranceRandomization.option_buildings)
+
+    def test_boarding_house_entrance_randomization_buildings(self):
+        self.perform_basic_checks_on_mod_with_er(ModNames.boarding_house, options.EntranceRandomization.option_buildings)
+
+    def test_all_mods_entrance_randomization_buildings(self):
+        self.perform_basic_checks_on_mod_with_er(all_mods, options.EntranceRandomization.option_buildings)
+
+    def perform_basic_checks_on_mod_with_er(self, mods: Union[str, Set[str]], er_option: int):
+        if isinstance(mods, str):
+            mods = {mods}
+        world_options = {
+            options.EntranceRandomization: er_option,
+            options.Mods: frozenset(mods),
+            options.ExcludeGingerIsland: options.ExcludeGingerIsland.option_false
+        }
+        with self.solo_world_sub_test(f"entrance_randomization: {er_option}, Mods: {mods}", world_options) as (multi_world, _):
+            self.assert_basic_checks(multi_world)
 
     def test_allsanity_all_mods_when_generate_then_basic_checks(self):
         with self.solo_world_sub_test(world_options=allsanity_mods_6_x_x()) as (multi_world, _):


### PR DESCRIPTION
## What is this fixing or adding?
Discord Convo between Black Sliver and myself starts here: https://discord.com/channels/731205301247803413/1214608557077700720/1333158359632969810

Short version is:
- Reduce the scope of the test (Don't test mods that don't interact with ER, don't test ER settings that are subsets of `Buildings`.
- Reduce the amount of things tested (No need to care about stray items, the other tests check that already
- Unroll the subtests into individual tests to play better with multithreading environments, leading to increased global performance for them.

Final improvement is about 65% on that one specific test, that took about 15 seconds out of the 90s test run. So globally, for stardew tests on my machine, it's nearly 10% improvement, probably better when multithreaded

## How was this tested?
How do you think lmao

## If this makes graphical changes, please attach screenshots.
Before:
![image](https://github.com/user-attachments/assets/82175e29-a448-4256-8f55-4d0930c2906d)
After: 
![image](https://github.com/user-attachments/assets/b01de74b-3cfc-46be-8712-1e3a06000cdf)
