### PR TITLE
Tests: Test that names are plain str type and not subclasses

### DIFF
--- a/test/general/test_names.py
+++ b/test/general/test_names.py
@@ -42,9 +42,14 @@ class TestNames(unittest.TestCase):
 
                 multiworld = setup_solo_multiworld(world_type)
 
-                with self.subTest("locations"):
+                with self.subTest("non-event locations"):
                     for location in multiworld.get_locations():
-                        self.assertIsStr(location.name)
+                        if not location.is_event:
+                            self.assertIsStr(location.name)
+                with self.subTest("event locations"):
+                    for location in multiworld.get_locations():
+                        if location.is_event:
+                            self.assertIsStr(location.name)
                 with self.subTest("regions"):
                     for region in multiworld.get_regions():
                         self.assertIsStr(region.name)
@@ -57,9 +62,14 @@ class TestNames(unittest.TestCase):
                 with self.subTest("precollected_items items"):
                     for item in multiworld.precollected_items[1]:
                         self.assertIsStr(item.name)
-                with self.subTest("pre_fill and earlier placed items"):
+                with self.subTest("non-event items placed in pre_fill and earlier"):
                     for loc in multiworld.get_filled_locations():
-                        self.assertIsStr(loc.item.name)
+                        if not loc.item.is_event:
+                            self.assertIsStr(loc.item.name)
+                with self.subTest("event items placed in pre_fill and earlier"):
+                    for loc in multiworld.get_filled_locations():
+                        if loc.item.is_event:
+                            self.assertIsStr(loc.item.name)
 
     def test_location_name_format(self) -> None:
         """Location names must not be all numeric in order to differentiate between ID and name in !hint_location"""

--- a/test/general/test_names.py
+++ b/test/general/test_names.py
@@ -1,8 +1,15 @@
 import unittest
 from worlds.AutoWorld import AutoWorldRegister
+from . import setup_solo_multiworld
 
 
 class TestNames(unittest.TestCase):
+    def assertIsStr(self, v: str):
+        """Helper for asserting the type of a value is exactly str, with a more helpful failure message."""
+        # The default message would only print the type of the value, but printing the value itself can be helpful in
+        # tracking down where the non-str type has come from.
+        self.assertIs(type(v), str, f"Expected plain str type, but got '{v}' of type '{type(v)}'")
+
     def test_item_names_format(self) -> None:
         """Item names must not be all numeric in order to differentiate between ID and name in !hint"""
         for gamename, world_type in AutoWorldRegister.world_types.items():
@@ -10,6 +17,49 @@ class TestNames(unittest.TestCase):
                 for item_name in world_type.item_name_to_id:
                     self.assertFalse(item_name.isnumeric(),
                                      f"Item name \"{item_name}\" is invalid. It must not be numeric.")
+
+    def test_names_are_plain_str(self) -> None:
+        """
+        Item/Location/Region/Entrance/Item Group/Location Group/Game names must be a plain `str` type and not a `str`
+        subclass because games may put these names into slot_data or write them into patch files.
+        """
+        for gamename, world_type in AutoWorldRegister.world_types.items():
+            with self.subTest(game=gamename):
+                self.assertIsStr(gamename)
+
+                with self.subTest("item_name_to_id"):
+                    for item_name in world_type.item_name_to_id:
+                        self.assertIsStr(item_name)
+                with self.subTest("location_name_to_id"):
+                    for location_name in world_type.location_name_to_id:
+                        self.assertIsStr(location_name)
+                with self.subTest("location_name_groups"):
+                    for location_group_name in world_type.location_name_groups:
+                        self.assertIsStr(location_group_name)
+                with self.subTest("item_name_groups"):
+                    for item_group_name in world_type.item_name_groups:
+                        self.assertIsStr(item_group_name)
+
+                multiworld = setup_solo_multiworld(world_type)
+
+                with self.subTest("locations"):
+                    for location in multiworld.get_locations():
+                        self.assertIsStr(location.name)
+                with self.subTest("regions"):
+                    for region in multiworld.get_regions():
+                        self.assertIsStr(region.name)
+                with self.subTest("entrances"):
+                    for entrance in multiworld.get_entrances():
+                        self.assertIsStr(entrance.name)
+                with self.subTest("itempool items"):
+                    for item in multiworld.itempool:
+                        self.assertIsStr(item.name)
+                with self.subTest("precollected_items items"):
+                    for item in multiworld.precollected_items[1]:
+                        self.assertIsStr(item.name)
+                with self.subTest("pre_fill and earlier placed items"):
+                    for loc in multiworld.get_filled_locations():
+                        self.assertIsStr(loc.item.name)
 
     def test_location_name_format(self) -> None:
         """Location names must not be all numeric in order to differentiate between ID and name in !hint_location"""

--- a/worlds/osrs/__init__.py
+++ b/worlds/osrs/__init__.py
@@ -378,7 +378,7 @@ class OSRSWorld(World):
             # Checks to make sure the task is actually in the list before trying to create its rules
             if qp_loc and q_loc:
                 # Create the QP Event Item
-                item_name = getattr(ItemNames, f"QP_{quest_attr_name}")
+                item_name = getattr(ItemNames, f"QP_{quest_attr_name}").value
                 qp_loc.place_locked_item(self.create_event(item_name))
 
                 # If a quest is excluded, don't actually consider it for quest point progression


### PR DESCRIPTION
## What is this fixing or adding?

A reoccurring issue with some custom apworld implementations is that they use `str` subclasses such as `StrEnum` (added in Python 3.11 so should not be used while AP supports 3.10) or multiple-inheritance of both `Enum` and `str` for their item/location/region names.

TUNIC can put the location names of other worlds into its slot_data, which is stored into the multidata using `pickle`. If one of these location names is a `str` subclass, archipelago.gg will refuse to load the multidata due to it containing a class it does not recognise/allow.

The Wind Waker writes item names to its patch file data using `yaml.safe_dump`, which will error if one of those item names is a `str` subclass.

One way to avoid this issue, is to force all worlds to ensure they they are only ever creating items/locations/etc. that are plain `str` and not subclasses, which is what this PR adds a test for.

Out of the core-verified worlds, with default options, OSRS was placing event items with their name set to a `str` subclass, this PR has changed this so that the event item names are always the `str` type.

## How was this tested?

I ran the test on core-verified worlds and many custom worlds, and then fixed the one occurrence in core-verified worlds.

---

Rather than requiring all worlds to ensure that their item/etc. names are plain `str`, it could instead be said that TUNIC and The Wind Waker (and any other worlds) should be responsible for ensuring any names they put into slot_data or their patch files are converted to plain `str` first.

slot_data containing `str` subclasses is json serializable, so the inability for slot_data to contain `str` subclasses could even be considered a core bug. `TestImplemented.test_slot_data()` and its documentation should be updated if `str` subclasses are not supported in slot_data.