### PR TITLE
LADX: improve fake tracker items

### DIFF
--- a/LinksAwakeningClient.py
+++ b/LinksAwakeningClient.py
@@ -638,6 +638,11 @@ class LinksAwakeningContext(CommonContext):
                 "password": self.password,
             })
 
+            # We can process linked items on already-checked checks now that we have slot_data
+            if self.client.tracker:
+                checked_checks = set(self.client.tracker.all_checks) - set(self.client.tracker.remaining_checks)
+                self.add_linked_items(checked_checks)
+
         # TODO - use watcher_event
         if cmd == "ReceivedItems":
             for index, item in enumerate(args["items"], start=args["index"]):
@@ -653,6 +658,13 @@ class LinksAwakeningContext(CommonContext):
         sync_msg = [{'cmd': 'Sync'}]
         await self.send_msgs(sync_msg)
 
+    def add_linked_items(self, checks):
+        for check in checks:
+            if check.value and check.linkedItem:
+                linkedItem = check.linkedItem
+                if 'condition' not in linkedItem or (self.slot_data and linkedItem['condition'](self.slot_data)):
+                    self.client.item_tracker.setExtraItem(check.linkedItem['item'], check.linkedItem['qty'])
+
     item_id_lookup = get_locations_to_id()
 
     async def run_game_loop(self):
@@ -661,11 +673,7 @@ class LinksAwakeningContext(CommonContext):
                 checkMetadataTable[check.id])] for check in ladxr_checks]
             self.new_checks(checks, [check.id for check in ladxr_checks])
 
-            for check in ladxr_checks:
-                if check.value and check.linkedItem:
-                    linkedItem = check.linkedItem
-                    if 'condition' not in linkedItem or linkedItem['condition'](self.slot_data):
-                        self.client.item_tracker.setExtraItem(check.linkedItem['item'], check.linkedItem['qty'])
+            self.add_linked_items(ladxr_checks)
 
         async def victory():
             await self.send_victory()

--- a/LinksAwakeningClient.py
+++ b/LinksAwakeningClient.py
@@ -33,7 +33,7 @@ from worlds.ladx.TrackerConsts import storage_key
 from worlds.ladx.ItemTracker import ItemTracker
 from worlds.ladx.LADXR.checkMetadata import checkMetadataTable
 from worlds.ladx.Locations import get_locations_to_id, meta_to_name
-from worlds.ladx.Tracker import LocationTracker, MagpieBridge
+from worlds.ladx.Tracker import LocationTracker, MagpieBridge, Check
 
 
 class GameboyException(Exception):
@@ -658,7 +658,7 @@ class LinksAwakeningContext(CommonContext):
         sync_msg = [{'cmd': 'Sync'}]
         await self.send_msgs(sync_msg)
 
-    def add_linked_items(self, checks):
+    def add_linked_items(self, checks: typing.List[Check]):
         for check in checks:
             if check.value and check.linkedItem:
                 linkedItem = check.linkedItem

--- a/worlds/ladx/ItemTracker.py
+++ b/worlds/ladx/ItemTracker.py
@@ -152,8 +152,6 @@ class ItemTracker:
         self.gameboy = gameboy
         self.loadItems()
         self.extraItems = {}
-        pass
-    extraItems = {}
 
     async def readRamByte(self, byte):
         return (await self.gameboy.read_memory_cache([byte]))[byte]

--- a/worlds/ladx/ItemTracker.py
+++ b/worlds/ladx/ItemTracker.py
@@ -151,6 +151,7 @@ class ItemTracker:
     def __init__(self, gameboy) -> None:
         self.gameboy = gameboy
         self.loadItems()
+        self.extraItems = {}
         pass
     extraItems = {}
 


### PR DESCRIPTION
This makes sure the tracker's fake items that are linked to checks have access to `slot_data` if necessary.  Items without a condition get handled right away, but otherwise have to wait until `slot_data` is available. It should fix [this issue](https://discord.com/channels/731205301247803413/1090819435893362768/1362169782354313539), where getting the seashell mansion check in seashell hunt mode makes the seashell count wrong.

I tested various combinations of connection timing between Magpie, the emulator, and the AP server along with save scumming the seashell mansion check.