### PR TITLE
Core and Various Worlds: define patch_file_ending to APPlayerContainer

### DIFF
--- a/worlds/Files.py
+++ b/worlds/Files.py
@@ -158,6 +158,7 @@ class APContainer:
 class APPlayerContainer(APContainer):
     """A zipfile containing at least archipelago.json meant for a player"""
     game: ClassVar[Optional[str]] = None
+    patch_file_ending: str = ""
 
     player: Optional[int]
     player_name: str
@@ -184,6 +185,7 @@ class APPlayerContainer(APContainer):
             "player": self.player,
             "player_name": self.player_name,
             "game": self.game,
+            "patch_file_ending": self.patch_file_ending,
         })
         return manifest
 
@@ -223,7 +225,6 @@ class APProcedurePatch(APAutoPatchInterface):
     """
     hash: Optional[str]  # base checksum of source file
     source_data: bytes
-    patch_file_ending: str = ""
     files: Dict[str, bytes]
 
     @classmethod
@@ -245,7 +246,6 @@ class APProcedurePatch(APAutoPatchInterface):
         manifest = super(APProcedurePatch, self).get_manifest()
         manifest["base_checksum"] = self.hash
         manifest["result_file_ending"] = self.result_file_ending
-        manifest["patch_file_ending"] = self.patch_file_ending
         manifest["procedure"] = self.procedure
         if self.procedure == APDeltaPatch.procedure:
             manifest["compatible_version"] = 5

--- a/worlds/civ_6/Container.py
+++ b/worlds/civ_6/Container.py
@@ -4,7 +4,7 @@ import io
 from typing import TYPE_CHECKING, Dict, List, Optional, cast
 import zipfile
 from BaseClasses import Location
-from worlds.Files import APContainer, AutoPatchRegister
+from worlds.Files import APPlayerContainer, AutoPatchRegister
 
 from .Enum import CivVICheckType
 from .Locations import CivVILocation, CivVILocationData
@@ -26,7 +26,7 @@ class CivTreeItem:
     ui_tree_row: int
 
 
-class CivVIContainer(APContainer, metaclass=AutoPatchRegister):
+class CivVIContainer(APPlayerContainer, metaclass=AutoPatchRegister):
     """
     Responsible for generating the dynamic mod files for the Civ VI multiworld
     """

--- a/worlds/civ_6/Container.py
+++ b/worlds/civ_6/Container.py
@@ -1,10 +1,9 @@
 from dataclasses import dataclass
 import os
-import io
 from typing import TYPE_CHECKING, Dict, List, Optional, cast
 import zipfile
 from BaseClasses import Location
-from worlds.Files import APPlayerContainer, AutoPatchRegister
+from worlds.Files import APPlayerContainer
 
 from .Enum import CivVICheckType
 from .Locations import CivVILocation, CivVILocationData
@@ -26,22 +25,19 @@ class CivTreeItem:
     ui_tree_row: int
 
 
-class CivVIContainer(APPlayerContainer, metaclass=AutoPatchRegister):
+class CivVIContainer(APPlayerContainer):
     """
     Responsible for generating the dynamic mod files for the Civ VI multiworld
     """
     game: Optional[str] = "Civilization VI"
     patch_file_ending = ".apcivvi"
 
-    def __init__(self, patch_data: Dict[str, str] | io.BytesIO, base_path: str = "", output_directory: str = "",
+    def __init__(self, patch_data: Dict[str, str], base_path: str = "", output_directory: str = "",
                  player: Optional[int] = None, player_name: str = "", server: str = ""):
-        if isinstance(patch_data, io.BytesIO):
-            super().__init__(patch_data, player, player_name, server)
-        else:
-            self.patch_data = patch_data
-            self.file_path = base_path
-            container_path = os.path.join(output_directory, base_path + ".apcivvi")
-            super().__init__(container_path, player, player_name, server)
+        self.patch_data = patch_data
+        self.file_path = base_path
+        container_path = os.path.join(output_directory, base_path + ".apcivvi")
+        super().__init__(container_path, player, player_name, server)
 
     def write_contents(self, opened_zipfile: zipfile.ZipFile) -> None:
         for filename, yml in self.patch_data.items():

--- a/worlds/factorio/Mod.py
+++ b/worlds/factorio/Mod.py
@@ -67,6 +67,7 @@ class FactorioModFile(worlds.Files.APPlayerContainer):
     game = "Factorio"
     compression_method = zipfile.ZIP_DEFLATED  # Factorio can't load LZMA archives
     writing_tasks: List[Callable[[], Tuple[str, Union[str, bytes]]]]
+    patch_file_ending = ".zip"
 
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)

--- a/worlds/kh2/OpenKH.py
+++ b/worlds/kh2/OpenKH.py
@@ -13,6 +13,7 @@ from worlds.Files import APPlayerContainer
 
 class KH2Container(APPlayerContainer):
     game: str = 'Kingdom Hearts 2'
+    patch_file_ending = ".zip"
 
     def __init__(self, patch_data: dict, base_path: str, output_directory: str,
         player=None, player_name: str = "", server: str = ""):

--- a/worlds/tww/__init__.py
+++ b/worlds/tww/__init__.py
@@ -11,7 +11,7 @@ from BaseClasses import ItemClassification as IC
 from BaseClasses import MultiWorld, Region, Tutorial
 from Options import Toggle
 from worlds.AutoWorld import WebWorld, World
-from worlds.Files import APPlayerContainer, AutoPatchRegister
+from worlds.Files import APPlayerContainer
 from worlds.generic.Rules import add_item_rule
 from worlds.LauncherComponents import Component, SuffixIdentifier, Type, components, icon_paths, launch_subprocess
 
@@ -51,7 +51,7 @@ components.append(
 icon_paths["The Wind Waker"] = "ap:worlds.tww/assets/icon.png"
 
 
-class TWWContainer(APPlayerContainer, metaclass=AutoPatchRegister):
+class TWWContainer(APPlayerContainer):
     """
     This class defines the container file for The Wind Waker.
     """


### PR DESCRIPTION
## What is this fixing or adding?
moves patch_file_ending handling to APPlayerContainer and updates the worlds using it to define their extensions

## How was this tested?
generated a room with template factorio/civ/kh2/wind waker on a localhost webhost and local generate.py and was able to download the files for all slots with both methods

## If this makes graphical changes, please attach screenshots.
