### PR TITLE
Stardew Valley: Make animal catalog logically year 2

### DIFF
--- a/worlds/stardew_valley/content/vanilla/pelican_town.py
+++ b/worlds/stardew_valley/content/vanilla/pelican_town.py
@@ -3,7 +3,7 @@ from ...data import villagers_data, fish_data
 from ...data.building import Building
 from ...data.game_item import GenericSource, ItemTag, Tag, CustomRuleSource
 from ...data.harvest import ForagingSource, SeasonalForagingSource, ArtifactSpotSource
-from ...data.requirement import ToolRequirement, BookRequirement, SkillRequirement
+from ...data.requirement import ToolRequirement, BookRequirement, SkillRequirement, YearRequirement
 from ...data.shop import ShopSource, MysteryBoxSource, ArtifactTroveSource, PrizeMachineSource, FishingTreasureChestSource
 from ...strings.artisan_good_names import ArtisanGood
 from ...strings.book_names import Book
@@ -209,7 +209,7 @@ pelican_town = ContentPack(
         # Books
         Book.animal_catalogue: (
             Tag(ItemTag.BOOK, ItemTag.BOOK_POWER),
-            ShopSource(money_price=5000, shop_region=Region.ranch),),
+            ShopSource(money_price=5000, shop_region=Region.ranch, other_requirements=(YearRequirement(2),)),),
         Book.book_of_mysteries: (
             Tag(ItemTag.BOOK, ItemTag.BOOK_POWER),
             MysteryBoxSource(amount=38),),  # After 38 boxes, there are 49.99% chances player received the book.


### PR DESCRIPTION
## What is this fixing or adding?
This book is only sold from year 2. https://stardewvalleywiki.com/Animal_Catalogue

## How was this tested?
Now there is a `16% progression item` required, accounting for year 2.

![image](https://github.com/user-attachments/assets/8e02270c-0cb9-4b87-82f1-033c3670c614)

## If this makes graphical changes, please attach screenshots.
N/A
