### PR TITLE
Utils: Improvements to visualize_regions for debugging GER usage

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -940,7 +940,8 @@ def freeze_support() -> None:
 
 def visualize_regions(root_region: Region, file_name: str, *,
                       show_entrance_names: bool = False, show_locations: bool = True, show_other_regions: bool = True,
-                      linetype_ortho: bool = True, regions_to_highlight: set[Region] | None = None) -> None:
+                      linetype_ortho: bool = True, regions_to_highlight: set[Region] | None = None,
+                      entrance_highlighting: dict[int, int] | None = None) -> None:
     """Visualize the layout of a world as a PlantUML diagram.
 
     :param root_region: The region from which to start the diagram from. (Usually the "Menu" region of your world.)
@@ -957,6 +958,8 @@ def visualize_regions(root_region: Region, file_name: str, *,
     :param show_other_regions: (default True) If enabled, regions that can't be reached by traversing exits are shown.
     :param linetype_ortho: (default True) If enabled, orthogonal straight line parts will be used; otherwise polylines.
     :param regions_to_highlight: Regions that will be highlighted in green if they are reachable.
+    :param entrance_highlighting: a mapping from your world's entrance randomization groups to RGB values, used to color
+        your entrances
 
     Example usage in World code:
     from Utils import visualize_regions
@@ -1001,18 +1004,28 @@ def visualize_regions(root_region: Region, file_name: str, *,
 
     def visualize_exits(region: Region) -> None:
         for exit_ in region.exits:
+            color: str = ""
+            if entrance_highlighting and exit_.randomization_group in entrance_highlighting:
+                color = f" #{entrance_highlighting[exit_.randomization_group]:0>6X}"
             if exit_.connected_region:
                 if show_entrance_names:
-                    uml.append(f"\"{fmt(region)}\" --> \"{fmt(exit_.connected_region)}\" : \"{fmt(exit_)}\"")
+                    uml.append(f"\"{fmt(region)}\" --> \"{fmt(exit_.connected_region)}\" : \"{fmt(exit_)}\"{color}")
                 else:
                     try:
-                        uml.remove(f"\"{fmt(exit_.connected_region)}\" --> \"{fmt(region)}\"")
-                        uml.append(f"\"{fmt(exit_.connected_region)}\" <--> \"{fmt(region)}\"")
+                        uml.remove(f"\"{fmt(exit_.connected_region)}\" --> \"{fmt(region)}\"{color}")
+                        uml.append(f"\"{fmt(exit_.connected_region)}\" <--> \"{fmt(region)}\"{color}")
                     except ValueError:
-                        uml.append(f"\"{fmt(region)}\" --> \"{fmt(exit_.connected_region)}\"")
+                        uml.append(f"\"{fmt(region)}\" --> \"{fmt(exit_.connected_region)}\"{color}")
             else:
-                uml.append(f"circle \"unconnected exit:\\n{fmt(exit_)}\"")
-                uml.append(f"\"{fmt(region)}\" --> \"unconnected exit:\\n{fmt(exit_)}\"")
+                uml.append(f"circle \"unconnected exit:\\n{fmt(exit_)}\" {color}")
+                uml.append(f"\"{fmt(region)}\" --> \"unconnected exit:\\n{fmt(exit_)}\"{color}")
+        for entrance in region.entrances:
+            color: str = ""
+            if entrance_highlighting and entrance.randomization_group in entrance_highlighting:
+                color = f" #{entrance_highlighting[entrance.randomization_group]:0>6X}"
+            if not entrance.parent_region:
+                uml.append(f"circle \"unconnected entrance:\\n{fmt(entrance)}\"{color}")
+                uml.append(f"\"unconnected entrance:\\n{fmt(entrance)}\" --> \"{fmt(region)}\"{color}")
 
     def visualize_locations(region: Region) -> None:
         any_lock = any(location.locked for location in region.locations)
@@ -1033,7 +1046,7 @@ def visualize_regions(root_region: Region, file_name: str, *,
         if other_regions := [region for region in multiworld.get_regions(root_region.player) if region not in seen]:
             uml.append("package \"other regions\" <<Cloud>> {")
             for region in other_regions:
-                uml.append(f"class \"{fmt(region)}\"")
+                visualize_region(region)
             uml.append("}")
 
     uml.append("@startuml")


### PR DESCRIPTION
## What is this fixing or adding?

- allow the user to pass in a dict[int, int] to visualize_regions that maps Entrance.randomization_group to a color in RGB form. This allows for better visualization of which dangling entrances should match, or which matching groups are not being correctly respected. Colors are user-provided instead of automatically generated to a) avoid various colorblindness concerns as much as possible, b) allow for highlighting of specific groups when debugging a particular issue.
- do full region visualization for unreached regions, so that entrances that could connect to new regions can be visualized.
- visualize unconnected entrances on regions, in addition to connected and unconnected exits, so that available ER targets can be visualized as well


## How was this tested?

Used it while debugging GER related issues on a world I'm working on at the moment.

## If this makes graphical changes, please attach screenshots.
Before:
![visualize_regions before](https://github.com/user-attachments/assets/30a7f4d4-cf69-4e5a-bb79-8d8ae99eb2a9)

After:
![visualize_regions upgrades](https://github.com/user-attachments/assets/d4005882-6dde-424f-aa5a-d09076e7cc53)

(Example .puml file available upon request.)
