### PR TITLE
Setup: offer the default-on option to clean /lib folder on update

### DIFF
--- a/inno_setup.iss
+++ b/inno_setup.iss
@@ -45,7 +45,7 @@ MinVersion={#min_windows}
 Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Tasks]
-Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}";
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}";
 Name: "deletelib"; Description: "Clean existing /lib folder and subfolders including /worlds"; Check: ShouldShowDeleteLibTask
 
 [Types]

--- a/inno_setup.iss
+++ b/inno_setup.iss
@@ -46,7 +46,7 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}";
-Name: "deletelib"; Description: "Clean existing /lib folder and subfolders including /worlds"; Check: ShouldShowDeleteLibTask
+Name: "deletelib"; Description: "Clean existing /lib folder and subfolders including /worlds (leave checked if unsure)"; Check: ShouldShowDeleteLibTask
 
 [Types]
 Name: "full"; Description: "Full installation"

--- a/inno_setup.iss
+++ b/inno_setup.iss
@@ -46,6 +46,7 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}";
+Name: "deletelib"; Description: "Clean existing /lib folder and subfolders including /worlds"; Check: ShouldShowDeleteLibTask
 
 [Types]
 Name: "full"; Description: "Full installation"
@@ -83,18 +84,8 @@ Filename: "{app}\ArchipelagoLauncher"; Description: "{cm:LaunchProgram,{#StringC
 Type: dirifempty; Name: "{app}"
 
 [InstallDelete]
-Type: files; Name: "{app}\lib\worlds\_bizhawk.apworld"
-Type: files; Name: "{app}\ArchipelagoLttPClient.exe"
-Type: files; Name: "{app}\ArchipelagoPokemonClient.exe"
+Type: files; Name: "{app}\*.exe"
 Type: files; Name: "{app}\data\lua\connector_pkmn_rb.lua"
-Type: filesandordirs; Name: "{app}\lib\worlds\rogue-legacy"
-Type: dirifempty; Name: "{app}\lib\worlds\rogue-legacy"
-Type: files; Name: "{app}\lib\worlds\sc2wol.apworld"
-Type: filesandordirs; Name: "{app}\lib\worlds\sc2wol"
-Type: dirifempty; Name: "{app}\lib\worlds\sc2wol"
-Type: filesandordirs; Name: "{app}\lib\worlds\bk_sudoku"
-Type: dirifempty; Name: "{app}\lib\worlds\bk_sudoku"
-Type: files; Name: "{app}\ArchipelagoLauncher(DEBUG).exe"
 Type: filesandordirs; Name: "{app}\SNI\lua*"
 Type: filesandordirs; Name: "{app}\EnemizerCLI*"
 #include "installdelete.iss"
@@ -259,5 +250,19 @@ begin
     // Not even an old version installed
     Log('VC Redist x64 is not already installed');
     Result := True;
+  end;
+end;
+
+function ShouldShowDeleteLibTask: Boolean;
+begin
+  Result := DirExists(ExpandConstant('{app}\lib'));
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+begin
+  if CurStep = ssInstall then
+  begin
+    if WizardIsTaskSelected('deletelib') then
+      DelTree(ExpandConstant('{app}\lib'), True, True, True);
   end;
 end;


### PR DESCRIPTION
## What is this fixing or adding?
![image](https://github.com/user-attachments/assets/815583f2-a0eb-4356-a39f-712f5a1b3595)
Usually, whenever something gets renamed, removed etc. it is as far as I remember, always forgotten to remove old files from existing installations, which is then fixed in a follow up PR. No more! - this now cleans all .exe from the install directory, and offers nuking /lib*

## How was this tested?
locally on windows 10

## If this makes graphical changes, please attach screenshots.
![image](https://github.com/user-attachments/assets/0a1e1530-e497-4d36-bb78-cbe2a74f4874)
