### PR TITLE
Terraria: Fix inaccessible Leading Landlord achievement when getfixedboi is enabled

### DIFF
--- a/worlds/terraria/Rules.dsv
+++ b/worlds/terraria/Rules.dsv
@@ -151,7 +151,7 @@ Magma Stone;
 // Evil
 Smashing, Poppet!;                  Achievement;
 Arms Dealer;                        Npc;
-Leading Landlord;                   Achievement;                                Nurse & Arms Dealer; // The logic is way more complex, but that doesn't affect anything
+Leading Landlord;                   Achievement | Not Getfixedboi;              Nurse & Arms Dealer; // The logic is way more complex, but that doesn't affect anything
 Completely Awesome;                 Achievement;                                Arms Dealer;
 Illegal Gun Parts;                  ;                                           Arms Dealer | Flamethrower;
 


### PR DESCRIPTION
## What is this fixing or adding?
The Leading Landlord achievement was discovered to be impossible to obtain in the secret getfixedboi seed, so removed it when getfixedboi is enabled.

## How was this tested?
I generated some worlds with different settings and checked to make sure the achievement is properly included/excluded based on settings.
