### PR TITLE
MultiServer.py: Store Hint Priority & the found attribute together in an IntFlag for efficiency

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -290,10 +290,10 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
                             f"{locations_data[location.player][location.address]}")
                         locations_data[location.player][location.address] = \
                             location.item.code, location.item.player, location.item.flags
-                        auto_status = HintStatus.HINT_AVOID if location.item.trap else HintStatus.HINT_PRIORITY
+                        auto_status = HintStatus.HINT_PRIORITY_AVOID if location.item.trap else HintStatus.HINT_PRIORITY_PRIORITY
                         if location.name in multiworld.worlds[location.player].options.start_location_hints:
                             if not location.item.trap:  # Unspecified status for location hints, except traps
-                                auto_status = HintStatus.HINT_UNSPECIFIED
+                                auto_status = HintStatus.HINT_PRIORITY_UNSPECIFIED
                             precollect_hint(location, auto_status)
                         elif location.item.name in multiworld.worlds[location.item.player].options.start_hints:
                             precollect_hint(location, auto_status)

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1124,7 +1124,7 @@ def register_location_checks(ctx: Context, team: int, slot: int, locations: typi
         ctx.save()
 
 
-def collect_hints(ctx: Context, team: int, slot: int, item: typing.Union[int, str], auto_status: HintStatus) \
+def collect_hints(ctx: Context, team: int, slot: int, item: typing.Union[int, str], auto_priority: HintStatus) \
         -> typing.List[Hint]:
     hints = []
     slots: typing.Set[int] = {slot}
@@ -1141,13 +1141,17 @@ def collect_hints(ctx: Context, team: int, slot: int, item: typing.Union[int, st
         else:
             found = location_id in ctx.location_checks[team, finding_player]
             entrance = ctx.er_hint_data.get(finding_player, {}).get(location_id, "")
-            new_status = auto_status
-            if found:
-                new_status = HintStatus.HINT_FOUND
-            elif item_flags & ItemClassification.trap:
-                new_status = HintStatus.HINT_AVOID
-            hints.append(Hint(receiving_player, finding_player, location_id, item_id, found, entrance,
-                                       item_flags, new_status))
+
+            is_pure_trap = (
+                ItemClassification.trap in item_flags
+                and not ItemClassification.useful in item_flags
+                and not ItemClassification.progression in item_flags
+            )
+            if is_pure_trap:
+                auto_priority = HintStatus.HINT_PRIORITY_AVOID
+            new_status = HintStatus.from_found_and_priority(found, auto_priority)
+
+            hints.append(Hint(receiving_player, finding_player, location_id, item_id, entrance, item_flags, new_status))
 
     return hints
 
@@ -1158,7 +1162,7 @@ def collect_hint_location_name(ctx: Context, team: int, slot: int, location: str
     return collect_hint_location_id(ctx, team, slot, seeked_location, auto_status)
 
 
-def collect_hint_location_id(ctx: Context, team: int, slot: int, seeked_location: int, auto_status: HintStatus) \
+def collect_hint_location_id(ctx: Context, team: int, slot: int, seeked_location: int, auto_priority: HintStatus) \
         -> typing.List[Hint]:
     prev_hint = ctx.get_hint(team, slot, seeked_location)
     if prev_hint:
@@ -1166,26 +1170,32 @@ def collect_hint_location_id(ctx: Context, team: int, slot: int, seeked_location
     result = ctx.locations[slot].get(seeked_location, (None, None, None))
     if any(result):
         item_id, receiving_player, item_flags = result
-
         found = seeked_location in ctx.location_checks[team, slot]
         entrance = ctx.er_hint_data.get(slot, {}).get(seeked_location, "")
-        new_status = auto_status
-        if found:
-            new_status = HintStatus.HINT_FOUND
-        elif item_flags & ItemClassification.trap:
-            new_status = HintStatus.HINT_AVOID
-        return [Hint(receiving_player, slot, seeked_location, item_id, found, entrance, item_flags,
-                              new_status)]
+
+        is_pure_trap = (
+            ItemClassification.trap in item_flags
+            and not ItemClassification.useful in item_flags
+            and not ItemClassification.progression in item_flags
+        )
+        if is_pure_trap:
+            auto_priority = HintStatus.HINT_PRIORITY_AVOID
+
+        new_status = HintStatus.from_found_and_priority(found, auto_priority)
+
+        return [Hint(receiving_player, slot, seeked_location, item_id, entrance, item_flags, new_status)]
     return []
 
 
 status_names: typing.Dict[HintStatus, str] = {
     HintStatus.HINT_FOUND: "(found)",
-    HintStatus.HINT_UNSPECIFIED: "(unspecified)",
-    HintStatus.HINT_NO_PRIORITY: "(no priority)",
-    HintStatus.HINT_AVOID: "(avoid)",
-    HintStatus.HINT_PRIORITY: "(priority)",
+    HintStatus.HINT_PRIORITY_UNSPECIFIED: "(unspecified)",
+    HintStatus.HINT_PRIORITY_NO_PRIORITY: "(no priority)",
+    HintStatus.HINT_PRIORITY_AVOID: "(avoid)",
+    HintStatus.HINT_PRIORITY_PRIORITY: "(priority)",
 }
+
+
 def format_hint(ctx: Context, team: int, hint: Hint) -> str:
     text = f"[Hint]: {ctx.player_names[team, hint.receiving_player]}'s " \
            f"{ctx.item_names[ctx.slot_info[hint.receiving_player].game][hint.item]} is " \
@@ -1195,7 +1205,7 @@ def format_hint(ctx: Context, team: int, hint: Hint) -> str:
     if hint.entrance:
         text += f" at {hint.entrance}"
     
-    return text + ". " + status_names.get(hint.status, "(unknown)")
+    return text + ". " + status_names.get(hint.status.as_display_status(), "(unknown)")
 
 
 def json_format_send_event(net_item: NetworkItem, receiving_player: int):
@@ -1599,7 +1609,7 @@ class ClientMessageProcessor(CommonCommandProcessor):
     def get_hints(self, input_text: str, for_location: bool = False) -> bool:
         points_available = get_client_points(self.ctx, self.client)
         cost = self.ctx.get_hint_cost(self.client.slot)
-        auto_status = HintStatus.HINT_UNSPECIFIED if for_location else HintStatus.HINT_PRIORITY
+        auto_status = HintStatus.HINT_PRIORITY_UNSPECIFIED if for_location else HintStatus.HINT_PRIORITY_PRIORITY
         if not input_text:
             hints = {hint.re_check(self.ctx, self.client.team) for hint in
                      self.ctx.hints[self.client.team, self.client.slot]}
@@ -1935,7 +1945,7 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
                 target_item, target_player, flags = ctx.locations[client.slot][location]
                 if create_as_hint:
                     hints.extend(collect_hint_location_id(ctx, client.team, client.slot, location,
-                                                          HintStatus.HINT_UNSPECIFIED))
+                                                          HintStatus.HINT_PRIORITY_UNSPECIFIED))
                 locs.append(NetworkItem(target_item, location, target_player, flags))
             ctx.notify_hints(client.team, hints, only_new=create_as_hint == 2)
             if locs and create_as_hint:
@@ -1975,7 +1985,7 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
                                     [{'cmd': 'InvalidPacket', "type": "arguments",
                                       "text": 'UpdateHint: Cannot manually update status to "HINT_FOUND"', "original_cmd": cmd}])
                 return
-            new_hint = new_hint.re_prioritize(ctx, status)
+            new_hint = new_hint.re_prioritize(status)
             if hint == new_hint:
                 return
             ctx.replace_hint(client.team, hint.finding_player, hint, new_hint)
@@ -2289,9 +2299,9 @@ class ServerCommandProcessor(CommonCommandProcessor):
                     hints = []
                     for item_name_from_group in self.ctx.item_name_groups[game][item]:
                         if item_name_from_group in self.ctx.item_names_for_game(game):  # ensure item has an ID
-                            hints.extend(collect_hints(self.ctx, team, slot, item_name_from_group, HintStatus.HINT_PRIORITY))
+                            hints.extend(collect_hints(self.ctx, team, slot, item_name_from_group, HintStatus.HINT_PRIORITY_PRIORITY))
                 else:  # item name or id
-                    hints = collect_hints(self.ctx, team, slot, item, HintStatus.HINT_PRIORITY)
+                    hints = collect_hints(self.ctx, team, slot, item, HintStatus.HINT_PRIORITY_PRIORITY)
 
                 if hints:
                     self.ctx.notify_hints(team, hints)
@@ -2326,16 +2336,16 @@ class ServerCommandProcessor(CommonCommandProcessor):
             if usable:
                 if isinstance(location, int):
                     hints = collect_hint_location_id(self.ctx, team, slot, location,
-                                                     HintStatus.HINT_UNSPECIFIED)
+                                                     HintStatus.HINT_PRIORITY_UNSPECIFIED)
                 elif game in self.ctx.location_name_groups and location in self.ctx.location_name_groups[game]:
                     hints = []
                     for loc_name_from_group in self.ctx.location_name_groups[game][location]:
                         if loc_name_from_group in self.ctx.location_names_for_game(game):
                             hints.extend(collect_hint_location_name(self.ctx, team, slot, loc_name_from_group,
-                                                                    HintStatus.HINT_UNSPECIFIED))
+                                                                    HintStatus.HINT_PRIORITY_UNSPECIFIED))
                 else:
                     hints = collect_hint_location_name(self.ctx, team, slot, location,
-                                                       HintStatus.HINT_UNSPECIFIED)
+                                                       HintStatus.HINT_PRIORITY_UNSPECIFIED)
                 if hints:
                     self.ctx.notify_hints(team, hints)
                 else:

