### PR TITLE
CC: don't try to reconnect on invalid version

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -907,6 +907,7 @@ async def process_server_cmd(ctx: CommonContext, args: dict):
             ctx.disconnected_intentionally = True
             ctx.event_invalid_game()
         elif 'IncompatibleVersion' in errors:
+            ctx.disconnected_intentionally = True
             raise Exception('Server reported your client version as incompatible. '
                             'This probably means you have to update.')
         elif 'InvalidItemsHandling' in errors:


### PR DESCRIPTION
## What is this fixing or adding?
an invalid version rejection isn't going to change by attempting again

## How was this tested?
changed my utils version to trigger the connection rejection and saw it not reconnect

## If this makes graphical changes, please attach screenshots.
