### PR TITLE
DLC Quest - Skip two long tests in the main pipeline

### DIFF
--- a/worlds/dlcquest/test/TestOptionsLong.py
+++ b/worlds/dlcquest/test/TestOptionsLong.py
@@ -1,10 +1,11 @@
+import unittest
 from typing import Dict
 
 from BaseClasses import MultiWorld
 from Options import NamedRange
-from .option_names import options_to_include
-from .checks.world_checks import assert_can_win, assert_same_number_items_locations
 from . import DLCQuestTestBase, setup_dlc_quest_solo_multiworld
+from .checks.world_checks import assert_can_win, assert_same_number_items_locations
+from .option_names import options_to_include
 
 
 def basic_checks(tester: DLCQuestTestBase, multiworld: MultiWorld):
@@ -38,6 +39,8 @@ class TestGenerateDynamicOptions(DLCQuestTestBase):
                             basic_checks(self, multiworld)
 
     def test_given_option_truple_when_generate_then_basic_checks(self):
+        if self.skip_long_tests:
+            raise unittest.SkipTest("Long tests disabled")
         num_options = len(options_to_include)
         for option1_index in range(0, num_options):
             for option2_index in range(option1_index + 1, num_options):
@@ -59,6 +62,8 @@ class TestGenerateDynamicOptions(DLCQuestTestBase):
                                     basic_checks(self, multiworld)
 
     def test_given_option_quartet_when_generate_then_basic_checks(self):
+        if self.skip_long_tests:
+            raise unittest.SkipTest("Long tests disabled")
         num_options = len(options_to_include)
         for option1_index in range(0, num_options):
             for option2_index in range(option1_index + 1, num_options):

--- a/worlds/dlcquest/test/__init__.py
+++ b/worlds/dlcquest/test/__init__.py
@@ -20,9 +20,7 @@ class DLCQuestTestBase(WorldTestBase):
     @classmethod
     def setUpClass(cls) -> None:
         super().setUpClass()
-        long_tests_key = "long"
-        if long_tests_key in os.environ:
-            cls.skip_long_tests = not bool(os.environ[long_tests_key])
+        cls.skip_long_tests = not bool(os.environ.get("long"))
 
     def world_setup(self, *args, **kwargs):
         super().world_setup(*args, **kwargs)

--- a/worlds/dlcquest/test/__init__.py
+++ b/worlds/dlcquest/test/__init__.py
@@ -1,19 +1,28 @@
-from typing import ClassVar
-
-from typing import Dict, FrozenSet, Tuple, Any
+import os
 from argparse import Namespace
+from typing import ClassVar
+from typing import Dict, FrozenSet, Tuple, Any
 
 from BaseClasses import MultiWorld
 from test.bases import WorldTestBase
-from .. import DLCqworld
 from test.general import gen_steps, setup_solo_multiworld as setup_base_solo_multiworld
 from worlds.AutoWorld import call_all
+from .. import DLCqworld
 
 
 class DLCQuestTestBase(WorldTestBase):
     game = "DLCQuest"
     world: DLCqworld
     player: ClassVar[int] = 1
+    # Set False to run tests that take long
+    skip_long_tests: bool = True
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        long_tests_key = "long"
+        if long_tests_key in os.environ:
+            cls.skip_long_tests = not bool(os.environ[long_tests_key])
 
     def world_setup(self, *args, **kwargs):
         super().world_setup(*args, **kwargs)


### PR DESCRIPTION
## What is this fixing or adding?
Specifically requested by @black-sliver on #4762 

Two tests were long, so I introduced a similar system to Stardew's, to skip them in the main pipeline but keep them accessible for local work

## How was this tested?
Ran the test suite, test is skipped
![image](https://github.com/user-attachments/assets/e0acb79f-ceef-4ed5-ab8f-1cf6a8148169)
