### PR TITLE
TUNIC: Fix combat logic poorly interacting with playthrough

### DIFF
--- a/worlds/tunic/combat_logic.py
+++ b/worlds/tunic/combat_logic.py
@@ -41,7 +41,7 @@ area_data: Dict[str, AreaStats] = {
     "Rooted Ziggurat": AreaStats(5, 5, 3, 5, 3, 3, 6, ["Sword", "Shield", "Magic"]),
     "Boss Scavenger": AreaStats(5, 5, 3, 5, 3, 3, 6, ["Sword", "Shield", "Magic"], is_boss=True),
     "Swamp": AreaStats(1, 1, 1, 1, 1, 1, 6, ["Sword", "Shield", "Magic"]),
-    "Cathedral": AreaStats(1, 1, 1, 1, 1, 1, 6, ["Sword", "Shield", "Magic"]),
+    # cathedral has the same requirements as Swamp
     # marked as boss because the garden knights can't get hurt by stick
     "Gauntlet": AreaStats(1, 1, 1, 1, 1, 1, 6, ["Sword", "Shield", "Magic"], is_boss=True),
     "The Heir": AreaStats(5, 5, 3, 5, 3, 3, 6, ["Sword", "Shield", "Magic", "Laurels"], is_boss=True),
@@ -49,8 +49,10 @@ area_data: Dict[str, AreaStats] = {
 
 
 # these are used for caching which areas can currently be reached in state
+# Gauntlet does not have exclusively higher stat requirements, so it will be checked separately
 boss_areas: List[str] = [name for name, data in area_data.items() if data.is_boss and name != "Gauntlet"]
-non_boss_areas: List[str] = [name for name, data in area_data.items() if not data.is_boss]
+# Swamp does not have exclusively higher stat requirements, so it will be checked separately
+non_boss_areas: List[str] = [name for name, data in area_data.items() if not data.is_boss and name != "Swamp"]
 
 
 class CombatState(IntEnum):
@@ -89,6 +91,7 @@ def has_combat_reqs(area_name: str, state: CollectionState, player: int) -> bool
     elif area_name in non_boss_areas:
         area_list = non_boss_areas
     else:
+        # this is to check Swamp and Gauntlet on their own
         area_list = [area_name]
 
     if met_combat_reqs:
@@ -114,7 +117,7 @@ def check_combat_reqs(area_name: str, state: CollectionState, player: int, alt_d
     extra_att_needed = 0
     extra_def_needed = 0
     extra_mp_needed = 0
-    has_magic = state.has_any({"Magic Wand", "Gun"}, player)
+    has_magic = state.has_any(("Magic Wand", "Gun"), player)
     stick_bool = False
     sword_bool = False
     for item in data.equipment:

--- a/worlds/tunic/er_rules.py
+++ b/worlds/tunic/er_rules.py
@@ -1467,12 +1467,12 @@ def set_er_region_rules(world: "TunicWorld", regions: Dict[str, Region], portal_
         set_rule(cath_entry_to_elev,
                  lambda state: options.entrance_rando
                  or has_ice_grapple_logic(False, IceGrappling.option_medium, state, world)
-                 or (has_ability(prayer, state, world) and has_combat_reqs("Cathedral", state, player)))
+                 or (has_ability(prayer, state, world) and has_combat_reqs("Swamp", state, player)))
 
         set_rule(cath_entry_to_main,
-                 lambda state: has_combat_reqs("Cathedral", state, player))
+                 lambda state: has_combat_reqs("Swamp", state, player))
         set_rule(cath_elev_to_main,
-                 lambda state: has_combat_reqs("Cathedral", state, player))
+                 lambda state: has_combat_reqs("Swamp", state, player))
 
         # for spots where you can go into and come out of an entrance to reset enemy aggro
         if world.options.entrance_rando:
@@ -1927,4 +1927,4 @@ def set_er_location_rules(world: "TunicWorld") -> None:
 
         # zip through the rubble to sneakily grab this chest, or just fight to it
         add_rule(world.get_location("Cathedral - [1F] Near Spikes"),
-                 lambda state: laurels_zip(state, world) or has_combat_reqs("Cathedral", state, player))
+                 lambda state: laurels_zip(state, world) or has_combat_reqs("Swamp", state, player))


### PR DESCRIPTION
## What is this fixing or adding?
Swamp and Cathedral were separated for no real reason in the combat logic -- they have the same stat requirements.
So now they are not separated.
Also Swamp gets checked on its own since it breaks the pattern of increasing stat requirements like Gauntlet does. This should fix an issue where it'll think some areas are inaccessible during playthrough calcs due to the order they do stuff in.

There's a separate fix for a logic bug being PR'd separately later

## How was this tested?
Test gens, making sure it didn't change which checks were in logic in a test case.