### PR TITLE
Core: Allow archipelago.json to be one layer deep in APContainer, add documentation for APContainer

### DIFF
--- a/docs/ap_container_specification.md
+++ b/docs/ap_container_specification.md
@@ -1,0 +1,52 @@
+# APContainer
+
+An APContainer is a zip file holding data or code that somehow extends Archipelago.  
+The main use currently is for patch files to be read by game clients.  
+In the future, [apworlds](apworld%20specification.md) may become a type of APContainer as well.
+
+## Specification
+
+An APContainer must be a zip archive.  
+This zip file can (and usually will) have a custom extension linking it to one specific purpose.
+
+An APContainer must contain a manifest file called `archipelago.json`.  
+This file must either in the root, or in the only subfolder of the root.  
+
+## Examples
+
+### Valid Containers
+
+```
+AP_69139584124759499357_P1_Player1.mygamepatch
+├── archipelago.json  # A flat zipfile structure with the manifest file next to the other files is ok.
+├── patch_data_1.json
+└── patch_data_2.json
+```
+
+
+```
+AP_69139584124759499357_P1_Player1.mygamepatch
+├── archipelago.json  # As long as the manifest is in the root, any amount of subfolders are allowed.
+└── patch_data
+    ├── patch_data_1.json
+    └── patch_data_2.json
+```
+
+```
+AP_69139584124759499357_P1_Player1.mygamepatch
+└── patch_data
+    ├── archipelago.json  # If the only thing in the root is a single directory, the manifest is allowed to be in it.
+    ├── patch_data_1.json
+    └── patch_data_2.json
+```
+
+### Invalid APContainers
+
+```
+AP_69139584124759499357_P1_Player1.mygamepatch
+├── manifest
+│   └── archipelago.json  # If there are multiple files/directories in the root, the manifest cannot be in a subdirectory.
+└── patch_data
+    ├── patch_data_1.json
+    └── patch_data_2.json
+```

--- a/worlds/Files.py
+++ b/worlds/Files.py
@@ -7,6 +7,7 @@ from enum import IntEnum
 import os
 import threading
 from io import BytesIO
+from pathlib import Path
 
 from typing import ClassVar, Dict, List, Literal, Tuple, Any, Optional, Union, BinaryIO, overload, Sequence
 
@@ -137,7 +138,22 @@ class APContainer:
                 raise InvalidDataError(f"{message}This might be the incorrect world version for this file") from e
 
     def read_contents(self, opened_zipfile: zipfile.ZipFile) -> Dict[str, Any]:
-        with opened_zipfile.open("archipelago.json", "r") as f:
+        try:
+            manifest_info = opened_zipfile.getinfo("archipelago.json")
+        except KeyError as e:
+            # Look for single directory in root
+            paths = {Path(info.filename).parts[0] for info in opened_zipfile.infolist()}
+            if len(paths) != 1:
+                raise e
+            only_folder = next(iter(paths))
+
+            # Look for archipelago.json in this single directory
+            try:
+                manifest_info = opened_zipfile.getinfo(f"{only_folder}/archipelago.json")
+            except KeyError:
+                raise e
+
+        with opened_zipfile.open(manifest_info, "r") as f:
             manifest = json.load(f)
         if manifest["compatible_version"] > self.version:
             raise Exception(f"File (version: {manifest['compatible_version']}) too new "


### PR DESCRIPTION
Alternative to https://github.com/ArchipelagoMW/Archipelago/pull/5261 + documentation