### PR TITLE
CI: ignore F824

### DIFF
--- a/.github/workflows/analyze-modified-files.yml
+++ b/.github/workflows/analyze-modified-files.yml
@@ -65,7 +65,7 @@ jobs:
         continue-on-error: false
         if: env.diff != '' && matrix.task == 'flake8'
         run: |
-          flake8 --count --select=E9,F63,F7,F82 --show-source --statistics ${{ env.diff }}
+          flake8 --count --select=E9,F63,F7,F82 --ignore F824 --show-source --statistics ${{ env.diff }}
 
       - name: "flake8: Lint modified files"
         continue-on-error: true


### PR DESCRIPTION
## What is this fixing or adding?

This disables an added check in flake8 that does not really fit the goal of the github action and currently throws a lot of errors.

Going forward we should think about which flake8 warnings we want to have mandatory since probably all uses here are wrong or basically dead code.

## How was this tested?

CI

## If this makes graphical changes, please attach screenshots.

❌ -> ✅