### PR TITLE
Core: Fix #4595 by using first type's docstring in a union type

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -13,6 +13,7 @@ import warnings
 from enum import IntEnum
 from threading import Lock
 from typing import cast, Any, BinaryIO, ClassVar, Dict, Iterator, List, Optional, TextIO, Tuple, Union, TypeVar
+from types import UnionType
 
 __all__ = [
     "get_settings", "fmt_doc", "no_gui",
@@ -282,7 +283,8 @@ class Group:
                 attr = cast(object, getattr(self, name))
                 attr_cls = type_hints[name] if name in type_hints else attr.__class__
                 attr_cls_origin = typing.get_origin(attr_cls)
-                while attr_cls_origin is Union:  # resolve to first type for doc string
+                # resolve to first type for doc string
+                while attr_cls_origin is Union or attr_cls_origin is UnionType:
                     attr_cls = typing.get_args(attr_cls)[0]
                     attr_cls_origin = typing.get_origin(attr_cls)
                 if attr_cls.__doc__ and attr_cls.__module__ != "builtins":

--- a/settings.py
+++ b/settings.py
@@ -13,7 +13,6 @@ import warnings
 from enum import IntEnum
 from threading import Lock
 from typing import cast, Any, BinaryIO, ClassVar, Dict, Iterator, List, Optional, TextIO, Tuple, Union, TypeVar
-from types import UnionType
 
 __all__ = [
     "get_settings", "fmt_doc", "no_gui",
@@ -284,7 +283,7 @@ class Group:
                 attr_cls = type_hints[name] if name in type_hints else attr.__class__
                 attr_cls_origin = typing.get_origin(attr_cls)
                 # resolve to first type for doc string
-                while attr_cls_origin is Union or attr_cls_origin is UnionType:
+                while attr_cls_origin is Union or attr_cls_origin is types.UnionType:
                     attr_cls = typing.get_args(attr_cls)[0]
                     attr_cls_origin = typing.get_origin(attr_cls)
                 if attr_cls.__doc__ and attr_cls.__module__ != "builtins":


### PR DESCRIPTION
## What is this fixing or adding?
Fixes #4595. Used Mysteryem's suggestion verbatim.

## How was this tested?
Deleted Jak's section in my host.yaml, ran the launcher, click "Open host.yaml." The section regenerated, this time with the correct docstring.

![image](https://github.com/user-attachments/assets/e026d8c0-9e0a-4d7d-be3f-d0ea59f8afec)

## If this makes graphical changes, please attach screenshots.
N/A