### PR TITLE
LADX: fix marin text splitting

### DIFF
--- a/worlds/ladx/LADXR/patches/aesthetics.py
+++ b/worlds/ladx/LADXR/patches/aesthetics.py
@@ -180,9 +180,10 @@ def noText(rom):
 
 def reduceMessageLengths(rom, rnd):
     # Into text from Marin. Got to go fast, so less text. (This intro text is very long)
-    lines = pkgutil.get_data(__name__, "marin.txt").decode("unicode_escape").splitlines()
-    lines = [l for l in lines if l.strip()]
-    rom.texts[0x01] = formatText(rnd.choice(lines).strip())
+    lines = pkgutil.get_data(__name__, "marin.txt").splitlines(keepends=True)
+    while lines and lines[-1].strip() == b'':
+        lines.pop(-1)
+    rom.texts[0x01] = formatText(rnd.choice(lines).strip().decode("unicode_escape"))
 
     # Reduce length of a bunch of common texts
     rom.texts[0xEA] = formatText("You've got a Guardian Acorn!")


### PR DESCRIPTION
## What is this fixing or adding?
Preserves newline characters within Marin text options rather than breaking it into separate options.

## How was this tested?
Generated and tested the rom to see that text with linebreaks works.