### PR TITLE
shapez: Change link to shapesanity cheat sheet

### DIFF
--- a/worlds/shapez/docs/de_shapez.md
+++ b/worlds/shapez/docs/de_shapez.md
@@ -57,7 +57,7 @@ Ein Pop-Up erscheint, das das/die erhaltene(n) Item(s) und eventuell weitere Inf
 
 Hier ist ein Spicker für die Englischarbeit (bloß nicht dem Lehrer zeigen):
 
-![image](https://raw.githubusercontent.com/BlastSlimey/Archipelago/refs/heads/main/worlds/shapez/docs/shapesanity_full.png)
+![image](https://raw.githubusercontent.com/ArchipelagoMW/Archipelago/refs/heads/main/worlds/shapez/docs/shapesanity_full.png)
 
 ## Kann ich auch weitere Mods neben dem AP Client installieren?
 

--- a/worlds/shapez/docs/de_shapez.md
+++ b/worlds/shapez/docs/de_shapez.md
@@ -57,7 +57,7 @@ Ein Pop-Up erscheint, das das/die erhaltene(n) Item(s) und eventuell weitere Inf
 
 Hier ist ein Spicker für die Englischarbeit (bloß nicht dem Lehrer zeigen):
 
-![image](https://raw.githubusercontent.com/ArchipelagoMW/Archipelago/refs/heads/main/worlds/shapez/docs/shapesanity_full.png)
+![image](/static/generated/docs/shapez/shapesanity_full.png)
 
 ## Kann ich auch weitere Mods neben dem AP Client installieren?
 

--- a/worlds/shapez/docs/en_shapez.md
+++ b/worlds/shapez/docs/en_shapez.md
@@ -56,7 +56,7 @@ A pop-up will show, which item(s) were received, with additional information on 
 
 Here's a cheat sheet:
 
-![image](https://raw.githubusercontent.com/ArchipelagoMW/Archipelago/refs/heads/main/worlds/shapez/docs/shapesanity_full.png)
+![image](/static/generated/docs/shapez/shapesanity_full.png)
 
 ## Can I use other mods alongside the AP client?
 

--- a/worlds/shapez/docs/en_shapez.md
+++ b/worlds/shapez/docs/en_shapez.md
@@ -56,7 +56,7 @@ A pop-up will show, which item(s) were received, with additional information on 
 
 Here's a cheat sheet:
 
-![image](https://raw.githubusercontent.com/BlastSlimey/Archipelago/refs/heads/main/worlds/shapez/docs/shapesanity_full.png)
+![image](https://raw.githubusercontent.com/ArchipelagoMW/Archipelago/refs/heads/main/worlds/shapez/docs/shapesanity_full.png)
 
 ## Can I use other mods alongside the AP client?
 


### PR DESCRIPTION
## What is this fixing or adding?
The shapesanity cheat sheet, which is uesd on the game's info page, is included in the apworld. The webhost shows it by accessing the file on the GitHub repo. This is to make the webhost use the AP main repo instead of the maintainer's repo.

## How was this tested?
👀 

## If this makes graphical changes, please attach screenshots.
This should prevent graphical changes if my repo goes down one day for some reason