### PR TITLE
The Messenger: do max on the initial math instead of doing it later

### DIFF
--- a/worlds/messenger/__init__.py
+++ b/worlds/messenger/__init__.py
@@ -228,7 +228,7 @@ class MessengerWorld(World):
                     f"({self.options.total_seals}). Adjusting to {total_seals}"
                 )
                 self.total_seals = total_seals
-            self.required_seals = int(self.options.percent_seals_required.value / 100 * self.total_seals)
+            self.required_seals = max(1, int(self.options.percent_seals_required.value / 100 * self.total_seals))
 
             seals = [self.create_item("Power Seal") for _ in range(self.total_seals)]
             itempool += seals

--- a/worlds/messenger/rules.py
+++ b/worlds/messenger/rules.py
@@ -34,7 +34,7 @@ class MessengerRules:
             "Artificer's Portal":
                 lambda state: state.has_all({"Demon King Crown", "Magic Firefly"}, self.player),
             "Shrink Down":
-                lambda state: state.has_all(NOTES, self.player) or self.has_enough_seals(state),
+                lambda state: state.has_all(NOTES, self.player),
             # the shop
             "Money Sink":
                 lambda state: state.has("Money Wrench", self.player) and self.can_shop(state),
@@ -313,6 +313,9 @@ class MessengerRules:
             "Water Mega Shard":
                 self.has_dart,
         }
+
+        if self.required_seals:
+            self.connection_rules["Shrink Down"] = self.has_enough_seals
 
     def has_wingsuit(self, state: CollectionState) -> bool:
         return state.has("Wingsuit", self.player)

--- a/worlds/messenger/rules.py
+++ b/worlds/messenger/rules.py
@@ -26,7 +26,7 @@ class MessengerRules:
         maximum_price = (world.multiworld.get_location("The Shop - Demon's Bane", self.player).cost +
                          world.multiworld.get_location("The Shop - Focused Power Sense", self.player).cost)
         self.maximum_price = min(maximum_price, world.total_shards)
-        self.required_seals = max(1, world.required_seals)
+        self.required_seals = world.required_seals
 
         # dict of connection names and requirements to traverse the exit
         self.connection_rules = {

--- a/worlds/messenger/test/test_shop_chest.py
+++ b/worlds/messenger/test/test_shop_chest.py
@@ -1,4 +1,4 @@
-from BaseClasses import ItemClassification, CollectionState
+from BaseClasses import CollectionState, ItemClassification
 from . import MessengerTestBase
 
 
@@ -10,8 +10,9 @@ class AllSealsRequired(MessengerTestBase):
     def test_chest_access(self) -> None:
         """Defaults to a total of 45 power seals in the pool and required."""
         with self.subTest("Access Dependency"):
-            self.assertEqual(len([seal for seal in self.multiworld.itempool if seal.name == "Power Seal"]),
-                             self.world.options.total_seals)
+            self.assertEqual(
+                len([seal for seal in self.multiworld.itempool if seal.name == "Power Seal"]),
+                self.world.options.total_seals)
             locations = ["Rescue Phantom"]
             items = [["Power Seal"]]
             self.assertAccessDependency(locations, items)
@@ -93,3 +94,22 @@ class MaxSealsWithShards(MessengerTestBase):
                           if seal.classification == ItemClassification.progression_skip_balancing]
         self.assertEqual(len(total_seals), 85)
         self.assertEqual(len(required_seals), 85)
+
+
+class NoSealsRequired(MessengerTestBase):
+    options = {
+        "goal": "power_seal_hunt",
+        "total_seals": 1,
+        "required_seals": 10,  # percentage
+    }
+
+    def test_seals_amount(self) -> None:
+        """Should be 1 seal and it should be progression."""
+        self.assertEqual(self.world.options.total_seals, 1)
+        self.assertEqual(self.world.total_seals, 1)
+        self.assertEqual(self.world.required_seals, 1)
+        total_seals = [item for item in self.multiworld.itempool if item.name == "Power Seal"]
+        required_seals = [item for item in self.multiworld.itempool if
+                          item.classification & ItemClassification.progression]
+        self.assertEqual(len(total_seals), 1)
+        self.assertEqual(len(required_seals), 1)

--- a/worlds/messenger/test/test_shop_chest.py
+++ b/worlds/messenger/test/test_shop_chest.py
@@ -100,7 +100,7 @@ class NoSealsRequired(MessengerTestBase):
     options = {
         "goal": "power_seal_hunt",
         "total_seals": 1,
-        "required_seals": 10,  # percentage
+        "percent_seals_required": 10,  # percentage
     }
 
     def test_seals_amount(self) -> None:
@@ -110,6 +110,6 @@ class NoSealsRequired(MessengerTestBase):
         self.assertEqual(self.world.required_seals, 1)
         total_seals = [item for item in self.multiworld.itempool if item.name == "Power Seal"]
         required_seals = [item for item in self.multiworld.itempool if
-                          item.classification & ItemClassification.progression]
+                          item.classification & ItemClassification.progression and item.name == "Power Seal"]
         self.assertEqual(len(total_seals), 1)
         self.assertEqual(len(required_seals), 1)

--- a/worlds/messenger/test/test_shop_chest.py
+++ b/worlds/messenger/test/test_shop_chest.py
@@ -110,6 +110,6 @@ class NoSealsRequired(MessengerTestBase):
         self.assertEqual(self.world.required_seals, 1)
         total_seals = [item for item in self.multiworld.itempool if item.name == "Power Seal"]
         required_seals = [item for item in self.multiworld.itempool if
-                          item.classification & ItemClassification.progression and item.name == "Power Seal"]
+                          item.advancement and item.name == "Power Seal"]
         self.assertEqual(len(total_seals), 1)
         self.assertEqual(len(required_seals), 1)


### PR DESCRIPTION
## What is this fixing or adding?
For some reason i was doing max(1, required_seals) in the rules, but not when creating items, making it possible for someone to have 0 required seals at the time of item creation (causing them to all be filler), but then they were still required for the completion condition.

## How was this tested?
debugging, same way it was found, but also added a test :)

## If this makes graphical changes, please attach screenshots.
