### PR TITLE
The Messenger: more generous portal validation

### DIFF
--- a/worlds/messenger/__init__.py
+++ b/worlds/messenger/__init__.py
@@ -270,21 +270,18 @@ class MessengerWorld(World):
             disconnect_entrances(self)
         add_closed_portal_reqs(self)
         # i need portal shuffle to happen after rules exist so i can validate it
-        attempts = 10
+        attempts = 20
         if self.options.shuffle_portals:
             self.portal_mapping = []
             self.spoiler_portal_mapping = {}
-            while attempts:
+            for _ in range(attempts):
                 disconnect_portals(self)
                 shuffle_portals(self)
                 if validate_portals(self):
                     break
-                if self.options.portal_plando:
-                    attempts -= 1
             # failsafe mostly for invalid plandoed portals with no transition shuffle
             else:
-                if not attempts:
-                    raise RuntimeError("Unable to generate valid portal output.")
+                raise RuntimeError("Unable to generate valid portal output.")
 
         if self.options.shuffle_transitions:
             shuffle_transitions(self)

--- a/worlds/messenger/__init__.py
+++ b/worlds/messenger/__init__.py
@@ -270,18 +270,21 @@ class MessengerWorld(World):
             disconnect_entrances(self)
         add_closed_portal_reqs(self)
         # i need portal shuffle to happen after rules exist so i can validate it
-        attempts = 5
+        attempts = 10
         if self.options.shuffle_portals:
             self.portal_mapping = []
             self.spoiler_portal_mapping = {}
-            for _ in range(attempts):
+            while attempts:
                 disconnect_portals(self)
                 shuffle_portals(self)
                 if validate_portals(self):
                     break
+                if self.options.portal_plando:
+                    attempts -= 1
             # failsafe mostly for invalid plandoed portals with no transition shuffle
             else:
-                raise RuntimeError("Unable to generate valid portal output.")
+                if not attempts:
+                    raise RuntimeError("Unable to generate valid portal output.")
 
         if self.options.shuffle_transitions:
             shuffle_transitions(self)


### PR DESCRIPTION
## What is this fixing or adding?
Makes portal shuffle continuously attempt to shuffle until it satisfies the condition. There's plenty of valid combinations for this, but the tests have been getting incredibly unlucky and this keeps failing. in actual practice, it very rarely fails, so i don't foresee this having any observable negative impact on players.

## How was this tested?
wasn't i need sleep