### PR TITLE
Launcher:  Newly installed custom worlds are not relative

### DIFF
--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -181,7 +181,7 @@ def _install_apworld(apworld_src: str = "") -> Optional[Tuple[pathlib.Path, path
         raise Exception(f"Installed APWorld successfully, but '{module_name}' is already loaded,\n"
                         "so a Launcher restart is required to use the new installation.\n"
                         "If the Launcher is not open, no action needs to be taken.")
-    world_source = worlds.WorldSource(str(target), is_zip=True)
+    world_source = worlds.WorldSource(str(target), is_zip=True, relative=False)
     bisect.insort(worlds.world_sources, world_source)
     world_source.load()
 


### PR DESCRIPTION
## What is this fixing or adding?

After installing a new apworld, we're currently not setting the relative flag on the worldsource.  This defaults to `relative=True` (ie, installed to lib/worlds).  This is not accurate.

## How was this tested?
* Installed a new world with my [APWorld Manager](https://github.com/silasary/Archipelago/releases/tag/apworld_manager-0.0.13) and verified it didn't claim the newly installed world was bundled with AP.

## If this makes graphical changes, please attach screenshots.
