### PR TITLE
Generate: don't force player name for weights files

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -224,10 +224,14 @@ def main(args=None) -> Tuple[argparse.Namespace, int]:
                             except Exception as e:
                                 raise Exception(f"Error setting {k} to {v} for player {player}") from e
 
-                    if path == args.weights_file_path:  # if name came from the weights file, just use base player name
-                        erargs.name[player] = f"Player{player}"
-                    elif player not in erargs.name:  # if name was not specified, generate it from filename
-                        erargs.name[player] = os.path.splitext(os.path.split(path)[-1])[0]
+                    # name was not specified
+                    if player not in erargs.name:
+                        if path == args.weights_file_path:
+                            # weights file, so we need to make the name unique
+                            erargs.name[player] = f"Player{player}"
+                        else:
+                            # use the filename
+                            erargs.name[player] = os.path.splitext(os.path.split(path)[-1])[0]
                     erargs.name[player] = handle_name(erargs.name[player], player, name_counter)
 
                     player += 1


### PR DESCRIPTION
## What is this fixing or adding?
Removes the forced naming in weights files, leaving a fallback for if one isn't specified.

## How was this tested?
Breakpointed with custom names and no names in both various game yamls and a weights yaml.