--- a/NetUtils.py
+++ b/NetUtils.py
@@ -11,12 +11,49 @@ if typing.TYPE_CHECKING:
 from Utils import ByValue, Version
 
 
-class HintStatus(ByValue, enum.IntEnum):
-    HINT_UNSPECIFIED = 0
-    HINT_NO_PRIORITY = 10
-    HINT_AVOID = 20
-    HINT_PRIORITY = 30
-    HINT_FOUND = 40
+class HintStatus(ByValue, enum.IntFlag):
+    # Lower 8 bits: Technical flags
+    HINT_FOUND = 0b00000001
+
+    # For "compatibility", only used in CommonClient
+    OLD_HINT_FORMAT = 0b10000000
+
+    # Upper 8 bits: Priorities
+    HINT_PRIORITY_UNSPECIFIED = 0  # For readable code
+    HINT_PRIORITY_NO_PRIORITY = 0b00000001 << 8
+    HINT_PRIORITY_AVOID = 0b00000010 << 8
+    HINT_PRIORITY_PRIORITY = 0b00000100 << 8
+
+    PRIORITY_MASK = 0b11111111 << 8
+
+    @property
+    def priority(self):
+        return self & HintStatus.PRIORITY_MASK
+
+    def with_priority(self, priority: HintStatus):
+        return (self & HintStatus.PRIORITY_MASK) | (priority & HintStatus.PRIORITY_MASK)
+
+    @property
+    def found(self):
+        return HintStatus.HINT_FOUND in self
+
+    def with_found(self, found: bool):
+        return (self & ~HintStatus.HINT_FOUND) | (found * HintStatus.HINT_FOUND)
+
+    @classmethod
+    def from_found_and_priority(cls, found: bool, priority: HintStatus):
+        return cls((HintStatus.HINT_FOUND * found) | priority)
+
+    def as_display_status(self):
+        if self.found:
+            return HintStatus.HINT_FOUND
+        if HintStatus.OLD_HINT_FORMAT in self:
+            return HintStatus.OLD_HINT_FORMAT
+        return self.priority
+
+    @property
+    def changeable(self):
+        return not self.found and not HintStatus.OLD_HINT_FORMAT in self
 
 
 class JSONMessagePart(typing.TypedDict, total=False):
