### PR TITLE
core:  Change template yaml to use uppercase {NUMBER} by default

### DIFF
--- a/data/options.yaml
+++ b/data/options.yaml
@@ -25,7 +25,7 @@
 #     {PLAYER} will be replaced with the player's slot number, if that slot number is greater than 1.
 #     {number} will be replaced with the counter value of the name.
 #     {NUMBER} will be replaced with the counter value of the name, if the counter value is greater than 1.
-name: Player{number}
+name: Player{NUMBER}
 
 # Used to describe your yaml. Useful if you have multiple files.
 description: {{ yaml_dump("Default %s Template" % game) }}


### PR DESCRIPTION
## What is this fixing or adding?
Changes the default slot name to something less likely to cause non-technical users confusion.

I see a lot of non-technical users who leave the {number} in place, because they assume removing it will break something.  They then get very confused when their slot has a `1` at the end of the name.  

This changes the default to use uppercase {NUMBER}, which only kicks in once there is more than one slot, thereby making their "choice" invisible.

## How was this tested?

wasn't.

## If this makes graphical changes, please attach screenshots.
