### PR TITLE
SA2B: Logic Fixes

### DIFF
--- a/worlds/sa2b/GateBosses.py
+++ b/worlds/sa2b/GateBosses.py
@@ -1,6 +1,7 @@
 import typing
 
 from BaseClasses import MultiWorld
+from Options import OptionError
 from worlds.AutoWorld import World
 
 from .Names import LocationName
@@ -99,8 +100,9 @@ def get_gate_bosses(world: World):
                     pass
 
                 if boss in plando_bosses:
-                    # TODO: Raise error here. Duplicates not allowed
-                    pass
+                    raise OptionError(f"Invalid input for option `plando_bosses`: "
+                                      f"No Duplicate Bosses permitted ({boss}) - for "
+                                      f"{world.player_name}")
 
                 plando_bosses[boss_num] = boss
 
@@ -108,13 +110,14 @@ def get_gate_bosses(world: World):
                     available_bosses.remove(boss)
 
     for x in range(world.options.number_of_level_gates):
-        if ("king boom boo" not in selected_bosses) and ("king boom boo" not in available_bosses) and ((x + 1) / world.options.number_of_level_gates) > 0.5:
-            available_bosses.extend(gate_bosses_with_requirements_table)
+        if (10 not in selected_bosses) and (king_boom_boo not in available_bosses) and ((x + 1) / world.options.number_of_level_gates) > 0.5:
+            available_bosses.extend(gate_bosses_with_requirements_table.keys())
             world.random.shuffle(available_bosses)
 
         chosen_boss = available_bosses[0]
         if plando_bosses[x] != "None":
-            available_bosses.append(plando_bosses[x])
+            if plando_bosses[x] not in available_bosses:
+                available_bosses.append(plando_bosses[x])
             chosen_boss = plando_bosses[x]
 
         selected_bosses.append(all_gate_bosses_table[chosen_boss])

--- a/worlds/sa2b/Rules.py
+++ b/worlds/sa2b/Rules.py
@@ -324,7 +324,8 @@ def set_mission_upgrade_rules_standard(multiworld: MultiWorld, world: World, pla
     add_rule_safe(multiworld, LocationName.iron_gate_5, player,
                   lambda state: state.has(ItemName.eggman_large_cannon, player))
     add_rule_safe(multiworld, LocationName.dry_lagoon_5, player,
-                  lambda state: state.has(ItemName.rouge_treasure_scope, player))
+                  lambda state: state.has(ItemName.rouge_pick_nails, player) and
+                                state.has(ItemName.rouge_treasure_scope, player))
     add_rule_safe(multiworld, LocationName.sand_ocean_5, player,
                   lambda state: state.has(ItemName.eggman_jet_engine, player))
     add_rule_safe(multiworld, LocationName.egg_quarters_5, player,
@@ -407,8 +408,7 @@ def set_mission_upgrade_rules_standard(multiworld: MultiWorld, world: World, pla
                  lambda state: state.has(ItemName.sonic_bounce_bracelet, player))
 
         add_rule(multiworld.get_location(LocationName.cosmic_wall_chao_1, player),
-                 lambda state: state.has(ItemName.eggman_mystic_melody, player) and
-                               state.has(ItemName.eggman_jet_engine, player))
+                 lambda state: state.has(ItemName.eggman_jet_engine, player))
 
         add_rule(multiworld.get_location(LocationName.cannon_core_chao_1, player),
                  lambda state: state.has(ItemName.tails_booster, player) and
@@ -1402,8 +1402,6 @@ def set_mission_upgrade_rules_standard(multiworld: MultiWorld, world: World, pla
                                 state.has(ItemName.eggman_large_cannon, player)))
         add_rule(multiworld.get_location(LocationName.dry_lagoon_lifebox_2, player),
                  lambda state: state.has(ItemName.rouge_treasure_scope, player))
