### PR TITLE
Launcher/Utils: reset LD_LIBRARY_PATH for system EXEs

### DIFF
--- a/Launcher.py
+++ b/Launcher.py
@@ -11,6 +11,7 @@ Additional components can be added to worlds.LauncherComponents.components.
 import argparse
 import logging
 import multiprocessing
+import os
 import shlex
 import subprocess
 import sys
@@ -41,13 +42,17 @@ def open_host_yaml():
     if is_linux:
         exe = which('sensible-editor') or which('gedit') or \
               which('xdg-open') or which('gnome-open') or which('kde-open')
-        subprocess.Popen([exe, file])
     elif is_macos:
         exe = which("open")
-        subprocess.Popen([exe, file])
     else:
         webbrowser.open(file)
+        return
 
+    env = os.environ
+    if "LD_LIBRARY_PATH" in env:
+        env = env.copy()
+        del env["LD_LIBRARY_PATH"]  # exe is a system binary, so reset LD_LIBRARY_PATH
+    subprocess.Popen([exe, file], env=env)
 
 def open_patch():
     suffixes = []
@@ -92,7 +97,11 @@ def open_folder(folder_path):
         return
 
     if exe:
-        subprocess.Popen([exe, folder_path])
+        env = os.environ
+        if "LD_LIBRARY_PATH" in env:
+            env = env.copy()
+            del env["LD_LIBRARY_PATH"]  # exe is a system binary, so reset LD_LIBRARY_PATH
+        subprocess.Popen([exe, folder_path], env=env)
     else:
         logging.warning(f"No file browser available to open {folder_path}")
 

--- a/Utils.py
+++ b/Utils.py
@@ -226,7 +226,12 @@ def open_file(filename: typing.Union[str, "pathlib.Path"]) -> None:
         from shutil import which
         open_command = which("open") if is_macos else (which("xdg-open") or which("gnome-open") or which("kde-open"))
         assert open_command, "Didn't find program for open_file! Please report this together with system details."
-        subprocess.call([open_command, filename])
+
+        env = os.environ
+        if "LD_LIBRARY_PATH" in env:
+            env = env.copy()
+            del env["LD_LIBRARY_PATH"]  # exe is a system binary, so reset LD_LIBRARY_PATH
+        subprocess.call([open_command, filename], env=env)
 
 
 # from https://gist.github.com/pypt/94d747fe5180851196eb#gistcomment-4015118 with some changes
@@ -708,12 +713,17 @@ def _mp_open_filename(res: "multiprocessing.Queue[typing.Optional[str]]", *args:
     res.put(open_filename(*args))
 
 
+def _run_for_stdout(*args: str):
+    env = os.environ
+    if "LD_LIBRARY_PATH" in env:
+        env = env.copy()
+        del env["LD_LIBRARY_PATH"]  # exe is a system binary, so reset LD_LIBRARY_PATH
+    return subprocess.run(args, capture_output=True, text=True, env=env).stdout.split("\n", 1)[0] or None
+
+
 def open_filename(title: str, filetypes: typing.Iterable[typing.Tuple[str, typing.Iterable[str]]], suggest: str = "") \
         -> typing.Optional[str]:
     logging.info(f"Opening file input dialog for {title}.")
-
-    def run(*args: str):
-        return subprocess.run(args, capture_output=True, text=True).stdout.split("\n", 1)[0] or None
 
     if is_linux:
         # prefer native dialog
@@ -721,12 +731,12 @@ def open_filename(title: str, filetypes: typing.Iterable[typing.Tuple[str, typin
         kdialog = which("kdialog")
         if kdialog:
             k_filters = '|'.join((f'{text} (*{" *".join(ext)})' for (text, ext) in filetypes))
-            return run(kdialog, f"--title={title}", "--getopenfilename", suggest or ".", k_filters)
+            return _run_for_stdout(kdialog, f"--title={title}", "--getopenfilename", suggest or ".", k_filters)
         zenity = which("zenity")
         if zenity:
             z_filters = (f'--file-filter={text} ({", ".join(ext)}) | *{" *".join(ext)}' for (text, ext) in filetypes)
             selection = (f"--filename={suggest}",) if suggest else ()
-            return run(zenity, f"--title={title}", "--file-selection", *z_filters, *selection)
+            return _run_for_stdout(zenity, f"--title={title}", "--file-selection", *z_filters, *selection)
 
     # fall back to tk
     try:
@@ -760,21 +770,18 @@ def _mp_open_directory(res: "multiprocessing.Queue[typing.Optional[str]]", *args
 
 
 def open_directory(title: str, suggest: str = "") -> typing.Optional[str]:
-    def run(*args: str):
-        return subprocess.run(args, capture_output=True, text=True).stdout.split("\n", 1)[0] or None
-
     if is_linux:
         # prefer native dialog
         from shutil import which
         kdialog = which("kdialog")
         if kdialog:
-            return run(kdialog, f"--title={title}", "--getexistingdirectory",
+            return _run_for_stdout(kdialog, f"--title={title}", "--getexistingdirectory",
                        os.path.abspath(suggest) if suggest else ".")
         zenity = which("zenity")
         if zenity:
             z_filters = ("--directory",)
             selection = (f"--filename={os.path.abspath(suggest)}/",) if suggest else ()
-            return run(zenity, f"--title={title}", "--file-selection", *z_filters, *selection)
+            return _run_for_stdout(zenity, f"--title={title}", "--file-selection", *z_filters, *selection)
 
     # fall back to tk
     try:
@@ -801,9 +808,6 @@ def open_directory(title: str, suggest: str = "") -> typing.Optional[str]:
 
 
 def messagebox(title: str, text: str, error: bool = False) -> None:
-    def run(*args: str):
-        return subprocess.run(args, capture_output=True, text=True).stdout.split("\n", 1)[0] or None
-
     if is_kivy_running():
         from kvui import MessageBox
         MessageBox(title, text, error).open()
@@ -814,10 +818,10 @@ def messagebox(title: str, text: str, error: bool = False) -> None:
         from shutil import which
         kdialog = which("kdialog")
         if kdialog:
-            return run(kdialog, f"--title={title}", "--error" if error else "--msgbox", text)
+            return _run_for_stdout(kdialog, f"--title={title}", "--error" if error else "--msgbox", text)
         zenity = which("zenity")
         if zenity:
-            return run(zenity, f"--title={title}", f"--text={text}", "--error" if error else "--info")
+            return _run_for_stdout(zenity, f"--title={title}", f"--text={text}", "--error" if error else "--info")
 
     elif is_windows:
         import ctypes


### PR DESCRIPTION
## What is this fixing or adding?

There are cases where LD_LIBRARY_PATH is set, which can break system binaries if a library exist in any directory listed in LD_LIBRARY_PATH but is older than the one shipped with the system. This removes the LD_LIBRARY_PATH env variable when executing system programs.

Specifically this happens with the AppImage that sets LD_LIBRARY_PATH to Archipelago/lib when run on SteamDeck and using kdeopen. That bug was reported somewhere on Discord.

## How was this tested?

Used Launcher -> Browse Files, Open host.yaml, Open Path, Various Clients
on both source and AppImage