### PR TITLE
kvui: re-enable settings menu

### DIFF
--- a/kvui.py
+++ b/kvui.py
@@ -943,10 +943,6 @@ class GameManager(ThemedApp):
         hints = self.ctx.stored_data.get(f"_read_hints_{self.ctx.team}_{self.ctx.slot}", [])
         self.hint_log.refresh_hints(hints)
 
-    # default F1 keybind, opens a settings menu, that seems to break the layout engine once closed
-    def open_settings(self, *largs):
-        pass
-
 
 class LogtoUI(logging.Handler):
     def __init__(self, on_log):


### PR DESCRIPTION
## What is this fixing or adding?
On base kivy we had to disable the settings menu (by default opened with F1) because  when we closed it the layout would fall apart. Now with  kivymd that does not happen anymore (for me).

## How was this tested?
![image](https://github.com/user-attachments/assets/d2eec151-243c-4b9a-a6a0-2768715891af)


## If this makes graphical changes, please attach screenshots.
![image](https://github.com/user-attachments/assets/01c53c1d-a83f-4c5c-acc7-c90a3c7b9b5c)

## Future
With the menu back, we can use it to put kivy specific settings into it  and add a button to access it, as  most people will not know about the F1 keybind.