### PR TITLE
FFMQ: Fix Collect/Remove Asymmetry

### DIFF
--- a/worlds/ffmq/__init__.py
+++ b/worlds/ffmq/__init__.py
@@ -166,7 +166,7 @@ class FFMQWorld(World):
             if state.has(self.item_id_to_name[i+2], self.player):
                 return self.item_id_to_name[i+2]
             if state.has(self.item_id_to_name[i+1], self.player):
-                return self.item_id_to_name[i+2]:
+                return self.item_id_to_name[i+2]
             if state.has(self.item_id_to_name[i], self.player):
                 return self.item_id_to_name[i+1]
             return self.item_id_to_name[i]

--- a/worlds/ffmq/__init__.py
+++ b/worlds/ffmq/__init__.py
@@ -163,7 +163,7 @@ class FFMQWorld(World):
                     return self.item_id_to_name[i+1]
                 return self.item_id_to_name[i]
             
-            if state.has(self.item_id_to_name[i+2], self.player)
+            if state.has(self.item_id_to_name[i+2], self.player):
                 return self.item_id_to_name[i+2]
             if state.has(self.item_id_to_name[i+1], self.player):
                 return self.item_id_to_name[i+2]:

--- a/worlds/ffmq/__init__.py
+++ b/worlds/ffmq/__init__.py
@@ -157,15 +157,17 @@ class FFMQWorld(World):
         if "Progressive" in item.name:
             i = item.code - 256
             if remove:
+                if state.has(self.item_id_to_name[i+2], self.player):
+                    return self.item_id_to_name[i+2]
                 if state.has(self.item_id_to_name[i+1], self.player):
-                    if state.has(self.item_id_to_name[i+2], self.player):
-                        return self.item_id_to_name[i+2]
                     return self.item_id_to_name[i+1]
                 return self.item_id_to_name[i]
-
+            
+            if state.has(self.item_id_to_name[i+2], self.player)
+                return self.item_id_to_name[i+2]
+            if state.has(self.item_id_to_name[i+1], self.player):
+                return self.item_id_to_name[i+2]:
             if state.has(self.item_id_to_name[i], self.player):
-                if state.has(self.item_id_to_name[i+1], self.player):
-                    return self.item_id_to_name[i+2]
                 return self.item_id_to_name[i+1]
             return self.item_id_to_name[i]
         return item.name


### PR DESCRIPTION
## What is this fixing or adding?

https://github.com/ArchipelagoMW/Archipelago/pull/5223
https://discord.com/channels/731205301247803413/731214280439103580/1398654817466978364

FFMQ does not properly handle remove/collect when progressive and non-progressive forms of items are being added.

## How was this tested?

Manually collecting from a shuffled list containing `["Progressive Axe", "Progressive Axe", "Progressive Axe", "Progressive Axe", "Progressive Axe", "Axe", "Axe", "Battle Axe", "Battle Axe", "Giant's Axe", "Giant's Axe"]` and then removing in the reverse order. while checking that state.prog_items was the same at each stage. This failed 48 out of 200 generations beforehand and 0 out of 200 afterwards.

This change likely also requires some kind of client update, since it would need to handle the mixed items the same way the logic does, otherwise you could be expected to perform impossible tasks.