### PR TITLE
Docs: add a "missable locations" question to apworld_dev_faq.md

### DIFF
--- a/docs/apworld_dev_faq.md
+++ b/docs/apworld_dev_faq.md
@@ -85,3 +85,14 @@ Common situations where this can happen include:
   Also, consider using the `options.as_dict("option_name", "option_two")` helper.
 * Using enums as Location/Item names in the datapackage. When building out `location_name_to_id` and `item_name_to_id`,
   make sure that you are not using your enum class for either the names or ids in these mappings.
+
+---
+
+### What if my game has "missable" or "one-time-only" locations or region connections?
+
+Archipelago logic assumes that once a region or location becomes reachable, it stays reachable forever. Slightly more formally: Receiving an AP item must never cause a region connection or location to "go out of logic" (become unreachable when it was previously reachable), and receiving AP items is the only kind of state change that AP logic acknowledges; nothing else is allowed to change reachability.
+
+So when a game violates this assumption, the options are:
+- Don't include that location/connection in logic
+- Mod the game to make that location/connection repeatable
+- Decide that resetting the save file is part of the game's logic, and warn players about that


### PR DESCRIPTION
## What is this fixing or adding?

see title

basically turning the conversation at https://discord.com/channels/731205301247803413/1214608557077700720/1368996789260128388 into a FAQ entry

## How was this tested?

reading

## If this makes graphical changes, please attach screenshots.

N/A