### PR TITLE
CVCotM: Clarify the Wii U VC version is unsupported

### DIFF
--- a/worlds/cvcotm/__init__.py
+++ b/worlds/cvcotm/__init__.py
@@ -19,8 +19,8 @@ from worlds.AutoWorld import WebWorld, World
 
 from .aesthetics import shuffle_sub_weapons, get_location_data, get_countdown_flags, populate_enemy_drops, \
     get_start_inventory_data
-from .rom import RomData, patch_rom, get_base_rom_path, CVCotMProcedurePatch, CVCOTM_CT_US_HASH, CVCOTM_AC_US_HASH, \
-    CVCOTM_VC_US_HASH
+from .rom import RomData, patch_rom, get_base_rom_path, CVCotMProcedurePatch, CVCOTM_CT_US_HASH, CVCOTM_AC_US_HASH
+    # CVCOTM_VC_US_HASH
 from .client import CastlevaniaCotMClient
 
 
@@ -29,7 +29,8 @@ class CVCotMSettings(settings.Group):
         """File name of the Castlevania CotM US rom"""
         copy_to = "Castlevania - Circle of the Moon (USA).gba"
         description = "Castlevania CotM (US) ROM File"
-        md5s = [CVCOTM_CT_US_HASH, CVCOTM_AC_US_HASH, CVCOTM_VC_US_HASH]
+        # md5s = [CVCOTM_CT_US_HASH, CVCOTM_AC_US_HASH, CVCOTM_VC_US_HASH]
+        md5s = [CVCOTM_CT_US_HASH, CVCOTM_AC_US_HASH]
 
     rom_file: RomFile = RomFile(RomFile.copy_to)
 

--- a/worlds/cvcotm/docs/en_Castlevania - Circle of the Moon.md
+++ b/worlds/cvcotm/docs/en_Castlevania - Circle of the Moon.md
@@ -153,11 +153,11 @@ Advance Collection ROM; most notably the fact that the audio does not function w
 which is currently a requirement to connect to a multiworld. This happens because all audio code was stripped
 from the ROM, and all sound is instead played by the collection through external means.
 
-For this reason, it is most recommended to obtain the ROM by dumping it from an original cartridge of the game that you legally own.
-Though, the Advance Collection *can* still technically be an option if you cannot do that and don't mind the lack of sound.
+The Wii U Virtual Console version is also tested, but due to much of the code being shifted it doesn't patch well at all without
+breaking things pretty badly. As such, it is completely unsupported at the moment.
 
-The Wii U Virtual Console version is currently untested. If you happen to have purchased it before the Wii U eShop shut down, you can try
-dumping and playing with it. However, at the moment, we cannot guarantee that it will work well due to it being untested.
+Due to the reasons mentioned above, it is most recommended to obtain the ROM by dumping it from an original cartridge of the
+game that you legally own. However, the Advance Collection *is* an option if you cannot do that and don't mind the lack of sound.
 
 Regardless of which released ROM you intend to try playing with, the US version of the game is required.
 

--- a/worlds/cvcotm/docs/en_Castlevania - Circle of the Moon.md
+++ b/worlds/cvcotm/docs/en_Castlevania - Circle of the Moon.md
@@ -153,8 +153,7 @@ Advance Collection ROM; most notably the fact that the audio does not function w
 which is currently a requirement to connect to a multiworld. This happens because all audio code was stripped
 from the ROM, and all sound is instead played by the collection through external means.
 
-The Wii U Virtual Console version is also tested, but due to much of the code being shifted it doesn't patch well at all without
-breaking things pretty badly. As such, it is completely unsupported at the moment.
+The Wii U Virtual Console version does not work due to changes in the code in that version.
 
 Due to the reasons mentioned above, it is most recommended to obtain the ROM by dumping it from an original cartridge of the
 game that you legally own. However, the Advance Collection *is* an option if you cannot do that and don't mind the lack of sound.

