### PR TITLE
Raft: Small Raft doc update, bugfix

### DIFF
--- a/worlds/raft/docs/setup_en.md
+++ b/worlds/raft/docs/setup_en.md
@@ -45,7 +45,8 @@
 ## Multiplayer Raft
 
 You're able to have multiple Raft players on a single Raftipelago world. This will work, with a few notes:
-- Only the player that creates/loads the world can connect to Archipelago (this is the "host" of the Raft world). Other players do not need to connect; everything will be routed through the the host.
+- Every player that joins the Raft world must have the Raftipelago mod loaded
+- Only the player that creates/loads the world can connect to Archipelago (this is the "host" of the Raft world). Other players do not need to run */connect*; everything will be routed through the the host.
 - Players other than the host will be labeled as a "Raft Player (Steam name)" when using ingame chat, which will be routed through Archipelago chat.
 - Ingame chat will only work when the host is connected to the Archipelago server.
 

--- a/worlds/raft/progressives.json
+++ b/worlds/raft/progressives.json
@@ -30,7 +30,7 @@
     "Steering Wheel": "progressive-engine",
     "Engine controls": "progressive-engine",
     "Scarecrow": "progressive-scarecrow",
-    "Advanced scarecrow": "progressive-scarecrow",
+    "Advanced Scarecrow": "progressive-scarecrow",
     "Simple collection net": "progressive-net",
     "Advanced collection net": "progressive-net",
     "Storage": "progressive-storage",


### PR DESCRIPTION
## What is this fixing or adding?
Add line to docs around requiring all Raft players joining a single Raft world requiring the Raftipelago mod
Fix `Advanced Scarecrow` not being replaced with `progressive-scarecrow` when progressives are enabled

## How was this tested?
Verified bug via generation from `main` and checking spoiler log, fixed issue and verified it was working properly through new generation and checking spoiler log.

## If this makes graphical changes, please attach screenshots.
N/A