### PR TITLE
Stardew Valley: remove BaseLogic generic so importing mixins is no longer needed

### DIFF
--- a/worlds/stardew_valley/logic/ability_logic.py
+++ b/worlds/stardew_valley/logic/ability_logic.py
@@ -1,22 +1,8 @@
-import typing
-from typing import Union
-
 from .base_logic import BaseLogicMixin, BaseLogic
-from .mine_logic import MineLogicMixin
-from .received_logic import ReceivedLogicMixin
-from .region_logic import RegionLogicMixin
-from .skill_logic import SkillLogicMixin
-from .tool_logic import ToolLogicMixin
-from ..mods.logic.magic_logic import MagicLogicMixin
 from ..stardew_rule import StardewRule
 from ..strings.region_names import Region
 from ..strings.skill_names import Skill, ModSkill
 from ..strings.tool_names import ToolMaterial, Tool
-
-if typing.TYPE_CHECKING:
-    from ..mods.logic.mod_logic import ModLogicMixin
-else:
-    ModLogicMixin = object
 
 
 class AbilityLogicMixin(BaseLogicMixin):
@@ -25,8 +11,7 @@ class AbilityLogicMixin(BaseLogicMixin):
         self.ability = AbilityLogic(*args, **kwargs)
 
 
-class AbilityLogic(BaseLogic[Union[AbilityLogicMixin, RegionLogicMixin, ReceivedLogicMixin, ToolLogicMixin, SkillLogicMixin, MineLogicMixin, MagicLogicMixin,
-ModLogicMixin]]):
+class AbilityLogic(BaseLogic):
     def can_mine_perfectly(self) -> StardewRule:
         return self.logic.mine.can_progress_in_the_mines_from_floor(160)
 

--- a/worlds/stardew_valley/logic/action_logic.py
+++ b/worlds/stardew_valley/logic/action_logic.py
@@ -1,11 +1,5 @@
-from typing import Union
-
 from Utils import cache_self1
 from .base_logic import BaseLogic, BaseLogicMixin
-from .has_logic import HasLogicMixin
-from .received_logic import ReceivedLogicMixin
-from .region_logic import RegionLogicMixin
-from .tool_logic import ToolLogicMixin
 from ..stardew_rule import StardewRule, True_
 from ..strings.generic_names import Generic
 from ..strings.geode_names import Geode
@@ -19,7 +13,7 @@ class ActionLogicMixin(BaseLogicMixin):
         self.action = ActionLogic(*args, **kwargs)
 
 
-class ActionLogic(BaseLogic[Union[ActionLogicMixin, RegionLogicMixin, ReceivedLogicMixin, HasLogicMixin, ToolLogicMixin]]):
+class ActionLogic(BaseLogic):
 
     def can_watch(self, channel: str = None):
         tv_rule = True_()

--- a/worlds/stardew_valley/logic/animal_logic.py
+++ b/worlds/stardew_valley/logic/animal_logic.py
@@ -6,11 +6,6 @@ from ..strings.building_names import Building
 from ..strings.forageable_names import Forageable
 from ..strings.machine_names import Machine
 
-if typing.TYPE_CHECKING:
-    from .logic import StardewLogic
-else:
-    StardewLogic = object
-
 
 class AnimalLogicMixin(BaseLogicMixin):
     def __init__(self, *args, **kwargs):
@@ -18,7 +13,7 @@ class AnimalLogicMixin(BaseLogicMixin):
         self.animal = AnimalLogic(*args, **kwargs)
 
 
-class AnimalLogic(BaseLogic[StardewLogic]):
+class AnimalLogic(BaseLogic):
 
     def can_incubate(self, egg_item: str) -> StardewRule:
         return self.logic.building.has_building(Building.coop) & self.logic.has(egg_item)

--- a/worlds/stardew_valley/logic/arcade_logic.py
+++ b/worlds/stardew_valley/logic/arcade_logic.py
@@ -1,8 +1,4 @@
-from typing import Union
-
 from .base_logic import BaseLogic, BaseLogicMixin
-from .received_logic import ReceivedLogicMixin
-from .region_logic import RegionLogicMixin
 from .. import options
 from ..stardew_rule import StardewRule, True_
 from ..strings.region_names import Region
@@ -14,7 +10,7 @@ class ArcadeLogicMixin(BaseLogicMixin):
         self.arcade = ArcadeLogic(*args, **kwargs)
 
 
-class ArcadeLogic(BaseLogic[Union[ArcadeLogicMixin, RegionLogicMixin, ReceivedLogicMixin]]):
+class ArcadeLogic(BaseLogic):
 
     def has_jotpk_power_level(self, power_level: int) -> StardewRule:
         if self.options.arcade_machine_locations != options.ArcadeMachineLocations.option_full_shuffling:

--- a/worlds/stardew_valley/logic/artisan_logic.py
+++ b/worlds/stardew_valley/logic/artisan_logic.py
@@ -1,8 +1,4 @@
-from typing import Union
-
 from .base_logic import BaseLogic, BaseLogicMixin
-from .has_logic import HasLogicMixin
-from .time_logic import TimeLogicMixin
 from ..data.artisan import MachineSource
 from ..data.game_item import ItemTag
 from ..stardew_rule import StardewRule
@@ -20,7 +16,7 @@ class ArtisanLogicMixin(BaseLogicMixin):
         self.artisan = ArtisanLogic(*args, **kwargs)
 
 
-class ArtisanLogic(BaseLogic[Union[ArtisanLogicMixin, TimeLogicMixin, HasLogicMixin]]):
+class ArtisanLogic(BaseLogic):
     def initialize_rules(self):
         # TODO remove this one too once fish are converted to sources
         self.registry.artisan_good_rules.update({ArtisanGood.specific_smoked_fish(fish): self.can_smoke(fish) for fish in all_fish})

--- a/worlds/stardew_valley/logic/base_logic.py
+++ b/worlds/stardew_valley/logic/base_logic.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
-from typing import TypeVar, Generic, Dict, Collection
+import typing
+from typing import Dict, Collection
 
 from ..content.game_content import StardewContent
 from ..options import StardewValleyOptions
 from ..stardew_rule import StardewRule
+
+if typing.TYPE_CHECKING:
+    from .logic import StardewLogic
 
 
 class LogicRegistry:
@@ -30,18 +34,16 @@ class BaseLogicMixin:
         pass
 
 
-T = TypeVar("T", bound=BaseLogicMixin)
-
-
-class BaseLogic(BaseLogicMixin, Generic[T]):
+class BaseLogic(BaseLogicMixin):
     player: int
     registry: LogicRegistry
     options: StardewValleyOptions
     content: StardewContent
     regions: Collection[str]
-    logic: T
+    logic: StardewLogic
 
-    def __init__(self, player: int, registry: LogicRegistry, options: StardewValleyOptions, content: StardewContent, regions: Collection[str], logic: T):
+    def __init__(self, player: int, registry: LogicRegistry, options: StardewValleyOptions, content: StardewContent, regions: Collection[str],
+                 logic: StardewLogic):
         super().__init__(player, registry, options, content, regions, logic)
         self.player = player
         self.registry = registry

--- a/worlds/stardew_valley/logic/book_logic.py
+++ b/worlds/stardew_valley/logic/book_logic.py
@@ -1,9 +1,5 @@
-from typing import Union
-
 from Utils import cache_self1
 from .base_logic import BaseLogicMixin, BaseLogic
-from .has_logic import HasLogicMixin
-from .received_logic import ReceivedLogicMixin
 from ..stardew_rule import StardewRule
 
 
@@ -13,7 +9,7 @@ class BookLogicMixin(BaseLogicMixin):
         self.book = BookLogic(*args, **kwargs)
 
 
-class BookLogic(BaseLogic[Union[ReceivedLogicMixin, HasLogicMixin]]):
+class BookLogic(BaseLogic):
 
     @cache_self1
     def has_book_power(self, book: str) -> StardewRule:

--- a/worlds/stardew_valley/logic/building_logic.py
+++ b/worlds/stardew_valley/logic/building_logic.py
@@ -1,20 +1,10 @@
-import typing
 from functools import cached_property
-from typing import Union
 
 from Utils import cache_self1
 from .base_logic import BaseLogic, BaseLogicMixin
