### PR TITLE
Webhost: update Flask to 3.1.1

### DIFF
--- a/WebHostLib/requirements.txt
+++ b/WebHostLib/requirements.txt
@@ -1,4 +1,4 @@
-flask>=3.1.0
+flask>=3.1.1
 werkzeug>=3.1.3
 pony>=0.7.19
 waitress>=3.0.2


### PR DESCRIPTION
Flask 3.1.1 is a security update. Afaik we don't use the impacted feature, but AP's Flask *could* be configured to use it, so we should update.