### PR TITLE
Timespinner: move options checks out of rules

### DIFF
--- a/worlds/timespinner/Locations.py
+++ b/worlds/timespinner/Locations.py
@@ -19,6 +19,29 @@ def get_location_datas(player: Optional[int], options: Optional[TimespinnerOptio
     flooded: Optional[PreCalculatedWeights] = precalculated_weights
     logic = TimespinnerLogic(player, options, precalculated_weights)
 
+    if options and options.specific_keycards:
+        has_keycard_B = logic.has_keycard_B_specific
+        has_keycard_C = logic.has_keycard_C_specific
+        has_keycard_D = logic.has_keycard_D_specific
+    else:
+        has_keycard_B = logic.has_keycard_B
+        has_keycard_C = logic.has_keycard_C
+        has_keycard_D = logic.has_keycard_D
+
+    if options and options.eye_spy:
+        can_break_walls = logic.has_oculus_ring
+    else:
+        can_break_walls = lambda state: True
+
+    if options and options.unchained_keys:
+        has_teleport = lambda state: True
+        can_teleport_to = logic.can_teleport_to_unchained
+    else:
+        has_teleport = logic.has_teleport
+        can_teleport_to = logic.can_teleport_to
+
+    lock_key_amadeus_enabled = options and options.lock_key_amadeus
+
     # 1337000 - 1337155 Generic locations
     # 1337171 - 1337175 New Pickup checks
     # 1337246 - 1337249 Ancient Pyramid
@@ -32,10 +55,10 @@ def get_location_datas(player: Optional[int], options: Optional[TimespinnerOptio
         LocationData('Lake desolation', 'Lake Desolation (Lower): Timespinner Wheel room',  1337005),
         LocationData('Lake desolation', 'Lake Desolation: Forget me not chest',  1337006, lambda state: logic.has_fire(state) and state.can_reach('Upper Lake Serene', 'Region', player)),
         LocationData('Lake desolation', 'Lake Desolation (Lower): Chicken chest', 1337007, logic.has_timestop),
-        LocationData('Lower lake desolation', 'Lake Desolation (Lower): Not so secret room',  1337008, logic.can_break_walls),
+        LocationData('Lower lake desolation', 'Lake Desolation (Lower): Not so secret room',  1337008, can_break_walls),
         LocationData('Lower lake desolation', 'Lake Desolation (Upper): Tank chest',  1337009, logic.has_timestop),
         LocationData('Upper lake desolation', 'Lake Desolation (Upper): Oxygen recovery room',  1337010),
-        LocationData('Upper lake desolation', 'Lake Desolation (Upper): Secret room',  1337011, logic.can_break_walls),
+        LocationData('Upper lake desolation', 'Lake Desolation (Upper): Secret room',  1337011, can_break_walls),
         LocationData('Upper lake desolation', 'Lake Desolation (Upper): Double jump cave platform',  1337012, logic.has_doublejump),
         LocationData('Upper lake desolation', 'Lake Desolation (Upper): Double jump cave floor',  1337013),
         LocationData('Upper lake desolation', 'Lake Desolation (Upper): Sparrow chest',  1337014),
@@ -47,9 +70,9 @@ def get_location_datas(player: Optional[int], options: Optional[TimespinnerOptio
         LocationData('Library', 'Library: Warp gate',  1337020),
         LocationData('Library', 'Library: Librarian',  1337021),
         LocationData('Library', 'Library: Reading nook chest',  1337022),
-        LocationData('Library', 'Library: Storage room chest 1',  1337023, logic.has_keycard_D),
-        LocationData('Library', 'Library: Storage room chest 2',  1337024, logic.has_keycard_D),
-        LocationData('Library', 'Library: Storage room chest 3',  1337025, logic.has_keycard_D),
+        LocationData('Library', 'Library: Storage room chest 1',  1337023, has_keycard_D),
+        LocationData('Library', 'Library: Storage room chest 2',  1337024, has_keycard_D),
+        LocationData('Library', 'Library: Storage room chest 3',  1337025, has_keycard_D),
         LocationData('Library top', 'Library: Backer room chest 5',  1337026),
         LocationData('Library top', 'Library: Backer room chest 4',  1337027),
         LocationData('Library top', 'Library: Backer room chest 3',  1337028),
@@ -57,8 +80,8 @@ def get_location_datas(player: Optional[int], options: Optional[TimespinnerOptio
         LocationData('Library top', 'Library: Backer room chest 1',  1337030),
         LocationData('Varndagroth tower left', 'Varndagroth Towers (Left): Elevator Key not required',  1337031),
         LocationData('Varndagroth tower left', 'Varndagroth Towers (Left): Ye olde Timespinner',  1337032),
-        LocationData('Varndagroth tower left', 'Varndagroth Towers (Left): Bottom floor',  1337033, logic.has_keycard_C),
-        LocationData('Varndagroth tower left', 'Varndagroth Towers (Left): Air vents secret',  1337034, logic.can_break_walls),
+        LocationData('Varndagroth tower left', 'Varndagroth Towers (Left): Bottom floor',  1337033, has_keycard_C),
+        LocationData('Varndagroth tower left', 'Varndagroth Towers (Left): Air vents secret',  1337034, can_break_walls),
         LocationData('Varndagroth tower left', 'Varndagroth Towers (Left): Elevator chest',  1337035, lambda state: state.has('Elevator Keycard', player)),
         LocationData('Varndagroth tower right (upper)', 'Varndagroth Towers: Bridge',  1337036),
         LocationData('Varndagroth tower right (elevator)', 'Varndagroth Towers (Right): Elevator chest',  1337037),
@@ -66,14 +89,14 @@ def get_location_datas(player: Optional[int], options: Optional[TimespinnerOptio
         LocationData('Varndagroth tower right (upper)', 'Varndagroth Towers (Right): Air vents right chest',  1337039, lambda state: state.has('Elevator Keycard', player) or logic.has_doublejump(state)),
         LocationData('Varndagroth tower right (upper)', 'Varndagroth Towers (Right): Air vents left chest',  1337040, lambda state: state.has('Elevator Keycard', player) or logic.has_doublejump(state)),
         LocationData('Varndagroth tower right (lower)', 'Varndagroth Towers (Right): Bottom floor',  1337041),
-        LocationData('Varndagroth tower right (elevator)', 'Varndagroth Towers (Right): Varndagroth',  1337042, logic.has_keycard_C),
+        LocationData('Varndagroth tower right (elevator)', 'Varndagroth Towers (Right): Varndagroth',  1337042, has_keycard_C),
         LocationData('Varndagroth tower right (elevator)', 'Varndagroth Towers (Right): Spider Hell',  1337043, logic.has_keycard_A),
         LocationData('Skeleton Shaft', 'Sealed Caves (Xarion): Skeleton',  1337044),
         LocationData('Sealed Caves (Xarion)', 'Sealed Caves (Xarion): Shroom jump room',  1337045, logic.has_timestop),
         LocationData('Sealed Caves (Xarion)', 'Sealed Caves (Xarion): Double shroom room',  1337046),
         LocationData('Sealed Caves (Xarion)', 'Sealed Caves (Xarion): Jacksquat room',  1337047, logic.has_forwarddash_doublejump),
         LocationData('Sealed Caves (Xarion)', 'Sealed Caves (Xarion): Below Jacksquat room',  1337048),
-        LocationData('Sealed Caves (Xarion)', 'Sealed Caves (Xarion): Secret room',  1337049, logic.can_break_walls),
+        LocationData('Sealed Caves (Xarion)', 'Sealed Caves (Xarion): Secret room',  1337049, can_break_walls),
         LocationData('Sealed Caves (Xarion)', 'Sealed Caves (Xarion): Bottom left room',  1337050),
         LocationData('Sealed Caves (Xarion)', 'Sealed Caves (Xarion): Last chance before Xarion',  1337051, logic.has_doublejump),
         LocationData('Sealed Caves (Xarion)', 'Sealed Caves (Xarion): Xarion',  1337052, lambda state: not flooded.flood_xarion or state.has('Water Mask', player)),
@@ -87,22 +110,22 @@ def get_location_datas(player: Optional[int], options: Optional[TimespinnerOptio
         LocationData('Military Fortress (hangar)', 'Military Fortress: Soldiers bridge',  1337060),
         LocationData('Military Fortress (hangar)', 'Military Fortress: Giantess room',  1337061),
         LocationData('Military Fortress (hangar)', 'Military Fortress: Giantess bridge',  1337062),
-        LocationData('Military Fortress (hangar)', 'Military Fortress: B door chest 2',  1337063, lambda state: logic.has_keycard_B(state) and (state.has('Water Mask', player) if flooded.flood_lab else logic.has_doublejump(state))),
-        LocationData('Military Fortress (hangar)', 'Military Fortress: B door chest 1',  1337064, lambda state: logic.has_keycard_B(state) and (state.has('Water Mask', player) if flooded.flood_lab else logic.has_doublejump(state))),
+        LocationData('Military Fortress (hangar)', 'Military Fortress: B door chest 2',  1337063, lambda state: has_keycard_B(state) and (state.has('Water Mask', player) if flooded.flood_lab else logic.has_doublejump(state))),
+        LocationData('Military Fortress (hangar)', 'Military Fortress: B door chest 1',  1337064, lambda state: has_keycard_B(state) and (state.has('Water Mask', player) if flooded.flood_lab else logic.has_doublejump(state))),
         LocationData('Military Fortress (hangar)', 'Military Fortress: Pedestal',  1337065, lambda state: state.has('Water Mask', player) if flooded.flood_lab else (logic.has_doublejump_of_npc(state) or logic.has_forwarddash_doublejump(state))),
         LocationData('The lab', 'Lab: Coffee break',  1337066),
         LocationData('The lab', 'Lab: Lower trash right',  1337067, logic.has_doublejump),
-        LocationData('The lab', 'Lab: Lower trash left',  1337068, lambda state: logic.has_doublejump_of_npc(state) if logic.lock_key_amadeus_enabled() else logic.has_upwarddash ),
+        LocationData('The lab', 'Lab: Lower trash left',  1337068, lambda state: logic.has_doublejump_of_npc(state) if lock_key_amadeus_enabled else logic.has_upwarddash ),
         LocationData('The lab', 'Lab: Below lab entrance',  1337069, logic.has_doublejump),
-        LocationData('The lab (power off)', 'Lab: Trash jump room',  1337070, lambda state: not logic.lock_key_amadeus_enabled() or logic.has_doublejump_of_npc(state) ),
-        LocationData('The lab (power off)', 'Lab: Dynamo Works',  1337071, lambda state: not logic.lock_key_amadeus_enabled() or (state.has_all(('Lab Access Research', 'Lab Access Dynamo'), player)) ),
+        LocationData('The lab (power off)', 'Lab: Trash jump room',  1337070, lambda state: not lock_key_amadeus_enabled or logic.has_doublejump_of_npc(state) ),
+        LocationData('The lab (power off)', 'Lab: Dynamo Works',  1337071, lambda state: not lock_key_amadeus_enabled or (state.has_all(('Lab Access Research', 'Lab Access Dynamo'), player)) ),
         LocationData('The lab (upper)', 'Lab: Genza (Blob Mom)',  1337072),
-        LocationData('The lab (power off)', 'Lab: Experiment #13',  1337073, lambda state: not logic.lock_key_amadeus_enabled() or state.has('Lab Access Experiment', player) ),
+        LocationData('The lab (power off)', 'Lab: Experiment #13',  1337073, lambda state: not lock_key_amadeus_enabled or state.has('Lab Access Experiment', player) ),
         LocationData('The lab (upper)', 'Lab: Download and chest room chest',  1337074),
-        LocationData('The lab (upper)', 'Lab: Lab secret',  1337075, logic.can_break_walls),
-        LocationData('The lab (power off)', 'Lab: Spider Hell',  1337076, lambda state: logic.has_keycard_A and not logic.lock_key_amadeus_enabled() or state.has('Lab Access Research', player)),
+        LocationData('The lab (upper)', 'Lab: Lab secret',  1337075, can_break_walls),
+        LocationData('The lab (power off)', 'Lab: Spider Hell',  1337076, lambda state: logic.has_keycard_A and not lock_key_amadeus_enabled or state.has('Lab Access Research', player)),
         LocationData('Emperors tower', 'Emperor\'s Tower: Courtyard bottom chest',  1337077),
-        LocationData('Emperors tower', 'Emperor\'s Tower: Courtyard floor secret',  1337078, lambda state: logic.has_upwarddash(state) and logic.can_break_walls(state)),
+        LocationData('Emperors tower', 'Emperor\'s Tower: Courtyard floor secret',  1337078, lambda state: logic.has_upwarddash(state) and can_break_walls(state)),
         LocationData('Emperors tower', 'Emperor\'s Tower: Courtyard upper chest',  1337079, lambda state: logic.has_upwarddash(state)),
         LocationData('Emperors tower', 'Emperor\'s Tower: Galactic sage room',  1337080),
         LocationData('Emperors tower', 'Emperor\'s Tower: Bottom right tower',  1337081),
@@ -119,7 +142,7 @@ def get_location_datas(player: Optional[int], options: Optional[TimespinnerOptio
         LocationData('Refugee Camp', 'Refugee Camp: Storage chest 1',  1337089),
         LocationData('Forest', 'Forest: Refugee camp roof',  1337090),
         LocationData('Forest', 'Forest: Bat jump ledge',  1337091, lambda state: logic.has_doublejump_of_npc(state) or logic.has_forwarddash_doublejump(state) or logic.has_fastjump_on_npc(state)),
-        LocationData('Forest', 'Forest: Green platform secret',  1337092, logic.can_break_walls),
+        LocationData('Forest', 'Forest: Green platform secret',  1337092, can_break_walls),
         LocationData('Forest', 'Forest: Rats guarded chest',  1337093),
         LocationData('Forest', 'Forest: Waterfall chest 1',  1337094, lambda state: state.has('Water Mask', player)),
         LocationData('Forest', 'Forest: Waterfall chest 2',  1337095, lambda state: state.has('Water Mask', player)),
@@ -129,7 +152,7 @@ def get_location_datas(player: Optional[int], options: Optional[TimespinnerOptio
         LocationData('Upper Lake Serene', 'Lake Serene (Upper): Rat nest',  1337099),
         LocationData('Upper Lake Serene', 'Lake Serene (Upper): Double jump cave platform',  1337100, logic.has_doublejump),
         LocationData('Upper Lake Serene', 'Lake Serene (Upper): Double jump cave floor',  1337101),
-        LocationData('Upper Lake Serene', 'Lake Serene (Upper): Cave secret',  1337102, logic.can_break_walls),
+        LocationData('Upper Lake Serene', 'Lake Serene (Upper): Cave secret',  1337102, can_break_walls),
         LocationData('Upper Lake Serene', 'Lake Serene: Before Big Bird', 1337175),
         LocationData('Upper Lake Serene', 'Lake Serene: Behind the vines',  1337103),
         LocationData('Upper Lake Serene', 'Lake Serene: Pyramid keys room',  1337104),
@@ -137,12 +160,12 @@ def get_location_datas(player: Optional[int], options: Optional[TimespinnerOptio
         LocationData('Lower Lake Serene', 'Lake Serene (Lower): Deep dive',  1337105),
         LocationData('Left Side forest Caves', 'Lake Serene (Lower): Under the eels',  1337106, lambda state: state.has('Water Mask', player)),
         LocationData('Lower Lake Serene', 'Lake Serene (Lower): Water spikes room',  1337107),
-        LocationData('Lower Lake Serene', 'Lake Serene (Lower): Underwater secret',  1337108, logic.can_break_walls),
+        LocationData('Lower Lake Serene', 'Lake Serene (Lower): Underwater secret',  1337108, can_break_walls),
         LocationData('Lower Lake Serene', 'Lake Serene (Lower): T chest',  1337109, lambda state: flooded.flood_lake_serene or logic.has_doublejump_of_npc(state)),
         LocationData('Left Side forest Caves', 'Lake Serene (Lower): Past the eels',  1337110, lambda state: state.has('Water Mask', player)),
         LocationData('Lower Lake Serene', 'Lake Serene (Lower): Underwater pedestal',  1337111, lambda state: flooded.flood_lake_serene or logic.has_doublejump(state)),
         LocationData('Caves of Banishment (upper)', 'Caves of Banishment (Maw): Shroom jump room',  1337112, lambda state: flooded.flood_maw or logic.has_doublejump(state)),
-        LocationData('Caves of Banishment (upper)', 'Caves of Banishment (Maw): Secret room',  1337113, lambda state: logic.can_break_walls(state) and (not flooded.flood_maw or state.has('Water Mask', player))),
+        LocationData('Caves of Banishment (upper)', 'Caves of Banishment (Maw): Secret room',  1337113, lambda state: can_break_walls(state) and (not flooded.flood_maw or state.has('Water Mask', player))),
         LocationData('Caves of Banishment (upper)', 'Caves of Banishment (Maw): Bottom left room',  1337114, lambda state: not flooded.flood_maw or state.has('Water Mask', player)),
         LocationData('Caves of Banishment (upper)', 'Caves of Banishment (Maw): Single shroom room',  1337115),
         LocationData('Caves of Banishment (upper)', 'Caves of Banishment (Maw): Jackpot room chest 1',  1337116, lambda state: flooded.flood_maw or logic.has_forwarddash_doublejump(state)),
@@ -165,7 +188,7 @@ def get_location_datas(player: Optional[int], options: Optional[TimespinnerOptio
         LocationData('Castle Ramparts', 'Castle Ramparts: Giantess guarded room',  1337130),
         LocationData('Castle Ramparts', 'Castle Ramparts: Knight and archer guarded room',  1337131),
         LocationData('Castle Ramparts', 'Castle Ramparts: Pedestal',  1337132),
-        LocationData('Castle Basement', 'Castle Basement: Secret pedestal',  1337133, logic.can_break_walls),
+        LocationData('Castle Basement', 'Castle Basement: Secret pedestal',  1337133, can_break_walls),
         LocationData('Castle Basement', 'Castle Basement: Clean the castle basement',  1337134),
         LocationData('Royal towers (lower)', 'Castle Keep: Yas queen room',  1337135, logic.has_pink),
         LocationData('Castle Basement', 'Castle Basement: Giantess guarded chest',  1337136),
@@ -176,7 +199,7 @@ def get_location_datas(player: Optional[int], options: Optional[TimespinnerOptio
         LocationData('Castle Keep', 'Castle Keep: Advisor jump', 1337171, logic.has_timestop),
         LocationData('Castle Keep', 'Castle Keep: Twins',  1337140, logic.has_timestop),
         LocationData('Castle Keep', 'Castle Keep: Royal guard tiny room',  1337141, lambda state: logic.has_doublejump(state) or logic.has_fastjump_on_npc(state)),
-        LocationData('Royal towers (lower)', 'Royal Towers: Floor secret',  1337142, lambda state: logic.has_doublejump(state) and logic.can_break_walls(state)),
+        LocationData('Royal towers (lower)', 'Royal Towers: Floor secret',  1337142, lambda state: logic.has_doublejump(state) and can_break_walls(state)),
         LocationData('Royal towers', 'Royal Towers: Pre-climb gap',  1337143),
         LocationData('Royal towers', 'Royal Towers: Long balcony',  1337144, lambda state: not flooded.flood_courtyard or state.has('Water Mask', player)),
         LocationData('Royal towers', 'Royal Towers: Past bottom struggle juggle',  1337145, lambda state: flooded.flood_courtyard or logic.has_doublejump_of_npc(state)),
@@ -195,8 +218,8 @@ def get_location_datas(player: Optional[int], options: Optional[TimespinnerOptio
         # Ancient pyramid locations
         LocationData('Ancient Pyramid (entrance)', 'Ancient Pyramid: Why not it\'s right there',  1337246),
         LocationData('Ancient Pyramid (left)', 'Ancient Pyramid: Conviction guarded room',  1337247),
-        LocationData('Ancient Pyramid (left)', 'Ancient Pyramid: Pit secret room',  1337248, lambda state: logic.can_break_walls(state) and (not flooded.flood_pyramid_shaft or state.has('Water Mask', player))),
-        LocationData('Ancient Pyramid (left)', 'Ancient Pyramid: Regret chest',  1337249, lambda state: logic.can_break_walls(state) and (state.has('Water Mask', player) if flooded.flood_pyramid_shaft else logic.has_doublejump(state))),
+        LocationData('Ancient Pyramid (left)', 'Ancient Pyramid: Pit secret room',  1337248, lambda state: can_break_walls(state) and (not flooded.flood_pyramid_shaft or state.has('Water Mask', player))),
+        LocationData('Ancient Pyramid (left)', 'Ancient Pyramid: Regret chest',  1337249, lambda state: can_break_walls(state) and (state.has('Water Mask', player) if flooded.flood_pyramid_shaft else logic.has_doublejump(state))),
         LocationData('Ancient Pyramid (right)', 'Ancient Pyramid: Nightmare Door chest',  1337236, lambda state: not flooded.flood_pyramid_back or state.has('Water Mask', player)),
         LocationData('Ancient Pyramid (right)', 'Killed Nightmare', EventId, lambda state: state.has_all({'Timespinner Wheel', 'Timespinner Spindle', 'Timespinner Gear 1', 'Timespinner Gear 2', 'Timespinner Gear 3'}, player) and (not flooded.flood_pyramid_back or state.has('Water Mask', player)))
     ]
@@ -212,13 +235,13 @@ def get_location_datas(player: Optional[int], options: Optional[TimespinnerOptio
             LocationData('Library', 'Library: V terminal 2 (Lake Desolation Map)',  1337161, lambda state: state.has_all({'Tablet', 'Library Keycard V'}, player)),
             LocationData('Library', 'Library: V terminal 3 (Vilete)',  1337162, lambda state: state.has_all({'Tablet', 'Library Keycard V'}, player)),
             LocationData('Library top', 'Library: Backer room terminal (Vandagray Metropolis Map)',  1337163, lambda state: state.has('Tablet', player)),
-            LocationData('Varndagroth tower right (elevator)', 'Varndagroth Towers (Right): Medbay terminal (Bleakness Research)',  1337164, lambda state: state.has('Tablet', player) and logic.has_keycard_B(state)),
+            LocationData('Varndagroth tower right (elevator)', 'Varndagroth Towers (Right): Medbay terminal (Bleakness Research)',  1337164, lambda state: state.has('Tablet', player) and has_keycard_B(state)),
             LocationData('The lab (upper)', 'Lab: Download and chest room terminal (Experiment #13)',  1337165, lambda state: state.has('Tablet', player)),
-            LocationData('The lab (power off)', 'Lab: Middle terminal (Amadeus Laboratory Map)',  1337166, lambda state: state.has('Tablet', player) and (not logic.lock_key_amadeus_enabled() or state.has('Lab Access Research', player))),
-            LocationData('The lab (power off)', 'Lab: Sentry platform terminal (Origins)',  1337167, lambda state: state.has('Tablet', player) and (not logic.lock_key_amadeus_enabled() or state.has('Lab Access Genza', player) or logic.can_teleport_to(state, "Time", "GateDadsTower"))),
+            LocationData('The lab (power off)', 'Lab: Middle terminal (Amadeus Laboratory Map)',  1337166, lambda state: state.has('Tablet', player) and (not lock_key_amadeus_enabled or state.has('Lab Access Research', player))),
+            LocationData('The lab (power off)', 'Lab: Sentry platform terminal (Origins)',  1337167, lambda state: state.has('Tablet', player) and (not lock_key_amadeus_enabled or state.has('Lab Access Genza', player) or (has_teleport(state) and can_teleport_to(state, "Time", "GateDadsTower")))),
             LocationData('The lab', 'Lab: Experiment 13 terminal (W.R.E.C Farewell)',  1337168, lambda state: state.has('Tablet', player)),
             LocationData('The lab', 'Lab: Left terminal (Biotechnology)',  1337169, lambda state: state.has('Tablet', player)),
-            LocationData('The lab (power off)', 'Lab: Right terminal (Experiment #11)',  1337170, lambda state: state.has('Tablet', player) and (not logic.lock_key_amadeus_enabled() or state.has('Lab Access Research', player)))
+            LocationData('The lab (power off)', 'Lab: Right terminal (Experiment #11)',  1337170, lambda state: state.has('Tablet', player) and (not lock_key_amadeus_enabled or state.has('Lab Access Research', player)))
         )
 
     # 1337176 - 1337176 Cantoran
@@ -235,11 +258,11 @@ def get_location_datas(player: Optional[int], options: Optional[TimespinnerOptio
             LocationData('Library top', 'Library: Memory - Library Gap (Lachiemi Sun)',  1337179),
             LocationData('Library top', 'Library: Memory - Mr. Hat Portrait (Moonlit Night)',  1337180),
             LocationData('Varndagroth tower left', 'Varndagroth Towers (Left): Memory - Elevator (Nomads)',  1337181, lambda state: state.has('Elevator Keycard', player)),
-            LocationData('Varndagroth tower right (lower)', 'Varndagroth Towers: Memory - Siren Elevator (Childhood)',  1337182, logic.has_keycard_B),
+            LocationData('Varndagroth tower right (lower)', 'Varndagroth Towers: Memory - Siren Elevator (Childhood)',  1337182, has_keycard_B),
             LocationData('Varndagroth tower right (lower)', 'Varndagroth Towers (Right): Memory - Bottom (Faron)',  1337183),
             LocationData('Military Fortress', 'Military Fortress: Memory - Bomber Climb (A Solution)',  1337184, lambda state: state.has('Timespinner Wheel', player) and logic.has_doublejump_of_npc(state)),
-            LocationData('The lab', 'Lab: Memory - Genza\'s Secret Stash 1 (An Old Friend)',  1337185, logic.can_break_walls),
-            LocationData('The lab', 'Lab: Memory - Genza\'s Secret Stash 2 (Twilight Dinner)',  1337186, logic.can_break_walls),
+            LocationData('The lab', 'Lab: Memory - Genza\'s Secret Stash 1 (An Old Friend)',  1337185, can_break_walls),
+            LocationData('The lab', 'Lab: Memory - Genza\'s Secret Stash 2 (Twilight Dinner)',  1337186, can_break_walls),
             LocationData('Emperors tower', 'Emperor\'s Tower: Memory - Way Up There (Final Circle)',  1337187, logic.has_doublejump_of_npc),
             LocationData('Forest', 'Forest: Journal - Rats (Lachiem Expedition)',  1337188),
             LocationData('Forest', 'Forest: Journal - Bat Jump Ledge (Peace Treaty)',  1337189, lambda state: logic.has_doublejump_of_npc(state) or logic.has_forwarddash_doublejump(state) or logic.has_fastjump_on_npc(state)),
@@ -260,7 +283,7 @@ def get_location_datas(player: Optional[int], options: Optional[TimespinnerOptio
     if not options or options.pyramid_start:
         location_table += (
             LocationData('Ancient Pyramid (entrance)', 'Dark Forest: Training Dummy',  1337233),
-            LocationData('Ancient Pyramid (entrance)', 'Temporal Gyre: Forest Entrance',  1337234, lambda state: logic.has_upwarddash(state) or logic.can_teleport_to(state, "Time", "GateGyre")),
+            LocationData('Ancient Pyramid (entrance)', 'Temporal Gyre: Forest Entrance',  1337234, lambda state: logic.has_upwarddash(state) or (has_teleport(state) and can_teleport_to(state, "Time", "GateGyre"))),
             LocationData('Ancient Pyramid (entrance)', 'Ancient Pyramid: Rubble',  1337235),
         )
 

--- a/worlds/timespinner/Locations.py
+++ b/worlds/timespinner/Locations.py
@@ -92,15 +92,15 @@ def get_location_datas(player: Optional[int], options: Optional[TimespinnerOptio
         LocationData('Military Fortress (hangar)', 'Military Fortress: Pedestal',  1337065, lambda state: state.has('Water Mask', player) if flooded.flood_lab else (logic.has_doublejump_of_npc(state) or logic.has_forwarddash_doublejump(state))),
         LocationData('The lab', 'Lab: Coffee break',  1337066),
         LocationData('The lab', 'Lab: Lower trash right',  1337067, logic.has_doublejump),
-        LocationData('The lab', 'Lab: Lower trash left',  1337068, lambda state: logic.has_doublejump_of_npc(state) if options.lock_key_amadeus else logic.has_upwarddash ),
+        LocationData('The lab', 'Lab: Lower trash left',  1337068, lambda state: logic.has_doublejump_of_npc(state) if logic.lock_key_amadeus_enabled() else logic.has_upwarddash ),
         LocationData('The lab', 'Lab: Below lab entrance',  1337069, logic.has_doublejump),
-        LocationData('The lab (power off)', 'Lab: Trash jump room',  1337070, lambda state: not options.lock_key_amadeus or logic.has_doublejump_of_npc(state) ),
-        LocationData('The lab (power off)', 'Lab: Dynamo Works',  1337071, lambda state: not options.lock_key_amadeus or (state.has_all(('Lab Access Research', 'Lab Access Dynamo'), player)) ),
+        LocationData('The lab (power off)', 'Lab: Trash jump room',  1337070, lambda state: not logic.lock_key_amadeus_enabled() or logic.has_doublejump_of_npc(state) ),
+        LocationData('The lab (power off)', 'Lab: Dynamo Works',  1337071, lambda state: not logic.lock_key_amadeus_enabled() or (state.has_all(('Lab Access Research', 'Lab Access Dynamo'), player)) ),
         LocationData('The lab (upper)', 'Lab: Genza (Blob Mom)',  1337072),
-        LocationData('The lab (power off)', 'Lab: Experiment #13',  1337073, lambda state: not options.lock_key_amadeus or state.has('Lab Access Experiment', player) ),
+        LocationData('The lab (power off)', 'Lab: Experiment #13',  1337073, lambda state: not logic.lock_key_amadeus_enabled() or state.has('Lab Access Experiment', player) ),
         LocationData('The lab (upper)', 'Lab: Download and chest room chest',  1337074),
         LocationData('The lab (upper)', 'Lab: Lab secret',  1337075, logic.can_break_walls),
-        LocationData('The lab (power off)', 'Lab: Spider Hell',  1337076, lambda state: logic.has_keycard_A and not options.lock_key_amadeus or state.has('Lab Access Research', player)),
+        LocationData('The lab (power off)', 'Lab: Spider Hell',  1337076, lambda state: logic.has_keycard_A and not logic.lock_key_amadeus_enabled() or state.has('Lab Access Research', player)),
         LocationData('Emperors tower', 'Emperor\'s Tower: Courtyard bottom chest',  1337077),
         LocationData('Emperors tower', 'Emperor\'s Tower: Courtyard floor secret',  1337078, lambda state: logic.has_upwarddash(state) and logic.can_break_walls(state)),
         LocationData('Emperors tower', 'Emperor\'s Tower: Courtyard upper chest',  1337079, lambda state: logic.has_upwarddash(state)),
@@ -203,7 +203,7 @@ def get_location_datas(player: Optional[int], options: Optional[TimespinnerOptio
 
     # 1337156 - 1337170 Downloads
     if not options or options.downloadable_items:
-        location_table += ( 
+        location_table += (
             LocationData('Library', 'Library: Terminal 2 (Lachiem)',  1337156, lambda state: state.has('Tablet', player)),
             LocationData('Library', 'Library: Terminal 1 (Windaria)',  1337157, lambda state: state.has('Tablet', player)),
             # 1337158 Is lost in time
@@ -214,11 +214,11 @@ def get_location_datas(player: Optional[int], options: Optional[TimespinnerOptio
             LocationData('Library top', 'Library: Backer room terminal (Vandagray Metropolis Map)',  1337163, lambda state: state.has('Tablet', player)),
             LocationData('Varndagroth tower right (elevator)', 'Varndagroth Towers (Right): Medbay terminal (Bleakness Research)',  1337164, lambda state: state.has('Tablet', player) and logic.has_keycard_B(state)),
             LocationData('The lab (upper)', 'Lab: Download and chest room terminal (Experiment #13)',  1337165, lambda state: state.has('Tablet', player)),
-            LocationData('The lab (power off)', 'Lab: Middle terminal (Amadeus Laboratory Map)',  1337166, lambda state: state.has('Tablet', player) and (not options.lock_key_amadeus or state.has('Lab Access Research', player))),
-            LocationData('The lab (power off)', 'Lab: Sentry platform terminal (Origins)',  1337167, lambda state: state.has('Tablet', player) and (not options.lock_key_amadeus or state.has('Lab Access Genza', player) or logic.can_teleport_to(state, "Time", "GateDadsTower"))),
+            LocationData('The lab (power off)', 'Lab: Middle terminal (Amadeus Laboratory Map)',  1337166, lambda state: state.has('Tablet', player) and (not logic.lock_key_amadeus_enabled() or state.has('Lab Access Research', player))),
+            LocationData('The lab (power off)', 'Lab: Sentry platform terminal (Origins)',  1337167, lambda state: state.has('Tablet', player) and (not logic.lock_key_amadeus_enabled() or state.has('Lab Access Genza', player) or logic.can_teleport_to(state, "Time", "GateDadsTower"))),
             LocationData('The lab', 'Lab: Experiment 13 terminal (W.R.E.C Farewell)',  1337168, lambda state: state.has('Tablet', player)),
             LocationData('The lab', 'Lab: Left terminal (Biotechnology)',  1337169, lambda state: state.has('Tablet', player)),
-            LocationData('The lab (power off)', 'Lab: Right terminal (Experiment #11)',  1337170, lambda state: state.has('Tablet', player) and (not options.lock_key_amadeus or state.has('Lab Access Research', player)))
+            LocationData('The lab (power off)', 'Lab: Right terminal (Experiment #11)',  1337170, lambda state: state.has('Tablet', player) and (not logic.lock_key_amadeus_enabled() or state.has('Lab Access Research', player)))
         )
 
     # 1337176 - 1337176 Cantoran
@@ -257,7 +257,7 @@ def get_location_datas(player: Optional[int], options: Optional[TimespinnerOptio
     # 1337199 - 1337232 Reserved for future use
 
     # 1337233 - 1337235 Pyramid Start checks
-    if not options or options.pyramid_start: 
+    if not options or options.pyramid_start:
         location_table += (
             LocationData('Ancient Pyramid (entrance)', 'Dark Forest: Training Dummy',  1337233),
             LocationData('Ancient Pyramid (entrance)', 'Temporal Gyre: Forest Entrance',  1337234, lambda state: logic.has_upwarddash(state) or logic.can_teleport_to(state, "Time", "GateGyre")),
@@ -279,5 +279,5 @@ def get_location_datas(player: Optional[int], options: Optional[TimespinnerOptio
             LocationData('Ifrit\'s Lair', 'Ifrit: Pre fight',  1337244),
             LocationData('Ifrit\'s Lair', 'Ifrit: Post fight (chest)', 1337245),
         )
- 
+
     return location_table

--- a/worlds/timespinner/LogicExtensions.py
+++ b/worlds/timespinner/LogicExtensions.py
@@ -7,16 +7,6 @@ from .PreCalculatedWeights import PreCalculatedWeights
 class TimespinnerLogic:
     player: int
 
-    flag_unchained_keys: bool
-    flag_eye_spy: bool
-    flag_specific_keycards: bool
-    flag_inverted: bool
-    flag_enter_sandman: bool
-    flag_back_to_the_future: bool
-    flag_prism_break: bool
-    flag_lock_key_amadeus: bool
-    flag_gate_keep: bool
-    flag_royal_roadblock: bool
     pyramid_keys_unlock: Optional[str]
     present_keys_unlock: Optional[str]
     past_keys_unlock: Optional[str]
@@ -26,20 +16,8 @@ class TimespinnerLogic:
                  precalculated_weights: Optional[PreCalculatedWeights]):
         self.player = player
 
-        self.flag_specific_keycards = bool(options and options.specific_keycards)
-        self.flag_inverted = bool(options and options.inverted)
-        self.flag_eye_spy = bool(options and options.eye_spy)
-        self.flag_unchained_keys = bool(options and options.unchained_keys)
-        self.flag_enter_sandman = bool(options and options.enter_sandman)
-        self.flag_back_to_the_future = bool(options and options.back_to_the_future)
-        self.flag_prism_break = bool(options and options.prism_break)
-        self.flag_lock_key_amadeus = bool(options and options.lock_key_amadeus)
-        self.flag_pyramid_start = bool(options and options.pyramid_start)
-        self.flag_gate_keep = bool(options and options.gate_keep)
-        self.flag_royal_roadblock = bool(options and options.gate_keep)
-
         if precalculated_weights:
-            if self.flag_unchained_keys:
+            if bool(options and options.unchained_keys):
                 self.pyramid_keys_unlock = None
                 self.present_keys_unlock = precalculated_weights.present_key_unlock
                 self.past_keys_unlock = precalculated_weights.past_key_unlock
@@ -83,41 +61,39 @@ class TimespinnerLogic:
         return state.has('Security Keycard A', self.player)
 
     def has_keycard_B(self, state: CollectionState) -> bool:
-        if self.flag_specific_keycards:
-            return state.has('Security Keycard B', self.player)
-        else:
-            return state.has_any({'Security Keycard A', 'Security Keycard B'}, self.player)
+        return state.has_any({'Security Keycard A', 'Security Keycard B'}, self.player)
 
     def has_keycard_C(self, state: CollectionState) -> bool:
-        if self.flag_specific_keycards:
-            return state.has('Security Keycard C', self.player)
-        else:
-            return state.has_any({'Security Keycard A', 'Security Keycard B', 'Security Keycard C'}, self.player)
+        return state.has_any({'Security Keycard A', 'Security Keycard B', 'Security Keycard C'}, self.player)
 
     def has_keycard_D(self, state: CollectionState) -> bool:
-        if self.flag_specific_keycards:
-            return state.has('Security Keycard D', self.player)
-        else:
-            return state.has_any({'Security Keycard A', 'Security Keycard B', 'Security Keycard C', 'Security Keycard D'}, self.player)
+        return state.has_any({'Security Keycard A', 'Security Keycard B', 'Security Keycard C', 'Security Keycard D'}, self.player)
 
-    def can_break_walls(self, state: CollectionState) -> bool:
-        if self.flag_eye_spy:
-            return state.has('Oculus Ring', self.player)
-        else:
-            return True
+    def has_keycard_B_specific(self, state: CollectionState) -> bool:
+        return state.has('Security Keycard B', self.player)
+
+    def has_keycard_C_specific(self, state: CollectionState) -> bool:
+        return state.has('Security Keycard C', self.player)
+
+    def has_keycard_D_specific(self, state: CollectionState) -> bool:
+        return state.has('Security Keycard D', self.player)
+
+    def has_oculus_ring(self, state: CollectionState) -> bool:
+        return state.has('Oculus Ring', self.player)
 
     def can_kill_all_3_bosses(self, state: CollectionState) -> bool:
-        if self.flag_prism_break:
-            return state.has_all({'Laser Access M', 'Laser Access I', 'Laser Access A'}, self.player)
         return state.has_all({'Killed Maw', 'Killed Twins', 'Killed Aelana'}, self.player)
 
+    def has_all_3_laser_access(self, state: CollectionState) -> bool:
+        return state.has_all({'Laser Access M', 'Laser Access I', 'Laser Access A'}, self.player)
+
     def has_teleport(self, state: CollectionState) -> bool:
-        return self.flag_unchained_keys or state.has('Twin Pyramid Key', self.player)
+        return state.has('Twin Pyramid Key', self.player)
 
     def can_teleport_to(self, state: CollectionState, era: str, gate: str) -> bool:
-        if not self.flag_unchained_keys:
-            return self.pyramid_keys_unlock == gate
+        return self.pyramid_keys_unlock == gate
 
+    def can_teleport_to_unchained(self, state: CollectionState, era: str, gate: str) -> bool:
         if era == "Present":
             return self.present_keys_unlock == gate and state.has("Modern Warp Beacon", self.player)
         elif era == "Past":
@@ -127,17 +103,5 @@ class TimespinnerLogic:
         else:
             raise Exception("Invallid Era: {}".format(era))
 
-    def has_pyramid_warp(self, state: CollectionState) -> bool:
-        return self.can_teleport_to(state, "Time", "GateGyre") or self.can_teleport_to(state, "Time", "GateLeftPyramid") or (not self.flag_unchained_keys and self.flag_enter_sandman)
-
-    def has_present_access_from_refugee_camp(self, state: CollectionState) -> bool:
-        return (self.flag_pyramid_start or self.flag_inverted) and self.flag_back_to_the_future and state.has_all({'Timespinner Wheel', 'Timespinner Spindle'}, self.player)
-
-    def lock_key_amadeus_enabled(self) -> bool:
-        return self.flag_lock_key_amadeus
-
     def can_traverse_drawbridge(self, state: CollectionState) -> bool:
-        return not self.flag_gate_keep or state.has('Drawbridge Key', self.player) or self.has_upwarddash(state)
-
-    def can_open_royal_towers_door(self, state: CollectionState) -> bool:
-        return not self.flag_royal_roadblock or self.has_pink(state)
+        return state.has('Drawbridge Key', self.player) or self.has_upwarddash(state)

--- a/worlds/timespinner/LogicExtensions.py
+++ b/worlds/timespinner/LogicExtensions.py
@@ -10,7 +10,12 @@ class TimespinnerLogic:
     flag_unchained_keys: bool
     flag_eye_spy: bool
     flag_specific_keycards: bool
+    flag_enter_sandman: bool
+    flag_back_to_the_future: bool
     flag_prism_break: bool
+    flag_lock_key_amadeus: bool
+    flag_gate_keep: bool
+    flag_royal_roadblock: bool
     pyramid_keys_unlock: Optional[str]
     present_keys_unlock: Optional[str]
     past_keys_unlock: Optional[str]
@@ -23,7 +28,13 @@ class TimespinnerLogic:
         self.flag_specific_keycards = bool(options and options.specific_keycards)
         self.flag_eye_spy = bool(options and options.eye_spy)
         self.flag_unchained_keys = bool(options and options.unchained_keys)
+        self.flag_enter_sandman = bool(options and options.enter_sandman)
+        self.flag_back_to_the_future = bool(options and options.back_to_the_future)
         self.flag_prism_break = bool(options and options.prism_break)
+        self.flag_lock_key_amadeus = bool(options and options.lock_key_amadeus)
+        self.flag_pyramid_start = bool(options and options.pyramid_start)
+        self.flag_gate_keep = bool(options and options.gate_keep)
+        self.flag_royal_roadblock = bool(options and options.gate_keep)
 
         if precalculated_weights:
             if self.flag_unchained_keys:
@@ -113,3 +124,18 @@ class TimespinnerLogic:
             return self.time_keys_unlock == gate and state.has("Mysterious Warp Beacon", self.player)
         else:
             raise Exception("Invallid Era: {}".format(era))
+
+    def has_pyramid_warp(self, state: CollectionState) -> bool:
+        return self.can_teleport_to(state, "Time", "GateGyre") or self.can_teleport_to(state, "Time", "GateLeftPyramid") or (not self.flag_unchained_keys and self.flag_enter_sandman)
+
+    def has_present_access_from_refugee_camp(self, state: CollectionState) -> bool:
+        return (self.flag_pyramid_start or self.flag_inverted) and self.flag_back_to_the_future and state.has_all({'Timespinner Wheel', 'Timespinner Spindle'}, self.player)
+
+    def lock_key_amadeus_enabled(self) -> bool:
+        return self.flag_lock_key_amadeus
+
+    def can_traverse_drawbridge(self, state: CollectionState) -> bool:
+        return not self.flag_gate_keep or state.has('Drawbridge Key', self.player) or self.has_upwarddash(state)
+
+    def can_open_royal_towers_door(self, state: CollectionState) -> bool:
+        return not self.flag_royal_roadblock or self.has_pink(state)

--- a/worlds/timespinner/LogicExtensions.py
+++ b/worlds/timespinner/LogicExtensions.py
@@ -10,6 +10,7 @@ class TimespinnerLogic:
     flag_unchained_keys: bool
     flag_eye_spy: bool
     flag_specific_keycards: bool
+    flag_inverted: bool
     flag_enter_sandman: bool
     flag_back_to_the_future: bool
     flag_prism_break: bool
@@ -26,6 +27,7 @@ class TimespinnerLogic:
         self.player = player
 
         self.flag_specific_keycards = bool(options and options.specific_keycards)
+        self.flag_inverted = bool(options and options.inverted)
         self.flag_eye_spy = bool(options and options.eye_spy)
         self.flag_unchained_keys = bool(options and options.unchained_keys)
         self.flag_enter_sandman = bool(options and options.enter_sandman)

--- a/worlds/timespinner/Regions.py
+++ b/worlds/timespinner/Regions.py
@@ -77,14 +77,14 @@ def create_regions_and_locations(world: MultiWorld, player: int, options: Timesp
     connect(world, player, 'Lake desolation', 'Space time continuum', logic.has_teleport)
     connect(world, player, 'Upper lake desolation', 'Lake desolation')
     connect(world, player, 'Upper lake desolation', 'Eastern lake desolation')
-    connect(world, player, 'Lower lake desolation', 'Lake desolation') 
+    connect(world, player, 'Lower lake desolation', 'Lake desolation')
     connect(world, player, 'Lower lake desolation', 'Eastern lake desolation')
     connect(world, player, 'Eastern lake desolation', 'Space time continuum', logic.has_teleport)
     connect(world, player, 'Eastern lake desolation', 'Library')
     connect(world, player, 'Eastern lake desolation', 'Lower lake desolation')
     connect(world, player, 'Eastern lake desolation', 'Upper lake desolation', lambda state: logic.has_fire(state) and state.can_reach('Upper Lake Serene', 'Region', player), "Upper Lake Serene")
     connect(world, player, 'Library', 'Eastern lake desolation')
-    connect(world, player, 'Library', 'Library top', lambda state: logic.has_doublejump(state) or state.has('Talaria Attachment', player)) 
+    connect(world, player, 'Library', 'Library top', lambda state: logic.has_doublejump(state) or state.has('Talaria Attachment', player))
     connect(world, player, 'Library', 'Varndagroth tower left', logic.has_keycard_D)
     connect(world, player, 'Library', 'Space time continuum', logic.has_teleport)
     connect(world, player, 'Library top', 'Library')
@@ -112,9 +112,9 @@ def create_regions_and_locations(world: MultiWorld, player: int, options: Timesp
     connect(world, player, 'Military Fortress (hangar)', 'The lab', lambda state: logic.has_keycard_B(state) and (state.has('Water Mask', player) if flooded.flood_lab else logic.has_doublejump(state)))
     connect(world, player, 'Temporal Gyre', 'Military Fortress')
     connect(world, player, 'The lab', 'Military Fortress')
-    connect(world, player, 'The lab', 'The lab (power off)', lambda state: options.lock_key_amadeus or logic.has_doublejump_of_npc(state))
+    connect(world, player, 'The lab', 'The lab (power off)', lambda state: logic.lock_key_amadeus_enabled() or logic.has_doublejump_of_npc(state))
     connect(world, player, 'The lab (power off)', 'The lab', lambda state: not flooded.flood_lab or state.has('Water Mask', player))
-    connect(world, player, 'The lab (power off)', 'The lab (upper)', lambda state: logic.has_forwarddash_doublejump(state) and ((not options.lock_key_amadeus) or state.has('Lab Access Genza', player)))
+    connect(world, player, 'The lab (power off)', 'The lab (upper)', lambda state: logic.has_forwarddash_doublejump(state) and ((not logic.lock_key_amadeus_enabled()) or state.has('Lab Access Genza', player)))
     connect(world, player, 'The lab (upper)', 'The lab (power off)')
     connect(world, player, 'The lab (upper)', 'Emperors tower', logic.has_forwarddash_doublejump)
     connect(world, player, 'The lab (upper)', 'Ancient Pyramid (entrance)', lambda state: state.has_all({'Timespinner Wheel', 'Timespinner Spindle', 'Timespinner Gear 1', 'Timespinner Gear 2', 'Timespinner Gear 3'}, player))
@@ -125,12 +125,12 @@ def create_regions_and_locations(world: MultiWorld, player: int, options: Timesp
     connect(world, player, 'Sealed Caves (Xarion)', 'Skeleton Shaft')
     connect(world, player, 'Sealed Caves (Xarion)', 'Space time continuum', logic.has_teleport)
     connect(world, player, 'Refugee Camp', 'Forest')
-    connect(world, player, 'Refugee Camp', 'Library', lambda state: (options.pyramid_start or options.inverted) and options.back_to_the_future and state.has_all({'Timespinner Wheel', 'Timespinner Spindle'}, player))
+    connect(world, player, 'Refugee Camp', 'Library', logic.has_present_access_from_refugee_camp)
     connect(world, player, 'Refugee Camp', 'Space time continuum', logic.has_teleport)
     connect(world, player, 'Forest', 'Refugee Camp')
     connect(world, player, 'Forest', 'Left Side forest Caves', lambda state: flooded.flood_lake_serene_bridge or state.has('Talaria Attachment', player) or logic.has_timestop(state))
     connect(world, player, 'Forest', 'Caves of Banishment (Sirens)')
-    connect(world, player, 'Forest', 'Castle Ramparts', lambda state: not options.gate_keep or state.has('Drawbridge Key', player) or logic.has_upwarddash(state))
+    connect(world, player, 'Forest', 'Castle Ramparts', logic.can_traverse_drawbridge)
     connect(world, player, 'Left Side forest Caves', 'Forest')
     connect(world, player, 'Left Side forest Caves', 'Upper Lake Serene', logic.has_timestop)
     connect(world, player, 'Left Side forest Caves', 'Lower Lake Serene', lambda state: not flooded.flood_lake_serene or state.has('Water Mask', player))
@@ -152,7 +152,7 @@ def create_regions_and_locations(world: MultiWorld, player: int, options: Timesp
     connect(world, player, 'Castle Ramparts', 'Space time continuum', logic.has_teleport)
     connect(world, player, 'Castle Keep', 'Castle Ramparts')
     connect(world, player, 'Castle Keep', 'Castle Basement', lambda state: not flooded.flood_basement or state.has('Water Mask', player))
-    connect(world, player, 'Castle Keep', 'Royal towers (lower)', lambda state: logic.has_doublejump(state) and (not options.royal_roadblock or logic.has_pink(state)))
+    connect(world, player, 'Castle Keep', 'Royal towers (lower)', lambda state: logic.has_doublejump(state) and logic.can_open_royal_towers_door(state))
     connect(world, player, 'Castle Keep', 'Space time continuum', logic.has_teleport)
     connect(world, player, 'Royal towers (lower)', 'Castle Keep')
     connect(world, player, 'Royal towers (lower)', 'Royal towers', lambda state: state.has('Timespinner Wheel', player) or logic.has_forwarddash_doublejump(state))
@@ -185,7 +185,7 @@ def create_regions_and_locations(world: MultiWorld, player: int, options: Timesp
     connect(world, player, 'Space time continuum', 'Caves of Banishment (upper)', lambda state: logic.can_teleport_to(state, "Past", "GateCavesOfBanishment"))
     connect(world, player, 'Space time continuum', 'Military Fortress (hangar)', lambda state: logic.can_teleport_to(state, "Present", "GateLabEntrance"))
     connect(world, player, 'Space time continuum', 'The lab (upper)', lambda state: logic.can_teleport_to(state, "Present", "GateDadsTower"))
-    connect(world, player, 'Space time continuum', 'Ancient Pyramid (entrance)', lambda state: logic.can_teleport_to(state, "Time", "GateGyre") or logic.can_teleport_to(state, "Time", "GateLeftPyramid") or (not options.unchained_keys and options.enter_sandman))
+    connect(world, player, 'Space time continuum', 'Ancient Pyramid (entrance)', logic.has_pyramid_warp)
     connect(world, player, 'Space time continuum', 'Ancient Pyramid (right)', lambda state: logic.can_teleport_to(state, "Time", "GateRightPyramid"))
 
     if options.gyre_archives:
@@ -231,7 +231,7 @@ def connectStartingRegion(world: MultiWorld, player: int, options: TimespinnerOp
     tutorial = world.get_region('Tutorial', player)
     space_time_continuum = world.get_region('Space time continuum', player)
 
-    if options.pyramid_start: 
+    if options.pyramid_start:
         starting_region = world.get_region('Ancient Pyramid (entrance)', player)
     elif options.inverted:
         starting_region = world.get_region('Refugee Camp', player)
@@ -249,7 +249,7 @@ def connectStartingRegion(world: MultiWorld, player: int, options: TimespinnerOp
     space_time_continuum.exits.append(teleport_back_to_start)
 
 
-def connect(world: MultiWorld, player: int, source: str, target: str, 
+def connect(world: MultiWorld, player: int, source: str, target: str,
             rule: Optional[Callable[[CollectionState], bool]] = None,
             indirect: str = ""):
 

--- a/worlds/timespinner/Regions.py
+++ b/worlds/timespinner/Regions.py
@@ -71,122 +71,165 @@ def create_regions_and_locations(world: MultiWorld, player: int, options: Timesp
     flooded: PreCalculatedWeights = precalculated_weights
     logic = TimespinnerLogic(player, options, precalculated_weights)
 
+    if options and options.specific_keycards:
+        has_keycard_B = logic.has_keycard_B_specific
+        has_keycard_C = logic.has_keycard_C_specific
+        has_keycard_D = logic.has_keycard_D_specific
+    else:
+        has_keycard_B = logic.has_keycard_B
+        has_keycard_C = logic.has_keycard_C
+        has_keycard_D = logic.has_keycard_D
+
+    if options and options.prism_break:
+        has_laser_access = logic.has_all_3_laser_access
+    else:
+        has_laser_access = logic.can_kill_all_3_bosses
+
+    if options and options.unchained_keys:
+        has_teleport = lambda state: True
+        can_teleport_to = logic.can_teleport_to_unchained
+    else:
+        has_teleport = logic.has_teleport
+        can_teleport_to = logic.can_teleport_to
+
+    if options and not options.unchained_keys and options.enter_sandman:
+        has_pyramid_warp = lambda state: True
+    else:
+        has_pyramid_warp = lambda state: can_teleport_to(state, "Time", "GateGyre") or can_teleport_to(state, "Time", "GateLeftPyramid")
+
+    if options and (options.pyramid_start or options.inverted) and options.back_to_the_future:
+        has_present_access_from_refugee_camp = lambda state: state.has_all({'Timespinner Wheel', 'Timespinner Spindle'}, player)
+    else:
+        has_present_access_from_refugee_camp = lambda state: False
+
+    lock_key_amadeus_enabled = options and options.lock_key_amadeus
+
+    if options and options.gate_keep:
+        can_traverse_drawbridge = logic.can_traverse_drawbridge
+    else:
+        can_traverse_drawbridge = lambda state: True
+
+    if options and options.royal_roadblock:
+        can_open_royal_towers_door = logic.has_pink
+    else:
+        can_open_royal_towers_door = lambda state: True
+
     connect(world, player, 'Lake desolation', 'Lower lake desolation', lambda state: flooded.flood_lake_desolation or logic.has_timestop(state) or state.has('Talaria Attachment', player))
     connect(world, player, 'Lake desolation', 'Upper lake desolation', lambda state: logic.has_fire(state) and state.can_reach('Upper Lake Serene', 'Region', player), "Upper Lake Serene")
     connect(world, player, 'Lake desolation', 'Skeleton Shaft', lambda state: flooded.flood_lake_desolation or logic.has_doublejump(state))
-    connect(world, player, 'Lake desolation', 'Space time continuum', logic.has_teleport)
+    connect(world, player, 'Lake desolation', 'Space time continuum', has_teleport)
     connect(world, player, 'Upper lake desolation', 'Lake desolation')
     connect(world, player, 'Upper lake desolation', 'Eastern lake desolation')
     connect(world, player, 'Lower lake desolation', 'Lake desolation')
     connect(world, player, 'Lower lake desolation', 'Eastern lake desolation')
-    connect(world, player, 'Eastern lake desolation', 'Space time continuum', logic.has_teleport)
+    connect(world, player, 'Eastern lake desolation', 'Space time continuum', has_teleport)
     connect(world, player, 'Eastern lake desolation', 'Library')
     connect(world, player, 'Eastern lake desolation', 'Lower lake desolation')
     connect(world, player, 'Eastern lake desolation', 'Upper lake desolation', lambda state: logic.has_fire(state) and state.can_reach('Upper Lake Serene', 'Region', player), "Upper Lake Serene")
     connect(world, player, 'Library', 'Eastern lake desolation')
     connect(world, player, 'Library', 'Library top', lambda state: logic.has_doublejump(state) or state.has('Talaria Attachment', player))
-    connect(world, player, 'Library', 'Varndagroth tower left', logic.has_keycard_D)
-    connect(world, player, 'Library', 'Space time continuum', logic.has_teleport)
+    connect(world, player, 'Library', 'Varndagroth tower left', has_keycard_D)
+    connect(world, player, 'Library', 'Space time continuum', has_teleport)
     connect(world, player, 'Library top', 'Library')
     connect(world, player, 'Varndagroth tower left', 'Library')
-    connect(world, player, 'Varndagroth tower left', 'Varndagroth tower right (upper)', logic.has_keycard_C)
-    connect(world, player, 'Varndagroth tower left', 'Varndagroth tower right (lower)', logic.has_keycard_B)
-    connect(world, player, 'Varndagroth tower left', 'Sealed Caves (Sirens)', lambda state: logic.has_keycard_B(state) and state.has('Elevator Keycard', player))
+    connect(world, player, 'Varndagroth tower left', 'Varndagroth tower right (upper)', has_keycard_C)
+    connect(world, player, 'Varndagroth tower left', 'Varndagroth tower right (lower)', has_keycard_B)
+    connect(world, player, 'Varndagroth tower left', 'Sealed Caves (Sirens)', lambda state: has_keycard_B(state) and state.has('Elevator Keycard', player))
     connect(world, player, 'Varndagroth tower left', 'Refugee Camp', lambda state: state.has('Timespinner Wheel', player) and state.has('Timespinner Spindle', player))
     connect(world, player, 'Varndagroth tower right (upper)', 'Varndagroth tower left')
     connect(world, player, 'Varndagroth tower right (upper)', 'Varndagroth tower right (elevator)', lambda state: state.has('Elevator Keycard', player))
     connect(world, player, 'Varndagroth tower right (elevator)', 'Varndagroth tower right (upper)')
     connect(world, player, 'Varndagroth tower right (elevator)', 'Varndagroth tower right (lower)')
-    connect(world, player, 'Varndagroth tower right (lower)', 'Varndagroth tower left', logic.has_keycard_B)
+    connect(world, player, 'Varndagroth tower right (lower)', 'Varndagroth tower left', has_keycard_B)
     connect(world, player, 'Varndagroth tower right (lower)', 'Varndagroth tower right (elevator)', lambda state: state.has('Elevator Keycard', player))
-    connect(world, player, 'Varndagroth tower right (lower)', 'Sealed Caves (Sirens)', lambda state: logic.has_keycard_B(state) and state.has('Elevator Keycard', player))
-    connect(world, player, 'Varndagroth tower right (lower)', 'Military Fortress', logic.can_kill_all_3_bosses)
-    connect(world, player, 'Varndagroth tower right (lower)', 'Space time continuum', logic.has_teleport)
+    connect(world, player, 'Varndagroth tower right (lower)', 'Sealed Caves (Sirens)', lambda state: has_keycard_B(state) and state.has('Elevator Keycard', player))
+    connect(world, player, 'Varndagroth tower right (lower)', 'Military Fortress', has_laser_access)
+    connect(world, player, 'Varndagroth tower right (lower)', 'Space time continuum', has_teleport)
     connect(world, player, 'Sealed Caves (Sirens)', 'Varndagroth tower left', lambda state: state.has('Elevator Keycard', player))
     connect(world, player, 'Sealed Caves (Sirens)', 'Varndagroth tower right (lower)', lambda state: state.has('Elevator Keycard', player))
-    connect(world, player, 'Sealed Caves (Sirens)', 'Space time continuum', logic.has_teleport)
-    connect(world, player, 'Military Fortress', 'Varndagroth tower right (lower)', logic.can_kill_all_3_bosses)
-    connect(world, player, 'Military Fortress', 'Temporal Gyre', lambda state: state.has('Timespinner Wheel', player) and logic.can_kill_all_3_bosses(state))
+    connect(world, player, 'Sealed Caves (Sirens)', 'Space time continuum', has_teleport)
+    connect(world, player, 'Military Fortress', 'Varndagroth tower right (lower)', has_laser_access)
+    connect(world, player, 'Military Fortress', 'Temporal Gyre', lambda state: state.has('Timespinner Wheel', player) and has_laser_access(state))
     connect(world, player, 'Military Fortress', 'Military Fortress (hangar)', logic.has_doublejump)
     connect(world, player, 'Military Fortress (hangar)', 'Military Fortress')
-    connect(world, player, 'Military Fortress (hangar)', 'The lab', lambda state: logic.has_keycard_B(state) and (state.has('Water Mask', player) if flooded.flood_lab else logic.has_doublejump(state)))
+    connect(world, player, 'Military Fortress (hangar)', 'The lab', lambda state: has_keycard_B(state) and (state.has('Water Mask', player) if flooded.flood_lab else logic.has_doublejump(state)))
     connect(world, player, 'Temporal Gyre', 'Military Fortress')
     connect(world, player, 'The lab', 'Military Fortress')
-    connect(world, player, 'The lab', 'The lab (power off)', lambda state: logic.lock_key_amadeus_enabled() or logic.has_doublejump_of_npc(state))
+    connect(world, player, 'The lab', 'The lab (power off)', lambda state: lock_key_amadeus_enabled or logic.has_doublejump_of_npc(state))
     connect(world, player, 'The lab (power off)', 'The lab', lambda state: not flooded.flood_lab or state.has('Water Mask', player))
-    connect(world, player, 'The lab (power off)', 'The lab (upper)', lambda state: logic.has_forwarddash_doublejump(state) and ((not logic.lock_key_amadeus_enabled()) or state.has('Lab Access Genza', player)))
+    connect(world, player, 'The lab (power off)', 'The lab (upper)', lambda state: logic.has_forwarddash_doublejump(state) and ((not lock_key_amadeus_enabled) or state.has('Lab Access Genza', player)))
     connect(world, player, 'The lab (upper)', 'The lab (power off)')
     connect(world, player, 'The lab (upper)', 'Emperors tower', logic.has_forwarddash_doublejump)
     connect(world, player, 'The lab (upper)', 'Ancient Pyramid (entrance)', lambda state: state.has_all({'Timespinner Wheel', 'Timespinner Spindle', 'Timespinner Gear 1', 'Timespinner Gear 2', 'Timespinner Gear 3'}, player))
     connect(world, player, 'Emperors tower', 'The lab (upper)')
     connect(world, player, 'Skeleton Shaft', 'Lake desolation')
     connect(world, player, 'Skeleton Shaft', 'Sealed Caves (Xarion)', logic.has_keycard_A)
-    connect(world, player, 'Skeleton Shaft', 'Space time continuum', logic.has_teleport)
+    connect(world, player, 'Skeleton Shaft', 'Space time continuum', has_teleport)
     connect(world, player, 'Sealed Caves (Xarion)', 'Skeleton Shaft')
-    connect(world, player, 'Sealed Caves (Xarion)', 'Space time continuum', logic.has_teleport)
+    connect(world, player, 'Sealed Caves (Xarion)', 'Space time continuum', has_teleport)
     connect(world, player, 'Refugee Camp', 'Forest')
-    connect(world, player, 'Refugee Camp', 'Library', logic.has_present_access_from_refugee_camp)
-    connect(world, player, 'Refugee Camp', 'Space time continuum', logic.has_teleport)
+    connect(world, player, 'Refugee Camp', 'Library', has_present_access_from_refugee_camp)
+    connect(world, player, 'Refugee Camp', 'Space time continuum', has_teleport)
     connect(world, player, 'Forest', 'Refugee Camp')
     connect(world, player, 'Forest', 'Left Side forest Caves', lambda state: flooded.flood_lake_serene_bridge or state.has('Talaria Attachment', player) or logic.has_timestop(state))
     connect(world, player, 'Forest', 'Caves of Banishment (Sirens)')
-    connect(world, player, 'Forest', 'Castle Ramparts', logic.can_traverse_drawbridge)
+    connect(world, player, 'Forest', 'Castle Ramparts', can_traverse_drawbridge)
     connect(world, player, 'Left Side forest Caves', 'Forest')
     connect(world, player, 'Left Side forest Caves', 'Upper Lake Serene', logic.has_timestop)
     connect(world, player, 'Left Side forest Caves', 'Lower Lake Serene', lambda state: not flooded.flood_lake_serene or state.has('Water Mask', player))
-    connect(world, player, 'Left Side forest Caves', 'Space time continuum', logic.has_teleport)
+    connect(world, player, 'Left Side forest Caves', 'Space time continuum', has_teleport)
     connect(world, player, 'Upper Lake Serene', 'Left Side forest Caves')
     connect(world, player, 'Upper Lake Serene', 'Lower Lake Serene', lambda state: not flooded.flood_lake_serene or state.has('Water Mask', player))
     connect(world, player, 'Lower Lake Serene', 'Upper Lake Serene')
     connect(world, player, 'Lower Lake Serene', 'Left Side forest Caves')
     connect(world, player, 'Lower Lake Serene', 'Caves of Banishment (upper)', lambda state: flooded.flood_lake_serene or logic.has_doublejump(state))
     connect(world, player, 'Caves of Banishment (upper)', 'Lower Lake Serene', lambda state: not flooded.flood_lake_serene or state.has('Water Mask', player))
-    connect(world, player, 'Caves of Banishment (upper)', 'Caves of Banishment (Maw)', lambda state: logic.has_doublejump(state) or state.has_any({'Gas Mask', 'Talaria Attachment'} or logic.has_teleport(state), player))
-    connect(world, player, 'Caves of Banishment (upper)', 'Space time continuum', logic.has_teleport)
+    connect(world, player, 'Caves of Banishment (upper)', 'Caves of Banishment (Maw)', lambda state: logic.has_doublejump(state) or state.has_any({'Gas Mask', 'Talaria Attachment'} or has_teleport(state), player))
+    connect(world, player, 'Caves of Banishment (upper)', 'Space time continuum', has_teleport)
     connect(world, player, 'Caves of Banishment (Maw)', 'Caves of Banishment (upper)', lambda state: logic.has_doublejump(state) if not flooded.flood_maw else state.has('Water Mask', player))
     connect(world, player, 'Caves of Banishment (Maw)', 'Caves of Banishment (Sirens)', lambda state: state.has_any({'Gas Mask', 'Talaria Attachment'}, player) )
-    connect(world, player, 'Caves of Banishment (Maw)', 'Space time continuum', logic.has_teleport)
+    connect(world, player, 'Caves of Banishment (Maw)', 'Space time continuum', has_teleport)
     connect(world, player, 'Caves of Banishment (Sirens)', 'Forest')
     connect(world, player, 'Castle Ramparts', 'Forest')
     connect(world, player, 'Castle Ramparts', 'Castle Keep')
-    connect(world, player, 'Castle Ramparts', 'Space time continuum', logic.has_teleport)
+    connect(world, player, 'Castle Ramparts', 'Space time continuum', has_teleport)
     connect(world, player, 'Castle Keep', 'Castle Ramparts')
     connect(world, player, 'Castle Keep', 'Castle Basement', lambda state: not flooded.flood_basement or state.has('Water Mask', player))
-    connect(world, player, 'Castle Keep', 'Royal towers (lower)', lambda state: logic.has_doublejump(state) and logic.can_open_royal_towers_door(state))
-    connect(world, player, 'Castle Keep', 'Space time continuum', logic.has_teleport)
+    connect(world, player, 'Castle Keep', 'Royal towers (lower)', lambda state: logic.has_doublejump(state) and can_open_royal_towers_door(state))
+    connect(world, player, 'Castle Keep', 'Space time continuum', has_teleport)
     connect(world, player, 'Royal towers (lower)', 'Castle Keep')
     connect(world, player, 'Royal towers (lower)', 'Royal towers', lambda state: state.has('Timespinner Wheel', player) or logic.has_forwarddash_doublejump(state))
-    connect(world, player, 'Royal towers (lower)', 'Space time continuum', logic.has_teleport)
+    connect(world, player, 'Royal towers (lower)', 'Space time continuum', has_teleport)
     connect(world, player, 'Royal towers', 'Royal towers (lower)')
     connect(world, player, 'Royal towers', 'Royal towers (upper)', logic.has_doublejump)
     connect(world, player, 'Royal towers (upper)', 'Royal towers')
     #connect(world, player, 'Ancient Pyramid (entrance)', 'The lab (upper)', lambda state: not is_option_enabled(world, player, "EnterSandman"))
     connect(world, player, 'Ancient Pyramid (entrance)', 'Ancient Pyramid (left)', logic.has_doublejump)
-    connect(world, player, 'Ancient Pyramid (entrance)', 'Space time continuum', logic.has_teleport)
+    connect(world, player, 'Ancient Pyramid (entrance)', 'Space time continuum', has_teleport)
     connect(world, player, 'Ancient Pyramid (left)', 'Ancient Pyramid (entrance)')
     connect(world, player, 'Ancient Pyramid (left)', 'Ancient Pyramid (right)', lambda state: flooded.flood_pyramid_shaft or logic.has_upwarddash(state))
-    connect(world, player, 'Ancient Pyramid (left)', 'Space time continuum', logic.has_teleport)
+    connect(world, player, 'Ancient Pyramid (left)', 'Space time continuum', has_teleport)
     connect(world, player, 'Ancient Pyramid (right)', 'Ancient Pyramid (left)', lambda state: flooded.flood_pyramid_shaft or logic.has_upwarddash(state))
-    connect(world, player, 'Ancient Pyramid (right)', 'Space time continuum', logic.has_teleport)
-    connect(world, player, 'Space time continuum', 'Lake desolation', lambda state: logic.can_teleport_to(state, "Present", "GateLakeDesolation"))
-    connect(world, player, 'Space time continuum', 'Lower lake desolation', lambda state: logic.can_teleport_to(state, "Present", "GateKittyBoss"))
-    connect(world, player, 'Space time continuum', 'Library', lambda state: logic.can_teleport_to(state, "Present", "GateLeftLibrary"))
-    connect(world, player, 'Space time continuum', 'Varndagroth tower right (lower)', lambda state: logic.can_teleport_to(state, "Present", "GateMilitaryGate"))
-    connect(world, player, 'Space time continuum', 'Skeleton Shaft', lambda state: logic.can_teleport_to(state, "Present", "GateSealedCaves"))
-    connect(world, player, 'Space time continuum', 'Sealed Caves (Sirens)', lambda state: logic.can_teleport_to(state, "Present", "GateSealedSirensCave"))
-    connect(world, player, 'Space time continuum', 'Sealed Caves (Xarion)', lambda state: logic.can_teleport_to(state, "Present", "GateXarion"))
-    connect(world, player, 'Space time continuum', 'Upper Lake Serene', lambda state: logic.can_teleport_to(state, "Past", "GateLakeSereneLeft"))
-    connect(world, player, 'Space time continuum', 'Left Side forest Caves', lambda state: logic.can_teleport_to(state, "Past", "GateLakeSereneRight"))
-    connect(world, player, 'Space time continuum', 'Refugee Camp', lambda state: logic.can_teleport_to(state, "Past", "GateAccessToPast"))
-    connect(world, player, 'Space time continuum', 'Castle Ramparts', lambda state: logic.can_teleport_to(state, "Past", "GateCastleRamparts"))
-    connect(world, player, 'Space time continuum', 'Castle Keep', lambda state: logic.can_teleport_to(state, "Past", "GateCastleKeep"))
-    connect(world, player, 'Space time continuum', 'Royal towers (lower)', lambda state: logic.can_teleport_to(state, "Past", "GateRoyalTowers"))
-    connect(world, player, 'Space time continuum', 'Caves of Banishment (Maw)', lambda state: logic.can_teleport_to(state, "Past", "GateMaw"))
-    connect(world, player, 'Space time continuum', 'Caves of Banishment (upper)', lambda state: logic.can_teleport_to(state, "Past", "GateCavesOfBanishment"))
-    connect(world, player, 'Space time continuum', 'Military Fortress (hangar)', lambda state: logic.can_teleport_to(state, "Present", "GateLabEntrance"))
-    connect(world, player, 'Space time continuum', 'The lab (upper)', lambda state: logic.can_teleport_to(state, "Present", "GateDadsTower"))
-    connect(world, player, 'Space time continuum', 'Ancient Pyramid (entrance)', logic.has_pyramid_warp)
-    connect(world, player, 'Space time continuum', 'Ancient Pyramid (right)', lambda state: logic.can_teleport_to(state, "Time", "GateRightPyramid"))
+    connect(world, player, 'Ancient Pyramid (right)', 'Space time continuum', has_teleport)
+    connect(world, player, 'Space time continuum', 'Lake desolation', lambda state: can_teleport_to(state, "Present", "GateLakeDesolation"))
+    connect(world, player, 'Space time continuum', 'Lower lake desolation', lambda state: can_teleport_to(state, "Present", "GateKittyBoss"))
+    connect(world, player, 'Space time continuum', 'Library', lambda state: can_teleport_to(state, "Present", "GateLeftLibrary"))
+    connect(world, player, 'Space time continuum', 'Varndagroth tower right (lower)', lambda state: can_teleport_to(state, "Present", "GateMilitaryGate"))
+    connect(world, player, 'Space time continuum', 'Skeleton Shaft', lambda state: can_teleport_to(state, "Present", "GateSealedCaves"))
+    connect(world, player, 'Space time continuum', 'Sealed Caves (Sirens)', lambda state: can_teleport_to(state, "Present", "GateSealedSirensCave"))
+    connect(world, player, 'Space time continuum', 'Sealed Caves (Xarion)', lambda state: can_teleport_to(state, "Present", "GateXarion"))
+    connect(world, player, 'Space time continuum', 'Upper Lake Serene', lambda state: can_teleport_to(state, "Past", "GateLakeSereneLeft"))
+    connect(world, player, 'Space time continuum', 'Left Side forest Caves', lambda state: can_teleport_to(state, "Past", "GateLakeSereneRight"))
+    connect(world, player, 'Space time continuum', 'Refugee Camp', lambda state: can_teleport_to(state, "Past", "GateAccessToPast"))
+    connect(world, player, 'Space time continuum', 'Castle Ramparts', lambda state: can_teleport_to(state, "Past", "GateCastleRamparts"))
+    connect(world, player, 'Space time continuum', 'Castle Keep', lambda state: can_teleport_to(state, "Past", "GateCastleKeep"))
+    connect(world, player, 'Space time continuum', 'Royal towers (lower)', lambda state: can_teleport_to(state, "Past", "GateRoyalTowers"))
+    connect(world, player, 'Space time continuum', 'Caves of Banishment (Maw)', lambda state: can_teleport_to(state, "Past", "GateMaw"))
+    connect(world, player, 'Space time continuum', 'Caves of Banishment (upper)', lambda state: can_teleport_to(state, "Past", "GateCavesOfBanishment"))
+    connect(world, player, 'Space time continuum', 'Military Fortress (hangar)', lambda state: can_teleport_to(state, "Present", "GateLabEntrance"))
+    connect(world, player, 'Space time continuum', 'The lab (upper)', lambda state: can_teleport_to(state, "Present", "GateDadsTower"))
+    connect(world, player, 'Space time continuum', 'Ancient Pyramid (entrance)', has_pyramid_warp)
+    connect(world, player, 'Space time continuum', 'Ancient Pyramid (right)', lambda state: can_teleport_to(state, "Time", "GateRightPyramid"))
 
     if options.gyre_archives:
         connect(world, player, 'The lab (upper)', 'Ravenlord\'s Lair', lambda state: state.has('Merchant Crow', player))


### PR DESCRIPTION
## What is this fixing or adding?
As suggested in #4559 just before it was merged (see https://github.com/ArchipelagoMW/Archipelago/pull/4559#pullrequestreview-2669170272), pulling the options checks directly out of the rules (here by using the established pattern of the world of caching the relevant options values in the world in LogicExtensions.py) should result in a performance improvement.

## How was this tested?
Reran numerous generations and inspected the results.

## If this makes graphical changes, please attach screenshots.
N/A