### PR TITLE
Settings: fix path resolution for escaped YAML folder names

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -14,6 +14,7 @@ from collections.abc import Iterator, Sequence
 from enum import IntEnum
 from threading import Lock
 from typing import cast, Any, BinaryIO, ClassVar, TextIO, TypeVar, Union
+from pathlib import Path
 
 __all__ = [
     "get_settings", "fmt_doc", "no_gui",
@@ -353,7 +354,7 @@ class Path(str):
 
 class _UserPath(str):
     def resolve(self) -> str:
-        if os.path.isabs(self):
+        if Path(self).is_absolute():
             return str(self)
         from Utils import user_path
         return user_path(_resolve_exe(self))


### PR DESCRIPTION
## What is this fixing or adding?

Replaces `os.path.isabs(...)` with `Path(...).is_absolute()` in `_UserPath.resolve()` to ensure paths such as `"Les(non-breaking space)Sims(non-breaking space)4"` from `host.yaml` are interpreted correctly. This addresses issues that occur when folder names include escaped characters or non-breaking spaces. This is common in localized Windows installations (e.g., French "Les Sims 4").

## How was this tested?

I tested this with the sims 4 apworld and a french localized game that created a folder that currently breaks without the change. This seems to have fixed the issue. 


## If this makes graphical changes, please attach screenshots.