### PR TITLE
Tests: Handle optional args for `get_all_state` patch

### DIFF
--- a/test/general/test_entrances.py
+++ b/test/general/test_entrances.py
@@ -48,13 +48,14 @@ class TestBase(unittest.TestCase):
 
                 original_get_all_state = multiworld.get_all_state
 
-                def patched_get_all_state(use_cache: bool | None = None, allow_partial_entrances: bool = False):
+                def patched_get_all_state(use_cache: bool | None = None, allow_partial_entrances: bool = False,
+                                          **kwargs):
                     self.assertTrue(allow_partial_entrances, (
                         "Before the connect_entrances step finishes, other worlds might still have partial entrances. "
                         "As such, any call to get_all_state must use allow_partial_entrances = True."
                     ))
 
-                    return original_get_all_state(use_cache, allow_partial_entrances)
+                    return original_get_all_state(use_cache, allow_partial_entrances, **kwargs)
 
                 multiworld.get_all_state = patched_get_all_state
 

--- a/test/general/test_entrances.py
+++ b/test/general/test_entrances.py
@@ -48,7 +48,7 @@ class TestBase(unittest.TestCase):
 
                 original_get_all_state = multiworld.get_all_state
 
-                def patched_get_all_state(use_cache: bool, allow_partial_entrances: bool = False):
+                def patched_get_all_state(use_cache: bool | None = None, allow_partial_entrances: bool = False):
                     self.assertTrue(allow_partial_entrances, (
                         "Before the connect_entrances step finishes, other worlds might still have partial entrances. "
                         "As such, any call to get_all_state must use allow_partial_entrances = True."


### PR DESCRIPTION
## What is this fixing or adding?
Changes the `patched_get_all_state` in `test_all_state_before_connect_entrances` to allow different arguments to be passed to it, since it currently fails in that case. Since #4795, `use_cache` has been optional (and gives a warning if set to something other than `None`), and it's had other optional kwargs besides in this test since #3046. Seemingly both of these things should be allowed even if calling `get_all_state` prior to `connect_entrances`.

## How was this tested?
Running the test on a world with an early call like `self.multiworld.get_all_state(allow_partial_entrances=True, collect_pre_fill_items=True)`.

## If this makes graphical changes, please attach screenshots.
❌->✅