### PR TITLE
Core: make accessibility_corrections only state.remove if the location was collected

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -348,10 +348,10 @@ def accessibility_corrections(multiworld: MultiWorld, state: CollectionState, lo
         if (location.item is not None and location.item.advancement and location.address is not None and not
                 location.locked and location.item.player not in minimal_players):
             pool.append(location.item)
-            state.remove(location.item)
             location.item = None
             if location in state.advancements:
                 state.advancements.remove(location)
+                state.remove(location.item)
             locations.append(location)
     if pool and locations:
         locations.sort(key=lambda loc: loc.progress_type != LocationProgressType.PRIORITY)


### PR DESCRIPTION
## What is this fixing or adding?
moves state.remove() to after the check to see if the location was already checked to not make prog_items go negative

## How was this tested?
have a seed for my unsupported world that runs into an assert that a collect override never goes negative that generates fine with this branch

## If this makes graphical changes, please attach screenshots.
