### PR TITLE
Lingo: Rework early good items

### DIFF
--- a/worlds/lingo/__init__.py
+++ b/worlds/lingo/__init__.py
@@ -164,18 +164,16 @@ class LingoWorld(World):
     def fill_hook(self, progitempool: List[Item], _: List[Item], _2: List[Item], fill_locations: List[Location]):
         if len(self.player_logic.good_item_options) > 0:
             good_location = self.get_location("Second Room - Good Luck")
+            good_items = list(filter(lambda progitem: progitem.player == self.player and
+                                                      progitem.name in self.player_logic.good_item_options,
+                                     progitempool))
 
-            if good_location.progress_type != LocationProgressType.EXCLUDED:
-                good_items = list(filter(lambda progitem: progitem.player == self.player and
-                                                          progitem.name in self.player_logic.good_item_options,
-                                         progitempool))
+            if good_location.progress_type != LocationProgressType.EXCLUDED and len(good_items) > 0:
+                good_item = self.random.choice(good_items)
+                good_location.place_locked_item(good_item)
 
-                if len(good_items) > 0:
-                    good_item = self.random.choice(good_items)
-                    progitempool.remove(good_item)
-
-                    good_location.place_locked_item(good_item)
-                    fill_locations.remove(good_location)
+                progitempool.remove(good_item)
+                fill_locations.remove(good_location)
 
     def fill_slot_data(self):
         slot_options = [

--- a/worlds/lingo/__init__.py
+++ b/worlds/lingo/__init__.py
@@ -160,7 +160,8 @@ class LingoWorld(World):
     def set_rules(self):
         self.multiworld.completion_condition[self.player] = lambda state: state.has("Victory", self.player)
 
-    def fill_hook(self, progitempool: list[Item], _: list[Item], _2: list[Item], fill_locations: list[Location]):
+    def fill_hook(self, progitempool: list[Item], usefulitempool: list[Item], filleritempool: list[Item],
+                  fill_locations: list[Location]):
         if len(self.player_logic.good_item_options) > 0:
             good_location = self.get_location("Second Room - Good Luck")
             good_items = list(filter(lambda progitem: progitem.player == self.player and

--- a/worlds/lingo/__init__.py
+++ b/worlds/lingo/__init__.py
@@ -2,7 +2,6 @@
 Archipelago init file for Lingo
 """
 from logging import warning
-from typing import List
 
 from BaseClasses import CollectionState, Item, ItemClassification, Tutorial, Location, LocationProgressType
 from Options import OptionError
@@ -161,7 +160,7 @@ class LingoWorld(World):
     def set_rules(self):
         self.multiworld.completion_condition[self.player] = lambda state: state.has("Victory", self.player)
 
-    def fill_hook(self, progitempool: List[Item], _: List[Item], _2: List[Item], fill_locations: List[Location]):
+    def fill_hook(self, progitempool: list[Item], _: list[Item], _2: list[Item], fill_locations: list[Location]):
         if len(self.player_logic.good_item_options) > 0:
             good_location = self.get_location("Second Room - Good Luck")
             good_items = list(filter(lambda progitem: progitem.player == self.player and

--- a/worlds/lingo/__init__.py
+++ b/worlds/lingo/__init__.py
@@ -160,21 +160,29 @@ class LingoWorld(World):
     def set_rules(self):
         self.multiworld.completion_condition[self.player] = lambda state: state.has("Victory", self.player)
 
+    def place_good_item(self, progitempool: list[Item], fill_locations: list[Location]):
+        if len(self.player_logic.good_item_options) == 0:
+            return
+
+        good_location = self.get_location("Second Room - Good Luck")
+        if good_location.progress_type == LocationProgressType.EXCLUDED or good_location not in fill_locations:
+            return
+
+        good_items = list(filter(lambda progitem: progitem.player == self.player and
+                                                  progitem.name in self.player_logic.good_item_options, progitempool))
+
+        if len(good_items) == 0:
+            return
+
+        good_item = self.random.choice(good_items)
+        good_location.place_locked_item(good_item)
+
+        progitempool.remove(good_item)
+        fill_locations.remove(good_location)
+
     def fill_hook(self, progitempool: list[Item], usefulitempool: list[Item], filleritempool: list[Item],
                   fill_locations: list[Location]):
-        if len(self.player_logic.good_item_options) > 0:
-            good_location = self.get_location("Second Room - Good Luck")
-            good_items = list(filter(lambda progitem: progitem.player == self.player and
-                                                      progitem.name in self.player_logic.good_item_options,
-                                     progitempool))
-
-            if good_location.progress_type != LocationProgressType.EXCLUDED and good_location in fill_locations and\
-                    len(good_items) > 0:
-                good_item = self.random.choice(good_items)
-                good_location.place_locked_item(good_item)
-
-                progitempool.remove(good_item)
-                fill_locations.remove(good_location)
+        self.place_good_item(progitempool, fill_locations)
 
     def fill_slot_data(self):
         slot_options = [

--- a/worlds/lingo/__init__.py
+++ b/worlds/lingo/__init__.py
@@ -2,8 +2,9 @@
 Archipelago init file for Lingo
 """
 from logging import warning
+from typing import List
 
-from BaseClasses import CollectionState, Item, ItemClassification, Tutorial
+from BaseClasses import CollectionState, Item, ItemClassification, Tutorial, Location, LocationProgressType
 from Options import OptionError
 from worlds.AutoWorld import WebWorld, World
 from .datatypes import Room, RoomEntrance
@@ -80,10 +81,6 @@ class LingoWorld(World):
             for item in self.player_logic.real_items:
                 state.collect(self.create_item(item), True)
 
-            # Exception to the above: a forced good item is not considered a "real item", but needs to be here anyway.
-            if self.player_logic.forced_good_item != "":
-                state.collect(self.create_item(self.player_logic.forced_good_item), True)
-
             all_locations = self.multiworld.get_locations(self.player)
             state.sweep_for_advancements(locations=all_locations)
 
@@ -104,11 +101,6 @@ class LingoWorld(World):
 
     def create_items(self):
         pool = [self.create_item(name) for name in self.player_logic.real_items]
-
-        if self.player_logic.forced_good_item != "":
-            new_item = self.create_item(self.player_logic.forced_good_item)
-            location_obj = self.multiworld.get_location("Second Room - Good Luck", self.player)
-            location_obj.place_locked_item(new_item)
 
         item_difference = len(self.player_logic.real_locations) - len(pool)
         if item_difference:
@@ -138,7 +130,7 @@ class LingoWorld(World):
 
                 trap_counts = {name: int(weight * traps / total_weight)
                                for name, weight in self.options.trap_weights.items()}
-                
+
                 trap_difference = traps - sum(trap_counts.values())
                 if trap_difference > 0:
                     allowed_traps = [name for name in TRAP_ITEMS if self.options.trap_weights[name] > 0]
@@ -168,6 +160,22 @@ class LingoWorld(World):
 
     def set_rules(self):
         self.multiworld.completion_condition[self.player] = lambda state: state.has("Victory", self.player)
+
+    def fill_hook(self, progitempool: List[Item], _: List[Item], _2: List[Item], fill_locations: List[Location]):
+        if len(self.player_logic.good_item_options) > 0:
+            good_location = self.get_location("Second Room - Good Luck")
+
+            if good_location.progress_type != LocationProgressType.EXCLUDED:
+                good_items = list(filter(lambda progitem: progitem.player == self.player and
+                                                          progitem.name in self.player_logic.good_item_options,
+                                         progitempool))
+
+                if len(good_items) > 0:
+                    good_item = self.random.choice(good_items)
+                    progitempool.remove(good_item)
+
+                    good_location.place_locked_item(good_item)
+                    fill_locations.remove(good_location)
 
     def fill_slot_data(self):
         slot_options = [

--- a/worlds/lingo/__init__.py
+++ b/worlds/lingo/__init__.py
@@ -167,7 +167,8 @@ class LingoWorld(World):
                                                       progitem.name in self.player_logic.good_item_options,
                                      progitempool))
 
-            if good_location.progress_type != LocationProgressType.EXCLUDED and len(good_items) > 0:
+            if good_location.progress_type != LocationProgressType.EXCLUDED and good_location in fill_locations and\
+                    len(good_items) > 0:
                 good_item = self.random.choice(good_items)
                 good_location.place_locked_item(good_item)
 

--- a/worlds/lingo/player_logic.py
+++ b/worlds/lingo/player_logic.py
@@ -95,7 +95,7 @@ class LingoPlayerLogic:
 
     painting_mapping: Dict[str, str]
 
-    forced_good_item: str
+    good_item_options: List[str]
 
     panel_reqs: Dict[str, Dict[str, AccessRequirements]]
     door_reqs: Dict[str, Dict[str, AccessRequirements]]
@@ -151,7 +151,7 @@ class LingoPlayerLogic:
         self.mastery_location = ""
         self.level_2_location = ""
         self.painting_mapping = {}
-        self.forced_good_item = ""
+        self.good_item_options = []
         self.panel_reqs = {}
         self.door_reqs = {}
         self.mastery_reqs = []
@@ -344,23 +344,23 @@ class LingoPlayerLogic:
 
             # Starting Room - Back Right Door gives access to OPEN and DEAD END.
             # Starting Room - Exit Door gives access to OPEN and TRACE.
-            good_item_options: List[str] = ["Starting Room - Back Right Door", "Second Room - Exit Door"]
+            self.good_item_options = ["Starting Room - Back Right Door", "Second Room - Exit Door"]
 
             if not color_shuffle:
                 if not world.options.enable_pilgrimage:
                     # HOT CRUST and THIS.
-                    good_item_options.append("Pilgrim Room - Sun Painting")
+                    self.good_item_options.append("Pilgrim Room - Sun Painting")
 
                 if world.options.group_doors:
                     # WELCOME BACK, CLOCKWISE, and DRAWL + RUNS.
-                    good_item_options.append("Welcome Back Doors")
+                    self.good_item_options.append("Welcome Back Doors")
                 else:
                     # WELCOME BACK and CLOCKWISE.
-                    good_item_options.append("Welcome Back Area - Shortcut to Starting Room")
+                    self.good_item_options.append("Welcome Back Area - Shortcut to Starting Room")
 
             if world.options.group_doors:
                 # Color hallways access (NOTE: reconsider when sunwarp shuffling exists).
-                good_item_options.append("Rhyme Room Doors")
+                self.good_item_options.append("Rhyme Room Doors")
 
             # When painting shuffle is off, most Starting Room paintings give color hallways access. The Wondrous's
             # painting does not, but it gives access to SHRINK and WELCOME BACK.
@@ -376,30 +376,7 @@ class LingoPlayerLogic:
                     continue
 
                 pdoor = DOORS_BY_ROOM[painting_obj.required_door.room][painting_obj.required_door.door]
-                good_item_options.append(pdoor.item_name)
-
-            # Copied from The Witness -- remove any plandoed items from the possible good items set.
-            for v in world.multiworld.plando_items[world.player]:
-                if v.get("from_pool", True):
-                    for item_key in {"item", "items"}:
-                        if item_key in v:
-                            if type(v[item_key]) is str:
-                                if v[item_key] in good_item_options:
-                                    good_item_options.remove(v[item_key])
-                            elif type(v[item_key]) is dict:
-                                for item, weight in v[item_key].items():
-                                    if weight and item in good_item_options:
-                                        good_item_options.remove(item)
-                            else:
-                                # Other type of iterable
-                                for item in v[item_key]:
-                                    if item in good_item_options:
-                                        good_item_options.remove(item)
-
-            if len(good_item_options) > 0:
-                self.forced_good_item = world.random.choice(good_item_options)
-                self.real_items.remove(self.forced_good_item)
-                self.real_locations.remove("Second Room - Good Luck")
+                self.good_item_options.append(pdoor.item_name)
 
     def randomize_paintings(self, world: "LingoWorld") -> bool:
         self.painting_mapping.clear()


### PR DESCRIPTION
## What is this fixing or adding?
In some circumstances, Lingo will attempt to force a random "good" item onto a specific sphere 1 check, in order to make early progression easier. The code for this used to have a block copied from The Witness in order to handle the situation where a potential good item was plando'd "from pool" onto another location.

This PR removes the plando check and moves the actual item placement into `fill_hook` (inspired by #3041). The eligible good items are still calculated in `generate_early`, but one is not chosen at this point. Because of this, all of the eligible good items remain in the "real items" list and the sphere 1 location remains in the "real locations" list. By the time `fill_hook` gets called, plando has been resolved, meaning any "from pool" placements will have caused eligible items to have been removed from the item pool. Thus, we can randomly select an eligible good item that's still present in the pool and place that onto the location.

Additionally, we no longer force a good item if the location is excluded.


## How was this tested?
pytest and test generations, with the good items criteria changed so that solo worlds are eligible.


## If this makes graphical changes, please attach screenshots.
