### PR TITLE
CommonClient: Clear out old cahced datapackages

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -638,6 +638,9 @@ class CommonContext:
         for game, game_data in data_package["games"].items():
             Utils.store_data_package_for_checksum(game, game_data)
 
+    async def delete_old_data_packages(self):
+        Utils.delete_old_data_packages()
+
     # data storage
 
     def set_notify(self, *keys: str) -> None:
@@ -965,6 +968,8 @@ async def process_server_cmd(ctx: CommonContext, args: dict):
 
         server_url = urllib.parse.urlparse(ctx.server_address)
         Utils.persistent_store("client", "last_server_address", server_url.netloc)
+
+        await ctx.delete_old_data_packages()
 
     elif cmd == 'ReceivedItems':
         start_index = args["index"]

--- a/Utils.py
+++ b/Utils.py
@@ -18,7 +18,7 @@ import warnings
 
 from argparse import Namespace
 from settings import Settings, get_settings
-from time import sleep
+from time import sleep, time
 from typing import BinaryIO, Coroutine, Optional, Set, Dict, Any, Union, TypeGuard
 from yaml import load, load_all, dump
 
@@ -360,6 +360,9 @@ def load_data_package_for_checksum(game: str, checksum: typing.Optional[str]) ->
         path = cache_path("datapackage", get_file_safe_name(game), f"{checksum}.json")
         if os.path.exists(path):
             try:
+                # Last modified time on the file is used to determine if the file has gone unused
+                # for a long time when deleting old data packages, so we refresh it when we use the package
+                os.utime(path, (time(), time()))
                 with open(path, "r", encoding="utf-8-sig") as f:
                     return json.load(f)
             except Exception as e:
@@ -386,6 +389,22 @@ def store_data_package_for_checksum(game: str, data: typing.Dict[str, Any]) -> N
                 json.dump(data, f, ensure_ascii=False, separators=(",", ":"))
         except Exception as e:
             logging.debug(f"Could not store data package: {e}")
+
+
+def delete_old_data_packages() -> None:
+    expiry_in_months = 6
+    expiry_in_seconds = expiry_in_months * 30 * 24 * 60 * 60
+
+    datapackage_folder = cache_path("datapackage")
+    game_folders = [game_folder.path for game_folder in os.scandir(datapackage_folder) if game_folder.is_dir()]
+    for game_folder in game_folders:
+        datapackage_files = [os.path.join(game_folder, file) for file in os.listdir(game_folder) if os.path.isfile(os.path.join(game_folder, file))]
+        for file_path in datapackage_files:
+            if time() - os.path.getmtime(file_path) > expiry_in_seconds:
+                os.remove(file_path)
+
+        if not os.listdir(game_folder):
+            os.rmdir(game_folder)
 
 
 def get_default_adjuster_settings(game_name: str) -> Namespace:


### PR DESCRIPTION
## What is this fixing or adding?
After CommonClient finishes connecting, clear out cached datapackage files that are older than 6 months (the time is flexible if you prefer a different one).  If a datapackage folder is emptied, also delete that game's datapackage folder.  Lastly, whenever CommonClient loads a datapackage, it updates the file's modified time to be the current time, making it so that packages that are being used are not getting deleted.  I am not familiar with the best libraries to use in python, so if you see a substitute library or function that would have been a better choice than the ones I used, please let me know.

## How was this tested?
I ran it locally (on Windows 10) and verified that it correctly deleted only old cache files and empty folders.  I also verified it updated the last modified time correctly.  I don't have any other operating systems to use for testing, if anybody would be willing to verify on other OSes that would be a nice thing to check.
