### PR TITLE
Minecraft: Stop using Utils.get_options

### DIFF
--- a/MinecraftClient.py
+++ b/MinecraftClient.py
@@ -14,6 +14,7 @@ import requests
 
 import Utils
 from Utils import is_windows
+from settings import get_settings
 
 atexit.register(input, "Press enter to exit.")
 
@@ -147,9 +148,11 @@ def find_jdk(version: str) -> str:
         if os.path.isfile(jdk_exe):
             return jdk_exe
     else:
-        jdk_exe = shutil.which(options["minecraft_options"].get("java", "java"))
+        jdk_exe = shutil.which(options.java)
         if not jdk_exe:
-            raise Exception("Could not find Java. Is Java installed on the system?")
+            jdk_exe = shutil.which("java") # try to fall back to system java
+            if not jdk_exe:
+                raise Exception("Could not find Java. Is Java installed on the system?")
         return jdk_exe
 
 
@@ -285,8 +288,8 @@ if __name__ == '__main__':
     # Change to executable's working directory
     os.chdir(os.path.abspath(os.path.dirname(sys.argv[0])))
 
-    options = Utils.get_options()
-    channel = args.channel or options["minecraft_options"]["release_channel"]
+    options = get_settings().minecraft_options
+    channel = args.channel or options.release_channel
     apmc_data = None
     data_version = args.data_version or None
 
@@ -299,8 +302,8 @@ if __name__ == '__main__':
 
     versions = get_minecraft_versions(data_version, channel)
 
-    forge_dir = options["minecraft_options"]["forge_directory"]
-    max_heap = options["minecraft_options"]["max_heap_size"]
+    forge_dir = options.forge_directory
+    max_heap = options.max_heap_size
     forge_version = args.forge or versions["forge"]
     java_version = args.java or versions["java"]
     mod_url = versions["url"]

--- a/worlds/minecraft/__init__.py
+++ b/worlds/minecraft/__init__.py
@@ -27,9 +27,15 @@ class MinecraftSettings(settings.Group):
         any games played on the "beta" channel have a high likelihood of no longer working on the "release" channel.
         """
 
-    forge_directory: ForgeDirectory = ForgeDirectory("Minecraft Forge server")
+    class JavaExecutable(settings.OptionalUserFilePath):
+        """
+        Path to Java executable. If not set, will attempt to fall back to Java system installation.
+        """
+
+    forge_directory: ForgeDirectory = ForgeDirectory("Minecraft NeoForge server")
     max_heap_size: str = "2G"
     release_channel: ReleaseChannel = ReleaseChannel("release")
+    java: JavaExecutable = JavaExecutable("")
 
 
 class MinecraftWebWorld(WebWorld):


### PR DESCRIPTION
## What is this fixing or adding?
The Minecraft Client uses `Utils.get_options`, which is deprecated. This changes the client to instead use the settings API.

As a debatably positive side-effect, the `java` option is no longer hidden in `host.yaml` and now has a docstring.

Resolves #4811 for Minecraft.

## How was this tested?
Ensured the client functions properly by letting it perform automated setup and spin up a Forge server.

## If this makes graphical changes, please attach screenshots.
N/A