### PR TITLE
Clients: stop updating datapackage in persistent_storage

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -624,9 +624,6 @@ class CommonContext:
 
     def consume_network_data_package(self, data_package: dict):
         self.update_data_package(data_package)
-        current_cache = Utils.persistent_load().get("datapackage", {}).get("games", {})
-        current_cache.update(data_package["games"])
-        Utils.persistent_store("datapackage", "games", current_cache)
         logger.info(f"Got new ID/Name DataPackage for {', '.join(data_package['games'])}")
         for game, game_data in data_package["games"].items():
             Utils.store_data_package_for_checksum(game, game_data)


### PR DESCRIPTION
## What is this fixing or adding?

Stops writing the data_package to the _persistent_storage.yaml, which is just wasted I/O since all new data packages will be loaded from the checksum cache.

Existing entries there are still loaded so that data packages that happen to be in there are still being used. This is still somewhat likely to happen for games that changed data package only once since the checksum cache was added.

## How was this tested?

Ctrl+Shift+F for current_cache.