### PR TITLE
CLI: add --item_category to generate categorized items JSON for current games

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -57,6 +57,7 @@ def mystery_argparse():
     parser.add_argument("--spoiler_only", action="store_true",
                         help="Skips generation assertion and multidata, outputting only a spoiler log. "
                              "Intended for debugging and testing purposes.")
+    parser.add_argument("--item_category", help="Generate a JSON file with categorized items for games used in the current seed", action="store_true")
     args = parser.parse_args()
 
     if args.skip_output and args.spoiler_only:
@@ -179,6 +180,7 @@ def main(args=None) -> tuple[argparse.Namespace, int]:
     erargs.spoiler_only = args.spoiler_only
     erargs.name = {}
     erargs.csv_output = args.csv_output
+    erargs.item_category = args.item_category
 
     settings_cache: dict[str, tuple[argparse.Namespace, ...]] = \
         {fname: (tuple(roll_settings(yaml, args.plando) for yaml in yamls) if args.sameoptions else None)


### PR DESCRIPTION
Generate a JSON file with categorized items for games used in the current seed

## What is this fixing or adding?
This adds a new command-line option `--item_category` to the seed generation script.
When enabled, it generates a JSON file listing all items categorized by game for the current seed.
This helps players and seed creators debug by clearly showing which items are necessary progression, useful, filler, or traps within their specific game.

## How was this tested?
Tested locally by generating seeds with the `--item_category` option enabled, verifying that the output JSON file is created and contains correctly categorized items for the games included in the seed.
Here’s an updated version including the mention of an example JSON file attachment for your merge request:

## If this makes graphical changes, please attach screenshots.
[AP_36370427103507645045_Item_Category.json](https://github.com/user-attachments/files/21326934/AP_36370427103507645045_Item_Category.json)
