### PR TITLE
Core: Make Generic ER only consider the current world in isolation by default

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -446,6 +446,20 @@ class MultiWorld():
             self._all_state = ret
         return ret
 
+    def get_single_player_all_state(self, player: int, allow_partial_entrances: bool = False) -> CollectionState:
+        ret = CollectionState(self, allow_partial_entrances)
+
+        world = self.worlds[player]
+
+        for item in self.itempool:
+            if item.player == player:
+                world.collect(ret, item)
+        for item in world.get_pre_fill_items():
+            world.collect(ret, item)
+        ret.sweep_for_advancements(world.get_locations())
+
+        return ret
+
     def get_items(self) -> List[Item]:
         return [loc.item for loc in self.get_filled_locations()] + self.itempool
 

--- a/entrance_rando.py
+++ b/entrance_rando.py
@@ -151,7 +151,7 @@ class ERPlacementState:
         self.pairings = []
         self.world = world
         self.coupled = coupled
-        self.collection_state = world.multiworld.get_all_state(False, True)
+        self.collection_state = world.multiworld.get_single_player_all_state(world.player, True)
 
     @property
     def placed_regions(self) -> set[Region]:
@@ -189,7 +189,7 @@ class ERPlacementState:
         copied_state.blocked_connections[self.world.player].remove(source_exit)
         copied_state.blocked_connections[self.world.player].update(target_entrance.connected_region.exits)
         copied_state.update_reachable_regions(self.world.player)
-        copied_state.sweep_for_advancements()
+        copied_state.sweep_for_advancements(self.world.get_locations())
         # test that at there are newly reachable randomized exits that are ACTUALLY reachable
         available_randomized_exits = copied_state.blocked_connections[self.world.player]
         for _exit in available_randomized_exits:
@@ -333,7 +333,7 @@ def randomize_entrances(
             entrance_lookup.remove(entrance)
         # propagate new connections
         er_state.collection_state.update_reachable_regions(world.player)
-        er_state.collection_state.sweep_for_advancements()
+        er_state.collection_state.sweep_for_advancements(world.get_locations())
         if on_connect:
             on_connect(er_state, placed_exits)
 

--- a/entrance_rando.py
+++ b/entrance_rando.py
@@ -145,13 +145,22 @@ class ERPlacementState:
     """The CollectionState backing the entrance randomization logic"""
     coupled: bool
     """Whether entrance randomization is operating in coupled mode"""
+    single_player_randomization: bool
+    """
+    Whether the entrance randomization is only considering the world, which is having its entrances randomized, in
+    isolation from the rest of the multiworld.
+    """
 
-    def __init__(self, world: World, coupled: bool):
+    def __init__(self, world: World, coupled: bool, single_player_randomization: bool = True):
         self.placements = []
         self.pairings = []
         self.world = world
         self.coupled = coupled
-        self.collection_state = world.multiworld.get_single_player_all_state(world.player, True)
+        self.single_player_randomization = single_player_randomization
+        if single_player_randomization:
+            self.collection_state = world.multiworld.get_single_player_all_state(world.player, True)
+        else:
+            self.collection_state = world.multiworld.get_all_state(False, True)
 
     @property
     def placed_regions(self) -> set[Region]:
@@ -189,7 +198,7 @@ class ERPlacementState:
         copied_state.blocked_connections[self.world.player].remove(source_exit)
         copied_state.blocked_connections[self.world.player].update(target_entrance.connected_region.exits)
         copied_state.update_reachable_regions(self.world.player)
-        copied_state.sweep_for_advancements(self.world.get_locations())
+        copied_state.sweep_for_advancements(self.world.get_locations() if self.single_player_randomization else None)
         # test that at there are newly reachable randomized exits that are ACTUALLY reachable
         available_randomized_exits = copied_state.blocked_connections[self.world.player]
         for _exit in available_randomized_exits:
@@ -297,7 +306,8 @@ def randomize_entrances(
         preserve_group_order: bool = False,
         er_targets: list[Entrance] | None = None,
         exits: list[Entrance] | None = None,
-        on_connect: Callable[[ERPlacementState, list[Entrance]], None] | None = None
+        on_connect: Callable[[ERPlacementState, list[Entrance]], None] | None = None,
+        single_player_randomization: bool = True,
 ) -> ERPlacementState:
     """
     Randomizes Entrances for a single world in the multiworld.
@@ -315,13 +325,18 @@ def randomize_entrances(
                   Remember to be deterministic! If not provided, automatically discovers all valid exits in your world.
     :param on_connect: A callback function which allows specifying side effects after a placement is completed
                        successfully and the underlying collection state has been updated.
+    :param single_player_randomization: Whether the randomization should only consider your World instance in isolation
+                                        from the rest of the multiworld. This should only be False when your world has
+                                        logic depending on part of another world or another world's items, or when some
+                                        of your world's items could have already been placed in another world's
+                                        locations.
     """
     if not world.explicit_indirect_conditions:
         raise EntranceRandomizationError("Entrance randomization requires explicit indirect conditions in order "
                                          + "to correctly analyze whether dead end regions can be required in logic.")
 
     start_time = time.perf_counter()
-    er_state = ERPlacementState(world, coupled)
+    er_state = ERPlacementState(world, coupled, single_player_randomization)
     entrance_lookup = EntranceLookup(world.random, coupled)
     # similar to fill, skip validity checks on entrances if the game is beatable on minimal accessibility
     perform_validity_check = True
@@ -333,7 +348,7 @@ def randomize_entrances(
             entrance_lookup.remove(entrance)
         # propagate new connections
         er_state.collection_state.update_reachable_regions(world.player)
-        er_state.collection_state.sweep_for_advancements(world.get_locations())
+        er_state.collection_state.sweep_for_advancements(world.get_locations() if single_player_randomization else None)
         if on_connect:
             on_connect(er_state, placed_exits)
 


### PR DESCRIPTION
## What is this fixing or adding?

Generic ER was constructing an 'all state' of the entire multiworld and performing sweeps across the entire multiworld.

In most cases, worlds do not logically depend on items/locations/entrances/regions belonging to other worlds, and in most cases, none of the current world's items will have been pre-placed into other worlds. Therefore, Generic ER can instead construct a single-player 'all state' and only sweep locations belonging to the current world.

This improves the performance of Generic ER by preventing its performance from scaling with the number of locations and items belonging to other worlds in the multiworld.

A `get_single_player_all_state()` helper function has been added to `MultiWorld`.

## How was this tested?

It has not been tested.

---
I put this together pretty quickly. The docstrings could probably do with some touching up, and these changes need to actually be tested beyond running the unit tests.

`MultiWorld.get_single_player_all_state()` could be inlined into `ERPlacementState.__init__()` if it is undesirable to add that new method to the `MultiWorld` class.