### PR TITLE
Launcher: Remove an unnecessary global

### DIFF
--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -88,7 +88,6 @@ processes = weakref.WeakSet()
 
 
 def launch_subprocess(func: Callable, name: str | None = None, args: Tuple[str, ...] = ()) -> None:
-    global processes
     import multiprocessing
     process = multiprocessing.Process(target=func, name=name, args=args)
     process.start()


### PR DESCRIPTION
## What is this fixing or adding?
Removes an unnecessary global, it caused a flake8 test failure: https://github.com/ArchipelagoMW/Archipelago/actions/runs/14185069387/job/39738807731?pr=4226

https://discord.com/channels/731205301247803413/1214608557077700720/1356480632737366056

## How was this tested?
Launched some clients through the launcher