### PR TITLE
Zillion: some code cleaning

### DIFF
--- a/worlds/zillion/__init__.py
+++ b/worlds/zillion/__init__.py
@@ -59,7 +59,7 @@ class ZillionWebWorld(WebWorld):
         "English",
         "setup_en.md",
         "setup/en",
-        ["beauxq"]
+        ["beauxq"],
     )]
 
     option_groups = z_option_groups
@@ -365,7 +365,7 @@ class ZillionWorld(World):
                 z_loc.zz_loc.item = multi_item
                 multi_items[z_loc.zz_loc.name] = (
                     z_loc.item.name,
-                    self.multiworld.get_player_name(z_loc.item.player)
+                    self.multiworld.get_player_name(z_loc.item.player),
                 )
         # debug_zz_loc_ids.sort()
         # for name, id_ in debug_zz_loc_ids.items():

--- a/worlds/zillion/client.py
+++ b/worlds/zillion/client.py
@@ -147,7 +147,7 @@ class ZillionContext(CommonContext):
 
         class ZillionManager(GameManager):
             logging_pairs = [
-                ("Client", "Archipelago")
+                ("Client", "Archipelago"),
             ]
             base_title = "Archipelago Zillion Client"
 
@@ -282,7 +282,7 @@ class ZillionContext(CommonContext):
 
             payload = {
                 "cmd": "Get",
-                "keys": [f"zillion-{self.auth}-doors"]
+                "keys": [f"zillion-{self.auth}-doors"],
             }
             async_start(self.send_msgs([payload]))
         elif cmd == "Retrieved":
@@ -326,7 +326,7 @@ class ZillionContext(CommonContext):
                     n_locations = len(self.missing_locations) + len(self.checked_locations) - 1  # -1 to ignore win
                     logger.info(f"New Check: {loc_name} ({self.ap_local_count}/{n_locations})")
                     async_start(self.send_msgs([
-                        {"cmd": "LocationChecks", "locations": [server_id]}
+                        {"cmd": "LocationChecks", "locations": [server_id]},
                     ]))
                 else:
                     # This will happen a lot in Zillion,
@@ -338,7 +338,7 @@ class ZillionContext(CommonContext):
                 if not self.finished_game:
                     async_start(self.send_msgs([
                         {"cmd": "LocationChecks", "locations": [loc_name_to_id["J-6 bottom far left"]]},
-                        {"cmd": "StatusUpdate", "status": ClientStatus.CLIENT_GOAL}
+                        {"cmd": "StatusUpdate", "status": ClientStatus.CLIENT_GOAL},
                     ]))
                     self.finished_game = True
             elif isinstance(event_from_game, events.DoorEventFromGame):
@@ -347,7 +347,7 @@ class ZillionContext(CommonContext):
                     payload = {
                         "cmd": "Set",
                         "key": f"zillion-{self.auth}-doors",
-                        "operations": [{"operation": "replace", "value": doors_b64}]
+                        "operations": [{"operation": "replace", "value": doors_b64}],
                     }
                     async_start(self.send_msgs([payload]))
             elif isinstance(event_from_game, events.MapEventFromGame):
@@ -367,7 +367,7 @@ class ZillionContext(CommonContext):
                 # TODO: colors in this text, like sni client?
                 logger.info(f"received {self.ap_id_to_name[ap_id]} from {from_name}")
             self.to_game.put_nowait(
-                events.ItemEventToGame(zz_item_ids)
+                events.ItemEventToGame(zz_item_ids),
             )
             self.next_item = len(self.items_received)
 
@@ -398,7 +398,7 @@ async def zillion_sync_task(ctx: ZillionContext) -> None:
         logger.info("Start Zillion in RetroArch, then use the /sms command to connect to it.")
     await asyncio.wait((
         asyncio.create_task(ctx.look_for_retroarch.wait()),
-        asyncio.create_task(ctx.exit_event.wait())
+        asyncio.create_task(ctx.exit_event.wait()),
     ), return_when=asyncio.FIRST_COMPLETED)
 
     last_log = ""
@@ -443,7 +443,7 @@ async def zillion_sync_task(ctx: ZillionContext) -> None:
                                         await asyncio.wait((
                                             asyncio.create_task(ctx.got_slot_data.wait()),
                                             asyncio.create_task(ctx.exit_event.wait()),
-                                            asyncio.create_task(asyncio.sleep(6))
+                                            asyncio.create_task(asyncio.sleep(6)),
                                         ), return_when=asyncio.FIRST_COMPLETED)  # to not spam connect packets
                             else:  # not correct seed name
                                 log_no_spam("incorrect seed - did you mix up roms?")
