### PR TITLE
Linux/AppImage: avoid adding cwd to LD_LIBRARY_PATH

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -481,7 +481,7 @@ tmp="${{exe#*/}}"
 if [ ! "${{#tmp}}" -lt "${{#exe}}" ]; then
     exe="{default_exe.parent}/$exe"
 fi
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$APPDIR/{default_exe.parent}/lib"
+export LD_LIBRARY_PATH="${{LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}}$APPDIR/{default_exe.parent}/lib"
 $APPDIR/$exe "$@"
 """)
         launcher_filename.chmod(0o755)


### PR DESCRIPTION
## What is this fixing or adding?

When LD_LIBRARY_PATH is not set, the old code would also add the current working directory to LD_LIBRARY_PATH, which is bad. (Potentially picking up libs from an unexpected folder.)

## How was this tested?

Looking at a debug print of it inside the AppImage with both LD_LIBRARY_PATH set and empty when launching.
The changed line was tested with both bash and dash.

See also Discord around here: <https://discord.com/channels/731205301247803413/731214280439103580/1375219855795421295>