@@ -278,7 +315,7 @@ class JSONtoTextParser(metaclass=HandlerMeta):
         return self._handle_color(node)
 
     def _handle_hint_status(self, node: JSONMessagePart):
-        node["color"] = status_colors.get(node["hint_status"], "red")
+        node["color"] = status_colors[HintStatus(node["hint_status"]).as_display_status()]
         return self._handle_color(node)
 
 
@@ -315,23 +352,24 @@ def add_json_location(parts: list, location_id: int, player: int = 0, **kwargs) 
 
 status_names: typing.Dict[HintStatus, str] = {
     HintStatus.HINT_FOUND: "(found)",
-    HintStatus.HINT_UNSPECIFIED: "(unspecified)",
-    HintStatus.HINT_NO_PRIORITY: "(no priority)",
-    HintStatus.HINT_AVOID: "(avoid)",
-    HintStatus.HINT_PRIORITY: "(priority)",
+    HintStatus.HINT_PRIORITY_PRIORITY: "(priority)",
+    HintStatus.HINT_PRIORITY_AVOID: "(avoid)",
+    HintStatus.HINT_PRIORITY_NO_PRIORITY: "(no priority)",
+    HintStatus.HINT_PRIORITY_UNSPECIFIED: "(unspecified)",
 }
 status_colors: typing.Dict[HintStatus, str] = {
     HintStatus.HINT_FOUND: "green",
-    HintStatus.HINT_UNSPECIFIED: "white",
-    HintStatus.HINT_NO_PRIORITY: "slateblue",
-    HintStatus.HINT_AVOID: "salmon",
-    HintStatus.HINT_PRIORITY: "plum",
+    HintStatus.HINT_PRIORITY_PRIORITY: "plum",
+    HintStatus.HINT_PRIORITY_AVOID: "salmon",
+    HintStatus.HINT_PRIORITY_NO_PRIORITY: "slateblue",
+    HintStatus.HINT_PRIORITY_UNSPECIFIED: "white",
 }
 
 
 def add_json_hint_status(parts: list, hint_status: HintStatus, text: typing.Optional[str] = None, **kwargs):
