### PR TITLE
Muse Dash: Fix using dict_keys instead of a string iteratable

### DIFF
--- a/worlds/musedash/Options.py
+++ b/worlds/musedash/Options.py
@@ -153,8 +153,9 @@ class TrapCountPercentage(Range):
     display_name = "Trap Percentage"
 
 
-class SongSet(OptionSet):
-    valid_keys = SONG_DATA.keys()
+class SongSet(OptionSet):    
+    valid_keys = {x for x in SONG_DATA.keys()}
+
 
 
 class IncludeSongs(SongSet):


### PR DESCRIPTION
## What is this fixing or adding?
Found by https://github.com/ArchipelagoMW/Archipelago/pull/4900. Muse dash was using the dict_keys of a dictionary and not a Iterable of strings.

## How was this tested?
Tests and running webhost.