### PR TITLE
HK: explicitly exclude palace items as well

### DIFF
--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -218,7 +218,11 @@ class HKWorld(World):
         wp = self.options.WhitePalace
         if wp <= WhitePalace.option_nopathofpain:
             exclusions.update(path_of_pain_locations)
-            exclusions.add("Soul_Totem-Path_of_Pain")
+            exclusions.update((
+                "Soul_Totem-Path_of_Pain",
+                "Lore_Tablet-Path_of_Pain_Entrance",
+                "Journal_Entry-Seal_of_Binding",
+                ))
         if wp <= WhitePalace.option_kingfragment:
             exclusions.update(white_palace_checks)
         if wp == WhitePalace.option_exclude:

--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -218,6 +218,7 @@ class HKWorld(World):
         wp = self.options.WhitePalace
         if wp <= WhitePalace.option_nopathofpain:
             exclusions.update(path_of_pain_locations)
+            exclusions.add("Soul_Totem-Path_of_Pain")
         if wp <= WhitePalace.option_kingfragment:
             exclusions.update(white_palace_checks)
         if wp == WhitePalace.option_exclude:
@@ -226,6 +227,9 @@ class HKWorld(World):
                 # If charms are randomized, this will be junk-filled -- so transitions and events are not progression
                 exclusions.update(white_palace_transitions)
                 exclusions.update(white_palace_events)
+            exclusions.update(item_name_groups["PalaceJournal"])
+            exclusions.update(item_name_groups["PalaceLore"])
+            exclusions.update(item_name_groups["PalaceTotem"])
         return exclusions
 
     def create_regions(self):


### PR DESCRIPTION
## What is this fixing or adding?
explicitly adds white palace filler to exclusions so they won't be valid filler names when the area is excluded

fyi this is harder to do in the rewrite so may just be removed instead

## How was this tested?
lightly, generated a game that had good chances to generate totem fillers and didn't see any palace totems outside of palace

## If this makes graphical changes, please attach screenshots.
