### PR TITLE
Kivy: swap from the tab carousel to navigation bar 

### DIFF
--- a/data/client.kv
+++ b/data/client.kv
@@ -24,15 +24,10 @@
 <BaseButton>:
     ripple_color: app.theme_cls.primaryColor
     ripple_duration_in_fast: 0.2
-<MDNavigationBar>
-    set_bars_color: True
 <MDNavigationItemBase>:
     on_press: app.screens.switch_screens(self)
-    active: False
-    label: label
 
     MDNavigationItemLabel:
-        id: label
         text: root.text
         theme_text_color: "Custom"
         text_color_active: app.theme_cls.primaryColor

--- a/data/client.kv
+++ b/data/client.kv
@@ -24,9 +24,19 @@
 <BaseButton>:
     ripple_color: app.theme_cls.primaryColor
     ripple_duration_in_fast: 0.2
-<MDTabsItemBase>:
-    ripple_color: app.theme_cls.primaryColor
-    ripple_duration_in_fast: 0.2
+<MDNavigationBar>
+    set_bars_color: True
+<MDNavigationItemBase>:
+    on_press: app.screens.switch_screens(self)
+    active: False
+    label: label
+
+    MDNavigationItemLabel:
+        id: label
+        text: root.text
+        theme_text_color: "Custom"
+        text_color_active: app.theme_cls.primaryColor
+        text_color_normal: 1, 1, 1, 1
 <TooltipLabel>:
     adaptive_height: True
     theme_font_size: "Custom"

--- a/kvui.py
+++ b/kvui.py
@@ -43,6 +43,7 @@ from kivy.core.image import ImageLoader, ImageLoaderBase, ImageData
 from kivy.base import ExceptionHandler, ExceptionManager
 from kivy.clock import Clock
 from kivy.factory import Factory
+from kivy.graphics import Color, Line
 from kivy.properties import BooleanProperty, ObjectProperty, NumericProperty, StringProperty
 from kivy.metrics import dp, sp
 from kivy.uix.widget import Widget
@@ -60,7 +61,10 @@ from kivymd.app import MDApp
 from kivymd.uix.gridlayout import MDGridLayout
 from kivymd.uix.floatlayout import MDFloatLayout
 from kivymd.uix.boxlayout import MDBoxLayout
-from kivymd.uix.tab.tab import MDTabsSecondary, MDTabsItem, MDTabsItemText, MDTabsCarousel
+from kivymd.uix.navigationbar import MDNavigationBar, MDNavigationItem
+from kivymd.uix.screen import MDScreen
+from kivymd.uix.screenmanager import MDScreenManager
+
 from kivymd.uix.menu import MDDropdownMenu
 from kivymd.uix.menu.menu import MDDropdownTextItem
 from kivymd.uix.dropdownitem import MDDropDownItem, MDDropDownItemText
@@ -722,59 +726,30 @@ class MessageBox(Popup):
         self.height += max(0, label.height - 18)
 
 
-class ClientTabs(MDTabsSecondary):
-    carousel: MDTabsCarousel
-    lock_swiping = True
+class MDNavigationItemBase(MDNavigationItem):
+    text = StringProperty(None)
 
-    def __init__(self, *args, **kwargs):
-        self.carousel = MDTabsCarousel(lock_swiping=True, anim_move_duration=0.2)
-        super().__init__(*args, MDDivider(size_hint_y=None, height=dp(1)), self.carousel, **kwargs)
-        self.size_hint_y = 1
+class MDNavigationItemUnderline(Widget):
+    def __init__(self, **kwargs):
+        super().__init__(size_hint=(None, None), height=2, **kwargs)
+        with self.canvas.before:
+            Color(0, 0, 0, 0)
+            self.line = Line(width=2)
 
-    def _check_panel_height(self, *args):
-        self.ids.tab_scroll.height = dp(38)
-
-    def update_indicator(
-        self, x: float = 0.0, w: float = 0.0, instance: MDTabsItem = None
-    ) -> None:
-        def update_indicator(*args):
-            indicator_pos = (0, 0)
-            indicator_size = (0, 0)
-
-            item_text_object = self._get_tab_item_text_icon_object()
-
-            if item_text_object:
-                indicator_pos = (
-                    instance.x + dp(12),
-                    self.indicator.pos[1]
-                    if not self._tabs_carousel
-                    else self._tabs_carousel.height,
-                )
-                indicator_size = (
-                    instance.width - dp(24),
-                    self.indicator_height,
-                )
-
-            Animation(
-                pos=indicator_pos,
-                size=indicator_size,
-                d=0 if not self.indicator_anim else self.indicator_duration,
-                t=self.indicator_transition,
-            ).start(self.indicator)
-
-        if not instance:
-            self.indicator.pos = (x, self.indicator.pos[1])
-            self.indicator.size = (w, self.indicator_height)
+class MDScreenManagerBase(MDScreenManager):
+    underline_bar: MDNavigationItemUnderline
+    def switch_screens(self, new_tab: MDNavigationItemBase) -> None:
+        name = new_tab.text
+        if self.screen_names.index(name) > self.screen_names.index(self.current_screen.name):
+            self.transition.direction = "left"
         else:
-            Clock.schedule_once(update_indicator)
+            self.transition.direction = "right"
+        self.current = name
+        self.update_underline(new_tab)
 
-    def remove_tab(self, tab, content=None):
-        if content is None:
-            content = tab.content
-        self.ids.container.remove_widget(tab)
-        self.carousel.remove_widget(content)
-        self.on_size(self, self.size)
-
+    def update_underline(self, tab: MDNavigationItemBase) -> None:
+        self.underline_bar.line.points = [tab.x, tab.y, tab.right, tab.y]
+        self.underline_bar.canvas.before.children[0].rgba = MDApp.get_running_app().theme_cls.primaryColor
 
 class CommandButton(MDButton, MDTooltip):
     def __init__(self, *args, manager: "GameManager", **kwargs):
