### PR TITLE
Core: Made want_reply follow the specs in the docs

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2037,7 +2037,7 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
                 value = func(value, operation["value"])
             ctx.stored_data[args["key"]] = args["value"] = value
             targets = set(ctx.stored_data_notification_clients[args["key"]])
-            if args.get("want_reply", True):
+            if args.get("want_reply", False):
                 targets.add(client)
             if targets:
                 ctx.broadcast(targets, [args])


### PR DESCRIPTION
## What is this fixing or adding?
The docs say want_reply needs to be True for a reply to be made. In reality not providing an argument also sends the reply. Not following these specs may lead to useless network usage and maybe some clients could be experiencing issues receiving packets they didn't ask for
I expect this to be a breaking change for some clients that rely on the reply being sent without them asking for one, but I'm putting that PR mainly so that the issue is not forgotten

## How was this tested?
It wasn't

## If this makes graphical changes, please attach screenshots.
