### PR TITLE
saving princess: fix use of subprocess helpers

### DIFF
--- a/worlds/saving_princess/__init__.py
+++ b/worlds/saving_princess/__init__.py
@@ -12,7 +12,7 @@ from .Constants import *
 
 def launch_client(*args: str):
     from .Client import launch
-    launch_subprocess(launch(*args), name=CLIENT_NAME)
+    launch_subprocess(launch, name=CLIENT_NAME, args=args)
 
 
 components.append(


### PR DESCRIPTION
## What is this fixing or adding?
launch_subprocess takes the Callable not the result of the Callable

## How was this tested?
i opened the client and then used the launcher while it waited for me to select my data files (instead of it currently hanging in that situation)

## If this makes graphical changes, please attach screenshots.
