### PR TITLE
Core: Fix some typing errors

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -23,7 +23,7 @@ from BaseClasses import seeddigits, get_seed, PlandoOptions
 from Utils import parse_yamls, version_tuple, __version__, tuplize_version
 
 
-def mystery_argparse():
+def mystery_argparse() -> argparse.Namespace:
     from settings import get_settings
     settings = get_settings()
     defaults = settings.generator
@@ -68,7 +68,7 @@ def mystery_argparse():
         args.weights_file_path = os.path.join(args.player_files_path, args.weights_file_path)
     if not os.path.isabs(args.meta_file_path):
         args.meta_file_path = os.path.join(args.player_files_path, args.meta_file_path)
-    args.plando: PlandoOptions = PlandoOptions.from_option_string(args.plando)
+    args.plando = PlandoOptions.from_option_string(args.plando)
 
     return args
 
@@ -180,7 +180,7 @@ def main(args=None) -> tuple[argparse.Namespace, int]:
     erargs.name = {}
     erargs.csv_output = args.csv_output
 
-    settings_cache: dict[str, tuple[argparse.Namespace, ...]] = \
+    settings_cache: dict[str, tuple[argparse.Namespace, ...] | None] = \
         {fname: (tuple(roll_settings(yaml, args.plando) for yaml in yamls) if args.sameoptions else None)
          for fname, yamls in weights_cache.items()}
 
@@ -204,7 +204,7 @@ def main(args=None) -> tuple[argparse.Namespace, int]:
     player_path_cache = {}
     for player in range(1, args.multi + 1):
         player_path_cache[player] = player_files.get(player, args.weights_file_path)
-    name_counter = Counter()
+    name_counter: Counter = Counter()
     erargs.player_options = {}
 
     player = 1
@@ -212,7 +212,8 @@ def main(args=None) -> tuple[argparse.Namespace, int]:
         path = player_path_cache[player]
         if path:
             try:
-                settings: tuple[argparse.Namespace, ...] = settings_cache[path] if settings_cache[path] else \
+                cached_settings = settings_cache[path]
+                settings: tuple[argparse.Namespace, ...] = cached_settings if cached_settings else \
                     tuple(roll_settings(yaml, args.plando) for yaml in weights_cache[path])
                 for settingsObject in settings:
                     for k, v in vars(settingsObject).items():
@@ -445,7 +446,7 @@ def roll_triggers(weights: dict, triggers: list, valid_keys: set) -> dict:
     return weights
 
 
-def handle_option(ret: argparse.Namespace, game_weights: dict, option_key: str, option: type(Options.Option), plando_options: PlandoOptions):
+def handle_option(ret: argparse.Namespace, game_weights: dict, option_key: str, option: type[Options.Option], plando_options: PlandoOptions):
     try:
         if option_key in game_weights:
             if not option.supports_weighting:

--- a/Options.py
+++ b/Options.py
@@ -499,9 +499,9 @@ class Choice(NumericOption):
 
 class TextChoice(Choice):
     """Allows custom string input and offers choices. Choices will resolve to int and text will resolve to string"""
-    value: typing.Union[str, int]
+    value: str | int
 
-    def __init__(self, value: typing.Union[str, int]):
+    def __init__(self, value: str | int):
         assert isinstance(value, str) or isinstance(value, int), \
             f"'{value}' is not a valid option for '{self.__class__.__name__}'"
         self.value = value
@@ -522,7 +522,7 @@ class TextChoice(Choice):
         return cls(text)
 
     @classmethod
-    def get_option_name(cls, value: T) -> str:
+    def get_option_name(cls, value: str | int) -> str:
         if isinstance(value, str):
             return value
         return super().get_option_name(value)
@@ -861,7 +861,8 @@ class OptionDict(Option[typing.Dict[str, typing.Any]], VerifyKeys, typing.Mappin
         else:
             raise NotImplementedError(f"Cannot Convert from non-dictionary, got {type(data)}")
 
-    def get_option_name(self, value):
+    @classmethod
+    def get_option_name(cls, value):
         return ", ".join(f"{key}: {v}" for key, v in value.items())
 
     def __getitem__(self, item: str) -> typing.Any:
@@ -941,7 +942,8 @@ class OptionList(Option[typing.List[typing.Any]], VerifyKeys):
             return cls(data)
         return cls.from_text(str(data))
 
-    def get_option_name(self, value):
+    @classmethod
+    def get_option_name(cls, value):
         return ", ".join(map(str, value))
 
     def __contains__(self, item):
@@ -965,8 +967,9 @@ class OptionSet(Option[typing.Set[str]], VerifyKeys):
         if is_iterable_except_str(data):
             return cls(data)
         return cls.from_text(str(data))
-
-    def get_option_name(self, value):
+    
+    @classmethod
+    def get_option_name(cls, value):
         return ", ".join(sorted(value))
 
     def __contains__(self, item):


### PR DESCRIPTION
## What is this fixing or adding?
I'm not sure if all of these are desired, but there's some typing errors in Generate and Options that seem like they can be fixed fairly painlessly.

The `@classmethod` additions for on `get_option_name` are since that's how it's defined in the base `Option` class, and since none of them use self it shouldn't have any effect. Worlds that add options already seem to make it a classmethod. Also the generic `T` annotation on `TextChoice` seems to just be a mistake when copying it from the base method.
Some more would be fixed in `Options.py` with #4813.
## How was this tested?
Tried finding the errors with mypy and pyright, and ran normal tests after.
## If this makes graphical changes, please attach screenshots.
⌨️🚫: 📉