### PR TITLE
TUNIC: Error message in the spot that UT errors at if you have an old APWorld

### DIFF
--- a/worlds/tunic/er_scripts.py
+++ b/worlds/tunic/er_scripts.py
@@ -330,7 +330,11 @@ def pair_portals(world: "TunicWorld", regions: Dict[str, Region]) -> Dict[Portal
                 else:
                     if not portal2:
                         raise Exception(f"Could not find entrance named {p_exit} for "
-                                        f"plando connections in {player_name}'s YAML.")
+                                        f"plando connections in {player_name}'s YAML.\n"
+                                        f"If you are using Universal Tracker, the most likely reason for this error "
+                                        f"is that the host generated with a newer version of the APWorld.\n"
+                                        f"Please check the TUNIC Randomizer Github and place the newest APWorld in your "
+                                        f"custom_worlds folder, and remove the one in lib/worlds if there is one there.")
                     dead_ends.remove(portal2)
 
             # update the traversal chart to say you can get from portal1's region to portal2's and vice versa


### PR DESCRIPTION
## What is this fixing or adding?
UT support for ER works by turning the entrance pairs sent in slot data into plando connections. Part of this fails if the APWorld does not have https://github.com/ArchipelagoMW/Archipelago/pull/3761 in it if the game was generated with #3761 in it.

So, just slapping in a longer error message to catch this issue in case that doesn't get into 0.6.1 or whatever the next version will be.