### PR TITLE
WebHost: remove team argument from tracker arguments where it's irrelevant

### DIFF
--- a/WebHostLib/templates/genericTracker.html
+++ b/WebHostLib/templates/genericTracker.html
@@ -98,7 +98,7 @@
                             <td>
                                 {% if hint.finding_player == player %}
                                     <b>{{ player_names_with_alias[(team, hint.finding_player)] }}</b>
-                                {% elif get_slot_info(team, hint.finding_player).type == 2 %}
+                                {% elif get_slot_info(hint.finding_player).type == 2 %}
                                     <i>{{ player_names_with_alias[(team, hint.finding_player)] }}</i>
                                 {% else %}
                                     <a href="{{ url_for("get_player_tracker", tracker=room.tracker, tracked_team=team, tracked_player=hint.finding_player) }}">
@@ -109,7 +109,7 @@
                             <td>
                                 {% if hint.receiving_player == player %}
                                     <b>{{ player_names_with_alias[(team, hint.receiving_player)] }}</b>
-                                {% elif get_slot_info(team, hint.receiving_player).type == 2 %}
+                                {% elif get_slot_info(hint.receiving_player).type == 2 %}
                                     <i>{{ player_names_with_alias[(team, hint.receiving_player)] }}</i>
                                 {% else %}
                                     <a href="{{ url_for("get_player_tracker", tracker=room.tracker, tracked_team=team, tracked_player=hint.receiving_player) }}">

--- a/WebHostLib/templates/multispheretracker.html
+++ b/WebHostLib/templates/multispheretracker.html
@@ -45,15 +45,15 @@
                     {%- set current_sphere = loop.index %}
                     {%- for player, sphere_location_ids in sphere.items() %}
                         {%- set checked_locations = tracker_data.get_player_checked_locations(team, player) %}
-                        {%- set finder_game = tracker_data.get_player_game(team, player) %}
-                        {%- set player_location_data = tracker_data.get_player_locations(team, player) %}
+                        {%- set finder_game = tracker_data.get_player_game(player) %}
+                        {%- set player_location_data = tracker_data.get_player_locations(player) %}
                         {%- for location_id in sphere_location_ids.intersection(checked_locations) %}
                         <tr>
                             {%- set item_id, receiver, item_flags = player_location_data[location_id] %}
-                            {%- set receiver_game = tracker_data.get_player_game(team, receiver) %}
+                            {%- set receiver_game = tracker_data.get_player_game(receiver) %}
                             <td>{{ current_sphere }}</td>
-                            <td>{{ tracker_data.get_player_name(team, player) }}</td>
-                            <td>{{ tracker_data.get_player_name(team, receiver) }}</td>
+                            <td>{{ tracker_data.get_player_name(player) }}</td>
+                            <td>{{ tracker_data.get_player_name(receiver) }}</td>
                             <td>{{ tracker_data.item_id_to_name[receiver_game][item_id] }}</td>
                             <td>{{ tracker_data.location_id_to_name[finder_game][location_id] }}</td>
                             <td>{{ finder_game }}</td>

--- a/WebHostLib/templates/multitrackerHintTable.html
+++ b/WebHostLib/templates/multitrackerHintTable.html
@@ -22,14 +22,14 @@
                 -%}
                     <tr>
                         <td>
-                            {% if get_slot_info(team, hint.finding_player).type == 2 %}
+                            {% if get_slot_info(hint.finding_player).type == 2 %}
                                 <i>{{ player_names_with_alias[(team, hint.finding_player)] }}</i>
                             {% else %}
                                 {{ player_names_with_alias[(team, hint.finding_player)] }}
                             {% endif %}
                         </td>
                         <td>
-                            {% if get_slot_info(team, hint.receiving_player).type == 2 %}
+                            {% if get_slot_info(hint.receiving_player).type == 2 %}
                                 <i>{{ player_names_with_alias[(team, hint.receiving_player)] }}</i>
                             {% else %}
                                 {{ player_names_with_alias[(team, hint.receiving_player)] }}


### PR DESCRIPTION
## What is this fixing or adding?
removes passing the team int when it's not needed.

## How was this tested?
locally with a few old rooms I had stored, making sure the tracker pages still render.