### PR TITLE
Core use embedded datapackage

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -315,6 +315,7 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
                     game_world.game: worlds.network_data_package["games"][game_world.game]
                     for game_world in multiworld.worlds.values()
                 }
+                data_package["Archipelago"] = worlds.network_data_package["games"]["Archipelago"]
 
                 checks_in_area: Dict[int, Dict[str, Union[int, List[int]]]] = {}
 

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -281,25 +281,6 @@ class Context:
             lambda: Utils.KeyedDefaultDict(lambda code: f'Unknown location (ID:{code})'))
         self.non_hintable_names = collections.defaultdict(frozenset)
 
-        self._load_game_data()
-
-    # Data package retrieval
-    def _load_game_data(self):
-        import worlds
-        self.gamespackage = worlds.network_data_package["games"]
-
-        self.item_name_groups = {world_name: world.item_name_groups for world_name, world in
-                                 worlds.AutoWorldRegister.world_types.items()}
-        self.location_name_groups = {world_name: world.location_name_groups for world_name, world in
-                                     worlds.AutoWorldRegister.world_types.items()}
-        for world_name, world in worlds.AutoWorldRegister.world_types.items():
-            self.non_hintable_names[world_name] = world.hint_blacklist
-
-        for game_package in self.gamespackage.values():
-            # remove groups from data sent to clients
-            del game_package["item_name_groups"]
-            del game_package["location_name_groups"]
-
     def _init_game_data(self):
         for game_name, game_package in self.gamespackage.items():
             if "checksum" in game_package:


### PR DESCRIPTION
## What is this fixing or adding?
prevents loading local datapackage and goes straight for embedded datapackage

## How was this tested?
locally on multiserver and webhost customserver, unfortunately it revealed that the needed Archipelago datapackage is usually missing, which leads to a crash when loading something without it.
This is addressed for at least new generations/rooms with https://github.com/ArchipelagoMW/Archipelago/pull/4880.
