### PR TITLE
Core: Add a test that checks all registered patches matches the name of a registered world

### DIFF
--- a/test/general/test_patches.py
+++ b/test/general/test_patches.py
@@ -2,9 +2,10 @@
 from worlds.AutoWorld import AutoWorldRegister
 from worlds.Files import AutoPatchRegister
 
+
 class TestPatches(unittest.TestCase):
     def test_patch_name_matches_game(self) -> None:
-        for gamename in AutoPatchRegister.patch_types.keys():
-            with self.subTest(game=gamename):
-                self.assertTrue(gamename in AutoWorldRegister.world_types, 
-                                f"Patch \"{gamename}\" does not match the name of any world.")
+        for game_name in AutoPatchRegister.patch_types:
+            with self.subTest(game=game_name):
+                self.assertIn(game_name, AutoWorldRegister.world_types, 
+                                f"Patch '{game_name}' does not match the name of any world.")

--- a/test/general/test_patches.py
+++ b/test/general/test_patches.py
@@ -1,0 +1,10 @@
+﻿import unittest
+from worlds.AutoWorld import AutoWorldRegister
+from worlds.Files import AutoPatchRegister
+
+class TestPatches(unittest.TestCase):
+    def test_patch_name_matches_game(self) -> None:
+        for gamename in AutoPatchRegister.patch_types.keys():
+            with self.subTest(game=gamename):
+                self.assertTrue(gamename in AutoWorldRegister.world_types, 
+                                f"Patch \"{gamename}\" does not match the name of any world.")

--- a/test/general/test_patches.py
+++ b/test/general/test_patches.py
@@ -7,5 +7,5 @@ class TestPatches(unittest.TestCase):
     def test_patch_name_matches_game(self) -> None:
         for game_name in AutoPatchRegister.patch_types:
             with self.subTest(game=game_name):
-                self.assertIn(game_name, AutoWorldRegister.world_types, 
-                                f"Patch '{game_name}' does not match the name of any world.")
+                self.assertIn(game_name, AutoWorldRegister.world_types.keys(),
+                              f"Patch '{game_name}' does not match the name of any world.")


### PR DESCRIPTION
## What is this fixing or adding?
Adds a test that ensures that every registered `APPatch` has a game name that matches the name of a `World`. This is a test because if these two do not match up, then the patch will not show up as a downloadable file in a Webhost room.

Open to adjustments as I'm not quite sure this test is in the right file, or things I may have missed which might make the test clearer.

## How was this tested?
Tested on https://github.com/cjmang/Archipelago/tree/gstla which had a slight typo in their patch name. Results in
```
SubTest failure: Traceback (most recent call last):
  File "C:\Users\deamo\AppData\Local\Programs\Python\Python312\Lib\unittest\case.py", line 58, in testPartExecutor
    yield
  File "C:\Users\deamo\AppData\Local\Programs\Python\Python312\Lib\unittest\case.py", line 539, in subTest
    yield
  File "D:\Deamon\Projects\Archipelago\test\general\test_patches.py", line 9, in test_patch_name_matches_game
    self.assertTrue(gamename in AutoWorldRegister.world_types,
AssertionError: False is not true : Patch "Golden Sun: The Lost Age" does not match the name of any world.
```
Succeeds on all current patches.