### PR TITLE
Paint: Minor generation performance improvements

### DIFF
--- a/worlds/paint/__init__.py
+++ b/worlds/paint/__init__.py
@@ -118,9 +118,11 @@ class PaintWorld(World):
 
 def location_exists_with_options(world: PaintWorld, location: int):
     l = location % 198600
-    return l <= world.options.logic_percent * 4 and (l % 4 == 0 or
-                                                    (l > world.options.half_percent_checks * 4 and l % 2 == 0) or
-                                                    l > world.options.quarter_percent_checks * 4)
+    return l <= world.options.logic_percent.value * 4 and (
+            l % 4 == 0 or
+            (l > world.options.half_percent_checks.value * 4 and l % 2 == 0) or
+            l > world.options.quarter_percent_checks.value * 4
+    )
 
 
 class PaintState(LogicMixin):

--- a/worlds/paint/__init__.py
+++ b/worlds/paint/__init__.py
@@ -36,11 +36,15 @@ class PaintWorld(World):
     item_name_to_id = item_table
     origin_region_name = "Canvas"
 
+    per_pixel_logic_percent: float
+
     def generate_early(self) -> None:
         if self.options.canvas_size_increment < 50 and self.options.logic_percent <= 55:
             if self.multiworld.players == 1:
                 raise OptionError("Logic Percent must be greater than 55 when generating a single-player world with "
                                   "Canvas Size Increment below 50.")
+        # The full canvas size is 800*600, so 480000 pixels.
+        self.per_pixel_logic_percent = self.options.logic_percent.value / 480000
 
     def get_filler_item_name(self) -> str:
         if self.random.randint(0, 99) >= self.options.trap_count:

--- a/worlds/paint/locations.py
+++ b/worlds/paint/locations.py
@@ -1,14 +1,22 @@
-from typing import NamedTuple, Dict
+from typing import NamedTuple, Dict, Optional
 
-from BaseClasses import CollectionState, Location
+from BaseClasses import CollectionState, Location, Region
 
 
 class PaintLocation(Location):
     game = "Paint"
+
+    required_percent: float
+
+    def __init__(self, player: int, name: str = '', address: Optional[int] = None, parent: Optional[Region] = None):
+        super().__init__(player, name, address, parent)
+        assert self.address is not None
+        self.required_percent = (self.address % 198600) / 4
+
     def access_rule(self, state: CollectionState):
         from .rules import paint_percent_available
         return paint_percent_available(state, state.multiworld.worlds[self.player], self.player) >=\
-               (self.address % 198600) / 4
+               self.required_percent
 
 
 class PaintLocationData(NamedTuple):

--- a/worlds/paint/locations.py
+++ b/worlds/paint/locations.py
@@ -2,6 +2,8 @@ from typing import NamedTuple, Dict, Optional
 
 from BaseClasses import CollectionState, Location, Region
 
+from .rules import paint_percent_available
+
 
 class PaintLocation(Location):
     game = "Paint"
@@ -14,7 +16,6 @@ class PaintLocation(Location):
         self.required_percent = (self.address % 198600) / 4
 
     def access_rule(self, state: CollectionState):
-        from .rules import paint_percent_available
         return paint_percent_available(state, state.multiworld.worlds[self.player], self.player) >=\
                self.required_percent
 

