### PR TITLE
Pokémon RB: Use new link for a new tracker

### DIFF
--- a/worlds/pokemon_rb/docs/setup_en.md
+++ b/worlds/pokemon_rb/docs/setup_en.md
@@ -15,7 +15,7 @@ As we are using BizHawk, this guide is only applicable to Windows and Linux syst
 
 ## Optional Software
 
-- [Pokémon Red and Blue Archipelago Map Tracker](https://github.com/coveleski/rb_tracker/releases/latest), for use with [PopTracker](https://github.com/black-sliver/PopTracker/releases)
+- [Pokémon Red and Blue Archipelago Map Tracker](https://github.com/palex00/rb_tracker/releases/latest), for use with [PopTracker](https://github.com/black-sliver/PopTracker/releases)
 
 
 ## Configuring BizHawk
@@ -109,7 +109,7 @@ server uses password, type in the bottom textfield `/connect <address>:<port> [p
 
 Pokémon Red and Blue has a fully functional map tracker that supports auto-tracking.
 
-1. Download [Pokémon Red and Blue Archipelago Map Tracker](https://github.com/coveleski/rb_tracker/releases/latest) and [PopTracker](https://github.com/black-sliver/PopTracker/releases).
+1. Download [Pokémon Red and Blue Archipelago Map Tracker](https://github.com/palex00/rb_tracker/releases/latest) and [PopTracker](https://github.com/black-sliver/PopTracker/releases).
 2. Open PopTracker, and load the Pokémon Red and Blue pack. 
 3. Click on the "AP" symbol at the top.
 4. Enter the AP address, slot name and password. 

--- a/worlds/pokemon_rb/docs/setup_es.md
+++ b/worlds/pokemon_rb/docs/setup_es.md
@@ -16,7 +16,7 @@ Al usar BizHawk, esta guía solo es aplicable en los sistemas de Windows y Linux
 
 ## Software Opcional
 
-- [Tracker de mapa para Pokémon Red and Blue Archipelago](https://github.com/coveleski/rb_tracker/releases/latest), para usar con [PopTracker](https://github.com/black-sliver/PopTracker/releases)
+- [Tracker de mapa para Pokémon Red and Blue Archipelago](https://github.com/palex00/rb_tracker/releases/latest), para usar con [PopTracker](https://github.com/black-sliver/PopTracker/releases)
 
 
 ## Configurando BizHawk
@@ -114,7 +114,7 @@ presiona enter (si el servidor usa contraseña, escribe en el campo de texto inf
 
 Pokémon Red and Blue tiene un mapa completamente funcional que soporta seguimiento automático. 
 
-1. Descarga el [Tracker de mapa para Pokémon Red and Blue Archipelago](https://github.com/coveleski/rb_tracker/releases/latest) y [PopTracker](https://github.com/black-sliver/PopTracker/releases). 
+1. Descarga el [Tracker de mapa para Pokémon Red and Blue Archipelago](https://github.com/palex00/rb_tracker/releases/latest) y [PopTracker](https://github.com/black-sliver/PopTracker/releases). 
 2. Abre PopTracker, y carga el pack de Pokémon Red and Blue.
 3. Haz clic en el símbolo "AP" en la parte superior.
 4. Ingresa la dirección de AP, nombre del slot y contraseña (si es que hay).


### PR DESCRIPTION
## What is this fixing or adding?
This is replacing the link to the Pokémon RB Tracker made by Coveleski & me to a new branch just maintained by me.

Coveleski and I have split, I have no control of the old branch, he hasn't written in the AP servers in ~6 months, the old version has several major bugs that this fork of mine fixes. I am one of the original authors but the whole thing is also MIT-licensed.

With Support from Alchav & GerbilJames (this was already discussed), I will also overhaul the tracker to implement many of the features other Pokémon-Trackers have, such as Auto-Map-Tabbing, Pokémon-Tracking, Encounter Tracking and maybe even ER-Tracking.

I am also submitting a PR to BlackSliver's Community Pack List to make the old pack update to this new fork, as well as hoping to get the pins changed in the #pokemon-rb channel.

Thanks for reading.