### PR TITLE
Adventure: Update AdventureDeltaPatch.read_contents to return the manifest as required by #4331

### DIFF
--- a/worlds/adventure/Rom.py
+++ b/worlds/adventure/Rom.py
@@ -182,10 +182,11 @@ class AdventureDeltaPatch(APPatch, metaclass=AutoPatchRegister):
                                     json.dumps(self.rom_deltas),
                                     compress_type=zipfile.ZIP_LZMA)
 
-    def read_contents(self, opened_zipfile: zipfile.ZipFile):
-        super(AdventureDeltaPatch, self).read_contents(opened_zipfile)
+    def read_contents(self, opened_zipfile: zipfile.ZipFile) -> dict[str, Any]:
+        manifest = super(AdventureDeltaPatch, self).read_contents(opened_zipfile)
         self.foreign_items = AdventureDeltaPatch.read_foreign_items(opened_zipfile)
         self.autocollect_items = AdventureDeltaPatch.read_autocollect_items(opened_zipfile)
+        return manifest
 
     @classmethod
     def get_source_data(cls) -> bytes:


### PR DESCRIPTION
As of https://github.com/ArchipelagoMW/Archipelago/pull/4331, APContainer.read_contents returns the manifest. It was missed by both Berserker and I that Adventure overrides this function and needs to be slightly changed as a result.