### PR TITLE
Core: Update Hint Priority

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
 
 from MultiServer import CommandProcessor
 from NetUtils import (Endpoint, decode, NetworkItem, encode, JSONtoTextParser, ClientStatus, Permission, NetworkSlot,
-                      RawJSONtoTextParser, add_json_text, add_json_location, add_json_item, JSONTypes, HintStatus, SlotType)
+                      RawJSONtoTextParser, add_json_text, add_json_location, add_json_item, JSONTypes, HintPriority, SlotType)
 from Utils import Version, stream_input, async_start
 from worlds import network_data_package, AutoWorldRegister
 import os
@@ -562,10 +562,10 @@ class CommonContext:
             self.input_task.cancel()
     
     # Hints
-    def update_hint(self, location: int, finding_player: int, status: typing.Optional[HintStatus]) -> None:
+    def update_hint(self, location: int, finding_player: int, priority: typing.Optional[HintPriority]) -> None:
         msg = {"cmd": "UpdateHint", "location": location, "player": finding_player}
-        if status is not None:
-            msg["status"] = status
+        if priority is not None:
+            msg["priority"] = priority
         async_start(self.send_msgs([msg]), name="update_hint")
     
     # DataPackage

--- a/Main.py
+++ b/Main.py
@@ -243,7 +243,7 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
 
             def write_multidata():
                 import NetUtils
-                from NetUtils import HintStatus
+                from NetUtils import HintPriority
                 slot_data = {}
                 client_versions = {}
                 games = {}
@@ -268,10 +268,10 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
                 for slot in multiworld.player_ids:
                     slot_data[slot] = multiworld.worlds[slot].fill_slot_data()
 
-                def precollect_hint(location: Location, auto_status: HintStatus):
+                def precollect_hint(location: Location, auto_priority: HintPriority):
                     entrance = er_hint_data.get(location.player, {}).get(location.address, "")
                     hint = NetUtils.Hint(location.item.player, location.player, location.address,
-                                         location.item.code, False, entrance, location.item.flags, auto_status)
+                                         location.item.code, False, entrance, location.item.flags, auto_priority)
                     precollected_hints[location.player].add(hint)
                     if location.item.player not in multiworld.groups:
                         precollected_hints[location.item.player].add(hint)
@@ -290,16 +290,21 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
                             f"{locations_data[location.player][location.address]}")
                         locations_data[location.player][location.address] = \
                             location.item.code, location.item.player, location.item.flags
-                        auto_status = HintStatus.HINT_AVOID if location.item.trap else HintStatus.HINT_PRIORITY
+                        auto_priority = HintPriority.HINT_DESIRED
+                        if location.item.trap:
+                            if location.item.advancement:
+                                auto_priority = HintPriority.HINT_AVOID_FOR_NOW
+                            else:
+                                auto_priority = HintPriority.HINT_AVOID
                         if location.name in multiworld.worlds[location.player].options.start_location_hints:
-                            if not location.item.trap:  # Unspecified status for location hints, except traps
-                                auto_status = HintStatus.HINT_UNSPECIFIED
-                            precollect_hint(location, auto_status)
+                            if not location.item.trap:  # Unspecified priority for location hints, except traps
+                                auto_priority = HintPriority.HINT_UNSPECIFIED
+                            precollect_hint(location, auto_priority)
                         elif location.item.name in multiworld.worlds[location.item.player].options.start_hints:
-                            precollect_hint(location, auto_status)
+                            precollect_hint(location, auto_priority)
                         elif any([location.item.name in multiworld.worlds[player].options.start_hints
                                   for player in multiworld.groups.get(location.item.player, {}).get("players", [])]):
