### PR TITLE
fix(env): Prevent module update during container runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,4 +94,5 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
     CMD curl -f http://localhost:${PORT:-80} || exit 1
 
+ENV SKIP_REQUIREMENTS_UPDATE=true
 ENTRYPOINT [ "python", "WebHost.py" ]

--- a/ModuleUpdate.py
+++ b/ModuleUpdate.py
@@ -21,7 +21,6 @@ _skip_update = bool(
     multiprocessing.parent_process() or 
     os.environ.get("SKIP_REQUIREMENTS_UPDATE", "").lower() in ("1", "true", "yes")
 )
-# _skip_update = bool(getattr(sys, "frozen", False) or multiprocessing.parent_process())
 update_ran = _skip_update
 
 

--- a/ModuleUpdate.py
+++ b/ModuleUpdate.py
@@ -16,7 +16,12 @@ elif sys.version_info < (3, 10, 1):
     raise RuntimeError(f"Incompatible Python Version found: {sys.version_info}. 3.10.1+ is supported.")
 
 # don't run update if environment is frozen/compiled or if not the parent process (skip in subprocess)
-_skip_update = bool(getattr(sys, "frozen", False) or multiprocessing.parent_process())
+_skip_update = bool(
+    getattr(sys, "frozen", False) or 
+    multiprocessing.parent_process() or 
+    os.environ.get("SKIP_REQUIREMENTS_UPDATE", "").lower() in ("1", "true", "yes")
+)
+# _skip_update = bool(getattr(sys, "frozen", False) or multiprocessing.parent_process())
 update_ran = _skip_update
 
 


### PR DESCRIPTION
## What is this fixing or adding?
Prevents `ModuleUpdate` from processing unnecessarily during container image runtime, by adding an environment variable as an additional check for `_skip_update`.
As an additional benefit, this fixes `aarch64` image support, where `dolphin-memory-engine` (not required for AP web hosting) is not packaged for said architecture.
The flag is set to `true` in the `Dockerfile`

## How was this tested?
Built new images for both `x86_64` and `aarch64` using these changes and deployed using the steps laid out in docs.