### PR TITLE
SMZ3: Fix distribution of Super Metroid prizes

### DIFF
--- a/worlds/smz3/TotalSMZ3/WorldState.py
+++ b/worlds/smz3/TotalSMZ3/WorldState.py
@@ -1,6 +1,5 @@
 from enum import Enum
 from typing import List
-from copy import copy
 
 from .Patch import DropPrize
 from .Region import RewardType
@@ -91,7 +90,11 @@ class WorldState:
             self.Green = 1
 
             if (distribution is not None): 
-                self = copy(distribution)
+                self.Boss = distribution.Boss
+                self.Blue = distribution.Blue
+                self.Red = distribution.Red
+                self.Pend = distribution.Pend
+                self.Green = distribution.Green
             if (boss is not None): 
                 self.Boss = boss
             if (blue is not None): 
@@ -111,11 +114,11 @@ class WorldState:
             p -= self.Boss
             if (p < 0): return (RewardType.AnyBossToken, WorldState.Distribution(self, boss = self.Boss - WorldState.Distribution.factor))
             p -= self.Blue
-            if (p - self.Blue < 0): return (RewardType.CrystalBlue, WorldState.Distribution(self, blue = self.Blue - WorldState.Distribution.factor))
+            if (p < 0): return (RewardType.CrystalBlue, WorldState.Distribution(self, blue = self.Blue - WorldState.Distribution.factor))
             p -= self.Red
-            if (p - self.Red < 0): return (RewardType.CrystalRed, WorldState.Distribution(self, red = self.Red - WorldState.Distribution.factor))
+            if (p < 0): return (RewardType.CrystalRed, WorldState.Distribution(self, red = self.Red - WorldState.Distribution.factor))
             p -= self.Pend
-            if (p - self.Pend < 0): return (RewardType.PendantNonGreen, WorldState.Distribution(self, pend = self.Pend - 1))
+            if (p < 0): return (RewardType.PendantNonGreen, WorldState.Distribution(self, pend = self.Pend - 1))
             return (RewardType.PendantGreen, WorldState.Distribution(self, green = self.Green - 1))
 
         def Generate(self, func):


### PR DESCRIPTION
## What is this fixing or adding?
A combination of two bugs that seem to have been introduced when converting the upstream code to Python:
- Distribution weights were being doubly subtracted from the given random number; this resulted in Blue Crystals being picked for SM bosses far more often than they should, as well as making it impossible to pick Red Crystals and Pendants for SM bosses. (`n - (12 + 15 + 15)` where `n` is between 0 and 35 is always less than 0)
- In the Distribution constructor, passing in another Distribution attempted to turn the newly instantiated Distribution into a copy of it... by overwriting self, which doesn't work. After leaving `__init__`, that copy (and the changes made to it afterwards by other parameters) would be tossed out, and the result would always be the default Distribution weights. This was masked by the above bug; fixing that one without fixing this one resulted in occasionally attempting to place three Red Crystals, two Green Pendants, etc.

## How was this tested?
Test generations showing Red Crystals and rarely, Pendants being placed on SM locations, where they were not before

