### PR TITLE
kvui: set home folder to non-default

### DIFF
--- a/kvui.py
+++ b/kvui.py
@@ -26,6 +26,9 @@ import Utils
 if Utils.is_frozen():
     os.environ["KIVY_DATA_DIR"] = Utils.local_path("data")
 
+import platformdirs
+os.environ["KIVY_HOME"] = os.path.join(platformdirs.user_config_dir("Archipelago", False), "kivy")
+
 from kivy.config import Config
 
 Config.set("input", "mouse", "mouse,disable_multitouch")

--- a/kvui.py
+++ b/kvui.py
@@ -28,6 +28,7 @@ if Utils.is_frozen():
 
 import platformdirs
 os.environ["KIVY_HOME"] = os.path.join(platformdirs.user_config_dir("Archipelago", False), "kivy")
+os.makedirs(os.environ["KIVY_HOME"], exist_ok=True)
 
 from kivy.config import Config
 


### PR DESCRIPTION
## What is this fixing or adding?
Avoids users facing this issue: https://discord.com/channels/731205301247803413/731205301818359821/1335120260998758461

## How was this tested?
I saw it make a folder on windows next to the datapackage cache:
/Archipelago/Cache/datapackage
/Archipelago/kivy/mods

are now both valid folders in my local appdata.