### PR TITLE
Docs: Update comment for create_item in world api.md

### DIFF
--- a/docs/world api.md
+++ b/docs/world api.md
@@ -561,7 +561,7 @@ from .items import is_progression  # this is just a dummy
 
 
 def create_item(self, item: str) -> MyGameItem:
-    # this is called when AP wants to create an item by name (for plando) or when you call it from your own code
+    # this is called when AP wants to create an item by name (for plando, start inventory, item links) or when you call it from your own code
     classification = ItemClassification.progression if is_progression(item) else ItemClassification.filler
     return MyGameItem(item, classification, self.item_name_to_id[item], self.player)
 


### PR DESCRIPTION
## What is this fixing or adding?
Update the comment to note that your world's `create_item` is used for start inventory and item links too, not just plando.
This seems to be an occasional issue in APWorlds where they'll effectively default items as filler and only call them progression as needed, so a little clarity here might help.