### PR TITLE
Stardew Valley: Fixed luck level requirements for slot machines

### DIFF
--- a/worlds/stardew_valley/data/craftable_data.py
+++ b/worlds/stardew_valley/data/craftable_data.py
@@ -386,7 +386,7 @@ coppper_slot_machine = skill_recipe(ModMachine.copper_slot_machine, ModSkill.luc
                                                                                        Forageable.salmonberry: 1, Material.clay: 1, Trash.joja_cola: 1}, ModNames.luck_skill)
 
 gold_slot_machine = skill_recipe(ModMachine.gold_slot_machine, ModSkill.luck, 4, {MetalBar.gold: 15, ModMachine.copper_slot_machine: 1}, ModNames.luck_skill)
-iridium_slot_machine = skill_recipe(ModMachine.iridium_slot_machine, ModSkill.luck, 4, {MetalBar.iridium: 15, ModMachine.gold_slot_machine: 1}, ModNames.luck_skill)
-radioactive_slot_machine = skill_recipe(ModMachine.radioactive_slot_machine, ModSkill.luck, 4, {MetalBar.radioactive: 15, ModMachine.iridium_slot_machine: 1}, ModNames.luck_skill)
+iridium_slot_machine = skill_recipe(ModMachine.iridium_slot_machine, ModSkill.luck, 6, {MetalBar.iridium: 15, ModMachine.gold_slot_machine: 1}, ModNames.luck_skill)
+radioactive_slot_machine = skill_recipe(ModMachine.radioactive_slot_machine, ModSkill.luck, 8, {MetalBar.radioactive: 15, ModMachine.iridium_slot_machine: 1}, ModNames.luck_skill)
 
 all_crafting_recipes_by_name = {recipe.item: recipe for recipe in all_crafting_recipes}


### PR DESCRIPTION
## What is this fixing or adding?
It was discovered today that the slot machine level requirements are 2-4-6-8, not 2-4-4-4. I suspect it was a bad copy paste job originally.

The mod data can be found here: https://github.com/Pet-Slime/StardewValley/blob/master/LuckSkillCode/ContentPatcher/%5BCP%5D%20LuckSkill/Data/CraftingData.json

## How was this tested?
Not much. It still passes tests, but I didn't make a new one, as this is an arbitrary value and the test would have to be just as arbitrary
