### PR TITLE
LADX: use generic slot name for slots 101+

### DIFF
--- a/LinksAwakeningClient.py
+++ b/LinksAwakeningClient.py
@@ -412,10 +412,10 @@ class LinksAwakeningClient():
             status = (await self.gameboy.async_read_memory_safe(LAClientConstants.wLinkStatusBits))[0]
 
         item_id -= LABaseID
-        # The player name table only goes up to 100, so don't go past that
+        # The player name table only goes up to 101, so don't go past that
         # Even if it didn't, the remote player _index_ byte is just a byte, so 255 max
-        if from_player > 100:
-            from_player = 100
+        if from_player > 101:
+            from_player = 101
 
         next_index += 1
         self.gameboy.write_memory(LAClientConstants.wLinkGiveItem, [

--- a/worlds/ladx/LADXR/generator.py
+++ b/worlds/ladx/LADXR/generator.py
@@ -262,7 +262,7 @@ def generateRom(args, world: "LinksAwakeningWorld"):
     all_items = world.multiworld.get_items()
     our_items = [item for item in all_items
                  if item.player == world.player
-                 and world.player < 100 # slots 100+ have a generic name for rom space reasons, so don't hint these
+                 and world.player < 101 # slots 101+ have a generic name for rom space reasons, so don't hint these
                  and item.location
                  and item.code is not None
                  and item.location.show_in_spoiler]

--- a/worlds/ladx/LADXR/generator.py
+++ b/worlds/ladx/LADXR/generator.py
@@ -262,6 +262,7 @@ def generateRom(args, world: "LinksAwakeningWorld"):
     all_items = world.multiworld.get_items()
     our_items = [item for item in all_items
                  if item.player == world.player
+                 and world.player < 100 # slots 100+ have a generic name for rom space reasons, so don't hint these
                  and item.location
                  and item.code is not None
                  and item.location.show_in_spoiler]

--- a/worlds/ladx/LADXR/generator.py
+++ b/worlds/ladx/LADXR/generator.py
@@ -324,9 +324,9 @@ def generateRom(args, world: "LinksAwakeningWorld"):
         mw = None
         if spot.item_owner != spot.location_owner:
             mw = spot.item_owner
-            if mw > 100:
+            if mw > 101:
                 # There are only 101 player name slots (99 + "The Server" + "another world"), so don't use more than that
-                mw = 100
+                mw = 101
         spot.patch(rom, spot.item, multiworld=mw)
     patches.enemies.changeBosses(rom, world_setup.boss_mapping)
     patches.enemies.changeMiniBosses(rom, world_setup.miniboss_mapping)

--- a/worlds/ladx/LADXR/generator.py
+++ b/worlds/ladx/LADXR/generator.py
@@ -262,7 +262,6 @@ def generateRom(args, world: "LinksAwakeningWorld"):
     all_items = world.multiworld.get_items()
     our_items = [item for item in all_items
                  if item.player == world.player
-                 and world.player < 101 # slots 101+ have a generic name for rom space reasons, so don't hint these
                  and item.location
                  and item.code is not None
                  and item.location.show_in_spoiler]

--- a/worlds/ladx/LADXR/patches/bank3e.py
+++ b/worlds/ladx/LADXR/patches/bank3e.py
@@ -5,15 +5,11 @@ from ..utils import formatText
 
 import pkgutil
 
-NAMES_TO_STORE = 100
-
 def hasBank3E(rom):
     return rom.banks[0x3E][0] != 0x00
 
 def generate_name(l, i):
-    if i == NAMES_TO_STORE - 1 and len(l) > NAMES_TO_STORE:
-        name = "Someone"
-    elif i < len(l):
+    if i < len(l):
         name = l[i]
     else:
         name = f"player {i}"
@@ -219,7 +215,7 @@ LocalOnlyItemAndMessage:
         + get_asm("bowwow.asm")
         + get_asm("message.asm")
         + get_asm("itemnames.asm")
-        + "".join(generate_name(["The Server"] + player_name_list, i ) for i in range(NAMES_TO_STORE)) # allocate
+        + "".join(generate_name(["The Server"] + player_name_list, i ) for i in range(100)) # allocate
         + 'db "another world", $ff\n'
         + get_asm("owl.asm"), 0x4000), fill_nop=True)
     # 3E:3300-3616: Multiworld flags per room (for both chests and dropped keys)

--- a/worlds/ladx/LADXR/patches/bank3e.py
+++ b/worlds/ladx/LADXR/patches/bank3e.py
@@ -5,11 +5,15 @@ from ..utils import formatText
 
 import pkgutil
 
+NAMES_TO_STORE = 100
+
 def hasBank3E(rom):
     return rom.banks[0x3E][0] != 0x00
 
 def generate_name(l, i):
-    if i < len(l):
+    if i == NAMES_TO_STORE - 1 and len(l) > NAMES_TO_STORE:
+        name = "Someone"
+    elif i < len(l):
         name = l[i]
     else:
         name = f"player {i}"
@@ -215,7 +219,7 @@ LocalOnlyItemAndMessage:
         + get_asm("bowwow.asm")
         + get_asm("message.asm")
         + get_asm("itemnames.asm")
-        + "".join(generate_name(["The Server"] + player_name_list, i ) for i in range(100)) # allocate
+        + "".join(generate_name(["The Server"] + player_name_list, i ) for i in range(NAMES_TO_STORE)) # allocate
         + 'db "another world", $ff\n'
         + get_asm("owl.asm"), 0x4000), fill_nop=True)
     # 3E:3300-3616: Multiworld flags per room (for both chests and dropped keys)


### PR DESCRIPTION
## What is this fixing or adding?
Regarding this bug report: https://discord.com/channels/731205301247803413/1395843213436125194

We store 100 player names on the rom for displaying on picking up or receiving items. Any slot higher than 100 is treated as if it were slot 100.

We actually already had the generic "another world" in the 101st slot, so this change caps the name slot to 101 instead of 100.

## How was this tested?
Generated, fuzzed, patched, made sure the rom works. Generated a game with 200 Yacht Dices.

<img width="482" height="492" alt="image" src="https://github.com/user-attachments/assets/3f3e22f3-ce7b-4a61-9ff6-33cc9786b7cd" />

<img width="482" height="492" alt="image" src="https://github.com/user-attachments/assets/4956e622-af9d-449c-b194-348d05012a72" />
