### PR TITLE
Super Metroid: change default difficulty options

### DIFF
--- a/worlds/sm/Options.py
+++ b/worlds/sm/Options.py
@@ -23,7 +23,7 @@ class Preset(Choice):
     option_solution = 9
     option_custom = 10
     option_varia_custom = 11
-    default = 2
+    default = 0
 
 class StartLocation(Choice):
     """Choose where you want to start the game."""
@@ -70,7 +70,7 @@ class MaxDifficulty(Choice):
     option_hardcore = 4
     option_mania = 5
     option_infinity = 6
-    default = 4
+    default = 0
 
 class MorphPlacement(Choice):
     """Influences where the Morphing Ball with be placed."""


### PR DESCRIPTION
## What is this fixing or adding?
This changes the default logic preset from Regular to Newbie and the default max difficulty from Hardcore to Easy in order to be more casual-friendly. As Archipelago has gotten more popular, more casual players have been trying out randomizers. However, the defaults in Super Metroid assume that the player has quite a bit of familiarity with Super Metroid speedruns or randomizers and thus a lot of tricks are put in logic that newer players can get walled by. New players are likely not to carefully read through all of the options to pick appropriate ones, especially in Super Metroid, where the "preset" option is not clearly described and the presets themselves are only catalogued on a site external to Archipelago. The #super-metroid channel in the Archipelago discord thus has plenty of examples of new players getting an unwelcome surprise from the default options being much more difficult than those of most other AP games, which generally have defaults that are casual-friendly. Several members of the APSM community in that channel expressed support for changing the defaults, so here we are.

## How was this tested?
Generated template options to confirm the defaults were set correctly, locally hosted the WebHost to check that the options were properly set to their new defaults on the website, generated a solo game using the default template and went through the spoiler log for that seed to verify that the logic was of an appropriate difficulty.

## If this makes graphical changes, please attach screenshots.
N/A