### PR TITLE
Core: Make it so release_mode, collect_mode and remaining_mode crash if the value is invalid

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -294,6 +294,14 @@ class Group:
             self._dumping = False
 
 
+class Permission(str):
+    def __new__(cls, value):
+        instance = super().__new__(cls, value)
+        if instance not in ("disabled", "enabled", "auto", "auto-enabled", "goal"):
+            raise ValueError(f"Tried to set {cls.__name__} setting to {value}, which is not allowed.")
+        return instance
+
+
 class Bool:
     # can't subclass bool, so we use this and Union or type: ignore
     def __bool__(self) -> bool:
@@ -547,7 +555,7 @@ class ServerOptions(Group):
         for a total of 5
         """
 
-    class ReleaseMode(str):
+    class ReleaseMode(Permission):
         """
         Release modes
         A Release sends out the remaining items *from* a world that releases
@@ -558,7 +566,7 @@ class ServerOptions(Group):
         "goal" -> release is allowed after goal completion
         """
 
-    class CollectMode(str):
+    class CollectMode(Permission):
         """
         Collect modes
         A Collect sends the remaining items *to* a world that collects
@@ -569,7 +577,7 @@ class ServerOptions(Group):
         "goal" -> collect is allowed after goal completion
         """
 
-    class RemainingMode(str):
+    class RemainingMode(Permission):
         """
         Remaining modes
         !remaining handling, that tells a client which items remain in their pool


### PR DESCRIPTION
Right now, you can put `release_mode: my_ass_is_on_fire` into your host.yaml and it'll happily accept that.
And the server side behavior is very strange, acting in some places like it's "disabled", and in other places like it's "goal"

This is the easiest change I could find to change this