### PR TITLE
Core: use pickletools.optimize in restricted_dumps

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -491,8 +491,8 @@ def restricted_dumps(obj: Any) -> bytes:
         restricted_loads(s)
     except pickle.UnpicklingError as e:
         raise pickle.PicklingError(e) from e
-
-    return s
+    import pickletools
+    return pickletools.optimize(s)
 
 
 class ByValue:


### PR DESCRIPTION
## What is this fixing or adding?
Since we clearly don't care about the cpu time and memory requirement of dumping, as we just doubled it, we may as well make loading at least faster.

## How was this tested?
no, but apparently this has a unittest