-        add_rule(multiworld.get_location(LocationName.sand_ocean_lifebox_2, player),
-                 lambda state: state.has(ItemName.eggman_jet_engine, player))
         add_rule(multiworld.get_location(LocationName.egg_quarters_lifebox_2, player),
                  lambda state: (state.has(ItemName.rouge_mystic_melody, player) and
                                 state.has(ItemName.rouge_treasure_scope, player)))
@@ -1724,6 +1722,9 @@ def set_mission_upgrade_rules_standard(multiworld: MultiWorld, world: World, pla
                  lambda state: state.has(ItemName.eggman_jet_engine, player))
         add_rule(multiworld.get_location(LocationName.white_jungle_itembox_8, player),
                  lambda state: state.has(ItemName.shadow_air_shoes, player))
+        add_rule(multiworld.get_location(LocationName.sky_rail_itembox_8, player),
+                 lambda state: (state.has(ItemName.shadow_air_shoes, player) and
+                                state.has(ItemName.shadow_mystic_melody, player)))
         add_rule(multiworld.get_location(LocationName.mad_space_itembox_8, player),
                  lambda state: state.has(ItemName.rouge_iron_boots, player))
         add_rule(multiworld.get_location(LocationName.cosmic_wall_itembox_8, player),
@@ -2308,8 +2309,7 @@ def set_mission_upgrade_rules_hard(multiworld: MultiWorld, world: World, player:
                  lambda state: state.has(ItemName.tails_booster, player))
 
         add_rule(multiworld.get_location(LocationName.cosmic_wall_chao_1, player),
-                 lambda state: state.has(ItemName.eggman_mystic_melody, player) and
-                               state.has(ItemName.eggman_jet_engine, player))
+                 lambda state: state.has(ItemName.eggman_jet_engine, player))
 
         add_rule(multiworld.get_location(LocationName.cannon_core_chao_1, player),
                  lambda state: state.has(ItemName.tails_booster, player) and
@@ -2980,8 +2980,6 @@ def set_mission_upgrade_rules_hard(multiworld: MultiWorld, world: World, player:
                                 state.has(ItemName.eggman_jet_engine, player)))
         add_rule(multiworld.get_location(LocationName.dry_lagoon_lifebox_2, player),
                  lambda state: state.has(ItemName.rouge_treasure_scope, player))
-        add_rule(multiworld.get_location(LocationName.sand_ocean_lifebox_2, player),
-                 lambda state: state.has(ItemName.eggman_jet_engine, player))
         add_rule(multiworld.get_location(LocationName.egg_quarters_lifebox_2, player),
                  lambda state: (state.has(ItemName.rouge_mystic_melody, player) and
                                 state.has(ItemName.rouge_treasure_scope, player)))
