### PR TITLE
Tests: Don't use `type` as `Callable`

### DIFF
--- a/test/general/test_entrance_rando.py
+++ b/test/general/test_entrance_rando.py
@@ -1,3 +1,4 @@
+from typing import Callable
 import unittest
 from enum import IntEnum
 
@@ -34,7 +35,7 @@ def generate_entrance_pair(region: Region, name_suffix: str, group: int):
 
 
 def generate_disconnected_region_grid(multiworld: MultiWorld, grid_side_length: int, region_size: int = 0,
-                                      region_type: type[Region] = Region):
+                                      region_creator: Callable[[str, int, MultiWorld], Region] = Region):
     """
     Generates a grid-like region structure for ER testing, where menu is connected to the top-left region, and each
     region "in vanilla" has 2 2-way exits going either down or to the right, until reaching the goal region in the
@@ -44,7 +45,7 @@ def generate_disconnected_region_grid(multiworld: MultiWorld, grid_side_length: 
         for col in range(grid_side_length):
             index = row * grid_side_length + col
             name = f"region{index}"
-            region = region_type(name, 1, multiworld)
+            region = region_creator(name, 1, multiworld)
             multiworld.regions.append(region)
             generate_locations(region_size, 1, region=region, tag=f"_{name}")
 
@@ -465,7 +466,7 @@ class TestRandomizeEntrances(unittest.TestCase):
             entrance_type = CustomEntrance
 
         multiworld = generate_test_multiworld()
-        generate_disconnected_region_grid(multiworld, 5, region_type=CustomRegion)
+        generate_disconnected_region_grid(multiworld, 5, region_creator=CustomRegion)
 
         self.assertRaises(EntranceRandomizationError, randomize_entrances, multiworld.worlds[1], False,
                           directionally_matched_group_lookup)


### PR DESCRIPTION
## What is this fixing or adding?

A `type[X]` annotation should not be used if all you're doing with it is calling it to get an instance of that type.

This is because `__init__` signatures regularly don't follow the base class `__init__` signature.
You can see that this is the case with many subclasses in AP. Most of the subclasses of `Region` in supported worlds would crash if passed to this function.

I know this is just for tests, so it wasn't made to work with all of those subclasses. But it should usually be safe to copy patterns from unit tests into application code.
If this `type[Region]` pattern were copied into core code, it would be bad.


## How was this tested?

just unit tests
