### PR TITLE
Docs: tests: add naming / file naming conventions

### DIFF
--- a/docs/tests.md
+++ b/docs/tests.md
@@ -14,7 +14,7 @@ In order to run tests from your world, you will need to create a `test` package 
 done by creating a `test` directory with a file named `__init__.py` inside it inside your world. By convention, a base
 for your world tests can be created in `bases.py` or any file that does not start with `test`, that you can then import
 into other modules. All tests should be defined in files named `test_*.py` (all lower case) and be member functions
-named `test_*` of classes named `*Test` that inherit from unittest.TestCase or a test base.
+named `test_*` of classes named `Test*` or `*Test` that inherit from `unittest.TestCase` or a test base.
 
 Defining anything inside `test/__init__.py` is deprecated. Defining TestBase there was previously the norm, however
 it complicates test discovery, because some worlds also put actual tests into `__init__.py`.

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -12,7 +12,12 @@ found in the [general test directory](/test/general).
 
 In order to run tests from your world, you will need to create a `test` package within your world package. This can be
 done by creating a `test` directory with a file named `__init__.py` inside it inside your world. By convention, a base
-for your world tests can be created in this file that you can then import into other modules.
+for your world tests can be created in `bases.py` or any file that does not start with `test`, that you can then import
+into other modules. All tests should be defined in files named `test_*.py` (all lower case) and be member functions
+named `test_*` of classes named `*Test` that inherit from unittest.TestCase or a test base.
+
+Defining anything inside `test/__init__.py` is deprecated. Defining TestBase there was previously the norm, however
+it complicates test discovery, because some worlds also put actual tests into `__init__.py`.
 
 ### WorldTestBase
 

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -26,7 +26,7 @@ interactions in the world interact as expected, you will want to use the [WorldT
 comes with the basics for test setup as well as a few preloaded tests that most worlds might want to check on varying
 options combinations.
 
-Example `/worlds/<my_game>/test/__init__.py`:
+Example `/worlds/<my_game>/test/bases.py`:
 
 ```python
 from test.bases import WorldTestBase
@@ -54,7 +54,7 @@ with `test_`.
 Example `/worlds/<my_game>/test/test_chest_access.py`:
 
 ```python
-from . import MyGameTestBase
+from .bases import MyGameTestBase
 
 
 class TestChestAccess(MyGameTestBase):

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -11,7 +11,7 @@ found in the [general test directory](/test/general).
 ## Defining World Tests
 
 In order to run tests from your world, you will need to create a `test` package within your world package. This can be
-done by creating a `test` directory with a file named `__init__.py` inside it inside your world. By convention, a base
+done by creating a `test` directory with an (empty) `__init__.py` inside it inside your world. By convention, a base
 for your world tests can be created in `bases.py` or any file that does not start with `test`, that you can then import
 into other modules. All tests should be defined in files named `test_*.py` (all lower case) and be member functions
 (named `test_*`) of classes (named `Test*` or `*Test`) that inherit from `unittest.TestCase` or a test base.

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -13,11 +13,11 @@ found in the [general test directory](/test/general).
 In order to run tests from your world, you will need to create a `test` package within your world package. This can be
 done by creating a `test` directory with a file named `__init__.py` inside it inside your world. By convention, a base
 for your world tests can be created in `bases.py` or any file that does not start with `test`, that you can then import
-into other modules. All tests should be defined in files named `test_*.py` (all lower case) and be member functions
-named `test_*` of classes named `Test*` or `*Test` that inherit from `unittest.TestCase` or a test base.
+into other modules. All tests should be defined in files (named `test_*.py`, all lower case) and be member functions
+(named `test_*`) of classes (named `Test*` or `*Test`) that inherit from `unittest.TestCase` or a test base.
 
-Defining anything inside `test/__init__.py` is deprecated. Defining TestBase there was previously the norm, however
-it complicates test discovery, because some worlds also put actual tests into `__init__.py`.
+Defining anything inside `test/__init__.py` is deprecated. Defining TestBase there was previously the norm; however,
+it complicates test discovery because some worlds also put actual tests into `__init__.py`.
 
 ### WorldTestBase
 

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -13,7 +13,7 @@ found in the [general test directory](/test/general).
 In order to run tests from your world, you will need to create a `test` package within your world package. This can be
 done by creating a `test` directory with a file named `__init__.py` inside it inside your world. By convention, a base
 for your world tests can be created in `bases.py` or any file that does not start with `test`, that you can then import
-into other modules. All tests should be defined in files (named `test_*.py`, all lower case) and be member functions
+into other modules. All tests should be defined in files named `test_*.py` (all lower case) and be member functions
 (named `test_*`) of classes (named `Test*` or `*Test`) that inherit from `unittest.TestCase` or a test base.
 
 Defining anything inside `test/__init__.py` is deprecated. Defining TestBase there was previously the norm; however,

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -11,7 +11,7 @@ found in the [general test directory](/test/general).
 ## Defining World Tests
 
 In order to run tests from your world, you will need to create a `test` package within your world package. This can be
-done by creating a `test` directory with an (empty) `__init__.py` inside it inside your world. By convention, a base
+done by creating a `test` directory inside your world with an (empty) `__init__.py` inside it. By convention, a base
 for your world tests can be created in `bases.py` or any file that does not start with `test`, that you can then import
 into other modules. All tests should be defined in files named `test_*.py` (all lower case) and be member functions
 (named `test_*`) of classes (named `Test*` or `*Test`) that inherit from `unittest.TestCase` or a test base.


### PR DESCRIPTION
## What is this fixing or adding?
Adds naming convention for files, class names and function names.
Deprecates putting stuff into `__init__.py`.
This may be relevant for test discovery in the future.

See discussion in #4969 

## How was this tested?

Reading.