### PR TITLE
Multiserver: remove GetDataPackage.exclusions handling

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1851,22 +1851,11 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
             await ctx.send_msgs(client, reply)
 
     elif cmd == "GetDataPackage":
-        exclusions = args.get("exclusions", [])
         if "games" in args:
             games = {name: game_data for name, game_data in ctx.gamespackage.items()
                      if name in set(args.get("games", []))}
             await ctx.send_msgs(client, [{"cmd": "DataPackage",
                                           "data": {"games": games}}])
-        # TODO: remove exclusions behaviour around 0.5.0
-        elif exclusions:
-            exclusions = set(exclusions)
-            games = {name: game_data for name, game_data in ctx.gamespackage.items()
-                     if name not in exclusions}
-
-            package = {"games": games}
-            await ctx.send_msgs(client, [{"cmd": "DataPackage",
-                                          "data": package}])
-
         else:
             await ctx.send_msgs(client, [{"cmd": "DataPackage",
                                           "data": {"games": ctx.gamespackage}}])


### PR DESCRIPTION
## What is this fixing or adding?
removes backcompat functionality for something not in spec since 0.3.1

## How was this tested?
wasn't, but i made sure there was no clients in main that somehow still mentioned this feature

## If this makes graphical changes, please attach screenshots.
