### PR TITLE
Tests: massively improve the memory leak test performance

### DIFF
--- a/test/general/test_memory.py
+++ b/test/general/test_memory.py
@@ -1,5 +1,6 @@
 import unittest
 
+from BaseClasses import MultiWorld
 from worlds.AutoWorld import AutoWorldRegister
 from . import setup_solo_multiworld
 
@@ -9,7 +10,7 @@ class TestWorldMemory(unittest.TestCase):
         """Tests that worlds don't leak references to MultiWorld or themselves with default options."""
         import gc
         import weakref
-        refs = {}
+        refs: dict[str, weakref.ReferenceType[MultiWorld]] = {}
         for game_name, world_type in AutoWorldRegister.world_types.items():
             with self.subTest("Game creation", game_name=game_name):
                 weak = weakref.ref(setup_solo_multiworld(world_type))

--- a/test/general/test_memory.py
+++ b/test/general/test_memory.py
@@ -9,8 +9,12 @@ class TestWorldMemory(unittest.TestCase):
         """Tests that worlds don't leak references to MultiWorld or themselves with default options."""
         import gc
         import weakref
+        refs = {}
         for game_name, world_type in AutoWorldRegister.world_types.items():
-            with self.subTest("Game", game_name=game_name):
+            with self.subTest("Game creation", game_name=game_name):
                 weak = weakref.ref(setup_solo_multiworld(world_type))
-                gc.collect()
+                refs[game_name] = weak
+        gc.collect()
+        for game_name, weak in refs.items():
+            with self.subTest("Game cleanup", game_name=game_name):
                 self.assertFalse(weak(), "World leaked a reference")


### PR DESCRIPTION
## What is this fixing or adding?

With the growing number of worlds, GC becomes the bottleneck and slows down the test.
It's not easy to track down actual time difference, because the GC run may also clear other tests' memory.

## How was this tested?

pytest