### PR TITLE
CV64: Fix some unrandomized locations containing unintended items on specific settings

### DIFF
--- a/worlds/cv64/rom.py
+++ b/worlds/cv64/rom.py
@@ -644,6 +644,9 @@ class CV64PatchExtensions(APPatchExtension):
             # Replace the PowerUp in the Forest Special1 Bridge 3HB rock with an L jewel if 3HBs aren't randomized
             if not options["multi_hit_breakables"]:
                 rom_data.write_byte(0x10C7A1, 0x03)
+            # Replace the PowerUp in one of the lizard lockers if the lizard locker items aren't randomized.
+            if not options["lizard_locker_items"]:
+                rom_data.write_byte(0xBFCA07, 0x03)
         # Change the appearance of the Pot-Pourri to that of a larger PowerUp regardless of the above setting, so other
         # game PermaUps are distinguishable.
         rom_data.write_int32s(0xEE558, [0x06005F08, 0x3FB00000, 0xFFFFFF00])
@@ -714,7 +717,11 @@ class CV64PatchExtensions(APPatchExtension):
         rom_data.write_int32(0x10CF38, 0x8000FF4D)  # CT final room door slab
         rom_data.write_int32(0x10CF44, 0x1000FF4D)  # CT Renon slab
         rom_data.write_int32(0x10C908, 0x0008FF4D)  # Villa foyer chandelier
-        rom_data.write_byte(0x10CF37, 0x04)  # pointer for CT final room door slab item data
+
+        # Change the pointer to the Clock Tower final room 3HB door slab drops to not share its values with those of the
+        # 3HB slab near Renon at the top of the room.
+        if options["multi_hit_breakables"]:
+            rom_data.write_byte(0x10CF37, 0x04)  # pointer for CT final room door slab item data
 
         # Once-per-frame gameplay checks
         rom_data.write_int32(0x6C848, 0x080FF40D)  # J 0x803FD034
@@ -1000,6 +1007,7 @@ def write_patch(world: "CV64World", patch: CV64ProcedurePatch, offset_data: Dict
         "multi_hit_breakables": world.options.multi_hit_breakables.value,
         "drop_previous_sub_weapon": world.options.drop_previous_sub_weapon.value,
         "countdown": world.options.countdown.value,
+        "lizard_locker_items": world.options.lizard_locker_items.value,
         "shopsanity": world.options.shopsanity.value,
         "panther_dash": world.options.panther_dash.value,
         "big_toss": world.options.big_toss.value,

--- a/worlds/cv64/rom.py
+++ b/worlds/cv64/rom.py
@@ -721,7 +721,7 @@ class CV64PatchExtensions(APPatchExtension):
         # Change the pointer to the Clock Tower final room 3HB door slab drops to not share its values with those of the
         # 3HB slab near Renon at the top of the room.
         if options["multi_hit_breakables"]:
-            rom_data.write_byte(0x10CF37, 0x04)  # pointer for CT final room door slab item data
+            rom_data.write_byte(0x10CF37, 0x04)
 
         # Once-per-frame gameplay checks
         rom_data.write_int32(0x6C848, 0x080FF40D)  # J 0x803FD034


### PR DESCRIPTION
## What is this fixing or adding?
Fixes the following locations:
- Castle Center: Far-left near-side lizard locker: Used to contain a free guaranteed PermaUp if the Permanent Powerups option was enabled and the Lizard Locker Items option was disabled, because I completely forgot about it at the time. Using that combination of settings now replaces it with a Red jewel(L) just like all the other regular unrandomized PowerUps.
- Clock Tower: Final room entrance slab - Items 1 and 2: This was unwittingly introduced by https://github.com/ArchipelagoMW/Archipelago/pull/4277 removing the entire if check for the Multi Hit Breakables option. This particular 3HB is weird because the IDs for the items it drops (normally two 500 GOLDs) are in the exact same address space pointed at by the other 3HB in this room, Renon's final offers slab (normally six 500 GOLDs and two Red jewel (L)s; the first two of the 500 GOLD IDs are shared between them). I normally change the address pointed at by the first 3HB to decouple its items when the 3HB items are randomized, but when that change is applied when the 3HB contents are not changed, the result because of the data that's normally at the newly-pointed address is one of the items is deleted entirely and the other becomes a free guaranteed Garden Key. Whoops!

## How was this tested?
Verified the locations had the intended items with and without the specific options combinations.