### PR TITLE
CommonClient: Fix crash when connecting to a server when using nogui

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -413,7 +413,8 @@ class CommonContext:
             await self.server.socket.close()
         if self.server_task is not None:
             await self.server_task
-        self.ui.update_hints()
+        if self.ui:
+            self.ui.update_hints()
 
     async def send_msgs(self, msgs: typing.List[typing.Any]) -> None:
         """ `msgs` JSON serializable """


### PR DESCRIPTION
## What is this fixing or adding?

When running the Archipelago Factorio Client with the `--nogui` flag, and then trying to connect, the connection commands try to update the UI, which doesn't exist when we start with `--nogui`

```
Task exception was never retrieved
future: <Task finished name='connecting' coro=<CommonContext.connect() done, defined at CommonClient.py:476> exception=AttributeError("'NoneType' object has no attribute 'update_hints'")>
Traceback (most recent call last):
  File "CommonClient.py", line 478, in connect
  File "CommonClient.py", line 416, in disconnect
AttributeError: 'NoneType' object has no attribute 'update_hints'
```

## How was this tested?
I ran the project from git with this change, and was then able to start the factorio client with `python FactorioClient.py --nogui`, and then was able to run the `/connect` command and successfully connect to the server.
