### PR TITLE
ArchipIDLE: new maintainer

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -22,7 +22,7 @@
 /worlds/aquaria/ @tioui
 
 # ArchipIDLE
-/worlds/archipidle/ @LegendaryLinux
+/worlds/archipidle/ @VxJasonxV
 
 # Blasphemous
 /worlds/blasphemous/ @TRPG0


### PR DESCRIPTION
Hello! I'm VxJasonxV. You may have seen me around Discord already.

I've been participating in and running some worlds with friends and wanted to get my feet wet with more. When I first added in ArchipIDLE into a world I was hosting https://idle.multiworld.link/'s certificate had just recently expired, and I found a bug with Edge, JavaScript `alert()` modals, and expired certificates.
Because I was capable of doing so, I stood up my own instance at https://noneedto.click/ with plans to make some QoL changes, and I guess I'm signing myself up to theme it for 2026.

I decided to get this started before the channel and game disappears as we leave the fools' month.

I also just took a look at the original address of APidle, and saw that the certificate was renewed. I assume Farrak took note and did this because there are a lot of other sites on that domain, so it got renewed along with the rest of things in his ownership. But as he's not back in Discord, I'm proceeding with this still.