### PR TITLE
Webhost: Fix Sphere Tracker crashing on item links

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -616,7 +616,7 @@ class MultiWorld():
         locations: Set[Location] = set()
         events: Set[Location] = set()
         for location in self.get_filled_locations():
-            if type(location.item.code) is int:
+            if type(location.item.code) is int and type(location.address) is int:
                 locations.add(location)
             else:
                 events.add(location)


### PR DESCRIPTION
## What is this fixing or adding?
fix item links yet again (this time for the webhost sphere tracker)

## How was this tested?
https://discord.com/channels/731205301247803413/1358879618580480090/1359648039148585101
gen'd this yaml before and after and saw it crash sphere tracker before and not crash after
also inspected multidata["spheres"] and saw no `None` after the change

## If this makes graphical changes, please attach screenshots.
