### PR TITLE
MultiServer.py: Another Hint Priority + Item Links bug oh boy

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1982,11 +1982,13 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
             new_hint = new_hint.re_prioritize(ctx, status)
             if hint == new_hint:
                 return
-            ctx.replace_hint(client.team, hint.finding_player, hint, new_hint)
-            ctx.replace_hint(client.team, hint.receiving_player, hint, new_hint)
+
+            concerning_slots = ctx.slot_set(hint.receiving_player) | {hint.finding_player}
+            for slot in concerning_slots:
+                ctx.replace_hint(client.team, slot, hint, new_hint)
             ctx.save()
-            ctx.on_changed_hints(client.team, hint.finding_player)
-            ctx.on_changed_hints(client.team, hint.receiving_player)
+            for slot in concerning_slots:
+                ctx.on_changed_hints(client.team, slot)
         
         elif cmd == 'StatusUpdate':
             update_client_status(ctx, client, args["status"])


### PR DESCRIPTION
Basically, hints for itemlink worlds' locations get stored in ctx.hints under
1. the location's player
2. **every individual player** that is participating in the itemlink.

Right now, the updatehint code tries to replace and resend the hint under the itemlinked player, which doesn't work.