### PR TITLE
Wargroove: Cleanup script_name component in LauncherComponents 

### DIFF
--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -232,8 +232,6 @@ components: List[Component] = [
     Component('ChecksFinder Client', 'ChecksFinderClient'),
     # Starcraft 2
     Component('Starcraft 2 Client', 'Starcraft2Client'),
-    # Wargroove
-    Component('Wargroove Client', 'WargrooveClient'),
     # Zillion
     Component('Zillion Client', 'ZillionClient',
               file_identifier=SuffixIdentifier('.apzl')),


### PR DESCRIPTION
## What is this fixing or adding?
wargroove component (and client) moved to apworld so this is unnecessary (and crashes setup)

## How was this tested?
running local setup.py now (it finished and ran clean)

## If this makes graphical changes, please attach screenshots.
