### PR TITLE
Lttp Adjuster: mock world.random 

### DIFF
--- a/LttPAdjuster.py
+++ b/LttPAdjuster.py
@@ -33,10 +33,15 @@ WINDOW_MIN_HEIGHT = 525
 WINDOW_MIN_WIDTH = 425
 
 class AdjusterWorld(object):
+    class AdjusterSubWorld(object):
+        def __init__(self, random):
+            self.random = random
+
     def __init__(self, sprite_pool):
         import random
         self.sprite_pool = {1: sprite_pool}
         self.per_slot_randoms = {1: random}
+        self.worlds = {1: AdjusterSubWorld(random)}
 
 
 class ArgumentDefaultsHelpFormatter(argparse.RawTextHelpFormatter):

--- a/LttPAdjuster.py
+++ b/LttPAdjuster.py
@@ -41,7 +41,7 @@ class AdjusterWorld(object):
         import random
         self.sprite_pool = {1: sprite_pool}
         self.per_slot_randoms = {1: random}
-        self.worlds = {1: AdjusterSubWorld(random)}
+        self.worlds = {1: self.AdjusterSubWorld(random)}
 
 
 class ArgumentDefaultsHelpFormatter(argparse.RawTextHelpFormatter):


### PR DESCRIPTION
## What is this fixing or adding?
mocks worlds[1].random in addition to per slot randoms now that lttp code is moved to using that
fixes a crash a user reported because `apply_rom_settings` was passed in a multiworld but that multiworld didn't have a worlds dict

## How was this tested?
I made sure making an instance from a python shell returned what i think it should, but did not test running the adjuster

## If this makes graphical changes, please attach screenshots.
