### PR TITLE
Core: make APContainer seek archipelago.json

### DIFF
--- a/worlds/Files.py
+++ b/worlds/Files.py
@@ -138,6 +138,7 @@ class APContainer:
 
     def read_contents(self, opened_zipfile: zipfile.ZipFile) -> Dict[str, Any]:
         try:
+            assert self.manifest_path.endswith("archipelago.json"), "Filename should be archipelago.json"
             manifest_info = opened_zipfile.getinfo(self.manifest_path)
         except KeyError as e:
             for info in opened_zipfile.infolist():


### PR DESCRIPTION
## What is this fixing or adding?
As discussed in discord, allows the manifest file  to reside in subfolders. Desired for APWorld manifests to reside inside their world folder.

## How was this tested?
unittests and minimally manually
