### PR TITLE
The Messenger: Expand limited movement option

### DIFF
--- a/worlds/messenger/options.py
+++ b/worlds/messenger/options.py
@@ -82,6 +82,11 @@ class MegaShards(Toggle):
 class LimitedMovement(Choice):
     """
     Removes either rope dart or wingsuit from the itempool. Forces logic to at least hard and accessibility to minimal.
+
+    Off: Both items will be in the pool.
+    Either: One of the items will be removed at random.
+    Dart: Rope Dart will be kept in the pool, causing Wingsuit to be removed.
+    Suit: Wingsuit will be kept in the pool, causing Rope Dart to be removed.
     """
     display_name = "Limited Movement"
     option_off = 0

--- a/worlds/messenger/options.py
+++ b/worlds/messenger/options.py
@@ -79,11 +79,18 @@ class MegaShards(Toggle):
     display_name = "Shuffle Mega Time Shards"
 
 
-class LimitedMovement(Toggle):
+class LimitedMovement(Choice):
     """
     Removes either rope dart or wingsuit from the itempool. Forces logic to at least hard and accessibility to minimal.
     """
     display_name = "Limited Movement"
+    option_off = 0
+    alias_false = 0
+    option_either = 1
+    alias_true = 1
+    alias_on = 1
+    option_dart = 2
+    option_suit = 3
 
 
 class EarlyMed(Toggle):


### PR DESCRIPTION
## What is this fixing or adding?
Changes the option from a toggle to a choice to allow the user to specify which item will be kept in the pool. I moved the choice into generate_early because this will allow me to prevent unreachable regions from ever being created with this option in the future. No timeline on when that'll happen since I currently have no idea which regions those are.

## How was this tested?
Generated a few times with break points and checked the spoiler with multiple players.