### PR TITLE
Docs: fix 'get_pre_fill_items' being typo'd as 'get_prefill_items'

### DIFF
--- a/docs/world api.md
+++ b/docs/world api.md
@@ -533,7 +533,7 @@ In addition, the following methods can be implemented and are called in this ord
   called to modify item placement before, during, and after the regular fill process; all finishing before
   `generate_output`. Any items that need to be placed during `pre_fill` should not exist in the itempool, and if there
   are any items that need to be filled this way, but need to be in state while you fill other items, they can be
-  returned from `get_prefill_items`.
+  returned from `get_pre_fill_items`.
 * `generate_output(self, output_directory: str)`
   creates the output files if there is output to be generated. When this is called,
   `self.multiworld.get_locations(self.player)` has all locations for the player, with attribute `item` pointing to the

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -382,7 +382,7 @@ class World(metaclass=AutoWorldRegister):
     def create_items(self) -> None:
         """
         Method for creating and submitting items to the itempool. Items and Regions must *not* be created and submitted
-        to the MultiWorld after this step. If items need to be placed during pre_fill use `get_prefill_items`.
+        to the MultiWorld after this step. If items need to be placed during pre_fill use `get_pre_fill_items`.
         """
         pass
 


### PR DESCRIPTION
## What is this fixing or adding?

Typos in the docs. This prevented me from finding the code for `get_pre_fill_items` during a dev chat on Discord.

## How was this tested?

:eyes: and Ctrl+Shift+F

## If this makes graphical changes, please attach screenshots.
