### PR TITLE
Generate: Better yaml parsing error messaging

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -252,7 +252,16 @@ def read_weights_yamls(path) -> Tuple[Any, ...]:
     except Exception as e:
         raise Exception(f"Failed to read weights ({path})") from e
 
-    return tuple(parse_yamls(yaml))
+    from yaml.error import MarkedYAMLError
+    try:
+        return tuple(parse_yamls(yaml))
+    except MarkedYAMLError as ex:
+        if ex.problem_mark:
+            lines = yaml.splitlines()
+            problem_line = lines[ex.problem_mark.line]
+            error_line = " " * ex.problem_mark.column + "^"
+            raise Exception(f"{ex.context} {ex.problem}\n{problem_line}\n{error_line}")
+        raise ex
 
 
 def interpret_on_off(value) -> bool:

--- a/Generate.py
+++ b/Generate.py
@@ -258,9 +258,12 @@ def read_weights_yamls(path) -> Tuple[Any, ...]:
     except MarkedYAMLError as ex:
         if ex.problem_mark:
             lines = yaml.splitlines()
-            problem_line = lines[ex.problem_mark.line]
+            if ex.context_mark:
+                relevant_lines = "\n".join(lines[ex.context_mark.line:ex.problem_mark.line+1])
+            else:
+                relevant_lines = lines[ex.problem_mark.line]
             error_line = " " * ex.problem_mark.column + "^"
-            raise Exception(f"{ex.context} {ex.problem}\n{problem_line}\n{error_line}")
+            raise Exception(f"{ex.context} {ex.problem}:\n{relevant_lines}\n{error_line}")
         raise ex
 
 

--- a/Generate.py
+++ b/Generate.py
@@ -263,7 +263,8 @@ def read_weights_yamls(path) -> Tuple[Any, ...]:
             else:
                 relevant_lines = lines[ex.problem_mark.line]
             error_line = " " * ex.problem_mark.column + "^"
-            raise Exception(f"{ex.context} {ex.problem}:\n{relevant_lines}\n{error_line}")
+            raise Exception(f"{ex.context} {ex.problem} on line {ex.problem_mark.line}:"
+                            f"\n{relevant_lines}\n{error_line}")
         raise ex
 
 


### PR DESCRIPTION
## What is this fixing or adding?
handles MarkedYAMLError for generate like settings does

shares a lot of code with #4531 but needed tweaks based on what data we have

## How was this tested?
ran through some common yaml issues like tab characters (inserted in the default two space yamls) and mixing of datatypes and looked at the generate output

## If this makes graphical changes, please attach screenshots.
