### PR TITLE
Pokemon Red/Blue: Set allow_partial_entrances to true when building a state for ER

### DIFF
--- a/worlds/pokemon_rb/regions.py
+++ b/worlds/pokemon_rb/regions.py
@@ -2414,6 +2414,7 @@ def door_shuffle(world, multiworld, player, badges, badge_locs):
                 loc.place_locked_item(badge)
 
         state = multiworld.state.copy()
+        state.allow_partial_entrances = True
         for item, data in item_table.items():
             if (data.id or item in poke_data.pokemon_data) and data.classification == ItemClassification.progression \
                     and ("Badge" not in item or world.options.badgesanity):


### PR DESCRIPTION
## What is this fixing or adding?
When creating a Pokemon RB world with ER, it creates a state for the purposes of guaranteeing a valid ER placement. However, this state does not have the flag added in 0.6.0 to allow for entrances being disconnected. This causes a generation failure when combined with a world that has it's entrances disconnected for later randomization with GER. This PR sets `allow_partial_entrances` to true on this state.

## How was this tested?
Generating along-side a world with disconnected entrances; specifically the 2.0.0 release of the Crystalis APWorld with the options `shuffle_houses` and `shuffle_areas` both set to true.  Said APWorld can be found here: https://github.com/Ars-Ignis/Archipelago/releases/tag/v2.0.0

I also ran all unit tests.
