### PR TITLE
TUNIC: Fix missing line for UT stuff

### DIFF
--- a/worlds/tunic/ut_stuff.py
+++ b/worlds/tunic/ut_stuff.py
@@ -681,7 +681,7 @@ poptracker_data: dict[str, int] = {
 # for setting up the poptracker integration
 tracker_world = {
     "map_page_maps": ["maps/maps_pop.json"],
-    "map_page_locations": ["locations/locations_pop_er.json"],
+    "map_page_locations": ["locations/locations_pop_er.json", "locations/locations_breakables.json"],
     "map_page_setting_key": "Slot:{player}:Current Map",
     "map_page_index": map_page_index,
     "external_pack_key": "ut_poptracker_path",


### PR DESCRIPTION
## What is this fixing or adding?
I feel like it should just auto-detect stuff like this, but whatever. At least it doesn't crash without this line in.
Fixes it so breakables actually show up on the map.

## How was this tested?
Genning game on 0.6.1, connecting latest UT to it, connecting latest poptracker, observing the hover text for a pot location.