### PR TITLE
Stardew Valley: Replace event creation stardew code with add_event

### DIFF
--- a/worlds/stardew_valley/__init__.py
+++ b/worlds/stardew_valley/__init__.py
@@ -299,12 +299,7 @@ class StardewValleyWorld(World):
 
         return StardewItem(item.name, override_classification, item.code, self.player)
 
-    def create_event_location(self, location_data: LocationData, rule: StardewRule = None, item: str | None = None):
-        if rule is None:
-            rule = True_()
-        if item is None:
-            item = location_data.name
-
+    def create_event_location(self, location_data: LocationData, rule: StardewRule, item: str):
         region = self.multiworld.get_region(location_data.region, self.player)
         region.add_event(location_data.name, item, rule, StardewLocation, StardewItem)
 

--- a/worlds/stardew_valley/__init__.py
+++ b/worlds/stardew_valley/__init__.py
@@ -299,17 +299,14 @@ class StardewValleyWorld(World):
 
         return StardewItem(item.name, override_classification, item.code, self.player)
 
-    def create_event_location(self, location_data: LocationData, rule: StardewRule = None, item: Optional[str] = None):
+    def create_event_location(self, location_data: LocationData, rule: StardewRule = None, item: str | None = None):
         if rule is None:
             rule = True_()
         if item is None:
             item = location_data.name
 
         region = self.multiworld.get_region(location_data.region, self.player)
-        location = StardewLocation(self.player, location_data.name, None, region)
-        location.access_rule = rule
-        region.locations.append(location)
-        location.place_locked_item(StardewItem(item, ItemClassification.progression, None, self.player))
+        region.add_event(location_data.name, item, rule, StardewLocation, StardewItem)
 
     def set_rules(self):
         set_rules(self)


### PR DESCRIPTION
## What is this fixing or adding?
Now that #2965 is merged, I want to use it!

`rule` and `item` are always passed to Stardew's `create_event_location`, so default are not required.

## How was this tested?
Gen and check that events are still there. (plus run the tests)

## If this makes graphical changes, please attach screenshots.
N/A