### PR TITLE
core: Reconfigure stdout to utf8

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -540,6 +540,7 @@ def init_logging(name: str, loglevel: typing.Union[str, int] = logging.INFO,
         if add_timestamp:
             stream_handler.setFormatter(formatter)
         root_logger.addHandler(stream_handler)
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 
     # Relay unhandled exceptions to logger.
     if not getattr(sys.excepthook, "_wrapped", False):  # skip if already modified


### PR DESCRIPTION
## What is this fixing or adding?
An alternative approach to #4926

## How was this tested?
Tested by using unicode characters in the Text Client in frozen and unfrozen builds on both Windows and Macos

## If this makes graphical changes, please attach screenshots.
