### PR TITLE
Tests: Add a test that ensures that collecting items doesn't make locations go out of logic

### DIFF
--- a/test/general/test_reachability.py
+++ b/test/general/test_reachability.py
@@ -79,3 +79,108 @@ class TestBase(unittest.TestCase):
                             locations.add(location)
                     self.assertGreater(len(locations), 0,
                                        msg="Need to be able to reach at least one location to get started.")
+
+    def test_collecting_and_removing_items_maintains_reachability(self):
+        """Test that worlds don't have situations where collecting an item makes a location become unreachable,
+        or removing an item makes a location become reachable. (Usually due to faulty "score calculation" algorithms)"""
+
+        for game_name, world_type in AutoWorldRegister.world_types.items():
+            with self.subTest(game_name, game_name=game_name):
+                multiworld = setup_solo_multiworld(
+                    world_type,
+                    steps=(
+                        "generate_early",
+                        "create_regions",
+                        "create_items",
+                        "set_rules",
+                        "connect_entrances",
+                        "generate_basic"
+                    )
+                )
+                proxy_world = multiworld.worlds[1]
+
+                # First, we need to get a random set of items.
+                # ALl of them need to be progression items. To ensure this, we need to do a bit of work.
+
+                # First, generate one copy of each item in the world's datapackage using the world's create_item.
+                items = [proxy_world.create_item(item_name) for item_name in world_type.item_name_to_id]
+                # Only keep progression items.
+                candidate_items = [item for item in items if item.advancement]
+
+                if not candidate_items:
+                    self.skipTest(f"{game_name} does not have any progression items.")
+
+                # Now, we choose random items over and over, allowing duplicates but handling them carefully.-+-
+                chosen_items = []
+                target_amount = len(candidate_items) / 2
+                while len(chosen_items) < target_amount:
+                    random_item = proxy_world.random.choice(candidate_items)
+
+                    # If the chosen candidate item is not already in our list of chosen items, just use that instance
+                    if random_item not in chosen_items:
+                        chosen_items.append(random_item)
+                        continue
+
+                    # Otherwise, we'll have to create a new copy.
+                    # Depending on the world's create_item, this new instance may not be an advancement.
+                    # If that's the case, we stop trying to use this item.
+                    second_or_higher_copy = proxy_world.create_item(random_item.name)
+                    if not second_or_higher_copy.advancement:
+                        candidate_items.remove(random_item)
+
+                        if not candidate_items:
+                            self.skipTest(
+                                f"Was not able to make {target_amount} progression items for game {game_name}."
+                            )
+
+                        continue
+
+                    chosen_items.append(random_item)
+
+                proxy_world.random.shuffle(chosen_items)
+
+                all_locations = list(proxy_world.get_locations())
+
+                state = CollectionState(multiworld)
+                reachable_locations = {
+                    location for location in all_locations if location.can_reach(state)
+                }
+                for item in chosen_items:
+                    prog_items_before = str(state.prog_items)  # For error message
+
+                    state.collect(item)
+
+                    new_reachable_locations = {
+                        location for location in all_locations if location.can_reach(state)
+                    }
+                    locations_that_became_unreachable = reachable_locations - new_reachable_locations
+
+                    self.assertFalse(
+                        locations_that_became_unreachable,
+                        f"Locations {locations_that_became_unreachable} became unreachable after collecting "
+                        f"{item} into state. Progression items were:\n"
+                        f"Before: {prog_items_before}\nAfter: {state.prog_items}"
+                    )
+
+                    reachable_locations = new_reachable_locations
+
+                proxy_world.random.shuffle(chosen_items)
+
+                for item in chosen_items:
+                    prog_items_before = str(state.prog_items)  # For error message
+
+                    state.remove(item)
+
+                    new_reachable_locations = {
+                        location for location in all_locations if location.can_reach(state)
+                    }
+                    locations_that_became_reachable = new_reachable_locations - reachable_locations
+
+                    self.assertFalse(
+                        locations_that_became_reachable,
+                        f"Locations {locations_that_became_reachable} became reachable after removing "
+                        f"{item} from state. Progression items were:\n"
+                        f"Before: {prog_items_before}\nAfter: {state.prog_items}"
+                    )
+
+                    reachable_locations = new_reachable_locations


### PR DESCRIPTION
And vice versa for remove.

This often comes up with "score calculation" algorithms, like Tunic's combat logic or Yacht Dice's score calculation.
In some games it can also come from a faulty .remove calculation.

Tested:
Tested this with Mario Kart Double Dash, which currently has an issue related to this that we discovered today.

Note: This would not actually hit Tunic's combat logic because that's not on in default options. This is a general issue with unit tests that I did not seek to fix here.