### PR TITLE
Stardew valley: Add Mod Recipes tests

### DIFF
--- a/worlds/stardew_valley/test/mods/TestModsFill.py
+++ b/worlds/stardew_valley/test/mods/TestModsFill.py
@@ -1,0 +1,15 @@
+from .. import SVTestBase
+from ... import options
+
+
+class TestNoGingerIslandCraftingRecipesAreRequired(SVTestBase):
+    options = {
+        options.Goal.internal_name: options.Goal.option_craft_master,
+        options.Craftsanity.internal_name: options.Craftsanity.option_all,
+        options.ExcludeGingerIsland.internal_name: options.ExcludeGingerIsland.option_true,
+        options.Mods.internal_name: frozenset(options.Mods.valid_keys)
+    }
+
+    @property
+    def run_default_tests(self) -> bool:
+        return True

--- a/worlds/stardew_valley/test/mods/TestModsFill.py
+++ b/worlds/stardew_valley/test/mods/TestModsFill.py
@@ -13,3 +13,16 @@ class TestNoGingerIslandCraftingRecipesAreRequired(SVTestBase):
     @property
     def run_default_tests(self) -> bool:
         return True
+
+
+class TestNoGingerIslandCookingRecipesAreRequired(SVTestBase):
+    options = {
+        options.Goal.internal_name: options.Goal.option_gourmet_chef,
+        options.Cooksanity.internal_name: options.Cooksanity.option_all,
+        options.ExcludeGingerIsland.internal_name: options.ExcludeGingerIsland.option_true,
+        options.Mods.internal_name: frozenset(options.Mods.valid_keys)
+    }
+
+    @property
+    def run_default_tests(self) -> bool:
+        return True


### PR DESCRIPTION
## What is this fixing or adding?
Black Sliver suggested this, from https://github.com/ArchipelagoMW/Archipelago/pull/4578
Adds two tests, that run the full base test suite including fill, for modded content without ginger island. One checks cooking recipes, the other checks crafting recipes, both have the related goal.

## How was this tested?
The new crafting test currently fails. It'll pass once https://github.com/ArchipelagoMW/Archipelago/pull/4578 is merged.