### PR TITLE
Options: Fix Triggers with non-int-valued Dictionaries

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -351,7 +351,11 @@ def update_weights(weights: dict, new_weights: dict, update_type: str, name: str
             elif isinstance(new_value, list):
                 cleaned_value.extend(new_value)
             elif isinstance(new_value, dict):
-                cleaned_value = dict(Counter(cleaned_value) + Counter(new_value))
+                for key, value in new_value.items():
+                    if isinstance(value, int):
+                        cleaned_value[key] = cleaned_value.get(key, 0) + value
+                    else:
+                        cleaned_value[key] = value
             else:
                 raise Exception(f"Cannot apply merge to non-dict, set, or list type {option_name},"
                                 f" received {type(new_value).__name__}.")
@@ -365,7 +369,11 @@ def update_weights(weights: dict, new_weights: dict, update_type: str, name: str
                 for element in new_value:
                     cleaned_value.remove(element)
             elif isinstance(new_value, dict):
-                cleaned_value = dict(Counter(cleaned_value) - Counter(new_value))
+                for key, value in new_value.items():
+                    if isinstance(value, int):
+                        cleaned_value[key] = cleaned_value.get(key, 0) - value
+                    else:
+                        cleaned_value[key] = value
             else:
                 raise Exception(f"Cannot apply remove to non-dict, set, or list type {option_name},"
                                 f" received {type(new_value).__name__}.")


### PR DESCRIPTION
## What is this fixing or adding?

https://github.com/ArchipelagoMW/Archipelago/issues/5230

## How was this tested?

Using generations that previously crashed when adding strings and seeing that they now worked and testing that the old behavior still worked as well.

-----

Maybe worth noting is that this doesn't work as one might expect if a dictionary supports both ints and non-ints as values. Since it will crash depending on whether the previous value was an int or not. If accounting for this is desired, we could do something like changing:
```py
for key, value in new_value.items():
    if isinstance(value, int):
        cleaned_value[key] = cleaned_value.get(key, 0) + value
```
into:
```py
 for key, value in new_value.items():
     original_value = cleaned_value.get(key)
     if isinstance(value, int) and isinstance(original_value, int):
         cleaned_value[key] = original_value + value
```