### PR TITLE
TWW: Remove unnecessary items from slot data

### DIFF
--- a/worlds/tww/Options.py
+++ b/worlds/tww/Options.py
@@ -755,6 +755,53 @@ class TWWOptions(PerGameCommonOptions):
     remove_music: RemoveMusic
     death_link: DeathLink
 
+    def get_slot_data_dict(self) -> dict[str, Any]:
+        """
+        Returns a dictionary of option name to value to be placed in
+        the slot data network package.
+
+        :return: Dictionary of option name to value for the slot data.
+        """
+        return self.as_dict(
+            "progression_dungeons",
+            "progression_tingle_chests",
+            "progression_dungeon_secrets",
+            "progression_puzzle_secret_caves",
+            "progression_combat_secret_caves",
+            "progression_savage_labyrinth",
+            "progression_great_fairies",
+            "progression_short_sidequests",
+            "progression_long_sidequests",
+            "progression_spoils_trading",
+            "progression_minigames",
+            "progression_battlesquid",
+            "progression_free_gifts",
+            "progression_mail",
+            "progression_platforms_rafts",
+            "progression_submarines",
+            "progression_eye_reef_chests",
+            "progression_big_octos_gunboats",
+            "progression_triforce_charts",
+            "progression_treasure_charts",
+            "progression_expensive_purchases",
+            "progression_island_puzzles",
+            "progression_misc",
+            "sword_mode",
+            "required_bosses",
+            "logic_obscurity",
+            "logic_precision",
+            "enable_tuner_logic",
+            "randomize_dungeon_entrances",
+            "randomize_secret_cave_entrances",
+            "randomize_miniboss_entrances",
+            "randomize_boss_entrances",
+            "randomize_secret_cave_inner_entrances",
+            "randomize_fairy_fountain_entrances",
+            "swift_sail",
+            "skip_rematch_bosses",
+            "remove_music",
+        )
+
     def get_output_dict(self) -> dict[str, Any]:
         """
         Returns a dictionary of option name to value to be placed in

--- a/worlds/tww/__init__.py
+++ b/worlds/tww/__init__.py
@@ -586,7 +586,7 @@ class TWWWorld(World):
 
         :return: A dictionary to be sent to the client when it connects to the server.
         """
-        slot_data = self.options.as_dict(*self.options_dataclass.type_hints)
+        slot_data = self.options.get_slot_data_dict()
 
         # Add entrances to `slot_data`. This is the same data that is written to the .aptww file.
         entrances = {


### PR DESCRIPTION
## What is this fixing or adding?
This PR limits the slot data for TWW to only necessary items. Complies with #5039.

## How was this tested?
Generated a seed and played through it for a bit. Checked that everything still worked, particularly the tracker. Cross-referenced the [tracker code](https://github.com/Mysteryem/ww-poptracker) to see which slot data items were being referenced.

## If this makes graphical changes, please attach screenshots.
N/A