### PR TITLE
Pokemon Red and Blue PC Item fix

### DIFF
--- a/worlds/pokemon_rb/regions.py
+++ b/worlds/pokemon_rb/regions.py
@@ -1587,7 +1587,11 @@ def create_regions(world):
         else:
             acceptable_item = lambda item: True
         for i, item in enumerate(world.item_pool):
-            if acceptable_item(item):
+            if acceptable_item(item) and ("Badge" not in item.name
+                                          and "Trap" not in item.name
+                                          and item.name != "Pokedex"
+                                          and "Coins" not in item.name
+                                          and "Progressive" not in item.name):
                 world.pc_item = world.item_pool.pop(i)
                 break
 

--- a/worlds/pokemon_rb/regions.py
+++ b/worlds/pokemon_rb/regions.py
@@ -1580,20 +1580,21 @@ def create_regions(world):
 
     world.random.shuffle(world.item_pool)
     if not world.options.key_items_only:
-        if "Player's House 2F - Player's PC" in world.options.exclude_locations:
-            acceptable_item = lambda item: item.excludable
-        elif "Player's House 2F - Player's PC" in world.options.priority_locations:
-            acceptable_item = lambda item: item.advancement
-        else:
-            acceptable_item = lambda item: True
+        def acceptable_item(item):
+            return ("Badge" not in item.name and "Trap" not in item.name and item.name != "Pokedex"
+                    and "Coins" not in item.name and "Progressive" not in item.name
+                    and ("Player's House 2F - Player's PC" not in world.options.exclude_locations or item.excludable)
+                    and ("Player's House 2F - Player's PC" not in world.options.priority_locations or item.advancement))
         for i, item in enumerate(world.item_pool):
-            if acceptable_item(item) and ("Badge" not in item.name
-                                          and "Trap" not in item.name
-                                          and item.name != "Pokedex"
-                                          and "Coins" not in item.name
-                                          and "Progressive" not in item.name):
+            if acceptable_item(item) and (item.name not in world.options.non_local_items.value):
                 world.pc_item = world.item_pool.pop(i)
                 break
+        else:
+            for i, item in enumerate(world.item_pool):
+                if acceptable_item(item):
+                    world.pc_item = world.item_pool.pop(i)
+                    break
+
 
     advancement_items = [item.name for item in world.item_pool if item.advancement] \
                         + [item.name for item in world.multiworld.precollected_items[world.player] if

--- a/worlds/pokemon_rb/regions.py
+++ b/worlds/pokemon_rb/regions.py
@@ -1584,7 +1584,8 @@ def create_regions(world):
             return ("Badge" not in item.name and "Trap" not in item.name and item.name != "Pokedex"
                     and "Coins" not in item.name and "Progressive" not in item.name
                     and ("Player's House 2F - Player's PC" not in world.options.exclude_locations or item.excludable)
-                    and ("Player's House 2F - Player's PC" not in world.options.priority_locations or item.advancement))
+                    and ("Player's House 2F - Player's PC" in world.options.exclude_locations or
+                         "Player's House 2F - Player's PC" not in world.options.priority_locations or item.advancement))
         for i, item in enumerate(world.item_pool):
             if acceptable_item(item) and (item.name not in world.options.non_local_items.value):
                 world.pc_item = world.item_pool.pop(i)


### PR DESCRIPTION
## What is this fixing or adding?
Fixes the early code to set aside a PC item so it respects the item rules needed so that items that do not work in this location are not placed there.

## How was this tested?
Generating default yaml with seed 6133628608690033011 and observing Marsh Badge placed on main, Poke Ball on this branch.