### PR TITLE
TUNIC: Fix zig skip showing up in decoupled + fixed shop

### DIFF
--- a/worlds/tunic/er_scripts.py
+++ b/worlds/tunic/er_scripts.py
@@ -255,8 +255,10 @@ def pair_portals(world: "TunicWorld", regions: Dict[str, Region]) -> Dict[Portal
                 else:
                     dead_ends.append(portal)
                     dead_end_direction_tracker[portal.direction] += 1
-            if portal.region == "Zig Skip Exit" and entrance_layout == EntranceLayout.option_fixed_shop:
+            if (portal.region == "Zig Skip Exit" and entrance_layout == EntranceLayout.option_fixed_shop
+                    and not decoupled):
                 # direction isn't meaningful here since zig skip cannot be in direction pairs mode
+                # don't add it in decoupled
                 two_plus.append(portal)
 
     # now we generate the shops and add them to the dead ends list


### PR DESCRIPTION
## What is this fixing or adding?
Fixes the wrong way on a true one-way showing up in decoupled.

## How was this tested?
Test gens, making sure it doesn't show up here, and making sure it all still works in general.