### PR TITLE
Subnautica: add empty tanks option

### DIFF
--- a/worlds/subnautica/__init__.py
+++ b/worlds/subnautica/__init__.py
@@ -41,7 +41,7 @@ class SubnauticaWorld(World):
     location_name_to_id = all_locations
     options_dataclass = options.SubnauticaOptions
     options: options.SubnauticaOptions
-    required_client_version = (0, 5, 0)
+    required_client_version = (0, 6, 2)
     origin_region_name = "Planet 4546B"
     creatures_to_scan: List[str]
 
@@ -155,6 +155,7 @@ class SubnauticaWorld(World):
             "creatures_to_scan": self.creatures_to_scan,
             "death_link": self.options.death_link.value,
             "free_samples": self.options.free_samples.value,
+            "empty_tanks": self.options.empty_tanks.value,
         }
 
         return slot_data

--- a/worlds/subnautica/options.py
+++ b/worlds/subnautica/options.py
@@ -129,6 +129,10 @@ class FillerItemsDistribution(ItemDict):
         return list(self.value.keys()), list(accumulate(self.value.values()))
 
 
+class EmptyTanks(DefaultOnToggle):
+    """Oxygen Tanks stored in inventory are empty if enabled."""
+
+
 @dataclass
 class SubnauticaOptions(PerGameCommonOptions):
     swim_rule: SwimRule
@@ -140,3 +144,4 @@ class SubnauticaOptions(PerGameCommonOptions):
     death_link: SubnauticaDeathLink
     start_inventory_from_pool: StartInventoryPool
     filler_items_distribution: FillerItemsDistribution
+    empty_tanks: EmptyTanks


### PR DESCRIPTION
## What is this fixing or adding?
Adds a new option that keeps tanks in inventory effectively empty.
Also forces an update of the client.

## How was this tested?
locally, with the new client https://github.com/Berserker66/ArchipelagoSubnauticaModSrc/releases/tag/1.9.0
