### PR TITLE
Kingdom Hearts: Fix logic error, small logic changes, update defaults

### DIFF
--- a/worlds/kh1/Options.py
+++ b/worlds/kh1/Options.py
@@ -173,17 +173,17 @@ class EXPMultiplier(NamedRange):
     Determines the multiplier to apply to EXP gained.
     """
     display_name = "EXP Multiplier"
-    default = 16
-    range_start = default // 4
+    default = 16 * 4
+    range_start = 16 // 4
     range_end = 128
     special_range_names = {
-        "0.25x": int(default // 4),
-        "0.5x": int(default // 2),
-        "1x": default,
-        "2x": default * 2,
-        "3x": default * 3,
-        "4x": default * 4,
-        "8x": default * 8,
+        "0.25x": int(16 // 4),
+        "0.5x": int(16 // 2),
+        "1x": 16,
+        "2x": 16 * 2,
+        "3x": 16 * 3,
+        "4x": 16 * 4,
+        "8x": 16 * 8,
     }
 
 class RequiredReportsEotW(Range):
@@ -316,7 +316,7 @@ class KeybladesUnlockChests(Toggle):
     """
     display_name = "Keyblades Unlock Chests"
 
-class InteractInBattle(Toggle):
+class InteractInBattle(DefaultOnToggle):
     """
     Allow Sora to talk to people, examine objects, and open chests in battle.
     """
@@ -328,7 +328,7 @@ class AdvancedLogic(Toggle):
     """
     display_name = "Advanced Logic"
 
-class ExtraSharedAbilities(Toggle):
+class ExtraSharedAbilities(DefaultOnToggle):
     """
     If on, adds extra shared abilities to the pool.  These can stack, so multiple high jumps make you jump higher and multiple glides make you superglide faster.
     """

--- a/worlds/kh1/Presets.py
+++ b/worlds/kh1/Presets.py
@@ -18,7 +18,7 @@ kh1_option_presets: Dict[str, Dict[str, Any]] = {
         "cups": False,
         "vanilla_emblem_pieces": True,
         
-        "exp_multiplier": 48,
+        "exp_multiplier": 64,
         "level_checks": 100,
         "force_stats_on_levels": 1,
         "strength_increase": 24,
@@ -61,7 +61,7 @@ kh1_option_presets: Dict[str, Dict[str, Any]] = {
         "cups": False,
         "vanilla_emblem_pieces": True,
         
-        "exp_multiplier": 48,
+        "exp_multiplier": 64,
         "level_checks": 100,
         "force_stats_on_levels": 1,
         "strength_increase": 24,
@@ -104,7 +104,7 @@ kh1_option_presets: Dict[str, Dict[str, Any]] = {
         "cups": True,
         "vanilla_emblem_pieces": False,
         
-        "exp_multiplier": 48,
+        "exp_multiplier": 64,
         "level_checks": 100,
         "force_stats_on_levels": 1,
         "strength_increase": 24,

--- a/worlds/kh1/Presets.py
+++ b/worlds/kh1/Presets.py
@@ -39,9 +39,9 @@ kh1_option_presets: Dict[str, Dict[str, Any]] = {
         
         "puppies": Puppies.option_triplets,
         "starting_worlds": 0,
-        "interact_in_battle": False,
+        "interact_in_battle": True,
         "advanced_logic": False,
-        "extra_shared_abilities": False,
+        "extra_shared_abilities": True,
         "exp_zero_in_pool": False,
         "donald_death_link": False,
         "goofy_death_link": False
@@ -82,9 +82,9 @@ kh1_option_presets: Dict[str, Dict[str, Any]] = {
         
         "puppies": Puppies.option_individual,
         "starting_worlds": 0,
-        "interact_in_battle": False,
+        "interact_in_battle": True,
         "advanced_logic": False,
-        "extra_shared_abilities": False,
+        "extra_shared_abilities": True,
         "exp_zero_in_pool": False,
         "donald_death_link": False,
         "goofy_death_link": False
@@ -167,9 +167,9 @@ kh1_option_presets: Dict[str, Dict[str, Any]] = {
         
         "puppies": Puppies.option_triplets,
         "starting_worlds": 0,
-        "interact_in_battle": False,
+        "interact_in_battle": True,
         "advanced_logic": False,
-        "extra_shared_abilities": False,
+        "extra_shared_abilities": True,
         "exp_zero_in_pool": False,
         "donald_death_link": False,
         "goofy_death_link": False

--- a/worlds/kh1/Rules.py
+++ b/worlds/kh1/Rules.py
@@ -265,9 +265,8 @@ def set_rules(kh1world):
         ))
     add_rule(kh1world.get_location("Wonderland Tea Party Garden Bear and Clock Puzzle Chest"),
         lambda state: (
-        
            state.has("Footprints", player)
-           or (options.advanced_logic and state.has("Progressive Glide", player))
+           or state.has("Progressive Glide", player)
         ))
     add_rule(kh1world.get_location("Wonderland Tea Party Garden Across From Bizarre Room Entrance Chest"),
         lambda state: (
@@ -642,7 +641,7 @@ def set_rules(kh1world):
             and
             (
                 has_emblems(state, player, options.keyblades_unlock_chests)
-                or (options.advanced_logic and state.has("High Jump", player, 2) and state.has("Progressive Glide", player))
+                or (state.has("High Jump", player, 2) and state.has("Progressive Glide", player))
                 or (options.advanced_logic and can_dumbo_skip(state, player) and state.has("Progressive Glide", player))
             )
         ))
@@ -693,7 +692,12 @@ def set_rules(kh1world):
     add_rule(kh1world.get_location("Hollow Bastion Lift Stop Heartless Sigil Door Gravity Chest"),
         lambda state: (
             state.has("Progressive Gravity", player)
-            and has_emblems(state, player, options.keyblades_unlock_chests)
+            and 
+            (
+                has_emblems(state, player, options.keyblades_unlock_chests)
+                or (state.has("High Jump", player, 2) and state.has("Progressive Glide", player))
+                or (options.advanced_logic and can_dumbo_skip(state, player) and state.has("Progressive Glide", player))
+            )
         ))
     add_rule(kh1world.get_location("Hollow Bastion Waterway Blizzard on Bubble Chest"),
         lambda state: (
@@ -1919,7 +1923,7 @@ def set_rules(kh1world):
         add_rule(kh1world.get_location("End of the World Final Rest Chest"),
             lambda state: state.has("Oblivion", player))
         add_rule(kh1world.get_location("Monstro Chamber 6 White Trinity Chest"),
-            lambda state: state.has("Oblivion", player))
+            lambda state: state.has("Wishing Star", player))
         if options.hundred_acre_wood:
             add_rule(kh1world.get_location("100 Acre Wood Meadow Inside Log Chest"),
                 lambda state: state.has("Oathkeeper", player))


### PR DESCRIPTION
## What is this fixing or adding?
Fixes an unreachable location when playing with the Keyblades Unlock Chests options
Update the rules on a few locations to match the beta branch
Update defaults on a few options to match where they're at in the beta branch 

## How was this tested?
Test generations and checked logic was working correctly with Universal Tracker.

## If this makes graphical changes, please attach screenshots.
N/A

Wanted to make a separate PR for this from the big reworking since that will need more substantial review and I remembered we've had this logic error for nearly a year now!