### PR TITLE
Webhost: Added ability to clamp port range and retry mechanism

### DIFF
--- a/WebHostLib/__init__.py
+++ b/WebHostLib/__init__.py
@@ -43,6 +43,27 @@ app.config["JOB_TIME"] = 600
 app.config["GENERATOR_MEMORY_LIMIT"] = 4294967296
 app.config['SESSION_PERMANENT'] = True
 
+# Room Pool configuration.
+
+# ROOM_PORT_MIN determines the minimum port range to allocate to a Room.
+# Default value is 49152 (i.e. minimum-allocatable port on a single machine)
+app.config["ROOM_PORT_MIN"] = 49152
+# ROOM_PORT_MIN determines the maximum port range to allocate to a Room.
+# Default value is 65535 (i.e. maximum-allocatable port on a single machine)
+app.config["ROOM_PORT_MAX"] = 65535
+
+# ROOM_PORT_ALLOC_TRIES controls how many retries the random port allocation will try before 
+# raising an exception. -1 disables the retry threshold. A
+# value greater greater than -1 will continue for number specified.
+# A sensible threshold for this would be to try the maximum number of ports, determined
+# from "ROOM_PORT_MIN" and "ROOM_PORT_MAX":
+# app.config["ROOM_PORT_ALLOC_TRIES"] = app.config["ROOM_PORT_MAX"] - app.config["ROOM_PORT_MIN"]
+app.config["ROOM_PORT_ALLOC_TRIES"] = -1
+
+# ROOM_PORT_OVERFLOW controls whether, once reaching the limit of retried ports available,
+# the room port numbers will go to a port number potentially outside of ROOM_PORT_MIN and ROOM_PORT_MAX.
+app.config["ROOM_PORT_OVERFLOW"] = True
+
 # waitress uses one thread for I/O, these are for processing of views that then get sent
 # archipelago.gg uses gunicorn + nginx; ignoring this option
 app.config["WAITRESS_THREADS"] = 10

--- a/WebHostLib/autolauncher.py
+++ b/WebHostLib/autolauncher.py
@@ -175,6 +175,10 @@ class MultiworldInstance():
         self.cert = config["SELFLAUNCHCERT"]
         self.key = config["SELFLAUNCHKEY"]
         self.host = config["HOST_ADDRESS"]
+        self.room_port_min = max(config["ROOM_PORT_MIN"], 49152)
+        self.room_port_max = min(config["ROOM_PORT_MAX"], 65535)
+        self.room_port_overflow = config["ROOM_PORT_OVERFLOW"]
+        self.room_port_alloc_tries = max(config["ROOM_PORT_ALLOC_TRIES"], -1)
         self.rooms_to_start = multiprocessing.Queue()
         self.rooms_shutting_down = multiprocessing.Queue()
         self.name = f"MultiHoster{id}"
