### PR TITLE
CI: update action ubuntu build runners to 22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,8 +99,8 @@ jobs:
           if-no-files-found: error
           retention-days: 7  # keep for 7 days, should be enough
 
-  build-ubuntu2004:
-    runs-on: ubuntu-20.04
+  build-ubuntu2204:
+    runs-on: ubuntu-22.04
     steps:
       # - copy code below to release.yml -
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,8 @@ jobs:
   # build-release-windows: # this is done by hand because of signing
   # build-release-macos: # LF volunteer
 
-  build-release-ubuntu2004:
-    runs-on: ubuntu-20.04
+  build-release-ubuntu2204:
+    runs-on: ubuntu-22.04
     steps:
       - name: Set env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV


### PR DESCRIPTION
## What is this fixing or adding?

GitHub has removal of the Ubuntu 20.04 image scheduled for April 15th 2025, at which point the CI actions using it would fail.
On top of that, Ubuntu 20.04 LTS support will reach EOL May 1st 2025, at which point we should not use it to bundle anything anymore.

We want to stick to the oldest available image to use the oldest possible libc as dependency, so this changes affected actions to use Ubuntu 22.04. If this is a problem for some users, such as Debian oldstable, we could build on a different image (not a GitHub image), however that involves some work, so we should first make this change and see if anyone reports problems.

## How was this tested?

CI Output -> AppImage -> Launcher -> Generate, Browse Files and Text Client
on Arch Linux and Ubuntu 24.04 VM