### PR TITLE
Stardew Valley: Added missing marriage requirement for the spouse stardrop

### DIFF
--- a/worlds/stardew_valley/rules.py
+++ b/worlds/stardew_valley/rules.py
@@ -864,7 +864,7 @@ def set_friendsanity_rules(logic: StardewLogic, multiworld: MultiWorld, player: 
     if not content.features.friendsanity.is_enabled:
         return
     set_rule(multiworld.get_location("Spouse Stardrop", player),
-             logic.relationship.has_hearts_with_any_bachelor(13))
+             logic.relationship.has_hearts_with_any_bachelor(13) & logic.relationship.can_get_married())
     set_rule(multiworld.get_location("Have a Baby", player),
              logic.relationship.can_reproduce(1))
     set_rule(multiworld.get_location("Have Another Baby", player),


### PR DESCRIPTION
## What is this fixing or adding?
Someone found a logic issue, where receiving 13 hearts was enough for "Spouse Stardrop" to be in logic, even without the beach bridge to actually get the pendant and get married.

## How was this tested?
Honestly, not much. It's a one liner.
