### PR TITLE
Core: Replace generator creation/iteration in CollectionState methods

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -871,19 +871,35 @@ class CollectionState():
 
     def has_all(self, items: Iterable[str], player: int) -> bool:
         """Returns True if each item name of items is in state at least once."""
-        return all(self.prog_items[player][item] for item in items)
+        player_prog_items = self.prog_items[player]
+        for item in items:
+            if not player_prog_items[item]:
+                return False
+        return True
 
     def has_any(self, items: Iterable[str], player: int) -> bool:
         """Returns True if at least one item name of items is in state at least once."""
-        return any(self.prog_items[player][item] for item in items)
+        player_prog_items = self.prog_items[player]
+        for item in items:
+            if player_prog_items[item]:
+                return True
+        return False
 
     def has_all_counts(self, item_counts: Mapping[str, int], player: int) -> bool:
         """Returns True if each item name is in the state at least as many times as specified."""
-        return all(self.prog_items[player][item] >= count for item, count in item_counts.items())
+        player_prog_items = self.prog_items[player]
+        for item, count in item_counts.items():
+            if player_prog_items[item] < count:
+                return False
+        return True
 
     def has_any_count(self, item_counts: Mapping[str, int], player: int) -> bool:
         """Returns True if at least one item name is in the state at least as many times as specified."""
-        return any(self.prog_items[player][item] >= count for item, count in item_counts.items())
+        player_prog_items = self.prog_items[player]
+        for item, count in item_counts.items():
+            if player_prog_items[item] >= count:
+                return True
+        return False
 
     def count(self, item: str, player: int) -> int:
         return self.prog_items[player][item]
@@ -911,11 +927,20 @@ class CollectionState():
 
     def count_from_list(self, items: Iterable[str], player: int) -> int:
         """Returns the cumulative count of items from a list present in state."""
-        return sum(self.prog_items[player][item_name] for item_name in items)
+        player_prog_items = self.prog_items[player]
+        total = 0
+        for item_name in items:
+            total += player_prog_items[item_name]
+        return total
 
     def count_from_list_unique(self, items: Iterable[str], player: int) -> int:
         """Returns the cumulative count of items from a list present in state. Ignores duplicates of the same item."""
-        return sum(self.prog_items[player][item_name] > 0 for item_name in items)
+        player_prog_items = self.prog_items[player]
+        total = 0
+        for item_name in items:
+            if player_prog_items[item_name] > 0:
+                total += 1
+        return total
 
     # item name group related
     def has_group(self, item_name_group: str, player: int, count: int = 1) -> bool:


### PR DESCRIPTION
## What is this fixing or adding?
Using generators in these functions incurs overhead to create the new generator instance, call the `any`/`all`/`sum` function and have the `any`/`all`/`sum` function iterate the generator, which in turn iterates the iterable.

Replacing the use of generators with for loops is faster.

Getting `self.prog_items[player]` once in advance also improves performance of iterating longer iterables.

## How was this tested?
I generated multiworlds with template yamls from A Hat in Time to Meritous alphabetically, `--skip_output --seed 1` and progression balancing. I ran 10 generations before this PR and 10 generations after this PR and averaged the results in each case:
| Before | PR | Reduction |
| --- | --- | --- |
| 19.08 | 18.68 | -2.11% |

The placement of all items was observed to be identical before and after this PR with the same seed.

---

I used `timeit` to pick implementations. From using `timeit`, it is clear that most implementations not using generators are faster for both large and small iterables.

The `has_` implementations are rather simple and there are not many alternatives with similar performance.
The `count_` implementations have more possibilities because some possible implementations can be better/worse with more/fewer of the counted items being in the state.

The `count_` implementations I picked performed best for me on Python 3.12 up to at least 6-element iterables. For larger iterables, there are usually options that scale slightly better. The precise performance and scaling of similar options will probably change between Python versions, so it is probably not too important which implementation is picked when they perform very similarly.

---
While looking at logic performance for #4458, I pre-calculated some logic and updated some functions to use `has_all()` instead of chaining 2 or 3 `has()` calls together. Without this PR, making that change actually made the world take longer to generate (the `has_all()` calls lost more time than the time saved by pre-calculating some of the logic). With this PR, the changes make the world generate faster as I had expected.