### PR TITLE
DLC Quest Bug Fix Start inventory lfod

### DIFF
--- a/worlds/dlcquest/Items.py
+++ b/worlds/dlcquest/Items.py
@@ -116,7 +116,7 @@ def create_items(world, world_options: Options.DLCQuestOptions, locations_count:
 def create_items_lfod(world_options, created_items, world, excluded_items):
     for item in items_by_group[Group.Freemium]:
         if item.name in excluded_items:
-            excluded_items.remove(item)
+            excluded_items.remove(item.name)
             continue
 
         if item.has_any_group(Group.DLC):

--- a/worlds/dlcquest/Items.py
+++ b/worlds/dlcquest/Items.py
@@ -101,20 +101,19 @@ def create_trap_items(world, world_options: Options.DLCQuestOptions, trap_needed
 def create_items(world, world_options: Options.DLCQuestOptions, locations_count: int, excluded_items: list[str], random: Random):
     created_items = []
     if world_options.campaign == Options.Campaign.option_basic or world_options.campaign == Options.Campaign.option_both:
-        create_items_basic(world_options, created_items, world, excluded_items)
+        create_items_campaign(world_options, created_items, world, excluded_items, Group.DLCQuest, 825, 250)
 
     if (world_options.campaign == Options.Campaign.option_live_freemium_or_die or
             world_options.campaign == Options.Campaign.option_both):
-        create_items_lfod(world_options, created_items, world, excluded_items)
+        create_items_campaign(world_options, created_items, world, excluded_items, Group.Freemium, 889, 200)
 
     trap_items = create_trap_items(world, world_options, locations_count - len(created_items), random)
     created_items += trap_items
 
     return created_items
 
-
-def create_items_lfod(world_options, created_items, world, excluded_items):
-    for item in items_by_group[Group.Freemium]:
+def create_items_campaign(world_options, created_items, world, excluded_items, group, total_coins, required_coins):
+    for item in items_by_group[group]:
         if item.name in excluded_items:
             excluded_items.remove(item.name)
             continue
@@ -127,9 +126,9 @@ def create_items_lfod(world_options, created_items, world, excluded_items):
                 created_items.append(world.create_item(item))
     if world_options.coinsanity == Options.CoinSanity.option_coin:
         if world_options.coinbundlequantity == -1:
-            create_coin_piece(created_items, world, 889, 200, Group.Freemium)
+            create_coin_piece(created_items, world, total_coins, required_coins, group)
             return
-        create_coin(world_options, created_items, world, 889, 200, Group.Freemium)
+        create_coin(world_options, created_items, world, total_coins, required_coins, group)
 
 
 def create_items_basic(world_options, created_items, world, excluded_items):

--- a/worlds/dlcquest/Items.py
+++ b/worlds/dlcquest/Items.py
@@ -30,7 +30,6 @@ class Group(enum.Enum):
     Deprecated = enum.auto()
 
 
-
 @dataclass(frozen=True)
 class ItemData:
     code_without_offset: offset
@@ -98,7 +97,8 @@ def create_trap_items(world, world_options: Options.DLCQuestOptions, trap_needed
     return traps
 
 
-def create_items(world, world_options: Options.DLCQuestOptions, locations_count: int, excluded_items: list[str], random: Random):
+def create_items(world, world_options: Options.DLCQuestOptions, locations_count: int, excluded_items: list[str],
+                 random: Random):
     created_items = []
     if world_options.campaign == Options.Campaign.option_basic or world_options.campaign == Options.Campaign.option_both:
         create_items_campaign(world_options, created_items, world, excluded_items, Group.DLCQuest, 825, 250)
@@ -112,7 +112,8 @@ def create_items(world, world_options: Options.DLCQuestOptions, locations_count:
 
     return created_items
 
-def create_items_campaign(world_options, created_items, world, excluded_items, group, total_coins, required_coins):
+
+def create_items_campaign(world_options: Options.DLCQuestOptions, created_items: list[DLCQuestItem], world, excluded_items: list[str], group: Group, total_coins: int, required_coins: int):
     for item in items_by_group[group]:
         if item.name in excluded_items:
             excluded_items.remove(item.name)
@@ -131,28 +132,10 @@ def create_items_campaign(world_options, created_items, world, excluded_items, g
         create_coin(world_options, created_items, world, total_coins, required_coins, group)
 
 
-def create_items_basic(world_options, created_items, world, excluded_items):
-    for item in items_by_group[Group.DLCQuest]:
-        if item.name in excluded_items:
-            excluded_items.remove(item.name)
-            continue
-
-        if item.has_any_group(Group.DLC):
-            created_items.append(world.create_item(item))
-        if item.has_any_group(Group.Item) and world_options.item_shuffle == Options.ItemShuffle.option_shuffled:
-            created_items.append(world.create_item(item))
-            if item.has_any_group(Group.Twice):
-                created_items.append(world.create_item(item))
-    if world_options.coinsanity == Options.CoinSanity.option_coin:
-        if world_options.coinbundlequantity == -1:
-            create_coin_piece(created_items, world, 825, 250, Group.DLCQuest)
-            return
-        create_coin(world_options, created_items, world, 825, 250, Group.DLCQuest)
-
-
 def create_coin(world_options, created_items, world, total_coins, required_coins, group):
     coin_bundle_required = math.ceil(required_coins / world_options.coinbundlequantity)
-    coin_bundle_useful = math.ceil((total_coins - coin_bundle_required * world_options.coinbundlequantity) / world_options.coinbundlequantity)
+    coin_bundle_useful = math.ceil(
+        (total_coins - coin_bundle_required * world_options.coinbundlequantity) / world_options.coinbundlequantity)
     for item in items_by_group[group]:
         if item.has_any_group(Group.Coin):
             for i in range(coin_bundle_required):
@@ -164,7 +147,7 @@ def create_coin(world_options, created_items, world, total_coins, required_coins
 def create_coin_piece(created_items, world, total_coins, required_coins, group):
     for item in items_by_group[group]:
         if item.has_any_group(Group.Piece):
-            for i in range(required_coins*10):
+            for i in range(required_coins * 10):
                 created_items.append(world.create_item(item))
             for i in range((total_coins - required_coins) * 10):
                 created_items.append(world.create_item(item, ItemClassification.useful))


### PR DESCRIPTION
start inventory error with lfod

https://discord.com/channels/731205301247803413/1392654857940373654

## What is this fixing or adding?
fixing a crash if you ask for some lfod only item  in start inventory

## How was this tested?
Previous gen that crash don't anymore and the fix was already test in basic campaign I forgot to copy it to lfod.

## If this makes graphical changes, please attach screenshots.
