### PR TITLE
assert_not_all_options

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -1315,7 +1315,7 @@ class CommonOptions(metaclass=OptionsMetaProperty):
         will be returned as a sorted list.
         """
         assert option_names, "options.as_dict() was used without any option names."
-        assert not len(option_names) == len(self.__class__.type_hints), "Specify only options you need."
+        assert len(option_names) < len(self.__class__.type_hints), "Specify only options you need."
         option_results = {}
         for option_name in option_names:
             if option_name not in type(self).type_hints:

--- a/Options.py
+++ b/Options.py
@@ -1315,6 +1315,7 @@ class CommonOptions(metaclass=OptionsMetaProperty):
         will be returned as a sorted list.
         """
         assert option_names, "options.as_dict() was used without any option names."
+        assert not len(option_names) == len(self.__class__.type_hints), "Specify only options you need."
         option_results = {}
         for option_name in option_names:
             if option_name not in type(self).type_hints:


### PR DESCRIPTION
## What is this fixing or adding?
Laziest way to do this, can add an actual test to the slot_data test if we have to and this ends up not being good enough.

## How was this tested?
`self.options.as_dict(*MessengerOptions.type_hints)`

## If this makes graphical changes, please attach screenshots.
