### PR TITLE
TUNIC: Deal with other games placing stuff in other worlds during pre_fill

### DIFF
--- a/worlds/tunic/__init__.py
+++ b/worlds/tunic/__init__.py
@@ -511,20 +511,18 @@ class TunicWorld(World):
             multiworld.random.shuffle(non_grass_fill_locations)
 
             for filler_item in grass_fill:
-                loc_to_fill = grass_fill_locations.pop()
-                # the if statement is to counteract people filling other people's locations in pre_fill
-                # they shouldn't be doing that, but I'd rather just put the filler in the item pool than crash gen
-                if loc_to_fill.item:
+                try:
+                    grass_fill_locations.pop().place_locked_item(filler_item)
+                except Exception:
+                    # the try except is to counteract people filling other people's locations in pre_fill
+                    # they shouldn't be doing that, but I'd rather just put the filler in the item pool than crash gen
                     multiworld.itempool.append(filler_item)
-                else:
-                    loc_to_fill.place_locked_item(filler_item)
 
             for filler_item in non_grass_fill:
-                loc_to_fill = non_grass_fill_locations.pop()
-                if loc_to_fill.item:
+                try:
+                    non_grass_fill_locations.pop().place_locked_item(filler_item)
+                except Exception:
                     multiworld.itempool.append(filler_item)
-                else:
-                    loc_to_fill.place_locked_item(filler_item)
 
     def create_regions(self) -> None:
         self.tunic_portal_pairs = {}


### PR DESCRIPTION
## What is this fixing or adding?
Yes yes, I know, you're not supposed to place stuff in other worlds during pre_fill (presumably, idk if the docs even say that anywhere). But, we've got like 300 non-verified apworlds around. So I'd rather just be more resilient than pout and say "but muh spec".

During the local filler stuff that Tunic does for grass and breakable shuffle, during pre_fill it'll grab a set of locations to fill during stage_pre_fill. If another world fills any of those locations between that Tunic slot's pre_fill and stage_pre_fill, it'll crash when doing place_locked_item. So, this will make it more resilient to that sort of crash by placing it in the item pool. I know we're not supposed to place stuff in the item pool during pre_fill, but you also aren't supposed to fill other worlds' locations during pre_fill. It's something that is out of spec that only happens if something else is out of spec, so I'd say that's fair game.

## How was this tested?
[LlisandurFF4.txt](https://github.com/user-attachments/files/21063444/LlisandurFF4.txt)
[Ixrec Tunic.txt](https://github.com/user-attachments/files/21064089/Ixrec.Tunic.txt)

Test gens with FF4FE. Yamls are attached (converted to .txt since github doesn't let you just upload .yamls).