### PR TITLE
MM2: fix seed bleed from shuffled weaknesses

### DIFF
--- a/worlds/mm2/rules.py
+++ b/worlds/mm2/rules.py
@@ -92,7 +92,7 @@ def set_rules(world: "MM2World") -> None:
         world.wily_5_weapons = slot_data["wily_5_weapons"]
     else:
         if world.options.random_weakness == RandomWeaknesses.option_shuffled:
-            weapon_tables = [table for weapon, table in weapon_damage.items() if weapon not in (0, 8)]
+            weapon_tables = [table.copy() for weapon, table in weapon_damage.items() if weapon not in (0, 8)]
             world.random.shuffle(weapon_tables)
             for i in range(1, 8):
                 world.weapon_damage[i] = weapon_tables.pop()


### PR DESCRIPTION
## What is this fixing or adding?
Just minor seed bleed caused by not copying the inner lists within the weapon_damage dict.

## How was this tested?
Put a debugger on a MM2 generation with shuffled weaknesses, watched static `weapon_damage` not change after `world.weapon_damage` was set.

## If this makes graphical changes, please attach screenshots.
