### PR TITLE
HK: workaround webhost bug with namedrange defaults out of range

### DIFF
--- a/worlds/hk/Options.py
+++ b/worlds/hk/Options.py
@@ -450,7 +450,7 @@ class GrubHuntGoal(NamedRange):
     display_name = "Grub Hunt Goal"
     range_start = 1
     range_end = 46
-    special_range_names = {"all": -1}
+    special_range_names = {"all": -1, "forty_six": 46}
     default = 46
 
 


### PR DESCRIPTION
## What is this fixing or adding?
makes a named range entry for the default 46 as a workaround for the current webhost bug

## How was this tested?
local webhost in a private browser to see defaults

## If this makes graphical changes, please attach screenshots.
