### PR TITLE
[ALttP] Don't crash generation if sprite paths don't exist

### DIFF
--- a/worlds/alttp/Rom.py
+++ b/worlds/alttp/Rom.py
@@ -515,9 +515,14 @@ def _populate_sprite_table():
                     logging.debug(f"Spritefile {file} could not be loaded as a valid sprite.")
 
             with concurrent.futures.ThreadPoolExecutor() as pool:
-                for dir in [user_path('data', 'sprites', 'alttpr'), user_path('data', 'sprites', 'custom')]:
+                sprite_paths = [user_path('data', 'sprites', 'alttpr'), user_path('data', 'sprites', 'custom')]
+                for dir in [dir for dir in sprite_paths if os.path.isdir(dir)]:
                     for file in os.listdir(dir):
                         pool.submit(load_sprite_from_file, os.path.join(dir, file))
+
+            if "link" not in _sprite_table:
+                logging.info("Link sprite was not loaded. Loading link from base rom")
+                load_sprite_from_file(get_base_rom_path())
 
 
 class Sprite():
@@ -554,6 +559,11 @@ class Sprite():
             self.sprite = filedata[0x80000:0x87000]
             self.palette = filedata[0xDD308:0xDD380]
             self.glove_palette = filedata[0xDEDF5:0xDEDF9]
+            h = hashlib.md5()
+            h.update(filedata)
+            if h.hexdigest() == LTTPJPN10HASH:
+                self.name = "Link"
+                self.author_name = "Nintendo"
         elif filedata.startswith(b'ZSPR'):
             self.from_zspr(filedata, filename)
         else:


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?

Fixes a crash in generation when a player who is generating a game that has alttp, but has chosen to not install the sprites, so as a result, "data/sprites/alttpr" and/or "data/sprites/custom" are missing from the data directory.

Also made sure the base link sprite gets loaded, if it was not loaded, as a result of either the directories completely missing, or the file "data/sprite/custom/link.apsprite" is missing.

## How was this tested?

Ran repeated generations with and without the directories present.


## If this makes graphical changes, please attach screenshots.
