### PR TITLE
Unittests: fix world unittests with unittest module

### DIFF
--- a/test/worlds/__init__.py
+++ b/test/worlds/__init__.py
@@ -12,7 +12,7 @@ def load_tests(loader, standard_tests, pattern):
     all_tests = [
         test_case for folder in folders if os.path.exists(folder)
         for test_collection in loader.discover(folder, top_level_dir=file_path)
-        for test_suite in test_collection
+        for test_suite in test_collection if isinstance(test_suite, unittest.suite.TestSuite)
         for test_case in test_suite
     ]
 


### PR DESCRIPTION
## What is this fixing or adding?
In #4762, the first instance of an entire module being skipped was added. The test collection does not account for an entire module being skipped, and thus started crashing with the following error `TypeError("'ModuleSkipped' object is not iterable")`.

## How was this tested?
Running unittests locally, and seeing that they were actually collected and ran.


## If this makes graphical changes, please attach screenshots.