-from .has_logic import HasLogicMixin
-from .received_logic import ReceivedLogicMixin
-from .region_logic import RegionLogicMixin
 from ..stardew_rule import StardewRule, true_
 from ..strings.building_names import Building
 from ..strings.region_names import Region
-
-if typing.TYPE_CHECKING:
-    from .source_logic import SourceLogicMixin
-else:
-    SourceLogicMixin = object
 
 AUTO_BUILDING_BUILDINGS = {Building.shipping_bin, Building.pet_bowl, Building.farm_house}
 
@@ -25,7 +15,7 @@ class BuildingLogicMixin(BaseLogicMixin):
         self.building = BuildingLogic(*args, **kwargs)
 
 
-class BuildingLogic(BaseLogic[Union[BuildingLogicMixin, RegionLogicMixin, ReceivedLogicMixin, HasLogicMixin, SourceLogicMixin]]):
+class BuildingLogic(BaseLogic):
 
     @cache_self1
     def can_build(self, building_name: str) -> StardewRule:

--- a/worlds/stardew_valley/logic/bundle_logic.py
+++ b/worlds/stardew_valley/logic/bundle_logic.py
@@ -1,16 +1,7 @@
 from functools import cached_property
-from typing import Union, List
+from typing import List
 
 from .base_logic import BaseLogicMixin, BaseLogic
-from .fishing_logic import FishingLogicMixin
-from .has_logic import HasLogicMixin
-from .money_logic import MoneyLogicMixin
-from .quality_logic import QualityLogicMixin
-from .quest_logic import QuestLogicMixin
-from .received_logic import ReceivedLogicMixin
-from .region_logic import RegionLogicMixin
-from .skill_logic import SkillLogicMixin
-from .time_logic import TimeLogicMixin
 from ..bundles.bundle import Bundle
 from ..stardew_rule import StardewRule, True_
 from ..strings.ap_names.community_upgrade_names import CommunityUpgrade
@@ -27,8 +18,7 @@ class BundleLogicMixin(BaseLogicMixin):
         self.bundle = BundleLogic(*args, **kwargs)
 
 
-class BundleLogic(BaseLogic[Union[ReceivedLogicMixin, HasLogicMixin, TimeLogicMixin, RegionLogicMixin, MoneyLogicMixin, QualityLogicMixin, FishingLogicMixin,
-SkillLogicMixin, QuestLogicMixin]]):
+class BundleLogic(BaseLogic):
     # Should be cached
     def can_complete_bundle(self, bundle: Bundle) -> StardewRule:
         item_rules = []

--- a/worlds/stardew_valley/logic/combat_logic.py
+++ b/worlds/stardew_valley/logic/combat_logic.py
@@ -1,12 +1,7 @@
 from functools import cached_property
-from typing import Union
 
 from Utils import cache_self1
 from .base_logic import BaseLogicMixin, BaseLogic
-from .has_logic import HasLogicMixin
-from .received_logic import ReceivedLogicMixin
-from .region_logic import RegionLogicMixin
-from ..mods.logic.magic_logic import MagicLogicMixin
 from ..stardew_rule import StardewRule, False_
 from ..strings.ap_names.ap_weapon_names import APWeapon
 from ..strings.performance_names import Performance
@@ -20,7 +15,7 @@ class CombatLogicMixin(BaseLogicMixin):
         self.combat = CombatLogic(*args, **kwargs)
 
 
-class CombatLogic(BaseLogic[Union[HasLogicMixin, CombatLogicMixin, RegionLogicMixin, ReceivedLogicMixin, MagicLogicMixin]]):
+class CombatLogic(BaseLogic):
     @cache_self1
     def can_fight_at_level(self, level: str) -> StardewRule:
         if level == Performance.basic:

--- a/worlds/stardew_valley/logic/cooking_logic.py
+++ b/worlds/stardew_valley/logic/cooking_logic.py
@@ -1,17 +1,7 @@
 from functools import cached_property
-from typing import Union
 
 from Utils import cache_self1
-from .action_logic import ActionLogicMixin
 from .base_logic import BaseLogicMixin, BaseLogic
-from .building_logic import BuildingLogicMixin
-from .has_logic import HasLogicMixin
-from .money_logic import MoneyLogicMixin
-from .received_logic import ReceivedLogicMixin
-from .region_logic import RegionLogicMixin
-from .relationship_logic import RelationshipLogicMixin
-from .season_logic import SeasonLogicMixin
-from .skill_logic import SkillLogicMixin
 from ..data.recipe_data import RecipeSource, StarterSource, ShopSource, SkillSource, FriendshipSource, \
     QueenOfSauceSource, CookingRecipe, ShopFriendshipSource
 from ..data.recipe_source import CutsceneSource, ShopTradeSource
@@ -29,8 +19,7 @@ class CookingLogicMixin(BaseLogicMixin):
         self.cooking = CookingLogic(*args, **kwargs)
 
 
-class CookingLogic(BaseLogic[Union[HasLogicMixin, ReceivedLogicMixin, RegionLogicMixin, SeasonLogicMixin, MoneyLogicMixin, ActionLogicMixin,
-BuildingLogicMixin, RelationshipLogicMixin, SkillLogicMixin, CookingLogicMixin]]):
+class CookingLogic(BaseLogic):
     @cached_property
     def can_cook_in_kitchen(self) -> StardewRule:
         return self.logic.building.has_building(Building.kitchen) | self.logic.skill.has_level(Skill.foraging, 9)

--- a/worlds/stardew_valley/logic/crafting_logic.py
+++ b/worlds/stardew_valley/logic/crafting_logic.py
@@ -1,15 +1,5 @@
-from typing import Union
-
 from Utils import cache_self1
 from .base_logic import BaseLogicMixin, BaseLogic
-from .has_logic import HasLogicMixin
-from .money_logic import MoneyLogicMixin
-from .quest_logic import QuestLogicMixin
-from .received_logic import ReceivedLogicMixin
-from .region_logic import RegionLogicMixin
-from .relationship_logic import RelationshipLogicMixin
-from .skill_logic import SkillLogicMixin
-from .special_order_logic import SpecialOrderLogicMixin
 from .. import options
 from ..data.craftable_data import CraftingRecipe
 from ..data.recipe_source import CutsceneSource, ShopTradeSource, ArchipelagoSource, LogicSource, SpecialOrderSource, \
@@ -25,8 +15,7 @@ class CraftingLogicMixin(BaseLogicMixin):
         self.crafting = CraftingLogic(*args, **kwargs)
 
 
-class CraftingLogic(BaseLogic[Union[ReceivedLogicMixin, HasLogicMixin, RegionLogicMixin, MoneyLogicMixin, RelationshipLogicMixin,
-SkillLogicMixin, SpecialOrderLogicMixin, CraftingLogicMixin, QuestLogicMixin]]):
+class CraftingLogic(BaseLogic):
     @cache_self1
     def can_craft(self, recipe: CraftingRecipe = None) -> StardewRule:
         if recipe is None:

--- a/worlds/stardew_valley/logic/farming_logic.py
+++ b/worlds/stardew_valley/logic/farming_logic.py
@@ -3,11 +3,6 @@ from typing import Union, Tuple
 
 from Utils import cache_self1
 from .base_logic import BaseLogicMixin, BaseLogic
-from .has_logic import HasLogicMixin
-from .received_logic import ReceivedLogicMixin
-from .region_logic import RegionLogicMixin
-from .season_logic import SeasonLogicMixin
-from .tool_logic import ToolLogicMixin
 from .. import options
 from ..stardew_rule import StardewRule, True_, false_
 from ..strings.fertilizer_names import Fertilizer
@@ -29,7 +24,7 @@ class FarmingLogicMixin(BaseLogicMixin):
         self.farming = FarmingLogic(*args, **kwargs)
 
 
-class FarmingLogic(BaseLogic[Union[HasLogicMixin, ReceivedLogicMixin, RegionLogicMixin, SeasonLogicMixin, ToolLogicMixin, FarmingLogicMixin]]):
+class FarmingLogic(BaseLogic):
 
     @cached_property
     def has_farming_tools(self) -> StardewRule:
