### PR TITLE
Undertale: Handle zero arg /auto_patch

### DIFF
--- a/UndertaleClient.py
+++ b/UndertaleClient.py
@@ -45,7 +45,7 @@ class UndertaleCommandProcessor(ClientCommandProcessor):
         if isinstance(self.ctx, UndertaleContext):
             os.makedirs(name=Utils.user_path("Undertale"), exist_ok=True)
             tempInstall = steaminstall
-            if not os.path.isfile(os.path.join(tempInstall, "data.win")):
+            if tempInstall and not os.path.isfile(os.path.join(tempInstall, "data.win")):
                 tempInstall = None
             if tempInstall is None:
                 tempInstall = "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Undertale"


### PR DESCRIPTION
## What is this fixing or adding?
handle zero arg /auto_patch gracefully so it doesn't crash on the os.path.join and instead continues to the fallback

## How was this tested?
ran `/auto_patch` and saw it go further in the codepath

## If this makes graphical changes, please attach screenshots.
