### PR TITLE
DS3: Don't Create Disabled Locations

### DIFF
--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -267,6 +267,10 @@ class DarkSouls3World(World):
                 # Don't allow missable duplicates of progression items to be expected progression.
                 if location.name in self.missable_dupe_prog_locs: continue
 
+                # Don't create DLC and NGP locations if those are disabled
+                if location.dlc and not self.options.enable_dlc: continue
+                if location.ngp and not self.options.enable_ngp: continue
+
                 # Replace non-randomized items with events that give the default item
                 event_item = (
                     self.create_item(location.default_item_name) if location.default_item_name


### PR DESCRIPTION
## What is this fixing or adding?

Previously only the DLC regions and entrances weren't being created, but the DLC and NGP locations that were not in those regions would still get created, even though they were disabled. In the NGP case, this actually means they were fully inaccessible. This changes the behavior to not create any DLC or NGP locations if those are disabled by the options.

## How was this tested?

Generations with enabled and disabled NGP and DLC to see that locations were no longer being created when they weren't supposed to be.

It's worth noting that this just _happens_ to work out since none of the DLC and NGP locations that are not already in DLC regions are required by any parts of the logic outside of DLC and NGP locations and regions. That is to say, the DLC regions and the NGP locations are entirely self-contained when it comes to logic. As a result, nothing in the logic has to be rewritten to account for these items no longer existing.