### PR TITLE
WebHostLib: Add conversion method for gen_options

### DIFF
--- a/NetUtils.py
+++ b/NetUtils.py
@@ -110,8 +110,10 @@ _base_types = str | int | bool | float | None | tuple["_base_types", ...] | dict
 
 
 def convert_to_base_types(obj: typing.Any) -> _base_types:
-    if isinstance(obj, (tuple, list, set, frozenset)):
+    if isinstance(obj, (tuple, list)):
         return tuple(convert_to_base_types(o) for o in obj)
+    elif isinstance(obj, (set, frozenset)):
+        return frozenset(convert_to_base_types(o) for o in obj)
     elif isinstance(obj, dict):
         return {convert_to_base_types(key): convert_to_base_types(value) for key, value in obj.items()}
     elif obj is None or type(obj) in (str, int, float, bool):

--- a/WebHostLib/api/generate.py
+++ b/WebHostLib/api/generate.py
@@ -8,7 +8,7 @@ from pony.orm import commit
 
 from WebHostLib import app
 from WebHostLib.check import get_yaml_data, roll_options
-from WebHostLib.generate import get_meta
+from WebHostLib.generate import get_meta, dump_options
 from WebHostLib.models import Generation, STATE_QUEUED, Seed, STATE_ERROR
 from . import api_endpoints
 
@@ -56,7 +56,7 @@ def generate_api():
                     "detail": results}, 400
         else:
             gen = Generation(
-                options=pickle.dumps({name: vars(options) for name, options in gen_options.items()}),
+                options=dump_options(gen_options),
                 # convert to json compatible
                 meta=json.dumps(meta), state=STATE_QUEUED,
                 owner=session["_id"])


### PR DESCRIPTION
## What is this fixing or adding?
Fix for `collections.Counter` objects in options (such as `StartInventory`) failing webhost generation because the `RestrictedPickler` change in #5169.

## How was this tested?
Local webhost generating a singleplayer Adventure world from the options page, and a world with a few template yamls on the generate game page.

## If this makes graphical changes, please attach screenshots.
