### PR TITLE
Docs: More type annotation changes

### DIFF
--- a/docs/entrance randomization.md
+++ b/docs/entrance randomization.md
@@ -352,14 +352,14 @@ direction_matching_group_lookup = {
 
 Terrain matching or dungeon shuffle:
 ```python
-def randomize_within_same_group(group: int) -> List[int]:
+def randomize_within_same_group(group: int) -> list[int]:
     return [group]
 identity_group_lookup = bake_target_group_lookup(world, randomize_within_same_group)
 ```
 
 Directional + area shuffle:
 ```python
-def get_target_groups(group: int) -> List[int]:
+def get_target_groups(group: int) -> list[int]:
     # example group: LEFT | CAVE
     # example result: [RIGHT | CAVE, DOOR | CAVE]
     direction = group & Groups.DIRECTION_MASK

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -79,7 +79,7 @@ Sent to clients when they connect to an Archipelago server.
 | generator_version     | [NetworkVersion](#NetworkVersion)             | Object denoting the version of Archipelago which generated the multiworld.                                                                                                                                                            |
 | tags                  | list\[str\]                                   | Denotes special features or capabilities that the sender is capable of. Example: `WebHost`                                                                                                                                            |
 | password              | bool                                          | Denoted whether a password is required to join this room.                                                                                                                                                                             |
-| permissions           | dict\[str, [Permission](#Permission)\[int\]\] | Mapping of permission name to [Permission](#Permission), keys are: "release", "collect" and "remaining".                                                                                                                              |
+| permissions           | dict\[str, [Permission](#Permission)\]        | Mapping of permission name to [Permission](#Permission), keys are: "release", "collect" and "remaining".                                                                                                                              |
 | hint_cost             | int                                           | The percentage of total locations that need to be checked to receive a hint from the server.                                                                                                                                          |
 | location_check_points | int                                           | The amount of hint points you receive per item/location check completed.                                                                                                                                                              |
 | games                 | list\[str\]                                   | List of games present in this multiworld.                                                                                                                                                                                             |
@@ -662,13 +662,14 @@ class SlotType(enum.IntFlag):
 An object representing static information about a slot.
 
 ```python
-import typing
+from collections.abc import Sequence
+from typing import NamedTuple
 from NetUtils import SlotType
-class NetworkSlot(typing.NamedTuple):
+class NetworkSlot(NamedTuple):
    name: str
    game: str
    type: SlotType
-   group_members: typing.List[int] = []  # only populated if type == group
+   group_members: Sequence[int] = []  # only populated if type == group
 ```
 
 ### Permission
@@ -686,8 +687,8 @@ class Permission(enum.IntEnum):
 ### Hint
 An object representing a Hint.
 ```python
-import typing
-class Hint(typing.NamedTuple):
+from typing import NamedTuple
+class Hint(NamedTuple):
     receiving_player: int
     finding_player: int
     location: int

--- a/docs/settings api.md
+++ b/docs/settings api.md
@@ -28,7 +28,7 @@ if it does not exist.
 ## Global Settings
 
 All non-world-specific settings are defined directly in settings.py.
-Each value needs to have a default. If the default should be `None`, define it as `typing.Optional` and assign `None`.
+Each value needs to have a default. If the default should be `None`, annotate it using `T | None = None`.
 
 To access a "global" config value, with correct typing, use one of
 ```python

--- a/docs/style.md
+++ b/docs/style.md
@@ -15,8 +15,10 @@
 * Prefer [format string literals](https://peps.python.org/pep-0498/) over string concatenation,
   use single quotes inside them: `f"Like {dct['key']}"`
 * Use type annotations where possible for function signatures and class members.
-* Use type annotations where appropriate for local variables (e.g. `var: List[int] = []`, or when the
-  type is hard or impossible to deduce.) Clear annotations help developers look up and validate API calls.
+* Use type annotations where appropriate for local variables (e.g. `var: list[int] = []`, or when the
+  type is hard or impossible to deduce). Clear annotations help developers look up and validate API calls.
+* Prefer new style type annotations for new code (e.g. `var: dict[str, str | int]` over
+  `var: Dict[str, Union[str, int]]`).
 * If a line ends with an open bracket/brace/parentheses, the matching closing bracket should be at the
   beginning of a line at the same indentation as the beginning of the line with the open bracket.
   ```python

--- a/docs/world api.md
+++ b/docs/world api.md
@@ -76,8 +76,8 @@ webhost:
 * `game_info_languages` (optional) list of strings for defining the existing game info pages your game supports. The
   documents must be prefixed with the same string as defined here. Default already has 'en'.
 
-* `options_presets` (optional) `Dict[str, Dict[str, Any]]` where the keys are the names of the presets and the values
-  are the options to be set for that preset. The options are defined as a `Dict[str, Any]` where the keys are the names
+* `options_presets` (optional) `dict[str, dict[str, Any]]` where the keys are the names of the presets and the values
+  are the options to be set for that preset. The options are defined as a `dict[str, Any]` where the keys are the names
   of the options and the values are the values to be set for that option. These presets will be available for users to
   select from on the game's options page.
 
@@ -745,7 +745,7 @@ from BaseClasses import CollectionState, MultiWorld
 from worlds.AutoWorld import LogicMixin
 
 class MyGameState(LogicMixin):
-    mygame_defeatable_enemies: Dict[int, Set[str]]  # per player
+    mygame_defeatable_enemies: dict[int, set[str]]  # per player
 
     def init_mixin(self, multiworld: MultiWorld) -> None:
         # Initialize per player with the corresponding "nothing" value, such as 0 or an empty set.
@@ -874,7 +874,7 @@ item/location pairs is unnecessary since the AP server already retains and freel
 that request it. The most common usage of slot data is sending option results that the client needs to be aware of.
 
 ```python
-def fill_slot_data(self) -> Dict[str, Any]:
+def fill_slot_data(self) -> dict[str, Any]:
     # In order for our game client to handle the generated seed correctly we need to know what the user selected
     # for their difficulty and final boss HP.
     # A dictionary returned from this method gets set as the slot_data and will be sent to the client after connecting.


### PR DESCRIPTION
## What is this fixing or adding?
Updates some old-style annotations in docs snippets, and adds a note to style.md since PEP 8 (and the linked PEP 484 and PEP 526 for typing) use old style annotations, but AP prefers new. A couple of other small changes.

## How was this tested?
👀

## If this makes graphical changes, please attach screenshots.
📜