### PR TITLE
Core: fix pickling plando texts

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -443,7 +443,8 @@ class RestrictedUnpickler(pickle.Unpickler):
             else:
                 mod = importlib.import_module(module)
             obj = getattr(mod, name)
-            if issubclass(obj, (self.options_module.Option, self.options_module.PlandoConnection)):
+            if issubclass(obj, (self.options_module.Option, self.options_module.PlandoConnection,
+                                self.options_module.PlandoText)):
                 return obj
         # Forbid everything else.
         raise pickle.UnpicklingError(f"global '{module}.{name}' is forbidden")


### PR DESCRIPTION
## What is this fixing or adding?
#4054 forgot that plando texts also got a NamedTuple added, so they also need to be added to the inclusion list.

## How was this tested?
Attempted to generate LttP with plando texts on WebHost, fails without this change.