### PR TITLE
MultiServer: Fix hinting an item that someone else already hinted in their slot not resolving correctly

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -783,7 +783,7 @@ class Context:
 
     def get_hint(self, team: int, finding_player: int, seeked_location: int) -> typing.Optional[Hint]:
         for hint in self.hints[team, finding_player]:
-            if hint.location == seeked_location:
+            if hint.location == seeked_location and hint.finding_player == finding_player:
                 return hint
         return None
     

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1135,7 +1135,7 @@ def collect_hints(ctx: Context, team: int, slot: int, item: typing.Union[int, st
     seeked_item_id = item if isinstance(item, int) else ctx.item_names_for_game(ctx.games[slot])[item]
     for finding_player, location_id, item_id, receiving_player, item_flags \
             in ctx.locations.find_item(slots, seeked_item_id):
-        prev_hint = ctx.get_hint(team, slot, location_id)
+        prev_hint = ctx.get_hint(team, finding_player, location_id)
         if prev_hint:
             hints.append(prev_hint)
         else:


### PR DESCRIPTION
Fixes https://github.com/ArchipelagoMW/Archipelago/issues/4654?notification_referrer_id=NT_kwDOA3N8G7QxNDgzMDI4MTQ3MDo1NzkwMDA1OQ#issuecomment-2661594964

There are two things going on here:

Problem 1: `get_hint` doesn't check that hint.finding_player == finding_player. This being necessary seems strange initially, but basically, each hint is present in both the finding player's **and** the receiving player's hint store.

Problem 2: The call to `get_hint` uses a variable from a different scope, in a way that I don't think was intended.

### Tested:
Barely, just tested that it resolves the issue at hand, not whether it breaks anything else, and had a cursory glance at the other two usages of `get_hint` to see if they still make sense.