### PR TITLE
ALTTP: Fix asymmetrical progressive item collect/remove

### DIFF
--- a/worlds/alttp/__init__.py
+++ b/worlds/alttp/__init__.py
@@ -458,10 +458,8 @@ class ALTTPWorld(World):
                         return None
             else:
                 if 'Sword' in item_name:
-                    if state.has('Golden Sword', item.player):
-                        pass
-                    elif (state.has('Tempered Sword', item.player) and
-                          self.difficulty_requirements.progressive_sword_limit >= 4):
+                    if (state.has('Tempered Sword', item.player) and
+                            self.difficulty_requirements.progressive_sword_limit >= 4):
                         return 'Golden Sword'
                     elif (state.has('Master Sword', item.player) and
                           self.difficulty_requirements.progressive_sword_limit >= 3):
@@ -472,17 +470,13 @@ class ALTTPWorld(World):
                     elif self.difficulty_requirements.progressive_sword_limit >= 1:
                         return 'Fighter Sword'
                 elif 'Glove' in item_name:
-                    if state.has('Titans Mitts', item.player):
-                        return
-                    elif state.has('Power Glove', item.player):
+                    if state.has('Power Glove', item.player):
                         return 'Titans Mitts'
                     else:
                         return 'Power Glove'
                 elif 'Shield' in item_name:
-                    if state.has('Mirror Shield', item.player):
-                        return
-                    elif (state.has('Red Shield', item.player) and
-                          self.difficulty_requirements.progressive_shield_limit >= 3):
+                    if (state.has('Red Shield', item.player) and
+                            self.difficulty_requirements.progressive_shield_limit >= 3):
                         return 'Mirror Shield'
                     elif (state.has('Blue Shield', item.player) and
                           self.difficulty_requirements.progressive_shield_limit >= 2):
@@ -490,11 +484,9 @@ class ALTTPWorld(World):
                     elif self.difficulty_requirements.progressive_shield_limit >= 1:
                         return 'Blue Shield'
                 elif 'Bow' in item_name:
-                    if state.has('Silver Bow', item.player):
-                        return
-                    elif state.has('Bow', item.player) and (self.difficulty_requirements.progressive_bow_limit >= 2
-                                                            or self.options.glitches_required == 'no_glitches'
-                                                            or self.options.swordless):
+                    if state.has('Bow', item.player) and (self.difficulty_requirements.progressive_bow_limit >= 2
+                                                          or self.options.glitches_required == 'no_glitches'
+                                                          or self.options.swordless):
                         # modes where silver bow is always required for ganon
                         return 'Silver Bow'
                     elif self.difficulty_requirements.progressive_bow_limit >= 1:


### PR DESCRIPTION
This is an example fix for asymmetrical progressive item collect/remove issues identified in the test added by https://github.com/ArchipelagoMW/Archipelago/pull/5223

An alternative to changing how progressive items are collected (this PR) would be changing existing use of collect/remove to check the return value of `CollectionState.collect()` to determine whether collecting an item did anything and there whether that item can be removed in the first place.

---

## What is this fixing or adding?

Normally, there is expected to be a maximum of 4 `Progressive Sword` items collected, but start inventory, item plando, and itemlink replacement items can result in additional copies being added to a multiworld.

Collecting a 5th `Progressive Sword` into a state would have no effect on the state, which meant that removing that 5th `Progressive Sword` from the state would have the same effect as removing the 4th `Progressive Sword` from the state, breaking the symmetry between `CollectionState.collect()` and `CollectionState.remove()`.

This patch changes `collect_item(remove=False)` to collect additional copies of the final progressive stage of each progressive item into the state when the final progressive stage has already been reached, so that removing a 5th `Progressive Sword` will reduce the count of `'Golden Sword'` in the state from `2` to `1` rather than from `1` to `0`, which should only happen when removing the 4th `Progressive Sword`.

## How was this tested?

ALTTP no longer fails the test added by https://github.com/ArchipelagoMW/Archipelago/pull/5223