### PR TITLE
CommonClient: Move command marker to last_autofillable_command

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -677,7 +677,7 @@ def get_input_text_from_response(text: str, command: str) -> typing.Optional[str
             if text.startswith(question):
                 name = get_text_between(text, "did you mean '",
                                         "'? (")
-                return f"!{command} {name}"
+                return f"{command} {name}"
     elif text.startswith("Missing: "):
         return text.replace("Missing: ", "!hint_location ")
     return None

--- a/kvui.py
+++ b/kvui.py
@@ -812,15 +812,15 @@ class GameManager(ThemedApp):
         self.log_panels: typing.Dict[str, Widget] = {}
 
         # keep track of last used command to autofill on click
-        self.last_autofillable_command = "hint"
-        autofillable_commands = ("hint_location", "hint", "getitem")
+        self.last_autofillable_command = "!hint"
+        autofillable_commands = ("!hint_location", "!hint", "!getitem")
         original_say = ctx.on_user_say
 
         def intercept_say(text):
             text = original_say(text)
             if text:
                 for command in autofillable_commands:
-                    if text.startswith("!" + command):
+                    if text.startswith(command):
                         self.last_autofillable_command = command
                         break
             return text


### PR DESCRIPTION
## What is this fixing or adding?
This changes the command marker `!` from being hardcoded in `get_input_text_from_response`, to being explicit in `last_autofillable_command`. This allows `/` commands to use `last_autofillable_command` to be autofilled when user presses the "Didn't find something that closely matches '_something wrong_', did you mean '_the correct name_'? (66% sure)" message.

I need this to fix an issue with the Stardew client tracker. Currently, when pressing the autofill questions, the `!hint` command gets filled instead of the correct `/explain` command. Setting the last command to `explain` autofills `!explain`, with the wrong command marker.  

Without this change, I would need to hook into the `ConnectBarTextInput` in intercept when the command is autofilled to change the marker. Every other client would also need to do that if they want the same behavior.

## How was this tested?
I made typo with `!hint`, `!hint_location`, `!getitem` to make sure they still work. I also tested with the `/explain` commands from the Stardew client. See this commit https://github.com/agilbert1412/Archipelago/commit/d2fdda4b2254300cd5b50800f841dfa7c1e59e61

## If this makes graphical changes, please attach screenshots.
<details><summary>Current Stardew Client behavior</summary>
<p>

https://github.com/user-attachments/assets/164c2b77-c292-425d-81e3-934e1034e512

</p>
</details> 

<details><summary>With this change + setting `last_autofillable_command` correctly in the client</summary>
<p>

https://github.com/user-attachments/assets/f6f0e5cb-00ff-4c2f-ab6b-25f79d1132c5

</p>
</details> 
