### PR TITLE
StardewValley: Removed / standardize the usage of "run default tests"

### DIFF
--- a/worlds/stardew_valley/test/TestBackpack.py
+++ b/worlds/stardew_valley/test/TestBackpack.py
@@ -33,11 +33,6 @@ class TestBackpackProgressive(SVTestBase):
 class TestBackpackEarlyProgressive(TestBackpackProgressive):
     options = {options.BackpackProgression.internal_name: options.BackpackProgression.option_early_progressive}
 
-    @property
-    def run_default_tests(self) -> bool:
-        # EarlyProgressive is default
-        return False
-
     def test_backpack(self):
         super().test_backpack()
 

--- a/worlds/stardew_valley/test/TestFishsanity.py
+++ b/worlds/stardew_valley/test/TestFishsanity.py
@@ -85,11 +85,6 @@ class TestFishsanityNoneVanilla(SVFishsanityTestBase):
         Fishsanity: Fishsanity.option_none,
     })
 
-    @property
-    def run_default_tests(self) -> bool:
-        # None is default
-        return False
-
 
 class TestFishsanityLegendaries_Vanilla(SVFishsanityTestBase):
     options = complete_options_with_default({
@@ -390,12 +385,12 @@ class TestFishsanityOnlyEasyFishes_QiBoard(SVFishsanityTestBase):
     )
 
 
-class TestFishsanityMasterAnglerSVEWithoutQuests(WorldAssertMixin, SVTestBase):
+class TestFishsanityMasterAnglerAllModsWithoutQuests(WorldAssertMixin, SVTestBase):
     options = {
         Fishsanity: Fishsanity.option_all,
         Goal: Goal.option_master_angler,
         QuestLocations: -1,
-        Mods: (ModNames.sve,),
+        Mods: frozenset(Mods.valid_keys),
     }
 
     def run_default_tests(self) -> bool:

--- a/worlds/stardew_valley/test/TestFriendsanity.py
+++ b/worlds/stardew_valley/test/TestFriendsanity.py
@@ -100,11 +100,6 @@ class TestFriendsanityNone(SVFriendsanityTestBase):
         Friendsanity: Friendsanity.option_none,
     }
 
-    @property
-    def run_default_tests(self) -> bool:
-        # None is default
-        return False
-
 
 class TestFriendsanityBachelors(SVFriendsanityTestBase):
     options = {

--- a/worlds/stardew_valley/test/TestGeneration.py
+++ b/worlds/stardew_valley/test/TestGeneration.py
@@ -126,11 +126,6 @@ class TestMonstersanityNone(SVTestBase):
         options.Fishsanity.internal_name: options.Fishsanity.option_all
     }
 
-    @property
-    def run_default_tests(self) -> bool:
-        # None is default
-        return False
-
     def test_when_generate_world_then_5_generic_weapons_in_the_pool(self):
         item_pool = [item.name for item in self.multiworld.itempool]
         self.assertEqual(item_pool.count("Progressive Weapon"), 5)
@@ -383,10 +378,6 @@ class TestShipsanityNone(SVTestBase):
     options = {
         Shipsanity.internal_name: Shipsanity.option_none
     }
-
-    def run_default_tests(self) -> bool:
-        # None is default
-        return False
 
     def test_no_shipsanity_locations(self):
         for location in self.get_real_locations():


### PR DESCRIPTION
## What is this fixing or adding?
While investigating something else, I found that a couple of our classes were probably written before we had the base class handle the `run_default_tests()` property, and they instead managed it themselves. For some I removed it, for some I fixed it, and for some I determines it was okay to let them self-determine and didn't touch it.

## How was this tested?
Ran the tests afterwards. It should be a very slight speed increase, as we now run fewer fill tests in the main pipeline, but not really noticeable. Maybe a second or so.
