### PR TITLE
Launcher: Add search box

### DIFF
--- a/Launcher.py
+++ b/Launcher.py
@@ -368,6 +368,7 @@ def run_gui(path: str, args: Any) -> None:
             refresh_components = self._refresh_components
 
             Window.bind(on_drop_file=self._on_drop_file)
+            Window.bind(on_keyboard=self._on_keyboard)
 
             for component in components:
                 self.cards.append(self.build_card(component))
@@ -403,6 +404,15 @@ def run_gui(path: str, args: Any) -> None:
                 run_component(component, file)
             else:
                 logging.warning(f"unable to identify component for {file}")
+
+        def _on_keyboard(self, window: Window, key: int, scancode: int, codepoint: str, modifier: list[str]):
+            # Activate search as soon as we start typing, no matter if we are focused on the search box or not.
+            # Focus first, then capture the first character we type, otherwise it gets swallowed and lost.
+            # Limit text input to ASCII non-control characters (space bar to tilde).
+            if not self.search_box.focus:
+                self.search_box.focus = True
+                if key in range(32, 126):
+                    self.search_box.text += codepoint
 
         def _stop(self, *largs):
             # ran into what appears to be https://groups.google.com/g/kivy-users/c/saWDLoYCSZ4 with PyCharm.

--- a/Launcher.py
+++ b/Launcher.py
@@ -230,7 +230,7 @@ def run_gui(path: str, args: Any) -> None:
     from kivy.properties import ObjectProperty
     from kivy.core.window import Window
     from kivy.metrics import dp
-    from kivymd.uix.button import MDIconButton
+    from kivymd.uix.button import MDIconButton, MDButton
     from kivymd.uix.card import MDCard
     from kivymd.uix.menu import MDDropdownMenu
     from kivymd.uix.snackbar import MDSnackbar, MDSnackbarText
@@ -340,7 +340,7 @@ def run_gui(path: str, args: Any) -> None:
             scroll_percent = self.button_layout.convert_distance_to_scroll(0, top)
             self.button_layout.scroll_y = max(0, min(1, scroll_percent[1]))
 
-        def filter_clients_by_type(self, caller):
+        def filter_clients_by_type(self, caller: MDButton):
             self._refresh_components(caller.type)
 
         def filter_clients_by_name(self, caller: MDTextField, name: str) -> None:

--- a/Launcher.py
+++ b/Launcher.py
@@ -346,13 +346,14 @@ def run_gui(path: str, args: Any) -> None:
         def filter_clients_by_name(self, caller: MDTextField, name: str) -> None:
             if len(name) == 0:
                 self._refresh_components(self.current_filter)
-            else:
-                sub_matches = [card for card in self.cards
-                               if name.lower() in card.component.display_name.lower()
-                               and card.component.type != Type.HIDDEN]
-                self.button_layout.layout.clear_widgets()
-                for card in sub_matches:
-                    self.button_layout.layout.add_widget(card)
+                return
+
+            sub_matches = [card for card in self.cards
+                           if name.lower() in card.component.display_name.lower()
+                           and card.component.type != Type.HIDDEN]
+            self.button_layout.layout.clear_widgets()
+            for card in sub_matches:
+                self.button_layout.layout.add_widget(card)
 
         def build(self):
             self.top_screen = Builder.load_file(Utils.local_path("data/launcher.kv"))

--- a/Launcher.py
+++ b/Launcher.py
@@ -346,26 +346,13 @@ def run_gui(path: str, args: Any) -> None:
         def filter_clients_by_name(self, caller: MDTextField, name: str) -> None:
             if len(name) == 0:
                 self._refresh_components(self.current_filter)
-                return
-            name = name
-            sub_matches = [card for card in self.cards if name.lower() in card.component.display_name.lower()]
-            self.button_layout.layout.clear_widgets()
-
-            for card in sub_matches:
-                self.button_layout.layout.add_widget(card)
-
-            if len(name) < 3:
-                return
             else:
-                name_scores = Utils.get_fuzzy_results(name, [card.component.display_name for card in self.cards])
-                card_scores = [
-                    (card, score)
-                    for name, score in name_scores if score > 25  # Score threshold
-                    for card in self.cards
-                    if card.component.display_name == name and card not in sub_matches
-                ]
-                for card_score in sorted(card_scores, key=lambda t: t[1], reverse=True):
-                    self.button_layout.layout.add_widget(card_score[0])
+                sub_matches = [card for card in self.cards
+                               if name.lower() in card.component.display_name.lower()
+                               and card.component.type != Type.HIDDEN]
+                self.button_layout.layout.clear_widgets()
+                for card in sub_matches:
+                    self.button_layout.layout.add_widget(card)
 
         def build(self):
             self.top_screen = Builder.load_file(Utils.local_path("data/launcher.kv"))

