### PR TITLE
The Messenger: fix some transition plando issues

### DIFF
--- a/worlds/messenger/options.py
+++ b/worlds/messenger/options.py
@@ -51,6 +51,12 @@ class TransitionPlando(PlandoConnections):
     entrances = frozenset(RANDOMIZED_CONNECTIONS.keys())
     exits = frozenset(RANDOMIZED_CONNECTIONS.values())
 
+    @classmethod
+    def can_connect(cls, entrance: str, exit: str) -> bool:
+        if entrance != "Glacial Peak - Left" and entrance.lower() in cls.exits:
+            return exit.lower() in cls.entrances
+        return exit.lower() not in cls.entrances
+
 
 class Logic(Choice):
     """

--- a/worlds/messenger/transitions.py
+++ b/worlds/messenger/transitions.py
@@ -30,10 +30,19 @@ def connect_plando(world: "MessengerWorld", plando_connections: TransitionPlando
 
     for plando_connection in plando_connections:
         # get the connecting regions
-        reg1 = world.get_region(plando_connection.entrance)
+        # need to handle these special because the names are unique but have the same parent region
+        if plando_connection.entrance in ("Artificer", "Tower HQ"):
+            reg1 = world.get_region("Tower HQ")
+            if plando_connection.entrance == "Artificer":
+                dangling_exit = world.get_entrance("Artificer's Portal")
+            else:
+                dangling_exit = world.get_entrance("Artificer's Challenge")
+            reg1.exits.remove(dangling_exit)
+        else:
+            reg1 = world.get_region(plando_connection.entrance)
+            remove_dangling_exit(reg1)
+        
         reg2 = world.get_region(plando_connection.exit)
-
-        remove_dangling_exit(reg1)
         remove_dangling_entrance(reg2)
         # connect the regions
         reg1.connect(reg2)


### PR DESCRIPTION
## What is this fixing or adding?
The connection plando works by having the user pass in the names of the regions, rather than the names of the entrances. Two of the connections actually use special names since they share the same parent region, so this adds special handling for those two connections, so they don't crash. This also makes it so that if the user specifies a one-way exit, it must also be a one-way entrance, and vice versa, because GER can't properly resolve these being uneven currently
## How was this tested?
Generated with minimal yaml with a few different plando connection combinations to check all the various edge cases.