### PR TITLE
SM: Fix FakeROM instances sharing the same data dictionary

### DIFF
--- a/worlds/sm/variaRandomizer/rom/rom.py
+++ b/worlds/sm/variaRandomizer/rom/rom.py
@@ -89,9 +89,12 @@ class ROM(object):
 
 class FakeROM(ROM):
     # to have the same code for real ROM and the webservice
-    def __init__(self, data={}):
+    def __init__(self, data=None):
         super(FakeROM, self).__init__()
-        self.data = data
+        if data is None:
+            self.data = {}
+        else:
+            self.data = data
         self.ipsPatches = []
 
     def write(self, bytes):


### PR DESCRIPTION
## What is this fixing or adding?

FakeROM instances were being created with default arguments, which included a mutable default argument data dictionary, so all FakeROM instances would be writing to and reading the same dictionary, resulting in broken patch data in multiworlds with more than one Super Metroid world.

This PR removes the mutable default argument to ensure that each FakeROM instance has its own data dictionary.

https://github.com/ArchipelagoMW/Archipelago/blob/6613c296523185ffd4ea9c37c4c6ffe21e797935/worlds/sm/variaRandomizer/rom/rompatcher.py#L58

https://github.com/ArchipelagoMW/Archipelago/blob/6613c296523185ffd4ea9c37c4c6ffe21e797935/worlds/sm/variaRandomizer/rom/rom.py#L92-L95

## How was this tested?
I have not tested it beyond generating. I have set up a test room of 20 Big Async filler Super Metroid yamls, generated with this PR backported onto AP 0.6.1 if someone would like to test the patches: https://archipelago.gg/room/6hjtd90yQSOfkJFKfdcKug

Edit:
Some testing has been done thanks to some helpful volunteers on the Archipelago discord https://discord.com/channels/731205301247803413/909599727341928538/1363897204863008880

The test multiworld with this PR applied https://archipelago.gg/room/6hjtd90yQSOfkJFKfdcKug was played and area and boss rando worked correctly on the tested slots. Slots 3, 12 and 19 were tested for area rando and boss rando transitions because transitions were known to have been problematic in AP 0.6.1.

A second test multiworld with the same seed (different placements due to some nondeterministic generation somewhere, but the options and transitions rolled the same), but without this PR was also created https://archipelago.gg/room/By_GP1_7T9qBmH9kWrG0UQ, slot 12 gave a black screen and slot 3 died on the first transition tried.
