### PR TITLE
CI: add optional windows release build and build attestation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,7 +165,7 @@ jobs:
             build/exe.*/ArchipelagoLauncher
             build/exe.*/ArchipelagoGenerate
             build/exe.*/ArchipelagoServer
-            dist/${{ env.APPIMAGE_NAME }}
+            dist/${{ env.APPIMAGE_NAME }}*
             dist/${{ env.TAR_NAME }}
       - name: Build Again
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,9 +28,10 @@ permissions:  # permissions required for attestation
 jobs:
   # build-release-macos: # LF volunteer
 
-  build-win: # RCs will still be built and signed by hand
+  build-win: # RCs and releases may still be built and signed by hand
     runs-on: windows-latest
     steps:
+      # - copy code below to release.yml -
       - uses: actions/checkout@v4
       - name: Install python
         uses: actions/setup-python@v5
@@ -69,6 +70,7 @@ jobs:
           $contents = Get-ChildItem -Path setups/*.exe -Force -Recurse
           $SETUP_NAME=$contents[0].Name
           echo "SETUP_NAME=$SETUP_NAME" >> $Env:GITHUB_ENV
+      # - copy code above to release.yml -
       - name: Attest Build
         if: ${{ github.event_name == 'workflow_dispatch' }}
         uses: actions/attest-build-provenance@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,10 @@ env:
   ENEMIZER_VERSION: 7.1
   APPIMAGETOOL_VERSION: 13
 
+permissions:  # permissions required for attestation
+  id-token: 'write'
+  attestations: 'write'
+
 jobs:
   # build-release-macos: # LF volunteer
 
@@ -77,6 +81,17 @@ jobs:
           cmp setup-player-templates.txt generated-player-templates.txt \
             || diff setup-player-templates.txt generated-player-templates.txt
           mv meta.yaml Players/Templates/
+      - name: Attest Build
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            build/exe.*/ArchipelagoLauncher.exe
+            build/exe.*/ArchipelagoLauncherDebug.exe
+            build/exe.*/ArchipelagoGenerate.exe
+            build/exe.*/ArchipelagoServer.exe
+            dist/${{ env.ZIP_NAME }}
+            setups/${{ env.SETUP_NAME }}
       - name: Test Generate
         shell: bash
         run: |
@@ -142,6 +157,16 @@ jobs:
           echo "APPIMAGE_NAME=$APPIMAGE_NAME" >> $GITHUB_ENV
           echo "TAR_NAME=$TAR_NAME" >> $GITHUB_ENV
       # - copy code above to release.yml -
+      - name: Attest Build
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            build/exe.*/ArchipelagoLauncher
+            build/exe.*/ArchipelagoGenerate
+            build/exe.*/ArchipelagoServer
+            dist/${{ env.APPIMAGE_NAME }}
+            dist/${{ env.TAR_NAME }}
       - name: Build Again
         run: |
           source venv/bin/activate

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,17 @@ jobs:
           $contents = Get-ChildItem -Path setups/*.exe -Force -Recurse
           $SETUP_NAME=$contents[0].Name
           echo "SETUP_NAME=$SETUP_NAME" >> $Env:GITHUB_ENV
+      - name: Attest Build
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            build/exe.*/ArchipelagoLauncher.exe
+            build/exe.*/ArchipelagoLauncherDebug.exe
+            build/exe.*/ArchipelagoGenerate.exe
+            build/exe.*/ArchipelagoServer.exe
+            dist/${{ env.ZIP_NAME }}
+            setups/${{ env.SETUP_NAME }}
       - name: Check build loads expected worlds
         shell: bash
         run: |
@@ -81,17 +92,6 @@ jobs:
           cmp setup-player-templates.txt generated-player-templates.txt \
             || diff setup-player-templates.txt generated-player-templates.txt
           mv meta.yaml Players/Templates/
-      - name: Attest Build
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-path: |
-            build/exe.*/ArchipelagoLauncher.exe
-            build/exe.*/ArchipelagoLauncherDebug.exe
-            build/exe.*/ArchipelagoGenerate.exe
-            build/exe.*/ArchipelagoServer.exe
-            dist/${{ env.ZIP_NAME }}
-            setups/${{ env.SETUP_NAME }}
       - name: Test Generate
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ env:
   ENEMIZER_VERSION: 7.1
   APPIMAGETOOL_VERSION: 13
 
+permissions:  # permissions required for attestation
+  id-token: 'write'
+  attestations: 'write'
+
 jobs:
   create-release:
     runs-on: ubuntu-latest
@@ -74,6 +78,14 @@ jobs:
           echo "APPIMAGE_NAME=$APPIMAGE_NAME" >> $GITHUB_ENV
           echo "TAR_NAME=$TAR_NAME" >> $GITHUB_ENV
       # - code above copied from build.yml -
