### PR TITLE
WebHost: Ensure that OptionSets and OptionLists get exported to yaml, even when nothing is selected

### DIFF
--- a/WebHostLib/options.py
+++ b/WebHostLib/options.py
@@ -155,7 +155,7 @@ def generate_weighted_yaml(game: str):
         options = {}
 
         for key, val in request.form.items():
-            if val == "ensure-empty-list":
+            if val == "_ensure-empty-list":
                 options[key] = {}
             elif "||" not in key:
                 if len(str(val)) == 0:
@@ -216,7 +216,7 @@ def generate_yaml(game: str):
         intent_generate = False
 
         for key, val in request.form.items(multi=True):
-            if val == "ensure-empty-list":
+            if val == "_ensure-empty-list":
                 options[key] = []
             elif options.get(key):
                 if not isinstance(options[key], list):

--- a/WebHostLib/options.py
+++ b/WebHostLib/options.py
@@ -155,7 +155,9 @@ def generate_weighted_yaml(game: str):
         options = {}
 
         for key, val in request.form.items():
-            if "||" not in key:
+            if val == "ensure-empty-list":
+                options[key] = {}
+            elif "||" not in key:
                 if len(str(val)) == 0:
                     continue
 
@@ -212,8 +214,11 @@ def generate_yaml(game: str):
     if request.method == "POST":
         options = {}
         intent_generate = False
+
         for key, val in request.form.items(multi=True):
-            if key in options:
+            if val == "ensure-empty-list":
+                options[key] = []
+            elif options.get(key):
                 if not isinstance(options[key], list):
                     options[key] = [options[key]]
                 options[key].append(val)

--- a/WebHostLib/templates/playerOptions/macros.html
+++ b/WebHostLib/templates/playerOptions/macros.html
@@ -134,7 +134,7 @@
 
 {% macro OptionList(option_name, option) %}
     {{ OptionTitle(option_name, option) }}
-    <input type="hidden" id="{{ option_name }}-{{ key }}-hidden" name="{{ option_name }}" value="ensure-empty-list"/>
+    <input type="hidden" id="{{ option_name }}-{{ key }}-hidden" name="{{ option_name }}" value="_ensure-empty-list"/>
     <div class="option-container">
         {% for key in (option.valid_keys if option.valid_keys is ordered else option.valid_keys|sort) %}
             <div class="option-entry">
@@ -147,7 +147,7 @@
 
 {% macro LocationSet(option_name, option) %}
     {{ OptionTitle(option_name, option) }}
-    <input type="hidden" id="{{ option_name }}-{{ key }}-hidden" name="{{ option_name }}" value="ensure-empty-list"/>
+    <input type="hidden" id="{{ option_name }}-{{ key }}-hidden" name="{{ option_name }}" value="_ensure-empty-list"/>
     <div class="option-container">
         {% for group_name in world.location_name_groups.keys()|sort %}
             {% if group_name != "Everywhere" %}
@@ -171,7 +171,7 @@
 
 {% macro ItemSet(option_name, option) %}
     {{ OptionTitle(option_name, option) }}
-    <input type="hidden" id="{{ option_name }}-{{ key }}-hidden" name="{{ option_name }}" value="ensure-empty-list"/>
+    <input type="hidden" id="{{ option_name }}-{{ key }}-hidden" name="{{ option_name }}" value="_ensure-empty-list"/>
     <div class="option-container">
         {% for group_name in world.item_name_groups.keys()|sort %}
             {% if group_name != "Everything" %}
@@ -195,7 +195,7 @@
 
 {% macro OptionSet(option_name, option) %}
     {{ OptionTitle(option_name, option) }}
-    <input type="hidden" id="{{ option_name }}-{{ key }}-hidden" name="{{ option_name }}" value="ensure-empty-list"/>
+    <input type="hidden" id="{{ option_name }}-{{ key }}-hidden" name="{{ option_name }}" value="_ensure-empty-list"/>
     <div class="option-container">
         {% for key in (option.valid_keys if option.valid_keys is ordered else option.valid_keys|sort) %}
             <div class="option-entry">

--- a/WebHostLib/templates/playerOptions/macros.html
+++ b/WebHostLib/templates/playerOptions/macros.html
@@ -134,6 +134,7 @@
 
 {% macro OptionList(option_name, option) %}
     {{ OptionTitle(option_name, option) }}
+    <input type="hidden" id="{{ option_name }}-{{ key }}-hidden" name="{{ option_name }}" value="ensure-empty-list"/>
     <div class="option-container">
         {% for key in (option.valid_keys if option.valid_keys is ordered else option.valid_keys|sort) %}
             <div class="option-entry">
@@ -192,6 +193,7 @@
 
 {% macro OptionSet(option_name, option) %}
     {{ OptionTitle(option_name, option) }}
+    <input type="hidden" id="{{ option_name }}-{{ key }}-hidden" name="{{ option_name }}" value="ensure-empty-list"/>
     <div class="option-container">
         {% for key in (option.valid_keys if option.valid_keys is ordered else option.valid_keys|sort) %}
             <div class="option-entry">

--- a/WebHostLib/templates/playerOptions/macros.html
+++ b/WebHostLib/templates/playerOptions/macros.html
@@ -147,6 +147,7 @@
 
 {% macro LocationSet(option_name, option) %}
     {{ OptionTitle(option_name, option) }}
+    <input type="hidden" id="{{ option_name }}-{{ key }}-hidden" name="{{ option_name }}" value="ensure-empty-list"/>
     <div class="option-container">
         {% for group_name in world.location_name_groups.keys()|sort %}
             {% if group_name != "Everywhere" %}