-                            precollect_hint(location, auto_status)
+                            precollect_hint(location, auto_priority)
 
                 # embedded data package
                 data_package = {

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -43,7 +43,7 @@ import NetUtils
 import Utils
 from Utils import version_tuple, restricted_loads, Version, async_start, get_intended_text
 from NetUtils import Endpoint, ClientStatus, NetworkItem, decode, encode, NetworkPlayer, Permission, NetworkSlot, \
-    SlotType, LocationStore, Hint, HintStatus
+    SlotType, LocationStore, Hint, HintPriority
 from BaseClasses import ItemClassification
 
 min_client_version = Version(0, 1, 6)
@@ -1124,7 +1124,7 @@ def register_location_checks(ctx: Context, team: int, slot: int, locations: typi
         ctx.save()
 
 
-def collect_hints(ctx: Context, team: int, slot: int, item: typing.Union[int, str], auto_status: HintStatus) \
+def collect_hints(ctx: Context, team: int, slot: int, item: typing.Union[int, str], auto_priority: HintPriority) \
         -> typing.List[Hint]:
     hints = []
     slots: typing.Set[int] = {slot}
@@ -1141,24 +1141,25 @@ def collect_hints(ctx: Context, team: int, slot: int, item: typing.Union[int, st
         else:
             found = location_id in ctx.location_checks[team, finding_player]
             entrance = ctx.er_hint_data.get(finding_player, {}).get(location_id, "")
-            new_status = auto_status
-            if found:
-                new_status = HintStatus.HINT_FOUND
-            elif item_flags & ItemClassification.trap:
-                new_status = HintStatus.HINT_AVOID
+            new_priority = auto_priority
+            if item_flags & ItemClassification.trap:
+                if item_flags & ItemClassification.progression:
+                    new_priority = HintPriority.HINT_AVOID_FOR_NOW
+                else:
+                    new_priority = HintPriority.HINT_AVOID
             hints.append(Hint(receiving_player, finding_player, location_id, item_id, found, entrance,
-                                       item_flags, new_status))
+                                       item_flags, new_priority))
 
     return hints
 
 
-def collect_hint_location_name(ctx: Context, team: int, slot: int, location: str, auto_status: HintStatus) \
+def collect_hint_location_name(ctx: Context, team: int, slot: int, location: str, auto_priority: HintPriority) \
         -> typing.List[Hint]:
     seeked_location: int = ctx.location_names_for_game(ctx.games[slot])[location]
-    return collect_hint_location_id(ctx, team, slot, seeked_location, auto_status)
+    return collect_hint_location_id(ctx, team, slot, seeked_location, auto_priority)
 
 
-def collect_hint_location_id(ctx: Context, team: int, slot: int, seeked_location: int, auto_status: HintStatus) \
+def collect_hint_location_id(ctx: Context, team: int, slot: int, seeked_location: int, auto_priority: HintPriority) \
         -> typing.List[Hint]:
     prev_hint = ctx.get_hint(team, slot, seeked_location)
     if prev_hint:
@@ -1169,23 +1170,17 @@ def collect_hint_location_id(ctx: Context, team: int, slot: int, seeked_location
 
         found = seeked_location in ctx.location_checks[team, slot]
         entrance = ctx.er_hint_data.get(slot, {}).get(seeked_location, "")
-        new_status = auto_status
-        if found:
-            new_status = HintStatus.HINT_FOUND
-        elif item_flags & ItemClassification.trap:
-            new_status = HintStatus.HINT_AVOID
+        new_priority = auto_priority
+        if item_flags & ItemClassification.trap:
+            if item_flags & ItemClassification.progression:
+                new_priority = HintPriority.HINT_AVOID_FOR_NOW
+            else:
+                new_priority = HintPriority.HINT_AVOID
         return [Hint(receiving_player, slot, seeked_location, item_id, found, entrance, item_flags,
-                              new_status)]
+                              new_priority)]
     return []
 
 
-status_names: typing.Dict[HintStatus, str] = {
-    HintStatus.HINT_FOUND: "(found)",
-    HintStatus.HINT_UNSPECIFIED: "(unspecified)",
-    HintStatus.HINT_NO_PRIORITY: "(no priority)",
-    HintStatus.HINT_AVOID: "(avoid)",
-    HintStatus.HINT_PRIORITY: "(priority)",
-}
 def format_hint(ctx: Context, team: int, hint: Hint) -> str:
     text = f"[Hint]: {ctx.player_names[team, hint.receiving_player]}'s " \
            f"{ctx.item_names[ctx.slot_info[hint.receiving_player].game][hint.item]} is " \
@@ -1195,7 +1190,7 @@ def format_hint(ctx: Context, team: int, hint: Hint) -> str:
     if hint.entrance:
         text += f" at {hint.entrance}"
     
-    return text + ". " + status_names.get(hint.status, "(unknown)")
+    return text + ". " + NetUtils.priority_names.get(hint.priority, "(unknown)")
 
 
 def json_format_send_event(net_item: NetworkItem, receiving_player: int):
@@ -1599,7 +1594,7 @@ class ClientMessageProcessor(CommonCommandProcessor):
     def get_hints(self, input_text: str, for_location: bool = False) -> bool:
         points_available = get_client_points(self.ctx, self.client)
         cost = self.ctx.get_hint_cost(self.client.slot)
-        auto_status = HintStatus.HINT_UNSPECIFIED if for_location else HintStatus.HINT_PRIORITY
+        auto_priority = HintPriority.HINT_UNSPECIFIED if for_location else HintPriority.HINT_DESIRED
         if not input_text:
             hints = {hint.re_check(self.ctx, self.client.team) for hint in
                      self.ctx.hints[self.client.team, self.client.slot]}
@@ -1625,9 +1620,9 @@ class ClientMessageProcessor(CommonCommandProcessor):
                 self.output(f"Sorry, \"{hint_name}\" is marked as non-hintable.")
                 hints = []
             elif not for_location:
-                hints = collect_hints(self.ctx, self.client.team, self.client.slot, hint_id, auto_status)
+                hints = collect_hints(self.ctx, self.client.team, self.client.slot, hint_id, auto_priority)
             else:
-                hints = collect_hint_location_id(self.ctx, self.client.team, self.client.slot, hint_id, auto_status)
+                hints = collect_hint_location_id(self.ctx, self.client.team, self.client.slot, hint_id, auto_priority)
 
         else:
             game = self.ctx.games[self.client.slot]
@@ -1647,16 +1642,16 @@ class ClientMessageProcessor(CommonCommandProcessor):
                     hints = []
                     for item_name in self.ctx.item_name_groups[game][hint_name]:
                         if item_name in self.ctx.item_names_for_game(game):  # ensure item has an ID
-                            hints.extend(collect_hints(self.ctx, self.client.team, self.client.slot, item_name, auto_status))
+                            hints.extend(collect_hints(self.ctx, self.client.team, self.client.slot, item_name, auto_priority))
                 elif not for_location and hint_name in self.ctx.item_names_for_game(game):  # item name
-                    hints = collect_hints(self.ctx, self.client.team, self.client.slot, hint_name, auto_status)
+                    hints = collect_hints(self.ctx, self.client.team, self.client.slot, hint_name, auto_priority)
                 elif hint_name in self.ctx.location_name_groups[game]:  # location group name
                     hints = []
                     for loc_name in self.ctx.location_name_groups[game][hint_name]:
                         if loc_name in self.ctx.location_names_for_game(game):
-                            hints.extend(collect_hint_location_name(self.ctx, self.client.team, self.client.slot, loc_name, auto_status))
+                            hints.extend(collect_hint_location_name(self.ctx, self.client.team, self.client.slot, loc_name, auto_priority))
                 else:  # location name
-                    hints = collect_hint_location_name(self.ctx, self.client.team, self.client.slot, hint_name, auto_status)
+                    hints = collect_hint_location_name(self.ctx, self.client.team, self.client.slot, hint_name, auto_priority)
 
             else:
                 self.output(response)
@@ -1935,7 +1930,7 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
                 target_item, target_player, flags = ctx.locations[client.slot][location]
                 if create_as_hint:
                     hints.extend(collect_hint_location_id(ctx, client.team, client.slot, location,
-                                                          HintStatus.HINT_UNSPECIFIED))
+                                                          HintPriority.HINT_UNSPECIFIED))
                 locs.append(NetworkItem(target_item, location, target_player, flags))
             ctx.notify_hints(client.team, hints, only_new=create_as_hint == 2)
             if locs and create_as_hint:
