### PR TITLE
Webhost: Update text for options you can't modify on webhost

### DIFF
--- a/WebHostLib/templates/weightedOptions/weightedOptions.html
+++ b/WebHostLib/templates/weightedOptions/weightedOptions.html
@@ -100,7 +100,7 @@
 
                                 {% else %}
                                     <div class="unsupported-option">
-                                        This option is not supported. Please edit your .yaml file manually.
+                                        This option cannot be modified here. Please edit your .yaml file manually.
                                     </div>
 
                                 {% endif %}


### PR DESCRIPTION
## What is this fixing or adding?
Currently it says "This option is not supported", which is meant to mean "You cannot edit this option on webhost because no one wrote something to let you do that".
I think it would be better if it said "This option cannot be modified here". It's less confusing, mostly.

## How was this tested?
Reading.