### PR TITLE
DLC Quest Bug Fix more item then location non existing start inventory

### DIFF
--- a/worlds/dlcquest/Items.py
+++ b/worlds/dlcquest/Items.py
@@ -98,7 +98,7 @@ def create_trap_items(world, world_options: Options.DLCQuestOptions, trap_needed
     return traps
 
 
-def create_items(world, world_options: Options.DLCQuestOptions, locations_count: int, excluded_items: list[Item], random: Random):
+def create_items(world, world_options: Options.DLCQuestOptions, locations_count: int, excluded_items: list[str], random: Random):
     created_items = []
     if world_options.campaign == Options.Campaign.option_basic or world_options.campaign == Options.Campaign.option_both:
         create_items_basic(world_options, created_items, world, excluded_items)

--- a/worlds/dlcquest/Items.py
+++ b/worlds/dlcquest/Items.py
@@ -98,7 +98,7 @@ def create_trap_items(world, world_options: Options.DLCQuestOptions, trap_needed
     return traps
 
 
-def create_items(world, world_options: Options.DLCQuestOptions, locations_count: int, random: Random):
+def create_items(world, world_options: Options.DLCQuestOptions, locations_count: int, excluded_items: list, random: Random):
     created_items = []
     if world_options.campaign == Options.Campaign.option_basic or world_options.campaign == Options.Campaign.option_both:
         create_items_basic(world_options, created_items, world)
@@ -107,7 +107,9 @@ def create_items(world, world_options: Options.DLCQuestOptions, locations_count:
             world_options.campaign == Options.Campaign.option_both):
         create_items_lfod(world_options, created_items, world)
 
-    trap_items = create_trap_items(world, world_options, locations_count - len(created_items), random)
+    existing_excluded_items = [excluded_item for excluded_item in excluded_items if excluded_item in created_items]
+
+    trap_items = create_trap_items(world, world_options, locations_count + len(existing_excluded_items) - len(created_items), random)
     created_items += trap_items
 
     return created_items

--- a/worlds/dlcquest/Items.py
+++ b/worlds/dlcquest/Items.py
@@ -101,22 +101,23 @@ def create_trap_items(world, world_options: Options.DLCQuestOptions, trap_needed
 def create_items(world, world_options: Options.DLCQuestOptions, locations_count: int, excluded_items: list[Item], random: Random):
     created_items = []
     if world_options.campaign == Options.Campaign.option_basic or world_options.campaign == Options.Campaign.option_both:
-        create_items_basic(world_options, created_items, world)
+        create_items_basic(world_options, created_items, world, excluded_items)
 
     if (world_options.campaign == Options.Campaign.option_live_freemium_or_die or
             world_options.campaign == Options.Campaign.option_both):
-        create_items_lfod(world_options, created_items, world)
+        create_items_lfod(world_options, created_items, world, excluded_items)
 
-    existing_excluded_items = [excluded_item for excluded_item in excluded_items if excluded_item in created_items]
-
-    trap_items = create_trap_items(world, world_options, locations_count + len(existing_excluded_items) - len(created_items), random)
+    trap_items = create_trap_items(world, world_options, locations_count - len(created_items), random)
     created_items += trap_items
 
     return created_items
 
 
-def create_items_lfod(world_options, created_items, world):
+def create_items_lfod(world_options, created_items, world, excluded_items):
     for item in items_by_group[Group.Freemium]:
+        if item in excluded_items:
+            excluded_items.remove(item)
+            continue
         if item.has_any_group(Group.DLC):
             created_items.append(world.create_item(item))
         if item.has_any_group(Group.Item) and world_options.item_shuffle == Options.ItemShuffle.option_shuffled:
@@ -130,8 +131,11 @@ def create_items_lfod(world_options, created_items, world):
         create_coin(world_options, created_items, world, 889, 200, Group.Freemium)
 
 
-def create_items_basic(world_options, created_items, world):
+def create_items_basic(world_options, created_items, world, excluded_items):
     for item in items_by_group[Group.DLCQuest]:
+        if item in excluded_items:
+            excluded_items.remove(item)
+            continue
         if item.has_any_group(Group.DLC):
             created_items.append(world.create_item(item))
         if item.has_any_group(Group.Item) and world_options.item_shuffle == Options.ItemShuffle.option_shuffled:

--- a/worlds/dlcquest/Items.py
+++ b/worlds/dlcquest/Items.py
@@ -115,7 +115,7 @@ def create_items(world, world_options: Options.DLCQuestOptions, locations_count:
 
 def create_items_lfod(world_options, created_items, world, excluded_items):
     for item in items_by_group[Group.Freemium]:
-        if item in excluded_items:
+        if item.name in excluded_items:
             excluded_items.remove(item)
             continue
         if item.has_any_group(Group.DLC):
@@ -133,8 +133,8 @@ def create_items_lfod(world_options, created_items, world, excluded_items):
 
 def create_items_basic(world_options, created_items, world, excluded_items):
     for item in items_by_group[Group.DLCQuest]:
-        if item in excluded_items:
-            excluded_items.remove(item)
+        if item.name in excluded_items:
+            excluded_items.remove(item.name)
             continue
         if item.has_any_group(Group.DLC):
             created_items.append(world.create_item(item))

--- a/worlds/dlcquest/Items.py
+++ b/worlds/dlcquest/Items.py
@@ -118,6 +118,7 @@ def create_items_lfod(world_options, created_items, world, excluded_items):
         if item.name in excluded_items:
             excluded_items.remove(item)
             continue
+
         if item.has_any_group(Group.DLC):
             created_items.append(world.create_item(item))
         if item.has_any_group(Group.Item) and world_options.item_shuffle == Options.ItemShuffle.option_shuffled:
@@ -136,6 +137,7 @@ def create_items_basic(world_options, created_items, world, excluded_items):
         if item.name in excluded_items:
             excluded_items.remove(item.name)
             continue
+
         if item.has_any_group(Group.DLC):
             created_items.append(world.create_item(item))
         if item.has_any_group(Group.Item) and world_options.item_shuffle == Options.ItemShuffle.option_shuffled:

--- a/worlds/dlcquest/Items.py
+++ b/worlds/dlcquest/Items.py
@@ -98,7 +98,7 @@ def create_trap_items(world, world_options: Options.DLCQuestOptions, trap_needed
     return traps
 
 
-def create_items(world, world_options: Options.DLCQuestOptions, locations_count: int, excluded_items: list, random: Random):
+def create_items(world, world_options: Options.DLCQuestOptions, locations_count: int, excluded_items: list[Item], random: Random):
     created_items = []
     if world_options.campaign == Options.Campaign.option_basic or world_options.campaign == Options.Campaign.option_both:
         create_items_basic(world_options, created_items, world)

--- a/worlds/dlcquest/__init__.py
+++ b/worlds/dlcquest/__init__.py
@@ -83,9 +83,7 @@ class DLCqworld(World):
             else:
                 early_items[self.player]["Movement Pack"] = 1
 
-        for item in items_to_exclude:
-            if item in self.multiworld.itempool:
-                self.multiworld.itempool.remove(item)
+
 
     def precollect_coinsanity(self):
         if self.options.campaign == Options.Campaign.option_basic:

--- a/worlds/dlcquest/__init__.py
+++ b/worlds/dlcquest/__init__.py
@@ -68,7 +68,7 @@ class DLCqworld(World):
         items_to_exclude = [excluded_items
                             for excluded_items in self.multiworld.precollected_items[self.player]]
 
-        created_items = create_items(self, self.options, locations_count + len(items_to_exclude), self.multiworld.random)
+        created_items = create_items(self, self.options, locations_count, items_to_exclude, self.multiworld.random)
 
         self.multiworld.itempool += created_items
 

--- a/worlds/dlcquest/__init__.py
+++ b/worlds/dlcquest/__init__.py
@@ -65,7 +65,7 @@ class DLCqworld(World):
                                for location in self.multiworld.get_locations(self.player)
                                if not location.advancement])
 
-        items_to_exclude = [excluded_items
+        items_to_exclude = [excluded_items.name
                             for excluded_items in self.multiworld.precollected_items[self.player]]
 
         created_items = create_items(self, self.options, locations_count, items_to_exclude, self.multiworld.random)


### PR DESCRIPTION

## What is this fixing or adding?
fix: Start inventory item would make a miss number of item from the number of location under certain condition

https://discord.com/channels/731205301247803413/1349141593692704829

## How was this tested?
Test where run and the world that failed to have the same number of location and item now work properly, other worlds with different item were tested