@@ -1945,9 +1940,9 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
         elif cmd == 'UpdateHint':
             location = args["location"]
             player = args["player"]
-            status = args["status"]
+            priority = args["priority"]
             if not isinstance(player, int) or not isinstance(location, int) \
-                    or (status is not None and not isinstance(status, int)):
+                    or (priority is not None and not isinstance(priority, int)):
                 await ctx.send_msgs(client,
                                     [{'cmd': 'InvalidPacket', "type": "arguments", "text": 'UpdateHint',
                                       "original_cmd": cmd}])
@@ -1961,21 +1956,16 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
                                       "original_cmd": cmd}])
                 return
             new_hint = hint
-            if status is None:
+            if priority is None:
                 return
             try:
-                status = HintStatus(status)
+                priority = HintPriority(priority)
             except ValueError:
                 await ctx.send_msgs(client,
                                     [{'cmd': 'InvalidPacket', "type": "arguments",
                                       "text": 'UpdateHint: Invalid Status', "original_cmd": cmd}])
                 return
-            if status == HintStatus.HINT_FOUND:
-                await ctx.send_msgs(client,
-                                    [{'cmd': 'InvalidPacket', "type": "arguments",
-                                      "text": 'UpdateHint: Cannot manually update status to "HINT_FOUND"', "original_cmd": cmd}])
-                return
-            new_hint = new_hint.re_prioritize(ctx, status)
+            new_hint = new_hint.re_prioritize(ctx, priority)
             if hint == new_hint:
                 return
             ctx.replace_hint(client.team, hint.finding_player, hint, new_hint)
@@ -2289,9 +2279,9 @@ class ServerCommandProcessor(CommonCommandProcessor):
                     hints = []
                     for item_name_from_group in self.ctx.item_name_groups[game][item]:
                         if item_name_from_group in self.ctx.item_names_for_game(game):  # ensure item has an ID
-                            hints.extend(collect_hints(self.ctx, team, slot, item_name_from_group, HintStatus.HINT_PRIORITY))
+                            hints.extend(collect_hints(self.ctx, team, slot, item_name_from_group, HintPriority.HINT_DESIRED))
                 else:  # item name or id
-                    hints = collect_hints(self.ctx, team, slot, item, HintStatus.HINT_PRIORITY)
+                    hints = collect_hints(self.ctx, team, slot, item, HintPriority.HINT_DESIRED)
 
                 if hints:
                     self.ctx.notify_hints(team, hints)
