### PR TITLE
Lingo: Mark some items as ProgUseful

### DIFF
--- a/worlds/lingo/items.py
+++ b/worlds/lingo/items.py
@@ -34,12 +34,34 @@ ITEMS_BY_GROUP: Dict[str, List[str]] = {}
 
 TRAP_ITEMS: List[str] = ["Slowness Trap", "Iceland Trap", "Atbash Trap"]
 
+PROGUSEFUL_ITEMS: List[str] = [
+    "Crossroads - Roof Access",
+    "Black",
+    "Red",
+    "Blue",
+    "Yellow",
+    "Purple",
+    "Sunwarps",
+    "Tenacious Entrance Panels",
+    "The Tenacious - Black Palindromes (Panels)",
+    "Hub Room - RAT (Panel)",
+    "Outside The Wanderer - WANDERLUST (Panel)",
+    "Orange Tower Panels"
+]
+
+
+def get_prog_item_classification(item_name: str):
+    if item_name in PROGUSEFUL_ITEMS:
+        return ItemClassification.progression | ItemClassification.useful
+    else:
+        return ItemClassification.progression
+
 
 def load_item_data():
     global ALL_ITEM_TABLE, ITEMS_BY_GROUP
 
     for color in ["Black", "Red", "Blue", "Yellow", "Green", "Orange", "Gray", "Brown", "Purple"]:
-        ALL_ITEM_TABLE[color] = ItemData(get_special_item_id(color), ItemClassification.progression,
+        ALL_ITEM_TABLE[color] = ItemData(get_special_item_id(color), get_prog_item_classification(color),
                                          ItemType.COLOR, False, [])
         ITEMS_BY_GROUP.setdefault("Colors", []).append(color)
 
@@ -53,16 +75,16 @@ def load_item_data():
                 door_groups.add(door.door_group)
 
             ALL_ITEM_TABLE[door.item_name] = \
-                ItemData(get_door_item_id(room_name, door_name), ItemClassification.progression, ItemType.NORMAL,
-                         door.has_doors, door.painting_ids)
+                ItemData(get_door_item_id(room_name, door_name), get_prog_item_classification(door.item_name),
+                         ItemType.NORMAL, door.has_doors, door.painting_ids)
             ITEMS_BY_GROUP.setdefault("Doors", []).append(door.item_name)
 
             if door.item_group is not None:
                 ITEMS_BY_GROUP.setdefault(door.item_group, []).append(door.item_name)
 
     for group in door_groups:
-        ALL_ITEM_TABLE[group] = ItemData(get_door_group_item_id(group),
-                                         ItemClassification.progression, ItemType.NORMAL, True, [])
+        ALL_ITEM_TABLE[group] = ItemData(get_door_group_item_id(group), get_prog_item_classification(group),
+                                         ItemType.NORMAL, True, [])
         ITEMS_BY_GROUP.setdefault("Doors", []).append(group)
 
     panel_groups: Set[str] = set()
@@ -72,11 +94,12 @@ def load_item_data():
                 panel_groups.add(panel_door.panel_group)
 
             ALL_ITEM_TABLE[panel_door.item_name] = ItemData(get_panel_door_item_id(room_name, panel_door_name),
-                                                            ItemClassification.progression, ItemType.NORMAL, False, [])
+                                                            get_prog_item_classification(panel_door.item_name),
+                                                            ItemType.NORMAL, False, [])
             ITEMS_BY_GROUP.setdefault("Panels", []).append(panel_door.item_name)
 
     for group in panel_groups:
-        ALL_ITEM_TABLE[group] = ItemData(get_panel_group_item_id(group), ItemClassification.progression,
+        ALL_ITEM_TABLE[group] = ItemData(get_panel_group_item_id(group), get_prog_item_classification(group),
                                          ItemType.NORMAL, False, [])
         ITEMS_BY_GROUP.setdefault("Panels", []).append(group)
 
@@ -101,7 +124,7 @@ def load_item_data():
 
     for item_name in PROGRESSIVE_ITEMS:
         ALL_ITEM_TABLE[item_name] = ItemData(get_progressive_item_id(item_name),
-                                             ItemClassification.progression, ItemType.NORMAL, False, [])
+                                             get_prog_item_classification(item_name), ItemType.NORMAL, False, [])
 
 
 # Initialize the item data at module scope.


### PR DESCRIPTION
## What is this fixing or adding?
Some progression items are additionally marked as useful now, which some clients use to indicate that the item is particularly important. The affected items are:

- "Crossroads - Roof Access", which almost always provides access to a large number of locations.
- The five colors that are the most prevalent across puzzles.
- "Sunwarps", which unlocks all sunwarps at once. This tends to grant access to multiple regions, and is required for the Pilgrimage goal.
- The panel doors that are required for roof access in panels mode door shuffle. These may block victory depending on the selected goal, and even if they don't, they provide access to a large number of locations via the roof.


## How was this tested?
pytest, test generation, played with a client that recognizes proguseful items.


## If this makes graphical changes, please attach screenshots.
