### PR TITLE
Core: Added a leading 0 to classification.as_flag

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1571,7 +1571,7 @@ class ItemClassification(IntFlag):
 
     def as_flag(self) -> int:
         """As Network API flag int."""
-        return int(self & 0b0111)
+        return int(self & 0b00111)
 
 
 class Item:


### PR DESCRIPTION
## What is this fixing or adding?
Since the addition of deprioritized, the enum has 5 bits accounted for in core. Every other classification got changed to use 5 digits but not as_flag, which was left at 4

## How was this tested?
I counted the number of digits in 0b00111 twice

## If this makes graphical changes, please attach screenshots.