--- a/worlds/cvcotm/docs/setup_en.md
+++ b/worlds/cvcotm/docs/setup_en.md
@@ -4,8 +4,7 @@
 
 - [Archipelago](https://github.com/ArchipelagoMW/Archipelago/releases/latest).
 - A Castlevania: Circle of the Moon ROM of the US version specifically. The Archipelago community cannot provide this.
-The Castlevania Advance Collection ROM can be used, but it has no audio. The Wii U Virtual Console ROM is unsupported
-and doesn't work at all.
+The Castlevania Advance Collection ROM can be used, but it has no audio. The Wii U Virtual Console ROM does not work.
 - [BizHawk](https://tasvideos.org/BizHawk/ReleaseHistory) 2.7 or later.
 
 ### Configuring BizHawk

--- a/worlds/cvcotm/docs/setup_en.md
+++ b/worlds/cvcotm/docs/setup_en.md
@@ -4,7 +4,8 @@
 
 - [Archipelago](https://github.com/ArchipelagoMW/Archipelago/releases/latest).
 - A Castlevania: Circle of the Moon ROM of the US version specifically. The Archipelago community cannot provide this.
-The Castlevania Advance Collection ROM can technically be used, but it has no audio. The Wii U Virtual Console ROM is untested.
+The Castlevania Advance Collection ROM can be used, but it has no audio. The Wii U Virtual Console ROM is unsupported
+and doesn't work at all.
 - [BizHawk](https://tasvideos.org/BizHawk/ReleaseHistory) 2.7 or later.
 
 ### Configuring BizHawk

--- a/worlds/cvcotm/rom.py
+++ b/worlds/cvcotm/rom.py
@@ -22,11 +22,9 @@ if TYPE_CHECKING:
 
 CVCOTM_CT_US_HASH = "50a1089600603a94e15ecf287f8d5a1f"  # Original GBA cartridge ROM
 CVCOTM_AC_US_HASH = "87a1bd6577b6702f97a60fc55772ad74"  # Castlevania Advance Collection ROM
-CVCOTM_VC_US_HASH = "2cc38305f62b337281663bad8c901cf9"  # Wii U Virtual Console ROM
+# CVCOTM_VC_US_HASH = "2cc38305f62b337281663bad8c901cf9"  # Wii U Virtual Console ROM
 
-# NOTE: The Wii U VC version is untested as of when this comment was written. I am only including its hash in case it
-# does work. If someone who has it can confirm it does indeed work, this comment should be removed. If it doesn't, the
-# hash should be removed in addition. See the Game Page for more information about supported versions.
+# The Wii U VC version is not currently supported. See the Game Page for more info.
 
 ARCHIPELAGO_IDENTIFIER_START = 0x7FFF00
 ARCHIPELAGO_IDENTIFIER = "ARCHIPELAG03"
@@ -518,7 +516,8 @@ class CVCotMPatchExtensions(APPatchExtension):
 
 
 class CVCotMProcedurePatch(APProcedurePatch, APTokenMixin):
-    hash = [CVCOTM_CT_US_HASH, CVCOTM_AC_US_HASH, CVCOTM_VC_US_HASH]
+    # hash = [CVCOTM_CT_US_HASH, CVCOTM_AC_US_HASH, CVCOTM_VC_US_HASH]
+    hash = [CVCOTM_CT_US_HASH, CVCOTM_AC_US_HASH]
     patch_file_ending: str = ".apcvcotm"
     result_file_ending: str = ".gba"
 
@@ -585,7 +584,8 @@ def get_base_rom_bytes(file_name: str = "") -> bytes:
 
         basemd5 = hashlib.md5()
         basemd5.update(base_rom_bytes)
-        if basemd5.hexdigest() not in [CVCOTM_CT_US_HASH, CVCOTM_AC_US_HASH, CVCOTM_VC_US_HASH]:
+        # if basemd5.hexdigest() not in [CVCOTM_CT_US_HASH, CVCOTM_AC_US_HASH, CVCOTM_VC_US_HASH]:
+        if basemd5.hexdigest() not in [CVCOTM_CT_US_HASH, CVCOTM_AC_US_HASH]:
             raise Exception("Supplied Base ROM does not match known MD5s for Castlevania: Circle of the Moon USA."
                             "Get the correct game and version, then dump it.")
         setattr(get_base_rom_bytes, "base_rom_bytes", base_rom_bytes)


### PR DESCRIPTION
## What is this fixing or adding?
@dontjoome some time ago managed to dump and test the Wii U VC version of Circle of the Moon to see if it worked, but it did not, and we determined that the reason why is because of code being shifted around into different places from where the patches expect things to be. The exact conversation can be found in the game's thread in future-game-design in the Archipelago Discord server. Due to the testing results, it now needs to be clarified that the VC version is completely unsupported, at least for now. The docs have been updated where they previously said VC was untested, and all usages of the VC ROM's hash are commented out so it should no longer be accepted (they can be easily uncommented back in if later needed).

## How was this tested?
Ensured the removal of the VC hash did not break anything by genning, patching, and connecting.