### PR TITLE
DS3: Link to the appropriate .NET runtime for Proton

### DIFF
--- a/worlds/dark_souls_3/docs/setup_en.md
+++ b/worlds/dark_souls_3/docs/setup_en.md
@@ -73,7 +73,7 @@ things to keep in mind:
 
 * To run the game itself, just run `launchmod_darksouls3.bat` under Proton.
 
-[.NET Runtime]: https://dotnet.microsoft.com/en-us/download/dotnet/8.0
+[.NET Runtime]: https://dotnet.microsoft.com/en-us/download/dotnet/6.0
 [WINE]: https://www.winehq.org/
 
 ## Troubleshooting


### PR DESCRIPTION
Linux users are reporting that only .NET runtime 6.0 works, and this is currently linking to 8.0