### PR TITLE
Stardew Valley: Fix a logic bug where the Tea Sapling would be considered available without having the recipe

### DIFF
--- a/worlds/stardew_valley/content/vanilla/base.py
+++ b/worlds/stardew_valley/content/vanilla/base.py
@@ -150,7 +150,8 @@ base_game = BaseGameContentPack(
         Seed.coffee_starter: (CustomRuleSource(lambda logic: logic.traveling_merchant.has_days(3) & logic.monster.can_kill_many(Monster.dust_sprite)),),
         Seed.coffee: (HarvestCropSource(seed=Seed.coffee_starter, seasons=(Season.spring, Season.summer,)),),
 
-        Vegetable.tea_leaves: (CustomRuleSource(lambda logic: logic.has(Sapling.tea) & logic.time.has_lived_months(2) & logic.season.has_any_not_winter()),),
+        Vegetable.tea_leaves: (
+        CustomRuleSource(lambda logic: logic.has(WildSeeds.tea_sapling) & logic.time.has_lived_months(2) & logic.season.has_any_not_winter()),),
     },
     artisan_good_sources={
         Beverage.beer: (MachineSource(item=Vegetable.wheat, machine=Machine.keg),),

--- a/worlds/stardew_valley/logic/logic.py
+++ b/worlds/stardew_valley/logic/logic.py
@@ -67,7 +67,6 @@ from ..strings.fish_names import Fish, Trash, WaterItem, WaterChest
 from ..strings.flower_names import Flower
 from ..strings.food_names import Meal, Beverage
 from ..strings.forageable_names import Forageable
-from ..strings.fruit_tree_names import Sapling
 from ..strings.generic_names import Generic
 from ..strings.geode_names import Geode
 from ..strings.gift_names import Gift
@@ -300,7 +299,6 @@ class StardewLogic(ReceivedLogicMixin, HasLogicMixin, RegionLogicMixin, Travelin
             Ore.radioactive: self.ability.can_mine_perfectly() & self.region.can_reach(Region.qi_walnut_room),
             RetainingSoil.basic: self.money.can_spend_at(Region.pierre_store, 100),
             RetainingSoil.quality: self.time.has_year_two & self.money.can_spend_at(Region.pierre_store, 150),
-            Sapling.tea: self.relationship.has_hearts(NPC.caroline, 2) & self.has(Material.fiber) & self.has(Material.wood),
             SpeedGro.basic: self.money.can_spend_at(Region.pierre_store, 100),
             SpeedGro.deluxe: self.time.has_year_two & self.money.can_spend_at(Region.pierre_store, 150),
             Trash.broken_cd: self.skill.can_crab_pot,

--- a/worlds/stardew_valley/strings/fruit_tree_names.py
+++ b/worlds/stardew_valley/strings/fruit_tree_names.py
@@ -7,4 +7,3 @@ class Sapling:
     pomegranate = "Pomegranate Sapling"
     banana = "Banana Sapling"
     mango = "Mango Sapling"
-    tea = "Tea Sapling"


### PR DESCRIPTION
## What is this fixing or adding?
There was a conflict with the rules of the Tea Sapling that was probably introduced with the 5.x.x update when Craftsanity was added. The previous rule was not removed when the proper crafting rules were introduced. This would create an additional option in the logic to obtain the Tea Sapling, which would only require Wood and Fiber, without considering access to the actual recipe. 

<img width="956" alt="image" src="https://github.com/user-attachments/assets/8b517986-3090-40a2-8faa-9d8217958626" />

Simply removing the rule fixes the issue.

## How was this tested?
Looking at the `/explain_item Tea Sapling` with the removed rule. Notice the part with `Has Wood (item) & Has Fiber (item)` is no longer there.

<img width="910" alt="image" src="https://github.com/user-attachments/assets/993ff569-8522-433b-8d23-adada5644dfd" />

## If this makes graphical changes, please attach screenshots.
N/A
