### PR TITLE
CV64: Allow holding Z to use the regular shimmy speed

### DIFF
--- a/worlds/cv64/data/patches.py
+++ b/worlds/cv64/data/patches.py
@@ -2893,3 +2893,18 @@ dog_bite_ice_trap_fix = [
     0x25291CB8,  # ADDIU T1, T1, 0x1CB8
     0x01200008   # JR    T1
 ]
+
+shimmy_speed_modifier = [
+    # Increases the player's speed while shimmying as long as they are not holding down Z. If they are holding Z, it
+    # will be the normal speed, allowing it to still be used to set up any tricks that might require the normal speed
+    # (like Left Tower Skip).
+    0x3C088038,  # LUI   T0, 0x8038
+    0x91087D7E,  # LBU   T0, 0x7D7E (T0)
+    0x31090020,  # ANDI  T1, T0, 0x0020
+    0x3C0A800A,  # LUI   T2, 0x800A
+    0x240B005A,  # ADDIU T3, R0, 0x005A
+    0x55200001,  # BNEZL T1,     [forward 0x01]
+    0x240B0032,  # ADDIU T3, R0, 0x0032
+    0xA14B3641,  # SB    T3, 0x3641 (T2)
+    0x0800B7C3   # J     0x8002DF0C
+]

--- a/worlds/cv64/rom.py
+++ b/worlds/cv64/rom.py
@@ -607,9 +607,10 @@ class CV64PatchExtensions(APPatchExtension):
         rom_data.write_int32(0xAA530, 0x080FF880)  # J 0x803FE200
         rom_data.write_int32s(0xBFE200, patches.coffin_cutscene_skipper)
 
-        # Increase shimmy speed
+        # Shimmy speed increase hack
         if options["increase_shimmy_speed"]:
-            rom_data.write_byte(0xA4241, 0x5A)
+            rom_data.write_int32(0x97EB4, 0x803FE9F0)
+            rom_data.write_int32s(0xBFE9F0, patches.shimmy_speed_modifier)
 
         # Disable landing fall damage
         if options["fall_guard"]:


### PR DESCRIPTION
## What is this fixing or adding?
With the Increase Shimmy Speed option on, instead of just flatly and always increasing the shimmy speed value for the entire duration of the seed, this adds a hack that will dynamically change it depending on whether or not Z is being held. It will be fast if Z is not held, and the vanilla slower speed if it is. This should be helpful for any niche situation wherein the slower speed would actually be preferred, such as setting up Left Tower Skip (which is logically expected of the player on the Hard logic difficulty).

## How was this tested?
Enabled the Increase Shimmy Speed option and made sure it worked for both characters.
Clip of it in action:

https://github.com/user-attachments/assets/04a8375b-1a02-4e76-8481-784d9c20d064