### PR TITLE
Stardew Valley: Radioactive slot machine should be a ginger island check

### DIFF
--- a/worlds/stardew_valley/data/locations.csv
+++ b/worlds/stardew_valley/data/locations.csv
@@ -2938,7 +2938,7 @@ id,region,name,tags,mod_name
 7440,Farm,Craft Copper Slot Machine,"CRAFTSANITY",Luck Skill
 7441,Farm,Craft Gold Slot Machine,"CRAFTSANITY",Luck Skill
 7442,Farm,Craft Iridium Slot Machine,"CRAFTSANITY",Luck Skill
-7443,Farm,Craft Radioactive Slot Machine,"CRAFTSANITY",Luck Skill
+7443,Farm,Craft Radioactive Slot Machine,"CRAFTSANITY,GINGER_ISLAND",Luck Skill
 7451,Adventurer's Guild,Magic Elixir Recipe,"CHEFSANITY,CHEFSANITY_PURCHASE",Magic
 7452,Adventurer's Guild,Travel Core Recipe,CRAFTSANITY,Magic
 7453,Alesia Shop,Haste Elixir Recipe,CRAFTSANITY,Stardew Valley Expanded


### PR DESCRIPTION
## What is this fixing or adding?
The slot machines added in the latest Luck Skill update were added to craftsanity, but turns out the last one requires a ginger island resource, so this makes it into a ginger island check

## How was this tested?
One of the shotgun tests ;)
