### PR TITLE
customserver: remove risky static datapackage optimization

### DIFF
--- a/WebHostLib/customserver.py
+++ b/WebHostLib/customserver.py
@@ -136,11 +136,6 @@ class WebHostContext(Context):
             self.item_name_groups[game] = static_item_name_groups.get(game, {})
             self.location_name_groups[game] = static_location_name_groups.get(game, {})
 
-        if not game_data_packages:
-            # all static -> use the static dicts directly
-            self.gamespackage = static_gamespackage
-            self.item_name_groups = static_item_name_groups
-            self.location_name_groups = static_location_name_groups
         return self._load(multidata, game_data_packages, True)
 
     @db_session


### PR DESCRIPTION
## What is this fixing or adding?

It's easy to forget that datapackage/groups could be shared, so this avoids screw-ups and makes it simpler to review MultiServer PRs. Also there is already a special case where _load can mutate static datapackage that should be fixed by this.

## How was this tested?

This wasn't tested directly, but the remaining code path is used heavily on archipelago.gg already.
