### PR TITLE
Core: Fix server_connect_bar being blank in CommonClient

### DIFF
--- a/kvui.py
+++ b/kvui.py
@@ -850,8 +850,8 @@ class GameManager(ThemedApp):
         # top part
         server_label = ServerLabel(width=dp(75))
         self.connect_layout.add_widget(server_label)
-        self.server_connect_bar = ConnectBarTextInput(text=self.ctx.suggested_address or "archipelago.gg:",
-                                                      pos_hint={"center_x": 0.5, "center_y": 0.5})
+        self.server_connect_bar = ConnectBarTextInput(pos_hint={"center_x": 0.5, "center_y": 0.5})
+        self.server_connect_bar.text = self.ctx.suggested_address or "archipelago.gg:"
 
         def connect_bar_validate(sender):
             if not self.ctx.server:


### PR DESCRIPTION
## What is this fixing or adding?

Pre-KivyMD the server connect bar would be pre-populated with the last server the user had connected to (via `self.ctx.suggested_address`) or `archipelago.gg:` if that was empty.

Post-KivyMD, the server connect bar is always blank.

I tried setting text manually instead of via the constructor, and it works now.

## How was this tested?

Launched CommonClient.py. Saw my last server in the connect bar. Connected to that, then disconnected and connected to a different server. Closed and relaunched the client, saw the second server now populated in the connect bar.

## If this makes graphical changes, please attach screenshots.
Fresh launch of CommonClient.py:

![image](https://github.com/user-attachments/assets/ded612cf-42fb-40b2-8499-ee123fef0681)
