### PR TITLE
TWW: Fix DeathLink

### DIFF
--- a/worlds/tww/Options.py
+++ b/worlds/tww/Options.py
@@ -800,6 +800,7 @@ class TWWOptions(PerGameCommonOptions):
             "swift_sail",
             "skip_rematch_bosses",
             "remove_music",
+            "death_link",
         )
 
     def get_output_dict(self) -> dict[str, Any]:


### PR DESCRIPTION
## What is this fixing or adding?
#5045 removed `"death_link"` from the slot data, unintentionally breaking DeathLink for TWW in 0.6.2. This PR restores it.

## How was this tested?
Ran a two-game multiworld locally (TWW and OOT), tested DeathLink before and after the change. The change restores DeathLink behaviour for TWW.

## If this makes graphical changes, please attach screenshots.
N/A