### PR TITLE
WebHost: Validation for themes

### DIFF
--- a/WebHostLib/misc.py
+++ b/WebHostLib/misc.py
@@ -12,10 +12,14 @@ from . import app, cache
 from .models import Seed, Room, Command, UUID, uuid4
 
 
-def get_world_theme(game_name: str):
+def get_world_theme(game_name: str) -> str:
+    available = ["dirt", "grass", "grassFlowers", "ice", "jungle", "ocean", "partyTime", "stone"]
+    chosen_theme = ""
     if game_name in AutoWorldRegister.world_types:
-        return AutoWorldRegister.world_types[game_name].web.theme
-    return 'grass'
+        chosen_theme = AutoWorldRegister.world_types[game_name].web.theme
+    if chosen_theme in available:
+        return chosen_theme
+    return "grass"
 
 
 @app.errorhandler(404)

--- a/WebHostLib/options.py
+++ b/WebHostLib/options.py
@@ -13,6 +13,7 @@ from Utils import local_path
 from worlds.AutoWorld import AutoWorldRegister
 from . import app, cache
 from .generate import get_meta
+from .misc import get_world_theme
 
 
 def create() -> None:
@@ -20,12 +21,6 @@ def create() -> None:
     yaml_folder = os.path.join(target_folder, "configs")
 
     Options.generate_yaml_templates(yaml_folder)
-
-
-def get_world_theme(game_name: str) -> str:
-    if game_name in AutoWorldRegister.world_types:
-        return AutoWorldRegister.world_types[game_name].web.theme
-    return 'grass'
 
 
 def render_options_page(template: str, world_name: str, is_complex: bool = False) -> Union[Response, str]:

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -225,7 +225,7 @@ class WebWorld(metaclass=WebWorldRegister):
     tutorials: List["Tutorial"]
     """docs folder will also be scanned for tutorial guides. Each Tutorial class is to be used for one guide."""
 
-    theme = "grass"
+    theme: str = "grass"
     """Choose a theme for you /game/* pages.
     Available: dirt, grass, grassFlowers, ice, jungle, ocean, partyTime, stone"""
 


### PR DESCRIPTION
## What is this fixing or adding?
Uses the available list of themes as a validation check for supplied web world themes. Also removes a duplicated function.

## How was this tested?
Hosting a local server and observing invalid themes getting turned to grass.

## If this makes graphical changes, please attach screenshots.
Transforms a "This page is out of logic!" error to grass theme.