### PR TITLE
BizHawkClient: Fix script to list all cores instead of explicit mapping

### DIFF
--- a/data/lua/connector_bizhawk_generic.lua
+++ b/data/lua/connector_bizhawk_generic.lua
@@ -365,18 +365,14 @@ request_handlers = {
     ["PREFERRED_CORES"] = function (req)
         local res = {}
         local preferred_cores = client.getconfig().PreferredCores
+        local systems_enumerator = preferred_cores.Keys:GetEnumerator()
 
         res["type"] = "PREFERRED_CORES_RESPONSE"
         res["value"] = {}
-        res["value"]["NES"] = preferred_cores.NES
-        res["value"]["SNES"] = preferred_cores.SNES
-        res["value"]["GB"] = preferred_cores.GB
-        res["value"]["GBC"] = preferred_cores.GBC
-        res["value"]["DGB"] = preferred_cores.DGB
-        res["value"]["SGB"] = preferred_cores.SGB
-        res["value"]["PCE"] = preferred_cores.PCE
-        res["value"]["PCECD"] = preferred_cores.PCECD
-        res["value"]["SGX"] = preferred_cores.SGX
+
+        while systems_enumerator:MoveNext() do
+            res["value"][systems_enumerator.Current] = preferred_cores[systems_enumerator.Current]
+        end
 
         return res
     end,


### PR DESCRIPTION
## What is this fixing or adding?

BizHawk has added new core options between versions and even changed the key for at least one system, so the current script can crash on a `PREFERRED_CORES` request (which is not useful for most clients, hence rare). The get config function appears to start reaching into C# territory, hence the original implementation, but this should be able to loop all the keys and send them to the client. And then the client can decide how to actually interpret it.

## How was this tested?

Ran the command via python in a client on BizHawk 2.7, 2.8, 2.9.1, and 2.10 to see that it returned a correct output.
