### PR TITLE
DS3: Update/Fix Excluded Locations Logging

### DIFF
--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -90,20 +90,21 @@ class DarkSouls3World(World):
         self.created_regions = set()
         self.all_excluded_locations.update(self.options.exclude_locations.value)
 
+        # This code doesn't work because tests don't verify options
         # Don't consider disabled locations to be AP-excluded
-        if not self.options.enable_dlc:
-            self.options.exclude_locations.value = {
-                location
-                for location in self.options.exclude_locations
-                if not location_dictionary[location].dlc
-            }
+        # if not self.options.enable_dlc:
+            # self.options.exclude_locations.value = {
+                # location
+                # for location in self.options.exclude_locations
+                # if not location_dictionary[location].dlc
+            # }
 
-        if not self.options.enable_ngp:
-            self.options.exclude_locations.value = {
-                location for
-                location in self.options.exclude_locations
-                if not location_dictionary[location].ngp
-            }
+        # if not self.options.enable_ngp:
+            # self.options.exclude_locations.value = {
+                # location for
+                # location in self.options.exclude_locations
+                # if not location_dictionary[location].ngp
+            # }
 
         # Inform Universal Tracker where Yhorm is being randomized to.
         if hasattr(self.multiworld, "re_gen_passthrough"):


### PR DESCRIPTION
## What is this fixing or adding?

DS3 has both the regular kind of excluded locations ("AP-excluded") and its own kind of excluded locations ("DS3-excluded"). Previously, there were several ways in which the spoiler log's list of "Excluded Locations" would include DS3-excluded locations and not just AP-excluded ones.

This does ~~three~~ two things:

1. ~~Removes disabled locations from the AP list entirely~~
    * ~~This means they are no longer listed in the AP-excluded section of the spoiler log~~
1. Removes non-randomized locations from the AP list slightly earlier
    * This means `missable_dupe_prog_locs` are no longer listed in the AP-excluded section of the spoiler log
2. Changes the DS3-excluded section of the spoiler log to also appear when `excluded_location_behavior` is set to `do_not_randomize`
    * This means the original `exclude_location` value is listed in the DS3-excluded section of the spoiler log

The first thing was removed because tests do not properly unfold/verify location groups and it led to KeyErrors.

## How was this tested?

Unit tests and several generations with different options to see that the AP excluded list now properly includes only AP-excluded locations and that the DS3 excluded list includes all of the excluded locations (except for the cases of NGP and DLC disabled locations because of the aforementioned core bug)