### PR TITLE
Core: Allow and require user-provided target name when splitting 1-way entrances for GER

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1022,17 +1022,20 @@ class Entrance:
     connected_region: Optional[Region] = None
     randomization_group: int
     randomization_type: EntranceType
+    vanilla_target_name: Optional[str]
     # LttP specific, TODO: should make a LttPEntrance
     addresses = None
     target = None
 
     def __init__(self, player: int, name: str = "", parent: Optional[Region] = None,
-                 randomization_group: int = 0, randomization_type: EntranceType = EntranceType.ONE_WAY) -> None:
+                 randomization_group: int = 0, randomization_type: EntranceType = EntranceType.ONE_WAY,
+                 vanilla_target_name: Optional[str] = None) -> None:
         self.name = name
         self.parent_region = parent
         self.player = player
         self.randomization_group = randomization_group
         self.randomization_type = randomization_type
+        self.vanilla_target_name = vanilla_target_name
 
     def can_reach(self, state: CollectionState) -> bool:
         assert self.parent_region, f"called can_reach on an Entrance \"{self}\" with no parent_region"

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1022,20 +1022,17 @@ class Entrance:
     connected_region: Optional[Region] = None
     randomization_group: int
     randomization_type: EntranceType
-    vanilla_target_name: Optional[str]
     # LttP specific, TODO: should make a LttPEntrance
     addresses = None
     target = None
 
     def __init__(self, player: int, name: str = "", parent: Optional[Region] = None,
-                 randomization_group: int = 0, randomization_type: EntranceType = EntranceType.ONE_WAY,
-                 vanilla_target_name: Optional[str] = None) -> None:
+                 randomization_group: int = 0, randomization_type: EntranceType = EntranceType.ONE_WAY) -> None:
         self.name = name
         self.parent_region = parent
         self.player = player
         self.randomization_group = randomization_group
         self.randomization_type = randomization_type
-        self.vanilla_target_name = vanilla_target_name
 
     def can_reach(self, state: CollectionState) -> bool:
         assert self.parent_region, f"called can_reach on an Entrance \"{self}\" with no parent_region"

