### PR TITLE
DS3: Fixes "US: Homeward Bone - foot, drop overlook" location

### DIFF
--- a/worlds/dark_souls_3/Locations.py
+++ b/worlds/dark_souls_3/Locations.py
@@ -706,7 +706,7 @@ location_tables: Dict[str, List[DS3LocationData]] = {
         DS3LocationData("US: Whip - back alley, behind wooden wall", "Whip", hidden=True),
         DS3LocationData("US: Great Scythe - building by white tree, balcony", "Great Scythe"),
         DS3LocationData("US: Homeward Bone - foot, drop overlook", "Homeward Bone",
-                        static='02,0:53100540::'),
+                        static='02,0:53100950::'),
         DS3LocationData("US: Large Soul of a Deserted Corpse - around corner by Cliff Underside",
                         "Large Soul of a Deserted Corpse", hidden=True),  # Hidden corner
         DS3LocationData("US: Ember - behind burning tree", "Ember"),


### PR DESCRIPTION
## What is this fixing or adding?
The `static` fields of `US: Homeward Bone - tower village, right at start`and `US: Homeward Bone - foot, drop overlook` were the same, and because of that, the [static randomizer](https://github.com/nex3/SoulsRandomizers/tree/archipelago-server) placed both of those items to `US: Homeward Bone - tower village, right at start`.

Reference (annotations.txt):
[`US: Homeward Bone - tower village, right at start`](https://github.com/nex3/SoulsRandomizers/blob/1c9d91334717240bbb937a236272eb3a00a784f4/dist/Base/annotations.txt#L2074C1-L2079C20)
[`US: Homeward Bone - foot, drop overlook`](https://github.com/nex3/SoulsRandomizers/blob/1c9d91334717240bbb937a236272eb3a00a784f4/dist/Base/annotations.txt#L2211C1-L2216C12)

## How was this tested?
Run 3 tests and checked them manually. Same YAML, item plando was used.

Before:
![before](https://github.com/user-attachments/assets/e5d28ee3-02fa-46f8-b39c-c6abe9c48726)

After:
![after](https://github.com/user-attachments/assets/68369298-c9af-4abd-9640-52ec873175f3)