--- a/Launcher.py
+++ b/Launcher.py
@@ -349,9 +349,10 @@ def run_gui(path: str, args: Any) -> None:
                 self._refresh_components(self.current_filter)
                 return
 
-            sub_matches = [card for card in self.cards
-                           if name.lower() in card.component.display_name.lower()
-                           and card.component.type != Type.HIDDEN]
+            sub_matches = [
+                card for card in self.cards
+                if name.lower() in card.component.display_name.lower() and card.component.type != Type.HIDDEN
+            ]
             self.button_layout.layout.clear_widgets()
             for card in sub_matches:
                 self.button_layout.layout.add_widget(card)

--- a/Launcher.py
+++ b/Launcher.py
@@ -342,6 +342,7 @@ def run_gui(path: str, args: Any) -> None:
 
         def filter_clients_by_type(self, caller: MDButton):
             self._refresh_components(caller.type)
+            self.search_box.text = ""
 
         def filter_clients_by_name(self, caller: MDTextField, name: str) -> None:
             if len(name) == 0:

--- a/data/launcher.kv
+++ b/data/launcher.kv
@@ -80,7 +80,7 @@ MDFloatLayout:
                 id: all
                 style: "text"
                 type: (Type.CLIENT, Type.TOOL, Type.ADJUSTER, Type.MISC)
-                on_release: app.filter_clients(self)
+                on_release: app.filter_clients_by_type(self)
 
                 MDButtonIcon:
                     icon: "asterisk"
@@ -90,7 +90,7 @@ MDFloatLayout:
                 id: client
                 style: "text"
                 type: (Type.CLIENT, )
-                on_release: app.filter_clients(self)
+                on_release: app.filter_clients_by_type(self)
 
                 MDButtonIcon:
                     icon: "controller"
@@ -100,7 +100,7 @@ MDFloatLayout:
                 id: Tool
                 style: "text"
                 type: (Type.TOOL, )
-                on_release: app.filter_clients(self)
+                on_release: app.filter_clients_by_type(self)
 
                 MDButtonIcon:
                     icon: "desktop-classic"
@@ -110,7 +110,7 @@ MDFloatLayout:
                 id: adjuster
                 style: "text"
                 type: (Type.ADJUSTER, )
-                on_release: app.filter_clients(self)
+                on_release: app.filter_clients_by_type(self)
 
                 MDButtonIcon:
                     icon: "wrench"
@@ -120,7 +120,7 @@ MDFloatLayout:
                 id: misc
                 style: "text"
                 type: (Type.MISC, )
-                on_release: app.filter_clients(self)
+                on_release: app.filter_clients_by_type(self)
 
                 MDButtonIcon:
                     icon: "dots-horizontal-circle-outline"
@@ -131,7 +131,7 @@ MDFloatLayout:
                 id: favorites
                 style: "text"
                 type: ("favorites", )
-                on_release: app.filter_clients(self)
+                on_release: app.filter_clients_by_type(self)
 
                 MDButtonIcon:
                     icon: "star"
@@ -141,5 +141,20 @@ MDFloatLayout:
             MDNavigationDrawerDivider:
 
 
-        ScrollBox:
-            id: button_layout
+        MDGridLayout:
+            id: main_layout
+            cols: 1
+            spacing: "10dp"
+
+            MDTextField:
+                id: search_box
+                mode: "outlined"
+
+                MDTextFieldLeadingIcon:
+                    icon: "magnify"
+
+                MDTextFieldHintText:
+                    text: "Search"
+
+            ScrollBox:
+                id: button_layout

--- a/data/launcher.kv
+++ b/data/launcher.kv
@@ -149,6 +149,7 @@ MDFloatLayout:
             MDTextField:
                 id: search_box
                 mode: "outlined"
+                set_text: app.filter_clients_by_name
 
                 MDTextFieldLeadingIcon:
                     icon: "magnify"


### PR DESCRIPTION
## What is this fixing or adding?
Adds a fuzzy search box to the Launcher main screen. Current notable behavior:

- Search bar is anchored to the top of the screen at all times.
- ~~Only starts searching when 3 or more characters are entered.~~
- Refreshes current filter (shows/un-hides relevant cards) when backspaced to 0 characters.
- ~~Uses `Utils.get_fuzzy_results` as opposed to "substring" or "startswith" options.~~
- ~~Hides cards with a search score < 25.~~
- ~~Sorts results by search score.~~

## How was this tested?
Played around with Launcher, PyCharm debugging. Could always use more testing.

## If this makes graphical changes, please attach screenshots.

https://github.com/user-attachments/assets/6d483740-a66e-4225-bf56-b9fbdf28e7b5

