### PR TITLE
Lingo: Add "shuffle_postgame" flag to slot data

### DIFF
--- a/worlds/lingo/__init__.py
+++ b/worlds/lingo/__init__.py
@@ -174,7 +174,7 @@ class LingoWorld(World):
             "death_link", "victory_condition", "shuffle_colors", "shuffle_doors", "shuffle_paintings", "shuffle_panels",
             "enable_pilgrimage", "sunwarp_access", "mastery_achievements", "level_2_requirement", "location_checks",
             "early_color_hallways", "pilgrimage_allows_roof_access", "pilgrimage_allows_paintings", "shuffle_sunwarps",
-            "group_doors", "speed_boost_mode"
+            "group_doors", "speed_boost_mode", "shuffle_postgame"
         ]
 
         slot_data = {


### PR DESCRIPTION
## What is this fixing or adding?
This allows the tracker to see whether postgame is shuffled in the player's world, and if it's not, allows it to hide locations/paintings accordingly.

## How was this tested?
Test generation with tracker.

## If this makes graphical changes, please attach screenshots.
