### PR TITLE
Pokemon RB: Add options to keep Poke Doll and Bicycle skips but not consider them in logic

### DIFF
--- a/worlds/pokemon_rb/options.py
+++ b/worlds/pokemon_rb/options.py
@@ -852,18 +852,22 @@ class IceTrapWeight(TrapWeight):
 
 
 class PokeDollSkip(Choice):
-    """Patch out the Pokemon Tower Poke Doll skip or have this skip considered in logic."""
+    """Patch out the Pokemon Tower Poke Doll skip, have this skip considered in logic or leave it unpatched but out of
+    logic."""
     display_name = "Poke Doll Skip"
     option_patched = 0
     option_in_logic = 1
+    option_out_of_logic = 2
     default = 0
 
 
 class BicycleGateSkips(Choice):
-    """Patch out the Route 16/18 Bicycle Gate skips or have these skips considered in logic."""
+    """Patch out the Route 16/18 Bicycle Gate skips, have these skips considered in logic or leave them unpatched but
+    out of logic."""
     display_name = "Bicycle Gate Skips"
     option_patched = 0
     option_in_logic = 1
+    option_out_of_logic = 2
     default = 0
 
 

--- a/worlds/pokemon_rb/regions.py
+++ b/worlds/pokemon_rb/regions.py
@@ -1743,7 +1743,7 @@ def create_regions(world):
     connect(multiworld, player, "Route 12-L", "Lavender Town")
     connect(multiworld, player, "Route 10-S", "Lavender Town")
     connect(multiworld, player, "Route 8", "Lavender Town")
-    connect(multiworld, player, "Pokemon Tower 6F", "Pokemon Tower 6F-S", lambda state: state.has("Silph Scope", player) or (state.has("Buy Poke Doll", player) and world.options.poke_doll_skip))
+    connect(multiworld, player, "Pokemon Tower 6F", "Pokemon Tower 6F-S", lambda state: state.has("Silph Scope", player) or (state.has("Buy Poke Doll", player) and world.options.poke_doll_skip == "in_logic"))
     connect(multiworld, player, "Route 8", "Route 8-Grass", lambda state: logic.can_cut(state, world, player), one_way=True)
     connect(multiworld, player, "Route 7", "Celadon City")
     connect(multiworld, player, "Celadon City", "Celadon City-G", lambda state: logic.can_cut(state, world, player))

--- a/worlds/pokemon_rb/rom.py
+++ b/worlds/pokemon_rb/rom.py
@@ -7,6 +7,7 @@ from worlds.Files import APProcedurePatch, APTokenMixin, APTokenTypes
 
 from . import poke_data
 from .items import item_table
+from .options import PokeDollSkip
 from .text import encode_text
 from .pokemon import set_mon_palettes
 from .regions import PokemonRBWarp, map_ids, town_map_coords
@@ -391,7 +392,7 @@ def generate_output(world: "PokemonRedBlueWorld", output_directory: str):
         write_bytes(rom_addresses["Option_Fix_Combat_Bugs_Heal_Effect"] + 1, 5)  # 5 bytes ahead
         write_bytes(rom_addresses["Option_Fix_Combat_Bugs_Heal_Stat_Modifiers"], 1)
 
-    if world.options.poke_doll_skip == "in_logic":
+    if world.options.poke_doll_skip:
         write_bytes(rom_addresses["Option_Silph_Scope_Skip"], 0x00)      # nop
         write_bytes(rom_addresses["Option_Silph_Scope_Skip"] + 1, 0x00)  # nop
         write_bytes(rom_addresses["Option_Silph_Scope_Skip"] + 2, 0x00)  # nop

--- a/worlds/pokemon_rb/rom.py
+++ b/worlds/pokemon_rb/rom.py
@@ -7,7 +7,6 @@ from worlds.Files import APProcedurePatch, APTokenMixin, APTokenTypes
 
 from . import poke_data
 from .items import item_table
-from .options import PokeDollSkip
 from .text import encode_text
 from .pokemon import set_mon_palettes
 from .regions import PokemonRBWarp, map_ids, town_map_coords


### PR DESCRIPTION
@palex00 Asked me to PR this.

## What is this fixing or adding?
This adds options to keep the Poke Doll and Bicycle skips in the game, but not consider them in logic

## How was this tested?
Ran some debug generations, and ensured the correct code paths were followed for patching/not patching the skips. 

## If this makes graphical changes, please attach screenshots.
N/A