### PR TITLE
The Witness: Add Glass Factory Entry Panel as a location in all options

### DIFF
--- a/worlds/witness/data/static_locations.py
+++ b/worlds/witness/data/static_locations.py
@@ -18,6 +18,7 @@ GENERAL_LOCATIONS = {
     "Outside Tutorial Outpost Entry Panel",
     "Outside Tutorial Outpost Exit Panel",
 
+    "Glass Factory Entry Panel",
     "Glass Factory Discard",
     "Glass Factory Back Wall 5",
     "Glass Factory Front 3",


### PR DESCRIPTION
In The Witness, we distinguish between "trivial door panels" and "non-trivial door panels".

"non-trivial door panels" are always checks regardless of options.
"trivial door panels" are only added as checks when playing specific door shuffle modes.

There has been one controversial panel sitting at the edge of this definition.
Glass Factory Entry Panel is a panel that you can't fail, and that is simple to solve, but it's not just a single line - There are multiple solutions.

Since the decision is more or less arbitrary, other factors can be considered.
The Witness really needs more locations on certain min-location-max-item options combinations. The itempool is already overflowing. Also, some seeds struggle to generate. This location has relatively low unlock requirements, so maybe it can help with that too.