### PR TITLE
Options: Add a column for player ID to --csv_output

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -1579,6 +1579,7 @@ def dump_player_options(multiworld: MultiWorld) -> None:
             player_output = {
                 "Game": multiworld.game[player],
                 "Name": multiworld.get_player_name(player),
+                "ID": player,
             }
             output.append(player_output)
             for option_key, option in world.options_dataclass.type_hints.items():
@@ -1591,7 +1592,7 @@ def dump_player_options(multiworld: MultiWorld) -> None:
                     game_option_names.append(display_name)
 
     with open(output_path(f"generate_{multiworld.seed_name}.csv"), mode="w", newline="") as file:
-        fields = ["Game", "Name", *all_option_names]
+        fields = ["ID", "Game", "Name", *all_option_names]
         writer = DictWriter(file, fields)
         writer.writeheader()
         writer.writerows(output)


### PR DESCRIPTION
## What is this fixing or adding?
Adds the player ID int to the .csv file produced when running with --csv_output. Stems from discussion here: https://discord.com/channels/731205301247803413/1347003627180523602

## How was this tested?
Created a multiworld with 20 players, half Lingo and half LttP (somewhat arbitrarily). Gave the yaml files random names so the player IDs wouldn't be in game order, and viewed the output to confirm it was still default sorted by game, but contained the player IDs as well.

## If this makes graphical changes, please attach screenshots.
It doesn't.