### PR TITLE
CI: update appimage runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ env:
   APPIMAGETOOL_VERSION: continuous
   APPIMAGETOOL_X86_64_HASH: '363dafac070b65cc36ca024b74db1f043c6f5cd7be8fca760e190dce0d18d684'
   APPIMAGE_RUNTIME_VERSION: continuous
-  APPIMAGE_RUNTIME_X86_64_HASH: 'e3c4dfb70eddf42e7e5a1d28dff396d30563aa9a901970aebe6f01f3fecf9f8e'
+  APPIMAGE_RUNTIME_X86_64_HASH: 'e70ffa9b69b211574d0917adc482dd66f25a0083427b5945783965d55b0b0a8b'
 
 permissions:  # permissions required for attestation
   id-token: 'write'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ env:
   APPIMAGETOOL_VERSION: continuous
   APPIMAGETOOL_X86_64_HASH: '363dafac070b65cc36ca024b74db1f043c6f5cd7be8fca760e190dce0d18d684'
   APPIMAGE_RUNTIME_VERSION: continuous
-  APPIMAGE_RUNTIME_X86_64_HASH: 'e3c4dfb70eddf42e7e5a1d28dff396d30563aa9a901970aebe6f01f3fecf9f8e'
+  APPIMAGE_RUNTIME_X86_64_HASH: 'e70ffa9b69b211574d0917adc482dd66f25a0083427b5945783965d55b0b0a8b'
 
 permissions:  # permissions required for attestation
   id-token: 'write'


### PR DESCRIPTION
## What is this fixing or adding?

Updates the hashes of appimage runtime.
If the next update happens in less than 6 Months, I think I'll fork it just to add tags, so we can upgrade at our own pace without breaking CI.

## How was this tested?

* Gave it a quick spin in an ubuntu vm.
* Downloaded the runtime, checked the gpg signature against what's in their repo, compared sha256sums.

```sh
gpg -o appimage-signing-pubkey.gpg --dearmor signing-pubkey.asc
gpg --no-default-keyring --keyring ./appimage-signing-pubkey.asc --verify runtime-x86_64.sig
```