### PR TITLE
Docs: Fix link for origin_region_name in world_api.md

### DIFF
--- a/docs/world api.md
+++ b/docs/world api.md
@@ -266,7 +266,7 @@ like entrance randomization in logic.
 
 Regions have a list called `exits`, containing `Entrance` objects representing transitions to other regions.
 
-There must be one special region (Called "Menu" by default, but configurable using [origin_region_name](https://github.com/ArchipelagoMW/Archipelago/blob/main/worlds/AutoWorld.py#L298-L299)),
+There must be one special region (Called "Menu" by default, but configurable using [origin_region_name](https://github.com/ArchipelagoMW/Archipelago/blob/main/worlds/AutoWorld.py#L310-L311)),
 from which the logic unfolds. AP assumes that a player will always be able to return to this starting region by resetting the game ("Save and quit").
 
 ### Entrances


### PR DESCRIPTION
## What is this fixing or adding?
As titled.
But also maybe we should just not have the direct line link and instead state how to find it, since there's a good chance the line it's on will change in the future, as well as for other similar links.

## How was this tested?
Looked at the link.