### PR TITLE
Core: move `gui_enabled` to Utils

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
 from MultiServer import CommandProcessor
 from NetUtils import (Endpoint, decode, NetworkItem, encode, JSONtoTextParser, ClientStatus, Permission, NetworkSlot,
                       RawJSONtoTextParser, add_json_text, add_json_location, add_json_item, JSONTypes, HintStatus, SlotType)
-from Utils import Version, stream_input, async_start
+from Utils import gui_enabled, Version, stream_input, async_start
 from worlds import network_data_package, AutoWorldRegister
 import os
 import ssl
@@ -34,9 +34,6 @@ if typing.TYPE_CHECKING:
     import argparse
 
 logger = logging.getLogger("Client")
-
-# without terminal, we have to use gui mode
-gui_enabled = not sys.stdout or "--nogui" not in sys.argv
 
 
 @Utils.cache_argsless

--- a/Utils.py
+++ b/Utils.py
@@ -830,6 +830,10 @@ def messagebox(title: str, text: str, error: bool = False) -> None:
         root.update()
 
 
+# without terminal, we have to use gui mode
+gui_enabled = not sys.stdout or "--nogui" not in sys.argv
+
+
 def title_sorted(data: typing.Iterable, key=None, ignore: typing.AbstractSet[str] = frozenset(("a", "the"))):
     """Sorts a sequence of text ignoring typical articles like "a" or "the" in the beginning."""
     def sorter(element: Union[str, Dict[str, Any]]) -> str:


### PR DESCRIPTION
## What is this fixing or adding?
Just moves the variable definition so it can be more easily used by non-CommonClient derived, but GUI-less apps.

## How was this tested?
`py CommonClient.py --nogui`
