### PR TITLE
CI: switch to new appimagetool

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,12 @@ on:
 
 env:
   ENEMIZER_VERSION: 7.1
-  APPIMAGETOOL_VERSION: 13
+  # NOTE: since appimage/appimagetool and appimage/type2-runtime does not have tags anymore,
+  #       we check the sha256 and require manual intervention if it was updated.
+  APPIMAGETOOL_VERSION: continuous
+  APPIMAGETOOL_X86_64_HASH: '363dafac070b65cc36ca024b74db1f043c6f5cd7be8fca760e190dce0d18d684'
+  APPIMAGE_RUNTIME_VERSION: continuous
+  APPIMAGE_RUNTIME_X86_64_HASH: 'e3c4dfb70eddf42e7e5a1d28dff396d30563aa9a901970aebe6f01f3fecf9f8e'
 
 permissions:  # permissions required for attestation
   id-token: 'write'
@@ -134,10 +139,13 @@ jobs:
       - name: Install build-time dependencies
         run: |
           echo "PYTHON=python3.12" >> $GITHUB_ENV
-          wget -nv https://github.com/AppImage/AppImageKit/releases/download/$APPIMAGETOOL_VERSION/appimagetool-x86_64.AppImage
+          wget -nv https://github.com/AppImage/appimagetool/releases/download/$APPIMAGETOOL_VERSION/appimagetool-x86_64.AppImage
+          echo "$APPIMAGETOOL_X86_64_HASH appimagetool-x86_64.AppImage" | sha256sum -c
+          wget -nv https://github.com/AppImage/type2-runtime/releases/download/$APPIMAGE_RUNTIME_VERSION/runtime-x86_64
+          echo "$APPIMAGE_RUNTIME_X86_64_HASH runtime-x86_64" | sha256sum -c
           chmod a+rx appimagetool-x86_64.AppImage
           ./appimagetool-x86_64.AppImage --appimage-extract
-          echo -e '#/bin/sh\n./squashfs-root/AppRun "$@"' > appimagetool
+          echo -e '#/bin/sh\n./squashfs-root/AppRun --runtime-file runtime-x86_64 "$@"' > appimagetool
           chmod a+rx appimagetool
       - name: Download run-time dependencies
         run: |


### PR DESCRIPTION
## What is this fixing or adding?

Fixes Linux build by switching to new appimagetool. The old downloads are dead now.
Since this does not have versions anymore, we check the sha256 and require manual intervention if it changed.
We also specify a specific runtime version (again, with sha256).

In the future we should look for a way to get reproducible appimages instead of just disallowing the build.

## How was this tested?

The built AppImage's Launcher works on my ubuntu22.04 VM and also tested the command line interface (i.e. start SNIClient directly).
I did not test any other system, but we don't have an alternative runtime anyway.

Also tested a couple of error cases in CI on my fork:

If the hash of either the appimagetool or runtime is unexpected, it errors in "Install build-time dependencies".

If the commandline for sha256sums was wrong, it'd also error in "Install build-time dependencies".

If the runtime was missing, it'd error in 'Store AppImage" with
`Error: No files were found with the provided path: dist/. No artifacts will be uploaded.`
(so it actually uses the runtime we specify even if it's missing)