### PR TITLE
Stardew Valley: Exclude rarecrows locations from night market when museumsanity is disabled

### DIFF
--- a/worlds/stardew_valley/locations.py
+++ b/worlds/stardew_valley/locations.py
@@ -279,6 +279,9 @@ def extend_festival_locations(randomized_locations: List[LocationData], options:
         return
 
     festival_locations = locations_by_tag[LocationTags.FESTIVAL]
+    if not options.museumsanity:
+        festival_locations = [location for location in festival_locations if location.name not in ("Rarecrow #7 (Tanuki)", "Rarecrow #8 (Tribal Mask)")]
+
     randomized_locations.extend(festival_locations)
     extend_hard_festival_locations(randomized_locations, options)
     extend_desert_festival_chef_locations(randomized_locations, options, random)

--- a/worlds/stardew_valley/logic/museum_logic.py
+++ b/worlds/stardew_valley/logic/museum_logic.py
@@ -1,13 +1,5 @@
-from typing import Union
-
 from Utils import cache_self1
-from .action_logic import ActionLogicMixin
 from .base_logic import BaseLogic, BaseLogicMixin
-from .has_logic import HasLogicMixin
-from .received_logic import ReceivedLogicMixin
-from .region_logic import RegionLogicMixin
-from .time_logic import TimeLogicMixin
-from .tool_logic import ToolLogicMixin
 from .. import options
 from ..data.museum_data import MuseumItem, all_museum_items, all_museum_artifacts, all_museum_minerals
 from ..stardew_rule import StardewRule, False_

--- a/worlds/stardew_valley/test/rules/TestMuseum.py
+++ b/worlds/stardew_valley/test/rules/TestMuseum.py
@@ -1,12 +1,16 @@
 from collections import Counter
+from unittest.mock import patch
 
 from ..bases import SVTestBase
-from ...options import Museumsanity
+from ..options import presets
+from ... import options, StardewLogic
+from ...logic.museum_logic import MuseumLogic
+from ...stardew_rule import false_, true_
 
 
 class TestMuseumMilestones(SVTestBase):
     options = {
-        Museumsanity.internal_name: Museumsanity.option_milestones
+        options.Museumsanity: options.Museumsanity.option_milestones
     }
 
     def test_50_milestone(self):
@@ -14,3 +18,32 @@ class TestMuseumMilestones(SVTestBase):
 
         milestone_rule = self.world.logic.museum.can_find_museum_items(50)
         self.assert_rule_false(milestone_rule, self.multiworld.state)
+
+
+class TestMuseumsanityDisabledExcludesMuseumFromOtherSanities(SVTestBase):
+    options = {
+        **presets.allsanity_mods_6_x_x(),
+        options.Museumsanity.internal_name: options.Museumsanity.option_none
+    }
+
+    def test_museum_donations_are_never_required_in_any_locations(self):
+        with patch("worlds.stardew_valley.logic.museum_logic.MuseumLogic") as MockMuseumLogic:
+            museum_logic: MuseumLogic = MockMuseumLogic.return_value
+            museum_logic.can_donate_museum_items.return_value = false_
+            museum_logic.can_donate_museum_artifacts.return_value = false_
+            museum_logic.can_find_museum_artifacts.return_value = false_
+            museum_logic.can_find_museum_minerals.return_value = false_
+            museum_logic.can_find_museum_items.return_value = false_
+            museum_logic.can_complete_museum.return_value = false_
+            museum_logic.can_donate.return_value = false_
+            # Allowing calls to can_find_museum_item since a lot of other logic depends on it, for minerals for instance.
+            museum_logic.can_find_museum_item.return_value = true_
+
+            regions = {region.name for region in self.multiworld.regions}
+            self.world.logic = StardewLogic(self.player, self.world.options, self.world.content, regions)
+            self.world.set_rules()
+
+            self.collect_everything()
+            for location in self.get_real_locations():
+                with self.subTest(location.name):
+                    self.assert_can_reach_location(location)


### PR DESCRIPTION
## What is this fixing or adding?
This excludes the two rarecrows locations from the night market when museumsanity is disabled. These checks require the player to make museum donations, which they probably did not want to since museumsanity was disabled.

The rarecrow items are still added to the pool, so players will still be able to check the "Collect All Rarecrows" location.

## How was this tested?
- Added a test making sure no location using the museum logic are added to the world. By extension, this also test regions where there are locations. 
- Generated worlds with and without museumsanity to make sure the locations are correctly removed.

## If this makes graphical changes, please attach screenshots.
N/A