### PR TITLE
DS3: Don't make unrandomized items into events

### DIFF
--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -273,9 +273,7 @@ class DarkSouls3World(World):
                     self.player,
                     location,
                     parent = new_region,
-                    event = True,
                 )
-                event_item.code = None
                 new_location.place_locked_item(event_item)
                 if location.name in excluded:
                     excluded.remove(location.name)


### PR DESCRIPTION
## What is this fixing or adding?

The DS3 static randomizer uses the relative ordering of location names to map between Archipelago's notion of location IDs and the static randomizer's. Treating unrandomized locations as excluded can break this behavior by removing some locations from the list, causing further locations to be incorrectly assigned.

The only reason this wasn't a bigger problem up to this point was that location order only matters on a per-region and per-item basis. That means this only causes problems in practice when a single region has multiple locations with the same default item, and some of those locations are randomized while others are not. Since exclusions (and thus randomization) are usually done based on item types, we managed to dodge this bullet for a long time.

## How was this tested?

I tested this with a few manual end-to-end tests with various different sets of unrandomized locations.