### PR TITLE
SoE: remove use of deprecated Utils.get_options()

### DIFF
--- a/worlds/soe/patch.py
+++ b/worlds/soe/patch.py
@@ -4,7 +4,6 @@ from typing import BinaryIO, Optional
 import Utils
 from worlds.Files import APDeltaPatch
 
-
 USHASH = '6e9c94511d04fac6e0a1e582c170be3a'
 
 
@@ -20,9 +19,9 @@ class SoEDeltaPatch(APDeltaPatch):
 
 
 def get_base_rom_path(file_name: Optional[str] = None) -> str:
-    options = Utils.get_options()
     if not file_name:
-        file_name = options["soe_options"]["rom_file"]
+        from . import SoEWorld
+        file_name = SoEWorld.settings.rom_file
     if not file_name:
         raise ValueError("Missing soe_options -> rom_file from host.yaml")
     if not os.path.exists(file_name):


### PR DESCRIPTION
## What is this fixing or adding?

Remove deprecated use of Utils.get_options() from SoE World.
The call to `user_path()`, or `get_base_rom_path()` in general, is not really required anymore with the settings API, but I tried to make the change as minimal as possible.

Resolves SoE for #4811 

## How was this tested?

* Generated with .sfc missing -> Cancel -> Gen stops with readable error
* Generated with .sfc missing -> Selected sfc -> Gen succeeds
* Generated with .sfc existing -> Gen succeeds
* Launcher -> Open Patch with .sfc missing -> Cancel -> Launching stops with readable error in MsgBox
* Launcher -> Open Patch with .sfc missing -> Selected sfc -> Patching + launching succeeds
* Launcher -> Open Patch with .sfc existing -> Patching + launching succeeds