### PR TITLE
Muse Dash: Update docs to recommend MelonLoader 0.7.0 rather than 0.6.1

### DIFF
--- a/worlds/musedash/docs/setup_en.md
+++ b/worlds/musedash/docs/setup_en.md
@@ -20,7 +20,7 @@
 2. Choose the automated tab, click the select button and browse to `MuseDash.exe`.
   - You can find the folder in steam by finding the game in your library, right clicking it and choosing *Manage→Browse Local Files*.
   - If you click the bar at the top telling you your current folder, this will give you a path you can copy. If you paste that into the window popped up by **MelonLoader**, it will automatically go to the same folder.
-3. Uncheck "Latest" and select v0.6.1. Then click install.
+3. Uncheck "Latest" and select v0.7.0. Then click install.
 4. Run the game once, and wait until you get to the Muse Dash start screen before exiting.
 5. Download the latest [Muse Dash Archipelago Mod](https://github.com/DeamonHunter/ArchipelagoMuseDash/releases/latest) and then extract that into the newly created `/Mods/` folder in MuseDash's install location.
   - All files must be under the `/Mods/` folder and not within a sub folder inside of `/Mods/`

--- a/worlds/musedash/docs/setup_en.md
+++ b/worlds/musedash/docs/setup_en.md
@@ -20,7 +20,7 @@
 2. Choose the automated tab, click the select button and browse to `MuseDash.exe`.
   - You can find the folder in steam by finding the game in your library, right clicking it and choosing *Manage→Browse Local Files*.
   - If you click the bar at the top telling you your current folder, this will give you a path you can copy. If you paste that into the window popped up by **MelonLoader**, it will automatically go to the same folder.
-3. Uncheck "Latest" and select v0.7.0. Then click install.
+3. Select v0.7.0. Then click install.
 4. Run the game once, and wait until you get to the Muse Dash start screen before exiting.
 5. Download the latest [Muse Dash Archipelago Mod](https://github.com/DeamonHunter/ArchipelagoMuseDash/releases/latest) and then extract that into the newly created `/Mods/` folder in MuseDash's install location.
   - All files must be under the `/Mods/` folder and not within a sub folder inside of `/Mods/`

--- a/worlds/musedash/docs/setup_es.md
+++ b/worlds/musedash/docs/setup_es.md
@@ -20,7 +20,7 @@
 2. Elije la pestaña "automated", haz clic en el botón "select" y busca tu `MuseDash.exe`.
   - Puedes encontrar la carpeta en Steam buscando el juego en tu biblioteca, haciendo clic derecho sobre el y elegir *Administrar→Ver archivos locales*.
   - Si haces clic en la barra superior que te indica la carpeta en la que estas, te dará la dirección de ésta para que puedas copiarla. Al pegar esa dirección en la ventana que **MelonLoader** abre, irá automaticamente a esa carpeta.
-3. Desmarca "Latest" y selecciona v0.6.1. Luego haz clic en "install".
+3. Desmarca "Latest" y selecciona v0.7.0. Luego haz clic en "install".
 4. Ejecuta el juego una vez, y espera hasta que aparezca la pantalla de inicio de Muse Dash antes de cerrarlo.
 5. Descarga la última version de [Muse Dash Archipelago Mod](https://github.com/DeamonHunter/ArchipelagoMuseDash/releases/latest) y extraelo en la nueva carpeta creada llamada `/Mods/`, localizada en la carpeta de instalación de Muse Dash.
   - Todos los archivos deben ir directamente en la carpeta `/Mods/`, y NO en una subcarpeta dentro de la carpeta `/Mods/`

--- a/worlds/musedash/docs/setup_es.md
+++ b/worlds/musedash/docs/setup_es.md
@@ -20,7 +20,7 @@
 2. Elije la pestaña "automated", haz clic en el botón "select" y busca tu `MuseDash.exe`.
   - Puedes encontrar la carpeta en Steam buscando el juego en tu biblioteca, haciendo clic derecho sobre el y elegir *Administrar→Ver archivos locales*.
   - Si haces clic en la barra superior que te indica la carpeta en la que estas, te dará la dirección de ésta para que puedas copiarla. Al pegar esa dirección en la ventana que **MelonLoader** abre, irá automaticamente a esa carpeta.
-3. Desmarca "Latest" y selecciona v0.7.0. Luego haz clic en "install".
+3. Selecciona v0.7.0. Luego haz clic en "install".
 4. Ejecuta el juego una vez, y espera hasta que aparezca la pantalla de inicio de Muse Dash antes de cerrarlo.
 5. Descarga la última version de [Muse Dash Archipelago Mod](https://github.com/DeamonHunter/ArchipelagoMuseDash/releases/latest) y extraelo en la nueva carpeta creada llamada `/Mods/`, localizada en la carpeta de instalación de Muse Dash.
   - Todos los archivos deben ir directamente en la carpeta `/Mods/`, y NO en una subcarpeta dentro de la carpeta `/Mods/`


### PR DESCRIPTION
## What is this fixing or adding?
Updates the docs to recommend a newer version and correct the wording because the launcher changed.

Paging @ShinyNT for double checking the spanish change.

## How was this tested?
N/A
