### PR TITLE
AdventureClient: Replace Utils.get_settings with settings.get_settings

### DIFF
--- a/AdventureClient.py
+++ b/AdventureClient.py
@@ -11,6 +11,7 @@ from typing import List
 
 
 import Utils
+from settings import get_settings
 from NetUtils import ClientStatus
 from Utils import async_start
 from CommonClient import CommonContext, server_loop, gui_enabled, ClientCommandProcessor, logger, \
@@ -80,8 +81,8 @@ class AdventureContext(CommonContext):
         self.local_item_locations = {}
         self.dragon_speed_info = {}
 
-        options = Utils.get_settings()
-        self.display_msgs = options["adventure_options"]["display_msgs"]
+        options = get_settings().adventure_options
+        self.display_msgs = options.display_msgs
 
     async def server_auth(self, password_requested: bool = False):
         if password_requested and not self.password:
@@ -102,7 +103,7 @@ class AdventureContext(CommonContext):
     def on_package(self, cmd: str, args: dict):
         if cmd == 'Connected':
             self.locations_array = None
-            if Utils.get_settings()["adventure_options"].get("death_link", False):
+            if get_settings().adventure_options.as_dict().get("death_link", False):
                 self.set_deathlink = True
             async_start(self.get_freeincarnates_used())
         elif cmd == "RoomInfo":
@@ -415,8 +416,9 @@ async def atari_sync_task(ctx: AdventureContext):
 
 
 async def run_game(romfile):
-    auto_start = Utils.get_settings()["adventure_options"].get("rom_start", True)
-    rom_args = Utils.get_settings()["adventure_options"].get("rom_args")
+    options = get_settings().adventure_options
+    auto_start = options.rom_start
+    rom_args = options.rom_args
     if auto_start is True:
         import webbrowser
         webbrowser.open(romfile)


### PR DESCRIPTION
## What is this fixing or adding?
Part of https://github.com/ArchipelagoMW/Archipelago/pull/4811
Replaces Utils.get_settings with settings.get_settings in AdventureClient.  The incorrect death_link check I think I should address separately.

## How was this tested?
Generated and ran a couple adventure MWs.

## If this makes graphical changes, please attach screenshots.
