### PR TITLE
Shivers: Fix get_pre_fill_items

### DIFF
--- a/worlds/shivers/__init__.py
+++ b/worlds/shivers/__init__.py
@@ -261,13 +261,13 @@ class ShiversWorld(World):
                     data.type == ItemType.POT_DUPLICATE]
         elif self.options.full_pots == "complete":
             return [self.create_item(name) for name, data in item_table.items() if
-                    data.type == ItemType.POT_COMPELTE_DUPLICATE]
+                    data.type == ItemType.POT_COMPLETE_DUPLICATE]
         else:
             pool = []
             pieces = [self.create_item(name) for name, data in item_table.items() if
                       data.type == ItemType.POT_DUPLICATE]
             complete = [self.create_item(name) for name, data in item_table.items() if
-                        data.type == ItemType.POT_COMPELTE_DUPLICATE]
+                        data.type == ItemType.POT_COMPLETE_DUPLICATE]
             for i in range(10):
                 if self.pot_completed_list[i] == 0:
                     pool.append(pieces[i])


### PR DESCRIPTION
## What is this fixing or adding?

Shivers cannot generate with LADX or with plando or anything else that utilizes get_pre_fill_items.

A typo that used to exist in Shivers (compelte instead of complete) was inside the plando items rewrite, and worked correctly. But the Shivers typo was later fixed and the plando rewrite was not.

## How was this tested?

Generating with LADX and plando