### PR TITLE
Muse Dash: implement new option, goal song pool

### DIFF
--- a/worlds/musedash/Options.py
+++ b/worlds/musedash/Options.py
@@ -176,12 +176,23 @@ class ExcludeSongs(SongSet):
     display_name = "Exclude Songs"
 
 
+class GoalSongPool(SongSet):
+    """
+    Songs listed here will randomly chosen to be the final song.
+    
+    If empty, the goal song will be chosen randomly from all included songs.
+    """
+    verify_item_name = True
+    display_name = "Goal Song Pool"
+
+
 md_option_groups = [
     OptionGroup("Song Choice", [
         DLCMusicPacks,
         StreamerModeEnabled,
         IncludeSongs,
         ExcludeSongs,
+        GoalSongPool,
     ]),
     OptionGroup("Difficulty", [
         GradeNeeded,
@@ -214,6 +225,7 @@ class MuseDashOptions(PerGameCommonOptions):
     death_link: DeathLink
     include_songs: IncludeSongs
     exclude_songs: ExcludeSongs
+    goal_song_pool: GoalSongPool
 
     # Removed
     allow_just_as_planned_dlc_songs: Removed

--- a/worlds/musedash/__init__.py
+++ b/worlds/musedash/__init__.py
@@ -86,6 +86,7 @@ class MuseDashWorld(World):
         # - Interim songs being equal to max starting song count.
         # Note: The worst settings still allow 25 songs (Streamer Mode + No DLC).
         starter_song_count = self.options.starting_song_count.value
+        goal_song_pool = self.options.goal_song_pool.value
 
         while True:
             # In most cases this should only need to run once
@@ -93,6 +94,24 @@ class MuseDashWorld(World):
                 dlc_songs, bool(streamer_mode.value), lower_diff_threshold, higher_diff_threshold)
 
             available_song_keys = self.handle_plando(available_song_keys, dlc_songs)
+
+            # Find the proposed goal songs and add them to a new list
+            victory_song_keys = []
+            for goal_song_canidate in goal_song_pool:
+                for index, available_song in enumerate(available_song_keys):
+                    if goal_song_canidate == available_song:
+                        # Include the canidates correlating index to the full list for later use
+                        victory_song_keys.append([index, available_song])
+
+            if victory_song_keys:
+                chosen_song_index = self.random.randrange(0, len(victory_song_keys))
+                self.victory_song_name = victory_song_keys[chosen_song_index][1]
+                # Replace the chosen goal song's index with the index from the full list we saved earlier.
+                chosen_song_index = victory_song_keys[chosen_song_index][0]
+            else:
+                chosen_song_index = self.random.randrange(0, len(available_song_keys))
+                self.victory_song_name = available_song_keys[chosen_song_index]
+            del available_song_keys[chosen_song_index]
 
             count_needed_for_start = max(0, starter_song_count - len(self.starting_songs))
             if len(available_song_keys) + len(self.included_songs) >= count_needed_for_start + 11:
@@ -137,22 +156,12 @@ class MuseDashWorld(World):
         # First, we must double check if the player has included too many guaranteed songs
         included_song_count = len(self.included_songs)
         if included_song_count > additional_song_count:
-            # If so, we want to thin the list, thus let's get the goal song and starter songs while we are at it.
+            # If so, we want to thin the list, thus let's get the starter songs while we are at it.
             self.random.shuffle(self.included_songs)
-            self.victory_song_name = self.included_songs.pop()
             while len(self.included_songs) > additional_song_count:
                 next_song = self.included_songs.pop()
                 if len(self.starting_songs) < starting_song_count:
                     self.starting_songs.append(next_song)
-        else:
-            # If not, choose a random victory song from the available songs
-            chosen_song = self.random.randrange(0, len(available_song_keys) + included_song_count)
-            if chosen_song < included_song_count:
-                self.victory_song_name = self.included_songs[chosen_song]
-                del self.included_songs[chosen_song]
-            else:
-                self.victory_song_name = available_song_keys[chosen_song - included_song_count]
-                del available_song_keys[chosen_song - included_song_count]
 
         # Next, make sure the starting songs are fulfilled
         if len(self.starting_songs) < starting_song_count:


### PR DESCRIPTION
## What is this fixing or adding?
This adds a new yaml option `goal_song_pool` which allows the user to provide a set of songs they would like to be the goal song.
Upon generating a seed, the generator will pick one of the provided songs at random to be the goal song.

This victory song is also now assigned inside of `generate_early()` instead of `create_song_pool()`

## How was this tested?
By generating multiple solo games from source and confirming the goal song was indeed listed in the yaml.