### PR TITLE
Core: add a post_balancing stage

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -214,6 +214,8 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
     else:
         logger.info("Progression balancing skipped.")
 
+    AutoWorld.call_all(multiworld, "post_balancing")
+
     # we're about to output using multithreading, so we're removing the global random state to prevent accidental use
     multiworld.random.passthrough = False
 

--- a/test/multiworld/test_multiworlds.py
+++ b/test/multiworld/test_multiworlds.py
@@ -1,3 +1,4 @@
+import copy
 import unittest
 from typing import ClassVar, List, Tuple
 from unittest import TestCase
@@ -79,10 +80,14 @@ class TestTwoPlayerMulti(MultiworldTestBase):
             distribute_items_restrictive(self.multiworld)
             call_all(self.multiworld, "post_fill")
             with self.subTest("Validating placements", seed=self.multiworld.seed):
-                post_fill_placements = self.multiworld.get_locations()
+                post_fill_placements = {location.name: location.item.name
+                                        for location in self.multiworld.get_locations()}
                 call_all(self.multiworld, "post_balancing")
-                post_balance_placements = self.multiworld.get_locations()
-                for fill_placement, balance_placement in zip(post_fill_placements, post_balance_placements):
-                    self.assertEqual(fill_placement, balance_placement, "Locations were modified in post_balancing")
-                    self.assertEqual(fill_placement.item, balance_placement.item, "Items were moved in post_balancing")
+                post_balance_placements = {location.name: location.item.name
+                                        for location in self.multiworld.get_locations()}
+                for fill_placement, balance_placement in zip(post_fill_placements.items(),
+                                                             post_balance_placements.items()):
+                    self.assertEqual(fill_placement[0], balance_placement[0],
+                                     "Locations were modified in post_balancing")
+                    self.assertEqual(fill_placement[1], balance_placement[1], "Items were moved in post_balancing")
             self.assertTrue(self.fulfills_accessibility(), "Collected all locations, but can't beat the game")

--- a/test/multiworld/test_multiworlds.py
+++ b/test/multiworld/test_multiworlds.py
@@ -78,4 +78,11 @@ class TestTwoPlayerMulti(MultiworldTestBase):
         with self.subTest("filling multiworld", games=world_type.game, seed=self.multiworld.seed):
             distribute_items_restrictive(self.multiworld)
             call_all(self.multiworld, "post_fill")
+            with self.subTest("Validating placements", seed=self.multiworld.seed):
+                post_fill_placements = self.multiworld.get_locations()
+                call_all(self.multiworld, "post_balancing")
+                post_balance_placements = self.multiworld.get_locations()
+                for fill_placement, balance_placement in zip(post_fill_placements, post_balance_placements):
+                    self.assertEqual(fill_placement, balance_placement, "Locations were modified in post_balancing")
+                    self.assertEqual(fill_placement.item, balance_placement.item, "Items were moved in post_balancing")
             self.assertTrue(self.fulfills_accessibility(), "Collected all locations, but can't beat the game")

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -417,6 +417,12 @@ class World(metaclass=AutoWorldRegister):
         This happens before progression balancing, so the items may not be in their final locations yet.
         """
 
+    def post_balancing(self) -> None:
+        """
+        Called after progression balancing. Can be assumed that nothing will move here or after, and as such, nothing
+        should be moved around here.
+        """
+
     def generate_output(self, output_directory: str) -> None:
         """
         This method gets called from a threadpool, do not use multiworld.random here.


### PR DESCRIPTION
## What is this fixing or adding?
title plus a test that worlds don't modify placements in it. hijacked an existing test to not balloon test run times.

## How was this tested?
ran generation and test with a barebones implementation that failed the test.

## If this makes graphical changes, please attach screenshots.
