### PR TITLE
The Witness: Move the Easter Egg Hunt option group lower so that the tooltip isn't cut off

### DIFF
--- a/worlds/witness/options.py
+++ b/worlds/witness/options.py
@@ -617,7 +617,7 @@ if is_easter_time():
     easter_special_option_group = OptionGroup("EASTER SPECIAL", [
         EasterEggHunt,
     ])
-    witness_option_groups = [easter_special_option_group, *witness_option_groups]
+    witness_option_groups.insert(2, easter_special_option_group)
 else:
     silly_options_group = next(group for group in witness_option_groups if group.name == "Silly Options")
     silly_options_group.options.append(EasterEggHunt)


### PR DESCRIPTION
The Easter Egg Hunt tooltip is quite enormous because it has to explain an entirely new mechanic that doesn't exist in the original game.

Unfortunately, on webhost, this results in part of it being cut off.

![image](https://github.com/user-attachments/assets/63c20b42-261c-4de6-b8a6-b9c0188e47c5)

This PR """fixes""" the issue by moving the Easter Egg Hunt option group lower.