### PR TITLE
shapez: Remove preset unittests

### DIFF
--- a/worlds/shapez/test/__init__.py
+++ b/worlds/shapez/test/__init__.py
@@ -92,17 +92,7 @@ class TestGlobalOptionsImport(TestCase):
                                               f"{max_levels_and_upgrades} instead.")
 
 
-class TestMinimum(ShapezTestBase):
-    options = options_presets["Minimum checks"]
-
-
-class TestMaximum(ShapezTestBase):
-    options = options_presets["Maximum checks"]
-
-
-class TestRestrictive(ShapezTestBase):
-    options = options_presets["Restrictive start"]
-
+# The following unittests are intended to test all code paths of the generator
 
 class TestAllRelevantOptions1(ShapezTestBase):
     options = {


### PR DESCRIPTION
## What is this fixing or adding?
shapez has been raising fill errors in restrictive preset-based unittests every now and then since it got merged (see [here](https://discord.com/channels/731205301247803413/1259157584783478814/1380211280110948422) for details).
This removes those unittests and adds a small comment regarding other unittests.

## How was this tested?
No tests (pun intended)

## If this makes graphical changes, please attach screenshots.
No changes