### PR TITLE
v6: Allow secret lab music to be randomized

### DIFF
--- a/worlds/v6/__init__.py
+++ b/worlds/v6/__init__.py
@@ -59,7 +59,7 @@ class V6World(World):
         self.multiworld.itempool += filltrinkets
 
     def generate_basic(self):
-        musiclist_o = [1,2,3,4,9,12]
+        musiclist_o = [1,2,3,4,9,11,12]
         musiclist_s = musiclist_o.copy()
         if self.options.music_rando:
             self.multiworld.random.shuffle(musiclist_s)


### PR DESCRIPTION
Credit to @mateon1 who noticed a crash when going into secret lab.

While future missing-music crashes are mitigated in the client itself, there is no reason to exclude the secret lab music from the randomization itself.