### PR TITLE
kvui: Fix hint tab formatting regression

### DIFF
--- a/kvui.py
+++ b/kvui.py
@@ -819,8 +819,9 @@ class HintLayout(BoxLayout):
 
     def fix_heights(self):
         for child in self.children:
-            fix_func = getattr(child, "fix_heights", None):
-            if fix_func: fix_func()
+            fix_func = getattr(child, "fix_heights", None)
+            if fix_func:
+                fix_func()
 
         
 status_names: typing.Dict[HintStatus, str] = {

--- a/kvui.py
+++ b/kvui.py
@@ -819,8 +819,8 @@ class HintLayout(BoxLayout):
 
     def fix_heights(self):
         for child in self.children:
-            if hasattr(child, "fix_heights"):
-                getattr(child, "fix_heights")()
+            fix_func = getattr(child, "fix_heights", None):
+            if fix_func: fix_func()
 
         
 status_names: typing.Dict[HintStatus, str] = {

--- a/kvui.py
+++ b/kvui.py
@@ -817,6 +817,11 @@ class HintLayout(BoxLayout):
         boxlayout.add_widget(AutocompleteHintInput())
         self.add_widget(boxlayout)
 
+    def fix_heights(self):
+        for child in self.children:
+            if hasattr(child, "fix_heights"):
+                getattr(child, "fix_heights")()
+
         
 status_names: typing.Dict[HintStatus, str] = {
     HintStatus.HINT_FOUND: "Found",


### PR DESCRIPTION
## What is this fixing or adding?
With the addition of the hint search bar, the type of the child of the TabbedPanel changed from HintLog to HintLayout. As HintLayout does not implement `fix_heights`, HintLog's `fix_heights` was never being reached. This simply implements `fix_heights` on HintLayout to call HintLog's `fix_heights`.

## How was this tested?
Manually by connecting to an AP server, hinting every item, and then attempting to rapidly scroll down the menu.

## If this makes graphical changes, please attach screenshots.
