### PR TITLE
TUNIC: Fix decoupled ER + ladder storage making invalid entrances

### DIFF
--- a/worlds/tunic/er_rules.py
+++ b/worlds/tunic/er_rules.py
@@ -56,18 +56,18 @@ def set_er_region_rules(world: "TunicWorld", regions: Dict[str, Region], portal_
         for portal1, portal2 in portal_pairs.items():
             if portal1.scene_destination() == portal_sd:
                 return portal1.name, get_portal_outlet_region(portal2, world)
-            if portal2.scene_destination() == portal_sd:
+            if portal2.scene_destination() == portal_sd and not (options.decoupled and options.entrance_rando):
                 return portal2.name, get_portal_outlet_region(portal1, world)
-        raise Exception("No matches found in get_portal_info")
+        raise Exception(f"No matches found in get_portal_info for {portal_sd}")
 
     # input scene destination tag, returns paired portal's name and region
     def get_paired_portal(portal_sd: str) -> Tuple[str, str]:
         for portal1, portal2 in portal_pairs.items():
             if portal1.scene_destination() == portal_sd:
                 return portal2.name, portal2.region
-            if portal2.scene_destination() == portal_sd:
+            if portal2.scene_destination() == portal_sd and not (options.decoupled and options.entrance_rando):
                 return portal1.name, portal1.region
-        raise Exception("no matches found in get_paired_portal")
+        raise Exception(f"No matches found in get_paired_portal for {portal_sd}")
 
     regions["Menu"].connect(
         connecting_region=regions["Overworld"])


### PR DESCRIPTION
## What is this fixing or adding?
I knew I should have made coupled just decoupled with paired entrances.

Basically it was searching for whether portal 1 or portal 2 in a portal pair were matching the name we were looking for, which is what is required if decoupled is not enabled. If decoupled is enabled, this becomes invalid since portal 2 does not lead to portal 1.

Also made the error message next to them a little better since it wasn't helpful when fixing this.

## How was this tested?
Test gens after fixing the issue to make sure it doesn't crop back up or crash.