### PR TITLE
Core: post-KivyMD cleanup

### DIFF
--- a/Launcher.py
+++ b/Launcher.py
@@ -247,7 +247,6 @@ def run_gui(path: str, args: Any) -> None:
             self.image = image_path
             super().__init__(args, kwargs)
 
-
     class Launcher(ThemedApp):
         base_title: str = "Archipelago Launcher"
         top_screen: MDFloatLayout = ObjectProperty(None)
@@ -333,6 +332,11 @@ def run_gui(path: str, args: Any) -> None:
 
             for card in cards:
                 self.button_layout.layout.add_widget(card)
+
+            top = self.button_layout.children[0].y + self.button_layout.children[0].height \
+                           - self.button_layout.height
+            scroll_percent = self.button_layout.convert_distance_to_scroll(0, top)
+            self.button_layout.scroll_y = max(0, min(1, scroll_percent[1]))
 
         def filter_clients(self, caller):
             self._refresh_components(caller.type)

--- a/Launcher.py
+++ b/Launcher.py
@@ -8,9 +8,7 @@ Archipelago Launcher
 Scroll down to components= to add components to the launcher as well as setup.py
 """
 
-import os
 import argparse
-import itertools
 import logging
 import multiprocessing
 import shlex
@@ -228,14 +226,13 @@ refresh_components: Optional[Callable[[], None]] = None
 
 
 def run_gui(path: str, args: Any) -> None:
-    from kvui import (ThemedApp, MDFloatLayout, MDGridLayout, MDButton, MDLabel, MDButtonText, ScrollBox, ApAsyncImage)
+    from kvui import (ThemedApp, MDFloatLayout, MDGridLayout, ScrollBox)
     from kivy.properties import ObjectProperty
     from kivy.core.window import Window
     from kivy.metrics import dp
     from kivymd.uix.button import MDIconButton
     from kivymd.uix.card import MDCard
     from kivymd.uix.menu import MDDropdownMenu
-    from kivymd.uix.relativelayout import MDRelativeLayout
     from kivymd.uix.snackbar import MDSnackbar, MDSnackbarText
 
     from kivy.lang.builder import Builder

--- a/Launcher.py
+++ b/Launcher.py
@@ -130,7 +130,7 @@ def handle_uri(path: str, launch_args: Tuple[str, ...]) -> None:
     from kivymd.uix.dialog import MDDialog, MDDialogHeadlineText, MDDialogContentContainer, MDDialogSupportingText
     from kivymd.uix.divider import MDDivider
 
-    if client_component is None:
+    if not client_component:
         run_component(text_client_component, *launch_args)
         return
     else:

--- a/data/client.kv
+++ b/data/client.kv
@@ -18,6 +18,7 @@
     theme_style: "Dark" # Light/Dark
     primary_palette: "Green" # Many options
     dynamic_scheme_name: "TONAL_SPOT"
+    dynamic_scheme_contrast: 0.0
 <MDLabel>:
     color: self.theme_cls.primaryColor
 <TooltipLabel>:
@@ -184,6 +185,7 @@
     bar_width: "12dp"
     scroll_wheel_distance: 40
     do_scroll_x: False
+    scroll_type: ['bars', 'content']
 
     MDBoxLayout:
         id: layout

--- a/data/launcher.kv
+++ b/data/launcher.kv
@@ -9,13 +9,13 @@
     MDRelativeLayout:
         ApAsyncImage:
             source: main.image
-            size: (40, 40)
+            size: (48, 48)
             size_hint_y: None
             pos_hint: {"center_x": 0.1, "center_y": 0.5}
 
         MDLabel:
             text: main.component.display_name
-            pos_hint:{"center_x": 0.5, "center_y": 0.85 if main.component.description else 0.65}
+            pos_hint:{"center_x": 0.5, "center_y": 0.75 if main.component.description else 0.65}
             halign: "center"
             font_style: "Title"
             role: "medium"

--- a/kvui.py
+++ b/kvui.py
@@ -93,13 +93,13 @@ class ThemedApp(MDApp):
         self.theme_cls.theme_style = getattr(text_colors, "theme_style", "Dark")
         self.theme_cls.primary_palette = getattr(text_colors, "primary_palette", "Green")
         self.theme_cls.dynamic_scheme_name = getattr(text_colors, "dynamic_scheme_name", "TONAL_SPOT")
-        self.theme_cls.dynamic_scheme_contrast = 0.0
+        self.theme_cls.dynamic_scheme_contrast = getattr(text_colors, "dynamic_scheme_contrast", 0.0)
 
 
 class ImageIcon(MDButtonIcon, AsyncImage):
     def __init__(self, *args, **kwargs):
         super().__init__(args, kwargs)
-        self.image = AsyncImage(**kwargs)
+        self.image = ApAsyncImage(**kwargs)
         self.add_widget(self.image)
 
     def add_widget(self, widget, index=0, canvas=None):
@@ -114,7 +114,7 @@ class ImageButton(MDIconButton):
             if val != "None":
                 image_args[kwarg.replace("image_", "")] = val
         super().__init__()
-        self.image = AsyncImage(**image_args)
+        self.image = ApAsyncImage(**image_args)
 
         def set_center(button, center):
             self.image.center_x = self.center_x


### PR DESCRIPTION
## What is this fixing or adding?
* Removed now unused imports from Launcher
* Moved ImageIcon and ImageButton to use ApAsyncImage for compatibility with apworlds
* Adjusted image size in the Launcher from 40x40 to 48x48. This is already larger than the size in previous versions, and a docs update is soon to follow.
* Expose `dynamic_scheme_contrast` to user.kv, allowing users to set high contrast.
* ScrollBox's default scroll_type was set to only content, so the scrollbar in Launcher was nonfunctional.
* Adjusted the spacing of the title of a component when a description is present to be closer to the center.
* Launcher now scrolls to the top automatically when changing between filters

## How was this tested?
Manually.

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/user-attachments/assets/473aeeda-7eb6-4736-9ab4-cef1a2c21e92)
