### PR TITLE
ALTTP: Swamp Palace West logic fix

### DIFF
--- a/worlds/alttp/Rules.py
+++ b/worlds/alttp/Rules.py
@@ -393,9 +393,7 @@ def global_rules(multiworld: MultiWorld, player: int):
     if world.options.pot_shuffle:
         # it could move the key to the top right platform which can only be reached with bombs
         add_rule(multiworld.get_location('Swamp Palace - Hookshot Pot Key', player), lambda state: can_use_bombs(state, player))
-    set_rule(multiworld.get_entrance('Swamp Palace (West)', player), lambda state: state._lttp_has_key('Small Key (Swamp Palace)', player, 6)
-        if state.has('Hookshot', player)
-        else state._lttp_has_key('Small Key (Swamp Palace)', player, 4))
+    set_rule(multiworld.get_entrance('Swamp Palace (West)', player), lambda state: state._lttp_has_key('Small Key (Swamp Palace)', player, 6))
     set_rule(multiworld.get_location('Swamp Palace - Big Chest', player), lambda state: state.has('Big Key (Swamp Palace)', player))
     if world.options.accessibility != 'full':
         allow_self_locking_items(multiworld.get_location('Swamp Palace - Big Chest', player), 'Big Key (Swamp Palace)')

--- a/worlds/alttp/test/dungeons/TestSwampPalace.py
+++ b/worlds/alttp/test/dungeons/TestSwampPalace.py
@@ -24,7 +24,7 @@ class TestSwampPalace(TestDungeon):
             ["Swamp Palace - Big Key Chest", False, [], ['Open Floodgate']],
             ["Swamp Palace - Big Key Chest", False, [], ['Hammer']],
             ["Swamp Palace - Big Key Chest", False, [], ['Small Key (Swamp Palace)']],
-            ["Swamp Palace - Big Key Chest", True, ['Open Floodgate', 'Small Key (Swamp Palace)', 'Small Key (Swamp Palace)', 'Small Key (Swamp Palace)', 'Small Key (Swamp Palace)', 'Flippers', 'Hammer']],
+            ["Swamp Palace - Big Key Chest", True, ['Open Floodgate', 'Small Key (Swamp Palace)', 'Small Key (Swamp Palace)', 'Small Key (Swamp Palace)', 'Small Key (Swamp Palace)', 'Small Key (Swamp Palace)', 'Small Key (Swamp Palace)', 'Flippers', 'Hammer']],
 
             ["Swamp Palace - Map Chest", False, []],
             ["Swamp Palace - Map Chest", False, [], ['Flippers']],
@@ -38,7 +38,7 @@ class TestSwampPalace(TestDungeon):
             ["Swamp Palace - West Chest", False, [], ['Open Floodgate']],
             ["Swamp Palace - West Chest", False, [], ['Hammer']],
             ["Swamp Palace - West Chest", False, [], ['Small Key (Swamp Palace)']],
-            ["Swamp Palace - West Chest", True, ['Open Floodgate', 'Small Key (Swamp Palace)', 'Small Key (Swamp Palace)', 'Small Key (Swamp Palace)', 'Small Key (Swamp Palace)', 'Flippers', 'Hammer']],
+            ["Swamp Palace - West Chest", True, ['Open Floodgate', 'Small Key (Swamp Palace)', 'Small Key (Swamp Palace)', 'Small Key (Swamp Palace)', 'Small Key (Swamp Palace)', 'Small Key (Swamp Palace)', 'Small Key (Swamp Palace)', 'Flippers', 'Hammer']],
 
             ["Swamp Palace - Compass Chest", False, []],
             ["Swamp Palace - Compass Chest", False, [], ['Flippers']],


### PR DESCRIPTION
## What is this fixing or adding?
Removes a lower key requirement for Swamp Palace West when a Hookshot is collected. Collecting an item should never make locations unreachable that are reachable without it.

## How was this tested?
We'll see if the unit tests pass :)