### PR TITLE
Core: Update UUID handling to be more easily sharable between libraries

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -412,7 +412,7 @@ def get_unique_identifier():
     common_path = cache_path("common.json")
     if os.path.exists(common_path):
         with open(common_path) as f:
-            common_file = json.loads(f.read())
+            common_file = json.load(f)
             uuid = common_file.get("uuid", None)
     else:
         common_file = {}

--- a/Utils.py
+++ b/Utils.py
@@ -409,7 +409,7 @@ def get_adjuster_settings(game_name: str) -> Namespace:
 
 @cache_argsless
 def get_unique_identifier():
-    common_path = os.path.expandvars(r"%LOCALAPPDATA%/Archipelago/common.yaml")
+    common_path = cache_path("common.yaml")
     if os.path.exists(common_path):
         with open(common_path) as f:
             common_file = unsafe_parse_yaml(f.read())
@@ -425,8 +425,8 @@ def get_unique_identifier():
 
     from uuid import uuid4
     uuid = str(uuid4())
+    common_file["uuid"] = uuid
     with open(common_path, "w") as f:
-        common_file["uuid"] = uuid
         f.write(dump(common_file, Dumper=Dumper))
     return uuid
 

--- a/Utils.py
+++ b/Utils.py
@@ -409,13 +409,25 @@ def get_adjuster_settings(game_name: str) -> Namespace:
 
 @cache_argsless
 def get_unique_identifier():
-    uuid = persistent_load().get("client", {}).get("uuid", None)
+    common_path = os.path.expandvars(r"%LOCALAPPDATA%/Archipelago/common.yaml")
+    if os.path.exists(common_path):
+        with open(common_path) as f:
+            common_file = unsafe_parse_yaml(f.read())
+            if common_file is None:
+                common_file = {}
+            uuid = common_file.get("uuid", None)
+    else:
+        common_file = {}
+        uuid = None
+
     if uuid:
         return uuid
 
-    import uuid
-    uuid = uuid.getnode()
-    persistent_store("client", "uuid", uuid)
+    from uuid import uuid4
+    uuid = str(uuid4())
+    with open(common_path, "w") as f:
+        common_file["uuid"] = uuid
+        f.write(dump(common_file, Dumper=Dumper))
     return uuid
 
 

--- a/Utils.py
+++ b/Utils.py
@@ -409,12 +409,10 @@ def get_adjuster_settings(game_name: str) -> Namespace:
 
 @cache_argsless
 def get_unique_identifier():
-    common_path = cache_path("common.yaml")
+    common_path = cache_path("common.json")
     if os.path.exists(common_path):
         with open(common_path) as f:
-            common_file = unsafe_parse_yaml(f.read())
-            if common_file is None:
-                common_file = {}
+            common_file = json.loads(f.read())
             uuid = common_file.get("uuid", None)
     else:
         common_file = {}
@@ -427,7 +425,7 @@ def get_unique_identifier():
     uuid = str(uuid4())
     common_file["uuid"] = uuid
     with open(common_path, "w") as f:
-        f.write(dump(common_file, Dumper=Dumper))
+        json.dump(common_file, f, separators=(",", ":"))
     return uuid
 
 

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -294,7 +294,7 @@ Sent by the client to initiate a connection to an Archipelago game session.
 | password       | str                               | If the game session requires a password, it should be passed here.                           |
 | game           | str                               | The name of the game the client is playing. Example: `A Link to the Past`                    |
 | name           | str                               | The player name for this client.                                                             |
-| uuid           | str                               | Unique identifier for player client.                                                         |
+| uuid           | str                               | Unique identifier for player client. Common cache found in %LOCALAPPDATA%/Archipelago.       |
 | version        | [NetworkVersion](#NetworkVersion) | An object representing the Archipelago version this client supports.                         |
 | items_handling | int                               | Flags configuring which items should be sent by the server. Read below for individual flags. |
 | tags           | list\[str\]                       | Denotes special features or capabilities that the sender is capable of. [Tags](#Tags)        |

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -294,7 +294,7 @@ Sent by the client to initiate a connection to an Archipelago game session.
 | password       | str                               | If the game session requires a password, it should be passed here.                           |
 | game           | str                               | The name of the game the client is playing. Example: `A Link to the Past`                    |
 | name           | str                               | The player name for this client.                                                             |
-| uuid           | str                               | Unique identifier for player. Cached in the user cache \Archipelago\Cache\common.yaml        |
+| uuid           | str                               | Unique identifier for player. Cached in the user cache \Archipelago\Cache\common.json        |
 | version        | [NetworkVersion](#NetworkVersion) | An object representing the Archipelago version this client supports.                         |
 | items_handling | int                               | Flags configuring which items should be sent by the server. Read below for individual flags. |
 | tags           | list\[str\]                       | Denotes special features or capabilities that the sender is capable of. [Tags](#Tags)        |

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -294,7 +294,7 @@ Sent by the client to initiate a connection to an Archipelago game session.
 | password       | str                               | If the game session requires a password, it should be passed here.                           |
 | game           | str                               | The name of the game the client is playing. Example: `A Link to the Past`                    |
 | name           | str                               | The player name for this client.                                                             |
-| uuid           | str                               | Unique identifier for player client. Common cache found in %LOCALAPPDATA%/Archipelago.       |
+| uuid           | str                               | Unique identifier for player. Cached in the user cache \Archipelago\Cache\common.yaml        |
 | version        | [NetworkVersion](#NetworkVersion) | An object representing the Archipelago version this client supports.                         |
 | items_handling | int                               | Flags configuring which items should be sent by the server. Read below for individual flags. |
 | tags           | list\[str\]                       | Denotes special features or capabilities that the sender is capable of. [Tags](#Tags)        |


### PR DESCRIPTION
## What is this fixing or adding?
moves uuid caching to appdata and uuid generation to be a random uuid instead of getnode's hardware address driven identifier and updates docs to point to the shared cache

obviously if we want to alter the specifics (like how we generate or where we cache it) of this we can, but I think as-is this makes the most sense with how uuid is intended to be used

## How was this tested?
ran the function without a file, with the file but without the uuid in it, and with a custom value in the file and got appropriate values back.

## If this makes graphical changes, please attach screenshots.
