### PR TITLE
TUNIC: Change non_local_items Earlier

### DIFF
--- a/worlds/tunic/__init__.py
+++ b/worlds/tunic/__init__.py
@@ -191,6 +191,10 @@ class TunicWorld(World):
             else:
                 self.options.local_fill.value = 0
 
+        if self.options.local_fill > 0 and self.settings.limit_grass_rando:
+            # discard grass from non_local if it's meant to be limited
+            self.options.non_local_items.value.discard("Grass")
+
         if self.options.grass_randomizer:
             if self.settings.limit_grass_rando and self.options.local_fill < 95 and self.multiworld.players > 1:
                 raise OptionError(f"TUNIC: Player {self.player_name} has their Local Fill option set too low. "
@@ -454,9 +458,6 @@ class TunicWorld(World):
         self.fill_items = []
         if self.options.local_fill > 0 and self.multiworld.players > 1:
             # skip items marked local or non-local, let fill deal with them in its own way
-            # discard grass from non_local if it's meant to be limited
-            if self.settings.limit_grass_rando:
-                self.options.non_local_items.value.discard("Grass")
             all_filler: List[TunicItem] = []
             non_filler: List[TunicItem] = []
             for tunic_item in tunic_items:


### PR DESCRIPTION
## What is this fixing or adding?

https://github.com/ArchipelagoMW/Archipelago/pull/4481 was merged and I missed that TUNIC was doing this in my manual search for instances of `local_items` that weren't caught by the unit test (or it didn't exist when I searched initially). I did another search today and found this instance and no others today. This moves the changes to `non_local_items` from `create_items` to `generate_early`

`self.multiworld.players > 1` is not checked because if `players == 1` then non_local_items doesn't matter and would just get emptied later anyway.

## How was this tested?

Modifying TUNIC's code to fail the unit test and seeing that with these changes the test no longer failed.