### PR TITLE
Core: StartInventoryFromPool opt-in

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -76,11 +76,7 @@ class MultiWorld():
     progression_balancing: Dict[int, Options.ProgressionBalancing]
     completion_condition: Dict[int, Callable[[CollectionState], bool]]
     indirect_connections: Dict[Region, Set[Entrance]]
-    exclude_locations: Dict[int, Options.ExcludeLocations]
-    priority_locations: Dict[int, Options.PriorityLocations]
-    start_inventory: Dict[int, Options.StartInventory]
-    start_hints: Dict[int, Options.StartHints]
-    start_location_hints: Dict[int, Options.StartLocationHints]
+    start_items_remove_from_pool: dict[int, Counter]
     item_links: Dict[int, Options.ItemLinks]
 
     game: Dict[int, str]
@@ -159,7 +155,6 @@ class MultiWorld():
         self.early_items = {player: {} for player in self.player_ids}
         self.local_early_items = {player: {} for player in self.player_ids}
         self.indirect_connections = {}
-        self.start_inventory_from_pool: Dict[int, Options.StartInventoryPool] = {}
 
         for player in range(1, players + 1):
             def set_player_attr(attr: str, val) -> None:
@@ -238,9 +233,10 @@ class MultiWorld():
         from worlds import AutoWorld
 
         item_links = {}
+        self.item_links = {player: self.worlds[player].options.item_links for player in self.player_ids}
         replacement_prio = [False, True, None]
         for player in self.player_ids:
-            for item_link in self.worlds[player].options.item_links.value:
+            for item_link in self.item_links[player]:
                 if item_link["name"] in item_links:
                     if item_links[item_link["name"]]["game"] != self.game[player]:
                         raise Exception(f"Cannot ItemLink across games. Link: {item_link['name']}")

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -373,6 +373,92 @@ class MultiWorld():
                 self.random.shuffle(items_to_add)
                 self.itempool.extend(items_to_add[:itemcount - len(self.itempool)])
 
+    def collect_starting_inventory(self):
+        """
+        Collects the player specified starting inventory into state and stores what needs to be removed from the pool
+        later.
+        """
+        from Options import StartInventoryPool
+        self.start_items_remove_from_pool = {player: Counter() for player in self.player_ids}
+        for player in self.player_ids:
+            for item_name, count in self.worlds[player].options.start_inventory.value.items():
+                if isinstance(self.worlds[player].options.start_inventory, StartInventoryPool):
+                    self.start_items_remove_from_pool[player][item_name] = count
+                for _ in range(count):
+                    self.push_precollected(self.create_item(item_name, player))
+    
+            for item_name, count in getattr(
+                    self.worlds[player].options,
+                    "start_inventory_from_pool",
+                    StartInventoryPool({})
+            ).value.items():
+                self.start_items_remove_from_pool[player][item_name] = count
+                for _ in range(count):
+                    self.push_precollected(self.create_item(item_name, player))
+            for item_name, count in self.start_items_remove_from_pool[player].items():
+                # remove from_pool items also from early items handling, as starting is plenty early.
+                early = self.early_items[player].get(item_name, 0)
+                if early:
+                    self.early_items[player][item_name] = max(0, early-count)
+                    self.start_items_remove_from_pool[player][item_name] -= early
+                    remaining_count = count-early
+                    if remaining_count > 0:
+                        local_early = self.local_early_items[player].get(item_name, 0)
+                        if local_early:
+                            self.early_items[player][item_name] = max(0, local_early - remaining_count)
+                            self.start_items_remove_from_pool[player][item_name] -= local_early
+                        del local_early
+                del early
+        # filter out any items that went to 0 or negative from early items
+        self.start_items_remove_from_pool = {
+            player: Counter(
+                {
+                    item_name: count
+                    for item_name, count in self.start_items_remove_from_pool[player].items()
+                    if count > 0
+                }
+            ) for player in self.player_ids
+        }
+
+    def remove_starting_inventory_from_pool(self):
+        """
+        Removes starting inventory flagged for removal from the itempool, logging a warning for anything it can't find.
+        """
+        # remove starting inventory from pool items.
+        # Because some worlds don't actually create items during create_items this has to be as late as possible.
+        target_per_player = {
+            player: sum(target_items.values())
+            for player, target_items in self.start_items_remove_from_pool.items()
+        }
+    
+        if target_per_player:
+            new_itempool: List[Item] = []
+    
+            # Make new itempool with start_inventory_from_pool items removed
+            for item in self.itempool:
+                if self.start_items_remove_from_pool[item.player].get(item.name, 0):
+                    self.start_items_remove_from_pool[item.player][item.name] -= 1
+                else:
+                    new_itempool.append(item)
+    
+            # Create filler in place of the removed items, warn if any items couldn't be found in the multiworld itempool
+            for player, target in target_per_player.items():
+                unfound_items = {
+                    item: count for item, count in self.start_items_remove_from_pool[player].items() if count
+                }
+    
+                if unfound_items:
+                    player_name = self.get_player_name(player)
+                    logging.getLogger().warning(
+                        f"{player_name} tried to remove items from their pool that don't exist: {unfound_items}"
+                    )
+    
+                needed_items = target_per_player[player] - sum(unfound_items.values())
+                new_itempool += [self.worlds[player].create_filler() for _ in range(needed_items)]
+    
+            assert len(self.itempool) == len(new_itempool), "Item Pool amounts should not change."
+            self.itempool[:] = new_itempool
+
     def secure(self):
         self.random = ThreadBarrierProxy(secrets.SystemRandom())
         self.is_race = True

