### PR TITLE
MultiServer: import get_settings from the correct module

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2419,8 +2419,10 @@ async def console(ctx: Context):
 
 
 def parse_args() -> argparse.Namespace:
+    from settings import get_settings
+
     parser = argparse.ArgumentParser()
-    defaults = Utils.get_settings()["server_options"].as_dict()
+    defaults = get_settings()["server_options"].as_dict()
     parser.add_argument('multidata', nargs="?", default=defaults["multidata"])
     parser.add_argument('--host', default=defaults["host"])
     parser.add_argument('--port', default=defaults["port"], type=int)

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2422,7 +2422,7 @@ def parse_args() -> argparse.Namespace:
     from settings import get_settings
 
     parser = argparse.ArgumentParser()
-    defaults = get_settings()["server_options"].as_dict()
+    defaults = get_settings().server_options.as_dict()
     parser.add_argument('multidata', nargs="?", default=defaults["multidata"])
     parser.add_argument('--host', default=defaults["host"])
     parser.add_argument('--port', default=defaults["port"], type=int)


### PR DESCRIPTION
## What is this fixing or adding?

Part of #4811 
Also switches from getitem to getattr for top level access to get proper type deduction for `as_dict`. Still uses dict access from that point on though.
Also makes the import lazy, which might be an improvement for customserver once Utils does not directly import settings anymore.

## How was this tested?

MultiServer still spins up