### PR TITLE
TUNIC: Update swamp and atoll fuse logic with weaponry

### DIFF
--- a/worlds/tunic/er_rules.py
+++ b/worlds/tunic/er_rules.py
@@ -689,7 +689,9 @@ def set_er_region_rules(world: "TunicWorld", regions: Dict[str, Region], portal_
     atoll_statue = regions["Ruined Atoll"].connect(
         connecting_region=regions["Ruined Atoll Statue"],
         rule=lambda state: has_ability(prayer, state, world)
-        and (has_ladder("Ladders in South Atoll", state, world)
+        and ((has_ladder("Ladders in South Atoll", state, world)
+              and state.has_any((laurels, grapple), player)
+              and (has_sword(state, player) or state.has_any((fire_wand, gun), player)))
              # shoot fuse and have the shot hit you mid-LS
              or (can_ladder_storage(state, world) and state.has(fire_wand, player)
                  and options.ladder_storage >= LadderStorage.option_hard)))
@@ -1083,6 +1085,7 @@ def set_er_region_rules(world: "TunicWorld", regions: Dict[str, Region], portal_
     swamp_mid_to_cath = regions["Swamp Mid"].connect(
         connecting_region=regions["Swamp to Cathedral Main Entrance Region"],
         rule=lambda state: (has_ability(prayer, state, world)
+                            and (has_sword(state, player))
                             and (state.has(laurels, player)
                                  # blam yourself in the face with a wand shot off the fuse
                                  or (can_ladder_storage(state, world) and state.has(fire_wand, player)

--- a/worlds/tunic/rules.py
+++ b/worlds/tunic/rules.py
@@ -125,7 +125,8 @@ def set_region_rules(world: "TunicWorld") -> None:
                        # there's some boxes in the way
                        and (has_melee(state, player) or state.has_any((gun, grapple, fire_wand), player)))
     world.get_entrance("Ruined Atoll -> Library").access_rule = \
-        lambda state: state.has_any({grapple, laurels}, player) and has_ability(prayer, state, world)
+        lambda state: (state.has_any({grapple, laurels}, player) and has_ability(prayer, state, world)
+                       and (has_sword(state, player) or state.has_any((fire_wand, gun), player)))
     world.get_entrance("Overworld -> Quarry").access_rule = \
         lambda state: (has_sword(state, player) or state.has(fire_wand, player)) \
         and (state.has_any({grapple, laurels, gun}, player) or can_ladder_storage(state, world))
@@ -141,7 +142,7 @@ def set_region_rules(world: "TunicWorld") -> None:
     world.get_entrance("Lower Quarry -> Rooted Ziggurat").access_rule = \
         lambda state: state.has(grapple, player) and has_ability(prayer, state, world)
     world.get_entrance("Swamp -> Cathedral").access_rule = \
-        lambda state: (state.has(laurels, player) and has_ability(prayer, state, world)) \
+        lambda state: (state.has(laurels, player) and has_ability(prayer, state, world) and has_sword(state, player)) \
         or has_ice_grapple_logic(False, IceGrappling.option_medium, state, world)
     world.get_entrance("Overworld -> Spirit Arena").access_rule = \
         lambda state: ((state.has(gold_hexagon, player, options.hexagon_goal.value) if options.hexagon_quest.value


### PR DESCRIPTION
## What is this fixing or adding?
Atoll to Library rule:
Add laurels/orb requirement, so you aren't punished for enemy rando
Add sword/gun/wand requirement, so you can deal with the frogs at the northwest fuse

Swamp to Cathedral rule:
Add sword requirement for dealing with the bird and ghosts near the second fuse, it costs too much mana to reasonably require the magic weapons instead

## How was this tested?
Test gens