### PR TITLE
Tests: Don't Modify Rules After `set_rules`

### DIFF
--- a/docs/world api.md
+++ b/docs/world api.md
@@ -492,6 +492,7 @@ In addition, the following methods can be implemented and are called in this ord
   after this step. Locations cannot be moved to different regions after this step.
 * `set_rules(self)`
   called to set access and item rules on locations and entrances.
+  You cannot modify rules after this step.
 * `connect_entrances(self)`
   by the end of this step, all entrances must exist and be connected to their source and target regions.
   Entrance randomization should be done here.

--- a/test/general/test_implemented.py
+++ b/test/general/test_implemented.py
@@ -126,3 +126,26 @@ class TestImplemented(unittest.TestCase):
                 self.assertEqual(len(multiworld.itempool), 0)
                 self.assertEqual(len(multiworld.get_locations()), 0)
                 self.assertEqual(len(multiworld.get_regions()), 0)
+
+    def test_rules_not_changed_after_set_rules(self):
+        gen_steps = ("generate_early", "create_regions", "create_items", "set_rules")
+        additional_steps = ("connect_entrances", "generate_basic", "pre_fill")
+        excluded_games = ("Ocarina of Time", "Pokemon Red and Blue")
+        worlds_to_test = {game: world
+                          for game, world in AutoWorldRegister.world_types.items() if game not in excluded_games}
+        for game_name, world_type in worlds_to_test.items():
+            with self.subTest("Game", game=game_name):
+                multiworld = setup_solo_multiworld(world_type, gen_steps)
+                old_location_rules = [location.access_rule for location in multiworld.get_locations()]
+                old_entrance_rules = [entrance.access_rule for entrance in multiworld.get_entrances()]
+                for step in additional_steps:
+                    with self.subTest("step", step=step):
+                        call_all(multiworld, step)
+                        current_location_rules = [location.access_rule for location in multiworld.get_locations()]
+                        current_entrance_rules = [entrance.access_rule for entrance in multiworld.get_entrances()]
+                        self.assertEqual(old_location_rules, current_location_rules,
+                                         f"{game_name} modified location rules during {step}")
+                        self.assertEqual(old_entrance_rules, current_entrance_rules,
+                                         f"{game_name} modified entrance rules during {step}")
+                    old_location_rules = current_location_rules
+                    old_entrance_rules = current_entrance_rules


### PR DESCRIPTION
## What is this fixing or adding?

Adds a test that worlds don't modify `Location.access_rule` or `Entrance.access_rule` after `set_rules`. Also clarified this in the world API doc.

It's very barebones, there's probably a better way to format and perform the test.

Ocarina of Time and Pokemon Red and Blue are exempted from the test because they are exempt from the `test_location_creation_steps` test (they remove locations in `generate_basic` and `pre_fill`)

## How was this tested?

The test, which TLoZ fails
* https://github.com/ArchipelagoMW/Archipelago/issues/4563
