### PR TITLE
MultiServer Extend datastore "update" operation to work on lists as well, acting as a pseudo "set union".

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -66,9 +66,13 @@ def pop_from_container(container, value):
     return container
 
 
-def update_dict(dictionary, entries):
-    dictionary.update(entries)
-    return dictionary
+def update_container_unique(container, entries):
+    if isinstance(container, list):
+        existing_container_as_set = set(container)
+        container.extend([entry for entry in entries if entry not in existing_container_as_set])
+    else:
+        container.update(entries)
+    return container
 
 
 def queue_gc():
@@ -109,7 +113,7 @@ modify_functions = {
     # lists/dicts:
     "remove": remove_from_list,
     "pop": pop_from_container,
-    "update": update_dict,
+    "update": update_container_unique,
 }
 
 
@@ -1135,7 +1139,7 @@ def collect_hints(ctx: Context, team: int, slot: int, item: typing.Union[int, st
     seeked_item_id = item if isinstance(item, int) else ctx.item_names_for_game(ctx.games[slot])[item]
     for finding_player, location_id, item_id, receiving_player, item_flags \
             in ctx.locations.find_item(slots, seeked_item_id):
-        prev_hint = ctx.get_hint(team, slot, location_id)
+        prev_hint = ctx.get_hint(team, finding_player, location_id)
         if prev_hint:
             hints.append(prev_hint)
         else:

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -470,7 +470,7 @@ The following operations can be applied to a datastorage key
 | right_shift | Applies a bitwise right-shift to the current value of the key by `value`. |
 | remove | List only: removes the first instance of `value` found in the list. |
 | pop | List or Dict: for lists it will remove the index of the `value` given. for dicts it removes the element with the specified key of `value`. |
-| update | Dict only: Updates the dictionary with the specified elements given in `value` creating new keys, or updating old ones if they previously existed. |
+| update | List or Dict: Adds the elements of `value` to the container if they weren't already present. In the case of a Dict, already present keys will have their corresponding values updated. |
 
 ### SetNotify
 Used to register your current session for receiving all [SetReply](#SetReply) packages of certain keys to allow your client to keep track of changes.


### PR DESCRIPTION
Several people have expressed that they would like it if there were a set type on datastorage.

This PR makes use of some free real estate by extending the `update` command to also work on lists (which currently raises an Exception). The effect is that only elements that weren't already present in the list are added, effectively making it act as a set as long as you only ever use `update`.