@@ -467,7 +467,7 @@ async def zillion_sync_task(ctx: ZillionContext) -> None:
                     await asyncio.wait((
                         asyncio.create_task(ctx.got_room_info.wait()),
                         asyncio.create_task(ctx.exit_event.wait()),
-                        asyncio.create_task(asyncio.sleep(6))
+                        asyncio.create_task(asyncio.sleep(6)),
                     ), return_when=asyncio.FIRST_COMPLETED)
             else:  # no name found in game
                 if not help_message_shown:

--- a/worlds/zillion/gen_data.py
+++ b/worlds/zillion/gen_data.py
@@ -19,7 +19,7 @@ class GenData:
         jsonable = {
             "multi_items": self.multi_items,
             "zz_game": self.zz_game.to_jsonable(),
-            "game_id": list(self.game_id)
+            "game_id": list(self.game_id),
         }
         return json.dumps(jsonable)
 
@@ -37,5 +37,5 @@ class GenData:
         return GenData(
             from_json["multi_items"],
             ZzGame.from_jsonable(from_json["zz_game"]),
-            bytes(from_json["game_id"])
+            bytes(from_json["game_id"]),
         )

--- a/worlds/zillion/id_maps.py
+++ b/worlds/zillion/id_maps.py
@@ -42,7 +42,7 @@ _zz_empty = zz_item_name_to_zz_item["empty"]
 
 
 def make_id_to_others(start_char: Chars) -> tuple[
-    dict[int, str], dict[int, int], dict[int, ZzItem]
+    dict[int, str], dict[int, int], dict[int, ZzItem],
 ]:
     """ returns id_to_name, id_to_zz_id, id_to_zz_item """
     id_to_name: dict[int, str] = {}
