### PR TITLE
MM2: fix invalid weakness failsafe and refactor weakness tests

### DIFF
--- a/worlds/mm2/rules.py
+++ b/worlds/mm2/rules.py
@@ -226,9 +226,9 @@ def set_rules(world: "MM2World") -> None:
                     # it should be impossible to be out of energy, simply because even if every boss took 1 from
                     # Quick Boomerang and no other, it would only be 28 off from defeating all 9,
                     # which Metal Blade should be able to cover
-                    wp, max_uses = max(((weapon, weapon_energy[weapon] // weapon_costs[weapon])
+                    max_uses, wp = max((weapon_energy[weapon] // weapon_costs[weapon], weapon)
                                        for weapon in weapon_weight
-                                       if weapon != 0 and (weapon != 8 or boss != 12)), key=lambda t: t[1])
+                                       if weapon != 0 and (weapon != 8 or boss != 12))
                     # Wily Machine cannot under any circumstances take damage from Time Stopper, prevent this
                     world.weapon_damage[wp][boss] = minimum_weakness_requirement[wp]
                     used = min(int(weapon_energy[wp] // weapon_costs[wp]),

--- a/worlds/mm2/rules.py
+++ b/worlds/mm2/rules.py
@@ -215,7 +215,7 @@ def set_rules(world: "MM2World") -> None:
                     continue
                 highest, wp = max(zip(weapon_weight.values(), weapon_weight.keys()))
                 uses = weapon_energy[wp] // weapon_costs[wp]
-                if int(uses * boss_damage[wp]) > boss_health[boss]:
+                if int(uses * boss_damage[wp]) >= boss_health[boss]:
                     used = ceil(boss_health[boss] / boss_damage[wp])
                     weapon_energy[wp] -= weapon_costs[wp] * used
                     boss_health[boss] = 0
@@ -226,9 +226,9 @@ def set_rules(world: "MM2World") -> None:
                     # it should be impossible to be out of energy, simply because even if every boss took 1 from
                     # Quick Boomerang and no other, it would only be 28 off from defeating all 9,
                     # which Metal Blade should be able to cover
-                    wp, max_uses = max((weapon, weapon_energy[weapon] // weapon_costs[weapon])
+                    wp, max_uses = max(((weapon, weapon_energy[weapon] // weapon_costs[weapon])
                                        for weapon in weapon_weight
-                                       if weapon != 0 and (weapon != 8 or boss != 12))
+                                       if weapon != 0 and (weapon != 8 or boss != 12)), key=lambda t: t[1])
                     # Wily Machine cannot under any circumstances take damage from Time Stopper, prevent this
                     world.weapon_damage[wp][boss] = minimum_weakness_requirement[wp]
                     used = min(int(weapon_energy[wp] // weapon_costs[wp]),

--- a/worlds/mm2/test/test_weakness.py
+++ b/worlds/mm2/test/test_weakness.py
@@ -2,9 +2,9 @@ from math import ceil
 
 from . import MM2TestBase
 from ..options import bosses
+from ..rules import minimum_weakness_requirement
 
 
-# Need to figure out how this test should work
 def validate_wily_5(base: MM2TestBase) -> None:
     world = base.multiworld.worlds[base.player]
     weapon_damage = world.weapon_damage
@@ -67,38 +67,54 @@ def validate_wily_5(base: MM2TestBase) -> None:
                 weapon_weight.pop(wp)
 
 
-class StrictWeaknessTests(MM2TestBase):
+class WeaknessTests(MM2TestBase):
     options = {
-        "strict_weakness": True,
         "yoku_jumps": True,
-        "enable_lasers": True
+        "enable_lasers": True,
     }
-
     def test_that_every_boss_has_a_weakness(self) -> None:
         world = self.multiworld.worlds[self.player]
         weapon_damage = world.weapon_damage
         for boss in range(14):
-            if not any(weapon_damage[weapon][boss] for weapon in range(9)):
+            if not any(weapon_damage[weapon][boss] >= minimum_weakness_requirement[weapon] for weapon in range(9)):
                 self.fail(f"Boss {boss} generated without weakness! Seed: {self.multiworld.seed}")
 
     def test_wily_5(self) -> None:
         validate_wily_5(self)
 
 
-class RandomStrictWeaknessTests(MM2TestBase):
+class StrictWeaknessTests(WeaknessTests):
+    options = {
+        "strict_weakness": True,
+        **WeaknessTests.options
+    }
+
+
+class RandomWeaknessTests(WeaknessTests):
+    options = {
+        "random_weakness": "randomized",
+        **WeaknessTests.options
+    }
+
+
+class ShuffledWeaknessTests(WeaknessTests):
+    options = {
+        "random_weakness": "shuffled",
+        **WeaknessTests.options
+    }
+
+
+class RandomStrictWeaknessTests(WeaknessTests):
     options = {
         "strict_weakness": True,
         "random_weakness": "randomized",
-        "yoku_jumps": True,
-        "enable_lasers": True
+        **WeaknessTests.options
     }
 
-    def test_that_every_boss_has_a_weakness(self) -> None:
-        world = self.multiworld.worlds[self.player]
-        weapon_damage = world.weapon_damage
-        for boss in range(14):
-            if not any(weapon_damage[weapon][boss] for weapon in range(9)):
-                self.fail(f"Boss {boss} generated without weakness! Seed: {self.multiworld.seed}")
 
-    def test_wily_5(self) -> None:
-        validate_wily_5(self)
+class ShuffledStrictWeaknessTests(WeaknessTests):
+    options = {
+        "strict_weakness": True,
+        "random_weakness": "shuffled",
+        **WeaknessTests.options
+    }


### PR DESCRIPTION
## What is this fixing or adding?
Probably the cause of most MM2 weakness failures. `max` compares against the first value of a tuple if given a list of tuples, which meant it would always give the last weapon in the list, rather than the weapon with the greatest excess energy.

This PR also includes a refactor to the weakness tests to now test `shuffled` boss weaknesses, as it has been the cause of several bugs in the past.

## How was this tested?
StrictRandomWeaknessTests with seed 94073898902878149535 produces a mathematically impossible world generation. The test no longer fails once this change is made.

## If this makes graphical changes, please attach screenshots.
