### PR TITLE
The Messenger: add invalid port handling to client launcher

### DIFF
--- a/worlds/messenger/client_setup.py
+++ b/worlds/messenger/client_setup.py
@@ -206,6 +206,14 @@ def launch_game(*args) -> None:
     parser.add_argument("url", type=str, nargs="?", help="Archipelago Webhost uri to auto connect to.")
     args = parser.parse_args(args)
 
+    if args.url:
+        from urllib.parse import urlparse
+        if not urlparse(args.url).port:
+            if not ask_yes_no_cancel(
+                    "Missing Port",
+                    "Invalid port in URL detected. This will cause the game to be unable to connect automatically, "
+                    "but can still be done manually through the in game options menu.\nContinue?"):
+                return
     if not is_windows:
         if args.url:
             open_file(f"steam://rungameid/764790//{args.url}/")

--- a/worlds/messenger/docs/setup_en.md
+++ b/worlds/messenger/docs/setup_en.md
@@ -51,6 +51,8 @@ These steps can also be followed to launch the game and check for mod updates af
    Steam asking if the game should be launched with arguments. These arguments are the URI which the mod uses to
    connect.
 5. Start a new save. You will already be connected in The Messenger and do not need to go through the menus.
+   * If you see the name entry prompt upon creating a new save, this means the connection failed. To fix this, return to
+     the main menu and follow the steps for [Manual Connection.](#manual-connection)
 
 ### Manual Connection
 


### PR DESCRIPTION
## What is this fixing or adding?
Since 0.5.1, the room page has been bugged and the url's sent to launcher from the webhost always have port 0. This causes game connection to fail and has been a very constant thorn in my side. This adds error state handling to the client launcher to warn the player when this happens, and adds information to the setup guide about how to recognize it and what to do.

## How was this tested?
`py Launcher.py "archipelago://test:None@archipelago.gg:0?game=The Messenger"`

## If this makes graphical changes, please attach screenshots.
