### PR TITLE
TWW: Fix generation failure with output file

### DIFF
--- a/worlds/tww/Options.py
+++ b/worlds/tww/Options.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Any
 
 from Options import (
     Choice,
@@ -751,6 +752,68 @@ class TWWOptions(PerGameCommonOptions):
     skip_rematch_bosses: SkipRematchBosses
     remove_music: RemoveMusic
     death_link: DeathLink
+
+    def get_output_dict(self) -> dict[str, Any]:
+        """
+        Returns a dictionary of option name to value to be placed in
+        the output APTWW file.
+
+        :return: Dictionary of option name to value for the output file.
+        """
+
+        # Note: these options' values must be able to be passed through
+        # `yaml.safe_dump`.
+        return self.as_dict(
+            "progression_dungeons",
+            "progression_tingle_chests",
+            "progression_dungeon_secrets",
+            "progression_puzzle_secret_caves",
+            "progression_combat_secret_caves",
+            "progression_savage_labyrinth",
+            "progression_great_fairies",
+            "progression_short_sidequests",
+            "progression_long_sidequests",
+            "progression_spoils_trading",
+            "progression_minigames",
+            "progression_battlesquid",
+            "progression_free_gifts",
+            "progression_mail",
+            "progression_platforms_rafts",
+            "progression_submarines",
+            "progression_eye_reef_chests",
+            "progression_big_octos_gunboats",
+            "progression_triforce_charts",
+            "progression_treasure_charts",
+            "progression_expensive_purchases",
+            "progression_island_puzzles",
+            "progression_misc",
+            "randomize_mapcompass",
+            "randomize_smallkeys",
+            "randomize_bigkeys",
+            "sword_mode",
+            "required_bosses",
+            "num_required_bosses",
+            "chest_type_matches_contents",
+            "hero_mode",
+            "logic_obscurity",
+            "logic_precision",
+            "randomize_dungeon_entrances",
+            "randomize_secret_cave_entrances",
+            "randomize_miniboss_entrances",
+            "randomize_boss_entrances",
+            "randomize_secret_cave_inner_entrances",
+            "randomize_fairy_fountain_entrances",
+            "mix_entrances",
+            "randomize_enemies",
+            "randomize_starting_island",
+            "randomize_charts",
+            "swift_sail",
+            "instant_text_boxes",
+            "reveal_full_sea_chart",
+            "add_shortcut_warps_between_dungeons",
+            "skip_rematch_bosses",
+            "remove_music",
+        )
 
 
 tww_option_groups: list[OptionGroup] = [

--- a/worlds/tww/__init__.py
+++ b/worlds/tww/__init__.py
@@ -462,7 +462,7 @@ class TWWWorld(World):
             "Seed": multiworld.seed_name,
             "Slot": player,
             "Name": self.player_name,
-            "Options": self.options.as_dict(*self.options_dataclass.type_hints),
+            "Options": self.options.get_output_dict(),
             "Required Bosses": self.boss_reqs.required_boss_item_locations,
             "Locations": {},
             "Entrances": {},


### PR DESCRIPTION
## What is this fixing or adding?
As referenced in #4931, The Wind Waker currently fails at generation.

This is due to `yaml.safe_dump` being used when creating the output APTWW file and it not being able to serialize the `OptionCounter` introduced in #3756. A few fixes were suggested, but in the end, I decided to change the output file to only include options used during patching, so as to also cut down on the file size. The means that the options that use `OptionCounter` (`start_inventory` and `start_inventory_from_pool`) are no longer included in the APTWW file.

I've also left a comment to also remind myself and future collaborators of the reasoning.

## How was this tested?
Generated a TWW world, patched using the resulting APTWW file, and checked a single location in-game, all of which worked fine.

## If this makes graphical changes, please attach screenshots.
N/A