### PR TITLE
Webhost: Fix defaults for NamedRange and TextChoice

### DIFF
--- a/WebHostLib/templates/playerOptions/macros.html
+++ b/WebHostLib/templates/playerOptions/macros.html
@@ -55,6 +55,9 @@
     {{ OptionTitle(option_name, option) }}
     <div class="named-range-container">
         <select id="{{ option_name }}-select" name="{{ option_name }}" data-option-name="{{ option_name }}" {{ "disabled" if option.default == "random" }}>
+            {% if option.default not in option.special_range_names.values() %}
+                <option value="{{ option.default }}" selected>Default ({{ option.default }})</option>
+            {% endif %}
             {% for key, val in option.special_range_names.items() %}
                 {% if option.default == val %}
                     <option value="{{ val }}" selected>{{ key|replace("_", " ")|title }} ({{ val }})</option>
@@ -62,6 +65,7 @@
                     <option value="{{ val }}">{{ key|replace("_", " ")|title }} ({{ val }})</option>
                 {% endif %}
             {% endfor %}
+
             <option value="custom" hidden>Custom</option>
         </select>
         <div class="named-range-wrapper js-required">
@@ -94,6 +98,9 @@
     <div class="text-choice-container">
         <div class="text-choice-wrapper">
             <select id="{{ option_name }}" name="{{ option_name }}" {{ "disabled" if option.default == "random" }}>
+            {% if option.default not in option.options.values()  %}
+                <option value="{{ option.default }}" selected="true">Custom ({{ option.default }})</option>
+            {% endif %}
             {% for id, name in option.name_lookup.items()|sort %}
                 {% if name != "random" %}
                     {% if option.default == id %}

--- a/WebHostLib/templates/playerOptions/macros.html
+++ b/WebHostLib/templates/playerOptions/macros.html
@@ -65,7 +65,6 @@
                     <option value="{{ val }}">{{ key|replace("_", " ")|title }} ({{ val }})</option>
                 {% endif %}
             {% endfor %}
-
             <option value="custom" hidden>Custom</option>
         </select>
         <div class="named-range-wrapper js-required">


### PR DESCRIPTION
## What is this fixing or adding?
Adds an element to the NamedRange and TextChoice in options page to account for defaults not having a name/text value.
To resolve #4503.

## How was this tested?
Running webhost and generated with weird defaults for Pokemon RB Trainer Name and Dexterity.