-    parts.append({"text": text if text != None else status_names.get(hint_status, "(unknown)"),
-                  "hint_status": hint_status, "type": JSONTypes.hint_status, **kwargs})
+    if text is None:
+        text = status_names[hint_status.as_display_status()]
+    parts.append({"text": text, "hint_status": hint_status, "type": JSONTypes.hint_status, **kwargs})
 
 
 class Hint(typing.NamedTuple):
@@ -339,25 +377,26 @@ class Hint(typing.NamedTuple):
     finding_player: int
     location: int
     item: int
-    found: bool
     entrance: str = ""
     item_flags: int = 0
-    status: HintStatus = HintStatus.HINT_UNSPECIFIED
+    status: HintStatus = HintStatus.from_found_and_priority(False, HintStatus.HINT_PRIORITY_UNSPECIFIED)
+
+    @property
+    def found(self):
+        return self.status.found
 
     def re_check(self, ctx, team) -> Hint:
-        if self.found and self.status == HintStatus.HINT_FOUND:
+        if self.found:
             return self
         found = self.location in ctx.location_checks[team, self.finding_player]
         if found:
-            return self._replace(found=found, status=HintStatus.HINT_FOUND)
+            return self._replace(status=self.status.with_found(True))
         return self
     
-    def re_prioritize(self, ctx, status: HintStatus) -> Hint:
-        if self.found and status != HintStatus.HINT_FOUND:
-            status = HintStatus.HINT_FOUND
-        if status != self.status:
-            return self._replace(status=status)
-        return self
+    def re_prioritize(self, status: HintStatus) -> Hint:
+        if status.priority == self.status.priority:
+            return self
+        return self._replace(status=status.with_priority(status.priority))
 
     def __hash__(self):
         return hash((self.receiving_player, self.finding_player, self.location, self.item, self.entrance))
@@ -388,6 +427,22 @@ class Hint(typing.NamedTuple):
     @property
     def local(self):
         return self.receiving_player == self.finding_player
+
+
+# From what I can tell, all the methods to make unpickling backwards compatible don't work for NamedTuples.
+# This is because you can't override __getattributes__ or __new__ on a NamedTuple.
+# The only approach I found was to reroute the Unpickler to a dummy class with a custom __new__ in its find_class.
+class CompatibleHint:
+    def __new__(cls, *args, **kwargs):
+        if type(args[4]) == bool:
+            # old hint format
+            legacy_found = args[4]
+
+            # No compatibility for old priority system, just revert to unspecified
+            new_hint_status = HintStatus.from_found_and_priority(legacy_found, HintStatus.HINT_PRIORITY_UNSPECIFIED)
+
+            args = (*args[:4], *args[5:-1], new_hint_status)
+        return Hint.__new__(Hint, *args, **kwargs)
 
 
 class _LocationStore(dict, typing.MutableMapping[int, typing.Dict[int, typing.Tuple[int, int, int]]]):

--- a/Utils.py
+++ b/Utils.py
@@ -430,6 +430,8 @@ class RestrictedUnpickler(pickle.Unpickler):
         # used by MultiServer -> savegame/multidata
         if module == "NetUtils" and name in {"NetworkItem", "ClientStatus", "Hint",
                                              "SlotType", "NetworkSlot", "HintStatus"}:
+            if name == "Hint":
+                name = "CompatibleHint"
             return getattr(self.net_utils_module, name)
         # Options and Plando are unpickled by WebHost -> Generate
         if module == "worlds.generic" and name == "PlandoItem":

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -349,30 +349,34 @@ This is useful in cases where an item appears in the game world, such as 'ledge 
 
 ### UpdateHint
 Sent to the server to update the status of a Hint. The client must be the 'receiving_player' of the Hint, or the update fails.
