### PR TITLE
Stardew Valley: Added moss to statue of blessings recipe

### DIFF
--- a/worlds/stardew_valley/data/craftable_data.py
+++ b/worlds/stardew_valley/data/craftable_data.py
@@ -305,7 +305,7 @@ hopper = ap_recipe(Craftable.hopper, {Material.hardwood: 10, MetalBar.iridium: 1
 cookout_kit = skill_recipe(Craftable.cookout_kit, Skill.foraging, 3, {Material.wood: 15, Material.fiber: 10, Material.coal: 3})
 tent_kit = skill_recipe(Craftable.tent_kit, Skill.foraging, 8, {Material.hardwood: 10, Material.fiber: 25, ArtisanGood.cloth: 1})
 
-statue_of_blessings = mastery_recipe(Statue.blessings, Skill.farming, {Material.sap: 999, Material.fiber: 999, Material.stone: 999})
+statue_of_blessings = mastery_recipe(Statue.blessings, Skill.farming, {Material.sap: 999, Material.fiber: 999, Material.stone: 999, Material.moss: 333})
 statue_of_dwarf_king = mastery_recipe(Statue.dwarf_king, Skill.mining, {MetalBar.iridium: 20})
 heavy_furnace = mastery_recipe(Machine.heavy_furnace, Skill.mining, {Machine.furnace: 2, MetalBar.iron: 3, Material.stone: 50})
 mystic_tree_seed = mastery_recipe(TreeSeed.mystic, Skill.foraging, {TreeSeed.acorn: 5, TreeSeed.maple: 5, TreeSeed.pine: 5, TreeSeed.mahogany: 5})


### PR DESCRIPTION
## What is this fixing or adding?
A player using Universal Tracker noticed that the statue was in logic in winter, because it did not have the proper moss ingredient in its recipe. I added the moss
Bug Report: https://discord.com/channels/731205301247803413/1090823633099833464/1375636325775966228
Recipe: https://stardewvalleywiki.com/Statue_Of_Blessings

## How was this tested?
Unit tests, not much more to do here
