### PR TITLE
DLCQuest: Add missing indirect conditions

### DIFF
--- a/worlds/dlcquest/Rules.py
+++ b/worlds/dlcquest/Rules.py
@@ -280,16 +280,19 @@ def set_boss_door_requirements_rules(player, world):
     set_rule(world.get_entrance("Boss Door", player), has_3_swords)
 
 
-def set_lfod_self_obtained_items_rules(world_options, player, world):
+def set_lfod_self_obtained_items_rules(world_options, player, multiworld):
     if world_options.item_shuffle != Options.ItemShuffle.option_disabled:
         return
-    set_rule(world.get_entrance("Vines", player),
+    world = multiworld.worlds[player]
+    set_rule(world.get_entrance("Vines"),
              lambda state: state.has("Incredibly Important Pack", player))
-    set_rule(world.get_entrance("Behind Rocks", player),
+    set_rule(world.get_entrance("Behind Rocks"),
              lambda state: state.can_reach("Cut Content", 'region', player))
-    set_rule(world.get_entrance("Pickaxe Hard Cave", player),
+    multiworld.register_indirect_condition(world.get_region("Cut Content"), world.get_entrance("Behind Rocks"))
+    set_rule(world.get_entrance("Pickaxe Hard Cave"),
              lambda state: state.can_reach("Cut Content", 'region', player) and
                            state.has("Name Change Pack", player))
+    multiworld.register_indirect_condition(world.get_region("Cut Content"), world.get_entrance("Pickaxe Hard Cave"))
 
 
 def set_lfod_shuffled_items_rules(world_options, player, world):


### PR DESCRIPTION
## What is this fixing or adding?

The `Behind Rocks` and `Pickaxe Hard Cave` Entrances require being able to reach the `Cut Content` region, but no indirect conditions were being registered for this region.

The `set_lfod_self_obtained_items_rules` function was also using a `world` parameter that was actually expecting a `MultiWorld` instance, so I have renamed it for clarity and updated the function to use `world.get_entrance()` rather than `multiworld.get_entrance()`.

Much of the rest of the file passes `MultiWorld` instances to `world` parameters, but fixing all of these is out of the scope of the changes in this PR, so has not been included.

## How was this tested?

I added the contents of the `TestImplemented.test_explicit_indirect_conditions_spheres` test from `test_implemented.py` to the end of the generator and ran `--skip_output` generations of DLCQuest using https://github.com/Eijebong/Archipelago-fuzzer

Before these changes, the test added to the end of the generator would frequently fail with (the raised error type is custom for ease of searching error logs):

```
Main.main.<locals>.IndirectConditionError: Sphere 7 created with explicit indirect conditions did not contain the same locations as sphere 7 created with implicit indirect conditions. There may be missing indirect conditions for connections to the locations' parent regions or connections from other regions which connect to these regions.
Locations that should have been reachable in sphere 7 and their parent regions:
[(Hard Cave Wall Jump coins freemium, Hard Cave Wall Jump), (Hard Cave coins freemium, Hard Cave), (Increased HP Pack, Hard Cave Wall Jump)]
```
The reported regions/locations would usually be the same as above, but would sometimes instead be:
`[(High Definition Next Gen Pack, Top Right), (Season Pass, Top Right), (Top Right coins freemium, Top Right)]`

With the indirect conditions added, the test added to the end of the generator no longer fails when running generations with the fuzzer.