### PR TITLE
Core: make the event checks int comparisons instead of None

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1323,7 +1323,7 @@ class Location:
     @property
     def is_event(self) -> bool:
         """Returns True if the address of this location is None, denoting it is an Event Location."""
-        return self.address is None
+        return self.address is not int
 
     @property
     def native_item(self) -> bool:

--- a/Main.py
+++ b/Main.py
@@ -281,10 +281,9 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
 
                 locations_data: Dict[int, Dict[int, Tuple[int, int, int]]] = {player: {} for player in multiworld.player_ids}
                 for location in multiworld.get_filled_locations():
-                    if type(location.address) == int:
-                        assert location.item.code is not None, "item code None should be event, " \
-                                                               "location.address should then also be None. Location: " \
-                                                               f" {location}, Item: {location.item}"
+                    if location.address is int:
+                        assert location.item.code is int, ("Locations with int address should have item with int address"
+                                                           f"Location: {location}, Item: {location.item}")
                         assert location.address not in locations_data[location.player], (
                             f"Locations with duplicate address. {location} and "
                             f"{locations_data[location.player][location.address]}")


### PR DESCRIPTION
## What is this fixing or adding?
Changes the check while building multidata and the is_event property to check for `not int` instead of `is None`, since any non int will get scrubbed from multidata, making it an "Event".

## How was this tested?
wasn't