### PR TITLE
Factorio: ensure increment is int

### DIFF
--- a/worlds/factorio/Client.py
+++ b/worlds/factorio/Client.py
@@ -406,7 +406,7 @@ async def get_info(ctx: FactorioContext, rcon_client: factorio_rcon.RCONClient):
     ctx.auth = info["slot_name"]
     ctx.seed_name = info["seed_name"]
     death_link = info["death_link"]
-    ctx.energy_link_increment = info.get("energy_link", 0)
+    ctx.energy_link_increment = int(info.get("energy_link", 0))
     logger.debug(f"Energy Link Increment: {ctx.energy_link_increment}")
     if ctx.energy_link_increment and ctx.ui:
         ctx.ui.enable_energy_link()

--- a/worlds/factorio/Client.py
+++ b/worlds/factorio/Client.py
@@ -255,7 +255,8 @@ async def game_watcher(ctx: FactorioContext):
                         if "DeathLink" in ctx.tags:
                             async_start(ctx.send_death())
                     if ctx.energy_link_increment:
-                        in_world_bridges = data["energy_bridges"]
+                        # 1 + quality * 0.3 for each bridge
+                        in_world_bridges: float = data["energy_bridges"]
                         if in_world_bridges:
                             in_world_energy = data["energy"]
                             if in_world_energy < (ctx.energy_link_increment * in_world_bridges):
@@ -263,14 +264,14 @@ async def game_watcher(ctx: FactorioContext):
                                 ctx.last_deplete = time.time()
                                 async_start(ctx.send_msgs([{
                                     "cmd": "Set", "key": ctx.energylink_key, "operations":
-                                        [{"operation": "add", "value": -ctx.energy_link_increment * in_world_bridges},
+                                        [{"operation": "add", "value": int(-ctx.energy_link_increment * in_world_bridges)},
                                          {"operation": "max", "value": 0}],
                                     "last_deplete": ctx.last_deplete
                                 }]))
                             # Above Capacity - (len(Bridges) * ENERGY_INCREMENT)
                             elif in_world_energy > (in_world_bridges * ctx.energy_link_increment * 5) - \
                                     ctx.energy_link_increment * in_world_bridges:
-                                value = ctx.energy_link_increment * in_world_bridges
+                                value = int(ctx.energy_link_increment * in_world_bridges)
                                 async_start(ctx.send_msgs([{
                                     "cmd": "Set", "key": ctx.energylink_key, "operations":
                                         [{"operation": "add", "value": value}]

--- a/worlds/factorio/__init__.py
+++ b/worlds/factorio/__init__.py
@@ -102,7 +102,7 @@ class Factorio(World):
     item_name_groups = {
         "Progressive": set(progressive_tech_table.keys()),
     }
-    required_client_version = (0, 5, 1)
+    required_client_version = (0, 6, 0)
     if Utils.version_tuple < required_client_version:
         raise Exception(f"Update Archipelago to use this world ({game}).")
     ordered_science_packs: typing.List[str] = MaxSciencePack.get_ordered_science_packs()


### PR DESCRIPTION
## What is this fixing or adding?
ensures the number coming from lua scope as basis for energy link is an int, so it doesn't end up changing energy link to a float.
The way factorio works, this should only be a problem if increment is > max_int, then it should be a float in json, but supposedly this happened: https://discord.com/channels/731205301247803413/1010929117748809758/1353846406816862228

## How was this tested?
Wasn't.

## If this makes graphical changes, please attach screenshots.
