### PR TITLE
Stardew Valley: Add test decorators to ensure all mods are tested once

### DIFF
--- a/worlds/stardew_valley/test/mods/TestMods.py
+++ b/worlds/stardew_valley/test/mods/TestMods.py
@@ -1,6 +1,7 @@
 import random
 
 from BaseClasses import get_seed
+from .utils import must_test_all_mods, testing_mod
 from .. import SVTestBase, SVTestCase, allsanity_mods_6_x_x, fill_dataclass_with_default
 from ..assertion import ModAssertMixin, WorldAssertMixin
 from ... import items, Group, ItemClassification, create_content
@@ -20,42 +21,72 @@ class TestGenerateModsOptions(WorldAssertMixin, ModAssertMixin, SVTestCase):
                 self.assert_basic_checks(multi_world)
                 self.assert_stray_mod_items(mod, multi_world)
 
-    # The following tests validate that ER still generates winnable and logically-sane games with given mods.
-    # Mods that do not interact with entrances are skipped
-    # Not all ER settings are tested, because 'buildings' is, essentially, a superset of all others
+    def test_allsanity_all_mods_when_generate_then_basic_checks(self):
+        with self.solo_world_sub_test(world_options=allsanity_mods_6_x_x()) as (multi_world, _):
+            self.assert_basic_checks(multi_world)
+
+    def test_allsanity_all_mods_exclude_island_when_generate_then_basic_checks(self):
+        world_options = allsanity_mods_6_x_x()
+        world_options.update({options.ExcludeGingerIsland.internal_name: options.ExcludeGingerIsland.option_true})
+        with self.solo_world_sub_test(world_options=world_options) as (multi_world, _):
+            self.assert_basic_checks(multi_world)
+
+
+@must_test_all_mods(
+    excluded_mods=[ModNames.ginger, ModNames.distant_lands, ModNames.skull_cavern_elevator, ModNames.wellwick, ModNames.magic, ModNames.binning_skill,
+                   ModNames.big_backpack, ModNames.luck_skill, ModNames.tractor, ModNames.shiko, ModNames.archaeology, ModNames.delores,
+                   ModNames.socializing_skill, ModNames.cooking_skill])
+class TestModsEntranceRandomization(WorldAssertMixin, SVTestCase):
+    """The following tests validate that ER still generates winnable and logically-sane games with given mods.
+    Mods that do not interact with entrances are skipped
+    Not all ER settings are tested, because 'buildings' is, essentially, a superset of all others
+    """
+
+    @testing_mod(mod=ModNames.deepwoods)
     def test_deepwoods_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.deepwoods, options.EntranceRandomization.option_buildings)
 
+    @testing_mod(mod=ModNames.juna)
     def test_juna_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.juna, options.EntranceRandomization.option_buildings)
 
+    @testing_mod(mod=ModNames.jasper)
     def test_jasper_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.jasper, options.EntranceRandomization.option_buildings)
 
+    @testing_mod(mod=ModNames.alec)
     def test_alec_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.alec, options.EntranceRandomization.option_buildings)
 
+    @testing_mod(mod=ModNames.yoba)
     def test_yoba_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.yoba, options.EntranceRandomization.option_buildings)
 
+    @testing_mod(mod=ModNames.eugene)
     def test_eugene_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.eugene, options.EntranceRandomization.option_buildings)
 
+    @testing_mod(mod=ModNames.ayeisha)
     def test_ayeisha_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.ayeisha, options.EntranceRandomization.option_buildings)
 
+    @testing_mod(mod=ModNames.riley)
     def test_riley_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.riley, options.EntranceRandomization.option_buildings)
 
+    @testing_mod(mod=ModNames.sve)
     def test_sve_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.sve, options.EntranceRandomization.option_buildings)
 
+    @testing_mod(mod=ModNames.alecto)
     def test_alecto_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.alecto, options.EntranceRandomization.option_buildings)
 
+    @testing_mod(mod=ModNames.lacey)
     def test_lacey_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.lacey, options.EntranceRandomization.option_buildings)
 
+    @testing_mod(mod=ModNames.boarding_house)
     def test_boarding_house_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.boarding_house, options.EntranceRandomization.option_buildings)
 
