### PR TITLE
[Webhost API + Docs] Adding in API bits to easily query if the room is online currently

### DIFF
--- a/WebHostLib/api/room.py
+++ b/WebHostLib/api/room.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict
 from uuid import UUID
+import datetime
 
 from flask import abort, url_for
 
@@ -32,8 +33,18 @@ def room_info(room_id: UUID) -> Dict[str, Any]:
                 "download": url_for("download_patch", patch_id=slot.id, room_id=room.id)
             }
             downloads.append(slot_download)
+    
+    delta = datetime.datetime.now(datetime.timezone.utc) - room.last_activity.replace(tzinfo=datetime.timezone.utc)
+    remaining_time = room.timeout - delta.total_seconds()
+    if remaining_time <= 0:
+        remaining_time = 0
+        room_status = "shutdown"
+    else:
+        room_status = "active"
 
     return {
+        "remaining_time": remaining_time,
+        "status": room_status,
         "tracker": to_url(room.tracker),
         "players": get_players(room.seed),
         "last_port": room.last_port,

--- a/docs/webhost api.md
+++ b/docs/webhost api.md
@@ -181,12 +181,16 @@ Endpoints to fetch information of the active WebHost room with the supplied room
 ### `/room_status/<suuid:room_id>`  
 <a name="roomstatus"></a>
 Will provide a dict of room data with the following keys:
+- Room shutdown / inavtivity timer (`remaining_time`)
+- Room status (`status`)
+    - `active` if the room is online
+    - `shutdown` if the room is shutdown and offline
 - Tracker SUUID (`tracker`)
 - A list of players (`players`)
     - Each item containing a list with the Slot name and Game
 - Last known hosted port (`last_port`)
 - Last activity timestamp (`last_activity`)
-- The room timeout counter (`timeout`)
+- The room timeout value (`timeout`)
 - A list of downloads for files required for gameplay (`downloads`)
     - Each item is a dict containings the download URL and slot (`slot`, `download`)
 
@@ -239,6 +243,8 @@ Example:
             "Ocarina of Time"
         ]
     ],
+    "remaining_time":59.928921,
+    "status":"active",
     "timeout": 7200,
     "tracker": "cf6989c0-4703-45d7-a317-2e5158431171"
 }


### PR DESCRIPTION
This adds in a new field to the room_status API to say if the room is active or shutdown, It also adds the time remaining (in seconds) till the room is shutdown.

This allows tools to quickly query the room's status and determine if it needs to keep processing websocket connections, or if it can wait and poke the API to determine if it's safe to reconnect.

I'm not sure the 'remaining_time' is really needed, but it was there anyway.

## What is this fixing or adding?
New fields on the room_status API endpoint
Also updates the API docs

## How was this tested?
Locally. I turned down the room shutdown timer to 60 seconds and confirmed it correctly reports the room's status and countdown timer upon query.

If you want to test this without waiting the full 2hours, change line 30 of models.py to a value of your choice. It'll adjust the timeout value that rooms use to determine when they need to shut down. (only applies to newly generated rooms)

## If this makes graphical changes, please attach screenshots.
N/A

Samples of the room_status endpoint JSON;
A room still active:
`{
    "downloads": [],
    "last_activity": "Thu, 17 Jul 2025 04:19:10 GMT",
    "last_port": 51800,
    "players": [
        [
            "Bridgeipelago",
            "Archipelago"
        ]
    ],
    "remaining_time": 59.928921,
    "status": "active",
    "timeout": 60,
    "tracker": "O4SiPjGGTOuawocRXxv3bA"
}`

A room is shutdown:
`{
    "downloads": [],
    "last_activity": "Thu, 17 Jul 2025 04:18:06 GMT",
    "last_port": 51800,
    "players": [
        [
            "Bridgeipelago",
            "Archipelago"
        ]
    ],
    "remaining_time": 0,
    "status": "shutdown",
    "timeout": 60,
    "tracker": "O4SiPjGGTOuawocRXxv3bA"
}`