### PR TITLE
The Messenger: fix indentation in setup guide

### DIFF
--- a/worlds/messenger/docs/setup_en.md
+++ b/worlds/messenger/docs/setup_en.md
@@ -29,15 +29,6 @@ These steps can also be followed to launch the game and check for mod updates af
        [The Messenger Randomizer Mod AP releases page](https://github.com/alwaysintreble/TheMessengerRandomizerModAP/releases)
     2. Extract the zip file to `TheMessenger/Mods/` of your game's install location
         * You cannot have both the non-AP randomizer and the AP randomizer installed at the same time
-    3. Optionally, Backup your save game
-        * On Windows
-            1. Press `Windows Key + R` to open run
-            2. Type `%appdata%` to access AppData
-            3. Navigate to `AppData/locallow/SabotageStudios/The Messenger`
-            4. Rename `SaveGame.txt` to any name of your choice
-        * On Linux
-            1. Navigate to `steamapps/compatdata/764790/pfx/drive_c/users/steamuser/AppData/LocalLow/Sabotage Studio/The Messenger`
-            2. Rename `SaveGame.txt` to any name of your choice
 
 ## Joining a MultiWorld Game
 

--- a/worlds/messenger/docs/setup_en.md
+++ b/worlds/messenger/docs/setup_en.md
@@ -23,21 +23,21 @@ These steps can also be followed to launch the game and check for mod updates af
 ### Manual Installation
 
 1. Download and install Courier Mod Loader using the instructions on the release page
-   * [Latest release is currently 0.7.1](https://github.com/Brokemia/Courier/releases)
+    * [Latest release is currently 0.7.1](https://github.com/Brokemia/Courier/releases)
 2. Download and install the randomizer mod
-   1. Download the latest TheMessengerRandomizerAP.zip from
-[The Messenger Randomizer Mod AP releases page](https://github.com/alwaysintreble/TheMessengerRandomizerModAP/releases)
-   2. Extract the zip file to `TheMessenger/Mods/` of your game's install location
-      * You cannot have both the non-AP randomizer and the AP randomizer installed at the same time
-   3. Optionally, Backup your save game
-      * On Windows
-        1. Press `Windows Key + R` to open run
-        2. Type `%appdata%` to access AppData
-        3. Navigate to `AppData/locallow/SabotageStudios/The Messenger`
-        4. Rename `SaveGame.txt` to any name of your choice
-      * On Linux
-        1. Navigate to `steamapps/compatdata/764790/pfx/drive_c/users/steamuser/AppData/LocalLow/Sabotage Studio/The Messenger`
-        2. Rename `SaveGame.txt` to any name of your choice
+    1. Download the latest TheMessengerRandomizerAP.zip from
+       [The Messenger Randomizer Mod AP releases page](https://github.com/alwaysintreble/TheMessengerRandomizerModAP/releases)
+    2. Extract the zip file to `TheMessenger/Mods/` of your game's install location
+        * You cannot have both the non-AP randomizer and the AP randomizer installed at the same time
+    3. Optionally, Backup your save game
+        * On Windows
+            1. Press `Windows Key + R` to open run
+            2. Type `%appdata%` to access AppData
+            3. Navigate to `AppData/locallow/SabotageStudios/The Messenger`
+            4. Rename `SaveGame.txt` to any name of your choice
+        * On Linux
+            1. Navigate to `steamapps/compatdata/764790/pfx/drive_c/users/steamuser/AppData/LocalLow/Sabotage Studio/The Messenger`
+            2. Rename `SaveGame.txt` to any name of your choice
 
 ## Joining a MultiWorld Game
 
@@ -57,15 +57,15 @@ These steps can also be followed to launch the game and check for mod updates af
 1. Launch the game
 2. Navigate to `Options > Archipelago Options`
 3. Enter connection info using the relevant option buttons
-   * **The game is limited to alphanumerical characters, `.`, and `-`.**
-   * This defaults to `archipelago.gg` and does not need to be manually changed if connecting to a game hosted on the
-     website.
-   * If using a name that cannot be entered in the in game menus, there is a config file (APConfig.toml) in the game
-     directory. When using this, all connection information must be entered in the file. 
+    * **The game is limited to alphanumerical characters, `.`, and `-`.**
+    * This defaults to `archipelago.gg` and does not need to be manually changed if connecting to a game hosted on the
+      website.
+    * If using a name that cannot be entered in the in game menus, there is a config file (APConfig.toml) in the game
+      directory. When using this, all connection information must be entered in the file. 
 4. Select the `Connect to Archipelago` button
 5. Navigate to save file selection
 6. Start a new game
-   * If you're already connected, deleting an existing save will not disconnect you and is completely safe. 
+    * If you're already connected, deleting an existing save will not disconnect you and is completely safe. 
 
 ## Continuing a MultiWorld Game
 


### PR DESCRIPTION
## What is this fixing or adding?
Fixes indentation that was all over the place for some reason. Also removes the now irrelevant save backup section. Client has had proper save management for a while now this is just leftover.

## How was this tested?
Checked that all the indentations were 4 characters instead of whatever was going on before. Checked the other documents but they were already correct.
