### PR TITLE
kvui: fix kwargs on ResizableTextField and ImageButton

### DIFF
--- a/kvui.py
+++ b/kvui.py
@@ -98,7 +98,7 @@ class ThemedApp(MDApp):
 
 class ImageIcon(MDButtonIcon, AsyncImage):
     def __init__(self, *args, **kwargs):
-        super().__init__(args, kwargs)
+        super().__init__(*args, **kwargs)
         self.image = ApAsyncImage(**kwargs)
         self.add_widget(self.image)
 
@@ -183,14 +183,16 @@ class ResizableTextField(MDTextField):
                 height_rule = subclass.properties.get("height", None)
                 if height_rule:
                     height_rule.ignore_prev = True
-        super().__init__(args, kwargs)
+        super().__init__(*args, **kwargs)
 
 
 def on_release(self: MDButton, *args):
     super(MDButton, self).on_release(args)
     self.on_leave()
 
+
 MDButton.on_release = on_release
+
 
 # I was surprised to find this didn't already exist in kivy :(
 class HoverBehavior(object):

--- a/kvui.py
+++ b/kvui.py
@@ -906,7 +906,7 @@ class GameManager(ThemedApp):
                                     pos_hint={"center_y": 0.575})
         info_button.bind(on_release=self.command_button_action)
         bottom_layout.add_widget(info_button)
-        self.textinput = CommandPromptTextInput(size_hint_y=None, height=dp(30), multiline=False, write_tab=False)
+        self.textinput = CommandPromptTextInput(size_hint_y=None, multiline=False, write_tab=False)
         self.textinput.bind(on_text_validate=self.on_message)
         info_button.height = self.textinput.height
         self.textinput.text_validate_unfocus = False


### PR DESCRIPTION
## What is this fixing or adding?
Alternative to #4894 that fixes the root problem, we were accidentally throwing args and kwargs into args.

## How was this tested?
Opened Text Client, saw that localhost was being set properly as the default text for the connect bar.


## If this makes graphical changes, please attach screenshots.
