### PR TITLE
Tests: Adding the assertAccessWith test helping method

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -418,6 +418,12 @@ class MultiWorld():
     def get_regions(self, player: Optional[int] = None) -> Collection[Region]:
         return self.regions if player is None else self.regions.region_cache[player].values()
 
+    def get_reachable_regions(self, state: Optional[CollectionState] = None,
+                                player: Optional[int] = None) -> List[Region]:
+        """Retrieve every region that can be reached from the `player` with the given `state`"""
+        state: CollectionState = state if state else self.state
+        return [region for region in self.get_regions(player) if region.can_reach(state)]
+
     def get_region(self, region_name: str, player: int) -> Region:
         return self.regions.region_cache[player][region_name]
 
@@ -492,6 +498,12 @@ class MultiWorld():
         return Utils.RepeatableChain(tuple(self.regions.entrance_cache[player].values()
                                            for player in self.regions.entrance_cache))
 
+    def get_reachable_entrances(self, state: Optional[CollectionState] = None,
+                                player: Optional[int] = None) -> List[Entrance]:
+        """Retrieve every entrance that can be reached from the `player` with the given `state`"""
+        state: CollectionState = state if state else self.state
+        return [entrance for entrance in self.get_entrances(player) if entrance.can_reach(state)]
+
     def register_indirect_condition(self, region: Region, entrance: Entrance):
         """Report that access to this Region can result in unlocking this Entrance,
         state.can_reach(Region) in the Entrance's traversal condition, as opposed to pure transition logic."""
@@ -509,7 +521,9 @@ class MultiWorld():
     def get_filled_locations(self, player: Optional[int] = None) -> List[Location]:
         return [location for location in self.get_locations(player) if location.item is not None]
 
-    def get_reachable_locations(self, state: Optional[CollectionState] = None, player: Optional[int] = None) -> List[Location]:
+    def get_reachable_locations(self, state: Optional[CollectionState] = None,
+                                player: Optional[int] = None) -> List[Location]:
+        """Retrieve every entrances that can be reached from the `player` with the given `state`"""
         state: CollectionState = state if state else self.state
         return [location for location in self.get_locations(player) if location.can_reach(state)]
 

--- a/test/bases.py
+++ b/test/bases.py
@@ -275,6 +275,58 @@ class WorldTestBase(unittest.TestCase):
         """Asserts that the game can be beaten with the current state"""
         self.assertEqual(self.multiworld.can_beat_game(self.multiworld.state), beatable)
 
+    def reachableSpot(self, state: CollectionState, resolution_hint:str = "Location") -> typing.List[str]:
+        """
+        Retrieve a list of spot that can be reached from the current player with the given `state`.
+        The `resolution_hint` parameter specifies which kind of sport to look at. It can take
+        "Location", "Entrance" or "Region" as values. Defaults to "Location".
+        """
+        assert resolution_hint in ("Location", "Region", "Entrance")
+        if resolution_hint == "Region":
+            reachable_spot: typing.List[str] = [location.name for location in
+                                         self.multiworld.get_reachable_regions(state, self.player)]
+        elif resolution_hint == "Entrance":
+            reachable_spot: typing.List[str] = [location.name for location in
+                                         self.multiworld.get_reachable_entrances(state, self.player)]
+        else:
+            reachable_spot: typing.List[str] = [location.name for location in
+                                         self.multiworld.get_reachable_locations(state, self.player)]
+        return reachable_spot
+
+
+    def assertAccessWith(self, spots:typing.List[str], item_names:typing.List[str],
+                         initial_items:typing.List[str] = None, resolution_hint:str = "Location"):
+        """
+        Assert that when the items are not collect, the spots are not reachable, but when
+        the items are collected, the spots are accessible. Also assert that no other new spots can be
+        accessed when the items are collected.
+        The `resolution_hint` parameter specifies which kind of sport to look at. It can take
+        "Location", "Entrance" or "Region" as values. Defaults to "Location".
+        """
+        if initial_items is None:
+            initial_items = []
+        assert resolution_hint in ("Location", "Region", "Entrance")
+        state = CollectionState(self.multiworld)
+        for item in initial_items:
+            state.collect(self.get_item_by_name(item))
+        reachable_spot_before = self.reachableSpot(state, resolution_hint)
+        for spot in spots:
+            self.assertFalse(state.can_reach(spot, resolution_hint, self.player),
+                             str(spot) + " is reachable without any items")
+        items = self.get_items_by_name(item_names)
+        for item in items:
+            state.collect(item)
+        reachable_spot_after = self.reachableSpot(state, resolution_hint)
+        for spot in reachable_spot_before:
+            reachable_spot_after.remove(spot)
+        for spot in spots:
+            reachable_spot_after.remove(spot)
+            self.assertTrue(state.can_reach(spot, resolution_hint, self.player),
+                            str(spot) + " is not reachable with " + str(item_names))
+        if len(reachable_spot_after) > 0:
+            self.assertTrue(len(reachable_spot_after) == 0, "Reachable with " + str(item_names) +
+                            " but not without: " + str(reachable_spot_after))
+
     # following tests are automatically run
     @property
     def run_default_tests(self) -> bool:

