### PR TITLE
Options: Add PlandoItems to Item & Location Option Group

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -1644,7 +1644,7 @@ class OptionGroup(typing.NamedTuple):
 
 
 item_and_loc_options = [LocalItems, NonLocalItems, StartInventory, StartInventoryPool, StartHints,
-                        StartLocationHints, ExcludeLocations, PriorityLocations, ItemLinks]
+                        StartLocationHints, ExcludeLocations, PriorityLocations, ItemLinks, PlandoItems]
 """
 Options that are always populated in "Item & Location Options" Option Group. Cannot be moved to another group.
 If desired, a custom "Item & Location Options" Option Group can be defined, but only for adding additional options to


### PR DESCRIPTION
## What is this fixing or adding?

This adds PlandoItems to the Item & Location Options option group. This makes it appear at the end of yamls (and the advanced options page), instead of at the top alongside progression balancing and accessibility.

## How was this tested?

Generating yamls and running webhost and finding the plando_items option