### PR TITLE
Plando Items: Better Warning for Nonexisting Worlds

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -890,7 +890,7 @@ def parse_planned_blocks(multiworld: MultiWorld) -> dict[int, list[PlandoItemBlo
                 worlds = set()
                 for listed_world in target_world:
                     if listed_world not in world_name_lookup:
-                        failed(f"Cannot place item to {target_world}'s world as that world does not exist.",
+                        failed(f"Cannot place item to {listed_world}'s world as that world does not exist.",
                                block.force)
                         continue
                     worlds.add(world_name_lookup[listed_world])


### PR DESCRIPTION
## What is this fixing or adding?

"Exception: Cannot place item to ['2', '1', '0']'s world as that world does not exist."
&rarr;
"Exception: Cannot place item to 0's world as that world does not exist."

## How was this tested?

Generating with an item plando block that used `world: ["2", "1", "0"]` with players named "2" and "1".