--- a/test/bases.py
+++ b/test/bases.py
@@ -170,6 +170,10 @@ class WorldTestBase(unittest.TestCase):
         self.multiworld.set_options(args)
         self.world = self.multiworld.worlds[self.player]
         for step in gen_steps:
+            if step == "create_regions":
+                self.multiworld.collect_starting_inventory()
+            elif step == "pre_fill":
+                self.multiworld.remove_starting_inventory_from_pool()
             call_all(self.multiworld, step)
 
     # methods that can be called within tests

--- a/test/general/__init__.py
+++ b/test/general/__init__.py
@@ -58,6 +58,10 @@ def setup_multiworld(worlds: Union[List[Type[World]], Type[World]], steps: Tuple
             setattr(args, key, updated_options)
     multiworld.set_options(args)
     for step in steps:
+        if step == "create_regions":
+            multiworld.collect_starting_inventory()
+        elif step == "pre_fill":
+            multiworld.remove_starting_inventory_from_pool()
         call_all(multiworld, step)
     return multiworld
 

--- a/worlds/messenger/__init__.py
+++ b/worlds/messenger/__init__.py
@@ -46,7 +46,16 @@ class MessengerWeb(WebWorld):
         ["alwaysintreble"],
     )
 
-    tutorials = [tut_en]
+    plando_en = Tutorial(
+        "Plando Options Guide",
+        "A guide to understanding and using The Messenger's plando options.",
+        "English",
+        "plando_en.md",
+        "plando/en",
+        ["alwaysintreble"],
+    )
+
+    tutorials = [tut_en, plando_en]
 
 
 class MessengerWorld(World):
@@ -190,13 +199,13 @@ class MessengerWorld(World):
     def create_items(self) -> None:
         # create items that are always in the item pool
         main_movement_items = ["Rope Dart", "Wingsuit"]
-        precollected_names = [item.name for item in self.multiworld.precollected_items[self.player]]
         itempool: list[MessengerItem] = [
             self.create_item(item)
             for item in self.item_name_to_id
             if item not in {
                 "Power Seal", *NOTES, *FIGURINES, *main_movement_items,
-                *precollected_names, *FILLER, *TRAPS,
+                *self.multiworld.start_items_remove_from_pool[self.player],
+                *FILLER, *TRAPS,
             }
         ]
 
@@ -208,11 +217,11 @@ class MessengerWorld(World):
         if self.options.goal == Goal.option_open_music_box:
             # make a list of all notes except those in the player's defined starting inventory, and adjust the
             # amount we need to put in the itempool and precollect based on that
-            notes = [note for note in NOTES if note not in precollected_names]
+            notes = [note for note in NOTES if note not in self.multiworld.start_items_remove_from_pool[self.player]]
             self.random.shuffle(notes)
-            precollected_notes_amount = NotesNeeded.range_end - \
-                                        self.options.notes_needed - \
-                                        (len(NOTES) - len(notes))
+            precollected_notes_amount = (NotesNeeded.range_end -
+                                         self.options.notes_needed -
+                                         (len(NOTES) - len(notes)))
             if precollected_notes_amount:
                 for note in notes[:precollected_notes_amount]:
                     self.multiworld.push_precollected(self.create_item(note))
@@ -244,6 +253,8 @@ class MessengerWorld(World):
         filler = [self.create_filler() for _ in range(remaining_fill)]
 
         self.multiworld.itempool += filler
+        # start inventory items aren't ever added to the pool so they don't need to be removed later
+        self.multiworld.start_items_remove_from_pool[self.player] = {}
 
     def set_rules(self) -> None:
         logic = self.options.logic_level

--- a/worlds/messenger/test/test_items.py
+++ b/worlds/messenger/test/test_items.py
@@ -1,0 +1,15 @@
+from . import MessengerTestBase
+
+
+class StartIventoryTest(MessengerTestBase):
+    options = {
+        "start_inventory": {
+            "Wingsuit": 1,
+            "Rope Dart": 1,
+        }
+    }
+
+    def test_items_removed_from_pool(self):
+        """Tests that the start inventory items don't exist in the itempool."""
+        for item in self.multiworld.itempool:
+            self.assertFalse(item in self.options["start_inventory"])


### PR DESCRIPTION
## What is this fixing or adding?
This allows worlds to choose whether they use StartInventory *or* StartInventoryPool for their primary start_inventory, thus allowing them to "opt out" of the regular behavior. Old behavior still stands so that worlds can have both if desired.

## How was this tested?
Generated with a few combinations and wrote a test for messenger using it. The test was also checked with and without messenger's special handling.
