### PR TITLE
CI: fix native tests toolchain on windows

### DIFF
--- a/.github/workflows/ctest.yml
+++ b/.github/workflows/ctest.yml
@@ -11,7 +11,7 @@ on:
       - '**.hh?'
       - '**.hpp'
       - '**.hxx'
-      - '**.CMakeLists'
+      - '**/CMakeLists.txt'
       - '.github/workflows/ctest.yml'
   pull_request:
     paths:
@@ -21,7 +21,7 @@ on:
       - '**.hh?'
       - '**.hpp'
       - '**.hxx'
-      - '**.CMakeLists'
+      - '**/CMakeLists.txt'
       - '.github/workflows/ctest.yml'
 
 jobs:

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -7,8 +7,8 @@ find_package(GTest REQUIRED)
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     add_definitions("/source-charset:utf-8")
-    set(CMAKE_CXX_FLAGS_DEBUG "/MTd")
-    set(CMAKE_CXX_FLAGS_RELEASE "/MT")
+    # set(CMAKE_CXX_FLAGS_DEBUG "/MDd") # this is the default
+    # set(CMAKE_CXX_FLAGS_RELEASE "/MD") # this is the default
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     # enable static analysis for gcc
     add_compile_options(-fanalyzer -Werror)

--- a/test/cpp/CMakeLists.txt
+++ b/test/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 project(ap-cpp-tests)
 
 enable_testing()


### PR DESCRIPTION
## What is this fixing or adding?

* gtest (the test runner/lib) now links to libc dynamically on windows (`/MD`). This updates the CMakeLists.txt to link dynamically
* updates cmake version in CMakeLists.txt to get rid of a warning
* also fixes a typo that would make changes to CMakeLists.txt not triggering the workflow run

## How was this tested?

CI