### PR TITLE
LADX: bomb as logical bush breaker

### DIFF
--- a/worlds/ladx/LADXR/logic/requirements.py
+++ b/worlds/ladx/LADXR/logic/requirements.py
@@ -253,7 +253,7 @@ def isConsumable(item) -> bool:
 
 class RequirementsSettings:
     def __init__(self, options):
-        self.bush = OR(SWORD, MAGIC_POWDER, MAGIC_ROD, POWER_BRACELET, BOOMERANG)
+        self.bush = OR(SWORD, MAGIC_POWDER, MAGIC_ROD, POWER_BRACELET, BOOMERANG, BOMB)
         self.pit_bush = OR(SWORD, MAGIC_POWDER, MAGIC_ROD, BOOMERANG, BOMB) # unique
         self.attack = OR(SWORD, BOMB, BOW, MAGIC_ROD, BOOMERANG)
         self.attack_hookshot = OR(SWORD, BOMB, BOW, MAGIC_ROD, BOOMERANG, HOOKSHOT) # hinox, shrouded stalfos


### PR DESCRIPTION
## What is this fixing or adding?
Upstream, bombs aren't considered as bush breakers in logic, for ammo count reasons. In AP we've increased the free refill bomb count from 10 to 30, so it makes sense to consider bombs as bush breakers now.