### PR TITLE
CC: Force Text Client to always connect with empty game

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -1095,7 +1095,7 @@ def run_as_textclient(*args):
             if password_requested and not self.password:
                 await super(TextContext, self).server_auth(password_requested)
             await self.get_username()
-            await self.send_connect()
+            await self.send_connect(game="")
 
         def on_package(self, cmd: str, args: dict):
             if cmd == "Connected":


### PR DESCRIPTION
## What is this fixing or adding?
For text client temporarily losing connection will cause a reconnect without a disconnect (which is good for users) but since ctx.game is cleared on disconnect, the previously connected game is sent but Connect.game being populated means the connection is not a no_location connection and must abide by a world's client version restriction causing some otherwise valid text client connections to get rejected

this just overrides text client's connect to always send an empty game string

## How was this tested?
opened text client, connected to localhost server with log network on that I then ran `/exit` on and spun back up, on auto reconnect the game value of the Connect packet was an empty string as expected

## If this makes graphical changes, please attach screenshots.
