### PR TITLE
Lingo: Fix painting gen failures on panels mode door shuffle

### DIFF
--- a/worlds/lingo/player_logic.py
+++ b/worlds/lingo/player_logic.py
@@ -394,7 +394,7 @@ class LingoPlayerLogic:
                     or painting.room in required_painting_rooms:
                 return False
 
-            if world.options.shuffle_doors == ShuffleDoors.option_none:
+            if world.options.shuffle_doors != ShuffleDoors.option_doors:
                 if painting.req_blocked_when_no_doors:
                     return False
 


### PR DESCRIPTION
## What is this fixing or adding?

When painting shuffle is combined with either vanilla doors or panels mode door shuffle, care needs to be taken to ensure that you can access the Owl Hallway without needing to be on the roof first, since entering the Owl Hallway is required for gaining roof access, and it can only be entered via painting in these modes. This was already implemented for vanilla doors, but parts of that fix mistakenly did not also apply to panels mode door shuffle, which has the exact same issues as vanilla doors. This change just broadens the scope of that fix.

## How was this tested?

The following YAML with the seed 56544133732371246502 is known to fail without the fix (the only entrance to Owl Hallway is placed on the painting at the top of the tower), and succeeds with the fix:

```yaml
name: Player1
game: Lingo
Lingo:
  accessibility: full
  shuffle_doors: panels
  group_doors: true
  shuffle_paintings: true
  shuffle_sunwarps: true
```

pytest was also used to ensure previous tests still passed.

## If this makes graphical changes, please attach screenshots.
