### PR TITLE
Item Plando: Fix `count` value

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -944,7 +944,9 @@ def parse_planned_blocks(multiworld: MultiWorld) -> dict[int, list[PlandoItemBlo
             if "min" not in count:
                 count["min"] = 0
             if "max" not in count:
-                count["max"] = len(new_block.items)
+                count["max"] = (min(len(new_block.items), len(new_block.resolved_locations))
+                                if new_block.resolved_locations else len(new_block.items))
+
 
             new_block.count = count
             plando_blocks[player].append(new_block)


### PR DESCRIPTION
## What is this fixing or adding?

Previously:
https://github.com/ArchipelagoMW/Archipelago/blob/d8576e72eb609cb9d779fe59f4243e3dd8afb9aa/Fill.py#L986-L988

`count` was based off the minimum of `items` and `locations`, but now:
https://github.com/ArchipelagoMW/Archipelago/blob/e0d31010664cc03e24900ccd7f4216c69647feac/Fill.py#L939-L940

It solely goes off of `items`, which is simply wrong.

## How was this tested?
Using the yaml below which has this plando block:
```yaml
    - items: [Colored Squares, Negative Shapers, Rotated Shapers]
      locations: [Tutorial Back Left, Tutorial Back Right]
      force: true
```
Before this change, this would crash since `items` was longer than `locations`. Now it correctly resolves only two locations.

[The Witness.json](https://github.com/user-attachments/files/20713194/The.Witness.json)