### PR TITLE
CI: Add GH_REPO environment variable to labeler

### DIFF
--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -6,6 +6,8 @@ on:
 permissions:
   contents: read
   pull-requests: write
+env:
+  GH_REPO: ${{ github.repository }}
 
 jobs:
   labeler:
@@ -25,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Add label'
-        run: "gh pr edit \"$PR_URL\" --add-label 'waiting-on: peer-review' --repo ArchipelagoMW/Archipelago"
+        run: "gh pr edit \"$PR_URL\" --add-label 'waiting-on: peer-review'"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -44,4 +46,3 @@ jobs:
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ArchipelagoMW/Archipelago

--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -6,8 +6,6 @@ on:
 permissions:
   contents: read
   pull-requests: write
-env:
-  GH_REPO: ArchipelagoMW/Archipelago
 
 jobs:
   labeler:
@@ -31,6 +29,7 @@ jobs:
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ArchipelagoMW/Archipelago
   unblock_draft_prs:
     name: 'Remove waiting-on labels'
     needs: labeler

--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -25,11 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Add label'
-        run: "gh pr edit \"$PR_URL\" --add-label 'waiting-on: peer-review'"
+        run: "gh pr edit \"$PR_URL\" --add-label 'waiting-on: peer-review' --repo ArchipelagoMW/Archipelago"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ArchipelagoMW/Archipelago
   unblock_draft_prs:
     name: 'Remove waiting-on labels'
     needs: labeler

--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -6,6 +6,8 @@ on:
 permissions:
   contents: read
   pull-requests: write
+env:
+  GH_REPO: ArchipelagoMW/Archipelago
 
 jobs:
   labeler:

--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -45,3 +45,4 @@ jobs:
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ArchipelagoMW/Archipelago


### PR DESCRIPTION
## What is this fixing or adding?

This attempts to fix a recent trend in failures with the labeler job, such as seen here: 
https://github.com/ArchipelagoMW/Archipelago/actions/runs/15431953364/job/43431278325?pr=5080

The cause of the change in behavior is unknown, though it is speculated to be either a change in the gh cli (not inferring the repo from the PR URL, if it ever did that) or in the actions runners' default environment configuration (removing GH_REPO, if it ever had that). Either way, it seems that we should be able to, at least theoretically, resolve the issue by manually specifying the repo. The env variable is easier as it can be set at the workflow level, but could also set it with a cli flag instead if desired.

## How was this tested?

Testing actions is literally the worst thing ever to exist on this planet so I have given up after an unreasonable amount of time and have no idea if this works but it probably can't make it worse.