### PR TITLE
AHIT: Fix client argument handling

### DIFF
--- a/AHITClient.py
+++ b/AHITClient.py
@@ -1,3 +1,4 @@
+import sys
 from worlds.ahit.Client import launch
 import Utils
 import ModuleUpdate
@@ -5,4 +6,4 @@ ModuleUpdate.update()
 
 if __name__ == "__main__":
     Utils.init_logging("AHITClient", exception_logger="Client")
-    launch()
+    launch(*sys.argv[1:])

--- a/worlds/ahit/Client.py
+++ b/worlds/ahit/Client.py
@@ -238,10 +238,10 @@ async def proxy_loop(ctx: AHITContext):
         logger.info("Aborting AHIT Proxy Client due to errors")
 
 
-def launch():
+def launch(*launch_args: str):
     async def main():
         parser = get_base_parser()
-        args = parser.parse_args()
+        args = parser.parse_args(launch_args)
 
         ctx = AHITContext(args.connect, args.password)
         logger.info("Starting A Hat in Time proxy server")

--- a/worlds/ahit/__init__.py
+++ b/worlds/ahit/__init__.py
@@ -16,9 +16,9 @@ from worlds.LauncherComponents import Component, components, icon_paths, launch 
 from Utils import local_path
 
 
-def launch_client():
+def launch_client(*args: str):
     from .Client import launch
-    launch_component(launch, name="AHITClient")
+    launch_component(launch, name="AHITClient", args=args)
 
 
 components.append(Component("A Hat in Time Client", "AHITClient", func=launch_client,


### PR DESCRIPTION
## What is this fixing or adding?
Changes the launch function for A Hat in Time's client to take in args as a parameter instead of calling `parser.parse_args()` with no arguments, which when launched through `Launcher.py AHITClient` includes the `AHITClient` arg itself and therefore crashes. I changed it to what's done in BizHawkClient, which also has optional arguments.
## How was this tested?
I tried opening the client with and without arguments when passing the name to launcher, as well as with the currently working methods of opening it inside the launcher GUI or running `AHITClient.py` directly.