### PR TITLE
MLSS: Fix generation error with emblem hunt and no digspots

### DIFF
--- a/worlds/mlss/Rules.py
+++ b/worlds/mlss/Rules.py
@@ -148,12 +148,13 @@ def set_rules(world: "MLSSWorld", excluded):
                           and StateLogic.canDash(state, world.player)
                           and StateLogic.canCrash(state, world.player)
         )
-        add_rule(
-            world.get_location(LocationName.BowsersCastleWendyLarryHallwayDigspot),
-            lambda state: StateLogic.ultra(state, world.player)
-                          and StateLogic.fire(state, world.player)
-                          and StateLogic.canCrash(state, world.player)
-        )
+        if world.options.chuckle_beans != 0:
+            add_rule(
+                world.get_location(LocationName.BowsersCastleWendyLarryHallwayDigspot),
+                lambda state: StateLogic.ultra(state, world.player)
+                              and StateLogic.fire(state, world.player)
+                              and StateLogic.canCrash(state, world.player)
+            )
         add_rule(
             world.get_location(LocationName.BowsersCastleBeforeFawfulFightBlock1),
             lambda state: StateLogic.canDig(state, world.player)


### PR DESCRIPTION
## What is this fixing or adding?

With Chuckle Bean digspots disabled, the `Bowser's Castle Wendy & Larry Hallway Digspot` location does not exist, but `Rules.set_rules` was not checking for this when the `Goal` was set to `Emblem Hunt` and was trying to set rules on this location anyway, crashing generation.

## How was this tested?

Generated before, both locally and on the website, with the default options changed to the `Goal` set to `Emblem Hunt` and `Chuckle Beans` set to `None` and observed the crash, and then generated with this PR and observed successful generation.
Zipped example yaml:
[EmblemNoDigspot.zip](https://github.com/user-attachments/files/19688653/EmblemNoDigspot.zip)

I don't really know MLSS, I just stopped the crashing.

```
Uncaught exception
Traceback (most recent call last):
  File "G:\git_Repos_other\Archipelago\Generate.py", line 552, in <module>
    multiworld = ERmain(erargs, seed)
                 ^^^^^^^^^^^^^^^^^^^^
  File "G:\git_Repos_other\Archipelago\Main.py", line 128, in main
    AutoWorld.call_all(multiworld, "set_rules")
  File "G:\git_Repos_other\Archipelago\worlds\AutoWorld.py", line 184, in call_all
    call_single(multiworld, method_name, player, *args)
  File "G:\git_Repos_other\Archipelago\worlds\AutoWorld.py", line 174, in call_single
    raise e
  File "G:\git_Repos_other\Archipelago\worlds\AutoWorld.py", line 167, in call_single
    ret = _timed_call(method, *args, multiworld=multiworld, player=player)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "G:\git_Repos_other\Archipelago\worlds\AutoWorld.py", line 153, in _timed_call
    ret = method(*args)
          ^^^^^^^^^^^^^
  File "G:\git_Repos_other\Archipelago\worlds\mlss\__init__.py", line 156, in set_rules
    set_rules(self, self.disabled_locations)
  File "G:\git_Repos_other\Archipelago\worlds\mlss\Rules.py", line 152, in set_rules
    world.get_location(LocationName.BowsersCastleWendyLarryHallwayDigspot),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "G:\git_Repos_other\Archipelago\worlds\AutoWorld.py", line 539, in get_location
    return self.multiworld.get_location(location_name, self.player)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "G:\git_Repos_other\Archipelago\BaseClasses.py", line 428, in get_location
    return self.regions.location_cache[player][location_name]
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
KeyError: "Bowser's Castle Wendy & Larry Hallway Digspot"
Exception in <bound method MLSSWorld.set_rules of <worlds.mlss.MLSSWorld object at 0x000001C97CF1AE40>> for player 2014, named Player2014.
```