### PR TITLE
DS3: Fix the name of "Red and White Round Shield"

### DIFF
--- a/worlds/dark_souls_3/Items.py
+++ b/worlds/dark_souls_3/Items.py
@@ -511,7 +511,7 @@ _vanilla_items = [
     DS3ItemData("Elkhorn Round Shield",                0x0133C510, DS3ItemCategory.SHIELD_INFUSIBLE),
     DS3ItemData("Warrior's Round Shield",              0x0133EC20, DS3ItemCategory.SHIELD_INFUSIBLE),
     DS3ItemData("Caduceus Round Shield",               0x01341330, DS3ItemCategory.SHIELD_INFUSIBLE),
-    DS3ItemData("Red and White Shield",                0x01343A40, DS3ItemCategory.SHIELD_INFUSIBLE),
+    DS3ItemData("Red and White Round Shield",          0x01343A40, DS3ItemCategory.SHIELD_INFUSIBLE),
     DS3ItemData("Blessed Red and White Shield+1",      0x01343FB9, DS3ItemCategory.SHIELD),
     DS3ItemData("Plank Shield",                        0x01346150, DS3ItemCategory.SHIELD_INFUSIBLE),
     DS3ItemData("Leather Shield",                      0x01348860, DS3ItemCategory.SHIELD_INFUSIBLE),

--- a/worlds/dark_souls_3/Locations.py
+++ b/worlds/dark_souls_3/Locations.py
@@ -732,8 +732,9 @@ location_tables: Dict[str, List[DS3LocationData]] = {
                         missable=True),  # requires projectile
         DS3LocationData("US: Flame Stoneplate Ring - hanging corpse by Mound-Maker transport",
                         "Flame Stoneplate Ring"),
-        DS3LocationData("US: Red and White Shield - chasm, hanging corpse", "Red and White Shield",
-                        static="02,0:53100740::", missable=True),  # requires projectile
+        DS3LocationData("US: Red and White Round Shield - chasm, hanging corpse",
+                        "Red and White Round Shield", static="02,0:53100740::",
+                        missable=True),  # requires projectile
         DS3LocationData("US: Small Leather Shield - first building, hanging corpse by entrance",
                         "Small Leather Shield"),
         DS3LocationData("US: Pale Tongue - tower village, hanging corpse", "Pale Tongue"),

--- a/worlds/dark_souls_3/docs/locations_en.md
+++ b/worlds/dark_souls_3/docs/locations_en.md
@@ -2239,7 +2239,7 @@ static _Dark Souls III_ randomizer].
 <tr><td>US: Pyromancy Flame - Cornyx</td><td>Given by Cornyx in Firelink Shrine or dropped.</td></tr>
 <tr><td>US: Red Bug Pellet - tower village building, basement</td><td>On the floor of the building after the Fire Demon encounter</td></tr>
 <tr><td>US: Red Hilted Halberd - chasm crypt</td><td>In the skeleton area accessible from Grave Key or dropping down from near Eygon</td></tr>
-<tr><td>US: Red and White Shield - chasm, hanging corpse</td><td>On a hanging corpse in the ravine accessible with the Grave Key or dropping down near Eygon, to the entrance of Irina&#x27;s prison. Must be shot down with an arrow or projective.</td></tr>
+<tr><td>US: Red and White Round Shield - chasm, hanging corpse</td><td>On a hanging corpse in the ravine accessible with the Grave Key or dropping down near Eygon, to the entrance of Irina&#x27;s prison. Must be shot down with an arrow or projective.</td></tr>
 <tr><td>US: Reinforced Club - by white tree</td><td>Near the Birch Tree where giant shoots arrows</td></tr>
 <tr><td>US: Repair Powder - first building, balcony</td><td>On the balcony of the first Undead Settlement building</td></tr>
 <tr><td>US: Rusted Coin - awning above Dilapidated Bridge</td><td>On a wooden ledge near the Dilapidated Bridge bonfire. Must be jumped to from near Cathedral Evangelist enemy</td></tr>


### PR DESCRIPTION
This item name is unusual in that it loses the word "round" when it's infused, *and* the only guaranteed drop in the base game is the infused "Blessed Red and White Round Shield +1". But since we're just listing the uninfused version, we should use the uninfused name.