### PR TITLE
Fill: Remove Safety Checks When `allow_partial` is Disabled

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -232,20 +232,15 @@ def fill_restrictive(multiworld: MultiWorld, base_state: CollectionState, locati
                 if not location.item:
                     location.progress_type = location.progress_type.EXCLUDED
 
-    if not allow_partial and len(unplaced_items) > 0 and len(locations) > 0:
-        # There are leftover unplaceable items and locations that won't accept them
-        if multiworld.can_beat_game():
-            logging.warning(
-                f"Not all items placed. Game beatable anyway.\nCould not place:\n"
-                f"{', '.join(str(item) for item in unplaced_items)}")
-        else:
-            raise FillError(f"No more spots to place {len(unplaced_items)} items. Remaining locations are invalid.\n"
-                            f"Unplaced items:\n"
-                            f"{', '.join(str(item) for item in unplaced_items)}\n"
-                            f"Unfilled locations:\n"
-                            f"{', '.join(str(location) for location in locations)}\n"
-                            f"Already placed {len(placements)}:\n"
-                            f"{', '.join(str(place) for place in placements)}", multiworld=multiworld)
+    if not allow_partial and unplaced_items:
+        # There are leftover unplaceable items
+        raise FillError(f"No more spots to place {len(unplaced_items)} items. Remaining locations are invalid.\n"
+                        f"Unplaced items:\n"
+                        f"{', '.join(str(item) for item in unplaced_items)}\n"
+                        f"Unfilled locations:\n"
+                        f"{', '.join(str(location) for location in locations)}\n"
+                        f"Already placed {len(placements)}:\n"
+                        f"{', '.join(str(place) for place in placements)}", multiworld=multiworld)
 
     item_pool.extend(unplaced_items)
 


### PR DESCRIPTION
Reopening of #4733

Directly from the original PR:

## What is this fixing or adding?
This removes the extra check that there are unfilled locations, and the safety check that the multiworld is still beatable when allow_partial is false. There are a few cases where fill_restrictive is called, and this should only change the behavior for a single case.
1. Equal amount of prog items to be placed and locations to be filled. With allow_partial any extra items will be returned to be handled elsewhere so it is my opinion this should crash.
2. More locations to be filled than there are items, but the remaining locations are invalid.  With us having the start_inventory escape for main fill (which does use allow_partial) this should always fail.
3. More locations to be filled than there are items, and all items have been placed. Currently, this code does not trigger, and it will still not with this change.
4. More prog items to be placed than there are locations to fill. With allow_partial set to False, this should crash, as that indicates (in my opinion) an error in pool submissions, but this currently passes silently allowing a world to call this method and just assume their items are all being placed.

## How was this tested?
Only ran unit tests. Needs scrutiny since it does change some behavior. As far as main fill is concerned, the only case where the second if is getting hit, will crash shortly after the panic_method handling so it's nonsensical for that use case.