@@ -71,16 +102,6 @@ class TestGenerateModsOptions(WorldAssertMixin, ModAssertMixin, SVTestCase):
             options.ExcludeGingerIsland: options.ExcludeGingerIsland.option_false
         }
         with self.solo_world_sub_test(f"entrance_randomization: {er_option}, Mods: {mods}", world_options) as (multi_world, _):
-            self.assert_basic_checks(multi_world)
-
-    def test_allsanity_all_mods_when_generate_then_basic_checks(self):
-        with self.solo_world_sub_test(world_options=allsanity_mods_6_x_x()) as (multi_world, _):
-            self.assert_basic_checks(multi_world)
-
-    def test_allsanity_all_mods_exclude_island_when_generate_then_basic_checks(self):
-        world_options = allsanity_mods_6_x_x()
-        world_options.update({options.ExcludeGingerIsland.internal_name: options.ExcludeGingerIsland.option_true})
-        with self.solo_world_sub_test(world_options=world_options) as (multi_world, _):
             self.assert_basic_checks(multi_world)
 
 

--- a/worlds/stardew_valley/test/mods/TestMods.py
+++ b/worlds/stardew_valley/test/mods/TestMods.py
@@ -42,51 +42,51 @@ class TestModsEntranceRandomization(WorldAssertMixin, SVTestCase):
     Not all ER settings are tested, because 'buildings' is, essentially, a superset of all others
     """
 
-    @mod_testing(mod=ModNames.deepwoods)
+    @mod_testing(ModNames.deepwoods)
     def test_deepwoods_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.deepwoods, options.EntranceRandomization.option_buildings)
 
-    @mod_testing(mod=ModNames.juna)
+    @mod_testing(ModNames.juna)
     def test_juna_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.juna, options.EntranceRandomization.option_buildings)
 
-    @mod_testing(mod=ModNames.jasper)
+    @mod_testing(ModNames.jasper)
     def test_jasper_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.jasper, options.EntranceRandomization.option_buildings)
 
-    @mod_testing(mod=ModNames.alec)
+    @mod_testing(ModNames.alec)
     def test_alec_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.alec, options.EntranceRandomization.option_buildings)
 
-    @mod_testing(mod=ModNames.yoba)
+    @mod_testing(ModNames.yoba)
     def test_yoba_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.yoba, options.EntranceRandomization.option_buildings)
 
-    @mod_testing(mod=ModNames.eugene)
+    @mod_testing(ModNames.eugene)
     def test_eugene_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.eugene, options.EntranceRandomization.option_buildings)
 
-    @mod_testing(mod=ModNames.ayeisha)
+    @mod_testing(ModNames.ayeisha)
     def test_ayeisha_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.ayeisha, options.EntranceRandomization.option_buildings)
 
-    @mod_testing(mod=ModNames.riley)
+    @mod_testing(ModNames.riley)
     def test_riley_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.riley, options.EntranceRandomization.option_buildings)
 
-    @mod_testing(mod=ModNames.sve)
+    @mod_testing(ModNames.sve)
     def test_sve_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.sve, options.EntranceRandomization.option_buildings)
 
-    @mod_testing(mod=ModNames.alecto)
+    @mod_testing(ModNames.alecto)
     def test_alecto_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.alecto, options.EntranceRandomization.option_buildings)
 
-    @mod_testing(mod=ModNames.lacey)
+    @mod_testing(ModNames.lacey)
     def test_lacey_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.lacey, options.EntranceRandomization.option_buildings)
 
-    @mod_testing(mod=ModNames.boarding_house)
+    @mod_testing(ModNames.boarding_house)
     def test_boarding_house_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.boarding_house, options.EntranceRandomization.option_buildings)
 

--- a/worlds/stardew_valley/test/mods/TestMods.py
+++ b/worlds/stardew_valley/test/mods/TestMods.py
@@ -1,7 +1,7 @@
 import random
 
 from BaseClasses import get_seed
-from .mod_testing_decorators import must_test_all_mods, mod_testing
+from .mod_testing_decorators import must_test_all_mods, tests_mod
 from .. import SVTestBase, SVTestCase, allsanity_mods_6_x_x, fill_dataclass_with_default
 from ..assertion import ModAssertMixin, WorldAssertMixin
 from ... import items, Group, ItemClassification, create_content
@@ -42,51 +42,51 @@ class TestModsEntranceRandomization(WorldAssertMixin, SVTestCase):
     Not all ER settings are tested, because 'buildings' is, essentially, a superset of all others
     """
 
