### PR TITLE
core: don't reconfigure stdout if it's fake

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -540,7 +540,8 @@ def init_logging(name: str, loglevel: typing.Union[str, int] = logging.INFO,
         if add_timestamp:
             stream_handler.setFormatter(formatter)
         root_logger.addHandler(stream_handler)
-        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+        if hasattr(sys.stdout, "reconfigure"):
+            sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 
     # Relay unhandled exceptions to logger.
     if not getattr(sys.excepthook, "_wrapped", False):  # skip if already modified


### PR DESCRIPTION
## What is this fixing or adding?

#5017 introduced a problem when sys.stdout was overridden with something that does not have reconfigure - such as subprocess capture in an IDE during test execution.
Reported on Discord here: <https://discord.com/channels/731205301247803413/731214280439103580/1374884066100379659>

## How was this tested?

Just reading and watching CI not fail. Hope people that can easily repro the problem test it a bit more.