@@ -800,6 +775,9 @@ class GameManager(ThemedApp):
 
     main_area_container: MDGridLayout
     """ subclasses can add more columns beside the tabs """
+
+    tabs: MDNavigationBar
+    screens: MDScreenManagerBase
 
     def __init__(self, ctx: context_type):
         self.title = self.base_title
@@ -830,7 +808,7 @@ class GameManager(ThemedApp):
     @property
     def tab_count(self):
         if hasattr(self, "tabs"):
-            return max(1, len(self.tabs.tab_list))
+            return max(1, len(self.tabs.children))
         return 1
 
     def on_start(self):
@@ -870,30 +848,29 @@ class GameManager(ThemedApp):
         self.grid.add_widget(self.progressbar)
 
         # middle part
-        self.tabs = ClientTabs(pos_hint={"center_x": 0.5, "center_y": 0.5})
-        self.tabs.add_widget(MDTabsItem(MDTabsItemText(text="All" if len(self.logging_pairs) > 1 else "Archipelago")))
-        self.log_panels["All"] = self.tabs.default_tab_content = UILog(*(logging.getLogger(logger_name)
-                                                                             for logger_name, name in
-                                                                             self.logging_pairs))
-        self.tabs.carousel.add_widget(self.tabs.default_tab_content)
+        self.screens = MDScreenManagerBase(pos_hint={"center_x": 0.5})
+        self.tabs = MDNavigationBar(orientation="horizontal", size_hint_y=None, height=dp(40), set_bars_color=True)
+        log_panel = self.log_panels["All"] = self.add_client_tab(
+            "All" if len(self.logging_pairs) > 1 else "Archipelago",
+            UILog(*(logging.getLogger(logger_name) for logger_name, name in self.logging_pairs)),
+        )
+        log_panel.active = True
+        self.screens.underline_bar = MDNavigationItemUnderline()
 
         for logger_name, display_name in self.logging_pairs:
             bridge_logger = logging.getLogger(logger_name)
             self.log_panels[display_name] = UILog(bridge_logger)
             if len(self.logging_pairs) > 1:
-                panel = MDTabsItem(MDTabsItemText(text=display_name))
-                panel.content = self.log_panels[display_name]
-                # show Archipelago tab if other logging is present
-                self.tabs.carousel.add_widget(panel.content)
-                self.tabs.add_widget(panel)
+                self.add_client_tab(display_name, self.log_panels[display_name])
 
-        hint_panel = self.add_client_tab("Hints", HintLayout())
         self.hint_log = HintLog(self.json_to_kivy_parser)
+        hint_panel = self.add_client_tab("Hints", HintLayout(self.hint_log))
         self.log_panels["Hints"] = hint_panel.content
-        hint_panel.content.add_widget(self.hint_log)
 
-        self.main_area_container = MDGridLayout(size_hint_y=1, rows=1)
+        self.main_area_container = MDGridLayout(size_hint_y=1, cols=1)
         self.main_area_container.add_widget(self.tabs)
+        self.main_area_container.add_widget(self.screens.underline_bar)
+        self.main_area_container.add_widget(self.screens)
 
         self.grid.add_widget(self.main_area_container)
 
@@ -933,22 +910,22 @@ class GameManager(ThemedApp):
     def add_client_tab(self, title: str, content: Widget, index: int = -1) -> Widget:
         """Adds a new tab to the client window with a given title, and provides a given Widget as its content.
          Returns the new tab widget, with the provided content being placed on the tab as content."""
-        new_tab = MDTabsItem(MDTabsItemText(text=title))
+        if self.tabs.children:
+            self.tabs.add_widget(MDDivider(orientation="vertical"))
+        new_tab = MDNavigationItemBase(text=title)
         new_tab.content = content
-        if -1 < index <= len(self.tabs.carousel.slides):
-            new_tab.bind(on_release=self.tabs.set_active_item)
-            new_tab._tabs = self.tabs
-            self.tabs.ids.container.add_widget(new_tab, index=index)
-            self.tabs.carousel.add_widget(new_tab.content, index=len(self.tabs.carousel.slides) - index)
+        new_screen = MDScreen(name=title)
+        new_screen.add_widget(content)
+        if -1 < index <= len(self.tabs.children):
+            index = len(self.tabs.children) - index
+            self.tabs.add_widget(new_tab, index=index)
+            self.screens.add_widget(new_screen, index=index)
         else:
             self.tabs.add_widget(new_tab)
-            self.tabs.carousel.add_widget(new_tab.content)
+            self.screens.add_widget(new_screen)
         return new_tab
 
     def update_texts(self, dt):
-        for slide in self.tabs.carousel.slides:
-            if hasattr(slide, "fix_heights"):
-                slide.fix_heights()  # TODO: remove this when Kivy fixes this upstream
         if self.ctx.server:
             self.title = self.base_title + " " + Utils.__version__ + \
                          f" | Connected to: {self.ctx.server_address} " \


### PR DESCRIPTION
## What is this fixing or adding?
Navigation bar is a bit less buggy, but it doesn't come with a built-in underline, so that had to be made custom. The only noticeable change here from the user perspective is that the underline is more responsive, while this offsets a bunch of boilerplate off to the kv to make it easier to maintain.

## How was this tested?
Tried out various clients that have various amounts of tabs and checked that they still behaved as expected. Still currently has an issue where the underline won't get moved to the proper position after everything has finished getting set up and not sure how to fix it.