### PR TITLE
WebHostLib: Properly format IDs in API responses 

### DIFF
--- a/WebHostLib/__init__.py
+++ b/WebHostLib/__init__.py
@@ -74,7 +74,7 @@ class B64UUIDConverter(BaseConverter):
 
 # short UUID
 app.url_map.converters["suuid"] = B64UUIDConverter
-app.jinja_env.filters['suuid'] = B64UUIDConverter.to_url
+app.jinja_env.filters["suuid"] = B64UUIDConverter.to_url
 app.jinja_env.filters["title_sorted"] = title_sorted
 
 

--- a/WebHostLib/__init__.py
+++ b/WebHostLib/__init__.py
@@ -74,7 +74,7 @@ class B64UUIDConverter(BaseConverter):
 
 # short UUID
 app.url_map.converters["suuid"] = B64UUIDConverter
-app.jinja_env.filters['suuid'] = lambda value: base64.urlsafe_b64encode(value.bytes).rstrip(b'=').decode('ascii')
+app.jinja_env.filters['suuid'] = B64UUIDConverter.to_url
 app.jinja_env.filters["title_sorted"] = title_sorted
 
 

--- a/WebHostLib/__init__.py
+++ b/WebHostLib/__init__.py
@@ -61,20 +61,26 @@ cache = Cache()
 Compress(app)
 
 
+def to_python(value):
+    return uuid.UUID(bytes=base64.urlsafe_b64decode(value + '=='))
+
+
+def to_url(value):
+    return base64.urlsafe_b64encode(value.bytes).rstrip(b'=').decode('ascii')
+
+
 class B64UUIDConverter(BaseConverter):
 
-    @staticmethod
-    def to_python(value):
-        return uuid.UUID(bytes=base64.urlsafe_b64decode(value + '=='))
+    def to_python(self, value):
+        return to_python(value)
 
-    @staticmethod
-    def to_url(value):
-        return base64.urlsafe_b64encode(value.bytes).rstrip(b'=').decode('ascii')
+    def to_url(self, value):
+        return to_url(value)
 
 
 # short UUID
 app.url_map.converters["suuid"] = B64UUIDConverter
-app.jinja_env.filters["suuid"] = B64UUIDConverter.to_url
+app.jinja_env.filters["suuid"] = to_url
 app.jinja_env.filters["title_sorted"] = title_sorted
 
 

--- a/WebHostLib/__init__.py
+++ b/WebHostLib/__init__.py
@@ -63,10 +63,12 @@ Compress(app)
 
 class B64UUIDConverter(BaseConverter):
 
-    def to_python(self, value):
+    @staticmethod
+    def to_python(value):
         return uuid.UUID(bytes=base64.urlsafe_b64decode(value + '=='))
 
-    def to_url(self, value):
+    @staticmethod
+    def to_url(value):
         return base64.urlsafe_b64encode(value.bytes).rstrip(b'=').decode('ascii')
 
 

--- a/WebHostLib/api/generate.py
+++ b/WebHostLib/api/generate.py
@@ -63,7 +63,7 @@ def generate_api():
             commit()
             return {"text": f"Generation of seed {gen.id} started successfully.",
                     "detail": gen.id,
-                    "encoded": app.url_map.converters["suuid"].to_url(None, gen.id),
+                    "encoded": app.url_map.converters["suuid"].to_url(gen.id),
                     "wait_api_url": url_for("api.wait_seed_api", seed=gen.id, _external=True),
                     "url": url_for("wait_seed", seed=gen.id, _external=True)}, 201
     except Exception as e:

--- a/WebHostLib/api/generate.py
+++ b/WebHostLib/api/generate.py
@@ -63,7 +63,7 @@ def generate_api():
             commit()
             return {"text": f"Generation of seed {gen.id} started successfully.",
                     "detail": gen.id,
-                    "encoded": app.url_map.converters["suuid"].to_url(gen.id),
+                    "encoded": app.url_map.converters["suuid"].to_url(None, gen.id),
                     "wait_api_url": url_for("api.wait_seed_api", seed=gen.id, _external=True),
                     "url": url_for("wait_seed", seed=gen.id, _external=True)}, 201
     except Exception as e:

--- a/WebHostLib/api/room.py
+++ b/WebHostLib/api/room.py
@@ -3,7 +3,7 @@ from uuid import UUID
 
 from flask import abort, url_for
 
-from WebHostLib import B64UUIDConverter
+from WebHostLib import to_url
 import worlds.Files
 from . import api_endpoints, get_players
 from ..models import Room
