### PR TITLE
template options: Fixing an issue that would sometimes cause uncommented docstrings

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -1505,12 +1505,16 @@ def generate_yaml_templates(target_folder: typing.Union[str, "pathlib.Path"], ge
     import os
 
     import yaml
-    from jinja2 import Template
+    from jinja2 import Template, Environment
+    from inspect import cleandoc
 
     from worlds import AutoWorldRegister
     from Utils import local_path, __version__
 
     full_path: str
+
+    jinja_env = Environment()
+    jinja_env.filters["cleandoc"] = cleandoc
 
     os.makedirs(target_folder, exist_ok=True)
 
@@ -1546,7 +1550,7 @@ def generate_yaml_templates(target_folder: typing.Union[str, "pathlib.Path"], ge
             option_groups = get_option_groups(world)
             with open(local_path("data", "options.yaml")) as f:
                 file_data = f.read()
-            res = Template(file_data).render(
+            res = jinja_env.from_string(file_data).render(
                 option_groups=option_groups,
                 __version__=__version__, game=game_name, yaml_dump=yaml_dump_scalar,
                 dictify_range=dictify_range,

--- a/data/options.yaml
+++ b/data/options.yaml
@@ -53,8 +53,8 @@ requires:
     {%- if option.__doc__ %}
     # {{ option.__doc__
         | trim
-        | replace('\n\n', '\n    \n')
-        | replace('\n    ', '\n# ')
+        | cleandoc
+        | replace('\n', '\n# ')
         | indent(4, first=False)
       }}
     {%- endif -%}


### PR DESCRIPTION
## What is this fixing or adding?
See discussion in this bug-reports channel thread: https://discord.com/channels/731205301247803413/1352896058392580097

> [Launcher] Generate Template Options sometimes fails to comment all description lines

This seems like a consistent problem on 3.13 and possibly a rare/sporadic problem for 3.12 users. Option description lines that should be commented in a template just aren't commented.

Python 3.13 calls `inspect.cleandoc` on docstrings before giving them to the user. This adds a challenge to making sure output is consistent between 3.13 and 3.12 users. I just added `inspect.cleandoc()` as a jinja filter and called it in the template.

## How was this tested?
* Generated template settings on 3.12 and verified that the indentation was to the correct level
* Generated template settings on 3.13 and verified the indentation matched 3.12

The indentation I was looking at was in the comment for `exclude_very_hard_missions` in Starcraft 2.yaml, which aligns the second line of "Default:" after the colon:

```yaml
    # Default: Not excluded for mission orders "Vanilla Shuffled" or "Grid" with Maximum Campaign Size >= 20,
    #          excluded for any other order
```

## If this makes graphical changes, please attach screenshots.
None