### PR TITLE
Core: Require registration of cross-world logic to improve scaling generation performance

### DIFF
--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -530,6 +530,9 @@ class HKWorld(World):
             for player, grub_player_count in per_player_grubs_per_player.items():
                 if player in all_grub_players:
                     multiworld.worlds[player].grub_player_count = grub_player_count
+                    # `player` can now have logic depending on items belonging to other worlds (groups), so this
+                    # cross-world logical dependency must be registered.
+                    multiworld.register_logic_dependency(player, grub_count_per_player.keys())
 
         for world in worlds:
             if world.player not in all_grub_players:


### PR DESCRIPTION
## What is this fixing or adding?

This adds a system for requiring worlds to register that they have logic depending on parts of another world in the multiworld.

The primary purpose of this change is to allow for generation functions to be more performant by making better decisions about which locations need to be checked for being reachable.

If collecting all advancement items in a single sphere collects items for only players 1, 3 and 5, then only the players 1, 3 and 5 can have newly reachable locations in the next sphere, except in the case that players 2, 4 or 6 have logic that depends on the worlds for players 1, 3 or 5.

Many of the functions used in generation currently always check all unreachable locations at each sphere, but if it is known which players *could* have reachable locations in the next sphere, then many locations can be skipped, increasing generation performance.

This increase in performance is specifically in scaling performance, a singleplayer multiworld should end up slightly slower, but singleplayer multiworlds are typically plenty fast enough already.

This PR is similar to part of #3812, except #3812 instead *assumes* that all worlds are only logically dependent on their own items/locations/etc. and double checks if its assumption was correct when it runs out of reachable locations. This PR would remove the need to double check because it will always be known which worlds each world logically depends on.

There are more areas of the generator that could see a performance benefit to being updated to make use of which worlds each world logically depends on, such as playthrough calculation (primarily the #3890 rewrite), `fulfills_accessibility` and `get_sendable_spheres`, but, for the purposes of not making this PR any larger, they have been left unchanged.

`get_spheres`, `sweep_for_advancements` and `can_beat_game` have been updated as part of this PR because they typically see a lot of use in generation of multiworlds and some functions need to be updated to show an increase in generation performance.

HK 'all-grubs' can have its completion condition logically dependent on items from an item link group world, so HK has been updated to register this logically dependency because it is required to do so with the changes in this PR.

'Rogue' apworlds, such as SlotLock and Scheherazade, that add additional cross-world logic requirements to other worlds may need to be adjusted with this PR, but doing so should still be considered 'rogue' behaviour in my opinion. A world should not touch another world's logic/items/etc. unless both worlds have agreed to it. The documentation added for this PR therefore specifically mentions tying together logic for worlds of the *same game*, which would not be considered 'rogue' behaviour.

## How was this tested?

Template yamls were used to generate multiworlds before and after this PR and were determined to produce identical results with an increase in scaling performance as the number of worlds in the multiworld increased.

A couple of new fill tests have also been added that use cross-world logic.

Main branch at 824caaffd0bc (note that this is before a number of worlds were recently core-verified and merged):
| `python -O .\Generate.py --skip_output --seed 1` | Original/s | With patch/s | Percent reduction |
| -- | -- | -- | -- |
| 1 of each template yaml from A Hat in Time to Meritous, except Final Fantasy, (37 worlds) | 13.7 | 12.5 | 8.4% |
| 1 of each template yaml from Minecraft to Zillion, except Sudoku, (36 worlds) | 35.3 | 33.8 | 4.4% |
| 1 of each template yaml, except Final Fantasy and Sudoku (73 worlds) | 101.2 | 84.1 | 16.9% |
| 2 of each template yaml, except Final Fantasy and Sudoku (146 worlds) | 302.9 | 184.2 | 39.2% |
| 4 of each template yaml, except Final Fantasy and Sudoku (292 worlds) | 722.0 | 372.0 | 48.5% |