### PR TITLE
Raft: Fix filler_item_types TypeError introduced in #4782

### DIFF
--- a/worlds/raft/__init__.py
+++ b/worlds/raft/__init__.py
@@ -93,7 +93,7 @@ class RaftWorld(World):
             dupeItemPool = list(dupeItemPool)
             # Finally, add items as necessary
             for item in dupeItemPool:
-                self.extraItemNamePool.append(self.replace_item_name_as_necessary(item))
+                self.extraItemNamePool.append(self.replace_item_name_as_necessary(item["name"]))
             
         assert self.extraItemNamePool, f"Don't know what extra items to create for {self.player_name}."
 


### PR DESCRIPTION
## What is this fixing or adding?

In #4782 a line wasn't refactored properly, causing generation errors if `filler_item_types` is set to `duplicates` or `both`

https://github.com/ArchipelagoMW/Archipelago/blob/a948697f3a2387d13862a194690c39af8da2dbd8/worlds/raft/__init__.py#L95

https://github.com/ArchipelagoMW/Archipelago/blob/eba757d2cd468182f4d0500ab87c45d379b225d2/worlds/raft/__init__.py#L96

## How was this tested?

Generations before and after with `filler_item_types` set to all three values.