### PR TITLE
[MMBN3] Adds beach access to "Help with Rehab" job bonus reward check

### DIFF
--- a/worlds/mmbn3/__init__.py
+++ b/worlds/mmbn3/__init__.py
@@ -278,6 +278,9 @@ class MMBN3World(World):
         self.multiworld.get_location(LocationName.Help_with_rehab, self.player).access_rule = \
             lambda state: \
                 state.can_reach_region(RegionName.Beach_Overworld, self.player)
+        self.multiworld.get_location(LocationName.Help_with_rehab_bonus, self.player).access_rule = \
+            lambda state: \
+                state.can_reach_region(RegionName.Beach_Overworld, self.player)
         self.multiworld.get_location(LocationName.Old_Master, self.player).access_rule = \
             lambda state: \
                 state.can_reach_region(RegionName.ACDC_Overworld, self.player) and \


### PR DESCRIPTION
## What is this fixing or adding?
The newly added check "Help With Rehab - Bonus" was not properly checking for Beach Area access to be completed, even though the original job reward was.

## How was this tested?
Generated a seed, added SubPET to inventory to access SciLab. Checked Universal Tracker to see that the "Help With Rehab - bonus" check was not in logic. Added PETCase to access Beach area, checked again, and confirmed the job is now in-logic.