### PR TITLE
Various: Make clients wait a second between emulator connection attempts

### DIFF
--- a/AdventureClient.py
+++ b/AdventureClient.py
@@ -406,6 +406,7 @@ async def atari_sync_task(ctx: AdventureContext):
                 except ConnectionRefusedError:
                     logger.debug("Connection Refused, Trying Again")
                     ctx.atari_status = CONNECTION_REFUSED_STATUS
+                    await asyncio.sleep(1)
                     continue
                 except CancelledError:
                     pass

--- a/MMBN3Client.py
+++ b/MMBN3Client.py
@@ -286,6 +286,7 @@ async def gba_sync_task(ctx: MMBN3Context):
             except ConnectionRefusedError:
                 logger.debug("Connection Refused, Trying Again")
                 ctx.gba_status = CONNECTION_REFUSED_STATUS
+                await asyncio.sleep(1)
                 continue
 
 

--- a/OoTClient.py
+++ b/OoTClient.py
@@ -277,6 +277,7 @@ async def n64_sync_task(ctx: OoTContext):
             except ConnectionRefusedError:
                 logger.debug("Connection Refused, Trying Again")
                 ctx.n64_status = CONNECTION_REFUSED_STATUS
+                await asyncio.sleep(1)
                 continue
 
 

--- a/Zelda1Client.py
+++ b/Zelda1Client.py
@@ -333,6 +333,7 @@ async def nes_sync_task(ctx: ZeldaContext):
             except ConnectionRefusedError:
                 logger.debug("Connection Refused, Trying Again")
                 ctx.nes_status = CONNECTION_REFUSED_STATUS
+                await asyncio.sleep(1)
                 continue
 
 


### PR DESCRIPTION
## What is this fixing or adding?

While debugging unrelated problems, I noticed that the OoTClient was constantly outputting "Attempting to connect to N64" and "Connection Refused, Trying Again" messages at a rate of 3-4 thousand per second. Since this was on Linux, all of those also ended up in my system log, i.e. written to disk. Which is, let's just call it, "not great".

This only affects the case where the emulator / Lua connection isn't running yet, because the connect timeout doesn't apply if the port is closed.

## How was this tested?

It wasn't. I'm opening this PR mainly in order to ask whether this was just never considered, or somehow isn't a problem for anybody else. I can't be the only one who doesn't enjoy 2x 4k messages/second ending up on their disk, and this code is ancient. Either nobody noticed (which is fine!), or there's a reason this change wasn't made yet, and I want to find out what that reason might be.

Note that these ending up in the system log is Linux specific, but trying to connect to a port several thousand times per second is still not great - CPU usage goes up to 100% while doing basically nothing.