@@ -184,7 +188,12 @@ class MultiworldInstance():
             return False
 
         process = multiprocessing.Process(group=None, target=run_server_process,
-                                          args=(self.name, self.ponyconfig, get_static_server_data(),
+                                          args=(self.name, self.ponyconfig,
+                                                self.room_port_min,
+                                                self.room_port_max,
+                                                self.room_port_overflow,
+                                                self.room_port_alloc_tries,
+                                                get_static_server_data(),
                                                 self.cert, self.key, self.host,
                                                 self.rooms_to_start, self.rooms_shutting_down),
                                           name=self.name)

--- a/WebHostLib/customserver.py
+++ b/WebHostLib/customserver.py
@@ -24,6 +24,8 @@ from Utils import restricted_loads, cache_argsless
 from .locker import Locker
 from .models import Command, GameDataPackage, Room, db
 
+class RoomPoolException(Exception)
+    pass
 
 class CustomClientMessageProcessor(ClientMessageProcessor):
     ctx: WebHostContext
@@ -100,13 +102,13 @@ class WebHostContext(Context):
             time.sleep(5)
 
     @db_session
-    def load(self, room_id: int):
+    def load(self, room_id: int, room_port_min: int, room_port_max: int):
         self.room_id = room_id
         room = Room.get(id=room_id)
         if room.last_port:
             self.port = room.last_port
         else:
-            self.port = get_random_port()
+            self.port = get_random_port(room_port_min, room_port_max)
 
         multidata = self.decompress(room.seed.multidata)
         game_data_packages = {}
@@ -171,8 +173,8 @@ class WebHostContext(Context):
         return d
 
 
-def get_random_port():
-    return random.randint(49152, 65535)
+def get_random_port(port_min: int, port_max: int):
+    return random.randint(port_min, port_max)
 
 
 @cache_argsless
@@ -224,7 +226,12 @@ def set_up_logging(room_id) -> logging.Logger:
     return logger
 
 
-def run_server_process(name: str, ponyconfig: dict, static_server_data: dict,
+def run_server_process(name: str, ponyconfig: dict,
+                       room_port_min: int,
+                       room_port_max: int,
+                       room_port_overflow: bool,
+                       room_port_alloc_tries: int,
+                       static_server_data: dict,
                        cert_file: typing.Optional[str], cert_key_file: typing.Optional[str],
                        host: str, rooms_to_run: multiprocessing.Queue, rooms_shutting_down: multiprocessing.Queue):
     from setproctitle import setproctitle
@@ -276,19 +283,50 @@ def run_server_process(name: str, ponyconfig: dict, static_server_data: dict,
             try:
                 logger = set_up_logging(room_id)
                 ctx = WebHostContext(static_server_data, logger)
-                ctx.load(room_id)
+                ctx.load(room_id, room_port_min, room_port_max)
                 ctx.init_save()
                 assert ctx.server is None
+
+                # Try the given port number. If the port allocated cannot be opened, get a random one
+                # from `websockets`:
                 try:
                     ctx.server = websockets.serve(
                         functools.partial(server, ctx=ctx), ctx.host, ctx.port, ssl=get_ssl_context())
-
                     await ctx.server
-                except OSError:  # likely port in use
-                    ctx.server = websockets.serve(
-                        functools.partial(server, ctx=ctx), ctx.host, 0, ssl=get_ssl_context())
+                except OSError as start_oserr:
+                    # If neither port allocation has been enabled, or room port overflows have been enabled,
+                    # then raise the exception
+                    if room_port_alloc_tries < 0 and room_port_overflow is False:
+                        ctx.logger.info(f"[{name}] Direct rethrow of exception as configuration disallows rethrows:")
+                        raise RoomPoolException() from start_oserr
 
-                    await ctx.server
+                    # The port is in use.
+                    # If the webserver has been configured to retry for ports, brute-force retry:
+                    if room_port_alloc_tries > -1:
+                        last_oserr = None
+                        for room_port_try in range(room_port_alloc_tries):
+                            next_port = get_random_port(room_port_min, room_port_max)
+                            try:
+                                ctx.server = websockets.serve(
+                                    functools.partial(server, ctx=ctx), ctx.host, next_port, ssl=get_ssl_context())
+                                await ctx.server
+                            except OSError as ose:
+                                ctx.logger.info(f"[{name}] Unable to allocate port {next_port}, trying next port \
+                                    (attempt {room_port_try+1} of {room_port_alloc_tries})...")
+                                last_oserr = ose
+                                continue
+
+                        if last_oserr is not None and room_port_overflow is False:
+                            raise RoomPoolException(f"[{name}] Exhausted retries to allocate a port.") from last_oserr
+
+                    # If we still haven't been able to create a server, let `websockets` find a free port.
+                    if room_port_overflow is True:
+                        ctx.logger.info(f'[{name}] Randomly-allocating system free port')
+                        ctx.server = websockets.serve(functools.partial(server, ctx=ctx), ctx.host, 0,
+                            ssl=get_ssl_context())
+                        await ctx.server
+
+                # Get the allocated port from the `websockets` connection:
                 port = 0
                 for wssocket in ctx.server.ws_server.sockets:
                     socketname = wssocket.getsockname()
@@ -298,6 +336,8 @@ def run_server_process(name: str, ponyconfig: dict, static_server_data: dict,
                             port = socketname[1]
                     elif wssocket.family == socket.AF_INET:
                         port = socketname[1]
+
+                # If a port number was allocated, then update the Room with the new port number:
                 if port:
                     ctx.logger.info(f'Hosting game at {host}:{port}')
                     with db_session:
@@ -317,6 +357,12 @@ def run_server_process(name: str, ponyconfig: dict, static_server_data: dict,
                 if ctx.saving:
                     ctx._save()
                     setattr(asyncio.current_task(), "save", None)
+            except RoomPoolException as e:
+                with db_session:
+                    room = Room.get(id=room_id)
+                    room.last_port = get_random_port(room_port_min, room_port_max)
+                logger.exception(e)
+                raise
             except Exception as e:
                 with db_session:
                     room = Room.get(id=room_id)


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?

This tries to add:

- The ability to clamp ports between a minimum and maximum value (`ROOM_PORT_MIN`, `ROOM_PORT_MAX`)
- The ability to fetch a new random port (between configured min and max values)
- The ability to retry, if configured (`ROOM_PORT_ALLOC_TRIES`)
- The ability to toggle `websockets` behaviour on/off, if configured (`ROOM_PORT_OVERFLOW`)

## How was this tested?

Tested locally, with a far tighter port range (5 open ports). I would like to add unit tests, if reviewer(s) believe this would be useful.

## If this makes graphical changes, please attach screenshots.

N/A

<hr/>

If direct communication would be easier to assist, please reach out on the Archipelago Discord server, as I may misunderstand multiple times. This is also the first time working on a public Python repo, and my knowledge of the project's structure is not the best.