### PR TITLE
Core: Take Counter back out of RestrictedUnpickler

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -441,9 +441,6 @@ class RestrictedUnpickler(pickle.Unpickler):
     def find_class(self, module: str, name: str) -> type:
         if module == "builtins" and name in safe_builtins:
             return getattr(builtins, name)
-        # used by OptionCounter
-        if module == "collections" and name == "Counter":
-            return collections.Counter
         # used by MultiServer -> savegame/multidata
         if module == "NetUtils" and name in {"NetworkItem", "ClientStatus", "Hint",
                                              "SlotType", "NetworkSlot", "HintStatus"}:


### PR DESCRIPTION
When we merge https://github.com/ArchipelagoMW/Archipelago/pull/5144, it is no longer necessary to allow pickling / unpickling Counter instances. This will then restore forward compatibility for hosting.
