### PR TITLE
Revert "Core: update websockets"

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -417,7 +417,7 @@ class CommonContext:
 
     async def send_msgs(self, msgs: typing.List[typing.Any]) -> None:
         """ `msgs` JSON serializable """
-        if not self.server or self.server.socket.state != websockets.protocol.State.OPEN:
+        if not self.server or not self.server.socket.open or self.server.socket.closed:
             return
         await self.server.socket.send(encode(msgs))
 

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -324,7 +324,7 @@ class Context:
 
     # General networking
     async def send_msgs(self, endpoint: Endpoint, msgs: typing.Iterable[dict]) -> bool:
-        if not endpoint.socket or endpoint.socket.state != websockets.protocol.State.OPEN:
+        if not endpoint.socket or not endpoint.socket.open:
             return False
         msg = self.dumper(msgs)
         try:
@@ -339,7 +339,7 @@ class Context:
             return True
 
     async def send_encoded_msgs(self, endpoint: Endpoint, msg: str) -> bool:
-        if not endpoint.socket or endpoint.socket.state != websockets.protocol.State.OPEN:
+        if not endpoint.socket or not endpoint.socket.open:
             return False
         try:
             await endpoint.socket.send(msg)
@@ -355,7 +355,7 @@ class Context:
     async def broadcast_send_encoded_msgs(self, endpoints: typing.Iterable[Endpoint], msg: str) -> bool:
         sockets = []
         for endpoint in endpoints:
-            if endpoint.socket and endpoint.socket.state == websockets.protocol.State.OPEN:
+            if endpoint.socket and endpoint.socket.open:
                 sockets.append(endpoint.socket)
         try:
             websockets.broadcast(sockets, msg)
@@ -924,7 +924,7 @@ async def on_client_joined(ctx: Context, client: Client):
                               "If your client supports it, "
                               "you may have additional local commands you can list with /help.",
                       {"type": "Tutorial"})
-    if not any(isinstance(extension, PerMessageDeflate) for extension in client.socket.protocol.extensions):
+    if not any(isinstance(extension, PerMessageDeflate) for extension in client.socket.extensions):
         ctx.notify_client(client, "Warning: your client does not support compressed websocket connections! "
                                   "It may stop working in the future. If you are a player, please report this to the "
                                   "client's developer.")
@@ -2107,7 +2107,7 @@ class ServerCommandProcessor(CommonCommandProcessor):
     def _cmd_exit(self) -> bool:
         """Shutdown the server"""
         try:
-            self.ctx.server.server.close()
+            self.ctx.server.ws_server.close()
         finally:
             self.ctx.exit_event.set()
         return True
@@ -2477,7 +2477,7 @@ async def auto_shutdown(ctx, to_cancel=None):
         await asyncio.wait_for(ctx.exit_event.wait(), ctx.auto_shutdown)
 
     def inactivity_shutdown():
-        ctx.server.server.close()
+        ctx.server.ws_server.close()
         ctx.exit_event.set()
         if to_cancel:
             for task in to_cancel:

--- a/WebHostLib/customserver.py
+++ b/WebHostLib/customserver.py
@@ -272,7 +272,7 @@ def run_server_process(name: str, ponyconfig: dict, static_server_data: dict,
 
                     await ctx.server
                 port = 0
-                for wssocket in ctx.server.server.sockets:
+                for wssocket in ctx.server.ws_server.sockets:
                     socketname = wssocket.getsockname()
                     if wssocket.family == socket.AF_INET6:
                         # Prefer IPv4, as most users seem to not have working ipv6 support

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 colorama>=0.4.6
-websockets>=15.0.1
+websockets>=13.0.1,<14
 PyYAML>=6.0.2
 jellyfish>=1.1.0
 jinja2>=3.1.4


### PR DESCRIPTION
Reverts ArchipelagoMW/Archipelago#4732

This broke BizhawkClient, and likely more, due to the removal of `socket.closed` (to my understanding)
https://discord.com/channels/731205301247803413/731214280439103580/1351637766596722731

I think we should still do this upgrade of course, but it needs more testing next time