### PR TITLE
Generate/Launcher: Add arg to prevent closing window on gen success and make Launcher use it.

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -57,6 +57,8 @@ def mystery_argparse():
     parser.add_argument("--spoiler_only", action="store_true",
                         help="Skips generation assertion and multidata, outputting only a spoiler log. "
                              "Intended for debugging and testing purposes.")
+    parser.add_argument("--confirm_exit", action="store_true",
+                        help="Prevents program from exiting after successful generation until enter is pressed.")
     args = parser.parse_args()
 
     if args.skip_output and args.spoiler_only:
@@ -179,6 +181,7 @@ def main(args=None) -> Tuple[argparse.Namespace, int]:
     erargs.spoiler_only = args.spoiler_only
     erargs.name = {}
     erargs.csv_output = args.csv_output
+    erargs.confirm_exit = args.confirm_exit
 
     settings_cache: Dict[str, Tuple[argparse.Namespace, ...]] = \
         {fname: (tuple(roll_settings(yaml, args.plando) for yaml in yamls) if args.sameoptions else None)
@@ -580,5 +583,7 @@ if __name__ == '__main__':
         gc.collect()  # need to collect to deref all hard references
         assert not weak(), f"MultiWorld object was not de-allocated, it's referenced {sys.getrefcount(weak())} times." \
                            " This would be a memory leak."
-    # in case of error-free exit should not need confirmation
-    atexit.unregister(confirmation)
+
+    # in case of error-free exit should not need confirmation (and not passed --confirm_exit flag)
+    if not erargs.confirm_exit:
+        atexit.unregister(confirmation)

--- a/Launcher.py
+++ b/Launcher.py
@@ -77,6 +77,10 @@ def generate_yamls():
     open_folder(target)
 
 
+def generate_game(*args):
+    launch([*get_exe("Generate"), "--confirm_exit", *args], True)
+
+
 def browse_files():
     open_folder(user_path())
 
@@ -102,6 +106,7 @@ components.extend([
     Component("Open host.yaml", func=open_host_yaml),
     Component("Open Patch", func=open_patch),
     Component("Generate Template Options", func=generate_yamls),
+    Component("Generate Multiworld", "Generate", func=generate_game),
     Component("Archipelago Website", func=lambda: webbrowser.open("https://archipelago.gg/")),
     Component("Discord Server", icon="discord", func=lambda: webbrowser.open("https://discord.gg/8Z65BR2")),
     Component("Unrated/18+ Discord Server", icon="discord",

--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -211,7 +211,6 @@ components: List[Component] = [
     # Core
     Component('Host', 'MultiServer', 'ArchipelagoServer', cli=True,
               file_identifier=SuffixIdentifier('.archipelago', '.zip')),
-    Component('Generate', 'Generate', cli=True),
     Component("Install APWorld", func=install_apworld, file_identifier=SuffixIdentifier(".apworld")),
     Component('Text Client', 'CommonClient', 'ArchipelagoTextClient', func=launch_textclient),
     Component('Links Awakening DX Client', 'LinksAwakeningClient',


### PR DESCRIPTION
## What is this fixing or adding?
Makes the following changes:

- Adds a new cli arg to **Generate.py** called `--confirm_exit` that prevents window from terminating until enter is pressed (for successful generations).
- Changes Launcher's "Generate" component to add this flag when clicked.
- Rename "Generate" display name to "Generate Multiworld" for clarity in Launcher.

## How was this tested?
Ran generation without argument to ensure previous behavior is present and that desired _"Press enter to close."_ text appears when not omitted.

Also ran Launcher to confirm CLI generator window appears and asks to close after a successful generation.

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/user-attachments/assets/9bd56bfb-beeb-428f-ab71-4ab1c9efce45)
![image](https://github.com/user-attachments/assets/cdd56a1a-7d5f-4fb5-9f10-804ddde4b215)
