### PR TITLE
Tests: test that option preset keys are valid option keys

### DIFF
--- a/test/general/test_options.py
+++ b/test/general/test_options.py
@@ -79,3 +79,12 @@ class TestOptions(unittest.TestCase):
                 for option_key, option in world_type.options_dataclass.type_hints.items():
                     with self.subTest(game=gamename, option=option_key):
                         pickle.dumps(option.from_any(option.default))
+
+    def test_option_presets(self):
+        """Test that all options set within an option preset are valid option names for the world"""
+        for game_name, world_type in AutoWorldRegister.world_types.items():
+            for preset_name, preset in world_type.web.options_presets.items():
+                with self.subTest(game=game_name, preset=preset_name):
+                    for option_name in preset:
+                        self.assertIn(option_name, world_type.options_dataclass.type_hints,
+                                      f"{option_name} is not a valid option name for {game_name}.")

--- a/test/general/test_options.py
+++ b/test/general/test_options.py
@@ -91,3 +91,4 @@ class TestOptions(unittest.TestCase):
                         if issubclass(world_type.options_dataclass.type_hints[option_name], Removed):
                             self.fail(f"{option_name} in game {game_name} has been removed, but is still present"
                                       f"in preset \"{preset_name}\".")
+                            

--- a/test/general/test_options.py
+++ b/test/general/test_options.py
@@ -1,7 +1,7 @@
 import unittest
 
 from BaseClasses import MultiWorld, PlandoOptions
-from Options import ItemLinks
+from Options import ItemLinks, Removed
 from worlds.AutoWorld import AutoWorldRegister
 
 
@@ -88,3 +88,6 @@ class TestOptions(unittest.TestCase):
                     for option_name in preset:
                         self.assertIn(option_name, world_type.options_dataclass.type_hints,
                                       f"{option_name} is not a valid option name for {game_name}.")
+                        if issubclass(world_type.options_dataclass.type_hints[option_name], Removed):
+                            self.fail(f"{option_name} in game {game_name} has been removed, but is still present"
+                                      f"in preset \"{preset_name}\".")

--- a/test/general/test_options.py
+++ b/test/general/test_options.py
@@ -91,4 +91,3 @@ class TestOptions(unittest.TestCase):
                         if issubclass(world_type.options_dataclass.type_hints[option_name], Removed):
                             self.fail(f"{option_name} in game {game_name} has been removed, but is still present"
                                       f"in preset \"{preset_name}\".")
-                            


### PR DESCRIPTION
## What is this fixing or adding?
Adds a unittest that checks to see if an option preset key is both a valid key for the options dataclass as well as if the option is a subclass of Removed. This won't catch every case (it misses one in KDL3 because of back-compat) but it should catch the majority.

## How was this tested?
Unittest.

## If this makes graphical changes, please attach screenshots.
