### PR TITLE
Core: ensure slot_data and er_hint_info are only base data types

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -316,13 +316,13 @@ def main(args, seed=None, baked_server_options: dict[str, object] | None = None)
                         spheres.append(dict(current_sphere))
 
                 multidata = {
-                    "slot_data": convert_to_base_types(slot_data),
+                    "slot_data": slot_data,
                     "slot_info": slot_info,
                     "connect_names": {name: (0, player) for player, name in multiworld.player_name.items()},
                     "locations": locations_data,
                     "checks_in_area": checks_in_area,
                     "server_options": baked_server_options,
-                    "er_hint_data": convert_to_base_types(er_hint_data),
+                    "er_hint_data": er_hint_data,
                     "precollected_items": precollected_items,
                     "precollected_hints": precollected_hints,
                     "version": tuple(version_tuple),
@@ -334,6 +334,9 @@ def main(args, seed=None, baked_server_options: dict[str, object] | None = None)
                     "race_mode": int(multiworld.is_race),
                 }
                 AutoWorld.call_all(multiworld, "modify_multidata", multidata)
+
+                for key in ("slot_data", "er_hint_data"):
+                    multidata[key] = convert_to_base_types(multidata[key])
 
                 multidata = zlib.compress(pickle.dumps(multidata), 9)
 

--- a/Main.py
+++ b/Main.py
@@ -12,6 +12,7 @@ import worlds
 from BaseClasses import CollectionState, Item, Location, LocationProgressType, MultiWorld
 from Fill import FillError, balance_multiworld_progression, distribute_items_restrictive, flood_items, \
     parse_planned_blocks, distribute_planned_blocks, resolve_early_locations_for_planned
+from NetUtils import convert_to_base_types
 from Options import StartInventoryPool
 from Utils import __version__, output_path, version_tuple
 from settings import get_settings
