### PR TITLE
Test: ensure get_all_state() does not error in between steps

### DIFF
--- a/test/general/test_state.py
+++ b/test/general/test_state.py
@@ -1,0 +1,29 @@
+import unittest
+
+from worlds.AutoWorld import AutoWorldRegister, call_all
+from . import setup_solo_multiworld
+
+
+class TestBase(unittest.TestCase):
+    gen_steps = (
+        "generate_early",
+        "create_regions",
+    )
+
+    test_steps = (
+        "create_items",
+        "set_rules",
+        "connect_entrances",
+        "generate_basic",
+        "pre_fill",
+    )
+
+    def test_all_state_is_available(self):
+        """Ensure all_state can be created at certain steps."""
+        for game_name, world_type in AutoWorldRegister.world_types.items():
+            with self.subTest("Game", game=game_name):
+                multiworld = setup_solo_multiworld(world_type, self.gen_steps)
+                for step in self.test_steps:
+                    with self.subTest("Step", step=step):
+                        call_all(multiworld, step)
+                        self.assertTrue(multiworld.get_all_state(False, True))


### PR DESCRIPTION
## What is this fixing or adding?
Ensures worlds leave state in a state where get_all_state works correctly on default settings.

## How was this tested?
locally, on which it passes for everything currently in main. However, based on https://discord.com/channels/731205301247803413/1336559625356705863/1336559625356705863, it should guard main from this failing if it gets merged first.
