### PR TITLE
CommonClient: Add '/clearchat' command, to clear the client's chat log

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -221,10 +221,12 @@ class ClientCommandProcessor(CommandProcessor):
         async_start(self.ctx.send_msgs([{"cmd": "StatusUpdate", "status": state}]), name="send StatusUpdate")
         return True
 
-    def _cmd_clearchat(self):
-        """Clears the text log"""
+    def _cmd_clearchat(self, which_log: str = "All"):
+        """Clears the specified text log.
+        'All' clears every text log."""
         if self.ctx.ui:
-            self.ctx.ui.log_panels["All"].clear()
+            if not self.ctx.ui.clear_chat(which_log):
+                self.output(f"Unknown tab '{which_log}'")
 
     def default(self, raw: str):
         """The default message parser to be used when parsing any messages that do not match a command"""

--- a/CommonClient.py
+++ b/CommonClient.py
@@ -221,6 +221,11 @@ class ClientCommandProcessor(CommandProcessor):
         async_start(self.ctx.send_msgs([{"cmd": "StatusUpdate", "status": state}]), name="send StatusUpdate")
         return True
 
+    def _cmd_clearchat(self):
+        """Clears the text log"""
+        if self.ctx.ui:
+            self.ctx.ui.log_panels["All"].clear()
+
     def default(self, raw: str):
         """The default message parser to be used when parsing any messages that do not match a command"""
         raw = self.ctx.on_user_say(raw)

--- a/CommonClient.py
+++ b/CommonClient.py
@@ -221,7 +221,7 @@ class ClientCommandProcessor(CommandProcessor):
         async_start(self.ctx.send_msgs([{"cmd": "StatusUpdate", "status": state}]), name="send StatusUpdate")
         return True
 
-    def _cmd_clearchat(self, which_log: str = "All"):
+    def _cmd_clear_chat(self, which_log: str = "All"):
         """Clears the specified text log.
         'All' clears every text log."""
         if self.ctx.ui:

--- a/kvui.py
+++ b/kvui.py
@@ -1125,6 +1125,22 @@ class GameManager(ThemedApp):
         hints = self.ctx.stored_data.get(f"_read_hints_{self.ctx.team}_{self.ctx.slot}", [])
         self.hint_log.refresh_hints(hints)
 
+    def clear_chat(self, which_log: str = "All") -> bool:
+        if which_log == "All":
+            for panel in self.ctx.ui.log_panels.values():
+                if isinstance(panel, UILog):
+                    panel.clear()
+            return True
+        elif which_log == self.tabs.default_tab_text:
+            self.ctx.ui.log_panels["All"].clear()
+            return True
+        else:
+            target_panel = self.ctx.ui.log_panels.get(which_log)
+            if target_panel is None:
+                return False
+            if isinstance(target_panel, UILog):
+                self.ctx.ui.log_panels[which_log].clear()
+            return True
 
 class LogtoUI(logging.Handler):
     def __init__(self, on_log):

--- a/kvui.py
+++ b/kvui.py
@@ -1168,6 +1168,11 @@ class UILog(MDRecycleView):
         if len(self.data) > self.messages:
             self.data.pop(0)
 
+    def clear(self):
+        """Clears the log to appear visibly empty"""
+        # Clearing the data causes AssertionErrors related to sizing RecycleView. An empty element fixes this.
+        self.data = [{'text': ''}]
+
     def fix_heights(self):
         """Workaround fix for divergent texture and layout heights"""
         for element in self.children[0].children:


### PR DESCRIPTION
## What is this fixing or adding?
`/clearchat` command to CommonClient. Clears the chat log. Noticed [someone looking for this on discord](https://discord.com/channels/731205301247803413/731205301818359821/1355984675163869299), and figured it wouldn't be that difficult to add.

## How was this tested?
Ran the command, chat was clean. Made sure there were no errors in the console. Typed a bunch of stuff in chat, then ran the command, chat was clean. Typed stuff in the chat after cleaning it, worked fine. Cleaned it again, worked fine.

Per below comment, tested with `--nogui`, where the command has no effect (but does not throw an error either, it simply does nothing). If the command could be, like, hidden from `/help` and such in nogui mode, that would probably be best, but I don't see an obvious clean way to do so.

## If this makes graphical changes, please attach screenshots.
Help text showing for new command:
![image](https://github.com/user-attachments/assets/6800bac7-6521-4e51-90ff-52e2fb0d666b)
After running the command:
![image](https://github.com/user-attachments/assets/c38c5f08-e63a-4a59-b9da-2f56cd64a646)
