### PR TITLE
kvui: actually fix [u] and [/u] appearing in copied hints

### DIFF
--- a/kvui.py
+++ b/kvui.py
@@ -589,8 +589,7 @@ class HintLabel(RecycleDataViewBehavior, MDBoxLayout):
                                     if self.entrance_text != "Vanilla"
                                     else "", ". (", self.status_text.lower(), ")"))
                     temp = MarkupLabel(text).markup
-                    text = "".join(
-                        part for part in temp if not part.startswith(("[color", "[/color]", "[ref=", "[/ref]")))
+                    text = "".join(part for part in temp if not part.startswith("["))
                     Clipboard.copy(escape_markup(text).replace("&amp;", "&").replace("&bl;", "[").replace("&br;", "]"))
                     return self.parent.select_with_touch(self.index, touch)
         else:


### PR DESCRIPTION
## What is this fixing or adding?
Clicking a hint in the hint tab copies it. It would copy like such as of hint priority:
`Emily Stardew's Mill is at One Way Room in Emily V6's World. ([u]no priority[/u])`
This was attempted to be fixed in #4794, but only one location's code was changed - this PR updates the other, properly fixing the issue.

## How was this tested?
`Emily Stardew's Mill is at One Way Room in Emily V6's World. (no priority)`
Copies properly from the hint tab now, where it did not before.