--- a/worlds/paint/rules.py
+++ b/worlds/paint/rules.py
@@ -50,12 +50,9 @@ def calculate_paint_percent_available(state: CollectionState, world: "PaintWorld
         b = min(b, 7)
     w = state.count("Progressive Canvas Width", player)
     h = state.count("Progressive Canvas Height", player)
-    # This code looks a little messy but it's a mathematical formula derived from the similarity calculations in the
-    # client. The first line calculates the maximum score achievable for a single pixel with the current items in the
-    # worst possible case. This per-pixel score is then multiplied by the number of pixels currently available (the
-    # starting canvas is 400x300) over the total number of pixels with everything unlocked (800x600) to get the
-    # total score achievable assuming the worst possible target image. Finally, this is multiplied by the logic percent
-    # option which restricts the logic so as to not require pixel perfection.
+    # This code calculates the total similarity in logic using the formula:
+    # (expected score per pixel) * (pixels currently available) * (logic percent from options) / (total pixel count)
+    # The expected score and logic percent per pixel are calculated elsewhere for efficiency.
     return (SINGLE_PIXEL_SCORE_LOOKUP[r, g, b] *
             min(400 + w * world.options.canvas_size_increment.value, 800) *
             min(300 + h * world.options.canvas_size_increment.value, 600) *

--- a/worlds/paint/rules.py
+++ b/worlds/paint/rules.py
@@ -1,8 +1,11 @@
 from itertools import product
 from math import sqrt
+from typing import TYPE_CHECKING
 
 from BaseClasses import CollectionState
-from . import PaintWorld
+
+if TYPE_CHECKING:
+    from . import PaintWorld
 
 
 # There are only 512 (8**3) possible sets of arguments when each of r, g and b can be from 0 inclusive to 7 inclusive,
@@ -23,14 +26,14 @@ def _make_single_pixel_score_lookup():
 SINGLE_PIXEL_SCORE_LOOKUP = _make_single_pixel_score_lookup()
 
 
-def paint_percent_available(state: CollectionState, world: PaintWorld, player: int) -> bool:
+def paint_percent_available(state: CollectionState, world: "PaintWorld", player: int) -> bool:
     if state.paint_percent_stale[player]:
         state.paint_percent_available[player] = calculate_paint_percent_available(state, world, player)
         state.paint_percent_stale[player] = False
     return state.paint_percent_available[player]
 
 
-def calculate_paint_percent_available(state: CollectionState, world: PaintWorld, player: int) -> float:
+def calculate_paint_percent_available(state: CollectionState, world: "PaintWorld", player: int) -> float:
     p = state.has("Pick Color", player)
     r = state.count("Progressive Color Depth (Red)", player)
     g = state.count("Progressive Color Depth (Green)", player)
@@ -57,7 +60,7 @@ def calculate_paint_percent_available(state: CollectionState, world: PaintWorld,
             world.options.logic_percent / 480000)
 
 
-def set_completion_rules(world: PaintWorld, player: int) -> None:
+def set_completion_rules(world: "PaintWorld", player: int) -> None:
     world.multiworld.completion_condition[player] = \
         lambda state: (paint_percent_available(state, world, player) >=
                        min(world.options.logic_percent, world.options.goal_percent))

--- a/worlds/paint/rules.py
+++ b/worlds/paint/rules.py
@@ -32,13 +32,17 @@ def paint_percent_available(state: CollectionState, world: PaintWorld, player: i
 
 def calculate_paint_percent_available(state: CollectionState, world: PaintWorld, player: int) -> float:
     p = state.has("Pick Color", player)
-    r = min(state.count("Progressive Color Depth (Red)", player), 7)
-    g = min(state.count("Progressive Color Depth (Green)", player), 7)
-    b = min(state.count("Progressive Color Depth (Blue)", player), 7)
+    r = state.count("Progressive Color Depth (Red)", player)
+    g = state.count("Progressive Color Depth (Green)", player)
+    b = state.count("Progressive Color Depth (Blue)", player)
     if not p:
         r = min(r, 2)
         g = min(g, 2)
         b = min(b, 2)
+    else:
+        r = min(r, 7)
+        g = min(g, 7)
+        b = min(b, 7)
     w = state.count("Progressive Canvas Width", player)
     h = state.count("Progressive Canvas Height", player)
     # This code looks a little messy but it's a mathematical formula derived from the similarity calculations in the

--- a/worlds/paint/rules.py
+++ b/worlds/paint/rules.py
@@ -55,12 +55,12 @@ def calculate_paint_percent_available(state: CollectionState, world: "PaintWorld
     # total score achievable assuming the worst possible target image. Finally, this is multiplied by the logic percent
     # option which restricts the logic so as to not require pixel perfection.
     return (SINGLE_PIXEL_SCORE_LOOKUP[r, g, b] *
-            min(400 + w * world.options.canvas_size_increment, 800) *
-            min(300 + h * world.options.canvas_size_increment, 600) *
-            world.options.logic_percent / 480000)
+            min(400 + w * world.options.canvas_size_increment.value, 800) *
+            min(300 + h * world.options.canvas_size_increment.value, 600) *
+            world.options.logic_percent.value / 480000)
 
 
 def set_completion_rules(world: "PaintWorld", player: int) -> None:
     world.multiworld.completion_condition[player] = \
         lambda state: (paint_percent_available(state, world, player) >=
-                       min(world.options.logic_percent, world.options.goal_percent))
+                       min(world.options.logic_percent.value, world.options.goal_percent.value))

--- a/worlds/paint/rules.py
+++ b/worlds/paint/rules.py
@@ -12,14 +12,16 @@ if TYPE_CHECKING:
 # so pre-calculate them.
 def _make_single_pixel_score_lookup():
     """
-    Create a lookup for the maximum possible score for a pixel in the worst case, for r, g and b from 0-7 inclusive.
+    Create a lookup for the maximum possible score for a pixel in the worst case, for r, g and b color depth from 0-7
+    inclusive.
     """
-    rgb = [(2 ** (7 - i) - 1) ** 2 for i in range(8)]
+    # The color depth calculation is the same for r, g and b, so can be calculated once for each possible input value.
+    color_depth = {i: (2 ** (7 - i) - 1) ** 2 for i in range(8)}
     return {
-        t: 1 - sqrt(
-            (rgb[t[0]] + rgb[t[1]] + rgb[t[2]]) * 12
+        (r, g, b): 1 - sqrt(
+            (color_depth[r] + color_depth[g] + color_depth[b]) * 12
         ) / 765
-        for t in product(range(8), repeat=3)
+        for r, g, b in product(range(8), repeat=3)
     }
 
 

--- a/worlds/paint/rules.py
+++ b/worlds/paint/rules.py
@@ -61,6 +61,6 @@ def calculate_paint_percent_available(state: CollectionState, world: "PaintWorld
 
 
 def set_completion_rules(world: "PaintWorld", player: int) -> None:
+    goal_percent = min(world.options.logic_percent.value, world.options.goal_percent.value)
     world.multiworld.completion_condition[player] = \
-        lambda state: (paint_percent_available(state, world, player) >=
-                       min(world.options.logic_percent.value, world.options.goal_percent.value))
+        lambda state: paint_percent_available(state, world, player) >= goal_percent

--- a/worlds/paint/rules.py
+++ b/worlds/paint/rules.py
@@ -57,7 +57,7 @@ def calculate_paint_percent_available(state: CollectionState, world: "PaintWorld
     return (SINGLE_PIXEL_SCORE_LOOKUP[r, g, b] *
             min(400 + w * world.options.canvas_size_increment.value, 800) *
             min(300 + h * world.options.canvas_size_increment.value, 600) *
-            world.options.logic_percent.value / 480000)
+            world.per_pixel_logic_percent)
 
 
 def set_completion_rules(world: "PaintWorld", player: int) -> None:


### PR DESCRIPTION
## What is this fixing or adding?

Multiple minor improvements to Paint generation performance. While the percentage reduction in generation duration looks nice, Paint generates so fast already that the absolute reduction in generation duration is minimal.

The main points for improving the performance:
- Use `.value` when performing arithmetic on or comparing Options. This is only really relevant for code that gets called a lot, such as access rules.
- Pre-calculate parts of code that get called from access rules, where possible/reasonable.

## How was this tested?

I ran 10 generations of 10 template Paint yamls with `python -O .\Generate.py --seed 1` with progression balancing and playthrough calculation enabled, and setting `PYTHONHASHSEED` to `0` in the environment variables to ensure a deterministic playthrough calculation (deterministic set ordering), and averaged the generation durations:

On Python 3.12.9, Windows 10:
| Main at 04a3f78605fa/s | PR/s | Reduction/s | Percent Reduction |
| --- | --- | --- | --- |
| 0.5083398700000543 | 0.3258710100002645 | 0.1824688599997898 | 35.89505186751736% |

Generating the same seeds before and after this PR were seen to produce identical output.