### PR TITLE
TUNIC: Lock pre-placed filler to make the game play nicer with prog balancing

### DIFF
--- a/worlds/tunic/__init__.py
+++ b/worlds/tunic/__init__.py
@@ -486,10 +486,10 @@ class TunicWorld(World):
             multiworld.random.shuffle(non_grass_fill_locations)
 
             for filler_item in grass_fill:
-                multiworld.push_item(grass_fill_locations.pop(), filler_item, collect=False)
+                grass_fill_locations.pop().place_locked_item(filler_item)
 
             for filler_item in non_grass_fill:
-                multiworld.push_item(non_grass_fill_locations.pop(), filler_item, collect=False)
+                non_grass_fill_locations.pop().place_locked_item(filler_item)
 
     def create_regions(self) -> None:
         self.tunic_portal_pairs = {}


### PR DESCRIPTION
## What is this fixing or adding?
Mysterem let me know that Tunic grass has an issue with prog balancing where it'll soak up progression items into its early spheres because of all the grass, and that locking the filler prevents that.
I can't really think of any downsides, so this seems fine?
Lemme know if someone thinks of a reason why it shouldn't be like this.

## How was this tested?
Test gens, looking at the spoiler log and vaguely seeing a trend of less early prog items being forced into Tunic, but not enough to call it statistically significant by any means.