### PR TITLE
Zillion: fix `read_contents` to be compatible with base class

### DIFF
--- a/worlds/zillion/patch.py
+++ b/worlds/zillion/patch.py
@@ -1,5 +1,5 @@
 import os
-from typing import BinaryIO
+from typing import Any, BinaryIO
 import zipfile
 
 from typing_extensions import override
@@ -46,9 +46,10 @@ class ZillionPatch(APAutoPatchInterface):
                                 compress_type=zipfile.ZIP_DEFLATED)
 
     @override
-    def read_contents(self, opened_zipfile: zipfile.ZipFile) -> None:
-        super().read_contents(opened_zipfile)
+    def read_contents(self, opened_zipfile: zipfile.ZipFile) -> dict[str, Any]:
+        manifest = super().read_contents(opened_zipfile)
         self.gen_data_str = opened_zipfile.read("gen_data.json").decode()
+        return manifest
 
     @override
     def patch(self, target: str) -> None:


### PR DESCRIPTION
## What is this fixing or adding?

fixes some of the inheritance structure that was broken by https://github.com/ArchipelagoMW/Archipelago/pull/4331

## How was this tested?

generated a patch file and applied it