### PR TITLE
Core: Better scaling explicit indirect conditions

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -776,9 +776,11 @@ class CollectionState():
                 self.path[new_region] = (new_region.name, self.path.get(connection, None))
 
                 # Retry connections if the new region can unblock them
-                for new_entrance in self.multiworld.indirect_connections.get(new_region, set()):
-                    if new_entrance in blocked_connections and new_entrance not in queue:
-                        queue.append(new_entrance)
+                entrances = self.multiworld.indirect_connections.get(new_region)
+                if entrances is not None:
+                    entrances = entrances.intersection(blocked_connections)
+                    entrances.difference_update(queue)
+                    queue.extend(entrances)
 
     def _update_reachable_regions_auto_indirect_conditions(self, player: int, queue: deque):
         reachable_regions = self.reachable_regions[player]


### PR DESCRIPTION
## What is this fixing or adding?

When the number of connections to retry was large and `queue` was large `new_entrance not in queue` would get slow.

For the average supported world, the difference this change makes is negligible.

For a game like Blasphemous, with a lot of explicit indirect conditions, generation of 10 template Blasphemous yamls with
`--skip_output --seed 1` and progression balancing disabled went from 19.0s to 17.9s (5.9% reduction in generation duration).

## How was this tested?

Ran generations before and after, producing identical results
