### PR TITLE
Setup: use sha256 for timestamp server

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -154,7 +154,7 @@ if os.path.exists("X:/pw.txt"):
     with open("X:/pw.txt", encoding="utf-8-sig") as f:
         pw = f.read()
     signtool = r'signtool sign /f X:/_SITS_Zertifikat_.pfx /p "' + pw + \
-               r'" /fd sha256 /tr http://timestamp.digicert.com/ '
+               r'" /fd sha256 /td sha256 /tr http://timestamp.digicert.com/ '
 else:
     signtool = None
 


### PR DESCRIPTION
## What is this fixing or adding?
uses sha256 instead of sha1 for the RFC 3161 timestamp server. Without this change, AP cannot currently be signed with the cert I have. However, that cert will fail at the end of April, hopefully I have a new one by then, but that is hinging on a coworker.

## How was this tested?
locally.
