### PR TITLE
LADX: Stop using Utils.get_options

### DIFF
--- a/LinksAwakeningClient.py
+++ b/LinksAwakeningClient.py
@@ -742,7 +742,8 @@ class LinksAwakeningContext(CommonContext):
                 await asyncio.sleep(1.0)
 
 def run_game(romfile: str) -> None:
-    auto_start = typing.cast(typing.Union[bool, str], LinksAwakeningWorld.settings.get("rom_start", True))
+    auto_start = typing.cast(typing.Union[bool, str], LinksAwakeningWorld.settings.rom_start)
+
     if auto_start is True:
         import webbrowser
         webbrowser.open(romfile)

--- a/LinksAwakeningClient.py
+++ b/LinksAwakeningClient.py
@@ -26,6 +26,7 @@ import typing
 from CommonClient import (CommonContext, get_base_parser, gui_enabled, logger,
                           server_loop)
 from NetUtils import ClientStatus
+from worlds.ladx import LinksAwakeningWorld
 from worlds.ladx.Common import BASE_ID as LABaseID
 from worlds.ladx.GpsTracker import GpsTracker
 from worlds.ladx.TrackerConsts import storage_key
@@ -741,8 +742,7 @@ class LinksAwakeningContext(CommonContext):
                 await asyncio.sleep(1.0)
 
 def run_game(romfile: str) -> None:
-    auto_start = typing.cast(typing.Union[bool, str],
-                            Utils.get_options()["ladx_options"].get("rom_start", True))
+    auto_start = typing.cast(typing.Union[bool, str], LinksAwakeningWorld.settings.rom_start)
     if auto_start is True:
         import webbrowser
         webbrowser.open(romfile)

--- a/LinksAwakeningClient.py
+++ b/LinksAwakeningClient.py
@@ -742,7 +742,7 @@ class LinksAwakeningContext(CommonContext):
                 await asyncio.sleep(1.0)
 
 def run_game(romfile: str) -> None:
-    auto_start = typing.cast(typing.Union[bool, str], LinksAwakeningWorld.settings.rom_start)
+    auto_start = LinksAwakeningWorld.settings.rom_start
 
     if auto_start is True:
         import webbrowser

--- a/LinksAwakeningClient.py
+++ b/LinksAwakeningClient.py
@@ -742,7 +742,7 @@ class LinksAwakeningContext(CommonContext):
                 await asyncio.sleep(1.0)
 
 def run_game(romfile: str) -> None:
-    auto_start = typing.cast(typing.Union[bool, str], LinksAwakeningWorld.settings.rom_start)
+    auto_start = typing.cast(typing.Union[bool, str], LinksAwakeningWorld.settings.get("rom_start", True))
     if auto_start is True:
         import webbrowser
         webbrowser.open(romfile)


### PR DESCRIPTION
## What is this fixing or adding?
Stops using the soon to be deprecated Utils.get_options
https://github.com/ArchipelagoMW/Archipelago/pull/4811

`LinksAwakeningWorld.settings` seems preferable to `settings.get_settings().ladx_options` since its one less thing to change for the ladx beta (which has a different game name)

## How was this tested?
Ran a patch file through the ladx client a few times, while fiddling with `host.yaml`