### PR TITLE
Docs: Include that DeathLink cause can be an empty string

### DIFF
--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -756,8 +756,8 @@ Tags are represented as a list of strings, the common client tags follow:
 ### DeathLink
 A special kind of Bounce packet that can be supported by any AP game. It targets the tag "DeathLink" and carries the following data:
 
-| Name   | Type  | Notes                                                                                                                                                  |
-|--------|-------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
-| time   | float | Unix Time Stamp of time of death.                                                                                                                      |
-| cause  | str   | Optional. Text to explain the cause of death. When provided, or checked, this should contain the player name, ex. "Berserker was run over by a train." |
-| source | str   | Name of the player who first died. Can be a slot name, but can also be a name from within a multiplayer game.                                          |
+| Name   | Type  | Notes                                                                                                                                                                            |
+|--------|-------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| time   | float | Unix Time Stamp of time of death.                                                                                                                                                |
+| cause  | str   | Optional. Text to explain the cause of death. When provided, or checked, if the string is non-empty, it should contain the player name, ex. "Berserker was run over by a train." |
+| source | str   | Name of the player who first died. Can be a slot name, but can also be a name from within a multiplayer game.                                                                    |


### PR DESCRIPTION
## What is this fixing or adding?

Adds a bit of text to specify that the `cause` for a DeathLink packet can be an empty string.

## How was this tested?

Reading