### PR TITLE
Launcher: find component by suffix

### DIFF
--- a/Launcher.py
+++ b/Launcher.py
@@ -170,6 +170,11 @@ def handle_uri(path: str, launch_args: Tuple[str, ...]) -> None:
 def identify(path: Union[None, str]) -> Tuple[Union[None, str], Union[None, Component]]:
     if path is None:
         return None, None
+    else:
+        suffix = "." + path.split(".")[-1]
+        from worlds.LauncherComponents import component_by_suffix
+        if suffix in component_by_suffix:
+            return path, component_by_suffix[suffix]
     for component in components:
         if component.handles_file(path):
             return path, component

--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -8,6 +8,9 @@ from typing import Optional, Callable, List, Iterable, Tuple
 from Utils import local_path, open_filename
 
 
+component_by_suffix = {}
+
+
 class Type(Enum):
     TOOL = auto()
     MISC = auto()
@@ -48,6 +51,12 @@ class Component:
             Type.ADJUSTER if "Adjuster" in display_name else Type.MISC)
         self.func = func
         self.file_identifier = file_identifier
+        if isinstance(file_identifier, SuffixIdentifier):
+            for suffix in file_identifier.suffixes:
+                if suffix in component_by_suffix:
+                    raise Exception("TODO")
+                else:
+                    component_by_suffix[suffix] = self
         self.game_name = game_name
         self.supports_uri = supports_uri
 


### PR DESCRIPTION
## What is this fixing or adding?
make a crude component lookup on init and change launcher identify to check that lookup first
we already have a special patch register that just has a list of file extensions, why not make a lookup for it

any better ideas on how to manage the lookup welcome

## How was this tested?
barely

## If this makes graphical changes, please attach screenshots.
