### PR TITLE
BizHawkClient: Store seed name sent by the server for clients to check

### DIFF
--- a/worlds/_bizhawk/context.py
+++ b/worlds/_bizhawk/context.py
@@ -41,6 +41,7 @@ class BizHawkClientCommandProcessor(ClientCommandProcessor):
 
 class BizHawkClientContext(CommonContext):
     command_processor = BizHawkClientCommandProcessor
+    server_seed_name: str | None = None
     auth_status: AuthStatus
     password_requested: bool
     client_handler: BizHawkClient | None
@@ -68,6 +69,8 @@ class BizHawkClientContext(CommonContext):
         if cmd == "Connected":
             self.slot_data = args.get("slot_data", None)
             self.auth_status = AuthStatus.AUTHENTICATED
+        elif cmd == "RoomInfo":
+            self.server_seed_name = args.get("seed_name", None)
 
         if self.client_handler is not None:
             self.client_handler.on_package(self, cmd, args)
@@ -100,6 +103,7 @@ class BizHawkClientContext(CommonContext):
 
     async def disconnect(self, allow_autoreconnect: bool=False):
         self.auth_status = AuthStatus.NOT_AUTHENTICATED
+        self.server_seed_name = None
         await super().disconnect(allow_autoreconnect)
 
 


### PR DESCRIPTION
## What is this fixing or adding?

Right now, order matters if a world client wants to use `CommonContext.seed_name` to validate that the player is connecting to the right seed. The connection to the emulator must be made (and the world client must read the seed name from the emulator) before the player connects to the server, otherwise `CommonContext.seed_name` will still be `None` when `RoomInfo` is received, so no validation happens, and then the world client can't retroactively check, because the seed name isn't stored anywhere.

So this just catches the seed name and stores it on the context so that a world client can do its own validation if the connection to the server has already been made.

## How was this tested?

Wasn't