@@ -170,6 +171,7 @@
 
 {% macro ItemSet(option_name, option) %}
     {{ OptionTitle(option_name, option) }}
+    <input type="hidden" id="{{ option_name }}-{{ key }}-hidden" name="{{ option_name }}" value="ensure-empty-list"/>
     <div class="option-container">
         {% for group_name in world.item_name_groups.keys()|sort %}
             {% if group_name != "Everything" %}

--- a/WebHostLib/templates/weightedOptions/macros.html
+++ b/WebHostLib/templates/weightedOptions/macros.html
@@ -139,6 +139,7 @@
 {% endmacro %}
 
 {% macro OptionList(option_name, option) %}
+    <input type="hidden" id="{{ option_name }}-{{ key }}-hidden" name="{{ option_name }}" value="ensure-empty-list"/>
     <div class="list-container">
         {% for key in (option.valid_keys if option.valid_keys is ordered else option.valid_keys|sort) %}
             <div class="list-entry">
@@ -202,6 +203,7 @@
 {% endmacro %}
 
 {% macro OptionSet(option_name, option) %}
+    <input type="hidden" id="{{ option_name }}-{{ key }}-hidden" name="{{ option_name }}" value="ensure-empty-list"/>
     <div class="set-container">
         {% for key in (option.valid_keys if option.valid_keys is ordered else option.valid_keys|sort) %}
             <div class="set-entry">

--- a/WebHostLib/templates/weightedOptions/macros.html
+++ b/WebHostLib/templates/weightedOptions/macros.html
@@ -159,6 +159,7 @@
 {% endmacro %}
 
 {% macro LocationSet(option_name, option, world) %}
+    <input type="hidden" id="{{ option_name }}-{{ key }}-hidden" name="{{ option_name }}" value="ensure-empty-list"/>
     <div class="set-container">
         {% for group_name in world.location_name_groups.keys()|sort %}
             {% if group_name != "Everywhere" %}
@@ -181,6 +182,7 @@
 {% endmacro %}
 
 {% macro ItemSet(option_name, option, world) %}
+    <input type="hidden" id="{{ option_name }}-{{ key }}-hidden" name="{{ option_name }}" value="ensure-empty-list"/>
     <div class="set-container">
         {% for group_name in world.item_name_groups.keys()|sort %}
             {% if group_name != "Everything" %}

--- a/WebHostLib/templates/weightedOptions/macros.html
+++ b/WebHostLib/templates/weightedOptions/macros.html
@@ -139,7 +139,7 @@
 {% endmacro %}
 
 {% macro OptionList(option_name, option) %}
-    <input type="hidden" id="{{ option_name }}-{{ key }}-hidden" name="{{ option_name }}" value="ensure-empty-list"/>
+    <input type="hidden" id="{{ option_name }}-{{ key }}-hidden" name="{{ option_name }}" value="_ensure-empty-list"/>
     <div class="list-container">
         {% for key in (option.valid_keys if option.valid_keys is ordered else option.valid_keys|sort) %}
             <div class="list-entry">
@@ -159,7 +159,7 @@
 {% endmacro %}
 
 {% macro LocationSet(option_name, option, world) %}
-    <input type="hidden" id="{{ option_name }}-{{ key }}-hidden" name="{{ option_name }}" value="ensure-empty-list"/>
+    <input type="hidden" id="{{ option_name }}-{{ key }}-hidden" name="{{ option_name }}" value="_ensure-empty-list"/>
     <div class="set-container">
         {% for group_name in world.location_name_groups.keys()|sort %}
             {% if group_name != "Everywhere" %}
@@ -182,7 +182,7 @@
 {% endmacro %}
 
 {% macro ItemSet(option_name, option, world) %}
-    <input type="hidden" id="{{ option_name }}-{{ key }}-hidden" name="{{ option_name }}" value="ensure-empty-list"/>
+    <input type="hidden" id="{{ option_name }}-{{ key }}-hidden" name="{{ option_name }}" value="_ensure-empty-list"/>
     <div class="set-container">
         {% for group_name in world.item_name_groups.keys()|sort %}
             {% if group_name != "Everything" %}
@@ -205,7 +205,7 @@
 {% endmacro %}
 
 {% macro OptionSet(option_name, option) %}
-    <input type="hidden" id="{{ option_name }}-{{ key }}-hidden" name="{{ option_name }}" value="ensure-empty-list"/>
+    <input type="hidden" id="{{ option_name }}-{{ key }}-hidden" name="{{ option_name }}" value="_ensure-empty-list"/>
     <div class="set-container">
         {% for key in (option.valid_keys if option.valid_keys is ordered else option.valid_keys|sort) %}
             <div class="set-entry">


### PR DESCRIPTION
Say we have an option like this:

```
class AllowedTricks(OptionSet):
    valid_keys = {"Sword Skip", "Shield Skip", "XD Skip"}
    default = {"Shield Skip"}
```

On WebHost, this will be displayed as three checkboxes.

If any of them are checked, the option exports correctly to yaml when clicking the "Export Yaml" button.

However, if none of them are selected, the allowed_tricks option will be **missing from the generated yaml entirely**.
This is because unchecked checkboxes are not sent as POST data, which means the generate_yaml endpoint will not be aware of the existence of the option at all.

This however causes an issue - When an option is not present in the yaml, it will be treated as its **default value**.

So even though the user manually unchecked "Shield Skip", since the option is now entirely absent from their yaml, it will assume its default value, which includes "Shield Skip".

This effectively means games cannot have non-empty default values for OptionSets and OptionLists right now.

We fix this here by adding a hidden input to OptionSets and OptionLists that ensures they get an empty list associated with them (or dict, in the case of weighted options... listen, don't ask too many questions about weighted options).