### PR TITLE
KH2: Fix lambda capture issue with weapon slot logic

### DIFF
--- a/worlds/kh2/Rules.py
+++ b/worlds/kh2/Rules.py
@@ -263,7 +263,7 @@ class KH2WorldRules(KH2Rules):
 
         weapon_region = self.multiworld.get_region(RegionName.Keyblade, self.player)
         for location in weapon_region.locations:
-            add_rule(location, lambda state: state.has(exclusion_table["WeaponSlots"][location.name], self.player))
+            add_rule(location, lambda state, exclusion_item=exclusion_table["WeaponSlots"][location.name]: state.has(exclusion_item, self.player))
             if location.name in Goofy_Checks:
                 add_item_rule(location, lambda item: item.player == self.player and item.name in GoofyAbility_Table.keys())
             elif location.name in Donald_Checks:

--- a/worlds/kh2/Rules.py
+++ b/worlds/kh2/Rules.py
@@ -263,14 +263,15 @@ class KH2WorldRules(KH2Rules):
 
         weapon_region = self.multiworld.get_region(RegionName.Keyblade, self.player)
         for location in weapon_region.locations:
-            exclusion_item = exclusion_table["WeaponSlots"][location.name]
-            add_rule(location, lambda state, e_item=exclusion_item: state.has(e_item, self.player))
-            if location.name in Goofy_Checks:
-                add_item_rule(location, lambda item: item.player == self.player and item.name in GoofyAbility_Table.keys())
-            elif location.name in Donald_Checks:
-                add_item_rule(location, lambda item: item.player == self.player and item.name in DonaldAbility_Table.keys())
-            else:
-                add_item_rule(location, lambda item: item.player == self.player and item.name in SupportAbility_Table.keys())
+            if location.name in exclusion_table["WeaponSlots"]:  # shop items and starting items are not in this list
+                exclusion_item = exclusion_table["WeaponSlots"][location.name]
+                add_rule(location, lambda state, e_item=exclusion_item: state.has(e_item, self.player))
+                if location.name in Goofy_Checks:
+                    add_item_rule(location, lambda item: item.player == self.player and item.name in GoofyAbility_Table.keys())
+                elif location.name in Donald_Checks:
+                    add_item_rule(location, lambda item: item.player == self.player and item.name in DonaldAbility_Table.keys())
+                else:
+                    add_item_rule(location, lambda item: item.player == self.player and item.name in SupportAbility_Table.keys())
 
     def set_kh2_goal(self):
         final_xemnas_location = self.multiworld.get_location(LocationName.FinalXemnasEventLocation, self.player)

--- a/worlds/kh2/Rules.py
+++ b/worlds/kh2/Rules.py
@@ -263,7 +263,8 @@ class KH2WorldRules(KH2Rules):
 
         weapon_region = self.multiworld.get_region(RegionName.Keyblade, self.player)
         for location in weapon_region.locations:
-            add_rule(location, lambda state, exclusion_item=exclusion_table["WeaponSlots"][location.name]: state.has(exclusion_item, self.player))
+            exclusion_item = exclusion_table["WeaponSlots"][location.name]
+            add_rule(location, lambda state, e_item=exclusion_item: state.has(e_item, self.player))
             if location.name in Goofy_Checks:
                 add_item_rule(location, lambda item: item.player == self.player and item.name in GoofyAbility_Table.keys())
             elif location.name in Donald_Checks:

--- a/worlds/kh2/Rules.py
+++ b/worlds/kh2/Rules.py
@@ -266,12 +266,13 @@ class KH2WorldRules(KH2Rules):
             if location.name in exclusion_table["WeaponSlots"]:  # shop items and starting items are not in this list
                 exclusion_item = exclusion_table["WeaponSlots"][location.name]
                 add_rule(location, lambda state, e_item=exclusion_item: state.has(e_item, self.player))
-                if location.name in Goofy_Checks:
-                    add_item_rule(location, lambda item: item.player == self.player and item.name in GoofyAbility_Table.keys())
-                elif location.name in Donald_Checks:
-                    add_item_rule(location, lambda item: item.player == self.player and item.name in DonaldAbility_Table.keys())
-                else:
-                    add_item_rule(location, lambda item: item.player == self.player and item.name in SupportAbility_Table.keys())
+
+            if location.name in Goofy_Checks:
+                add_item_rule(location, lambda item: item.player == self.player and item.name in GoofyAbility_Table.keys())
+            elif location.name in Donald_Checks:
+                add_item_rule(location, lambda item: item.player == self.player and item.name in DonaldAbility_Table.keys())
+            else:
+                add_item_rule(location, lambda item: item.player == self.player and item.name in SupportAbility_Table.keys())
 
     def set_kh2_goal(self):
         final_xemnas_location = self.multiworld.get_location(LocationName.FinalXemnasEventLocation, self.player)


### PR DESCRIPTION
All weapon slot locations use the logic of the Ultimate Mushroom Slot because the runtime variable of the loop (location) is not captured properly.

This also crashes because some weapon slots don't have an exclusion_table item defined. I don't really know what to do about that as I don't know anything about the game.