-    @mod_testing(ModNames.deepwoods)
+    @tests_mod(ModNames.deepwoods)
     def test_deepwoods_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.deepwoods, options.EntranceRandomization.option_buildings)
 
-    @mod_testing(ModNames.juna)
+    @tests_mod(ModNames.juna)
     def test_juna_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.juna, options.EntranceRandomization.option_buildings)
 
-    @mod_testing(ModNames.jasper)
+    @tests_mod(ModNames.jasper)
     def test_jasper_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.jasper, options.EntranceRandomization.option_buildings)
 
-    @mod_testing(ModNames.alec)
+    @tests_mod(ModNames.alec)
     def test_alec_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.alec, options.EntranceRandomization.option_buildings)
 
-    @mod_testing(ModNames.yoba)
+    @tests_mod(ModNames.yoba)
     def test_yoba_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.yoba, options.EntranceRandomization.option_buildings)
 
-    @mod_testing(ModNames.eugene)
+    @tests_mod(ModNames.eugene)
     def test_eugene_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.eugene, options.EntranceRandomization.option_buildings)
 
-    @mod_testing(ModNames.ayeisha)
+    @tests_mod(ModNames.ayeisha)
     def test_ayeisha_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.ayeisha, options.EntranceRandomization.option_buildings)
 
-    @mod_testing(ModNames.riley)
+    @tests_mod(ModNames.riley)
     def test_riley_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.riley, options.EntranceRandomization.option_buildings)
 
-    @mod_testing(ModNames.sve)
+    @tests_mod(ModNames.sve)
     def test_sve_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.sve, options.EntranceRandomization.option_buildings)
 
-    @mod_testing(ModNames.alecto)
+    @tests_mod(ModNames.alecto)
     def test_alecto_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.alecto, options.EntranceRandomization.option_buildings)
 
-    @mod_testing(ModNames.lacey)
+    @tests_mod(ModNames.lacey)
     def test_lacey_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.lacey, options.EntranceRandomization.option_buildings)
 
-    @mod_testing(ModNames.boarding_house)
+    @tests_mod(ModNames.boarding_house)
     def test_boarding_house_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.boarding_house, options.EntranceRandomization.option_buildings)
 

--- a/worlds/stardew_valley/test/mods/TestMods.py
+++ b/worlds/stardew_valley/test/mods/TestMods.py
@@ -1,7 +1,7 @@
 import random
 
 from BaseClasses import get_seed
-from .utils import must_test_all_mods, testing_mod
+from .mod_testing_decorators import must_test_all_mods, mod_testing
 from .. import SVTestBase, SVTestCase, allsanity_mods_6_x_x, fill_dataclass_with_default
 from ..assertion import ModAssertMixin, WorldAssertMixin
 from ... import items, Group, ItemClassification, create_content