@@ -2326,16 +2316,16 @@ class ServerCommandProcessor(CommonCommandProcessor):
             if usable:
                 if isinstance(location, int):
                     hints = collect_hint_location_id(self.ctx, team, slot, location,
-                                                     HintStatus.HINT_UNSPECIFIED)
+                                                     HintPriority.HINT_UNSPECIFIED)
                 elif game in self.ctx.location_name_groups and location in self.ctx.location_name_groups[game]:
                     hints = []
                     for loc_name_from_group in self.ctx.location_name_groups[game][location]:
                         if loc_name_from_group in self.ctx.location_names_for_game(game):
                             hints.extend(collect_hint_location_name(self.ctx, team, slot, loc_name_from_group,
-                                                                    HintStatus.HINT_UNSPECIFIED))
+                                                                    HintPriority.HINT_UNSPECIFIED))
                 else:
                     hints = collect_hint_location_name(self.ctx, team, slot, location,
-                                                       HintStatus.HINT_UNSPECIFIED)
+                                                       HintPriority.HINT_UNSPECIFIED)
                 if hints:
                     self.ctx.notify_hints(team, hints)
                 else:

--- a/NetUtils.py
+++ b/NetUtils.py
@@ -11,12 +11,14 @@ if typing.TYPE_CHECKING:
 from Utils import ByValue, Version
 
 
-class HintStatus(ByValue, enum.IntEnum):
-    HINT_FOUND = 0
-    HINT_UNSPECIFIED = 1
-    HINT_NO_PRIORITY = 10
-    HINT_AVOID = 20
-    HINT_PRIORITY = 30
+class HintPriority(ByValue, enum.IntEnum):
+    HINT_UNSPECIFIED = 0     # No priority has been specified yet
+    HINT_CAN_SKIP = 10       # The item can be skipped
+    HINT_MIGHT_WANT = 20     # The player is unsure if they want the item or not
+    HINT_AVOID = 30          # The item should be avoided if at all possible
+    HINT_AVOID_FOR_NOW = 40  # The item should be avoided for now, but may be needed later
+    HINT_DESIRED = 50        # The item should be collected, as it will be very helpful
+    HINT_NEEDED = 60         # The item should be collected, as it is necessary to progress
 
 
 class JSONMessagePart(typing.TypedDict, total=False):
@@ -28,8 +30,8 @@ class JSONMessagePart(typing.TypedDict, total=False):
     player: int
     # if type == item indicates item flags
     flags: int
-    # if type == hint_status
-    hint_status: HintStatus
+    # if type == hint_priority
+    hint_priority: HintPriority
 
 
 class ClientStatus(ByValue, enum.IntEnum):
@@ -195,7 +197,7 @@ class JSONTypes(str, enum.Enum):
     location_name = "location_name"
     location_id = "location_id"
     entrance_name = "entrance_name"
-    hint_status = "hint_status"
+    hint_priority = "hint_priority"
 
 
 class JSONtoTextParser(metaclass=HandlerMeta):
@@ -277,8 +279,8 @@ class JSONtoTextParser(metaclass=HandlerMeta):
         node["color"] = 'blue'
         return self._handle_color(node)
 
-    def _handle_hint_status(self, node: JSONMessagePart):
-        node["color"] = status_colors.get(node["hint_status"], "red")
+    def _handle_hint_priority(self, node: JSONMessagePart):
+        node["color"] = priority_colors.get(node["hint_priority"], "red")
         return self._handle_color(node)
 
 
@@ -313,25 +315,29 @@ def add_json_location(parts: list, location_id: int, player: int = 0, **kwargs) 
     parts.append({"text": str(location_id), "player": player, "type": JSONTypes.location_id, **kwargs})
 
 
