### PR TITLE
MMBN3: Allow use of a specified program for rom_start

### DIFF
--- a/MMBN3Client.py
+++ b/MMBN3Client.py
@@ -295,7 +295,7 @@ async def run_game(romfile):
         auto_start = True
     else:
         auto_start = options.get("rom_start", True)
-    if auto_start:
+    if auto_start is True:
         import webbrowser
         webbrowser.open(romfile)
     elif os.path.isfile(auto_start):

--- a/MMBN3Client.py
+++ b/MMBN3Client.py
@@ -290,11 +290,8 @@ async def gba_sync_task(ctx: MMBN3Context):
 
 
 async def run_game(romfile):
-    options = Utils.get_options().get("mmbn3_options", None)
-    if options is None:
-        auto_start = True
-    else:
-        auto_start = options.get("rom_start", True)
+    from settings import get_settings
+    auto_start = get_settings().mmbn3_options.rom_start
     if auto_start is True:
         import webbrowser
         webbrowser.open(romfile)

--- a/worlds/mmbn3/__init__.py
+++ b/worlds/mmbn3/__init__.py
@@ -26,8 +26,15 @@ class MMBN3Settings(settings.Group):
         description = "MMBN3 ROM File"
         md5s = [MMBN3DeltaPatch.hash]
 
+    class RomStart(str):
+        """
+        Set this to false to never autostart a rom (such as after patching),
+                    true  for operating system default program
+        Alternatively, a path to a program to open the .z64 file with
+        """
+
     rom_file: RomFile = RomFile(RomFile.copy_to)
-    rom_start: bool = True
+    rom_start: typing.Union[RomStart, bool] = True
 
 
 class MMBN3Web(WebWorld):

--- a/worlds/mmbn3/__init__.py
+++ b/worlds/mmbn3/__init__.py
@@ -30,7 +30,7 @@ class MMBN3Settings(settings.Group):
         """
         Set this to false to never autostart a rom (such as after patching),
                     true  for operating system default program
-        Alternatively, a path to a program to open the .z64 file with
+        Alternatively, a path to a program to open the .gba file with
         """
 
     rom_file: RomFile = RomFile(RomFile.copy_to)

--- a/worlds/mmbn3/__init__.py
+++ b/worlds/mmbn3/__init__.py
@@ -34,7 +34,7 @@ class MMBN3Settings(settings.Group):
         """
 
     rom_file: RomFile = RomFile(RomFile.copy_to)
-    rom_start: typing.Union[RomStart, bool] = True
+    rom_start: RomStart | bool = True
 
 
 class MMBN3Web(WebWorld):


### PR DESCRIPTION
## What is this fixing or adding?
Fixes an issue where specifying a file or program for rom_start in MMBN3's host.yaml options just opened it in the default program anyway due to truthiness of a string

## How was this tested?
Changed rom_start to notepad, loaded patch, confirmed notepad opened instead of bizhawk.