### PR TITLE
Plando Items: Fix `count` with empty `locations`/`location`

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -1524,9 +1524,11 @@ class PlandoItems(Option[typing.List[PlandoItem]]):
                                           f"dictionary, not {type(items)}")
                     locations = item.get("locations", [])
                     if not locations:
-                        locations = item.get("location", ["Everywhere"])
+                        locations = item.get("location", [])
                         if locations:
                             count = 1
+                        else:
+                            locations = ["Everywhere"]
                         if isinstance(locations, str):
                             locations = [locations]
                         if not isinstance(locations, list):


### PR DESCRIPTION
## What is this fixing or adding?
```yaml
  plando_items:
    - items: ["Shapers", "Shapers", "Shapers", "Shapers"]
```
This block currently only grabs one "Shapers" item and not four because `locations` and `location` are undefined and the default of `["Everywhere"]` is truthy, setting `count` to 1.

## How was this tested?

The block shown above now adds four copies of the item instead of one. It only sets the `count` to 1 if `location` was actually provided and then sets it to the default value.