### PR TITLE
Hollow Knight: Include Lumafly links to install mods

### DIFF
--- a/worlds/hk/docs/setup_en.md
+++ b/worlds/hk/docs/setup_en.md
@@ -8,8 +8,14 @@
 
 ## Installing the Archipelago Mod using Lumafly
 1. Launch Lumafly and ensure it locates your Hollow Knight installation directory.
-2. Click the "Install" button near the "Archipelago" mod entry.
-   * If desired, also install "Archipelago Map Mod" to use as an in-game tracker.
+2. Install the Archipelago mods by doing either of the following:
+   * Click one of the links below to allow Lumafly to install the mods. Lumafly will prompt for confirmation.
+     * [Archipelago and dependencies only](https://themulhima.github.io/Lumafly/commands/download/?mods=Archipelago)
+     * [Archipelago with rando essentials](https://themulhima.github.io/Lumafly/commands/download/?mods=Archipelago/Archipelago%20Map%20Mod/RecentItemsDisplay/DebugMod/RandoStats/Additional%20Timelines/CompassAlwaysOn/AdditionalMaps/)
+       (includes Archipelago Map Mod, RecentItemsDisplay, DebugMod, RandoStats, AdditionalTimelines, CompassAlwaysOn,
+       and AdditionalMaps).
+   * Click the "Install" button near the "Archipelago" mod entry. If desired, also install "Archipelago Map Mod"
+     to use as an in-game tracker.
 3. Launch the game, you're all set!
 
 ### What to do if Lumafly fails to find your installation directory


### PR DESCRIPTION
## What is this fixing or adding?

This adds redirect links to the setup instructions for Hollow Knight which use Lumafly's custom URL scheme to install mods

## How was this tested?

Read it, clicked the links on my branch to make sure they worked

