### PR TITLE
Heretic: Update Steam URL

### DIFF
--- a/worlds/heretic/docs/setup_en.md
+++ b/worlds/heretic/docs/setup_en.md
@@ -2,7 +2,7 @@
 
 ## Required Software
 
-- [Heretic (e.g. Steam version)](https://store.steampowered.com/app/2390/Heretic_Shadow_of_the_Serpent_Riders/)
+- [Heretic (e.g. Steam version)](https://store.steampowered.com/app/3286930/Heretic__Hexen/)
 - [Archipelago Crispy DOOM](https://github.com/Daivuk/apdoom/releases) (Same download for DOOM 1993, DOOM II and Heretic)
 
 ## Optional Software


### PR DESCRIPTION
## What is this fixing or adding?
They did it again. As of August 7th, 2025, Heretic was merged with Hexen and provided a new game ID on Steam, rendering the old one defunct. This PR updates the old URL to the new one. Luckily for us, they treated this new remaster just like Doom + Doom II and retained the original DOS version's data files.

## How was this tested?
Reading