### PR TITLE
Stardew Valley: Exclude maximum one resource packs from pool when in start inventory

### DIFF
--- a/worlds/stardew_valley/__init__.py
+++ b/worlds/stardew_valley/__init__.py
@@ -1,7 +1,7 @@
 import logging
 import typing
 from random import Random
-from typing import Dict, Any, Iterable, Optional, List, TextIO, cast
+from typing import Dict, Any, Iterable, Optional, List, TextIO
 
 from BaseClasses import Region, Entrance, Location, Item, Tutorial, ItemClassification, MultiWorld, CollectionState
 from Options import PerGameCommonOptions
@@ -148,8 +148,8 @@ class StardewValleyWorld(World):
         self.precollect_farm_type_items()
         items_to_exclude = [excluded_items
                             for excluded_items in self.multiworld.precollected_items[self.player]
-                            if not item_table[excluded_items.name].has_any_group(Group.RESOURCE_PACK,
-                                                                                 Group.FRIENDSHIP_PACK)]
+                            if item_table[excluded_items.name].has_any_group(Group.MAXIMUM_ONE)
+                            or not item_table[excluded_items.name].has_any_group(Group.RESOURCE_PACK, Group.FRIENDSHIP_PACK)]
 
         if self.options.season_randomization == SeasonRandomization.option_disabled:
             items_to_exclude = [item for item in items_to_exclude

--- a/worlds/stardew_valley/items.py
+++ b/worlds/stardew_valley/items.py
@@ -181,7 +181,7 @@ def create_items(item_factory: StardewItemFactory, locations_count: int, items_t
     items += unique_filler_items
     logger.debug(f"Created {len(unique_filler_items)} unique filler items")
 
-    resource_pack_items = fill_with_resource_packs_and_traps(item_factory, options, random, items, locations_count)
+    resource_pack_items = fill_with_resource_packs_and_traps(item_factory, options, random, items + items_to_exclude, locations_count - len(items))
     items += resource_pack_items
     logger.debug(f"Created {len(resource_pack_items)} resource packs")
 
@@ -727,7 +727,7 @@ def weapons_count(options: StardewValleyOptions):
 
 def fill_with_resource_packs_and_traps(item_factory: StardewItemFactory, options: StardewValleyOptions, random: Random,
                                        items_already_added: List[Item],
-                                       number_locations: int) -> List[Item]:
+                                       available_item_slots: int) -> List[Item]:
     include_traps = options.trap_items != TrapItems.option_no_traps
     items_already_added_names = [item.name for item in items_already_added]
     useful_resource_packs = [pack for pack in items_by_group[Group.RESOURCE_PACK_USEFUL]
@@ -750,10 +750,9 @@ def fill_with_resource_packs_and_traps(item_factory: StardewItemFactory, options
     priority_filler_items = remove_excluded_items(priority_filler_items, options)
 
     number_priority_items = len(priority_filler_items)
-    required_resource_pack = number_locations - len(items_already_added)
-    if required_resource_pack < number_priority_items:
+    if available_item_slots < number_priority_items:
         chosen_priority_items = [item_factory(resource_pack) for resource_pack in
-                                 random.sample(priority_filler_items, required_resource_pack)]
+                                 random.sample(priority_filler_items, available_item_slots)]
         return chosen_priority_items
 
     items = []
@@ -761,24 +760,24 @@ def fill_with_resource_packs_and_traps(item_factory: StardewItemFactory, options
                                           ItemClassification.trap if resource_pack.classification == ItemClassification.trap else ItemClassification.useful)
                              for resource_pack in priority_filler_items]
     items.extend(chosen_priority_items)
-    required_resource_pack -= number_priority_items
+    available_item_slots -= number_priority_items
     all_filler_packs = [filler_pack for filler_pack in all_filler_packs
                         if Group.MAXIMUM_ONE not in filler_pack.groups or
                         (filler_pack.name not in [priority_item.name for priority_item in
                                                   priority_filler_items] and filler_pack.name not in items_already_added_names)]
 
-    while required_resource_pack > 0:
+    while available_item_slots > 0:
         resource_pack = random.choice(all_filler_packs)
         exactly_2 = Group.EXACTLY_TWO in resource_pack.groups
-        while exactly_2 and required_resource_pack == 1:
+        while exactly_2 and available_item_slots == 1:
             resource_pack = random.choice(all_filler_packs)
             exactly_2 = Group.EXACTLY_TWO in resource_pack.groups
         classification = ItemClassification.useful if resource_pack.classification == ItemClassification.progression else resource_pack.classification
         items.append(item_factory(resource_pack, classification))
-        required_resource_pack -= 1
+        available_item_slots -= 1
         if exactly_2:
             items.append(item_factory(resource_pack, classification))
-            required_resource_pack -= 1
+            available_item_slots -= 1
         if exactly_2 or Group.MAXIMUM_ONE in resource_pack.groups:
             all_filler_packs.remove(resource_pack)
 

--- a/worlds/stardew_valley/strings/wallet_item_names.py
+++ b/worlds/stardew_valley/strings/wallet_item_names.py
@@ -9,3 +9,4 @@ class Wallet:
     dark_talisman = "Dark Talisman"
     club_card = "Club Card"
     mastery_of_the_five_ways = "Mastery Of The Five Ways"
+    key_to_the_town = "Key To The Town"

--- a/worlds/stardew_valley/test/TestItems.py
+++ b/worlds/stardew_valley/test/TestItems.py
@@ -1,4 +1,4 @@
-from BaseClasses import MultiWorld, get_seed
+from BaseClasses import MultiWorld, get_seed, ItemClassification
 from . import setup_solo_multiworld, SVTestCase, solo_multiworld
 from .options.presets import allsanity_no_mods_6_x_x, get_minsanity_options
 from .. import StardewValleyWorld
@@ -70,6 +70,22 @@ class TestItems(SVTestCase):
             self.assertEqual(len(season_items), 3)
             starting_seasons_rolled.add(f"{starting_season_items[0]}")
         self.assertEqual(len(starting_seasons_rolled), 4)
+
+
+class TestStartInventoryFillersAreProperlyExcluded(SVTestCase):
+    def test_given_maximum_one_resource_pack_in_start_inventory_when_create_items_then_item_is_properly_excluded(self):
+        assert item_table[Wallet.key_to_the_town].classification == ItemClassification.useful \
+               and {Group.MAXIMUM_ONE, Group.RESOURCE_PACK_USEFUL}.issubset(item_table[Wallet.key_to_the_town].groups), \
+            "'Key to the Town' is no longer suitable to test this usecase."
+
+        options = {
+            "start_inventory": {
+                Wallet.key_to_the_town: 1,
+            }
+        }
+
+        with solo_multiworld(options, world_caching=False) as (multiworld, world):
+            self.assertNotIn(world.create_item(Wallet.key_to_the_town), multiworld.get_items())
 
 
 class TestMetalDetectors(SVTestCase):


### PR DESCRIPTION
## What is this fixing or adding?
This correctly exclude resources packs with the "MAXIMUM_ONE" group from the itempool when they are in the start inventory. Now, if you place the "Key To The Town" (to only name one) in your start inventory, you will not get a second one later on.

## How was this tested?
Wrote a new test! 

## If this makes graphical changes, please attach screenshots.
N/A