@@ -42,51 +42,51 @@ class TestModsEntranceRandomization(WorldAssertMixin, SVTestCase):
     Not all ER settings are tested, because 'buildings' is, essentially, a superset of all others
     """
 
-    @testing_mod(mod=ModNames.deepwoods)
+    @mod_testing(mod=ModNames.deepwoods)
     def test_deepwoods_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.deepwoods, options.EntranceRandomization.option_buildings)
 
-    @testing_mod(mod=ModNames.juna)
+    @mod_testing(mod=ModNames.juna)
     def test_juna_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.juna, options.EntranceRandomization.option_buildings)
 
-    @testing_mod(mod=ModNames.jasper)
+    @mod_testing(mod=ModNames.jasper)
     def test_jasper_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.jasper, options.EntranceRandomization.option_buildings)
 
-    @testing_mod(mod=ModNames.alec)
+    @mod_testing(mod=ModNames.alec)
     def test_alec_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.alec, options.EntranceRandomization.option_buildings)
 
-    @testing_mod(mod=ModNames.yoba)
+    @mod_testing(mod=ModNames.yoba)
     def test_yoba_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.yoba, options.EntranceRandomization.option_buildings)
 
-    @testing_mod(mod=ModNames.eugene)
+    @mod_testing(mod=ModNames.eugene)
     def test_eugene_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.eugene, options.EntranceRandomization.option_buildings)
 
-    @testing_mod(mod=ModNames.ayeisha)
+    @mod_testing(mod=ModNames.ayeisha)
     def test_ayeisha_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.ayeisha, options.EntranceRandomization.option_buildings)
 
-    @testing_mod(mod=ModNames.riley)
+    @mod_testing(mod=ModNames.riley)
     def test_riley_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.riley, options.EntranceRandomization.option_buildings)
 
-    @testing_mod(mod=ModNames.sve)
+    @mod_testing(mod=ModNames.sve)
     def test_sve_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.sve, options.EntranceRandomization.option_buildings)
 
-    @testing_mod(mod=ModNames.alecto)
+    @mod_testing(mod=ModNames.alecto)
     def test_alecto_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.alecto, options.EntranceRandomization.option_buildings)
 
-    @testing_mod(mod=ModNames.lacey)
+    @mod_testing(mod=ModNames.lacey)
     def test_lacey_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.lacey, options.EntranceRandomization.option_buildings)
 
-    @testing_mod(mod=ModNames.boarding_house)
+    @mod_testing(mod=ModNames.boarding_house)
     def test_boarding_house_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.boarding_house, options.EntranceRandomization.option_buildings)
 

--- a/worlds/stardew_valley/test/mods/TestMods.py
+++ b/worlds/stardew_valley/test/mods/TestMods.py
@@ -1,7 +1,7 @@
 import random
 
 from BaseClasses import get_seed
-from .mod_testing_decorators import must_test_all_mods, tests_mod
+from .mod_testing_decorators import must_test_all_mods, is_testing_mod
 from .. import SVTestBase, SVTestCase, allsanity_mods_6_x_x, fill_dataclass_with_default
 from ..assertion import ModAssertMixin, WorldAssertMixin
 from ... import items, Group, ItemClassification, create_content
@@ -42,51 +42,51 @@ class TestModsEntranceRandomization(WorldAssertMixin, SVTestCase):
     Not all ER settings are tested, because 'buildings' is, essentially, a superset of all others
     """
 
-    @tests_mod(ModNames.deepwoods)
+    @is_testing_mod(ModNames.deepwoods)
     def test_deepwoods_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.deepwoods, options.EntranceRandomization.option_buildings)
 
-    @tests_mod(ModNames.juna)
+    @is_testing_mod(ModNames.juna)
     def test_juna_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.juna, options.EntranceRandomization.option_buildings)
 
-    @tests_mod(ModNames.jasper)
+    @is_testing_mod(ModNames.jasper)
     def test_jasper_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.jasper, options.EntranceRandomization.option_buildings)
 
-    @tests_mod(ModNames.alec)
+    @is_testing_mod(ModNames.alec)
     def test_alec_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.alec, options.EntranceRandomization.option_buildings)
 
-    @tests_mod(ModNames.yoba)
+    @is_testing_mod(ModNames.yoba)
     def test_yoba_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.yoba, options.EntranceRandomization.option_buildings)
 
-    @tests_mod(ModNames.eugene)
+    @is_testing_mod(ModNames.eugene)
     def test_eugene_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.eugene, options.EntranceRandomization.option_buildings)
 
-    @tests_mod(ModNames.ayeisha)
+    @is_testing_mod(ModNames.ayeisha)
     def test_ayeisha_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.ayeisha, options.EntranceRandomization.option_buildings)
 
-    @tests_mod(ModNames.riley)
+    @is_testing_mod(ModNames.riley)
     def test_riley_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.riley, options.EntranceRandomization.option_buildings)
 
-    @tests_mod(ModNames.sve)
+    @is_testing_mod(ModNames.sve)
     def test_sve_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.sve, options.EntranceRandomization.option_buildings)
 
-    @tests_mod(ModNames.alecto)
+    @is_testing_mod(ModNames.alecto)
     def test_alecto_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.alecto, options.EntranceRandomization.option_buildings)
 
-    @tests_mod(ModNames.lacey)
+    @is_testing_mod(ModNames.lacey)
     def test_lacey_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.lacey, options.EntranceRandomization.option_buildings)
 
-    @tests_mod(ModNames.boarding_house)
+    @is_testing_mod(ModNames.boarding_house)
     def test_boarding_house_entrance_randomization_buildings(self):
         self.perform_basic_checks_on_mod_with_er(ModNames.boarding_house, options.EntranceRandomization.option_buildings)
 

