### PR TITLE
Jak and Daxter: Post-merge Polish

### DIFF
--- a/worlds/jakanddaxter/docs/en_Jak and Daxter The Precursor Legacy.md
+++ b/worlds/jakanddaxter/docs/en_Jak and Daxter The Precursor Legacy.md
@@ -18,7 +18,7 @@
 - [What do Traps do?](#what-do-traps-do)
 - [What kind of Traps are there?](#what-kind-of-traps-are-there)
 - [I got soft-locked and cannot leave, how do I get out of here?](#i-got-soft-locked-and-cannot-leave-how-do-i-get-out-of-here)
-- [Why did I get an Option Error when generating a seed, and how do I fix it?](#why-did-i-get-an-option-error-when-generating-a-seed-and-how-do-i-fix-it)
+- [How do I generate seeds with 1 Orb Orbsanity and other extreme options?](#how-do-i-generate-seeds-with-1-orb-orbsanity-and-other-extreme-options)
 - [How do I check my player options in-game?](#how-do-i-check-my-player-options-in-game)
 - [How does the HUD work?](#how-does-the-hud-work)
 - [I think I found a bug, where should I report it?](#i-think-i-found-a-bug-where-should-i-report-it)
@@ -201,16 +201,19 @@ Open the game's menu, navigate to `Options`, then `Archipelago Options`, then `W
 Selecting this option will ask if you want to be teleported to Geyser Rock. From there, you can teleport back 
 to the nearest sage's hut to continue your journey.
 
-## Why did I get an Option Error when generating a seed and how do I fix it
+## How do I generate seeds with 1 orb orbsanity and other extreme options?
 Depending on your player YAML, Jak and Daxter can have a lot of items, which can sometimes be overwhelming or 
 disruptive to multiworld games. There are also options that are mutually incompatible with each other, even in a solo
 game. To prevent the game from disrupting multiworlds, or generating an impossible solo seed, some options have
-Singleplayer and Multiplayer Minimums and Maximums, collectively called "friendly limits."
+"friendly limits" that prevent you from choosing more extreme values.
 
-If you're generating a solo game, or your multiworld host agrees to your request, you can override those limits by
-editing the `host.yaml`. In the Archipelago Launcher, click `Open host.yaml`, then search for `jakanddaxter_options`,
-then search for `enforce_friendly_options`, then change this value from `true` to `false`. Disabling this allows for 
-more disruptive and challenging options, but it may cause seed generation to fail. **Use at your own risk!**
+You can override **some**, not all, of those limits by editing the `host.yaml`. In the Archipelago Launcher, click 
+`Open host.yaml`, then search for `jakanddaxter_options`, then search for `enforce_friendly_options`, then change this 
+value from `true` to `false`. You can then generate a seed locally, and upload that to the Archipelago website to host
+for you (or host it yourself). 
+
+**Remember:** disabling this setting allows for more disruptive and challenging options, but it may cause seed 
+generation to fail. **Use at your own risk!**
 
 ## How do I check my player options in-game
 When you connect your text client to the Archipelago Server, the server will tell the game what options were chosen

--- a/worlds/jakanddaxter/docs/setup_en.md
+++ b/worlds/jakanddaxter/docs/setup_en.md
@@ -4,7 +4,6 @@
 
 - A legally purchased copy of *Jak And Daxter: The Precursor Legacy.*
 - [The OpenGOAL Launcher](https://opengoal.dev/)
-- [The Jak and Daxter .APWORLD package](https://github.com/ArchipelaGOAL/Archipelago/releases)
 
 At this time, this method of setup works on Windows only, but Linux support is a strong likelihood in the near future as OpenGOAL itself supports Linux.
 
@@ -75,7 +74,7 @@ If you are in the middle of an async game, and you do not want to update the mod
 ### New Game
 
 - Run the Archipelago Launcher.
-- From the right-most list, find and click `Jak and Daxter Client`.
+- From the client list, find and click `Jak and Daxter Client`.
 - 3 new windows should appear:
     - The OpenGOAL compiler will launch and compile the game. They should take about 30 seconds to compile.
         - You should hear a musical cue to indicate the compilation was a success. If you do not, see the Troubleshooting section.

--- a/worlds/jakanddaxter/options.py
+++ b/worlds/jakanddaxter/options.py
@@ -48,8 +48,9 @@ class GlobalOrbsanityBundleSize(Choice):
     """The orb bundle size for Global Orbsanity. This only applies if "Enable Orbsanity" is set to "Global."
     There are 2000 orbs in the game, so your bundle size must be a factor of 2000.
 
-    Multiplayer Minimum: 10
-    Multiplayer Maximum: 200"""
+    This value is restricted to safe minimum and maximum values to ensure valid singleplayer games and
+    non-disruptive multiplayer games, but the host can remove this restriction by turning off enforce_friendly_options
+    in host.yaml."""
     display_name = "Global Orbsanity Bundle Size"
     option_1_orb = 1
     option_2_orbs = 2
@@ -80,7 +81,9 @@ class PerLevelOrbsanityBundleSize(Choice):
     """The orb bundle size for Per Level Orbsanity. This only applies if "Enable Orbsanity" is set to "Per Level."
     There are 50, 150, or 200 orbs per level, so your bundle size must be a factor of 50.
 
-    Multiplayer Minimum: 10"""
+    This value is restricted to safe minimum and maximum values to ensure valid singleplayer games and
+    non-disruptive multiplayer games, but the host can remove this restriction by turning off enforce_friendly_options
+    in host.yaml."""
     display_name = "Per Level Orbsanity Bundle Size"
     option_1_orb = 1
     option_2_orbs = 2

--- a/worlds/jakanddaxter/options.py
+++ b/worlds/jakanddaxter/options.py
@@ -324,7 +324,7 @@ class CompletionCondition(Choice):
     option_cross_fire_canyon = 69
     option_cross_mountain_pass = 87
     option_cross_lava_tube = 89
-    option_defeat_dark_eco_plant = 6
+    # option_defeat_dark_eco_plant = 6
     option_defeat_klaww = 86
     option_defeat_gol_and_maia = 112
     option_open_100_cell_door = 116

--- a/worlds/jakanddaxter/regions.py
+++ b/worlds/jakanddaxter/regions.py
@@ -115,8 +115,8 @@ def create_regions(world: "JakAndDaxterWorld"):
     elif options.jak_completion_condition == CompletionCondition.option_cross_lava_tube:
         multiworld.completion_condition[player] = lambda state: state.can_reach(gmc, "Region", player)
 
-    elif options.jak_completion_condition == CompletionCondition.option_defeat_dark_eco_plant:
-        multiworld.completion_condition[player] = lambda state: state.can_reach(fjp, "Region", player)
+    # elif options.jak_completion_condition == CompletionCondition.option_defeat_dark_eco_plant:
+    #     multiworld.completion_condition[player] = lambda state: state.can_reach(fjp, "Region", player)
 
     elif options.jak_completion_condition == CompletionCondition.option_defeat_klaww:
         multiworld.completion_condition[player] = lambda state: state.can_reach(mp, "Region", player)

--- a/worlds/jakanddaxter/test/test_trades.py
+++ b/worlds/jakanddaxter/test/test_trades.py
@@ -4,14 +4,14 @@ from .bases import JakAndDaxterTestBase
 class TradesCostNothingTest(JakAndDaxterTestBase):
     options = {
         "enable_orbsanity": 2,
-        "global_orbsanity_bundle_size": 5,
+        "global_orbsanity_bundle_size": 10,
         "citizen_orb_trade_amount": 0,
         "oracle_orb_trade_amount": 0
     }
 
     def test_orb_items_are_filler(self):
         self.collect_all_but("")
-        self.assertNotIn("5 Precursor Orbs", self.multiworld.state.prog_items)
+        self.assertNotIn("10 Precursor Orbs", self.multiworld.state.prog_items)
 
     def test_trades_are_accessible(self):
         self.assertTrue(self.multiworld
@@ -22,15 +22,15 @@ class TradesCostNothingTest(JakAndDaxterTestBase):
 class TradesCostEverythingTest(JakAndDaxterTestBase):
     options = {
         "enable_orbsanity": 2,
-        "global_orbsanity_bundle_size": 5,
+        "global_orbsanity_bundle_size": 10,
         "citizen_orb_trade_amount": 120,
         "oracle_orb_trade_amount": 150
     }
 
     def test_orb_items_are_progression(self):
         self.collect_all_but("")
-        self.assertIn("5 Precursor Orbs", self.multiworld.state.prog_items[self.player])
-        self.assertEqual(396, self.multiworld.state.prog_items[self.player]["5 Precursor Orbs"])
+        self.assertIn("10 Precursor Orbs", self.multiworld.state.prog_items[self.player])
+        self.assertEqual(198, self.multiworld.state.prog_items[self.player]["10 Precursor Orbs"])
 
     def test_trades_are_accessible(self):
         self.collect_all_but("")


### PR DESCRIPTION
## What is this fixing or adding?
- Cleans up a few missed references in the setup guide.
- Refactors Options class to use metaclass and decorators to enforce friendly limits on multiple levels.    
  - Templates generated from the website, even ones with `random` should not fail generation because the website will only allow values inside the friendly limits. 
  - _Uploaded_ yamls to the website with `random`, should also now respect friendly limits without the need for `random-range` shenanigans.
  - _Uploaded_ yamls to the website, or yamls that are used to generate locally, that have hard-defined values outside the friendly limits, will be clamped/dragged/massaged into those limits (with logged warnings).
- Removed an early completion goal that was playing havoc with fill. Not enough people seem to use this goal, so its loss will not be mourned.

## How was this tested?
Locally. Ran the webhost, generated on the website, ran the launcher, generated from the launcher, generated template yamls. Attempted the entire suite of tests with friendly options off and on.

## If this makes graphical changes, please attach screenshots.
N/A