### PR TITLE
Core: always embed Archipelago

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -315,6 +315,7 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
                     game_world.game: worlds.network_data_package["games"][game_world.game]
                     for game_world in multiworld.worlds.values()
                 }
+                data_package["Archipelago"] = worlds.network_data_package["games"]["Archipelago"]
 
                 checks_in_area: Dict[int, Dict[str, Union[int, List[int]]]] = {}
 


### PR DESCRIPTION
## What is this fixing or adding?
Makes it so that the Archipelago datapackage is always present, even if no spectator slots are, as the Server is "playing" Archipelago

## How was this tested?
with https://github.com/ArchipelagoMW/Archipelago/pull/4881

