### PR TITLE
The Messenger: do all empty state validation during portal shuffle

### DIFF
--- a/worlds/messenger/__init__.py
+++ b/worlds/messenger/__init__.py
@@ -16,8 +16,8 @@ from .portals import PORTALS, add_closed_portal_reqs, disconnect_portals, shuffl
 from .regions import LEVELS, MEGA_SHARDS, LOCATIONS, REGION_CONNECTIONS
 from .rules import MessengerHardRules, MessengerOOBRules, MessengerRules
 from .shop import FIGURINES, PROG_SHOP_ITEMS, SHOP_ITEMS, USEFUL_SHOP_ITEMS, shuffle_shop_prices
-from .subclasses import MessengerEntrance, MessengerItem, MessengerRegion, MessengerShopLocation
-from .transitions import shuffle_transitions
+from .subclasses import MessengerItem, MessengerRegion, MessengerShopLocation
+from .transitions import disconnect_entrances, shuffle_transitions
 
 components.append(
     Component("The Messenger", component_type=Type.CLIENT, func=launch_game, game_name="The Messenger", supports_uri=True)
@@ -266,6 +266,8 @@ class MessengerWorld(World):
         #     MessengerOOBRules(self).set_messenger_rules()
 
     def connect_entrances(self) -> None:
+        if self.options.shuffle_transitions:
+            disconnect_entrances(self)
         add_closed_portal_reqs(self)
         # i need portal shuffle to happen after rules exist so i can validate it
         attempts = 5

--- a/worlds/messenger/portals.py
+++ b/worlds/messenger/portals.py
@@ -292,12 +292,10 @@ def disconnect_portals(world: "MessengerWorld") -> None:
 
 
 def validate_portals(world: "MessengerWorld") -> bool:
-    if world.options.shuffle_transitions:
-        return True
-    new_state = CollectionState(world.multiworld)
+    new_state = CollectionState(world.multiworld, True)
     new_state.update_reachable_regions(world.player)
     reachable_locs = 0
-    for loc in world.multiworld.get_locations(world.player):
+    for loc in world.get_locations():
         reachable_locs += loc.can_reach(new_state)
         if reachable_locs > 5:
             return True

--- a/worlds/messenger/subclasses.py
+++ b/worlds/messenger/subclasses.py
@@ -10,25 +10,8 @@ if TYPE_CHECKING:
     from . import MessengerWorld
 
 
-class MessengerEntrance(Entrance):
-    world: "MessengerWorld | None" = None
-
-    def can_connect_to(self, other: Entrance, dead_end: bool, state: "ERPlacementState") -> bool:
-        can_connect = super().can_connect_to(other, dead_end, state)
-        world: MessengerWorld = getattr(self, "world", None)
-        if not world or world.reachable_locs or not can_connect:
-            return can_connect
-        empty_state = CollectionState(world.multiworld, True)
-        self.connected_region = other.connected_region
-        empty_state.update_reachable_regions(world.player)
-        world.reachable_locs = any(loc.can_reach(empty_state) and not loc.is_event for loc in world.get_locations())
-        self.connected_region = None
-        return world.reachable_locs and (not state.coupled or self.name != other.name)
-
-
 class MessengerRegion(Region):
     parent: str | None
-    entrance_type = MessengerEntrance
 
     def __init__(self, name: str, world: "MessengerWorld", parent: str | None = None) -> None:
         super().__init__(name, world.player, world.multiworld)


### PR DESCRIPTION
## What is this fixing or adding?
Currently messenger attempts to guarantee the player has access to at least a few locations with empty state during GER, but as this reduces the amount of valid entrances significantly GER gets hung up on it not being able to connect stuff and throws a fit. This forces all of the validation to be done during portal shuffle every time with disconnected entrances, so that all entrance connections can just be valid. If portal shuffle is disabled this is irrelevant since one of the starting portals guarantees reaching some locations.

## How was this tested?
Ran a bunch of generations with the option combination that keeps throwing test failures.