@@ -3593,8 +3591,7 @@ def set_mission_upgrade_rules_expert(multiworld: MultiWorld, world: World, playe
                  lambda state: state.has(ItemName.tails_booster, player))
 
         add_rule(multiworld.get_location(LocationName.cosmic_wall_chao_1, player),
-                 lambda state: state.has(ItemName.eggman_mystic_melody, player) and
-                               state.has(ItemName.eggman_jet_engine, player))
+                 lambda state: state.has(ItemName.eggman_jet_engine, player))
 
         add_rule(multiworld.get_location(LocationName.cannon_core_chao_1, player),
                  lambda state: state.has(ItemName.eggman_jet_engine, player) and
@@ -3642,9 +3639,6 @@ def set_mission_upgrade_rules_expert(multiworld: MultiWorld, world: World, playe
                  lambda state: state.has(ItemName.eggman_jet_engine, player))
         add_rule(multiworld.get_location(LocationName.cosmic_wall_pipe_2, player),
                  lambda state: state.has(ItemName.eggman_jet_engine, player))
-
-        add_rule(multiworld.get_location(LocationName.cannon_core_pipe_2, player),
-                 lambda state: state.has(ItemName.tails_booster, player))
 
         add_rule(multiworld.get_location(LocationName.prison_lane_pipe_3, player),
                  lambda state: state.has(ItemName.tails_bazooka, player))
@@ -3771,10 +3765,6 @@ def set_mission_upgrade_rules_expert(multiworld: MultiWorld, world: World, playe
         add_rule(multiworld.get_location(LocationName.cosmic_wall_beetle, player),
                  lambda state: state.has(ItemName.eggman_jet_engine, player))
 
-        add_rule(multiworld.get_location(LocationName.cannon_core_beetle, player),
-                 lambda state: state.has(ItemName.tails_booster, player) and
-                               state.has(ItemName.knuckles_hammer_gloves, player))
-
     # Animal Upgrade Requirements
     if world.options.animalsanity:
         add_rule(multiworld.get_location(LocationName.hidden_base_animal_2, player),
@@ -3839,8 +3829,7 @@ def set_mission_upgrade_rules_expert(multiworld: MultiWorld, world: World, playe
         add_rule(multiworld.get_location(LocationName.weapons_bed_animal_8, player),
                  lambda state: state.has(ItemName.eggman_jet_engine, player))
         add_rule(multiworld.get_location(LocationName.security_hall_animal_8, player),
-                 lambda state: state.has(ItemName.rouge_pick_nails, player) and
-                               state.has(ItemName.rouge_iron_boots, player))
+                 lambda state: state.has(ItemName.rouge_iron_boots, player))
         add_rule(multiworld.get_location(LocationName.cosmic_wall_animal_8, player),
                  lambda state: state.has(ItemName.eggman_jet_engine, player))
 
@@ -3976,8 +3965,6 @@ def set_mission_upgrade_rules_expert(multiworld: MultiWorld, world: World, playe
                                state.has(ItemName.tails_bazooka, player))
         add_rule(multiworld.get_location(LocationName.crazy_gadget_animal_16, player),
                  lambda state: state.has(ItemName.sonic_flame_ring, player))
-        add_rule(multiworld.get_location(LocationName.final_rush_animal_16, player),
-                 lambda state: state.has(ItemName.sonic_bounce_bracelet, player))
 
         add_rule(multiworld.get_location(LocationName.final_chase_animal_17, player),
                  lambda state: state.has(ItemName.shadow_flame_ring, player))
@@ -4035,8 +4022,6 @@ def set_mission_upgrade_rules_expert(multiworld: MultiWorld, world: World, playe
                  lambda state: state.has(ItemName.eggman_jet_engine, player))
         add_rule(multiworld.get_location(LocationName.dry_lagoon_lifebox_2, player),
                  lambda state: state.has(ItemName.rouge_treasure_scope, player))
-        add_rule(multiworld.get_location(LocationName.sand_ocean_lifebox_2, player),
-                 lambda state: state.has(ItemName.eggman_jet_engine, player))
         add_rule(multiworld.get_location(LocationName.egg_quarters_lifebox_2, player),
                  lambda state: state.has(ItemName.rouge_treasure_scope, player))
 


### PR DESCRIPTION
## What is this fixing or adding?
- Fixed King Boom Boo being able to appear in multiple boss gates
- `Final Rush - 16 Animals (Expert)` no longer requires `Sonic - Bounce Bracelet`
- `Dry Lagoon - 5 (Standard)` now requires `Rouge - Pick Nails`
- `Sand Ocean - Extra Life Box 2 (Standard/Hard/Expert)` no longer requires `Eggman - Jet Engine`
- `Security Hall - 8 Animals (Expert)` no longer requires `Rouge - Pick Nails`
- `Sky Rail - Item Box 8 (Standard)` now requires `Shadow - Air Shoes` and `Shadow - Mystic Melody`
- `Cosmic Wall - Chao Key 1 (Standard/Hard/Expert)` no longer requires `Eggman - Mystic Melody`
- `Cannon's Core - Pipe 2 (Expert)` no longer requires `Tails - Booster`
- `Cannon's Core - Gold Beetle` no longer requires `Tails - Booster` nor `Knuckles - Hammer Gloves`

## How was this tested?
Generations and spoiler checking

## If this makes graphical changes, please attach screenshots.
