### PR TITLE
Stardew Valley: Precollect building items in deterministic order

### DIFF
--- a/worlds/stardew_valley/__init__.py
+++ b/worlds/stardew_valley/__init__.py
@@ -206,7 +206,8 @@ class StardewValleyWorld(World):
         if not building_progression.is_progressive:
             return
 
-        for building in building_progression.starting_buildings:
+        # starting_buildings is a set, so sort for deterministic order.
+        for building in sorted(building_progression.starting_buildings):
             item, quantity = building_progression.to_progressive_item(building)
             for _ in range(quantity):
                 self.multiworld.push_precollected(self.create_item(item))


### PR DESCRIPTION
## What is this fixing or adding?

#4239 refactored buildings, but introduced iteration of a set when precollecting the building items into start inventory.

This patch sorts the new `building_progression.starting_buildings` set before iterating it, to ensure the items are precollected in a deterministic order.

The iteration order of sets varies between separate Python processes due to set order being partially based on the hashes of the objects in the set and because each Python process uses a random hash seed by default.

## How was this tested?
I ran the determinstic generation tests in #4410 and Stardew Valley passes the tests with this change.