### PR TITLE
Core: only raise min_client_version for new gens

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -458,8 +458,12 @@ class Context:
         self.generator_version = Version(*decoded_obj["version"])
         clients_ver = decoded_obj["minimum_versions"].get("clients", {})
         self.minimum_client_versions = {}
+        if self.generator_version < Version(0, 6, 2):
+            min_version = Version(0, 1, 6)
+        else:
+            min_version = min_client_version
         for player, version in clients_ver.items():
-            self.minimum_client_versions[player] = max(Version(*version), min_client_version)
+            self.minimum_client_versions[player] = max(Version(*version), min_version)
 
         self.slot_info = decoded_obj["slot_info"]
         self.games = {slot: slot_info.game for slot, slot_info in self.slot_info.items()}


### PR DESCRIPTION
## What is this fixing or adding?
as brought up here https://discord.com/channels/731205301247803413/731214280439103580/1362929155657957519 it might be good to give leeway to existing Seeds

## How was this tested?
no