-status_names: typing.Dict[HintStatus, str] = {
-    HintStatus.HINT_FOUND: "(found)",
-    HintStatus.HINT_UNSPECIFIED: "(unspecified)",
-    HintStatus.HINT_NO_PRIORITY: "(no priority)",
-    HintStatus.HINT_AVOID: "(avoid)",
-    HintStatus.HINT_PRIORITY: "(priority)",
+priority_names: typing.Dict[HintPriority, str] = {
+    HintPriority.HINT_UNSPECIFIED: "(unspecified)",
+    HintPriority.HINT_CAN_SKIP: "(can skip)",
+    HintPriority.HINT_MIGHT_WANT: "(might want)",
+    HintPriority.HINT_AVOID: "(avoid)",
+    HintPriority.HINT_AVOID_FOR_NOW: "(avoid for now)",
+    HintPriority.HINT_DESIRED: "(desired)",
+    HintPriority.HINT_NEEDED: "(needed)",
 }
-status_colors: typing.Dict[HintStatus, str] = {
-    HintStatus.HINT_FOUND: "green",
-    HintStatus.HINT_UNSPECIFIED: "white",
-    HintStatus.HINT_NO_PRIORITY: "slateblue",
-    HintStatus.HINT_AVOID: "salmon",
-    HintStatus.HINT_PRIORITY: "plum",
+priority_colors: typing.Dict[HintPriority, str] = {
+    HintPriority.HINT_UNSPECIFIED: "white",
+    HintPriority.HINT_CAN_SKIP: "slateblue",
+    HintPriority.HINT_MIGHT_WANT: "slateblue",
+    HintPriority.HINT_AVOID: "salmon",
+    HintPriority.HINT_AVOID_FOR_NOW: "salmon",
+    HintPriority.HINT_DESIRED: "plum",
+    HintPriority.HINT_NEEDED: "plum",
 }
 
 
-def add_json_hint_status(parts: list, hint_status: HintStatus, text: typing.Optional[str] = None, **kwargs):
-    parts.append({"text": text if text != None else status_names.get(hint_status, "(unknown)"),
-                  "hint_status": hint_status, "type": JSONTypes.hint_status, **kwargs})
+def add_json_hint_priority(parts: list, hint_priority: HintPriority, text: typing.Optional[str] = None, **kwargs):
+    parts.append({"text": text if text != None else priority_names.get(hint_priority, "(unknown)"),
+                  "hint_priority": hint_priority, "type": JSONTypes.hint_priority, **kwargs})
 
 
 class Hint(typing.NamedTuple):
@@ -342,21 +348,19 @@ class Hint(typing.NamedTuple):
     found: bool
     entrance: str = ""
     item_flags: int = 0
-    status: HintStatus = HintStatus.HINT_UNSPECIFIED
+    priority: HintPriority = HintPriority.HINT_UNSPECIFIED
 
     def re_check(self, ctx, team) -> Hint:
-        if self.found and self.status == HintStatus.HINT_FOUND:
+        if self.found:
             return self
         found = self.location in ctx.location_checks[team, self.finding_player]
         if found:
-            return self._replace(found=found, status=HintStatus.HINT_FOUND)
+            return self._replace(found=found)
         return self
     
-    def re_prioritize(self, ctx, status: HintStatus) -> Hint:
-        if self.found and status != HintStatus.HINT_FOUND:
-            status = HintStatus.HINT_FOUND
-        if status != self.status:
-            return self._replace(status=status)
+    def re_prioritize(self, ctx, priority: HintPriority) -> Hint:
+        if priority != self.priority:
+            return self._replace(priority=priority)
         return self
 
     def __hash__(self):
@@ -378,7 +382,7 @@ class Hint(typing.NamedTuple):
         else:
             add_json_text(parts, "'s World")
         add_json_text(parts, ". ")
-        add_json_hint_status(parts, self.status)
+        add_json_hint_priority(parts, self.priority)
 
         return {"cmd": "PrintJSON", "data": parts, "type": "Hint",
                 "receiving": self.receiving_player,

--- a/Utils.py
+++ b/Utils.py
@@ -429,7 +429,7 @@ class RestrictedUnpickler(pickle.Unpickler):
             return getattr(builtins, name)
         # used by MultiServer -> savegame/multidata
         if module == "NetUtils" and name in {"NetworkItem", "ClientStatus", "Hint",
-                                             "SlotType", "NetworkSlot", "HintStatus"}:
+                                             "SlotType", "NetworkSlot", "HintPriority"}:
             return getattr(self.net_utils_module, name)
         # Options and Plando are unpickled by WebHost -> Generate
         if module == "worlds.generic" and name == "PlandoItem":

--- a/data/client.kv
+++ b/data/client.kv
@@ -59,7 +59,7 @@
     finding_text: "Finding Player"
     location_text: "Location"
     entrance_text: "Entrance"
-    status_text: "Status"
+    priority_text: "Status"
     TooltipLabel:
         id: receiving
         sort_key: 'receiving'
@@ -96,9 +96,9 @@
         valign: 'center'
         pos_hint: {"center_y": 0.5}
     TooltipLabel:
-        id: status
-        sort_key: 'status'
-        text: root.status_text
+        id: priority
+        sort_key: 'priority'
+        text: root.priority_text
         halign: 'center'
         valign: 'center'
         pos_hint: {"center_y": 0.5}

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -348,31 +348,33 @@ This is useful in cases where an item appears in the game world, such as 'ledge 
 | create_as_hint | int | If non-zero, the scouted locations get created and broadcasted as a player-visible hint. <br/>If 2 only new hints are broadcast, however this does not remove them from the LocationInfo reply. |
 
 ### UpdateHint
-Sent to the server to update the status of a Hint. The client must be the 'receiving_player' of the Hint, or the update fails.
+Sent to the server to update the priority of a Hint. The client must be the 'receiving_player' of the Hint, or the update fails.
 
 ### Arguments
 | Name | Type | Notes |
 | ---- | ---- | ----- |
 | player | int | The ID of the player whose location is being hinted for. |
 | location | int | The ID of the location to update the hint for. If no hint exists for this location, the packet is ignored. |
-| status | [HintStatus](#HintStatus) | Optional. If included, sets the status of the hint to this status. Cannot set `HINT_FOUND`, or change the status from `HINT_FOUND`. |
+| priority | [HintPriority](#HintPriority) | Optional. If included, sets the priority of the hint to this priority. |
 
-#### HintStatus
-An enumeration containing the possible hint states.
+#### HintPriority
+An enumeration containing the possible hint priorities. Each of these priorities is specified by the player who will *receive* the hinted item.
 
 ```python
 import enum
-class HintStatus(enum.IntEnum):
-    HINT_FOUND = 0        # The location has been collected. Status cannot be changed once found.
-    HINT_UNSPECIFIED = 1  # The receiving player has not specified any status
-    HINT_NO_PRIORITY = 10 # The receiving player has specified that the item is unneeded
-    HINT_AVOID = 20       # The receiving player has specified that the item is detrimental
-    HINT_PRIORITY = 30    # The receiving player has specified that the item is needed
+class HintPriority(enum.IntEnum):
+    HINT_UNSPECIFIED = 0     # No priority has been specified yet
+    HINT_CAN_SKIP = 10       # The item can be skipped
+    HINT_MIGHT_WANT = 20     # The player is unsure if they want the item or not
+    HINT_AVOID = 30          # The item should be avoided if at all possible
+    HINT_AVOID_FOR_NOW = 40  # The item should be avoided for now, but may be needed later
+    HINT_DESIRED = 50        # The item should be collected, as it will be very helpful
+    HINT_NEEDED = 60         # The item should be collected, as it is necessary to progress
 ```
+- Hints for items with `ItemClassification.trap` AND `ItemClassification.progression` default to `HINT_AVOID_FOR_NOW`.
 - Hints for items with `ItemClassification.trap` default to `HINT_AVOID`.
 - Hints created with `LocationScouts`, `!hint_location`, or similar (hinting a location) default to `HINT_UNSPECIFIED`.
-- Hints created with `!hint` or similar (hinting an item for yourself) default to `HINT_PRIORITY`.
-- Once a hint is collected, its' status is updated to `HINT_FOUND` automatically, and can no longer be changed.
+- Hints created with `!hint` or similar (hinting an item for yourself) default to `HINT_DESIRED`.
 
 ### StatusUpdate
 Sent to the server to update on the sender's status. Examples include readiness or goal completion. (Example: defeated Ganon in A Link to the Past)
@@ -558,7 +560,7 @@ class JSONMessagePart(TypedDict):
     color: Optional[str] # only available if type is a color
     flags: Optional[int] # only available if type is an item_id or item_name
     player: Optional[int] # only available if type is either item or location
-    hint_status: Optional[HintStatus] # only available if type is hint_status
+    hint_priority: Optional[HintPriority] # only available if type is hint_priority
 ```
 
 `type` is used to denote the intent of the message part. This can be used to indicate special information which may be rendered differently depending on client. How these types are displayed in Archipelago's ALttP client is not the end-all be-all. Other clients may choose to interpret and display these messages differently.
@@ -574,7 +576,7 @@ Possible values for `type` include:
 | location_id | Location ID, should be resolved to Location Name |
 | location_name | Location Name, not currently used over network, but supported by reference Clients. |
 | entrance_name | Entrance Name. No ID mapping exists. |
-| hint_status | The [HintStatus](#HintStatus) of the hint. Both `text` and `hint_status` are given. |
+| hint_priority | The [HintPriority](#HintPriority) of the hint. Both `text` and `hint_priority` are given. |
 | color | Regular text that should be colored. Only `type` that will contain `color` data. |
 
 
@@ -678,7 +680,7 @@ class Hint(typing.NamedTuple):
     found: bool
     entrance: str = ""
     item_flags: int = 0
-    status: HintStatus = HintStatus.HINT_UNSPECIFIED
+    priority: HintPriority = HintPriority.HINT_UNSPECIFIED
 ```
 
 ### Data Package Contents

--- a/kvui.py
+++ b/kvui.py
@@ -73,7 +73,7 @@ from kivy.uix.image import AsyncImage
 
 fade_in_animation = Animation(opacity=0, duration=0) + Animation(opacity=1, duration=0.25)
 
-from NetUtils import JSONtoTextParser, JSONMessagePart, SlotType, HintStatus
+from NetUtils import JSONtoTextParser, JSONMessagePart, SlotType, HintPriority
 from Utils import async_start, get_input_text_from_response
 
 if typing.TYPE_CHECKING:
@@ -367,7 +367,7 @@ class HintLabel(RecycleDataViewBehavior, BoxLayout):
         self.finding_text = ""
         self.location_text = ""
         self.entrance_text = ""
-        self.status_text = ""
+        self.priority_text = ""
         self.hint = {}
         for child in self.children:
             child.bind(texture_size=self.set_height)
@@ -377,19 +377,19 @@ class HintLabel(RecycleDataViewBehavior, BoxLayout):
         self.dropdown = DropDown()
 
         def set_value(button):
-            self.dropdown.select(button.status)
+            self.dropdown.select(button.priority)
 
         def select(instance, data):
             ctx.update_hint(self.hint["location"],
                             self.hint["finding_player"],
                             data)
 
-        for status in (HintStatus.HINT_NO_PRIORITY, HintStatus.HINT_PRIORITY, HintStatus.HINT_AVOID):
-            name = status_names[status]
-            status_button = Button(text=name, size_hint_y=None, height=dp(50))
-            status_button.status = status
-            status_button.bind(on_release=set_value)
-            self.dropdown.add_widget(status_button)
+        for priority in reversed(HintPriority):
+            name = priority_names[priority]
+            priority_button = Button(text=name, size_hint_y=None, height=dp(50))
+            priority_button.priority = priority
+            priority_button.bind(on_release=set_value)
+            self.dropdown.add_widget(priority_button)
 
         self.dropdown.bind(on_select=select)
 
@@ -404,8 +404,8 @@ class HintLabel(RecycleDataViewBehavior, BoxLayout):
         self.finding_text = data["finding"]["text"]
         self.location_text = data["location"]["text"]
         self.entrance_text = data["entrance"]["text"]
-        self.status_text = data["status"]["text"]
-        self.hint = data["status"]["hint"]
+        self.priority_text = data["priority"]["text"]
+        self.hint = data["priority"]["hint"]
         self.height = self.minimum_height
         return super(HintLabel, self).refresh_view_attrs(rv, index, data)
 
@@ -415,21 +415,21 @@ class HintLabel(RecycleDataViewBehavior, BoxLayout):
             return True
         if self.index:  # skip header
             if self.collide_point(*touch.pos):
-                status_label = self.ids["status"]
-                if status_label.collide_point(*touch.pos):
-                    if self.hint["status"] == HintStatus.HINT_FOUND:
+                priority_label = self.ids["priority"]
+                if priority_label.collide_point(*touch.pos):
+                    if self.hint["found"]:
                         return
                     ctx = App.get_running_app().ctx
                     if ctx.slot_concerns_self(self.hint["receiving_player"]):  # If this player owns this hint
                         # open a dropdown
-                        self.dropdown.open(self.ids["status"])
+                        self.dropdown.open(self.ids["priority"])
                 elif self.selected:
                     self.parent.clear_selection()
                 else:
                     text = "".join((self.receiving_text, "\'s ", self.item_text, " is at ", self.location_text, " in ",
                                     self.finding_text, "\'s World", (" at " + self.entrance_text)
                                     if self.entrance_text != "Vanilla"
-                                    else "", ". (", self.status_text.lower(), ")"))
+                                    else "", ". (", self.priority_text.lower(), ")"))
                     temp = MarkupLabel(text).markup
                     text = "".join(
                         part for part in temp if not part.startswith(("[color", "[/color]", "[ref=", "[/ref]")))
@@ -443,8 +443,8 @@ class HintLabel(RecycleDataViewBehavior, BoxLayout):
             for child in self.children:
                 if child.collide_point(*touch.pos):
                     key = child.sort_key
-                    if key == "status":
-                        parent.hint_sorter = lambda element: element["status"]["hint"]["status"]
+                    if key == "priority":
+                        parent.hint_sorter = HintLog.hint_sorter
                     else: parent.hint_sorter = lambda element: remove_between_brackets.sub("", element[key]["text"]).lower()
                     if key == parent.sort_key:
                         # second click reverses order
@@ -815,19 +815,23 @@ class HintLayout(BoxLayout):
         self.add_widget(boxlayout)
 
         
-status_names: typing.Dict[HintStatus, str] = {
-    HintStatus.HINT_FOUND: "Found",
-    HintStatus.HINT_UNSPECIFIED: "Unspecified",
-    HintStatus.HINT_NO_PRIORITY: "No Priority",
-    HintStatus.HINT_AVOID: "Avoid",
-    HintStatus.HINT_PRIORITY: "Priority",
+priority_names: typing.Dict[HintPriority, str] = {
+    HintPriority.HINT_UNSPECIFIED: "Unspecified",
+    HintPriority.HINT_CAN_SKIP: "Can Skip",
+    HintPriority.HINT_MIGHT_WANT: "Might Want",
+    HintPriority.HINT_AVOID: "Avoid",
+    HintPriority.HINT_AVOID_FOR_NOW: "Avoid For Now",
+    HintPriority.HINT_DESIRED: "Desired",
+    HintPriority.HINT_NEEDED: "Needed",
 }
-status_colors: typing.Dict[HintStatus, str] = {
-    HintStatus.HINT_FOUND: "green",
-    HintStatus.HINT_UNSPECIFIED: "white",
-    HintStatus.HINT_NO_PRIORITY: "cyan",
-    HintStatus.HINT_AVOID: "salmon",
-    HintStatus.HINT_PRIORITY: "plum",
+priority_colors: typing.Dict[HintPriority, str] = {
+    HintPriority.HINT_UNSPECIFIED: "white",
+    HintPriority.HINT_CAN_SKIP: "cyan",
+    HintPriority.HINT_MIGHT_WANT: "cyan",
+    HintPriority.HINT_AVOID: "salmon",
+    HintPriority.HINT_AVOID_FOR_NOW: "salmon",
+    HintPriority.HINT_DESIRED: "plum",
+    HintPriority.HINT_NEEDED: "plum",
 }
 
 
@@ -839,8 +843,8 @@ class HintLog(RecycleView):
         "finding": {"text": "[u]Finding Player[/u]"},
         "location": {"text": "[u]Location[/u]"},
         "entrance": {"text": "[u]Entrance[/u]"},
-        "status": {"text": "[u]Status[/u]",
-                   "hint": {"receiving_player": -1, "location": -1, "finding_player": -1, "status": ""}},
+        "priority": {"text": "[u]Priority[/u]",
+                     "hint": {"receiving_player": -1, "location": -1, "finding_player": -1, "found": False, "priority": ""}},
         "striped": True,
     }
 
@@ -858,13 +862,13 @@ class HintLog(RecycleView):
         data = []
         ctx = App.get_running_app().ctx
         for hint in hints:
-            if not hint.get("status"): # Allows connecting to old servers
-                hint["status"] = HintStatus.HINT_FOUND if hint["found"] else HintStatus.HINT_UNSPECIFIED
-            hint_status_node = self.parser.handle_node({"type": "color",
-                                                        "color": status_colors.get(hint["status"], "red"),
-                                                        "text": status_names.get(hint["status"], "Unknown")})
-            if hint["status"] != HintStatus.HINT_FOUND and ctx.slot_concerns_self(hint["receiving_player"]):
-                hint_status_node = f"[u]{hint_status_node}[/u]"
+            if not hint.get("priority"):  # Allows connecting to old servers
+                hint["priority"] = HintPriority.HINT_UNSPECIFIED
+            hint_priority_node = self.parser.handle_node({"type": "color",
+                                                        "color": "green" if hint["found"] else priority_colors.get(hint["priority"], "red"),
+                                                        "text": "Found" if hint["found"] else priority_names.get(hint["priority"], "Unknown")})
+            if not hint["found"] and ctx.slot_concerns_self(hint["receiving_player"]):
+                hint_priority_node = f"[u]{hint_priority_node}[/u]"
             data.append({
                 "receiving": {"text": self.parser.handle_node({"type": "player_id", "text": hint["receiving_player"]})},
                 "item": {"text": self.parser.handle_node({
@@ -882,8 +886,8 @@ class HintLog(RecycleView):
                 "entrance": {"text": self.parser.handle_node({"type": "color" if hint["entrance"] else "text",
                                                               "color": "blue", "text": hint["entrance"]
                                                               if hint["entrance"] else "Vanilla"})},
-                "status": {
-                    "text": hint_status_node,
+                "priority": {
+                    "text": hint_priority_node,
                     "hint": hint,
                 },
             })
@@ -896,7 +900,9 @@ class HintLog(RecycleView):
 
     @staticmethod
     def hint_sorter(element: dict) -> str:
-        return element["status"]["hint"]["status"]  # By status by default
+        # By priority by default
+        # Found hints sort to one end of priority
+        return "" if element["priority"]["hint"]["found"] else str(element["priority"]["hint"]["priority"])
 
     def fix_heights(self):
         """Workaround fix for divergent texture and layout heights"""


### PR DESCRIPTION
## What is this fixing or adding?

'Found' is no longer part of the priority, though it still shows in the same column in CommonClient.
The removal of 'found' moves 'Unspecified' to the value '0', which some people cared about as a better default value.
This resolves #4620 #4625.

'Status' has been renamed 'Priority' in all relevant locations, per discussion that it makes more sense now that it does not include 'Found'. It specifically holds the *user chosen priority of the hint*, and should not have crossover with server-determined status such as 'found'.

Additional priorities have been added as well. per [this proposal and discussion](https://discord.com/channels/731205301247803413/731214280439103580/1332258944701173762)

The default priority of `avoid` for `trap` classification items, is now overruled by a default `avoid for now` for `trap + progression` joint-classification items, with the addition of the new `avoid for now` priority.

## How was this tested?

Ran a local server + commonclient and tested all ui-related changes.

## If this makes graphical changes, please attach screenshots.

![image](https://github.com/user-attachments/assets/e1b7b911-e6fd-4327-86d6-f5f9eec48889)
![image](https://github.com/user-attachments/assets/54e78861-cd9f-4343-a269-0dabf59a49d2)
![image](https://github.com/user-attachments/assets/246b24e3-ff1c-455e-9182-4bd57503e8a8)
