### PR TITLE
Plando Items: Add `item_group_unfolding` option

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -1485,7 +1485,7 @@ class PlandoItem:
     force: bool | typing.Literal["silent"] = "silent"
     count: int | bool | dict[str, int] = False
     percentage: int = 100
-    item_group_method: typing.Literal["all", "even", "random"] = "random"
+    item_group_method: typing.Literal["all", "uniform", "random"] = "random"
 
 
 class PlandoItems(Option[typing.List[PlandoItem]]):
@@ -1507,8 +1507,8 @@ class PlandoItems(Option[typing.List[PlandoItem]]):
         for item in data:
             if isinstance(item, typing.Mapping):
                 item_group_method = item.get("item_group_method", "random")
-                if item_group_method not in ("all", "even", "random"):
-                    raise Exception(f"Plando `item_group_method` has to be \"all\", \"even\", or \"random\", "
+                if item_group_method not in ("all", "uniform", "random"):
+                    raise Exception(f"Plando `item_group_method` has to be \"all\", \"uniform\", or \"random\", "
                                     f"not {item_group_method}")
                 percentage = item.get("percentage", 100)
                 if not isinstance(percentage, int):
@@ -1586,7 +1586,7 @@ class PlandoItems(Option[typing.List[PlandoItem]]):
                                     plando.items[key] = True
                             elif plando.item_group_method == "all":
                                 plando.items.update({key: value for key in filtered_items})
-                            elif plando.item_group_method == "even":
+                            elif plando.item_group_method == "uniform":
                                 quotient, remainder = divmod(value, len(filtered_items))
                                 plando.items.update({key: quotient for key in filtered_items})
                                 for key in random.sample(filtered_items, k=remainder):

--- a/Options.py
+++ b/Options.py
@@ -1485,7 +1485,7 @@ class PlandoItem:
     force: bool | typing.Literal["silent"] = "silent"
     count: int | bool | dict[str, int] = False
     percentage: int = 100
-    item_group_method: typing.Literal["all", "uniform", "random"] = "random"
+    item_group_unfolding: typing.Literal["all", "uniform", "random"] = "random"
 
 
 class PlandoItems(Option[typing.List[PlandoItem]]):
@@ -1506,10 +1506,10 @@ class PlandoItems(Option[typing.List[PlandoItem]]):
         value: typing.List[PlandoItem] = []
         for item in data:
             if isinstance(item, typing.Mapping):
-                item_group_method = item.get("item_group_method", "random")
-                if item_group_method not in ("all", "uniform", "random"):
-                    raise Exception(f"Plando `item_group_method` has to be \"all\", \"uniform\", or \"random\", "
-                                    f"not {item_group_method}")
+                item_group_unfolding = item.get("item_group_unfolding", "random")
+                if item_group_unfolding not in ("all", "uniform", "random"):
+                    raise Exception(f"Plando `item_group_unfolding` has to be \"all\", \"uniform\", or \"random\", "
+                                    f"not {item_group_unfolding}")
                 percentage = item.get("percentage", 100)
                 if not isinstance(percentage, int):
                     raise OptionError(f"Plando `percentage` has to be int, not {type(percentage)}.")
@@ -1546,7 +1546,7 @@ class PlandoItems(Option[typing.List[PlandoItem]]):
                         raise OptionError(f"Plando 'from_pool' has to be true or false, not {from_pool!r}.")
                     if not (isinstance(force, bool) or force == "silent"):
                         raise OptionError(f"Plando `force` has to be true or false or `silent`, not {force!r}.")
-                    value.append(PlandoItem(items, locations, world, from_pool, force, count, percentage, item_group_method))
+                    value.append(PlandoItem(items, locations, world, from_pool, force, count, percentage, item_group_unfolding))
             elif isinstance(item, PlandoItem):
                 if roll_percentage(item.percentage):
                     value.append(item)
@@ -1584,9 +1584,9 @@ class PlandoItems(Option[typing.List[PlandoItem]]):
                             if value is True:
                                 for key in filtered_items:
                                     plando.items[key] = True
-                            elif plando.item_group_method == "all":
+                            elif plando.item_group_unfolding == "all":
                                 plando.items.update({key: value for key in filtered_items})
-                            elif plando.item_group_method == "uniform":
+                            elif plando.item_group_unfolding == "uniform":
                                 quotient, remainder = divmod(value, len(filtered_items))
                                 plando.items.update({key: quotient for key in filtered_items})
                                 for key in random.sample(filtered_items, k=remainder):

--- a/worlds/generic/docs/plando_en.md
+++ b/worlds/generic/docs/plando_en.md
@@ -91,6 +91,12 @@ Each block can have several different options to tailor it the way you like.
     * **If `min` is defined,** it will place at least `min` many items (can be combined with `max`).
     * **If `max` is defined,** it will place at most `max` many items (can be combined with `min`).
 
+* `item_group_unfolding` determines how item groups with numerical values (`number`) are unfolded into items.
+    * `random`: Uses a total of `number` items in the group (duplicates allowed). **(Default)**
+    * `all`: Uses `number` of each item in the group.
+    * `uniform`: Uses a total of `number` items in the group (duplicates allowed), but using as close to the
+      same amount of each as possible.
+
 ### Available Items and Locations
 
 A list of all available items and locations can be found in the [website's datapackage](/datapackage). The items and 
@@ -215,6 +221,21 @@ The first block will place the player's Biggoron Sword, Bow, Magic Meter, streng
 dungeon major item chests. Because the from_pool value is `false`, a copy of these items is added to these locations, 
 while the originals remain in the item pool to be shuffled. The second block will place the Kokiri Sword in the Deku 
 Tree Slingshot Chest, again not from the pool.
+
+```yaml
+  plando_items:
+    - items:
+        Clocks: 3
+    - items:
+        Clocks: 2
+      item_group_unfolding: "all"
+    - items:
+        Clocks: 7
+      item_group_unfolding: "uniform"
+```
+The first block will place 3 random Clocks (there are Blue, Green, and Red Clocks). This could place one of each,
+three of one, or any other combination. The second block will place 2 of each clock (6 total). The third block will
+place 2 of each clock and 1 additional random clock.
 
 ## Boss Plando
 


### PR DESCRIPTION
## What is this fixing or adding?

This adds a way for users to specify how item groups should be unfolded in their plando blocks. The default value ("random") is ho it worked before this PR. Two new values are also added:
* `all` which applies the specified number to every item in the group
* `uniform` which spreads the specified number across every item in the group as uniformly as possible (none of the values differ by more than 1)

## How was this tested?

Generations and looking at the plando results.