### PR TITLE
TUNIC: Fix Gun being missing from combat_items, and some misc combat logic changes

### DIFF
--- a/worlds/tunic/combat_logic.py
+++ b/worlds/tunic/combat_logic.py
@@ -140,24 +140,14 @@ def check_combat_reqs(area_name: str, state: CollectionState, player: int, alt_d
                 # need sword for bosses
                 if data.is_boss:
                     return False
-                equipment.remove("Sword")
-                if has_magic:
-                    if "Magic" not in equipment:
-                        equipment.append("Magic")
-                    # +4 mp pretty much makes up for the lack of sword, at least in Quarry
-                    extra_mp_needed += 4
-                    if stick_bool:
-                        # stick is a backup plan, and doesn't scale well, so let's require a little less
-                        equipment.append("Stick")
-                        extra_att_needed -= 2
-                    else:
-                        extra_mp_needed += 2
-                        extra_att_needed -= 32
-                elif stick_bool:
+                if stick_bool:
+                    equipment.remove("Sword")
                     equipment.append("Stick")
                     # may revise this later based on feedback
                     extra_att_needed += 3
                     extra_def_needed += 2
+                    # this is for when it changes over to the magic-only state if it needs to later
+                    extra_mp_needed += 4
                 else:
                     return False
 
@@ -204,7 +194,7 @@ def check_combat_reqs(area_name: str, state: CollectionState, player: int, alt_d
                 equip_list.append("Magic")
             more_modified_stats = AreaStats(modified_stats.att_level - 32, modified_stats.def_level,
                                             modified_stats.potion_level, modified_stats.hp_level,
-                                            modified_stats.sp_level, modified_stats.mp_level + 4,
+                                            modified_stats.sp_level, modified_stats.mp_level + 2,
                                             modified_stats.potion_count, equip_list, data.is_boss)
             if check_combat_reqs("none", state, player, more_modified_stats):
                 return True
@@ -222,7 +212,7 @@ def has_required_stats(data: AreaStats, state: CollectionState, player: int) -> 
     player_att, att_offerings = get_att_level(state, player)
 
     # if you have 2 more attack than needed, we can forego needing mp
-    if data.mp_level > 1:
+    if data.mp_level > 1 and "Magic" in data.equipment:
         if player_att < data.att_level + 2:
             player_mp, mp_offerings = get_mp_level(state, player)
             if player_mp < data.mp_level:

--- a/worlds/tunic/er_rules.py
+++ b/worlds/tunic/er_rules.py
@@ -1832,7 +1832,7 @@ def set_er_location_rules(world: "TunicWorld") -> None:
     if world.options.combat_logic == CombatLogic.option_on:
         combat_logic_to_loc("Overworld - [Northeast] Flowers Holy Cross", "Garden Knight")
         combat_logic_to_loc("Overworld - [Northwest] Chest Near Quarry Gate", "Before Well", dagger=True)
-        combat_logic_to_loc("Overworld - [Northeast] Chest Above Patrol Cave", "Garden Knight", dagger=True)
+        combat_logic_to_loc("Overworld - [Northeast] Chest Above Patrol Cave", "West Garden", dagger=True)
         combat_logic_to_loc("Overworld - [Southwest] West Beach Guarded By Turret", "Overworld", dagger=True)
         combat_logic_to_loc("Overworld - [Southwest] West Beach Guarded By Turret 2", "Overworld")
         combat_logic_to_loc("Overworld - [Southwest] Bombable Wall Near Fountain", "Before Well", dagger=True)

--- a/worlds/tunic/items.py
+++ b/worlds/tunic/items.py
@@ -212,7 +212,7 @@ slot_data_item_names = [
 
 combat_items: List[str] = [name for name, data in item_table.items()
                            if data.combat_ic and IC.progression in data.combat_ic]
-combat_items.extend(["Stick", "Sword", "Sword Upgrade", "Magic Wand", "Hero's Laurels"])
+combat_items.extend(["Stick", "Sword", "Sword Upgrade", "Magic Wand", "Hero's Laurels", "Gun"])
 
 item_name_to_id: Dict[str, int] = {name: item_base_id + data.item_id_offset for name, data in item_table.items()}
 


### PR DESCRIPTION
## What is this fixing or adding?
Primarily, this fixes the Gun being missed from the combat_items list, since that had caused a failure where the gun was collected and the logic got weird afterwards. Testing with the failure seed treble provided, just that one-line change fixed the seed.

Other than that, I did the following:
- Very slightly refactored check_combat_reqs to remove a very unnecessary check for if you have magic, when we're already doing a changeover to "what if you didn't have your melee weapon?" down below.
- Changed the combat requirements for one location from a boss name to a non-boss name, since that location shouldn't strictly require a sword
- Added a new test to make sure the cache is actually working properly

## How was this tested?
Unit tests