### PR TITLE
Core: make completion_condition a world method

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -160,6 +160,7 @@ class MultiWorld():
         self.local_early_items = {player: {} for player in self.player_ids}
         self.indirect_connections = {}
         self.start_inventory_from_pool: Dict[int, Options.StartInventoryPool] = {}
+        self.completion_condition = {}
 
         for player in range(1, players + 1):
             def set_player_attr(attr: str, val) -> None:
@@ -168,7 +169,6 @@ class MultiWorld():
             set_player_attr('plando_texts', {})
             set_player_attr('plando_connections', [])
             set_player_attr('game', "Archipelago")
-            set_player_attr('completion_condition', lambda state: True)
         self.worlds = {}
         self.per_slot_randoms = Utils.DeprecateDict("Using per_slot_randoms is now deprecated. Please use the "
                                                     "world's random object instead (usually self.random)")
@@ -233,6 +233,8 @@ class MultiWorld():
             options_dataclass: type[Options.PerGameCommonOptions] = world_type.options_dataclass
             self.worlds[player].options = options_dataclass(**{option_key: getattr(args, option_key)[player]
                                                                for option_key in options_dataclass.type_hints})
+            # TODO for back compatibility
+            self.completion_condition[player] = self.worlds[player].completion_condition
 
     def set_item_links(self):
         from worlds import AutoWorld

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -485,6 +485,16 @@ class World(metaclass=AutoWorldRegister):
         logging.warning(f"World {self} is generating a filler item without custom filler pool.")
         return self.multiworld.random.choice(tuple(self.item_name_to_id.keys()))
 
+    def completion_condition(self, state: CollectionState) -> bool:
+        """
+        Called to determine if the player can currently reach the goal or "win".
+
+        :param state: The CollectionState to check for the goal with.
+
+        :return: True if the player can reach their goal.
+        """
+        return True
+
     @classmethod
     def create_group(cls, multiworld: "MultiWorld", new_player_id: int, players: Set[int]) -> World:
         """


### PR DESCRIPTION
## What is this fixing or adding?
Makes completion_condition an overridable world method instead of worlds needing to assign it to a dictionary. The dictionary still exists, just gets the values set when the worlds are instantiated now. There may be a better way to do this, but I definitely don't want to do it in the World constructor. Since the dictionary is still there and still used it's back compatible. Not sure if the format should change in some way or this is even worth the effort but had the idea so :shrug:

## How was this tested?
Ran tests and ran generation with messenger, both old and new way, to make sure goal still worked.