--- a/worlds/stardew_valley/test/mods/mod_testing_decorators.py
+++ b/worlds/stardew_valley/test/mods/mod_testing_decorators.py
@@ -39,10 +39,10 @@ def _must_test_all_mods(cls: Type[unittest.TestCase], excluded_mods: Iterable[st
     return cls
 
 
-def tests_mod(mod: str) -> partial[Callable]:
-    return partial(_tests_mod, mod=mod)
+def is_testing_mod(mod: str) -> partial[Callable]:
+    return partial(_is_testing_mod, mod=mod)
 
 
-def _tests_mod(func: Callable, mod: str) -> Callable:
+def _is_testing_mod(func: Callable, mod: str) -> Callable:
     setattr(func, "tested_mod", mod)
     return func

--- a/worlds/stardew_valley/test/mods/mod_testing_decorators.py
+++ b/worlds/stardew_valley/test/mods/mod_testing_decorators.py
@@ -3,7 +3,7 @@ from collections.abc import Collection
 from functools import wraps, partial
 from typing import Type
 
-from worlds.stardew_valley import options
+from ... import options
 
 
 def must_test_all_mods(cls: Type[unittest.TestCase] | None = None, /, *, excluded_mods: Collection[str] = None):
@@ -32,9 +32,9 @@ def must_test_all_mods(cls: Type[unittest.TestCase] | None = None, /, *, exclude
     return cls
 
 
-def testing_mod(func=None, /, *, mod: str):
+def mod_testing(func=None, /, *, mod: str):
     if func is None:
-        return partial(testing_mod, mod=mod)
+        return partial(mod_testing, mod=mod)
 
     @wraps(func)
     def wrapper(self: unittest.TestCase, *args, **kwargs):

--- a/worlds/stardew_valley/test/mods/mod_testing_decorators.py
+++ b/worlds/stardew_valley/test/mods/mod_testing_decorators.py
@@ -39,10 +39,10 @@ def _must_test_all_mods(cls: Type[unittest.TestCase], excluded_mods: Iterable[st
     return cls
 
 
-def mod_testing(mod: str) -> partial[Callable]:
-    return partial(_mod_testing, mod=mod)
+def tests_mod(mod: str) -> partial[Callable]:
+    return partial(_tests_mod, mod=mod)
 
 
-def _mod_testing(func: Callable, mod: str) -> Callable:
+def _tests_mod(func: Callable, mod: str) -> Callable:
     setattr(func, "tested_mod", mod)
     return func

--- a/worlds/stardew_valley/test/mods/utils.py
+++ b/worlds/stardew_valley/test/mods/utils.py
@@ -1,0 +1,44 @@
+import unittest
+from collections.abc import Collection
+from functools import wraps, partial
+from typing import Type
+
+from worlds.stardew_valley import options
+
+
+def must_test_all_mods(cls: Type[unittest.TestCase] | None = None, /, *, excluded_mods: Collection[str] = None):
+    if cls is None:
+        return partial(must_test_all_mods, excluded_mods=excluded_mods)
+
+    if excluded_mods is None:
+        setattr(cls, "tested_mods", set())
+    else:
+        setattr(cls, "tested_mods", set(excluded_mods))
+
+    orignal_tear_down_class = cls.tearDownClass
+
+    @wraps(cls.tearDownClass)
+    def wrapper():
+        tested_mods: set[str] = getattr(cls, "tested_mods")
+
+        diff = set(options.Mods.valid_keys) - tested_mods
+        if diff:
+            raise AssertionError(f"Mods {diff} were not tested")
+
+        return orignal_tear_down_class()
+
+    cls.tearDownClass = wrapper
+
+    return cls
+
+
+def testing_mod(func=None, /, *, mod: str):
+    if func is None:
+        return partial(testing_mod, mod=mod)
+
+    @wraps(func)
+    def wrapper(self: unittest.TestCase, *args, **kwargs):
+        getattr(self, "tested_mods").add(mod)
+        return func(self, *args, **kwargs)
+
+    return wrapper


### PR DESCRIPTION
## What is this fixing or adding?
Supersedes #4557

This creates two decorators to be used on a test class and a test method. They are designed to ensure that those tests are not forgotten when adding a new mod. If a mod in added with `@testing_mod` or in the `excluded_mods` parameter of `@must_test_all_mods`, the tests will fail in the `tearDownClass` of the test class.

This will enable unrolling the other mod tests, now that we can ensure maintainability is not hurt.

## How was this tested?
https://github.com/ArchipelagoMW/Archipelago/pull/4571

## If this makes graphical changes, please attach screenshots.
N/A