### PR TITLE
Timespinner: fix logic error relating to risky warp to Emperor's Towe…

### DIFF
--- a/worlds/timespinner/Regions.py
+++ b/worlds/timespinner/Regions.py
@@ -115,7 +115,7 @@ def create_regions_and_locations(world: MultiWorld, player: int, options: Timesp
     connect(world, player, 'The lab', 'The lab (power off)', lambda state: options.lock_key_amadeus or logic.has_doublejump_of_npc(state))
     connect(world, player, 'The lab (power off)', 'The lab', lambda state: not flooded.flood_lab or state.has('Water Mask', player))
     connect(world, player, 'The lab (power off)', 'The lab (upper)', lambda state: logic.has_forwarddash_doublejump(state) and ((not options.lock_key_amadeus) or state.has('Lab Access Genza', player)))
-    connect(world, player, 'The lab (upper)', 'The lab (power off)')
+    connect(world, player, 'The lab (upper)', 'The lab (power off)', lambda state: options.lock_key_amadeus and state.has('Lab Access Genza', player))
     connect(world, player, 'The lab (upper)', 'Emperors tower', logic.has_forwarddash_doublejump)
     connect(world, player, 'The lab (upper)', 'Ancient Pyramid (entrance)', lambda state: state.has_all({'Timespinner Wheel', 'Timespinner Spindle', 'Timespinner Gear 1', 'Timespinner Gear 2', 'Timespinner Gear 3'}, player))
     connect(world, player, 'Emperors tower', 'The lab (upper)')


### PR DESCRIPTION
…r and lab access

## What is this fixing or adding?
A logic error was discovered related to the Risky Warps flag when the destination location is the Emperor's Tower; without this fix the logic will assume you can unconditionally access the rest of the Lab despite there being a laser to block access. This is only possible in the specific condition that the Lock Key Amadeus flag is on and the player has the Lab Access Genza item; otherwise lab access is expected to be through the front lab entrance.

## How was this tested?
Generated a large number of seeds; inspected the resulting playthroughs to confirm that no seeds that have this warp require access to locations outside of the upper lab area.

## If this makes graphical changes, please attach screenshots.
N/A