### PR TITLE
Fix issue with names including civ-breaking characters

### DIFF
--- a/worlds/civ_6/Container.py
+++ b/worlds/civ_6/Container.py
@@ -44,9 +44,10 @@ class CivVIContainer(APPlayerContainer):
             opened_zipfile.writestr(filename, yml)
         super().write_contents(opened_zipfile)
 
+
 def sanitize_value(value: str) -> str:
-  """Removes values that can cause issues in XML"""
-  return value.replace('"', "'").replace('&', 'and')
+    """Removes values that can cause issues in XML"""
+    return value.replace('"', "'").replace('&', 'and').replace('{', '').replace('}', '')
 
 
 def get_cost(world: 'CivVIWorld', location: CivVILocationData) -> int:
@@ -87,8 +88,10 @@ def generate_new_items(world: 'CivVIWorld') -> str:
     boost_civics = []
 
     if world.options.boostsanity:
-        boost_techs = [location for location in locations if location.location_type == CivVICheckType.BOOST and location.name.split("_")[1] == "TECH"]
-        boost_civics = [location for location in locations if location.location_type == CivVICheckType.BOOST and location.name.split("_")[1] == "CIVIC"]
+        boost_techs = [location for location in locations if location.location_type ==
+                       CivVICheckType.BOOST and location.name.split("_")[1] == "TECH"]
+        boost_civics = [location for location in locations if location.location_type ==
+                        CivVICheckType.BOOST and location.name.split("_")[1] == "CIVIC"]
         techs += boost_techs
         civics += boost_civics
 


### PR DESCRIPTION


## What is this fixing or adding?
0.6.2 allows players to include `{` and `}` in their name. This causes issues with Civ's markup language. I have  added these values as ones to exclude

## How was this tested?
Generated a game with a player that had these values and verified it worked.
