### PR TITLE
Factorio: fix FloatRanges writing effectively nil into the mod

### DIFF
--- a/worlds/factorio/Options.py
+++ b/worlds/factorio/Options.py
@@ -8,17 +8,20 @@ from schema import Schema, Optional, And, Or, SchemaError
 from Options import Choice, OptionDict, OptionSet, DefaultOnToggle, Range, DeathLink, Toggle, \
     StartInventoryPool, PerGameCommonOptions, OptionGroup
 
+
 # schema helpers
 class FloatRange:
     def __init__(self, low, high):
         self._low = low
         self._high = high
 
-    def validate(self, value):
+    def validate(self, value) -> float:
         if not isinstance(value, (float, int)):
             raise SchemaError(f"should be instance of float or int, but was {value!r}")
         if not self._low <= value <= self._high:
             raise SchemaError(f"{value} is not between {self._low} and {self._high}")
+        return float(value)
+
 
 LuaBool = Or(bool, And(int, lambda n: n in (0, 1)))
 


### PR DESCRIPTION
## What is this fixing or adding?
Fixes that since https://github.com/ArchipelagoMW/Archipelago/pull/4421 any world_gen floats  are written as None into the mod. None loads the global of the name None, which is not defined, so it loads nil, when nil is given in the table Factorio defaults to default world settings.

## How was this tested?
![image](https://github.com/user-attachments/assets/dbac9af5-fd0c-4588-a10e-1c72a7a243df)
No longer None in this text.