+Only the priority bits of the HintStatus bitflag will be updated, technical status bits will be ignored.
 
 ### Arguments
 | Name | Type | Notes |
 | ---- | ---- | ----- |
 | player | int | The ID of the player whose location is being hinted for. |
 | location | int | The ID of the location to update the hint for. If no hint exists for this location, the packet is ignored. |
-| status | [HintStatus](#HintStatus) | Optional. If included, sets the status of the hint to this status. Cannot set `HINT_FOUND`, or change the status from `HINT_FOUND`. |
+| status | [HintStatus](#HintStatus) | Optional. If included, sets the priority bits of the status of the hint to this status. |
 
 #### HintStatus
 An enumeration containing the possible hint states.
 
 ```python
 import enum
-class HintStatus(enum.IntEnum):
-    HINT_UNSPECIFIED = 0  # The receiving player has not specified any status
-    HINT_NO_PRIORITY = 10 # The receiving player has specified that the item is unneeded
-    HINT_AVOID = 20       # The receiving player has specified that the item is detrimental
-    HINT_PRIORITY = 30    # The receiving player has specified that the item is needed
-    HINT_FOUND = 40       # The location has been collected. Status cannot be changed once found.
+class HintStatus(enum.IntFlag):
+    # Lower 8 bits: Technical flags
+    HINT_FOUND = 0b00000001
+
+    # Upper 8 bits: Priorities
+    HINT_PRIORITY_UNSPECIFIED = 0  # For readable code
+    HINT_PRIORITY_NO_PRIORITY = 0b00000001 << 8
+    HINT_PRIORITY_AVOID = 0b00000010 << 8
+    HINT_PRIORITY_PRIORITY = 0b00000100 << 8
 ```
-- Hints for items with `ItemClassification.trap` default to `HINT_AVOID`.
+- Hints for items with only `ItemClassification.trap` default to `HINT_AVOID`.
 - Hints created with `LocationScouts`, `!hint_location`, or similar (hinting a location) default to `HINT_UNSPECIFIED`.
 - Hints created with `!hint` or similar (hinting an item for yourself) default to `HINT_PRIORITY`.
-- Once a hint is collected, its' status is updated to `HINT_FOUND` automatically, and can no longer be changed.
+- Once a hint is collected, its status is updated to `HINT_FOUND` automatically, and can no longer be changed.
 
 ### StatusUpdate
 Sent to the server to update on the sender's status. Examples include readiness or goal completion. (Example: defeated Ganon in A Link to the Past)
@@ -668,17 +672,19 @@ class Permission(enum.IntEnum):
 
 ### Hint
 An object representing a Hint.
+
 ```python
 import typing
+
+
 class Hint(typing.NamedTuple):
-    receiving_player: int
-    finding_player: int
-    location: int
-    item: int
-    found: bool
-    entrance: str = ""
-    item_flags: int = 0
-    status: HintStatus = HintStatus.HINT_UNSPECIFIED
+  receiving_player: int
+  finding_player: int
+  location: int
+  item: int
+  entrance: str = ""
+  item_flags: int = 0
+  status: HintStatus = HintStatus.from_found_and_priority(False, HintStatus.HINT_PRIORITY_UNSPECIFIED)
 ```
 
 ### Data Package Contents


### PR DESCRIPTION
This was discussed in the Discord some time ago.

There were a lot of considerations when making this, the main one being backwards compatibility.
I'm going to refer to versions without HintPriority as 0.5.1, versions with the current implementation of HintPriority as 0.6.0, and this PR as... "this PR".

Connecting a "this PR" CommonClient to an 0.5.1 game should correctly report Found / Not Found.
Connecting a "this PR" CommonClient to a 0.6.0 game will only report Found / Not Found. I really don't think it's worth it to make a proper compatibility layer beyond that, but I'm willing to be convinced otherwise.

Loading a 0.5.1 savegame on "this PR" MultiServer.py should correctly convert all the hints to unspecified priority with their found status retained.
Loading a 0.6.0 savegame on "this PR" MultiServer.py will strip all of the hints of their priority and set it to unspecified, while retaining the correct found status. This is the part I'm most unhappy about, as the release of 0.6.1 would wipe everyone's priority. I might make a compatibility layer here if enough people think it's an issue.

I left room for 6 more "technical flags" and theoretically infinite new statuses.