### PR TITLE
CVCotM: Add Nerf Roc Wing to Slot Data and HoD max ups to other_game_item_appearances

### DIFF
--- a/worlds/cvcotm/__init__.py
+++ b/worlds/cvcotm/__init__.py
@@ -211,7 +211,8 @@ class CVCotMWorld(World):
                 "ignore_cleansing": self.options.ignore_cleansing.value,
                 "skip_tutorials": self.options.skip_tutorials.value,
                 "required_last_keys": self.required_last_keys,
-                "completion_goal": self.options.completion_goal.value}
+                "completion_goal": self.options.completion_goal.value,
+                "nerf_roc_wing": self.options.nerf_roc_wing.value}
 
     def get_filler_item_name(self) -> str:
         return self.random.choice(FILLER_ITEM_NAMES)

--- a/worlds/cvcotm/aesthetics.py
+++ b/worlds/cvcotm/aesthetics.py
@@ -48,11 +48,17 @@ class OtherGameAppearancesInfo(TypedDict):
 
 
 other_game_item_appearances: Dict[str, Dict[str, OtherGameAppearancesInfo]] = {
-    # NOTE: Symphony of the Night is currently an unsupported world not in main.
+    # NOTE: Symphony of the Night and Harmony of Dissonance are custom worlds that are not core verified.
     "Symphony of the Night": {"Life Vessel": {"type": 0xE4,
                                               "appearance": 0x01},
                               "Heart Vessel": {"type": 0xE4,
                                                "appearance": 0x00}},
+
+    "Castlevania - Harmony of Dissonance": {"Life Max Up": {"type": 0xE4,
+                                                            "appearance": 0x01},
+                                            "Heart Max Up": {"type": 0xE4,
+                                                             "appearance": 0x00}},
+
     "Timespinner": {"Max HP": {"type": 0xE4,
                                "appearance": 0x01},
                     "Max Aura": {"type": 0xE4,

--- a/worlds/cvcotm/docs/en_Castlevania - Circle of the Moon.md
+++ b/worlds/cvcotm/docs/en_Castlevania - Circle of the Moon.md
@@ -3,7 +3,7 @@
 ## Quick Links
 - [Setup](/tutorial/Castlevania%20-%20Circle%20of%20the%20Moon/setup/en)
 - [Options Page](/games/Castlevania%20-%20Circle%20of%20the%20Moon/player-options)
-- [PopTracker Pack](https://github.com/sassyvania/Circle-of-the-Moon-Rando-AP-Map-Tracker-/releases/latest)
+- [PopTracker Pack](https://github.com/BowserCrusher/Circle-of-the-Moon-AP-Tracker/releases/latest)
 - [Repo for the original, standalone CotMR](https://github.com/calm-palm/cotm-randomizer)
 - [Web version of the above randomizer](https://rando.circleofthemoon.com/)
 - [A more in-depth guide to CotMR's nuances](https://docs.google.com/document/d/1uot4BD9XW7A--A8ecgoY8mLK_vSoQRpY5XCkzgas87c/view?usp=sharing)

--- a/worlds/cvcotm/docs/setup_en.md
+++ b/worlds/cvcotm/docs/setup_en.md
@@ -22,7 +22,7 @@ clear it.
 
 ## Optional Software
 
-- [Castlevania: Circle of the Moon AP Tracker](https://github.com/sassyvania/Circle-of-the-Moon-Rando-AP-Map-Tracker-/releases/latest), for use with
+- [Castlevania: Circle of the Moon AP Tracker](https://github.com/BowserCrusher/Circle-of-the-Moon-AP-Tracker/releases/latest), for use with
 [PopTracker](https://github.com/black-sliver/PopTracker/releases).
 
 ## Generating and Patching a Game
@@ -64,7 +64,7 @@ perfectly safe to make progress offline; everything will re-sync when you reconn
 
 Castlevania: Circle of the Moon has a fully functional map tracker that supports auto-tracking.
 
-1. Download [Castlevania: Circle of the Moon AP Tracker](https://github.com/sassyvania/Circle-of-the-Moon-Rando-AP-Map-Tracker-/releases/latest) and
+1. Download [Castlevania: Circle of the Moon AP Tracker](https://github.com/BowserCrusher/Circle-of-the-Moon-AP-Tracker/releases/latest) and
 [PopTracker](https://github.com/black-sliver/PopTracker/releases).
 2. Put the tracker pack into `packs/` in your PopTracker install.
 3. Open PopTracker, and load the Castlevania: Circle of the Moon pack.


### PR DESCRIPTION
## What is this fixing or adding?
Adds the Nerf Roc Wing option value to slot_data so that @BowserCrusher's [PopTracker pack](https://github.com/BowserCrusher/Circle-of-the-Moon-AP-Tracker) can auto-enable it. Also changes the tracker links in the docs to instead point to its new maintainer's release page.

In addition, adds Harmony of Dissonance max ups to the `other_game_item_appearances` dict so that max ups for HoD players will show up as those max ups in CotM.

## How was this tested?
Connected and verified that `nerf_roc_wing` was in `ctx.slot_data`, verified the new PopTracker links were working on a local webhost, and also made sure the HoD max ups were showing up as the CotM max ups in-game.