### PR TITLE
CommonClient: fix extra panels added to `main_area_container`

### DIFF
--- a/kvui.py
+++ b/kvui.py
@@ -921,9 +921,11 @@ class GameManager(ThemedApp):
         hint_panel = self.add_client_tab("Hints", HintLayout(self.hint_log))
         self.log_panels["Hints"] = hint_panel.content
 
-        self.main_area_container = MDGridLayout(size_hint_y=1, cols=1)
-        self.main_area_container.add_widget(self.tabs)
-        self.main_area_container.add_widget(self.screens)
+        self.main_area_container = MDGridLayout(size_hint_y=1, rows=1)
+        tab_container = MDGridLayout(size_hint_y=1, cols=1)
+        tab_container.add_widget(self.tabs)
+        tab_container.add_widget(self.screens)
+        self.main_area_container.add_widget(tab_container)
 
         self.grid.add_widget(self.main_area_container)
 


### PR DESCRIPTION
## What is this fixing or adding?

https://github.com/ArchipelagoMW/Archipelago/pull/4930 broke worlds that use an extra panel in the main area of the client.

This fixes that.

## How was this tested?

not very much yet - just opened `ZillionClient` and used "/map" command a few times and clicked on tabs
