### PR TITLE
chore(ci): exclude deployment and Docker files from unit test workflow triggers

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -24,6 +24,9 @@
     - '!worlds/**'
     - '!WebHost.py'
     - '!WebHostLib/**'
+    - '!Dockerfile'
+    - '!.dockerignore'
+    - '!deploy/**'
   - any-glob-to-any-file: # exceptions to the above rules of "stuff that isn't core"
     - 'worlds/generic/**/*.py'
     - 'worlds/*.py'

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -8,18 +8,24 @@ on:
     paths:
       - '**'
       - '!docs/**'
+      - '!deploy/**'
       - '!setup.py'
+      - '!Dockerfile'
       - '!*.iss'
       - '!.gitignore'
+      - '!.dockerignore'
       - '!.github/workflows/**'
       - '.github/workflows/unittests.yml'
   pull_request:
     paths:
       - '**'
       - '!docs/**'
+      - '!deploy/**'
       - '!setup.py'
+      - '!Dockerfile'
       - '!*.iss'
       - '!.gitignore'
+      - '!.dockerignore'
       - '!.github/workflows/**'
       - '.github/workflows/unittests.yml'
 


### PR DESCRIPTION
## What is this fixing or adding?
- Update labeler config to exclude Dockerfile, .dockerignore, and deploy directory
- Modify unittests workflow to ignore changes in deploy directory and Docker-related files

## How was this tested?
Created [spinoff branch](https://github.com/a-priestley/Archipelago/tree/ci_test) with dummy changes to verify that unit tests are not run.
Initiated a PR into this branch to verify that `affects_core` label is not applied (labeler was not run).
Initiated PR into fork main (labeler was run -- [failed](https://github.com/a-priestley/Archipelago/actions/runs/16400826095/job/46340010835?pr=2) due to unset permissions in my repo, but I believe the difference in behavior from the first PR confirms that the proposed modification is valid.)

