### PR TITLE
HK: fix docs whitespace

### DIFF
--- a/worlds/hk/docs/setup_en.md
+++ b/worlds/hk/docs/setup_en.md
@@ -3,34 +3,34 @@
 ## Required Software
 * Download and unzip the Lumafly Mod Manager from the [Lumafly website](https://themulhima.github.io/Lumafly/).
 * A legal copy of Hollow Knight.
-   * Steam, Gog, and Xbox Game Pass versions of the game are supported.
-   * Windows, Mac, and Linux (including Steam Deck) are supported.
+    * Steam, Gog, and Xbox Game Pass versions of the game are supported.
+    * Windows, Mac, and Linux (including Steam Deck) are supported.
 
 ## Installing the Archipelago Mod using Lumafly
 1. Launch Lumafly and ensure it locates your Hollow Knight installation directory.
 2. Install the Archipelago mods by doing either of the following:
-   * Click one of the links below to allow Lumafly to install the mods. Lumafly will prompt for confirmation.
-     * [Archipelago and dependencies only](https://themulhima.github.io/Lumafly/commands/download/?mods=Archipelago)
-     * [Archipelago with rando essentials](https://themulhima.github.io/Lumafly/commands/download/?mods=Archipelago/Archipelago%20Map%20Mod/RecentItemsDisplay/DebugMod/RandoStats/Additional%20Timelines/CompassAlwaysOn/AdditionalMaps/)
-       (includes Archipelago Map Mod, RecentItemsDisplay, DebugMod, RandoStats, AdditionalTimelines, CompassAlwaysOn,
-       and AdditionalMaps).
-   * Click the "Install" button near the "Archipelago" mod entry. If desired, also install "Archipelago Map Mod"
-     to use as an in-game tracker.
+    * Click one of the links below to allow Lumafly to install the mods. Lumafly will prompt for confirmation.
+        * [Archipelago and dependencies only](https://themulhima.github.io/Lumafly/commands/download/?mods=Archipelago)
+        * [Archipelago with rando essentials](https://themulhima.github.io/Lumafly/commands/download/?mods=Archipelago/Archipelago%20Map%20Mod/RecentItemsDisplay/DebugMod/RandoStats/Additional%20Timelines/CompassAlwaysOn/AdditionalMaps/)
+          (includes Archipelago Map Mod, RecentItemsDisplay, DebugMod, RandoStats, AdditionalTimelines, CompassAlwaysOn,
+          and AdditionalMaps).
+    * Click the "Install" button near the "Archipelago" mod entry. If desired, also install "Archipelago Map Mod"
+      to use as an in-game tracker.
 3. Launch the game, you're all set!
 
 ### What to do if Lumafly fails to find your installation directory
 1. Find the directory manually.
-   * Xbox Game Pass:
-      1. Enter the Xbox app and move your mouse over "Hollow Knight" on the left sidebar. 
-      2. Click the three points then click "Manage".
-      3. Go to the "Files" tab and select "Browse...". 
-      4. Click "Hollow Knight", then "Content", then click the path bar and copy it.
-   * Steam:
-      1. You likely put your Steam library in a non-standard place. If this is the case, you probably know where 
-         it is. Find your steam library and then find the Hollow Knight folder and copy the path.
-         * Windows - `C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight`
-         * Linux/Steam Deck - ~/.local/share/Steam/steamapps/common/Hollow Knight
-         * Mac - ~/Library/Application Support/Steam/steamapps/common/Hollow Knight/hollow_knight.app
+    * Xbox Game Pass:
+        1. Enter the Xbox app and move your mouse over "Hollow Knight" on the left sidebar. 
+        2. Click the three points then click "Manage".
+        3. Go to the "Files" tab and select "Browse...". 
+        4. Click "Hollow Knight", then "Content", then click the path bar and copy it.
+    * Steam:
+        1. You likely put your Steam library in a non-standard place. If this is the case, you probably know where 
+           it is. Find your steam library and then find the Hollow Knight folder and copy the path.
+            * Windows - `C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight`
+            * Linux/Steam Deck - ~/.local/share/Steam/steamapps/common/Hollow Knight
+            * Mac - ~/Library/Application Support/Steam/steamapps/common/Hollow Knight/hollow_knight.app
 2. Run Lumafly as an administrator and, when it asks you for the path, paste the path you copied.
 
 ## Configuring your YAML File
@@ -49,9 +49,9 @@ website to generate a YAML using a graphical interface.
 4. Enter the correct settings for your Archipelago server.
 5. Hit **Start** to begin the game. The game will stall for a few seconds while it does all item placements.
 6. The game will immediately drop you into the randomized game. 
-   * If you are waiting for a countdown then wait for it to lapse before hitting Start.
-   * Or hit Start then pause the game once you're in it.
-   
+    * If you are waiting for a countdown then wait for it to lapse before hitting Start.
+    * Or hit Start then pause the game once you're in it.
+
 ## Hints and other commands
 While playing in a multiworld, you can interact with the server using various commands listed in the 
 [commands guide](/tutorial/Archipelago/commands/en). You can use the Archipelago Text Client to do this,

--- a/worlds/hk/docs/setup_pt_br.md
+++ b/worlds/hk/docs/setup_pt_br.md
@@ -3,28 +3,28 @@
 ## Programas obrigatórios
 * Baixe e extraia o Lumafly Mod Manager (gerenciador de mods Lumafly) do [Site Lumafly](https://themulhima.github.io/Lumafly/).
 * Uma cópia legal de Hollow Knight.
-   * Versões Steam, Gog, e Xbox Game Pass do jogo são suportadas.
-   * Windows, Mac, e Linux (incluindo Steam Deck) são suportados.
+    * Versões Steam, Gog, e Xbox Game Pass do jogo são suportadas.
+    * Windows, Mac, e Linux (incluindo Steam Deck) são suportados.
 
 ## Instalando o mod Archipelago Mod usando Lumafly
 1. Abra o Lumafly e confirme que ele localizou sua pasta de instalação do Hollow Knight.
 2. Clique em "Install (instalar)" perto da opção "Archipelago" mod.
-   * Se quiser, instale também o "Archipelago Map Mod (mod do mapa do archipelago)" para usá-lo como rastreador dentro do jogo.
+    * Se quiser, instale também o "Archipelago Map Mod (mod do mapa do archipelago)" para usá-lo como rastreador dentro do jogo.
 3. Abra o jogo, tudo preparado!
 
 ### O que fazer se o Lumafly falha em encontrar a sua pasta de instalação
 1. Encontre a pasta manualmente.
-   * Xbox Game Pass:
-      1. Entre no seu aplicativo Xbox e mova seu mouse em cima de "Hollow Knight" na sua barra da esquerda. 
-      2. Clique nos 3 pontos depois clique gerenciar.
-      3. Vá nos arquivos e selecione procurar. 
-      4. Clique em "Hollow Knight", depois em "Content (Conteúdo)", depois clique na barra com o endereço e a copie.
-   * Steam:
-      1. Você provavelmente colocou sua biblioteca Steam num local não padrão. Se esse for o caso você provavelmente sabe onde está.
-         . Encontre sua biblioteca Steam, depois encontre a pasta do Hollow Knight e copie seu endereço.
-         * Windows - `C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight`
-         * Linux/Steam Deck - `~/.local/share/Steam/steamapps/common/Hollow Knight`
-         * Mac - `~/Library/Application Support/Steam/steamapps/common/Hollow Knight/hollow_knight.app`
+    * Xbox Game Pass:
+        1. Entre no seu aplicativo Xbox e mova seu mouse em cima de "Hollow Knight" na sua barra da esquerda. 
+        2. Clique nos 3 pontos depois clique gerenciar.
+        3. Vá nos arquivos e selecione procurar. 
+        4. Clique em "Hollow Knight", depois em "Content (Conteúdo)", depois clique na barra com o endereço e a copie.
+    * Steam:
+        1. Você provavelmente colocou sua biblioteca Steam num local não padrão. Se esse for o caso você provavelmente sabe onde está.
+           Encontre sua biblioteca Steam, depois encontre a pasta do Hollow Knight e copie seu endereço.
+            * Windows - `C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight`
+            * Linux/Steam Deck - `~/.local/share/Steam/steamapps/common/Hollow Knight`
+            * Mac - `~/Library/Application Support/Steam/steamapps/common/Hollow Knight/hollow_knight.app`
 2. Rode o Lumafly como administrador e, quando ele perguntar pelo endereço do arquivo, cole o endereço do arquivo que você copiou.
 
 ## Configurando seu arquivo YAML
@@ -43,9 +43,9 @@ para gerar o YAML usando a interface gráfica.
 4. Coloque as configurações corretas do seu servidor Archipelago.
 5. Aperte em **Começar**. O jogo vai travar por uns segundos enquanto ele coloca todos itens.
 6. O jogo vai te colocar imediatamente numa partida randomizada. 
-   * Se você está esperando uma contagem então espere ele cair antes de apertar começar.
-   * Ou clique em começar e pause o jogo enquanto estiver nele.
-   
+    * Se você está esperando uma contagem então espere ele cair antes de apertar começar.
+    * Ou clique em começar e pause o jogo enquanto estiver nele.
+
 ## Dicas e outros comandos
 Enquanto jogar um multiworld, você pode interagir com o servidor usando vários comandos listados no
 [Guia de comandos](/tutorial/Archipelago/commands/en). Você pode usar o cliente de texto do Archipelago para isso,


### PR DESCRIPTION
## What is this fixing or adding?
reformats the whitespace in hk docs to preemptively be prepared for the change in md parsing in #4074
(and deleted an extra period in the pt_br version)

## How was this tested?
webhost in current and in 4074 and :eyes:

## If this makes graphical changes, please attach screenshots.
