### PR TITLE
TUNIC: Update logic for chest in fortress dark area

### DIFF
--- a/worlds/tunic/er_rules.py
+++ b/worlds/tunic/er_rules.py
@@ -1697,7 +1697,7 @@ def set_er_location_rules(world: "TunicWorld") -> None:
 
     # Beneath the Vault
     set_rule(world.get_location("Beneath the Fortress - Bridge"),
-             lambda state: state.has(lantern, player) and
+             lambda state: has_lantern(state, world) and
                            (has_melee(state, player) or state.has_any((laurels, fire_wand, ice_dagger, gun), player)))
 
     # Quarry

--- a/worlds/tunic/er_rules.py
+++ b/worlds/tunic/er_rules.py
@@ -1697,7 +1697,8 @@ def set_er_location_rules(world: "TunicWorld") -> None:
 
     # Beneath the Vault
     set_rule(world.get_location("Beneath the Fortress - Bridge"),
-             lambda state: has_melee(state, player) or state.has_any((laurels, fire_wand, ice_dagger, gun), player))
+             lambda state: state.has(lantern, player) and
+                           (has_melee(state, player) or state.has_any((laurels, fire_wand, ice_dagger, gun), player)))
 
     # Quarry
     set_rule(world.get_location("Quarry - [Central] Above Ladder Dash Chest"),
@@ -1876,11 +1877,6 @@ def set_er_location_rules(world: "TunicWorld") -> None:
         combat_logic_to_loc("West Garden - [West Highlands] Upper Left Walkway", "West Garden")
         combat_logic_to_loc("West Garden - [Central Highlands] Holy Cross (Blue Lines)", "West Garden")
         combat_logic_to_loc("West Garden - [Central Highlands] Behind Guard Captain", "West Garden")
-
-        # with combat logic on, I presume the player will want to be able to see to avoid the spiders
-        set_rule(world.get_location("Beneath the Fortress - Bridge"),
-                 lambda state: has_lantern(state, world)
-                 and (state.has_any({laurels, fire_wand, "Gun"}, player) or has_melee(state, player)))
 
         combat_logic_to_loc("Eastern Vault Fortress - [West Wing] Candles Holy Cross", "Eastern Vault Fortress",
                             dagger=True)

--- a/worlds/tunic/rules.py
+++ b/worlds/tunic/rules.py
@@ -328,7 +328,8 @@ def set_location_rules(world: "TunicWorld") -> None:
 
     # Beneath the Vault
     set_rule(world.get_location("Beneath the Fortress - Bridge"),
-             lambda state: has_melee(state, player) or state.has_any((laurels, fire_wand, ice_dagger, gun), player))
+             lambda state: state.has(lantern, player) and
+                           (has_melee(state, player) or state.has_any((laurels, fire_wand, ice_dagger, gun), player)))
     set_rule(world.get_location("Beneath the Fortress - Obscured Behind Waterfall"),
              lambda state: has_melee(state, player) and has_lantern(state, world))
 

--- a/worlds/tunic/rules.py
+++ b/worlds/tunic/rules.py
@@ -328,7 +328,7 @@ def set_location_rules(world: "TunicWorld") -> None:
 
     # Beneath the Vault
     set_rule(world.get_location("Beneath the Fortress - Bridge"),
-             lambda state: state.has(lantern, player) and
+             lambda state: has_lantern(state, world) and
                            (has_melee(state, player) or state.has_any((laurels, fire_wand, ice_dagger, gun), player)))
     set_rule(world.get_location("Beneath the Fortress - Obscured Behind Waterfall"),
              lambda state: has_melee(state, player) and has_lantern(state, world))


### PR DESCRIPTION
## What is this fixing or adding?
Adds lantern as a requirement for a chest in a lit section of an otherwise dark area. It didn't originally require lantern as it seemed easy enough to navigate to through a short dark section, but players requested it be changed.

## How was this tested?
Test gens

## If this makes graphical changes, please attach screenshots.