--- a/entrance_rando.py
+++ b/entrance_rando.py
@@ -265,14 +265,19 @@ def bake_target_group_lookup(world: World, get_target_groups: Callable[[int], li
     return { group: get_target_groups(group) for group in unique_groups }
 
 
-def disconnect_entrance_for_randomization(entrance: Entrance, target_group: int | None = None) -> None:
+def disconnect_entrance_for_randomization(entrance: Entrance, target_group: int | None = None,
+                                          one_way_target_name: str | None = None) -> None:
     """
     Given an entrance in a "vanilla" region graph, splits that entrance to prepare it for randomization
-    in randomize_entrances. This should be done after setting the type and group of the entrance.
+    in randomize_entrances. This should be done after setting the type and group of the entrance. Because it attempts
+    to meet strict entrance naming requirements for coupled mode, this function may produce unintuitive results when
+    called only on a single entrance; it produces eventually-correct outputs only after calling it on all entrances.
 
     :param entrance: The entrance which will be disconnected in preparation for randomization.
     :param target_group: The group to assign to the created ER target. If not specified, the group from
                          the original entrance will be copied.
+    :param one_way_target_name: The name of the created ER target if `entrance` is one-way. This argument
+                                is required for one-way entrances and is ignored otherwise.
     """
     child_region = entrance.connected_region
     parent_region = entrance.parent_region
@@ -289,9 +294,9 @@ def disconnect_entrance_for_randomization(entrance: Entrance, target_group: int 
     else:
         # for 1-ways, the child region needs a target. naming is not a concern for coupling so we
         # allow it to be user provided (and require it, to prevent an unhelpful assumed name in pairings)
-        if not entrance.vanilla_target_name:
-            raise ValueError("Cannot disconnect a one-way entrance without a vanilla target name specified")
-        target = child_region.create_er_target(entrance.vanilla_target_name)
+        if not one_way_target_name:
+            raise ValueError("Cannot disconnect a one-way entrance without a target name specified")
+        target = child_region.create_er_target(one_way_target_name)
     target.randomization_type = entrance.randomization_type
     target.randomization_group = target_group or entrance.randomization_group
 

--- a/entrance_rando.py
+++ b/entrance_rando.py
@@ -287,8 +287,11 @@ def disconnect_entrance_for_randomization(entrance: Entrance, target_group: int 
         # targets in the child region will be created when the other direction edge is disconnected
         target = parent_region.create_er_target(entrance.name)
     else:
-        # for 1-ways, the child region needs a target and coupling/naming is not a concern
-        target = child_region.create_er_target(child_region.name)
+        # for 1-ways, the child region needs a target. naming is not a concern for coupling so we
+        # allow it to be user provided (and require it, to prevent an unhelpful assumed name in pairings)
+        if not entrance.vanilla_target_name:
+            raise ValueError("Cannot disconnect a one-way entrance without a vanilla target name specified")
+        target = child_region.create_er_target(entrance.vanilla_target_name)
     target.randomization_type = entrance.randomization_type
     target.randomization_group = target_group or entrance.randomization_group
 

--- a/test/general/test_entrance_rando.py
+++ b/test/general/test_entrance_rando.py
@@ -146,6 +146,7 @@ class TestDisconnectForRandomization(unittest.TestCase):
         e = r1.create_exit("e")
         e.randomization_type = EntranceType.ONE_WAY
         e.randomization_group = 1
+        e.vanilla_target_name = "foo"
         e.connect(r2)
 
         disconnect_entrance_for_randomization(e)
@@ -158,9 +159,21 @@ class TestDisconnectForRandomization(unittest.TestCase):
 
         self.assertEqual(1, len(r2.entrances))
         self.assertIsNone(r2.entrances[0].parent_region)
-        self.assertEqual("r2", r2.entrances[0].name)
+        self.assertEqual("foo", r2.entrances[0].name)
         self.assertEqual(EntranceType.ONE_WAY, r2.entrances[0].randomization_type)
         self.assertEqual(1, r2.entrances[0].randomization_group)
+
+    def test_disconnect_default_1way_no_vanilla_target_raises(self):
+        multiworld = generate_test_multiworld()
+        r1 = Region("r1", 1, multiworld)
+        r2 = Region("r2", 1, multiworld)
+        e = r1.create_exit("e")
+        e.randomization_type = EntranceType.ONE_WAY
+        e.randomization_group = 1
+        e.connect(r2)
+
+        with self.assertRaises(ValueError):
+            disconnect_entrance_for_randomization(e)
 
     def test_disconnect_uses_alternate_group(self):
         multiworld = generate_test_multiworld()
@@ -169,6 +182,7 @@ class TestDisconnectForRandomization(unittest.TestCase):
         e = r1.create_exit("e")
         e.randomization_type = EntranceType.ONE_WAY
         e.randomization_group = 1
+        e.vanilla_target_name = "foo"
         e.connect(r2)
 
         disconnect_entrance_for_randomization(e, 2)
@@ -181,7 +195,7 @@ class TestDisconnectForRandomization(unittest.TestCase):
 
         self.assertEqual(1, len(r2.entrances))
         self.assertIsNone(r2.entrances[0].parent_region)
-        self.assertEqual("r2", r2.entrances[0].name)
+        self.assertEqual("foo", r2.entrances[0].name)
         self.assertEqual(EntranceType.ONE_WAY, r2.entrances[0].randomization_type)
         self.assertEqual(2, r2.entrances[0].randomization_group)
 

--- a/test/general/test_entrance_rando.py
+++ b/test/general/test_entrance_rando.py
@@ -146,10 +146,9 @@ class TestDisconnectForRandomization(unittest.TestCase):
         e = r1.create_exit("e")
         e.randomization_type = EntranceType.ONE_WAY
         e.randomization_group = 1
-        e.vanilla_target_name = "foo"
         e.connect(r2)
 
-        disconnect_entrance_for_randomization(e)
+        disconnect_entrance_for_randomization(e, one_way_target_name="foo")
 
         self.assertIsNone(e.connected_region)
         self.assertEqual([], r1.entrances)
@@ -182,10 +181,9 @@ class TestDisconnectForRandomization(unittest.TestCase):
         e = r1.create_exit("e")
         e.randomization_type = EntranceType.ONE_WAY
         e.randomization_group = 1
-        e.vanilla_target_name = "foo"
         e.connect(r2)
 
-        disconnect_entrance_for_randomization(e, 2)
+        disconnect_entrance_for_randomization(e, 2, "foo")
 
         self.assertIsNone(e.connected_region)
         self.assertEqual([], r1.entrances)


### PR DESCRIPTION
## What is this fixing or adding?

When calling `disconnect_entrance_for_randomization`, the target name of the created target was assumed to be the child region name. This is frequently not a useful assumption as the chosen name will end up in pairings and not be useful to the client which knows nothing about the region structure. Furthermore, it is currently not possible to access the created ER target at all to correct the bad assumption.

To resolve this, I added a `vanilla_target_name` attribute to `Entrance`. This is well-aligned with the typical programming model for ER where entrances are initialized from data and then ER happens much later; this way the data can just be updated instead of trying to keep track of it up until the disconnect call to pass as a parameter. This attribute is currently optional in all situations other than disconnecting one-ways, but this may change later.

I am flagging this as a release blocker as it is a significant contractual change; introducing this after the first stable release of GER (0.6.0) would be a breaking change to anyone using the current implementation of disconnect.

## How was this tested?

Added tests for new behavior
