### PR TITLE
TWW: Fix swords in swordless mode

### DIFF
--- a/worlds/tww/randomizers/ItemPool.py
+++ b/worlds/tww/randomizers/ItemPool.py
@@ -110,6 +110,15 @@ def get_pool_core(world: "TWWWorld") -> tuple[list[str], list[str]]:
             else:
                 filler_pool.extend([item] * data.quantity)
 
+    # If the player starts with a sword, add one to the precollected items list and remove one from the item pool.
+    if world.options.sword_mode == "start_with_sword":
+        precollected_items.append("Progressive Sword")
+        progression_pool.remove("Progressive Sword")
+    # Or, if it's swordless mode, remove all swords from the item pool.
+    elif world.options.sword_mode == "swordless":
+        while "Progressive Sword" in useful_pool:
+            useful_pool.remove("Progressive Sword")
+
     # Assign useful and filler items to item pools in the world.
     world.random.shuffle(useful_pool)
     world.random.shuffle(filler_pool)
@@ -140,17 +149,6 @@ def get_pool_core(world: "TWWWorld") -> tuple[list[str], list[str]]:
         )
     pool.extend(progression_pool)
     num_items_left_to_place -= len(progression_pool)
-
-    # If the player starts with a sword, add one to the precollected items list and remove one from the item pool.
-    if world.options.sword_mode == "start_with_sword":
-        precollected_items.append("Progressive Sword")
-        num_items_left_to_place += 1
-        pool.remove("Progressive Sword")
-    # Or, if it's swordless mode, remove all swords from the item pool.
-    elif world.options.sword_mode == "swordless":
-        while "Progressive Sword" in pool:
-            num_items_left_to_place += 1
-            pool.remove("Progressive Sword")
 
     # Place useful items, then filler items to fill out the remaining locations.
     pool.extend([world.get_filler_item_name(strict=False) for _ in range(num_items_left_to_place)])

--- a/worlds/tww/randomizers/ItemPool.py
+++ b/worlds/tww/randomizers/ItemPool.py
@@ -116,8 +116,7 @@ def get_pool_core(world: "TWWWorld") -> tuple[list[str], list[str]]:
         progression_pool.remove("Progressive Sword")
     # Or, if it's swordless mode, remove all swords from the item pool.
     elif world.options.sword_mode == "swordless":
-        while "Progressive Sword" in useful_pool:
-            useful_pool.remove("Progressive Sword")
+        useful_pool = [item for item in useful_pool if item != "Progressive Sword"]
 
     # Assign useful and filler items to item pools in the world.
     world.random.shuffle(useful_pool)


### PR DESCRIPTION
## What is this fixing or adding?
This PR fixes a bug in swordless mode where swords were being placed into the item pool. This was because the swords remained in the useful items pool in the old code and were thus potentially added after progression items were placed.
Fixes #5102.

## How was this tested?
Generated a spoiler log before and after the change with swordless mode and ensured no swords were placed. Checked the other sword modes as well to ensure swords were placed correctly for those as well.

## If this makes graphical changes, please attach screenshots.
N/A