### PR TITLE
OoT: Stop using Utils.get_options

### DIFF
--- a/OoTClient.py
+++ b/OoTClient.py
@@ -12,6 +12,7 @@ from CommonClient import CommonContext, server_loop, gui_enabled, \
 import Utils
 from Utils import async_start
 from worlds import network_data_package
+from worlds.oot import OOTWorld
 from worlds.oot.Rom import Rom, compress_rom_file
 from worlds.oot.N64Patch import apply_patch_file
 from worlds.oot.Utils import data_path
@@ -280,7 +281,7 @@ async def n64_sync_task(ctx: OoTContext):
 
 
 async def run_game(romfile):
-    auto_start = Utils.get_options()["oot_options"].get("rom_start", True)
+    auto_start = OOTWorld.settings.rom_start
     if auto_start is True:
         import webbrowser
         webbrowser.open(romfile)
@@ -295,7 +296,7 @@ async def patch_and_run_game(apz5_file):
     decomp_path = base_name + '-decomp.z64'
     comp_path = base_name + '.z64'
     # Load vanilla ROM, patch file, compress ROM
-    rom_file_name = Utils.get_options()["oot_options"]["rom_file"]
+    rom_file_name = OOTWorld.settings.rom_file
     rom = Rom(rom_file_name)
 
     sub_file = None

--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -30,7 +30,6 @@ from .Patches import OoTContainer, patch_rom
 from .N64Patch import create_patch_file
 from .Cosmetics import patch_cosmetics
 
-from settings import get_settings
 from BaseClasses import MultiWorld, CollectionState, Tutorial, LocationProgressType
 from Options import Range, Toggle, VerifyKeys, Accessibility, PlandoConnections
 from Fill import fill_restrictive, fast_fill, FillError

--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -203,7 +203,8 @@ class OOTWorld(World):
 
     @classmethod
     def stage_assert_generate(cls, multiworld: MultiWorld):
-        rom = Rom(file=get_settings()['oot_options']['rom_file'])
+        oot_settings = OOTWorld.settings
+        rom = Rom(file=oot_settings.rom_file)
 
 
     # Option parsing, handling incompatible options, building useful-item table
@@ -1087,7 +1088,8 @@ class OOTWorld(World):
             self.hint_rng = self.random
 
             outfile_name = self.multiworld.get_out_file_name_base(self.player)
-            rom = Rom(file=get_settings()['oot_options']['rom_file'])
+            oot_settings = OOTWorld.settings
+            rom = Rom(file=oot_settings.rom_file)
             try:
                 if self.hints != 'none':
                     buildWorldGossipHints(self)


### PR DESCRIPTION
## What is this fixing or adding?
Replace usage of `Utils.get_options` and `settings.get_settings()` in Ocarina of Time with the newer settings API from `OOTWorld`.

Resolves https://github.com/ArchipelagoMW/Archipelago/pull/4811 for Ocarina of Time.

## How was this tested?
Generated a patched file and client functions.