@@ -53,19 +53,19 @@ def make_id_to_others(start_char: Chars) -> tuple[
         name_to_zz_item = {
             "Apple": _zz_rescue_0,
             "Champ": _zz_rescue_1,
-            "JJ": _zz_empty
+            "JJ": _zz_empty,
         }
     elif start_char == "Apple":
         name_to_zz_item = {
             "Apple": _zz_empty,
             "Champ": _zz_rescue_1,
-            "JJ": _zz_rescue_0
+            "JJ": _zz_rescue_0,
         }
     else:  # Champ
         name_to_zz_item = {
             "Apple": _zz_rescue_0,
             "Champ": _zz_empty,
-            "JJ": _zz_rescue_1
+            "JJ": _zz_rescue_1,
         }
 
     for name, ap_id in item_name_to_id.items():
@@ -150,10 +150,10 @@ def get_slot_info(regions: Iterable[RegionData],
             rescues[str(i)] = {
                 "start_char": ri.start_char,
                 "room_code": ri.room_code,
-                "mask": ri.mask
+                "mask": ri.mask,
             }
     return {
         "start_char": start_char,
         "rescues": rescues,
-        "loc_mem_to_id": loc_memory_to_loc_id
+        "loc_mem_to_id": loc_memory_to_loc_id,
     }

--- a/worlds/zillion/logic.py
+++ b/worlds/zillion/logic.py
@@ -25,15 +25,15 @@ def set_randomizer_locs(cs: CollectionState, p: int, zz_r: Randomizer) -> int:
     z_world = cs.multiworld.worlds[p]
     assert isinstance(z_world, ZillionWorld)
 
-    _hash = p
+    hash_ = p
     for z_loc in z_world.my_locations:
         zz_name = z_loc.zz_loc.name
         zz_item = z_loc.item.zz_item \
             if isinstance(z_loc.item, ZillionItem) and z_loc.item.player == p \
             else zz_empty
         zz_r.locations[zz_name].item = zz_item
-        _hash += (hash(zz_name) * (z_loc.zz_loc.req.gun + 2)) ^ hash(zz_item)
-    return _hash
+        hash_ += (hash(zz_name) * (z_loc.zz_loc.req.gun + 2)) ^ hash(zz_item)
+    return hash_
 
 
 def item_counts(cs: CollectionState, p: int) -> tuple[tuple[str, int], ...]:
@@ -67,11 +67,11 @@ class ZillionLogicCache:
         returns frozenset of accessible zilliandomizer locations
         """
         # caching this function because it would be slow
-        _hash = set_randomizer_locs(cs, self._player, self._zz_r)
+        hash_ = set_randomizer_locs(cs, self._player, self._zz_r)
         counts = item_counts(cs, self._player)
-        _hash += hash(counts)
+        hash_ += hash(counts)
 
-        cntr, locs = self._cache.get(_hash, _cache_miss)
+        cntr, locs = self._cache.get(hash_, _cache_miss)
         if cntr == cs.prog_items[self._player]:
             # print("cache hit")
             return locs
@@ -90,6 +90,6 @@ class ZillionLogicCache:
         tr = frozenset(self._zz_r.get_locations(have_req))
 
         # save result in cache
-        self._cache[_hash] = (cs.prog_items[self._player].copy(), tr)
+        self._cache[hash_] = (cs.prog_items[self._player].copy(), tr)
 
         return tr

--- a/worlds/zillion/options.py
+++ b/worlds/zillion/options.py
@@ -6,7 +6,7 @@ from Options import Choice, DefaultOnToggle, NamedRange, OptionGroup, PerGameCom
 
 from zilliandomizer.options import (
     Options as ZzOptions, char_to_gun, char_to_jump, ID,
-    VBLR as ZzVBLR, Chars, ItemCounts as ZzItemCounts
+    VBLR as ZzVBLR, Chars, ItemCounts as ZzItemCounts,
 )
 from zilliandomizer.options.parsing import validate as zz_validate
 
@@ -23,7 +23,7 @@ class ZillionContinues(NamedRange):
     display_name = "continues"
     special_range_names = {
         "vanilla": 3,
-        "infinity": 21
+        "infinity": 21,
     }
 
 
@@ -247,7 +247,7 @@ class ZillionStartingCards(NamedRange):
     range_end = 10
     display_name = "starting cards"
     special_range_names = {
-        "vanilla": 0
+        "vanilla": 0,
     }
 
 
@@ -315,8 +315,8 @@ class ZillionOptions(PerGameCommonOptions):
 z_option_groups = [
     OptionGroup("item counts", [
         ZillionIDCardCount, ZillionBreadCount, ZillionOpaOpaCount, ZillionZillionCount,
-        ZillionFloppyDiskCount, ZillionScopeCount, ZillionRedIDCardCount
-    ])
+        ZillionFloppyDiskCount, ZillionScopeCount, ZillionRedIDCardCount,
+    ]),
 ]
 
 
@@ -361,7 +361,7 @@ def validate(options: ZillionOptions) -> tuple[ZzOptions, Counter[str]]:
         "Zillion": options.zillion_count,
         "Floppy Disk": options.floppy_disk_count,
         "Scope": options.scope_count,
-        "Red ID Card": options.red_id_card_count
+        "Red ID Card": options.red_id_card_count,
     })
     minimums = Counter({
         "ID Card": 0,
@@ -370,7 +370,7 @@ def validate(options: ZillionOptions) -> tuple[ZzOptions, Counter[str]]:
         "Zillion": guns_required,
         "Floppy Disk": floppy_req.value,
         "Scope": 0,
-        "Red ID Card": 1
+        "Red ID Card": 1,
     })
     for key in minimums:
         item_counts[key] = max(minimums[key], item_counts[key])
@@ -426,7 +426,7 @@ def validate(options: ZillionOptions) -> tuple[ZzOptions, Counter[str]]:
         bool(options.early_scope.value),
         True,  # balance defense
         starting_cards.value,
-        map_gen
+        map_gen,
     )
     zz_validate(zz_op)
     return zz_op, item_counts

--- a/worlds/zillion/test/TestGoal.py
+++ b/worlds/zillion/test/TestGoal.py
@@ -104,7 +104,7 @@ class TestGoalAppleStart(ZillionTestBase):
         "start_char": "Apple",
         "jump_levels": "balanced",
         "gun_levels": "low",
-        "zillion_count": 5
+        "zillion_count": 5,
     }
 
     def test_guns_jj_first(self) -> None:
@@ -131,7 +131,7 @@ class TestGoalChampStart(ZillionTestBase):
         "jump_levels": "low",
         "gun_levels": "balanced",
         "opa_opa_count": 5,
-        "opas_per_level": 1
+        "opas_per_level": 1,
     }
 
     def test_jump_jj_first(self) -> None:

--- a/worlds/zillion/test/TestOptions.py
+++ b/worlds/zillion/test/TestOptions.py
@@ -18,7 +18,7 @@ class OptionsTest(ZillionTestBase):
         """ all of the valid values for the AP options map to valid values for ZZ options """
         for option_name, vblr_class in (
             ("jump_levels", ZillionJumpLevels),
-            ("gun_levels", ZillionGunLevels)
+            ("gun_levels", ZillionGunLevels),
         ):
             for value in vblr_class.name_lookup.values():
                 self.options = {option_name: value}


### PR DESCRIPTION
## What is this fixing or adding?

some cleaning:
- https://docs.astral.sh/ruff/rules/missing-trailing-comma/
- Underscore at the end of a variable name is the standard way to avoid shadowing built-ins.
  - (Underscore at the beginning means "unused" for local variables.)

## How was this tested?

a generation