### PR TITLE
LTTP/SDV: use .name when appropriate in subtests

### DIFF
--- a/worlds/alttp/test/options/test_dungeon_fill.py
+++ b/worlds/alttp/test/options/test_dungeon_fill.py
@@ -38,7 +38,7 @@ class DungeonFillTestBase(TestCase):
     def test_original_dungeons(self):
         self.generate_with_options(DungeonItem.option_original_dungeon)
         for location in self.multiworld.get_filled_locations():
-            with (self.subTest(location=location)):
+            with (self.subTest(location=location.name)):
                 if location.parent_region.dungeon is None:
                     self.assertIs(location.item.dungeon, None)
                 else:
@@ -52,7 +52,7 @@ class DungeonFillTestBase(TestCase):
     def test_own_dungeons(self):
         self.generate_with_options(DungeonItem.option_own_dungeons)
         for location in self.multiworld.get_filled_locations():
-            with self.subTest(location=location):
+            with self.subTest(location=location.name):
                 if location.parent_region.dungeon is None:
                     self.assertIs(location.item.dungeon, None)
                 else:

--- a/worlds/alttp/test/options/test_dungeon_fill.py
+++ b/worlds/alttp/test/options/test_dungeon_fill.py
@@ -38,7 +38,7 @@ class DungeonFillTestBase(TestCase):
     def test_original_dungeons(self):
         self.generate_with_options(DungeonItem.option_original_dungeon)
         for location in self.multiworld.get_filled_locations():
-            with (self.subTest(location=location.name)):
+            with (self.subTest(location_name=location.name)):
                 if location.parent_region.dungeon is None:
                     self.assertIs(location.item.dungeon, None)
                 else:
@@ -52,7 +52,7 @@ class DungeonFillTestBase(TestCase):
     def test_own_dungeons(self):
         self.generate_with_options(DungeonItem.option_own_dungeons)
         for location in self.multiworld.get_filled_locations():
-            with self.subTest(location=location.name):
+            with self.subTest(location_name=location.name):
                 if location.parent_region.dungeon is None:
                     self.assertIs(location.item.dungeon, None)
                 else:

--- a/worlds/stardew_valley/test/regions/TestEntranceClassifications.py
+++ b/worlds/stardew_valley/test/regions/TestEntranceClassifications.py
@@ -11,7 +11,7 @@ class EntranceRandomizationAssertMixin:
         non_progression_connections = [connection for connection in all_connections.values() if RandomizationFlag.BIT_NON_PROGRESSION in connection.flag]
 
         for non_progression_connections in non_progression_connections:
-            with self.subTest(connection=non_progression_connections):
+            with self.subTest(connection=non_progression_connections.name):
                 self.assert_can_reach_entrance(non_progression_connections.name)
 
 

--- a/worlds/stardew_valley/test/regions/TestRegionConnections.py
+++ b/worlds/stardew_valley/test/regions/TestRegionConnections.py
@@ -12,14 +12,14 @@ from ...regions.regions import create_all_regions, create_all_connections
 class TestVanillaRegionsConnectionsWithGingerIsland(unittest.TestCase):
     def test_region_exits_lead_somewhere(self):
         for region in vanilla_data.regions_with_ginger_island_by_name.values():
-            with self.subTest(region=region):
+            with self.subTest(region=region.name):
                 for exit_ in region.exits:
                     self.assertIn(exit_, vanilla_data.connections_with_ginger_island_by_name,
                                   f"{region.name} is leading to {exit_} but it does not exist.")
 
     def test_connection_lead_somewhere(self):
         for connection in vanilla_data.connections_with_ginger_island_by_name.values():
-            with self.subTest(connection=connection):
+            with self.subTest(connection=connection.name):
                 self.assertIn(connection.destination, vanilla_data.regions_with_ginger_island_by_name,
                               f"{connection.name} is leading to {connection.destination} but it does not exist.")
 
@@ -27,14 +27,14 @@ class TestVanillaRegionsConnectionsWithGingerIsland(unittest.TestCase):
 class TestVanillaRegionsConnectionsWithoutGingerIsland(unittest.TestCase):
     def test_region_exits_lead_somewhere(self):
         for region in vanilla_data.regions_without_ginger_island_by_name.values():
-            with self.subTest(region=region):
+            with self.subTest(region=region.name):
                 for exit_ in region.exits:
                     self.assertIn(exit_, vanilla_data.connections_without_ginger_island_by_name,
                                   f"{region.name} is leading to {exit_} but it does not exist.")
 
     def test_connection_lead_somewhere(self):
         for connection in vanilla_data.connections_without_ginger_island_by_name.values():
-            with self.subTest(connection=connection):
+            with self.subTest(connection=connection.name):
                 self.assertIn(connection.destination, vanilla_data.regions_without_ginger_island_by_name,
                               f"{connection.name} is leading to {connection.destination} but it does not exist.")
 


### PR DESCRIPTION
## What is this fixing or adding?
use name strings for subtest args instead of full objects

## How was this tested?
ran the tests locally and gh will do the same

## If this makes graphical changes, please attach screenshots.