+      - name: Attest Build
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            build/exe.*/ArchipelagoLauncher
+            build/exe.*/ArchipelagoGenerate
+            build/exe.*/ArchipelagoServer
+            dist/*
       - name: Add to Release
         uses: softprops/action-gh-release@975c1b265e11dd76618af1c374e7981f9a6ff44a
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ env:
 permissions:  # permissions required for attestation
   id-token: 'write'
   attestations: 'write'
+  contents: 'write'  # additionally required for release
 
 jobs:
   create-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
 
   build-release-win:
     runs-on: windows-latest
-    if: ${{ true }}  # change to true to skip if release is built by hand
+    if: ${{ true }}  # change to false to skip if release is built by hand
     needs: create-release
     steps:
       - name: Set env

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
 
   build-release-win:
     runs-on: windows-latest
-    if: ${{ false }}  # change to true to skip if release is built by hand
+    if: ${{ true }}  # change to true to skip if release is built by hand
     needs: create-release
     steps:
       - name: Set env

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
   build-release-win:
     runs-on: windows-latest
     if: ${{ false }}  # change to true to skip if release is built by hand
+    needs: create-release
     steps:
       - name: Set env
         shell: bash
@@ -101,6 +102,7 @@ jobs:
 
   build-release-ubuntu2204:
     runs-on: ubuntu-22.04
+    needs: create-release
     steps:
       - name: Set env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,74 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # build-release-windows: # this is done by hand because of signing
   # build-release-macos: # LF volunteer
+
+  build-release-win:
+    runs-on: windows-latest
+    if: ${{ false }}  # change to true to skip if release is built by hand
+    steps:
+      - name: Set env
+        shell: bash
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      # - code below copied from build.yml -
+      - uses: actions/checkout@v4
+      - name: Install python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '~3.12.7'
+          check-latest: true
+      - name: Download run-time dependencies
+        run: |
+          Invoke-WebRequest -Uri https://github.com/Ijwu/Enemizer/releases/download/${Env:ENEMIZER_VERSION}/win-x64.zip -OutFile enemizer.zip
+          Expand-Archive -Path enemizer.zip -DestinationPath EnemizerCLI -Force
+          choco install innosetup --version=6.2.2 --allow-downgrade
+      - name: Build
+        run: |
+          python -m pip install --upgrade pip
+          python setup.py build_exe --yes
+          if ( $? -eq $false ) {
+            Write-Error "setup.py failed!"
+            exit 1
+          }
+          $NAME="$(ls build | Select-String -Pattern 'exe')".Split('.',2)[1]
+          $ZIP_NAME="Archipelago_$NAME.7z"
+          echo "$NAME -> $ZIP_NAME"
+          echo "ZIP_NAME=$ZIP_NAME" >> $Env:GITHUB_ENV
+          New-Item -Path dist -ItemType Directory -Force
+          cd build
+          Rename-Item "exe.$NAME" Archipelago
+          7z a -mx=9 -mhe=on -ms "../dist/$ZIP_NAME" Archipelago
+          Rename-Item Archipelago "exe.$NAME"  # inno_setup.iss expects the original name
+      - name: Build Setup
+        run: |
+          & "${env:ProgramFiles(x86)}\Inno Setup 6\iscc.exe" inno_setup.iss /DNO_SIGNTOOL
+          if ( $? -eq $false ) {
+            Write-Error "Building setup failed!"
+            exit 1
+          }
+          $contents = Get-ChildItem -Path setups/*.exe -Force -Recurse
+          $SETUP_NAME=$contents[0].Name
+          echo "SETUP_NAME=$SETUP_NAME" >> $Env:GITHUB_ENV
+      # - code above copied from build.yml -
+      - name: Attest Build
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            build/exe.*/ArchipelagoLauncher.exe
+            build/exe.*/ArchipelagoLauncherDebug.exe
+            build/exe.*/ArchipelagoGenerate.exe
+            build/exe.*/ArchipelagoServer.exe
+            setups/*
+      - name: Add to Release
+        uses: softprops/action-gh-release@975c1b265e11dd76618af1c374e7981f9a6ff44a
+        with:
+          draft: true  # see above
+          prerelease: false
+          name: Archipelago ${{ env.RELEASE_VERSION }}
+          files: |
+            setups/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-release-ubuntu2204:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## What is this fixing or adding?

* Adds windows build to release.yml
  This can be disabled by changing a single boolean.

* Adds build attestation to release.yml

* Ensures fixed job order in release.yml (this was jank before)

* Adds build attestation to build.yml
  This allows users to verify the origin (action, repo, commit) of a file.

  It's also possible to find an attestation just from the file hash,
  so this may or may not improve security in the future.

  Skips attestation for builds that are triggered automatically.

  Per github doc:
  > You should not sign:
  > * Frequent builds that are just for automated testing.
  > [...]


## How was this tested?

Looking at CI.

Here is a run of the new release action with Windows builds enabled:
https://github.com/black-sliver/Archipelago/actions/runs/14720916838

Here is a run of the new build action that was triggered manually:
https://github.com/black-sliver/Archipelago/actions/runs/14720937475