### PR TITLE
AHiT: Add Death Link amnesty options

### DIFF
--- a/worlds/ahit/Options.py
+++ b/worlds/ahit/Options.py
@@ -632,6 +632,14 @@ class DeathLinkAmnesty(Range):
     default = 0
 
 
+class DWDeathLinkAmnesty(Range):
+    """Amount of forgiven deaths before sending a Death Link during Death Wish levels."""
+    display_name = "Death Wish Amnesty"
+    range_start = 0
+    range_end = 30
+    default = 5
+
+
 @dataclass
 class AHITOptions(PerGameCommonOptions):
     EndGoal:                  EndGoal
@@ -708,6 +716,7 @@ class AHITOptions(PerGameCommonOptions):
 
     death_link:               DeathLink
     death_link_amnesty:       DeathLinkAmnesty
+    dw_death_link_amnesty:    DWDeathLinkAmnesty
 
 
 ahit_option_groups: Dict[str, List[Any]] = {
@@ -778,4 +787,5 @@ slot_data_options: List[str] = [
 
     "death_link",
     "death_link_amnesty",
+    "dw_death_link_amnesty",
 ]

--- a/worlds/ahit/Options.py
+++ b/worlds/ahit/Options.py
@@ -623,6 +623,15 @@ class ParadeTrapWeight(Range):
     default = 20
 
 
+class DeathLinkAmnesty(Range):
+    """Amount of forgiven deaths before sending a Death Link.
+    0 means that every death will send a Death Link."""
+    display_name = "Death Link Amnesty"
+    range_start = 0
+    range_end = 20
+    default = 0
+
+
 @dataclass
 class AHITOptions(PerGameCommonOptions):
     EndGoal:                  EndGoal
@@ -698,6 +707,7 @@ class AHITOptions(PerGameCommonOptions):
     ParadeTrapWeight:         ParadeTrapWeight
 
     death_link:               DeathLink
+    death_link_amnesty:       DeathLinkAmnesty
 
 
 ahit_option_groups: Dict[str, List[Any]] = {
@@ -767,4 +777,5 @@ slot_data_options: List[str] = [
     "MaxPonCost",
 
     "death_link",
+    "death_link_amnesty",
 ]


### PR DESCRIPTION
## What is this fixing or adding?
Adds an option to make death links happen only after a certain amount of deaths, similar to amnesty options in some other games. (Functionality in https://github.com/CookieCat45/AHIT-APRandomizer/pull/2)

## How was this tested?
I have tested using the options in a local multiworld and with some different configurations.

## If this makes graphical changes, please attach screenshots.
