### PR TITLE
Launcher: add skip_open_folder arg to Generate Template Options

### DIFF
--- a/Launcher.py
+++ b/Launcher.py
@@ -75,12 +75,18 @@ def open_patch():
             launch([*exe, file], component.cli)
 
 
-def generate_yamls():
+def generate_yamls(*args):
     from Options import generate_yaml_templates
+
+    usage = f"{os.path.basename(sys.argv[0])} 'Generate Template Options' -- [-h] [--skip_open_folder]"
+    parser = argparse.ArgumentParser(usage=usage)
+    parser.add_argument("--skip_open_folder", action="store_true")
+    args = parser.parse_args(args)
 
     target = Utils.user_path("Players", "Templates")
     generate_yaml_templates(target, False)
-    open_folder(target)
+    if not args.skip_open_folder:
+        open_folder(target)
 
 
 def browse_files():


### PR DESCRIPTION
## What is this fixing or adding?

Adds an arg to the "Generate Template Options" launcher component named --skip_open_folder, that when set, will make it so that the templates folder won't be automatically opened.

## How was this tested?

`python Launcher.py "Generate Template Options"`: opens the folder

`python Launcher.py "Generate Template Options" -- --skip_open_folder`: doesn't open the folder. Still creates the template files

## If this makes graphical changes, please attach screenshots.
