### PR TITLE
Factorio: prevent invalid starting items count

### DIFF
--- a/worlds/factorio/Options.py
+++ b/worlds/factorio/Options.py
@@ -235,6 +235,12 @@ class FactorioStartItems(OptionDict):
     """Mapping of Factorio internal item-name to amount granted on start."""
     display_name = "Starting Items"
     default = {"burner-mining-drill": 4, "stone-furnace": 4,  "raw-fish": 50}
+    schema = Schema(
+        {
+            str: And(int, lambda n: n > 0,
+                     error="amount of starting items has to be a positive integer"),
+        }
+    )
 
 
 class FactorioFreeSampleBlacklist(OptionSet):


### PR DESCRIPTION
## What is this fixing or adding?
prevents < 1 item counts in starting items

## How was this tested?
```
  starting_items:
    # Mapping of Factorio internal item-name to amount granted on start.
    burner-mining-drill: 0
    raw-fish: 50
    stone-furnace: 4

schema.SchemaError: amount of starting items has to be a positive integer
```
