### PR TITLE
OoT: Fix .remove() not invalidating cached reachability

### DIFF
--- a/worlds/oot/__init__.py
+++ b/worlds/oot/__init__.py
@@ -1324,10 +1324,20 @@ class OOTWorld(World):
             state.prog_items[self.player][alt_item_name] -= count
             if state.prog_items[self.player][alt_item_name] < 1:
                 del (state.prog_items[self.player][alt_item_name])
+            # invalidate caches, nothing can be trusted anymore now
+            state.child_reachable_regions[self.player] = set()
+            state.child_blocked_connections[self.player] = set()
+            state.adult_reachable_regions[self.player] = set()
+            state.adult_blocked_connections[self.player] = set()
             state._oot_stale[self.player] = True
             return True
         changed = super().remove(state, item)
         if changed:
+            # invalidate caches, nothing can be trusted anymore now
+            state.child_reachable_regions[self.player] = set()
+            state.child_blocked_connections[self.player] = set()
+            state.adult_reachable_regions[self.player] = set()
+            state.adult_blocked_connections[self.player] = set()
             state._oot_stale[self.player] = True
         return changed
 


### PR DESCRIPTION
## What is this fixing or adding?

Collecting an item into a CollectionState without sweeping, finding all reachable locations, removing that item from the state, and then finding all reachable locations again could result in more locations being reachable than before the item was initially collected into the CollectionState.

This issue was present because OoT was not invalidating its reachable region caches for the different ages when items were removed from the CollectionState.

To fix the issue, this PR has updated `OOTWorld.remove()` to invalid its caches, like how `CollectionState.remove()` invalidates the core Archipelago caches.

## How was this tested?

