### PR TITLE
Timespinner: add support for spider traps from new client release

### DIFF
--- a/worlds/timespinner/Items.py
+++ b/worlds/timespinner/Items.py
@@ -208,7 +208,9 @@ item_table: Dict[str, ItemData] = {
     'Lab Access Research': ItemData('Lab Access', 1337196, progression=True),
     'Lab Access Dynamo': ItemData('Lab Access', 1337197, progression=True),
     'Drawbridge Key': ItemData('Key', 1337198, progression=True),
-    # 1337199 - 1337248 Reserved
+    # 1337199 Reserved
+    'Spider Trap': ItemData('Trap', 1337200, 0, trap=True),
+    # 1337201 - 1337248 Reserved
     'Max Sand': ItemData('Stat', 1337249, 14)
 }
 

--- a/worlds/timespinner/Options.py
+++ b/worlds/timespinner/Options.py
@@ -367,8 +367,8 @@ class TrapChance(Range):
 class Traps(OptionList):
     """List of traps that may be in the item pool to find"""
     display_name = "Traps Types"
-    valid_keys = { "Meteor Sparrow Trap", "Poison Trap", "Chaos Trap", "Neurotoxin Trap", "Bee Trap", "Throw Stun Trap" }
-    default = [ "Meteor Sparrow Trap", "Poison Trap", "Chaos Trap", "Neurotoxin Trap", "Bee Trap", "Throw Stun Trap" ]
+    valid_keys = { "Meteor Sparrow Trap", "Poison Trap", "Chaos Trap", "Neurotoxin Trap", "Bee Trap", "Throw Stun Trap", "Spider Trap" }
+    default = [ "Meteor Sparrow Trap", "Poison Trap", "Chaos Trap", "Neurotoxin Trap", "Bee Trap", "Throw Stun Trap", "Spider Trap" ]
 
 class PresentAccessWithWheelAndSpindle(Toggle):
     """When inverted, allows using the refugee camp warp when both the Timespinner Wheel and Spindle is acquired."""


### PR DESCRIPTION
## What is this fixing or adding?
v1.35.0 of the Timespinner randomiser added Spider Traps; this adds corresponding support into the apworld. (https://github.com/Jarno458/TsRandomizer/pull/174 will need to land upstream before this works completely)

## How was this tested?
Generated some worlds to confirm placement of the new trap.

## If this makes graphical changes, please attach screenshots.
N/A