### PR TITLE
Civ6: Use AutoPatchRegister to make patch downloadable on webhost

### DIFF
--- a/worlds/civ_6/Container.py
+++ b/worlds/civ_6/Container.py
@@ -1,9 +1,10 @@
 from dataclasses import dataclass
 import os
+import io
 from typing import TYPE_CHECKING, Dict, List, Optional, cast
 import zipfile
 from BaseClasses import Location
-from worlds.Files import APContainer
+from worlds.Files import APContainer, AutoPatchRegister
 
 from .Enum import CivVICheckType
 from .Locations import CivVILocation, CivVILocationData
@@ -25,18 +26,22 @@ class CivTreeItem:
     ui_tree_row: int
 
 
-class CivVIContainer(APContainer):
+class CivVIContainer(APContainer, metaclass=AutoPatchRegister):
     """
     Responsible for generating the dynamic mod files for the Civ VI multiworld
     """
     game: Optional[str] = "Civilization VI"
+    patch_file_ending = ".apcivvi"
 
-    def __init__(self, patch_data: Dict[str, str], base_path: str, output_directory: str,
+    def __init__(self, patch_data: Dict[str, str] | io.BytesIO, base_path: str = "", output_directory: str = "",
                  player: Optional[int] = None, player_name: str = "", server: str = ""):
-        self.patch_data = patch_data
-        self.file_path = base_path
-        container_path = os.path.join(output_directory, base_path + ".apcivvi")
-        super().__init__(container_path, player, player_name, server)
+        if isinstance(patch_data, io.BytesIO):
+            super().__init__(patch_data, player, player_name, server)
+        else:
+            self.patch_data = patch_data
+            self.file_path = base_path
+            container_path = os.path.join(output_directory, base_path + ".apcivvi")
+            super().__init__(container_path, player, player_name, server)
 
     def write_contents(self, opened_zipfile: zipfile.ZipFile) -> None:
         for filename, yml in self.patch_data.items():


### PR DESCRIPTION
## What is this fixing or adding?
uses AutoPatchRegister on civ's APContainer to automatically register its output file and handle webhost using the handler to read the bytes

the BytesIO cutout is for a part of WebHostLib/upload.py which calls the constructor of the proper handler with the bytes, and then immediately calls read() to grab the player id, I'm not married to this particular handling of it, but without some handling the constructor fails

## How was this tested?
generated solo games on localhost and downloaded the patches

## If this makes graphical changes, please attach screenshots.
