### PR TITLE
[TLOZ] Updated to remove deprecated call.

### DIFF
--- a/worlds/tloz/Rom.py
+++ b/worlds/tloz/Rom.py
@@ -70,6 +70,6 @@ def get_base_rom_bytes(file_name: str = "") -> bytes:
     return base_rom_bytes
 
 
-def get_base_rom_path(file_name: str = "") -> str:
+def get_base_rom_path() -> str:
     from . import TLoZWorld
     return TLoZWorld.settings.rom_file


### PR DESCRIPTION
## What is this fixing or adding?
Removing call to `Utils.get_options()`

Addresses #4811.

## How was this tested?
After making the change:

- tested that generation still worked when the correct rom was present.
- tested that patching still worked when the correct rom was present.
- tested that generation still worked when the correct rom needed to be found by the user.
- tested that patching still worked when the correct rom needed to be found by the user..

## If this makes graphical changes, please attach screenshots.
