### PR TITLE
Core/Various Worlds: Fix crash/freeze with unicode characters

### DIFF
--- a/AdventureClient.py
+++ b/AdventureClient.py
@@ -511,7 +511,7 @@ if __name__ == '__main__':
 
     import colorama
 
-    colorama.init()
+    colorama.just_fix_windows_console()
 
     asyncio.run(main())
     colorama.deinit()

--- a/CommonClient.py
+++ b/CommonClient.py
@@ -1128,7 +1128,7 @@ def run_as_textclient(*args):
     args = handle_url_arg(args, parser=parser)
 
     # use colorama to display colored text highlighting on windows
-    colorama.init()
+    colorama.just_fix_windows_console()
 
     asyncio.run(main(args))
     colorama.deinit()

--- a/FF1Client.py
+++ b/FF1Client.py
@@ -261,7 +261,7 @@ if __name__ == '__main__':
 
     parser = get_base_parser()
     args = parser.parse_args()
-    colorama.init()
+    colorama.just_fix_windows_console()
 
     asyncio.run(main(args))
     colorama.deinit()

--- a/LinksAwakeningClient.py
+++ b/LinksAwakeningClient.py
@@ -705,6 +705,6 @@ async def main():
     await ctx.shutdown()
 
 if __name__ == '__main__':
-    colorama.init()
+    colorama.just_fix_windows_console()
     asyncio.run(main())
     colorama.deinit()

--- a/MMBN3Client.py
+++ b/MMBN3Client.py
@@ -370,7 +370,7 @@ if __name__ == "__main__":
 
     import colorama
 
-    colorama.init()
+    colorama.just_fix_windows_console()
 
     asyncio.run(main())
     colorama.deinit()

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -47,7 +47,7 @@ from NetUtils import Endpoint, ClientStatus, NetworkItem, decode, encode, Networ
 from BaseClasses import ItemClassification
 
 min_client_version = Version(0, 1, 6)
-colorama.init()
+colorama.just_fix_windows_console()
 
 
 def remove_from_list(container, value):

--- a/OoTClient.py
+++ b/OoTClient.py
@@ -346,7 +346,7 @@ if __name__ == '__main__':
 
     import colorama
 
-    colorama.init()
+    colorama.just_fix_windows_console()
 
     asyncio.run(main())
     colorama.deinit()

--- a/SNIClient.py
+++ b/SNIClient.py
@@ -735,6 +735,6 @@ async def main() -> None:
 
 
 if __name__ == '__main__':
-    colorama.init()
+    colorama.just_fix_windows_console()
     asyncio.run(main())
     colorama.deinit()

--- a/UndertaleClient.py
+++ b/UndertaleClient.py
@@ -500,7 +500,7 @@ def main():
 
     import colorama
 
-    colorama.init()
+    colorama.just_fix_windows_console()
 
     asyncio.run(_main())
     colorama.deinit()

--- a/WargrooveClient.py
+++ b/WargrooveClient.py
@@ -446,6 +446,6 @@ if __name__ == '__main__':
     parser = get_base_parser(description="Wargroove Client, for text interfacing.")
 
     args, rest = parser.parse_known_args()
-    colorama.init()
+    colorama.just_fix_windows_console()
     asyncio.run(main(args))
     colorama.deinit()

--- a/Zelda1Client.py
+++ b/Zelda1Client.py
@@ -386,7 +386,7 @@ if __name__ == '__main__':
     parser.add_argument('diff_file', default="", type=str, nargs="?",
                         help='Path to a Archipelago Binary Patch file')
     args = parser.parse_args()
-    colorama.init()
+    colorama.just_fix_windows_console()
 
     asyncio.run(main(args))
     colorama.deinit()

--- a/worlds/_bizhawk/context.py
+++ b/worlds/_bizhawk/context.py
@@ -272,6 +272,6 @@ def launch(*launch_args: str) -> None:
 
     Utils.init_logging("BizHawkClient", exception_logger="Client")
     import colorama
-    colorama.init()
+    colorama.just_fix_windows_console()
     asyncio.run(main())
     colorama.deinit()

--- a/worlds/ahit/Client.py
+++ b/worlds/ahit/Client.py
@@ -261,6 +261,6 @@ def launch():
     # options = Utils.get_options()
 
     import colorama
-    colorama.init()
+    colorama.just_fix_windows_console()
     asyncio.run(main())
     colorama.deinit()

--- a/worlds/factorio/Client.py
+++ b/worlds/factorio/Client.py
@@ -530,7 +530,7 @@ server_args = ("--rcon-port", rcon_port, "--rcon-password", rcon_password)
 def launch():
     import colorama
     global executable, server_settings, server_args
-    colorama.init()
+    colorama.just_fix_windows_console()
 
     if server_settings:
         server_settings = os.path.abspath(server_settings)

--- a/worlds/kh1/Client.py
+++ b/worlds/kh1/Client.py
@@ -295,6 +295,6 @@ def launch():
     parser = get_base_parser(description="KH1 Client, for text interfacing.")
 
     args, rest = parser.parse_known_args()
-    colorama.init()
+    colorama.just_fix_windows_console()
     asyncio.run(main(args))
     colorama.deinit()

--- a/worlds/kh2/Client.py
+++ b/worlds/kh2/Client.py
@@ -974,6 +974,6 @@ def launch():
     parser = get_base_parser(description="KH2 Client, for text interfacing.")
 
     args, rest = parser.parse_known_args()
-    colorama.init()
+    colorama.just_fix_windows_console()
     asyncio.run(main(args))
     colorama.deinit()

--- a/worlds/sc2/Client.py
+++ b/worlds/sc2/Client.py
@@ -1625,6 +1625,6 @@ def get_location_offset(mission_id):
 
 
 def launch():
-    colorama.init()
+    colorama.just_fix_windows_console()
     asyncio.run(main())
     colorama.deinit()

--- a/worlds/zillion/client.py
+++ b/worlds/zillion/client.py
@@ -516,6 +516,6 @@ async def main() -> None:
 
 
 def launch() -> None:
-    colorama.init()
+    colorama.just_fix_windows_console()
     asyncio.run(main())
     colorama.deinit()

--- a/worlds/zork_grand_inquisitor/client.py
+++ b/worlds/zork_grand_inquisitor/client.py
@@ -177,7 +177,7 @@ def main() -> None:
 
     import colorama
 
-    colorama.init()
+    colorama.just_fix_windows_console()
 
     asyncio.run(_main())
 


### PR DESCRIPTION
## What is this fixing or adding?

This PR fixes a crash related to colorama when trying to log non-ascii characters as seen in https://discord.com/channels/731205301247803413/1339934780283682846 and https://discord.com/channels/731205301247803413/1323760193917685842. If your world was using colorama.init() that call has also been replaced.

## How was this tested?

Originally tested with the changes just in CommonClient.py and location/item names containing é from the Pokemon Platinum manual did not cause the client to freeze up. When compared with the regular unmodified 0.5.1 text client, it did not have the freezing problem. When the client freezes it spams the log with error messages leading to very large log files. I also tested this on the main branch with and without the change and I saw a noticeable difference.

## If this makes graphical changes, please attach screenshots.
