### PR TITLE
WebHost: Standardize some 404 redirects

### DIFF
--- a/WebHostLib/misc.py
+++ b/WebHostLib/misc.py
@@ -35,6 +35,10 @@ def start_playing():
 @app.route('/games/<string:game>/info/<string:lang>')
 @cache.cached()
 def game_info(game, lang):
+    try:
+        AutoWorldRegister.world_types[game]
+    except KeyError:
+        return abort(404)
     return render_template('gameInfo.html', game=game, lang=lang, theme=get_world_theme(game))
 
 
@@ -52,6 +56,10 @@ def games():
 @app.route('/tutorial/<string:game>/<string:file>/<string:lang>')
 @cache.cached()
 def tutorial(game, file, lang):
+    try:
+        AutoWorldRegister.world_types[game]
+    except KeyError:
+        return abort(404)
     return render_template("tutorial.html", game=game, file=file, lang=lang, theme=get_world_theme(game))
 
 

--- a/WebHostLib/misc.py
+++ b/WebHostLib/misc.py
@@ -36,7 +36,9 @@ def start_playing():
 @cache.cached()
 def game_info(game, lang):
     try:
-        AutoWorldRegister.world_types[game]
+        world = AutoWorldRegister.world_types[game]
+        if lang not in world.web.game_info_languages:
+            raise KeyError("Sorry, this game's info page is not available in that language yet.")
     except KeyError:
         return abort(404)
     return render_template('gameInfo.html', game=game, lang=lang, theme=get_world_theme(game))
@@ -57,7 +59,9 @@ def games():
 @cache.cached()
 def tutorial(game, file, lang):
     try:
-        AutoWorldRegister.world_types[game]
+        world = AutoWorldRegister.world_types[game]
+        if lang not in [tut.link.split("/")[1] for tut in world.web.tutorials]:
+            raise KeyError("Sorry, the tutorial is not available in that language yet.")
     except KeyError:
         return abort(404)
     return render_template("tutorial.html", game=game, file=file, lang=lang, theme=get_world_theme(game))

--- a/WebHostLib/options.py
+++ b/WebHostLib/options.py
@@ -6,7 +6,7 @@ from typing import Dict, Union
 from docutils.core import publish_parts
 
 import yaml
-from flask import redirect, render_template, request, Response
+from flask import redirect, render_template, request, Response, abort
 
 import Options
 from Utils import local_path
@@ -142,7 +142,10 @@ def weighted_options_old():
 @app.route("/games/<string:game>/weighted-options")
 @cache.cached()
 def weighted_options(game: str):
-    return render_options_page("weightedOptions/weightedOptions.html", game, is_complex=True)
+    try:
+        return render_options_page("weightedOptions/weightedOptions.html", game, is_complex=True)
+    except KeyError:
+        return abort(404)
 
 
 @app.route("/games/<string:game>/generate-weighted-yaml", methods=["POST"])
@@ -197,7 +200,10 @@ def generate_weighted_yaml(game: str):
 @app.route("/games/<string:game>/player-options")
 @cache.cached()
 def player_options(game: str):
-    return render_options_page("playerOptions/playerOptions.html", game, is_complex=False)
+    try:
+        return render_options_page("playerOptions/playerOptions.html", game, is_complex=False)
+    except KeyError:
+        return abort(404)
 
 
 # YAML generator for player-options

--- a/WebHostLib/static/assets/gameInfo.js
+++ b/WebHostLib/static/assets/gameInfo.js
@@ -42,10 +42,5 @@ window.addEventListener('load', () => {
                 scrollTarget?.scrollIntoView();
             }
         });
-    }).catch((error) => {
-        console.error(error);
-        gameInfo.innerHTML =
-            `<h2>This page is out of logic!</h2>
-            <h3>Click <a href="${window.location.origin}">here</a> to return to safety.</h3>`;
     });
 });

--- a/WebHostLib/static/assets/tutorial.js
+++ b/WebHostLib/static/assets/tutorial.js
@@ -49,10 +49,5 @@ window.addEventListener('load', () => {
                 scrollTarget?.scrollIntoView();
             }
         });
-    }).catch((error) => {
-        console.error(error);
-        tutorialWrapper.innerHTML =
-            `<h2>This page is out of logic!</h2>
-            <h3>Click <a href="${window.location.origin}/tutorial">here</a> to return to safety.</h3>`;
     });
 });

--- a/worlds/alttp/__init__.py
+++ b/worlds/alttp/__init__.py
@@ -121,6 +121,7 @@ class ALTTPWeb(WebWorld):
     )
 
     tutorials = [setup_en, setup_de, setup_es, setup_fr, msu, msu_es, msu_fr, plando, oof_sound]
+    game_info_languages = ["en", "fr"]
 
 
 class ALTTPWorld(World):

--- a/worlds/aquaria/__init__.py
+++ b/worlds/aquaria/__init__.py
@@ -41,6 +41,7 @@ class AquariaWeb(WebWorld):
     )
 
     tutorials = [setup, setup_fr]
+    game_info_languages = ["en", "fr"]
 
 
 class AquariaWorld(World):

--- a/worlds/clique/__init__.py
+++ b/worlds/clique/__init__.py
@@ -31,6 +31,7 @@ class CliqueWebWorld(WebWorld):
     )
     
     tutorials = [setup_en, setup_de]
+    game_info_languages = ["en", "de"]
 
 
 class CliqueWorld(World):

--- a/worlds/dlcquest/__init__.py
+++ b/worlds/dlcquest/__init__.py
@@ -34,6 +34,7 @@ class DLCqwebworld(WebWorld):
         ["Deoxis"]
     )
     tutorials = [setup_en, setup_fr]
+    game_info_languages = ["en", "fr"]
 
 
 class DLCqworld(World):

--- a/worlds/ffmq/__init__.py
+++ b/worlds/ffmq/__init__.py
@@ -44,6 +44,7 @@ class FFMQWebWorld(WebWorld):
         )
     
     tutorials = [setup_en, setup_fr]
+    game_info_languages = ["en", "fr"]
 
 
 class FFMQWorld(World):

--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -129,6 +129,7 @@ class OOTWeb(WebWorld):
 
     tutorials = [setup, setup_es, setup_fr, setup_de]
     option_groups = oot_option_groups
+    game_info_languages = ["en", "de"]
 
 
 class OOTWorld(World):

--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -41,6 +41,7 @@ class Starcraft2WebWorld(WebWorld):
     )
 
     tutorials = [setup_en, setup_fr]
+    game_info_languages = ["en", "fr"]
 
 
 class SC2World(World):


### PR DESCRIPTION
## What is this fixing or adding?
Some web pages don't use the usual 404 redirect page. They either use a JS-generated page like `tutorial` and `game-info`, or they throw an unformatted 500 error like `player-options` and `weighted-options`.

I added some `abort(404)` calls for those pages if the game name is not supported by Archipelago.

## How was this tested?
Ran WebHost locally, tried to go to pages for Inscryption 2, a game that does not exist yet.

## If this makes graphical changes, please attach screenshots.
Before:
![image](https://github.com/user-attachments/assets/0a807692-4640-4a34-83b4-42f584d47592)
![image](https://github.com/user-attachments/assets/15cc6dca-1ba7-4388-84ec-d99b2575437c)

After:
![image](https://github.com/user-attachments/assets/cda07552-8057-4589-b8de-a3582096120f)
![image](https://github.com/user-attachments/assets/1d9fee60-dc98-4731-9a20-78856c32f647)

