### PR TITLE
Revert "Core: Take Counter back out of RestrictedUnpickler"

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -442,6 +442,7 @@ class RestrictedUnpickler(pickle.Unpickler):
         if module == "builtins" and name in safe_builtins:
             return getattr(builtins, name)
         # used by OptionCounter
+        # necessary because the actual Options class instances are pickled when transfered to WebHost generation pool
         if module == "collections" and name == "Counter":
             return collections.Counter
         # used by MultiServer -> savegame/multidata


### PR DESCRIPTION
Reverts ArchipelagoMW/Archipelago#5169

We do actually pickle and unpickle entire options classes on WebHost for generation, and after some discussion, there does not seem to be an immediate way around this.

Relevant lines of code that cause the error: 
https://github.com/ArchipelagoMW/Archipelago/blob/main/WebHostLib/generate.py#L87
https://github.com/ArchipelagoMW/Archipelago/blob/main/WebHostLib/autolauncher.py#L51

Relevant discussion on Discord: https://discordapp.com/channels/731205301247803413/731214280439103580/1393340018315235479