### PR TITLE
CI: only trigger release action for bare semver

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ name: Release
 on:
   push:
     tags:
-      - '*.*.*'
+      - 'v?[0-9]+.[0-9]+.[0-9]*'
 
 env:
   ENEMIZER_VERSION: 7.1


### PR DESCRIPTION
## What is this fixing or adding?

Allows AP forks to push mygame-1.0.0 or mygame-v1.0.0 tags without running the release action.
The new glob now matches `x`.`y`.`z` with an optional leading "v" with an optional suffix (such as "-rc1")

## How was this tested?

Pushed 4 tags to
https://github.com/black-sliver/action-test
and the action only ran for 2 of them.

See https://github.com/black-sliver/action-test/tags and https://github.com/black-sliver/action-test/actions .