--- a/worlds/aquaria/test/test_abyss_transturtle_access.py
+++ b/worlds/aquaria/test/test_abyss_transturtle_access.py
@@ -1,0 +1,26 @@
+"""
+Author: Louis M
+Date: Sat, 22 Mar 2025 13:23:48 +0000
+Description: Unit test used to test accessibility of entrances with and without Abyss transturtle
+"""
+from BaseClasses import CollectionState
+from . import AquariaTestBase, after_home_water_locations
+from ..Items import ItemNames
+from ..Locations import AquariaLocationNames
+from ..Options import UnconfineHomeWater
+
+
+class AbyssTransturtleTest(AquariaTestBase):
+    """Unit test used to test accessibility of entrances with and without Abyss Transturtle"""
+    options = {
+        "unconfine_home_water": UnconfineHomeWater.option_via_transturtle
+    }
+
+    def test_abyss_transturtle_location(self) -> None:
+        """Test entrances that require Abyss transturtle"""
+        entrances = [
+            'Abyss right area, transturtle'
+        ]
+        tested_items = [ItemNames.TRANSTURTLE_ABYSS]
+        self.assertAccessWith(entrances, tested_items, resolution_hint="Region")
+

--- a/worlds/aquaria/test/test_right_veil_transturtle_access.py
+++ b/worlds/aquaria/test/test_right_veil_transturtle_access.py
@@ -1,0 +1,33 @@
+"""
+Author: Louis M
+Date: Sat, 22 Mar 2025 13:23:48 +0000
+Description: Unit test used to test accessibility of entrances with and without Veil top right transturtle
+"""
+from BaseClasses import CollectionState
+from . import AquariaTestBase, after_home_water_locations
+from ..Items import ItemNames
+from ..Locations import AquariaLocationNames
+from ..Options import UnconfineHomeWater
+
+
+class RightVeilTransturtleTest(AquariaTestBase):
+    """Unit test used to test accessibility of entrances with and without Right Veil Transturtle"""
+    options = {
+        "unconfine_home_water": UnconfineHomeWater.option_via_transturtle
+    }
+
+    def test_right_veil_transturtle_location(self) -> None:
+        """Test entrances that require right veil transturtle"""
+        entrances = [
+            'Sun Temple left area entrance to The Veil top right area, left of temple',
+            'The Veil top right area, left of temple to Sun Temple left area entrance',
+            'The Veil top right area, left of temple to The Veil top right area, fish pass left of temple',
+            'The Veil top right area, fish pass left of temple to The Veil top right area, left of temple',
+            'The Veil top right area, fish pass left of temple to Octopus Cave bottom entrance',
+            'Octopus Cave bottom entrance to The Veil top right area, fish pass left of temple',
+            'Home Waters, turtle room to The Veil top right area, left of temple'
+        ]
+        tested_items = [ItemNames.TRANSTURTLE_VEIL_TOP_RIGHT]
+        initial_items = [ItemNames.FISH_FORM]
+        self.assertAccessWith(entrances, tested_items, initial_items, "Entrance")
+

--- a/worlds/aquaria/test/test_simon_says_transturtle_access.py
+++ b/worlds/aquaria/test/test_simon_says_transturtle_access.py
@@ -1,0 +1,27 @@
+"""
+Author: Louis M
+Date: Sat, 22 Mar 2025 13:23:48 +0000
+Description: Unit test used to test accessibility of entrances with and without Simon Says transturtle
+"""
+from BaseClasses import CollectionState
+from . import AquariaTestBase, after_home_water_locations
+from ..Items import ItemNames
+from ..Locations import AquariaLocationNames
+from ..Options import UnconfineHomeWater
+
+
+class SimonSaysTransturtleTest(AquariaTestBase):
+    """Unit test used to test accessibility of entrances with and without Simon Says Transturtle"""
+    options = {
+        "unconfine_home_water": UnconfineHomeWater.option_via_transturtle
+    }
+
+    def test_simon_says_transturtle_location(self) -> None:
+        """Test entrances that require Simon Says transturtle"""
+        entrances = [
+            AquariaLocationNames.SIMON_SAYS_AREA_TRANSTURTLE,
+            AquariaLocationNames.SIMON_SAYS_AREA_BEATING_SIMON_SAYS
+        ]
+        tested_items = [ItemNames.TRANSTURTLE_SIMON_SAYS]
+        self.assertAccessWith(entrances, tested_items)
+


### PR DESCRIPTION
## What is this fixing or adding?

I created a testing utility method for my own world and I think that it can be useful to other world maintainer. So, I have put it in the bases.py, with the other assert methods.

I have created the `assertAccessWith` method that works a little bit like `assertAccessDependency` but with the difference that unlike `assertAccessDependency`, the `assertAccessWith` does not collect all items other than the ones that are tested. We can specify what items to initially collect in the test. There is some tests that I could not find a way to test with `assertAccessDependency` that I can now test with  `assertAccessWith` (like locations that can be accessed with two different set of items for example).

The new assertAccessWith works like this:
* The world test method must give 4 arguments (2 optional) to the assertAccessWith method:
   * spots: The locations or regions or entrances that should be reachable with the given items (the resolution_hint arguments indicate what type of spots to check);
   * item_names: The items that should be tested;
   * initial_items (Optional): a set of items that are already collected;
   * resolution_hint: A hinting argument used to tell the assertAccessWith method what to test. It can take 3 values:
      * "Location": Will test accessibility of locations (this is the default value if the argument is omitted)
      * "Region": Will test accessibility of regions
      * "Entrance": Will test accessibility of entrances
* The assertAccessWith method will validate 3 things:
   * No location/region/entrance in the `spots` argument are accessible without the items specified by `item_names`;
   * After collecting items specified by `item_names`, all location/region/entrance in the `spots` argument become accessible;
   * No other location/region/entrance became accessible after collecting items specified by `item_names`

Note that I also created the methods `get_reachable_regions` and `get_reachable_entrances` in BaseClasses.py that are similar to `get_reachable_locations` but for regions and entrances instead of locations. I tried to remain faithful to the existing implementation.

## How was this tested?

I created 3 tests for the Aquaria World that used the 3 types of spots (Locations, Regions and Entrances) with various kinds of arguments. I tried to keep them simple so that dev could easily understand how it worked.