### PR TITLE
Core: Sort unreachable advancement locations written to the spoiler

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1914,7 +1914,8 @@ class Spoiler:
             if self.unreachables:
                 outfile.write('\n\nUnreachable Progression Items:\n\n')
                 outfile.write(
-                    '\n'.join(['%s: %s' % (unreachable.item, unreachable) for unreachable in self.unreachables]))
+                    '\n'.join(['%s: %s' % (unreachable.item, unreachable)
+                               for unreachable in sorted(self.unreachables)]))
 
             if self.paths:
                 outfile.write('\n\nPaths:\n\n')


### PR DESCRIPTION
## What is this fixing or adding?
`self.unreachables` is a set, so its iteration order changes depending on the Python process' random internal hash seed.

This change sorts the unreachable advancement locations before outputting them to the spoiler. Comparing spoilers generated with the same seed can be a simple method to check that a multiworld is generating deterministically (while ignoring the playthrough because playthrough is deliberately nondeterministic). The unreachable advancement locations were being written to the spoiler in a nondeterministic order.

Note that unreachable advancement locations are currently only written when the playthrough is enabled.

## How was this tested?

I generated a fixed seed with minimal accessibility and an early goal twice and observed that the order of the unreachable progression items/locations was the same in both times.

