### PR TITLE
ALttP: Fix `pre_fill` State Sweeping Too Early

### DIFF
--- a/worlds/alttp/__init__.py
+++ b/worlds/alttp/__init__.py
@@ -505,10 +505,11 @@ class ALTTPWorld(World):
     def pre_fill(self):
         from Fill import fill_restrictive, FillError
         attempts = 5
-        all_state = self.multiworld.get_all_state(use_cache=False)
+        all_state = self.multiworld.get_all_state(perform_sweep=False)
         crystals = [self.create_item(name) for name in ['Red Pendant', 'Blue Pendant', 'Green Pendant', 'Crystal 1', 'Crystal 2', 'Crystal 3', 'Crystal 4', 'Crystal 7', 'Crystal 5', 'Crystal 6']]
         for crystal in crystals:
             all_state.remove(crystal)
+        all_state.sweep_for_advancements()
         crystal_locations = [self.get_location('Turtle Rock - Prize'),
                              self.get_location('Eastern Palace - Prize'),
                              self.get_location('Desert Palace - Prize'),


### PR DESCRIPTION
## What is this fixing or adding?

ALttP's `pre_fill` makes a state and that state performs a sweep, picking up pre-placed items, such as a plando'ed Moon Pearl. The sweep it performed before the Crystals/Pendants are removed the state, so the fill performed afterwards is invalid/incorrect.

https://discord.com/channels/731205301247803413/1395423424515670030

## How was this tested?

```yaml
  plando_items:
   - item: Moon Pearl
     location: Master Sword Pedestal
     force: true
```