### PR TITLE
Launcher: Fix Cli Components when installed to a directory with a space

### DIFF
--- a/Launcher.py
+++ b/Launcher.py
@@ -196,7 +196,8 @@ def get_exe(component: str | Component) -> Sequence[str] | None:
 def launch(exe, in_terminal=False):
     if in_terminal:
         if is_windows:
-            subprocess.Popen(['start', *exe], shell=True)
+            # intentionally using a window title with a space so it gets quoted and treated as a title
+            subprocess.Popen(["start", "Running Archipelago", *exe], shell=True)
             return
         elif is_linux:
             terminal = which('x-terminal-emulator') or which('gnome-terminal') or which('xterm')


### PR DESCRIPTION
## What is this fixing or adding?
fixes running launcher components when the install path has a space in it by intentionally defining a title that will resolve to being quoted so start reads it as a title instead of hoping the first `start` arg is not quoted automatically

the full context: 
* `start` will act differently if the first arg is quoted or not, treating any quoted arg as a title instead of the executable to launch
* Popen when passed a list of args will escape any submitted quotes, and quote any list entries with spaces to protect from args being malformed and running unintended programs on the machine
* this means if there is no space in the executable path (the first arg of `start`) everything works as expected, but if there *is* a space then the executable path is instead treated as a title and it stops working as expected
* the fix for this is not straightforward (unless we want to lose the protection that the list-version of the args gives) because since it protects against quotes we cannot just use literal quotes in our args
* this means that in order to consistently define a title arg (one with quotes or it won't be interpreted as such) we **need** to define an arg with spaces

## How was this tested?
using a source install with a space in the path and opening Host through the launcher gui

## If this makes graphical changes, please attach screenshots.