@@ -315,13 +316,13 @@ def main(args, seed=None, baked_server_options: dict[str, object] | None = None)
                         spheres.append(dict(current_sphere))
 
                 multidata = {
-                    "slot_data": slot_data,
+                    "slot_data": convert_to_base_types(slot_data),
                     "slot_info": slot_info,
                     "connect_names": {name: (0, player) for player, name in multiworld.player_name.items()},
                     "locations": locations_data,
                     "checks_in_area": checks_in_area,
                     "server_options": baked_server_options,
-                    "er_hint_data": er_hint_data,
+                    "er_hint_data": convert_to_base_types(er_hint_data),
                     "precollected_items": precollected_items,
                     "precollected_hints": precollected_hints,
                     "version": tuple(version_tuple),

--- a/NetUtils.py
+++ b/NetUtils.py
@@ -99,7 +99,7 @@ def _scan_for_TypedTuples(obj: typing.Any) -> typing.Any:
         data = obj._asdict()
         data["class"] = obj.__class__.__name__
         return data
-    if isinstance(obj, (tuple, list, set)):
+    if isinstance(obj, (tuple, list, set, frozenset)):
         return tuple(_scan_for_TypedTuples(o) for o in obj)
     if isinstance(obj, dict):
         return {key: _scan_for_TypedTuples(value) for key, value in obj.items()}

--- a/NetUtils.py
+++ b/NetUtils.py
@@ -106,10 +106,10 @@ def _scan_for_TypedTuples(obj: typing.Any) -> typing.Any:
     return obj
 
 
-_base_types = str | int | bool | float | None
+_base_types = str | int | bool | float | None | tuple["_base_types", ...] | dict["_base_types", "base_types"]
 
 
-def convert_to_base_types(obj: typing.Any) -> _base_types | tuple[_base_types, ...] | dict[_base_types, _base_types]:
+def convert_to_base_types(obj: typing.Any) -> _base_types:
     if isinstance(obj, (tuple, list, set, frozenset)):
         return tuple(convert_to_base_types(o) for o in obj)
     elif isinstance(obj, dict):

--- a/NetUtils.py
+++ b/NetUtils.py
@@ -111,7 +111,7 @@ def convert_to_base_types(obj: typing.Any) -> typing.Any:
         return tuple(convert_to_base_types(o) for o in obj)
     elif isinstance(obj, dict):
         return {convert_to_base_types(key): convert_to_base_types(value) for key, value in obj.items()}
-    elif type(obj) in (str, int, float):
+    elif type(obj) in (str, int, float, bool):
         return obj
     else:
         raise Exception(f"Cannot handle {type(obj)}")

--- a/NetUtils.py
+++ b/NetUtils.py
@@ -111,8 +111,17 @@ def convert_to_base_types(obj: typing.Any) -> typing.Any:
         return tuple(convert_to_base_types(o) for o in obj)
     elif isinstance(obj, dict):
         return {convert_to_base_types(key): convert_to_base_types(value) for key, value in obj.items()}
-    elif type(obj) in (str, int, float, bool):
+    elif obj is None or type(obj) in (str, int, float, bool):
         return obj
+    # unwrap simple types to their base, such as StrEnum
+    elif isinstance(obj, str):
+        return str(obj)
+    elif isinstance(obj, bool):
+        return bool(obj)
+    elif isinstance(obj, int):
+        return int(obj)
+    elif isinstance(obj, float):
+        return float(obj)
     else:
         raise Exception(f"Cannot handle {type(obj)}")
 

--- a/NetUtils.py
+++ b/NetUtils.py
@@ -119,8 +119,6 @@ def convert_to_base_types(obj: typing.Any) -> _base_types:
     # unwrap simple types to their base, such as StrEnum
     elif isinstance(obj, str):
         return str(obj)
-    elif isinstance(obj, bool):
-        return bool(obj)
     elif isinstance(obj, int):
         return int(obj)
     elif isinstance(obj, float):

--- a/NetUtils.py
+++ b/NetUtils.py
@@ -106,7 +106,10 @@ def _scan_for_TypedTuples(obj: typing.Any) -> typing.Any:
     return obj
 
 
-def convert_to_base_types(obj: typing.Any) -> typing.Any:
+_base_types = str | int | bool | float | None
+
+
+def convert_to_base_types(obj: typing.Any) -> _base_types | tuple[_base_types, ...] | dict[_base_types, _base_types]:
     if isinstance(obj, (tuple, list, set, frozenset)):
         return tuple(convert_to_base_types(o) for o in obj)
     elif isinstance(obj, dict):

--- a/NetUtils.py
+++ b/NetUtils.py
@@ -107,7 +107,7 @@ def _scan_for_TypedTuples(obj: typing.Any) -> typing.Any:
 
 
 def convert_to_base_types(obj: typing.Any) -> typing.Any:
-    if isinstance(obj, (tuple, list, set)):
+    if isinstance(obj, (tuple, list, set, frozenset)):
         return tuple(convert_to_base_types(o) for o in obj)
     elif isinstance(obj, dict):
         return {convert_to_base_types(key): convert_to_base_types(value) for key, value in obj.items()}

--- a/NetUtils.py
+++ b/NetUtils.py
@@ -99,11 +99,22 @@ def _scan_for_TypedTuples(obj: typing.Any) -> typing.Any:
         data = obj._asdict()
         data["class"] = obj.__class__.__name__
         return data
-    if isinstance(obj, (tuple, list, set, frozenset)):
+    if isinstance(obj, (tuple, list, set)):
         return tuple(_scan_for_TypedTuples(o) for o in obj)
     if isinstance(obj, dict):
         return {key: _scan_for_TypedTuples(value) for key, value in obj.items()}
     return obj
+
+
+def convert_to_base_types(obj: typing.Any) -> typing.Any:
+    if isinstance(obj, (tuple, list, set)):
+        return tuple(convert_to_base_types(o) for o in obj)
+    elif isinstance(obj, dict):
+        return {convert_to_base_types(key): convert_to_base_types(value) for key, value in obj.items()}
+    elif type(obj) in (str, int, float):
+        return obj
+    else:
+        raise Exception(f"Cannot handle {type(obj)}")
 
 
 _encode = JSONEncoder(

--- a/test/general/test_implemented.py
+++ b/test/general/test_implemented.py
@@ -1,7 +1,7 @@
 import unittest
 
 from Fill import distribute_items_restrictive
-from NetUtils import encode
+from NetUtils import convert_to_base_types
 from worlds.AutoWorld import AutoWorldRegister, call_all
 from worlds import failed_world_loads
 from . import setup_solo_multiworld
@@ -47,7 +47,7 @@ class TestImplemented(unittest.TestCase):
                 call_all(multiworld, "post_fill")
                 for key, data in multiworld.worlds[1].fill_slot_data().items():
                     self.assertIsInstance(key, str, "keys in slot data must be a string")
-                    self.assertIsInstance(encode(data), str, f"object {type(data).__name__} not serializable.")
+                    convert_to_base_types(data)  # only put base data types into slot data
 
     def test_no_failed_world_loads(self):
         if failed_world_loads:


### PR DESCRIPTION
## What is this fixing or adding?
converts slot data and er hint info into base structures that json well (int, float, str, dict, tuple).

## How was this tested?
I generated with Factorio and loaded the .archipelago into multiserver

