### PR TITLE
OOT: Have beehives that only appear as a child not be in logic if only adult can break beehives

### DIFF
--- a/worlds/oot/data/LogicHelpers.json
+++ b/worlds/oot/data/LogicHelpers.json
@@ -66,6 +66,7 @@
     "can_break_heated_crate": "deadly_bonks != 'ohko' or (Fairy and (can_use(Goron_Tunic) or damage_multiplier != 'ohko')) or can_use(Nayrus_Love) or can_blast_or_smash",
     "can_break_lower_beehive": "can_use(Boomerang) or can_use(Hookshot) or Bombs or (logic_beehives_bombchus and has_bombchus)",
     "can_break_upper_beehive": "can_use(Boomerang) or can_use(Hookshot) or (logic_beehives_bombchus and has_bombchus)",
+    "can_break_upper_beehive_child": "is_child and (can_use(Boomerang) or (logic_beehives_bombchus and has_bombchus))",
     # can_use and helpers
     # The parser reduces this to smallest form based on item category.
     # Note that can_use(item) is False for any item not covered here.

--- a/worlds/oot/data/LogicHelpers.json
+++ b/worlds/oot/data/LogicHelpers.json
@@ -66,7 +66,7 @@
     "can_break_heated_crate": "deadly_bonks != 'ohko' or (Fairy and (can_use(Goron_Tunic) or damage_multiplier != 'ohko')) or can_use(Nayrus_Love) or can_blast_or_smash",
     "can_break_lower_beehive": "can_use(Boomerang) or can_use(Hookshot) or Bombs or (logic_beehives_bombchus and has_bombchus)",
     "can_break_upper_beehive": "can_use(Boomerang) or can_use(Hookshot) or (logic_beehives_bombchus and has_bombchus)",
-    "can_break_upper_beehive_child": "is_child and (can_use(Boomerang) or (logic_beehives_bombchus and has_bombchus))",
+    "can_break_upper_beehive_child": "can_use(Boomerang) or (logic_beehives_bombchus and has_bombchus and is_child)",
     # can_use and helpers
     # The parser reduces this to smallest form based on item category.
     # Note that can_use(item) is False for any item not covered here.

--- a/worlds/oot/data/World/Overworld.json
+++ b/worlds/oot/data/World/Overworld.json
@@ -2233,8 +2233,8 @@
             "ZD Pot 3": "True",
             "ZD Pot 4": "True",
             "ZD Pot 5": "True",
-            "ZD In Front of King Zora Beehive 1": "is_child and can_break_upper_beehive",
-            "ZD In Front of King Zora Beehive 2": "is_child and can_break_upper_beehive",
+            "ZD In Front of King Zora Beehive 1": "can_break_upper_beehive_child",
+            "ZD In Front of King Zora Beehive 2": "can_break_upper_beehive_child",
             "ZD GS Frozen Waterfall": "
                 is_adult and at_night and
                 (Hookshot or Bow or Magic_Meter or logic_domain_gs)",
@@ -2259,7 +2259,7 @@
         "scene": "Zoras Domain",
         "hint": "ZORAS_DOMAIN",
         "locations": {
-            "ZD Behind King Zora Beehive": "is_child and can_break_upper_beehive"
+            "ZD Behind King Zora Beehive": "can_break_upper_beehive_child"
         },
         "exits": {
             "Zoras Domain": "


### PR DESCRIPTION
## What is this fixing or adding?
In Zora's Domain, there are 3 beehives that only appear as Child Link. The current logic checks if Child Link has access to the area and if Child Link or Adult Link can break beehives. The problem is that these beehives do not appear to Adult Link, so if Child Link has access to the area and Adult Link can break beehives, but Child Link cannot, these 3 locations are still considered to be in logic even though they would be unobtainable.
Example can be seen in [this async](https://archipelago.gg/sphere_tracker/rz5YP6RBTYuAaxhkPhiRvw) where the player Me555 has access to the location "ZD In Front of King Zora Beehive 1" in Sphere 3, but based on the player's settings, could only be obtained with the "Boomerang" which was obtained in Sphere 5. 
You can also look at [this playthrough](https://archipelago.gg/dl_spoiler/8Iu1cIymS9yVrscnnX70lg) where the Boomerang is placed in one of the beehives and still successfully generated even though it should have been inaccessible with the player's settings as well as [this playthrough](https://archipelago.gg/dl_spoiler/iADu8ItqSn-1ngSY4EIC3w) where the location was accessible in Sphere 2, but shouldn't have been until the boomerang was obtained in Sphere 16.

This fix adds a new helper that checks if child can access the location and break beehives and removes checking if adult can break the beehive then adds that rule to the three locations.


## How was this tested?
Huge thanks to @palex00 for running the generations for these tests! I tested this fix with three scenarios:
First Test Scenario: I used plando to place the boomerang and light arrows in two of the affected locations while also not putting the logic trick to break beehives with bombchus. Expectation was for a "Game appears as unbeatable. Aborting." error to appear unlike with the first playthrough that I posted above and the generation failed as expected (see Test Scenario 1 Results.txt)

Second Test Scenario: I used plando to place the light arrows to be at one of the locations, then used plando to place the 4 items to give access (bomb bag, zeldas lullaby, ocarina and hookshot) to be at sphere 1 locations and boomerang to be at a later location. Expectation was that rather than the check to be accessible in Sphere 2 like before, that it would only be accessible once the Boomerang was obtained and it worked as expected (see Test Scenario 2 Results.txt)

Third Test Scenario: This is basically a sanity test to ensure that the Logical Trick for "Bombchu breaking beehives" is not affected by my change. It's basically a combination of the first two tests where a bunch of access items are early and boomerang is plando'd to one of those locations with light arrows. Expectation is that rather than having the locations be accessible in Sphere 2, they will be after bombchus can be refilled (by shop or bombchu bowling minigame). This worked as expected as the location was accessible in Sphere 3 after bombchus were purchasable from a shop in Sphere 2!

## If this makes graphical changes, please attach screenshots.
Results of the First Test Scenario: [Test Scenario 1 Results.txt](https://github.com/user-attachments/files/18808649/Test.Scenario.1.Results.txt)
Results of the Second Test Scenario: 
[Test Scenario 2 Results.txt](https://github.com/user-attachments/files/18808650/Test.Scenario.2.Results.txt)
Results of the Third Test Scenario: 
[Test Scenario 3 Results.txt](https://github.com/user-attachments/files/18808651/Test.Scenario.3.Results.txt)
