### PR TITLE
Core: Update minimum required server version

### DIFF
--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -295,7 +295,7 @@ class World(metaclass=AutoWorldRegister):
     future. Protocol level compatibility check moved to MultiServer.min_client_version.
     """
 
-    required_server_version: Tuple[int, int, int] = (0, 5, 0)
+    required_server_version: Tuple[int, int, int] = (0, 6, 2)
     """update this if the resulting multidata breaks forward-compatibility of the server"""
 
     hint_blacklist: ClassVar[FrozenSet[str]] = frozenset()


### PR DESCRIPTION
https://github.com/ArchipelagoMW/Archipelago/pull/3756 broke forward compatibility, meaning 0.6.2 generated games can't be hosted on a 0.6.1 server.

That's fine, but I forgot to bump the minimum required server version, which makes the errors look weird