### PR TITLE
Civ 6: Remove erroneous boost prereqs for computers boost

### DIFF
--- a/worlds/civ_6/data/boosts.py
+++ b/worlds/civ_6/data/boosts.py
@@ -78,8 +78,8 @@ boosts: List[CivVIBoostData] = [
     CivVIBoostData(
         "BOOST_TECH_IRON_WORKING",
         "ERA_CLASSICAL",
-        ["TECH_MINING"],
-        1,
+        ["TECH_MINING", "TECH_BRONZE_WORKING"],
+        2,
         "DEFAULT",
     ),
     CivVIBoostData(
@@ -165,15 +165,9 @@ boosts: List[CivVIBoostData] = [
         "BOOST_TECH_CASTLES",
         "ERA_MEDIEVAL",
         [
-            "CIVIC_DIVINE_RIGHT",
-            "CIVIC_EXPLORATION",
-            "CIVIC_REFORMED_CHURCH",
             "CIVIC_SUFFRAGE",
             "CIVIC_TOTALITARIANISM",
             "CIVIC_CLASS_STRUGGLE",
-            "CIVIC_DIGITAL_DEMOCRACY",
-            "CIVIC_CORPORATE_LIBERTARIANISM",
-            "CIVIC_SYNTHETIC_TECHNOCRACY",
         ],
         1,
         "DEFAULT",


### PR DESCRIPTION
Addresses https://github.com/ArchipelagoMW/Archipelago/issues/5133#issuecomment-2997733895

## What is this fixing or adding?
Removes prereqs that were invalid for computers boost

## How was this tested?
tests ran/passed, generated several builds, verified the logic lines up with reality.
