### PR TITLE
FF1: New Maintainership

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -72,6 +72,9 @@
 # Faxanadu
 /worlds/faxanadu/ @Daivuk
 
+# Final Fantasy (1)
+# /worlds/ff1/ @Rosalie-A
+
 # Final Fantasy Mystic Quest
 /worlds/ffmq/ @Alchav @wildham0
 
@@ -240,9 +243,6 @@
 # The following worlds in this repo are currently unmaintained, but currently still work in core. If any update breaks
 # compatibility, these worlds may be deleted. If you are interested in stepping up as maintainer for
 # any of these worlds, please review `/docs/world maintainer.md` documentation.
-
-# Final Fantasy (1)
-# /worlds/ff1/
 
 # Ocarina of Time
 # /worlds/oot/


### PR DESCRIPTION
## What is this fixing or adding?
Submitting myself for FF1 AP maintainership. It's a pretty lightweight world and nothing much is likely to go wrong with it in future merges (since 99% of its functionality is on the offsite randomizer) but I did write the new Bizhawk Client for it. I originally wasn't planning on doing this but gave it some thought and decided, hey, someone's gotta, and I wouldn't want to see FF1 fall by the wayside in AP. Might as well be the person who's written most of the code users will interact with in the world now.

I could have included it in that PR but I figured this was two separate discussions to have.

## How was this tested?
I looked at the file.

## If this makes graphical changes, please attach screenshots.