@@ -34,7 +34,7 @@ def room_info(room_id: UUID) -> Dict[str, Any]:
             downloads.append(slot_download)
 
     return {
-        "tracker": B64UUIDConverter(room.tracker),
+        "tracker": to_url(room.tracker),
         "players": get_players(room.seed),
         "last_port": room.last_port,
         "last_activity": room.last_activity,

--- a/WebHostLib/api/room.py
+++ b/WebHostLib/api/room.py
@@ -3,6 +3,7 @@ from uuid import UUID
 
 from flask import abort, url_for
 
+from WebHostLib import B64UUIDConverter
 import worlds.Files
 from . import api_endpoints, get_players
 from ..models import Room
@@ -33,7 +34,7 @@ def room_info(room_id: UUID) -> Dict[str, Any]:
             downloads.append(slot_download)
 
     return {
-        "tracker": room.tracker,
+        "tracker": B64UUIDConverter(room.tracker),
         "players": get_players(room.seed),
         "last_port": room.last_port,
         "last_activity": room.last_activity,

--- a/WebHostLib/api/user.py
+++ b/WebHostLib/api/user.py
@@ -1,6 +1,7 @@
 from flask import session, jsonify
 from pony.orm import select
 
+from WebHostLib import B64UUIDConverter
 from WebHostLib.models import Room, Seed
 from . import api_endpoints, get_players
 
@@ -10,13 +11,13 @@ def get_rooms():
     response = []
     for room in select(room for room in Room if room.owner == session["_id"]):
         response.append({
-            "room_id": room.id,
-            "seed_id": room.seed.id,
+            "room_id": B64UUIDConverter.to_url(room.id),
+            "seed_id": B64UUIDConverter.to_url(room.seed.id),
             "creation_time": room.creation_time,
             "last_activity": room.last_activity,
             "last_port": room.last_port,
             "timeout": room.timeout,
-            "tracker": room.tracker,
+            "tracker": B64UUIDConverter.to_url(room.tracker),
         })
     return jsonify(response)
 
@@ -26,7 +27,7 @@ def get_seeds():
     response = []
     for seed in select(seed for seed in Seed if seed.owner == session["_id"]):
         response.append({
-            "seed_id": seed.id,
+            "seed_id": B64UUIDConverter.to_url(seed.id),
             "creation_time": seed.creation_time,
             "players": get_players(seed),
         })

--- a/WebHostLib/api/user.py
+++ b/WebHostLib/api/user.py
@@ -1,7 +1,7 @@
 from flask import session, jsonify
 from pony.orm import select
 
-from WebHostLib import B64UUIDConverter
+from WebHostLib import to_url
 from WebHostLib.models import Room, Seed
 from . import api_endpoints, get_players
 
@@ -11,13 +11,13 @@ def get_rooms():
     response = []
     for room in select(room for room in Room if room.owner == session["_id"]):
         response.append({
-            "room_id": B64UUIDConverter.to_url(room.id),
-            "seed_id": B64UUIDConverter.to_url(room.seed.id),
+            "room_id": to_url(room.id),
+            "seed_id": to_url(room.seed.id),
             "creation_time": room.creation_time,
             "last_activity": room.last_activity,
             "last_port": room.last_port,
             "timeout": room.timeout,
-            "tracker": B64UUIDConverter.to_url(room.tracker),
+            "tracker": to_url(room.tracker),
         })
     return jsonify(response)
 
@@ -27,7 +27,7 @@ def get_seeds():
     response = []
     for seed in select(seed for seed in Seed if seed.owner == session["_id"]):
         response.append({
-            "seed_id": B64UUIDConverter.to_url(seed.id),
+            "seed_id": to_url(seed.id),
             "creation_time": seed.creation_time,
             "players": get_players(seed),
         })

--- a/test/hosting/webhost.py
+++ b/test/hosting/webhost.py
@@ -158,7 +158,7 @@ def set_room_timeout(room_id: str, timeout: float) -> None:
     from WebHostLib.models import Room
     from WebHostLib import app
 
-    room_uuid = app.url_map.converters["suuid"].to_python(room_id)
+    room_uuid = to_python(room_id)
     with db_session:
         room: Room = Room.get(id=room_uuid)
         room.timeout = timeout
@@ -170,7 +170,7 @@ def get_multidata_for_room(webhost_client: "FlaskClient", room_id: str) -> bytes
     from WebHostLib.models import Room
     from WebHostLib import app
 
-    room_uuid = app.url_map.converters["suuid"].to_python(room_id)
+    room_uuid = to_python(room_id)
     with db_session:
         room: Room = Room.get(id=room_uuid)
         return cast(bytes, room.seed.multidata)
@@ -182,7 +182,7 @@ def set_multidata_for_room(webhost_client: "FlaskClient", room_id: str, data: by
     from WebHostLib.models import Room
     from WebHostLib import app
 
-    room_uuid = app.url_map.converters["suuid"].to_python(room_id)
+    room_uuid = to_python(room_id)
     with db_session:
         room: Room = Room.get(id=room_uuid)
         room.seed.multidata = data

--- a/test/hosting/webhost.py
+++ b/test/hosting/webhost.py
@@ -103,7 +103,7 @@ def stop_room(app_client: "FlaskClient",
     poll_interval = 2
 
     print(f"Stopping room {room_id}")
-    room_uuid = app.url_map.converters["suuid"].to_python(None, room_id)  # type: ignore[arg-type]
+    room_uuid = app.url_map.converters["suuid"].to_python(room_id)
 
     if timeout is not None:
         sleep(.1)  # should not be required, but other things might use threading
@@ -156,7 +156,7 @@ def set_room_timeout(room_id: str, timeout: float) -> None:
     from WebHostLib.models import Room
     from WebHostLib import app
 
-    room_uuid = app.url_map.converters["suuid"].to_python(None, room_id)  # type: ignore[arg-type]
+    room_uuid = app.url_map.converters["suuid"].to_python(room_id)
     with db_session:
         room: Room = Room.get(id=room_uuid)
         room.timeout = timeout
@@ -168,7 +168,7 @@ def get_multidata_for_room(webhost_client: "FlaskClient", room_id: str) -> bytes
     from WebHostLib.models import Room
     from WebHostLib import app
 
-    room_uuid = app.url_map.converters["suuid"].to_python(None, room_id)  # type: ignore[arg-type]
+    room_uuid = app.url_map.converters["suuid"].to_python(room_id)
     with db_session:
         room: Room = Room.get(id=room_uuid)
         return cast(bytes, room.seed.multidata)
@@ -180,7 +180,7 @@ def set_multidata_for_room(webhost_client: "FlaskClient", room_id: str, data: by
     from WebHostLib.models import Room
     from WebHostLib import app
 
-    room_uuid = app.url_map.converters["suuid"].to_python(None, room_id)  # type: ignore[arg-type]
+    room_uuid = app.url_map.converters["suuid"].to_python(room_id)
     with db_session:
         room: Room = Room.get(id=room_uuid)
         room.seed.multidata = data

--- a/test/hosting/webhost.py
+++ b/test/hosting/webhost.py
@@ -2,6 +2,8 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, cast
 
+from WebHostLib import to_python
+
 if TYPE_CHECKING:
     from flask import Flask
     from werkzeug.test import Client as FlaskClient
@@ -103,7 +105,7 @@ def stop_room(app_client: "FlaskClient",
     poll_interval = 2
 
     print(f"Stopping room {room_id}")
-    room_uuid = app.url_map.converters["suuid"].to_python(room_id)
+    room_uuid = to_python(room_id)
 
     if timeout is not None:
         sleep(.1)  # should not be required, but other things might use threading


### PR DESCRIPTION
## What is this fixing or adding?
update the id formatter to use staticmethods to not fake the unused self arg, and then use the formatter for the user session endpoints

found testing #4887
the user session responses have unusable ids that cause the id parser on webhost to error out with a `ValueError: bytes is not a 16-char string`
this also refactors the formatter class to use the staticmethod decorator like it's already being used

## How was this tested?
```py
import requests

s = requests.Session()

# grab the session cookie for my localhost which has existing data
s.get("http://localhost/session/a66f6a05-5c23-4473-8cc0-f9b2c70c27bb")
api_base = "http://localhost/api"

get_rooms_response = s.get(f"{api_base}/get_rooms")
assert get_rooms_response.status_code == 200, "get_rooms failed"
rooms = get_rooms_response.json()
first_room = rooms[1]["room_id"]
room_status_response = s.get(f"{api_base}/room_status/{first_room}")
assert room_status_response.status_code == 200, "room_status failed"
room_data = room_status_response.json()
print(room_data)
```
and manually pinging the different apis and using returned ids in more api calls in browser

## If this makes graphical changes, please attach screenshots.
