### PR TITLE
Core: Institute limit of 10000 items on StartInventory

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -1353,7 +1353,7 @@ class StartInventory(ItemDict):
     verify_item_name = True
     display_name = "Start Inventory"
     rich_text_doc = True
-    max = 30000
+    max = 10000
 
 
 class StartInventoryPool(StartInventory):

--- a/Options.py
+++ b/Options.py
@@ -1349,7 +1349,7 @@ class NonLocalItems(ItemSet):
 
 
 class StartInventory(ItemDict):
-    """Start with these items. Capped at 30000 per item."""
+    """Start with these items. Capped at 10000 per item."""
     verify_item_name = True
     display_name = "Start Inventory"
     rich_text_doc = True

--- a/Options.py
+++ b/Options.py
@@ -1349,7 +1349,7 @@ class NonLocalItems(ItemSet):
 
 
 class StartInventory(ItemDict):
-    """Start with these items. Capped at 10000 per item."""
+    """Start with these items."""
     verify_item_name = True
     display_name = "Start Inventory"
     rich_text_doc = True

--- a/Options.py
+++ b/Options.py
@@ -1349,10 +1349,11 @@ class NonLocalItems(ItemSet):
 
 
 class StartInventory(ItemDict):
-    """Start with these items."""
+    """Start with these items. Capped at 30000 per item."""
     verify_item_name = True
     display_name = "Start Inventory"
     rich_text_doc = True
+    max = 30000
 
 
 class StartInventoryPool(StartInventory):


### PR DESCRIPTION
Someone ate up a bunch of server resources by adding 10 million rare candies to their starting inventory. It's probably high time we put a limit on that.

Thanks to StartInventory being an OptionCounter now, we have a very easy way of adding a per-item cap.

Why 10000? Kinda just vibes. I can imagine scenarios where adding 10'000 of some in-game resource might be reasonable. I know Witness players often start with 10000 speed boosts, for example, so that they have 20 * 10000s of speed, which is like 2.5 days, which might legitimately run out if you're not the fastest at solving puzzles.

This is per item, maybe it'd be good to have an overall limit as well?