### PR TITLE
Pokémon R/B: Fix Rock Tunnel B1F randomization

### DIFF
--- a/worlds/pokemon_rb/rock_tunnel.py
+++ b/worlds/pokemon_rb/rock_tunnel.py
@@ -262,7 +262,11 @@ def randomize_rock_tunnel(data, random):
                 floor(7, 11)
             else:
                 floor(8, 11)
-                floor(9, 11)
+                if current_map[12][10]==32:
+                    # (10,12) is wide
+                    single(9, 11)
+                else:
+                    floor(9, 11)
         elif r == 3:
             floor(9, 9)
             floor(9, 10)

--- a/worlds/pokemon_rb/rock_tunnel.py
+++ b/worlds/pokemon_rb/rock_tunnel.py
@@ -267,6 +267,10 @@ def randomize_rock_tunnel(data, random):
                     single(9, 11)
                 else:
                     floor(9, 11)
+            if 31 in (current_map[8][6],current_map[8][7]):
+                # (6,7) or (7,7) are tall
+                floor(6, 10)
+                wide(7, 9)
         elif r == 3:
             floor(9, 9)
             floor(9, 10)

--- a/worlds/pokemon_rb/rock_tunnel.py
+++ b/worlds/pokemon_rb/rock_tunnel.py
@@ -186,7 +186,9 @@ def randomize_rock_tunnel(data, random):
         r = random.choice([1, 3])
         floor(12, r)
         floor(12, r + 1)
-
+        if current_map[4][12] + current_map[5][12] == 2:
+            # (12,4) and (12,5) are floor
+            wide(11,4)
     elif c == 2:
         r = random.randint(0, 6)
         if r == 0:

--- a/worlds/pokemon_rb/rock_tunnel.py
+++ b/worlds/pokemon_rb/rock_tunnel.py
@@ -243,12 +243,19 @@ def randomize_rock_tunnel(data, random):
         r = random.randint(r, 6)
         if r == 6:
             #late open
-            r2 = random.randint(0, 2)
-            floor(1 + (r2 * 2), 14)
-            floor(2 + (r2 * 2), 14)
+            if random.randint(0, 1):
+                floor(1, 14)
+                floor(2, 14)
+            else:
+                floor(3, 14)
+                floor(4, 14)
         elif r == 5:
-            floor(6, 12)
-            floor(6, 13)
+            if random.randint(0,1):
+                floor(6, 12)
+                floor(6, 13)
+            else:
+                floor(5, 14)
+                floor(6, 14)
         elif r == 4:
             if random.randint(0, 1):
                 floor(6, 11)

--- a/worlds/pokemon_rb/rock_tunnel.py
+++ b/worlds/pokemon_rb/rock_tunnel.py
@@ -177,7 +177,11 @@ def randomize_rock_tunnel(data, random):
         if random.randint(0, 1):
             floor(10, 7)
             floor(11, 7)
-            tall(random.randint(12, 17), 8)
+            if current_map[10][13]==1:
+                # (13,10) is floor
+                tall(random.randint(14, 16), 8)
+            else:
+                tall(random.randint(12, 16), 8)
         else:
             floor(12, 5)
             floor(12, 6)

--- a/worlds/pokemon_rb/rock_tunnel.py
+++ b/worlds/pokemon_rb/rock_tunnel.py
@@ -227,6 +227,9 @@ def randomize_rock_tunnel(data, random):
             #early block
             wide(13, random.randint(2, 5))
             tall(random.randint(14, 15), 1)
+            if not 1 in (current_map[1][14],current_map[2][13]):
+                # wide(13,2) and tall(14,1) overlap
+                single(13,2)
         elif r == 1:
             if random.randint(0, 1):
                 tall(16, 5)

--- a/worlds/pokemon_rb/rock_tunnel.py
+++ b/worlds/pokemon_rb/rock_tunnel.py
@@ -185,7 +185,7 @@ def randomize_rock_tunnel(data, random):
             wide(17, random.randint(3, 5))
         r = random.choice([1, 3])
         floor(12, r)
-        floor(12,  + 1)
+        floor(12, r + 1)
 
     elif c == 2:
         r = random.randint(0, 6)


### PR DESCRIPTION
This pull request fixes (as of yet unreported) issues with the optional randomization of Rock Tunnel's layout in Pokémon Red and Blue.

## What is this fixing?

The randomization feature was designed to create a cave layout, which - like in the base game - creates one linear path through the tunnel, using every ladder connecting the two floors.

Currently, the function occasionally creates the following on the bottom floor:

- Rocks with their top half missing (see screenshot below)
- Gaps in the walls, connecting all four ladders
- Rocks cutting off one ladder from the other three (happens rarely)

According to my tests, those are the only issues with the randomization; they are now fixed.

![rock_tunnel_half_rocks](https://github.com/user-attachments/assets/91046e35-f1b7-49f6-8bf9-89f35ac68fa1)

## How was this tested?

- Python code to mass verify that seeds produce valid caves (i.e.: no incomplete rocks, one path through)
- Python code to print out Rock Tunnel layout from a patched rom (used to test that the above code works)
- Built several games; played and completed one of them