### PR TITLE
WebHost: Fix regression on 404 redirects

### DIFF
--- a/WebHostLib/misc.py
+++ b/WebHostLib/misc.py
@@ -87,19 +87,22 @@ def start_playing():
 @cache.cached()
 def game_info(game, lang):
     """Game Info Pages"""
-    theme = get_world_theme(game)
-    secure_game_name = secure_filename(game)
-    lang = secure_filename(lang)
-    document = render_markdown(os.path.join(
-        app.static_folder, "generated", "docs",
-        secure_game_name, f"{lang}_{secure_game_name}.md"
-    ))
-    return render_template(
-        "markdown_document.html",
-        title=f"{game} Guide",
-        html_from_markdown=document,
-        theme=theme,
-    )
+    try:
+        theme = get_world_theme(game)
+        secure_game_name = secure_filename(game)
+        lang = secure_filename(lang)
+        document = render_markdown(os.path.join(
+            app.static_folder, "generated", "docs",
+            secure_game_name, f"{lang}_{secure_game_name}.md"
+        ))
+        return render_template(
+            "markdown_document.html",
+            title=f"{game} Guide",
+            html_from_markdown=document,
+            theme=theme,
+        )
+    except FileNotFoundError:
+        return abort(404)
 
 
 @app.route('/games')
@@ -112,19 +115,22 @@ def games():
 @app.route('/tutorial/<string:game>/<string:file>')
 @cache.cached()
 def tutorial(game: str, file: str):
-    theme = get_world_theme(game)
-    secure_game_name = secure_filename(game)
-    file = secure_filename(file)
-    document = render_markdown(os.path.join(
-        app.static_folder, "generated", "docs",
-        secure_game_name, file+".md"
-    ))
-    return render_template(
-        "markdown_document.html",
-        title=f"{game} Guide",
-        html_from_markdown=document,
-        theme=theme,
-    )
+    try:
+        theme = get_world_theme(game)
+        secure_game_name = secure_filename(game)
+        file = secure_filename(file)
+        document = render_markdown(os.path.join(
+            app.static_folder, "generated", "docs",
+            secure_game_name, file+".md"
+        ))
+        return render_template(
+            "markdown_document.html",
+            title=f"{game} Guide",
+            html_from_markdown=document,
+            theme=theme,
+        )
+    except FileNotFoundError:
+        return abort(404)
 
 
 @app.route('/tutorial/')


### PR DESCRIPTION
## What is this fixing or adding?
Reintroduces the try/except blocks for rendering tutorial and game info pages. Since these functions have been refactored, the exception we need to catch is now a FileNotFoundError rather than a KeyError. The result 

## How was this tested?
Local webhost, tried to navigate to pages for "Inscryption 2" and/or looking for its German docs (a language they does not have).

## If this makes graphical changes, please attach screenshots.
See #4642.