### PR TITLE
Tests: Ignore .github directories in package test

### DIFF
--- a/test/general/test_packages.py
+++ b/test/general/test_packages.py
@@ -8,7 +8,12 @@ class TestPackages(unittest.TestCase):
         to indicate full package rather than namespace package."""
         import Utils
 
+        # Ignore directories with these names.
+        ignore_dirs = {".github"}
+
         worlds_path = Utils.local_path("worlds")
         for dirpath, dirnames, filenames in os.walk(worlds_path):
+            # Drop ignored directories from dirnames, excluding them from walking.
+            dirnames[:] = [d for d in dirnames if d not in ignore_dirs]
             with self.subTest(directory=dirpath):
                 self.assertEqual("__init__.py" in filenames, any(file.endswith(".py") for file in filenames))


### PR DESCRIPTION
## What is this fixing or adding?
### What is this?
The package test now ignores .github directories (can be changed to exclude more or less directories).

### Why is it needed?
There are some APWorlds that use python scripts for GitHub Actions (contained in .github), but then doing so would fail the unit tests.
There is always adding an `__init__.py` in there, but then python would treat the .github directory as a module, which isn't always the desired behavior.

## How was this tested?
Ran the Unit Tests with and without python scripts in the .github directories, and tested to see if it still caught .py scripts without `__init__.py` in other directories.
