### PR TITLE
Settings: Handle empty Groups

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -270,14 +270,15 @@ class Group:
             # fetch class to avoid going through getattr
             cls = self.__class__
             type_hints = cls.get_type_hints()
-            if not type_hints:
-                # write empty dict for empty Group
+            entries = [e for e in self]
+            if not type_hints and not entries:
+                # write empty dict for empty Group with no instance values
                 cls._dump_value(type_hints, f, indent="  " * level)
             # validate group
             for name in cls.__annotations__.keys():
                 assert hasattr(cls, name), f"{cls}.{name} is missing a default value"
             # dump ordered members
-            for name in self:
+            for name in entries:
                 attr = cast(object, getattr(self, name))
                 attr_cls = type_hints[name] if name in type_hints else attr.__class__
                 attr_cls_origin = typing.get_origin(attr_cls)

--- a/settings.py
+++ b/settings.py
@@ -271,9 +271,9 @@ class Group:
             cls = self.__class__
             type_hints = cls.get_type_hints()
             entries = [e for e in self]
-            if not type_hints and not entries:
+            if not entries:
                 # write empty dict for empty Group with no instance values
-                cls._dump_value(type_hints, f, indent="  " * level)
+                cls._dump_value({}, f, indent="  " * level)
             # validate group
             for name in cls.__annotations__.keys():
                 assert hasattr(cls, name), f"{cls}.{name} is missing a default value"

--- a/settings.py
+++ b/settings.py
@@ -270,7 +270,8 @@ class Group:
             # fetch class to avoid going through getattr
             cls = self.__class__
             type_hints = cls.get_type_hints()
-            if type_hints == {}:
+            if not type_hints:
+                # write empty dict for empty Group
                 cls._dump_value(type_hints, f, indent="  " * level)
             # validate group
             for name in cls.__annotations__.keys():

--- a/settings.py
+++ b/settings.py
@@ -109,7 +109,7 @@ class Group:
     def get_type_hints(cls) -> Dict[str, Any]:
         """Returns resolved type hints for the class"""
         if cls._type_cache is None:
-            if not isinstance(next(iter(cls.__annotations__.values())), str):
+            if not cls.__annotations__ or not isinstance(next(iter(cls.__annotations__.values())), str):
                 # non-str: assume already resolved
                 cls._type_cache = cls.__annotations__
             else:
@@ -270,6 +270,8 @@ class Group:
             # fetch class to avoid going through getattr
             cls = self.__class__
             type_hints = cls.get_type_hints()
+            if type_hints == {}:
+                cls._dump_value(type_hints, f, indent="  " * level)
             # validate group
             for name in cls.__annotations__.keys():
                 assert hasattr(cls, name), f"{cls}.{name} is missing a default value"


### PR DESCRIPTION
## What is this fixing or adding?
alternative to #4452
issue was an apworld that defined
```py
class mySettings(settings.Group):
    pass
```
and added it as their world.settings type hint to register it, causing late crashes 

while the previous solution tried to crash the world early enough to not affect other worlds' settings, this pr instead aims to accept an empty Group as valid and to handle an empty dict type cache directly
export empty groups as an empty dict instead of crashing

## How was this tested?
made emerald null out their settings class
on an empty file exported as
```
pokemon_emerald_settings:
  {}
```
`get_settings().pokemon_emerald_settings` returned the class which did not have attributes as expected
reverting emerald changes and re-saving the file populated the section as expected
```
pokemon_emerald_settings:
  # File name of your English Pokemon Emerald ROM
  rom_file: "Pokemon - Emerald Version (USA, Europe).gba"
```

## If this makes graphical changes, please attach screenshots.
