### PR TITLE
CI: Fix peer review tag on undrafting a PR

### DIFF
--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -22,8 +22,8 @@ jobs:
     name: 'Apply peer review label'
     needs: labeler
     if: >-
-      (github.event.action == 'opened' || github.event.action == 'reopened' || 
-      github.event.action == 'ready_for_review') && !github.event.pull_request.draft
+      github.event.action == 'ready_for_review' ||
+      ((github.event.action == 'opened' || github.event.action == 'reopened') && !github.event.pull_request.draft)
     runs-on: ubuntu-latest
     steps:
       - name: 'Add label'


### PR DESCRIPTION
## What is this fixing or adding?
Currently the workflow for applying tags seems to skip the intended `waiting-on: peer-review` tag addition when a draft gets marked ready for review, I think because of the `if` requiring the PR not to be a draft even when the action is `ready_for_review`. Brought up for a bit in the discord for #5242. https://discord.com/channels/731205301247803413/731214280439103580/1398758018924941524

## How was this tested?
Haven't. Apparently it's hard to test actions changes on forks (probably especially the case when you have an open PR on the main branch...).

## If this makes graphical changes, please attach screenshots.
<img width="100" alt="image" src="https://github.com/user-attachments/assets/3d969efc-070a-47d3-87e1-21db7521a18c" />
