### PR TITLE
DKC3: Add missing indirect conditions

### DIFF
--- a/worlds/dkc3/Regions.py
+++ b/worlds/dkc3/Regions.py
@@ -802,8 +802,10 @@ def connect_regions(world: World, level_list):
     for i in range(0, len(kremwood_forest_levels) - 1):
         connect(world, world.player, names, LocationName.kremwood_forest_region, kremwood_forest_levels[i])
 
-    connect(world, world.player, names, LocationName.kremwood_forest_region, kremwood_forest_levels[-1],
-            lambda state: (state.can_reach(LocationName.riverside_race_flag, "Location", world.player)))
+    connection = connect(world, world.player, names, LocationName.kremwood_forest_region, kremwood_forest_levels[-1],
+                         lambda state: (state.can_reach(LocationName.riverside_race_flag, "Location", world.player)))
+    world.multiworld.register_indirect_condition(world.get_location(LocationName.riverside_race_flag).parent_region,
+                                                 connection)
 
     # Cotton-Top Cove Connections
     cotton_top_cove_levels = [
@@ -837,8 +839,11 @@ def connect_regions(world: World, level_list):
         connect(world, world.player, names, LocationName.mekanos_region, LocationName.sky_high_secret_region,
                 lambda state: (state.has(ItemName.bowling_ball, world.player, 1)))
     else:
-        connect(world, world.player, names, LocationName.mekanos_region, LocationName.sky_high_secret_region,
-                lambda state: (state.can_reach(LocationName.bleaks_house, "Location", world.player)))
+        connection = connect(world, world.player, names, LocationName.mekanos_region,
+                             LocationName.sky_high_secret_region,
+                             lambda state: (state.can_reach(LocationName.bleaks_house, "Location", world.player)))
+        world.multiworld.register_indirect_condition(world.get_location(LocationName.bleaks_house).parent_region,
+                                                     connection)
 
     # K3 Connections
     k3_levels = [
@@ -946,3 +951,4 @@ def connect(world: World, player: int, used_names: typing.Dict[str, int], source
 
     source_region.exits.append(connection)
     connection.connect(target_region)
+    return connection


### PR DESCRIPTION
## What is this fixing or adding?

A couple of Entrance access rules were checking for being able to reach a Location, but a Location first checks for being able to reach its parent Region, so it needs to be registered that access to that parent Region can give access to the Entrance.

## How was this tested?

I added the contents of the `TestImplemented.test_explicit_indirect_conditions_spheres` test from `test_implemented.py` to the end of the generator and ran `--skip_output` generations of DKC3 using https://github.com/Eijebong/Archipelago-fuzzer

Before these changes, the test added to the end of the generator would frequently fail with (the raised error type is custom for ease of searching error logs):

```
Main.main.<locals>.IndirectConditionError: Sphere 2 created with explicit indirect conditions did not contain the same locations as sphere 2 created with implicit indirect conditions. There may be missing indirect conditions for connections to the locations' parent regions or connections from other regions which connect to these regions.
Locations that should have been reachable in sphere 2 and their parent regions:
[(Arich's Hoard (2-1), Arich's Hoard Region (2-1))]
```

The location and region names would vary in the second part of the name, e.g. sometimes they would be `[(Arich's Hoard (41-0), Arich's Hoard Region (41-0))]` or other numbers instead.

With the indirect condition added for Arich's Hoard, the test added to the end of the generator no longer failed.

There is a second missing indirect condition for Bleak's House, but it seems that even when missing its indirect condition, the test does not fail, so it could mean that access to Bleak's House logically never ends up as the last requirement to traverse the Entrance, but maybe this could change in the future, at which point, the missing indirect condition could affect logic.