@@ -44,6 +39,8 @@ class FarmingLogic(BaseLogic[Union[HasLogicMixin, ReceivedLogicMixin, RegionLogi
             return self.logic.has(Fertilizer.quality)
         if tier >= 3:
             return self.logic.has(Fertilizer.deluxe)
+
+        return self.logic.false_
 
     @cache_self1
     def can_plant_and_grow_item(self, seasons: Union[str, Tuple[str]]) -> StardewRule:

--- a/worlds/stardew_valley/logic/festival_logic.py
+++ b/worlds/stardew_valley/logic/festival_logic.py
@@ -1,20 +1,4 @@
-from typing import Union
-
-from .action_logic import ActionLogicMixin
-from .animal_logic import AnimalLogicMixin
-from .artisan_logic import ArtisanLogicMixin
 from .base_logic import BaseLogicMixin, BaseLogic
-from .fishing_logic import FishingLogicMixin
-from .gift_logic import GiftLogicMixin
-from .has_logic import HasLogicMixin
-from .money_logic import MoneyLogicMixin
-from .monster_logic import MonsterLogicMixin
-from .museum_logic import MuseumLogicMixin
-from .received_logic import ReceivedLogicMixin
-from .region_logic import RegionLogicMixin
-from .relationship_logic import RelationshipLogicMixin
-from .skill_logic import SkillLogicMixin
-from .time_logic import TimeLogicMixin
 from ..options import FestivalLocations
 from ..stardew_rule import StardewRule
 from ..strings.animal_product_names import AnimalProduct
@@ -36,8 +20,7 @@ class FestivalLogicMixin(BaseLogicMixin):
         self.festival = FestivalLogic(*args, **kwargs)
 
 
-class FestivalLogic(BaseLogic[Union[HasLogicMixin, ReceivedLogicMixin, FestivalLogicMixin, ArtisanLogicMixin, AnimalLogicMixin, MoneyLogicMixin, TimeLogicMixin,
-SkillLogicMixin, RegionLogicMixin, ActionLogicMixin, MonsterLogicMixin, RelationshipLogicMixin, FishingLogicMixin, MuseumLogicMixin, GiftLogicMixin]]):
+class FestivalLogic(BaseLogic):
 
     def initialize_rules(self):
         self.registry.festival_rules.update({

--- a/worlds/stardew_valley/logic/fishing_logic.py
+++ b/worlds/stardew_valley/logic/fishing_logic.py
@@ -1,17 +1,8 @@
-from typing import Union
-
 from Utils import cache_self1
 from .base_logic import BaseLogicMixin, BaseLogic
-from .has_logic import HasLogicMixin
-from .received_logic import ReceivedLogicMixin
-from .region_logic import RegionLogicMixin
-from .season_logic import SeasonLogicMixin
-from .skill_logic import SkillLogicMixin
-from .tool_logic import ToolLogicMixin
 from ..data import fish_data
 from ..data.fish_data import FishItem
-from ..options import ExcludeGingerIsland
-from ..options import SpecialOrderLocations
+from ..options import ExcludeGingerIsland, SpecialOrderLocations
 from ..stardew_rule import StardewRule, True_, False_
 from ..strings.ap_names.mods.mod_items import SVEQuestItem
 from ..strings.craftable_names import Fishing
@@ -28,8 +19,7 @@ class FishingLogicMixin(BaseLogicMixin):
         self.fishing = FishingLogic(*args, **kwargs)
 
 
-class FishingLogic(BaseLogic[Union[HasLogicMixin, FishingLogicMixin, ReceivedLogicMixin, RegionLogicMixin, SeasonLogicMixin, ToolLogicMixin,
-SkillLogicMixin]]):
+class FishingLogic(BaseLogic):
     def can_fish_in_freshwater(self) -> StardewRule:
         return self.logic.skill.can_fish() & self.logic.region.can_reach_any((Region.forest, Region.town, Region.mountain))
 

--- a/worlds/stardew_valley/logic/gift_logic.py
+++ b/worlds/stardew_valley/logic/gift_logic.py
@@ -1,7 +1,6 @@
 from functools import cached_property
 
 from .base_logic import BaseLogic, BaseLogicMixin
-from .has_logic import HasLogicMixin
 from ..stardew_rule import StardewRule
 from ..strings.animal_product_names import AnimalProduct
 from ..strings.gift_names import Gift
@@ -13,7 +12,7 @@ class GiftLogicMixin(BaseLogicMixin):
         self.gifts = GiftLogic(*args, **kwargs)
 
 
-class GiftLogic(BaseLogic[HasLogicMixin]):
+class GiftLogic(BaseLogic):
 
     @cached_property
     def has_any_universal_love(self) -> StardewRule:

--- a/worlds/stardew_valley/logic/goal_logic.py
+++ b/worlds/stardew_valley/logic/goal_logic.py
@@ -1,5 +1,3 @@
-import typing
-
 from .base_logic import BaseLogic, BaseLogicMixin
 from ..data.craftable_data import all_crafting_recipes_by_name
 from ..data.recipe_data import all_cooking_recipes_by_name
@@ -12,11 +10,6 @@ from ..strings.quest_names import Quest
 from ..strings.season_names import Season
 from ..strings.wallet_item_names import Wallet
 
-if typing.TYPE_CHECKING:
-    from .logic import StardewLogic
-else:
-    StardewLogic = object
-
 
 class GoalLogicMixin(BaseLogicMixin):
     def __init__(self, *args, **kwargs):
@@ -24,7 +17,7 @@ class GoalLogicMixin(BaseLogicMixin):
         self.goal = GoalLogic(*args, **kwargs)
 
 
-class GoalLogic(BaseLogic[StardewLogic]):
+class GoalLogic(BaseLogic):
 
     def can_complete_community_center(self) -> StardewRule:
         return self.logic.bundle.can_complete_community_center

--- a/worlds/stardew_valley/logic/grind_logic.py
+++ b/worlds/stardew_valley/logic/grind_logic.py
@@ -38,7 +38,7 @@ class GrindLogicMixin(BaseLogicMixin):
         self.grind = GrindLogic(*args, **kwargs)
 
 
-class GrindLogic(BaseLogic[Union[GrindLogicMixin, HasLogicMixin, ReceivedLogicMixin, RegionLogicMixin, BookLogicMixin, TimeLogicMixin, ToolLogicMixin]]):
+class GrindLogic(BaseLogic):
 
     def can_grind_mystery_boxes(self, quantity: int) -> StardewRule:
         opening_rule = self.logic.region.can_reach(Region.blacksmith)

--- a/worlds/stardew_valley/logic/harvesting_logic.py
+++ b/worlds/stardew_valley/logic/harvesting_logic.py
@@ -1,15 +1,7 @@
 from functools import cached_property
-from typing import Union
 
 from Utils import cache_self1
 from .base_logic import BaseLogicMixin, BaseLogic
-from .farming_logic import FarmingLogicMixin
-from .has_logic import HasLogicMixin
-from .received_logic import ReceivedLogicMixin
-from .region_logic import RegionLogicMixin
-from .season_logic import SeasonLogicMixin
-from .time_logic import TimeLogicMixin
-from .tool_logic import ToolLogicMixin
 from ..data.harvest import ForagingSource, HarvestFruitTreeSource, HarvestCropSource
 from ..stardew_rule import StardewRule
 from ..strings.ap_names.community_upgrade_names import CommunityUpgrade
@@ -22,8 +14,7 @@ class HarvestingLogicMixin(BaseLogicMixin):
         self.harvesting = HarvestingLogic(*args, **kwargs)
 
 
-class HarvestingLogic(BaseLogic[Union[HarvestingLogicMixin, HasLogicMixin, ReceivedLogicMixin, RegionLogicMixin, SeasonLogicMixin, ToolLogicMixin,
-FarmingLogicMixin, TimeLogicMixin]]):
+class HarvestingLogic(BaseLogic):
 
     @cached_property
     def can_harvest_from_fruit_bats(self) -> StardewRule:

--- a/worlds/stardew_valley/logic/has_logic.py
+++ b/worlds/stardew_valley/logic/has_logic.py
@@ -2,7 +2,7 @@ from .base_logic import BaseLogic
 from ..stardew_rule import StardewRule, And, Or, Has, Count, true_, false_, HasProgressionPercent
 
 
-class HasLogicMixin(BaseLogic[None]):
+class HasLogicMixin(BaseLogic):
     true_ = true_
     false_ = false_
 

--- a/worlds/stardew_valley/logic/logic_and_mods_design.md
+++ b/worlds/stardew_valley/logic/logic_and_mods_design.md
@@ -12,7 +12,7 @@ class TimeLogicMixin(BaseLogicMixin):
         self.time = TimeLogic(*args, **kwargs)
 
 
-class TimeLogic(BaseLogic[Union[TimeLogicMixin, ReceivedLogicMixin]]):
+class TimeLogic(BaseLogic):
 
     def has_lived_months(self, number: int) -> StardewRule:
         return self.logic.received(Event.month_end, number)

--- a/worlds/stardew_valley/logic/mine_logic.py
+++ b/worlds/stardew_valley/logic/mine_logic.py
@@ -1,14 +1,5 @@
-from typing import Union
-
 from Utils import cache_self1
 from .base_logic import BaseLogicMixin, BaseLogic
-from .combat_logic import CombatLogicMixin
-from .cooking_logic import CookingLogicMixin
-from .has_logic import HasLogicMixin
-from .received_logic import ReceivedLogicMixin
-from .region_logic import RegionLogicMixin
-from .skill_logic import SkillLogicMixin
-from .tool_logic import ToolLogicMixin
 from .. import options
 from ..stardew_rule import StardewRule, True_
 from ..strings.performance_names import Performance
@@ -23,8 +14,7 @@ class MineLogicMixin(BaseLogicMixin):
         self.mine = MineLogic(*args, **kwargs)
 
 
-class MineLogic(BaseLogic[Union[HasLogicMixin, MineLogicMixin, RegionLogicMixin, ReceivedLogicMixin, CombatLogicMixin, ToolLogicMixin,
-SkillLogicMixin, CookingLogicMixin]]):
+class MineLogic(BaseLogic):
     # Regions
     def can_mine_in_the_mines_floor_1_40(self) -> StardewRule:
         return self.logic.region.can_reach(Region.mines_floor_5)

--- a/worlds/stardew_valley/logic/money_logic.py
+++ b/worlds/stardew_valley/logic/money_logic.py
@@ -1,5 +1,4 @@
 import typing
-from typing import Union
 
 from Utils import cache_self1
 from .base_logic import BaseLogicMixin, BaseLogic
@@ -16,7 +15,7 @@ from ..strings.currency_names import Currency
 from ..strings.region_names import Region, LogicRegion
 
 if typing.TYPE_CHECKING:
-    from .shipping_logic import ShippingLogicMixin
+    pass
 else:
     ShippingLogicMixin = object
 
@@ -30,8 +29,7 @@ class MoneyLogicMixin(BaseLogicMixin):
         self.money = MoneyLogic(*args, **kwargs)
 
 
-class MoneyLogic(BaseLogic[Union[RegionLogicMixin, MoneyLogicMixin, TimeLogicMixin, RegionLogicMixin, ReceivedLogicMixin, HasLogicMixin, SeasonLogicMixin,
-GrindLogicMixin, ShippingLogicMixin]]):
+class MoneyLogic(BaseLogic):
 
     @cache_self1
     def can_have_earned_total(self, amount: int) -> StardewRule:

--- a/worlds/stardew_valley/logic/money_logic.py
+++ b/worlds/stardew_valley/logic/money_logic.py
@@ -1,23 +1,10 @@
-import typing
-
 from Utils import cache_self1
 from .base_logic import BaseLogicMixin, BaseLogic
-from .grind_logic import GrindLogicMixin
-from .has_logic import HasLogicMixin
-from .received_logic import ReceivedLogicMixin
-from .region_logic import RegionLogicMixin
-from .season_logic import SeasonLogicMixin
-from .time_logic import TimeLogicMixin
 from ..data.shop import ShopSource
 from ..options import SpecialOrderLocations
 from ..stardew_rule import StardewRule, True_, HasProgressionPercent, False_, true_
 from ..strings.currency_names import Currency
 from ..strings.region_names import Region, LogicRegion
-
-if typing.TYPE_CHECKING:
-    pass
-else:
-    ShippingLogicMixin = object
 
 qi_gem_rewards = ("100 Qi Gems", "50 Qi Gems", "40 Qi Gems", "35 Qi Gems", "25 Qi Gems",
                   "20 Qi Gems", "15 Qi Gems", "10 Qi Gems")

--- a/worlds/stardew_valley/logic/monster_logic.py
+++ b/worlds/stardew_valley/logic/monster_logic.py
@@ -20,7 +20,7 @@ class MonsterLogicMixin(BaseLogicMixin):
         self.monster = MonsterLogic(*args, **kwargs)
 
 
-class MonsterLogic(BaseLogic[Union[HasLogicMixin, MonsterLogicMixin, RegionLogicMixin, CombatLogicMixin, TimeLogicMixin]]):
+class MonsterLogic(BaseLogic):
 
     @cached_property
     def all_monsters_by_name(self):

--- a/worlds/stardew_valley/logic/museum_logic.py
+++ b/worlds/stardew_valley/logic/museum_logic.py
@@ -22,7 +22,7 @@ class MuseumLogicMixin(BaseLogicMixin):
         self.museum = MuseumLogic(*args, **kwargs)
 
 
-class MuseumLogic(BaseLogic[Union[ReceivedLogicMixin, HasLogicMixin, TimeLogicMixin, RegionLogicMixin, ActionLogicMixin, ToolLogicMixin, MuseumLogicMixin]]):
+class MuseumLogic(BaseLogic):
 
     def can_donate_museum_items(self, number: int) -> StardewRule:
         return self.logic.region.can_reach(Region.museum) & self.logic.museum.can_find_museum_items(number)

--- a/worlds/stardew_valley/logic/pet_logic.py
+++ b/worlds/stardew_valley/logic/pet_logic.py
@@ -1,11 +1,6 @@
 import math
-from typing import Union
 
 from .base_logic import BaseLogicMixin, BaseLogic
-from .received_logic import ReceivedLogicMixin
-from .region_logic import RegionLogicMixin
-from .time_logic import TimeLogicMixin
-from .tool_logic import ToolLogicMixin
 from ..content.feature.friendsanity import pet_heart_item_name
 from ..stardew_rule import StardewRule, True_
 from ..strings.region_names import Region
@@ -17,7 +12,7 @@ class PetLogicMixin(BaseLogicMixin):
         self.pet = PetLogic(*args, **kwargs)
 
 
-class PetLogic(BaseLogic[Union[RegionLogicMixin, ReceivedLogicMixin, TimeLogicMixin, ToolLogicMixin]]):
+class PetLogic(BaseLogic):
     def has_pet_hearts(self, hearts: int = 1) -> StardewRule:
         assert hearts >= 0, "You can't have negative hearts with a pet."
         if hearts == 0:

--- a/worlds/stardew_valley/logic/quality_logic.py
+++ b/worlds/stardew_valley/logic/quality_logic.py
@@ -14,7 +14,7 @@ class QualityLogicMixin(BaseLogicMixin):
         self.quality = QualityLogic(*args, **kwargs)
 
 
-class QualityLogic(BaseLogic[Union[SkillLogicMixin, FarmingLogicMixin]]):
+class QualityLogic(BaseLogic):
 
     @cache_self1
     def can_grow_crop_quality(self, quality: str) -> StardewRule:

--- a/worlds/stardew_valley/logic/quest_logic.py
+++ b/worlds/stardew_valley/logic/quest_logic.py
@@ -1,21 +1,6 @@
-from typing import Dict, Union
+from typing import Dict
 
 from .base_logic import BaseLogicMixin, BaseLogic
-from .building_logic import BuildingLogicMixin
-from .combat_logic import CombatLogicMixin
-from .cooking_logic import CookingLogicMixin
-from .fishing_logic import FishingLogicMixin
-from .has_logic import HasLogicMixin
-from .mine_logic import MineLogicMixin
-from .money_logic import MoneyLogicMixin
-from .received_logic import ReceivedLogicMixin
-from .region_logic import RegionLogicMixin
-from .relationship_logic import RelationshipLogicMixin
-from .season_logic import SeasonLogicMixin
-from .skill_logic import SkillLogicMixin
-from .time_logic import TimeLogicMixin
-from .tool_logic import ToolLogicMixin
-from .wallet_logic import WalletLogicMixin
 from ..stardew_rule import StardewRule, Has, True_
 from ..strings.ap_names.community_upgrade_names import CommunityUpgrade
 from ..strings.artisan_good_names import ArtisanGood
@@ -43,9 +28,7 @@ class QuestLogicMixin(BaseLogicMixin):
         self.quest = QuestLogic(*args, **kwargs)
 
 
-class QuestLogic(BaseLogic[Union[HasLogicMixin, ReceivedLogicMixin, MoneyLogicMixin, MineLogicMixin, RegionLogicMixin, RelationshipLogicMixin, ToolLogicMixin,
-                                 FishingLogicMixin, CookingLogicMixin, CombatLogicMixin, SeasonLogicMixin, SkillLogicMixin, WalletLogicMixin, QuestLogicMixin,
-                                 BuildingLogicMixin, TimeLogicMixin]]):
+class QuestLogic(BaseLogic):
 
     def initialize_rules(self):
         self.update_rules({

--- a/worlds/stardew_valley/logic/received_logic.py
+++ b/worlds/stardew_valley/logic/received_logic.py
@@ -8,7 +8,7 @@ from ..items import item_table
 from ..stardew_rule import StardewRule, Received, TotalReceived
 
 
-class ReceivedLogicMixin(BaseLogic[HasLogicMixin], BaseLogicMixin):
+class ReceivedLogicMixin(BaseLogic, BaseLogicMixin):
     def received(self, item: str, count: Optional[int] = 1) -> StardewRule:
         assert count >= 0, "Can't receive a negative amount of item."
 

--- a/worlds/stardew_valley/logic/region_logic.py
+++ b/worlds/stardew_valley/logic/region_logic.py
@@ -29,7 +29,7 @@ class RegionLogicMixin(BaseLogicMixin):
         self.region = RegionLogic(*args, **kwargs)
 
 
-class RegionLogic(BaseLogic[Union[RegionLogicMixin, HasLogicMixin]]):
+class RegionLogic(BaseLogic):
 
     @cache_self1
     def can_reach(self, region_name: str) -> StardewRule:

--- a/worlds/stardew_valley/logic/relationship_logic.py
+++ b/worlds/stardew_valley/logic/relationship_logic.py
@@ -4,13 +4,6 @@ from typing import Union
 
 from Utils import cache_self1
 from .base_logic import BaseLogic, BaseLogicMixin
-from .building_logic import BuildingLogicMixin
-from .gift_logic import GiftLogicMixin
-from .has_logic import HasLogicMixin
-from .received_logic import ReceivedLogicMixin
-from .region_logic import RegionLogicMixin
-from .season_logic import SeasonLogicMixin
-from .time_logic import TimeLogicMixin
 from ..content.feature import friendsanity
 from ..data.villagers_data import Villager
 from ..stardew_rule import StardewRule, True_, false_, true_
@@ -23,7 +16,7 @@ from ..strings.season_names import Season
 from ..strings.villager_names import NPC, ModNPC
 
 if typing.TYPE_CHECKING:
-    from ..mods.logic.mod_logic import ModLogicMixin
+    pass
 else:
     ModLogicMixin = object
 
@@ -43,8 +36,7 @@ class RelationshipLogicMixin(BaseLogicMixin):
         self.relationship = RelationshipLogic(*args, **kwargs)
 
 
-class RelationshipLogic(BaseLogic[Union[RelationshipLogicMixin, BuildingLogicMixin, SeasonLogicMixin, TimeLogicMixin, GiftLogicMixin, RegionLogicMixin,
-ReceivedLogicMixin, HasLogicMixin, ModLogicMixin]]):
+class RelationshipLogic(BaseLogic):
 
     def can_date(self, npc: str) -> StardewRule:
         return self.logic.relationship.has_hearts(npc, 8) & self.logic.has(Gift.bouquet)

--- a/worlds/stardew_valley/logic/relationship_logic.py
+++ b/worlds/stardew_valley/logic/relationship_logic.py
@@ -1,5 +1,4 @@
 import math
-import typing
 from typing import Union
 
 from Utils import cache_self1
@@ -14,11 +13,6 @@ from ..strings.gift_names import Gift
 from ..strings.region_names import Region
 from ..strings.season_names import Season
 from ..strings.villager_names import NPC, ModNPC
-
-if typing.TYPE_CHECKING:
-    pass
-else:
-    ModLogicMixin = object
 
 possible_kids = ("Cute Baby", "Ugly Baby")
 

--- a/worlds/stardew_valley/logic/requirement_logic.py
+++ b/worlds/stardew_valley/logic/requirement_logic.py
@@ -1,20 +1,7 @@
 import functools
-from typing import Union, Iterable
+from typing import Iterable
 
 from .base_logic import BaseLogicMixin, BaseLogic
-from .book_logic import BookLogicMixin
-from .combat_logic import CombatLogicMixin
-from .fishing_logic import FishingLogicMixin
-from .has_logic import HasLogicMixin
-from .quest_logic import QuestLogicMixin
-from .received_logic import ReceivedLogicMixin
-from .region_logic import RegionLogicMixin
-from .relationship_logic import RelationshipLogicMixin
-from .season_logic import SeasonLogicMixin
-from .skill_logic import SkillLogicMixin
-from .time_logic import TimeLogicMixin
-from .tool_logic import ToolLogicMixin
-from .walnut_logic import WalnutLogicMixin
 from ..data.game_item import Requirement
 from ..data.requirement import ToolRequirement, BookRequirement, SkillRequirement, SeasonRequirement, YearRequirement, CombatRequirement, QuestRequirement, \
     RelationshipRequirement, FishingRequirement, WalnutRequirement, RegionRequirement
@@ -26,8 +13,7 @@ class RequirementLogicMixin(BaseLogicMixin):
         self.requirement = RequirementLogic(*args, **kwargs)
 
 
-class RequirementLogic(BaseLogic[Union[RequirementLogicMixin, HasLogicMixin, ReceivedLogicMixin, ToolLogicMixin, SkillLogicMixin, BookLogicMixin,
-SeasonLogicMixin, TimeLogicMixin, CombatLogicMixin, QuestLogicMixin, RelationshipLogicMixin, FishingLogicMixin, WalnutLogicMixin, RegionLogicMixin]]):
+class RequirementLogic(BaseLogic):
 
     def meet_all_requirements(self, requirements: Iterable[Requirement]):
         if not requirements:

--- a/worlds/stardew_valley/logic/season_logic.py
+++ b/worlds/stardew_valley/logic/season_logic.py
@@ -18,7 +18,7 @@ class SeasonLogicMixin(BaseLogicMixin):
         self.season = SeasonLogic(*args, **kwargs)
 
 
-class SeasonLogic(BaseLogic[Union[HasLogicMixin, SeasonLogicMixin, TimeLogicMixin, ReceivedLogicMixin]]):
+class SeasonLogic(BaseLogic):
 
     @cached_property
     def has_spring(self) -> StardewRule:

--- a/worlds/stardew_valley/logic/shipping_logic.py
+++ b/worlds/stardew_valley/logic/shipping_logic.py
@@ -20,7 +20,7 @@ class ShippingLogicMixin(BaseLogicMixin):
         self.shipping = ShippingLogic(*args, **kwargs)
 
 
-class ShippingLogic(BaseLogic[Union[ReceivedLogicMixin, ShippingLogicMixin, BuildingLogicMixin, RegionLogicMixin, HasLogicMixin]]):
+class ShippingLogic(BaseLogic):
 
     @cached_property
     def can_use_shipping_bin(self) -> StardewRule:

--- a/worlds/stardew_valley/logic/skill_logic.py
+++ b/worlds/stardew_valley/logic/skill_logic.py
@@ -4,16 +4,7 @@ from typing import Union, Tuple
 
 from Utils import cache_self1
 from .base_logic import BaseLogicMixin, BaseLogic
-from .combat_logic import CombatLogicMixin
-from .harvesting_logic import HarvestingLogicMixin
-from .has_logic import HasLogicMixin
-from .received_logic import ReceivedLogicMixin
-from .region_logic import RegionLogicMixin
-from .season_logic import SeasonLogicMixin
-from .time_logic import TimeLogicMixin
-from .tool_logic import ToolLogicMixin
 from ..data.harvest import HarvestCropSource
-from ..mods.logic.magic_logic import MagicLogicMixin
 from ..mods.logic.mod_skills_levels import get_mod_skill_levels
 from ..stardew_rule import StardewRule, true_, True_, False_
 from ..strings.craftable_names import Fishing
@@ -26,7 +17,7 @@ from ..strings.tool_names import ToolMaterial, Tool
 from ..strings.wallet_item_names import Wallet
 
 if typing.TYPE_CHECKING:
-    from ..mods.logic.mod_logic import ModLogicMixin
+    pass
 else:
     ModLogicMixin = object
 
@@ -40,8 +31,7 @@ class SkillLogicMixin(BaseLogicMixin):
         self.skill = SkillLogic(*args, **kwargs)
 
 
-class SkillLogic(BaseLogic[Union[HasLogicMixin, ReceivedLogicMixin, RegionLogicMixin, SeasonLogicMixin, TimeLogicMixin, ToolLogicMixin, SkillLogicMixin,
-CombatLogicMixin, MagicLogicMixin, HarvestingLogicMixin, ModLogicMixin]]):
+class SkillLogic(BaseLogic):
 
     # Should be cached
     def can_earn_level(self, skill: str, level: int) -> StardewRule:

--- a/worlds/stardew_valley/logic/skill_logic.py
+++ b/worlds/stardew_valley/logic/skill_logic.py
@@ -1,4 +1,3 @@
-import typing
 from functools import cached_property
 from typing import Union, Tuple
 
@@ -15,11 +14,6 @@ from ..strings.region_names import Region
 from ..strings.skill_names import Skill, all_mod_skills, all_vanilla_skills
 from ..strings.tool_names import ToolMaterial, Tool
 from ..strings.wallet_item_names import Wallet
-
-if typing.TYPE_CHECKING:
-    pass
-else:
-    ModLogicMixin = object
 
 fishing_regions = (Region.beach, Region.town, Region.forest, Region.mountain, Region.island_south, Region.island_west)
 vanilla_skill_items = ("Farming Level", "Mining Level", "Foraging Level", "Fishing Level", "Combat Level")

--- a/worlds/stardew_valley/logic/source_logic.py
+++ b/worlds/stardew_valley/logic/source_logic.py
@@ -1,17 +1,7 @@
 import functools
-from typing import Union, Any, Iterable
+from typing import Any, Iterable
 
-from .animal_logic import AnimalLogicMixin
-from .artisan_logic import ArtisanLogicMixin
 from .base_logic import BaseLogicMixin, BaseLogic
-from .grind_logic import GrindLogicMixin
-from .harvesting_logic import HarvestingLogicMixin
-from .has_logic import HasLogicMixin
-from .money_logic import MoneyLogicMixin
-from .received_logic import ReceivedLogicMixin
-from .region_logic import RegionLogicMixin
-from .requirement_logic import RequirementLogicMixin
-from .tool_logic import ToolLogicMixin
 from ..data.animal import IncubatorSource, OstrichIncubatorSource
 from ..data.artisan import MachineSource
 from ..data.game_item import GenericSource, Source, GameItem, CustomRuleSource
@@ -26,8 +16,7 @@ class SourceLogicMixin(BaseLogicMixin):
         self.source = SourceLogic(*args, **kwargs)
 
 
-class SourceLogic(BaseLogic[Union[SourceLogicMixin, HasLogicMixin, ReceivedLogicMixin, HarvestingLogicMixin, MoneyLogicMixin, RegionLogicMixin,
-ArtisanLogicMixin, ToolLogicMixin, RequirementLogicMixin, GrindLogicMixin, AnimalLogicMixin]]):
+class SourceLogic(BaseLogic):
 
     def has_access_to_item(self, item: GameItem):
         rules = []

--- a/worlds/stardew_valley/logic/special_order_logic.py
+++ b/worlds/stardew_valley/logic/special_order_logic.py
@@ -1,22 +1,6 @@
-from typing import Dict, Union
+from typing import Dict
 
-from .ability_logic import AbilityLogicMixin
-from .arcade_logic import ArcadeLogicMixin
-from .artisan_logic import ArtisanLogicMixin
 from .base_logic import BaseLogicMixin, BaseLogic
-from .cooking_logic import CookingLogicMixin
-from .has_logic import HasLogicMixin
-from .mine_logic import MineLogicMixin
-from .money_logic import MoneyLogicMixin
-from .monster_logic import MonsterLogicMixin
-from .received_logic import ReceivedLogicMixin
-from .region_logic import RegionLogicMixin
-from .relationship_logic import RelationshipLogicMixin
-from .season_logic import SeasonLogicMixin
-from .shipping_logic import ShippingLogicMixin
-from .skill_logic import SkillLogicMixin
-from .time_logic import TimeLogicMixin
-from .tool_logic import ToolLogicMixin
 from ..content.vanilla.ginger_island import ginger_island_content_pack
 from ..content.vanilla.qi_board import qi_board_content_pack
 from ..stardew_rule import StardewRule, Has, false_
@@ -44,10 +28,7 @@ class SpecialOrderLogicMixin(BaseLogicMixin):
         self.special_order = SpecialOrderLogic(*args, **kwargs)
 
 
-class SpecialOrderLogic(BaseLogic[Union[HasLogicMixin, ReceivedLogicMixin, RegionLogicMixin, SeasonLogicMixin, TimeLogicMixin, MoneyLogicMixin,
-ShippingLogicMixin, ArcadeLogicMixin, ArtisanLogicMixin, RelationshipLogicMixin, ToolLogicMixin, SkillLogicMixin,
-MineLogicMixin, CookingLogicMixin,
-AbilityLogicMixin, SpecialOrderLogicMixin, MonsterLogicMixin]]):
+class SpecialOrderLogic(BaseLogic):
 
     def initialize_rules(self):
         self.update_rules({

--- a/worlds/stardew_valley/logic/time_logic.py
+++ b/worlds/stardew_valley/logic/time_logic.py
@@ -22,7 +22,7 @@ class TimeLogicMixin(BaseLogicMixin):
         self.time = TimeLogic(*args, **kwargs)
 
 
-class TimeLogic(BaseLogic[Union[TimeLogicMixin, HasLogicMixin]]):
+class TimeLogic(BaseLogic):
 
     @cache_self1
     def has_lived_months(self, number: int) -> StardewRule:

--- a/worlds/stardew_valley/logic/tool_logic.py
+++ b/worlds/stardew_valley/logic/tool_logic.py
@@ -2,12 +2,6 @@ from typing import Union, Iterable, Tuple
 
 from Utils import cache_self1
 from .base_logic import BaseLogicMixin, BaseLogic
-from .has_logic import HasLogicMixin
-from .money_logic import MoneyLogicMixin
-from .received_logic import ReceivedLogicMixin
-from .region_logic import RegionLogicMixin
-from .season_logic import SeasonLogicMixin
-from ..mods.logic.magic_logic import MagicLogicMixin
 from ..stardew_rule import StardewRule, True_, False_
 from ..strings.ap_names.skill_level_names import ModSkillLevel
 from ..strings.region_names import Region, LogicRegion
@@ -40,7 +34,7 @@ class ToolLogicMixin(BaseLogicMixin):
         self.tool = ToolLogic(*args, **kwargs)
 
 
-class ToolLogic(BaseLogic[Union[ToolLogicMixin, HasLogicMixin, ReceivedLogicMixin, RegionLogicMixin, SeasonLogicMixin, MoneyLogicMixin, MagicLogicMixin]]):
+class ToolLogic(BaseLogic):
 
     def has_all_tools(self, tools: Iterable[Tuple[str, str]]):
         return self.logic.and_(*(self.logic.tool.has_tool(tool, material) for tool, material in tools))

--- a/worlds/stardew_valley/logic/traveling_merchant_logic.py
+++ b/worlds/stardew_valley/logic/traveling_merchant_logic.py
@@ -12,7 +12,7 @@ class TravelingMerchantLogicMixin(BaseLogicMixin):
         self.traveling_merchant = TravelingMerchantLogic(*args, **kwargs)
 
 
-class TravelingMerchantLogic(BaseLogic[Union[TravelingMerchantLogicMixin, ReceivedLogicMixin]]):
+class TravelingMerchantLogic(BaseLogic):
 
     def has_days(self, number_days: int = 1):
         if number_days <= 0:

--- a/worlds/stardew_valley/logic/wallet_logic.py
+++ b/worlds/stardew_valley/logic/wallet_logic.py
@@ -10,7 +10,7 @@ class WalletLogicMixin(BaseLogicMixin):
         self.wallet = WalletLogic(*args, **kwargs)
 
 
-class WalletLogic(BaseLogic[ReceivedLogicMixin]):
+class WalletLogic(BaseLogic):
 
     def can_speak_dwarf(self) -> StardewRule:
         return self.logic.received(Wallet.dwarvish_translation_guide)

--- a/worlds/stardew_valley/logic/walnut_logic.py
+++ b/worlds/stardew_valley/logic/walnut_logic.py
@@ -1,12 +1,6 @@
 from functools import cached_property
-from typing import Union
 
-from .ability_logic import AbilityLogicMixin
 from .base_logic import BaseLogic, BaseLogicMixin
-from .combat_logic import CombatLogicMixin
-from .has_logic import HasLogicMixin
-from .received_logic import ReceivedLogicMixin
-from .region_logic import RegionLogicMixin
 from ..options import ExcludeGingerIsland, Walnutsanity
 from ..stardew_rule import StardewRule, False_, True_
 from ..strings.ap_names.ap_option_names import WalnutsanityOptionName
@@ -24,8 +18,7 @@ class WalnutLogicMixin(BaseLogicMixin):
         self.walnut = WalnutLogic(*args, **kwargs)
 
 
-class WalnutLogic(BaseLogic[Union[WalnutLogicMixin, ReceivedLogicMixin, HasLogicMixin, RegionLogicMixin, CombatLogicMixin,
-AbilityLogicMixin]]):
+class WalnutLogic(BaseLogic):
 
     def has_walnut(self, number: int) -> StardewRule:
         if self.options.exclude_ginger_island == ExcludeGingerIsland.option_true:

--- a/worlds/stardew_valley/mods/logic/deepwoods_logic.py
+++ b/worlds/stardew_valley/mods/logic/deepwoods_logic.py
@@ -1,13 +1,5 @@
-from typing import Union
-
+from ..mod_data import ModNames
 from ...logic.base_logic import BaseLogicMixin, BaseLogic
-from ...logic.combat_logic import CombatLogicMixin
-from ...logic.cooking_logic import CookingLogicMixin
-from ...logic.has_logic import HasLogicMixin
-from ...logic.received_logic import ReceivedLogicMixin
-from ...logic.skill_logic import SkillLogicMixin
-from ...logic.tool_logic import ToolLogicMixin
-from ...mods.mod_data import ModNames
 from ...options import ElevatorProgression
 from ...stardew_rule import StardewRule, True_, true_
 from ...strings.ap_names.mods.mod_items import DeepWoodsItem
@@ -25,8 +17,7 @@ class DeepWoodsLogicMixin(BaseLogicMixin):
         self.deepwoods = DeepWoodsLogic(*args, **kwargs)
 
 
-class DeepWoodsLogic(BaseLogic[Union[SkillLogicMixin, ReceivedLogicMixin, HasLogicMixin, CombatLogicMixin, ToolLogicMixin, SkillLogicMixin,
-CookingLogicMixin]]):
+class DeepWoodsLogic(BaseLogic):
 
     def can_reach_woods_depth(self, depth: int) -> StardewRule:
         # Assuming you can always do the 10 first floor

--- a/worlds/stardew_valley/mods/logic/elevator_logic.py
+++ b/worlds/stardew_valley/mods/logic/elevator_logic.py
@@ -1,5 +1,4 @@
 from ...logic.base_logic import BaseLogicMixin, BaseLogic
-from ...logic.received_logic import ReceivedLogicMixin
 from ...mods.mod_data import ModNames
 from ...options import ElevatorProgression
 from ...stardew_rule import StardewRule, True_
@@ -11,7 +10,7 @@ class ModElevatorLogicMixin(BaseLogicMixin):
         self.elevator = ModElevatorLogic(*args, **kwargs)
 
 
-class ModElevatorLogic(BaseLogic[ReceivedLogicMixin]):
+class ModElevatorLogic(BaseLogic):
     def has_skull_cavern_elevator_to_floor(self, floor: int) -> StardewRule:
         if self.options.elevator_progression != ElevatorProgression.option_vanilla and ModNames.skull_cavern_elevator in self.options.mods:
             return self.logic.received("Progressive Skull Cavern Elevator", floor // 25)

--- a/worlds/stardew_valley/mods/logic/item_logic.py
+++ b/worlds/stardew_valley/mods/logic/item_logic.py
@@ -1,23 +1,7 @@
-from typing import Dict, Union
+from typing import Dict
 
 from ..mod_data import ModNames
 from ...logic.base_logic import BaseLogicMixin, BaseLogic
-from ...logic.combat_logic import CombatLogicMixin
-from ...logic.cooking_logic import CookingLogicMixin
-from ...logic.crafting_logic import CraftingLogicMixin
-from ...logic.farming_logic import FarmingLogicMixin
-from ...logic.fishing_logic import FishingLogicMixin
-from ...logic.has_logic import HasLogicMixin
-from ...logic.money_logic import MoneyLogicMixin
-from ...logic.museum_logic import MuseumLogicMixin
-from ...logic.quest_logic import QuestLogicMixin
-from ...logic.received_logic import ReceivedLogicMixin
-from ...logic.region_logic import RegionLogicMixin
-from ...logic.relationship_logic import RelationshipLogicMixin
-from ...logic.season_logic import SeasonLogicMixin
-from ...logic.skill_logic import SkillLogicMixin
-from ...logic.time_logic import TimeLogicMixin
-from ...logic.tool_logic import ToolLogicMixin
 from ...stardew_rule import StardewRule
 from ...strings.artisan_good_names import ModArtisanGood
 from ...strings.craftable_names import ModCraftable
@@ -39,9 +23,7 @@ class ModItemLogicMixin(BaseLogicMixin):
         self.item = ModItemLogic(*args, **kwargs)
 
 
-class ModItemLogic(BaseLogic[Union[CombatLogicMixin, ReceivedLogicMixin, CookingLogicMixin, FishingLogicMixin, HasLogicMixin, MoneyLogicMixin,
-RegionLogicMixin, SeasonLogicMixin, RelationshipLogicMixin, MuseumLogicMixin, ToolLogicMixin, CraftingLogicMixin, SkillLogicMixin, TimeLogicMixin, QuestLogicMixin,
-FarmingLogicMixin]]):
+class ModItemLogic(BaseLogic):
 
     def get_modded_item_rules(self) -> Dict[str, StardewRule]:
         items = dict()

--- a/worlds/stardew_valley/mods/logic/magic_logic.py
+++ b/worlds/stardew_valley/mods/logic/magic_logic.py
@@ -1,9 +1,4 @@
-from typing import Union
-
 from ...logic.base_logic import BaseLogicMixin, BaseLogic
-from ...logic.has_logic import HasLogicMixin
-from ...logic.received_logic import ReceivedLogicMixin
-from ...logic.region_logic import RegionLogicMixin
 from ...mods.mod_data import ModNames
 from ...stardew_rule import StardewRule, False_
 from ...strings.ap_names.skill_level_names import ModSkillLevel
@@ -18,7 +13,7 @@ class MagicLogicMixin(BaseLogicMixin):
 
 
 # TODO add logic.mods.magic for altar
-class MagicLogic(BaseLogic[Union[RegionLogicMixin, ReceivedLogicMixin, HasLogicMixin]]):
+class MagicLogic(BaseLogic):
     def can_use_clear_debris_instead_of_tool_level(self, level: int) -> StardewRule:
         if ModNames.magic not in self.options.mods:
             return False_()

--- a/worlds/stardew_valley/mods/logic/quests_logic.py
+++ b/worlds/stardew_valley/mods/logic/quests_logic.py
@@ -1,15 +1,7 @@
-from typing import Dict, Union
+from typing import Dict
 
 from ..mod_data import ModNames
 from ...logic.base_logic import BaseLogic, BaseLogicMixin
-from ...logic.has_logic import HasLogicMixin
-from ...logic.monster_logic import MonsterLogicMixin
-from ...logic.quest_logic import QuestLogicMixin
-from ...logic.received_logic import ReceivedLogicMixin
-from ...logic.region_logic import RegionLogicMixin
-from ...logic.relationship_logic import RelationshipLogicMixin
-from ...logic.season_logic import SeasonLogicMixin
-from ...logic.time_logic import TimeLogicMixin
 from ...stardew_rule import StardewRule
 from ...strings.animal_product_names import AnimalProduct
 from ...strings.ap_names.mods.mod_items import SVEQuestItem
@@ -34,8 +26,7 @@ class ModQuestLogicMixin(BaseLogicMixin):
         self.quest = ModQuestLogic(*args, **kwargs)
 
 
-class ModQuestLogic(BaseLogic[Union[HasLogicMixin, QuestLogicMixin, ReceivedLogicMixin, RegionLogicMixin,
-TimeLogicMixin, SeasonLogicMixin, RelationshipLogicMixin, MonsterLogicMixin]]):
+class ModQuestLogic(BaseLogic):
     def get_modded_quest_rules(self) -> Dict[str, StardewRule]:
         quests = dict()
         quests.update(self._get_juna_quest_rules())

--- a/worlds/stardew_valley/mods/logic/skills_logic.py
+++ b/worlds/stardew_valley/mods/logic/skills_logic.py
@@ -1,17 +1,4 @@
-from typing import Union
-
-from .magic_logic import MagicLogicMixin
-from ...logic.action_logic import ActionLogicMixin
 from ...logic.base_logic import BaseLogicMixin, BaseLogic
-from ...logic.building_logic import BuildingLogicMixin
-from ...logic.cooking_logic import CookingLogicMixin
-from ...logic.crafting_logic import CraftingLogicMixin
-from ...logic.fishing_logic import FishingLogicMixin
-from ...logic.has_logic import HasLogicMixin
-from ...logic.received_logic import ReceivedLogicMixin
-from ...logic.region_logic import RegionLogicMixin
-from ...logic.relationship_logic import RelationshipLogicMixin
-from ...logic.tool_logic import ToolLogicMixin
 from ...mods.mod_data import ModNames
 from ...stardew_rule import StardewRule, False_, True_, And
 from ...strings.building_names import Building
@@ -30,8 +17,7 @@ class ModSkillLogicMixin(BaseLogicMixin):
         self.skill = ModSkillLogic(*args, **kwargs)
 
 
-class ModSkillLogic(BaseLogic[Union[HasLogicMixin, ReceivedLogicMixin, RegionLogicMixin, ActionLogicMixin, RelationshipLogicMixin, BuildingLogicMixin,
-ToolLogicMixin, FishingLogicMixin, CookingLogicMixin, CraftingLogicMixin, MagicLogicMixin]]):
+class ModSkillLogic(BaseLogic):
     def has_mod_level(self, skill: str, level: int) -> StardewRule:
         if level <= 0:
             return True_()

--- a/worlds/stardew_valley/mods/logic/special_orders_logic.py
+++ b/worlds/stardew_valley/mods/logic/special_orders_logic.py
@@ -1,17 +1,6 @@
-from typing import Union
-
 from ..mod_data import ModNames
 from ...data.craftable_data import all_crafting_recipes_by_name
-from ...logic.action_logic import ActionLogicMixin
-from ...logic.artisan_logic import ArtisanLogicMixin
 from ...logic.base_logic import BaseLogicMixin, BaseLogic
-from ...logic.crafting_logic import CraftingLogicMixin
-from ...logic.has_logic import HasLogicMixin
-from ...logic.received_logic import ReceivedLogicMixin
-from ...logic.region_logic import RegionLogicMixin
-from ...logic.relationship_logic import RelationshipLogicMixin
-from ...logic.season_logic import SeasonLogicMixin
-from ...logic.wallet_logic import WalletLogicMixin
 from ...strings.ap_names.community_upgrade_names import CommunityUpgrade
 from ...strings.artisan_good_names import ArtisanGood
 from ...strings.craftable_names import Consumable, Edible, Bomb
@@ -33,8 +22,7 @@ class ModSpecialOrderLogicMixin(BaseLogicMixin):
         self.special_order = ModSpecialOrderLogic(*args, **kwargs)
 
 
-class ModSpecialOrderLogic(BaseLogic[Union[ActionLogicMixin, ArtisanLogicMixin, CraftingLogicMixin, HasLogicMixin, RegionLogicMixin,
-ReceivedLogicMixin, RelationshipLogicMixin, SeasonLogicMixin, WalletLogicMixin]]):
+class ModSpecialOrderLogic(BaseLogic):
     def get_modded_special_orders_rules(self):
         special_orders = {}
         if ModNames.juna in self.options.mods:

--- a/worlds/stardew_valley/mods/logic/sve_logic.py
+++ b/worlds/stardew_valley/mods/logic/sve_logic.py
@@ -1,18 +1,5 @@
-from typing import Union
-
 from ..mod_regions import SVERegion
 from ...logic.base_logic import BaseLogicMixin, BaseLogic
-from ...logic.combat_logic import CombatLogicMixin
-from ...logic.cooking_logic import CookingLogicMixin
-from ...logic.has_logic import HasLogicMixin
-from ...logic.money_logic import MoneyLogicMixin
-from ...logic.quest_logic import QuestLogicMixin
-from ...logic.received_logic import ReceivedLogicMixin
-from ...logic.region_logic import RegionLogicMixin
-from ...logic.relationship_logic import RelationshipLogicMixin
-from ...logic.season_logic import SeasonLogicMixin
-from ...logic.time_logic import TimeLogicMixin
-from ...logic.tool_logic import ToolLogicMixin
 from ...strings.ap_names.mods.mod_items import SVELocation, SVERunes, SVEQuestItem
 from ...strings.quest_names import ModQuest
 from ...strings.quest_names import Quest
@@ -27,8 +14,7 @@ class SVELogicMixin(BaseLogicMixin):
         self.sve = SVELogic(*args, **kwargs)
 
 
-class SVELogic(BaseLogic[Union[HasLogicMixin, ReceivedLogicMixin, QuestLogicMixin, RegionLogicMixin, RelationshipLogicMixin, TimeLogicMixin, ToolLogicMixin,
-                               CookingLogicMixin, MoneyLogicMixin, CombatLogicMixin, SeasonLogicMixin]]):
+class SVELogic(BaseLogic):
     def initialize_rules(self):
         self.registry.sve_location_rules.update({
             SVELocation.tempered_galaxy_sword: self.logic.money.can_spend_at(SVERegion.alesia_shop, 350000),

--- a/worlds/stardew_valley/mods/logic/sve_logic.py
+++ b/worlds/stardew_valley/mods/logic/sve_logic.py
@@ -1,8 +1,7 @@
 from ..mod_regions import SVERegion
 from ...logic.base_logic import BaseLogicMixin, BaseLogic
 from ...strings.ap_names.mods.mod_items import SVELocation, SVERunes, SVEQuestItem
-from ...strings.quest_names import ModQuest
-from ...strings.quest_names import Quest
+from ...strings.quest_names import Quest, ModQuest
 from ...strings.region_names import Region
 from ...strings.tool_names import Tool, ToolMaterial
 from ...strings.wallet_item_names import Wallet


### PR DESCRIPTION
## What is this fixing or adding?
This removes the necessity to add logic mixins in the generic type argument of `BaseLogic`. Now, `BaseLogic` just import `StardewLogic` for its `logic` attribute for type checking. All logic is available from all sub logic class, no longer need to add the correct mixin when you want to use rules from other file! 

## How was this tested?
Yes

## If this makes graphical changes, please attach screenshots.
N/A