### PR TITLE
CC: add assert to catch any continued use of old datapackage lookup api

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -201,6 +201,7 @@ class CommonContext:
 
         # noinspection PyTypeChecker
         def __getitem__(self, key: str) -> typing.Mapping[int, str]:
+            assert isinstance(key, str), f"ctx.{self.lookup_type}_names used with an id, use the lookup_in_ helpers instead"
             return self._game_store[key]
 
         def __len__(self) -> int:


### PR DESCRIPTION
## What is this fixing or adding?
since cc clients don't get good unit tests and the output of a failure to move to the new datapackage lookup api is not straightforward, this simple assert catches most if not all invalid uses of the NameLookupDicts with explicit messaging

## How was this tested?
`self.ctx.location_names[123]` and saw the error

## If this makes graphical changes, please attach screenshots.
