### PR TITLE
Fix sitemap for the tutorial

### DIFF
--- a/WebHostLib/templates/siteMap.html
+++ b/WebHostLib/templates/siteMap.html
@@ -31,12 +31,12 @@
 
         <h2>Tutorials</h2>
         <ul>
-            <li><a href="/tutorial/Archipelago/setup/en">Multiworld Setup Tutorial</a></li>
-            <li><a href="/tutorial/Archipelago/mac/en">Setup Guide for Mac</a></li>
-            <li><a href="/tutorial/Archipelago/commands/en">Server and Client Commands</a></li>
-            <li><a href="/tutorial/Archipelago/advanced_settings/en">Advanced YAML Guide</a></li>
-            <li><a href="/tutorial/Archipelago/triggers/en">Triggers Guide</a></li>
-            <li><a href="/tutorial/Archipelago/plando/en">Plando Guide</a></li>
+            <li><a href="/tutorial/Archipelago/setup_en">Multiworld Setup Tutorial</a></li>
+            <li><a href="/tutorial/Archipelago/mac_en">Setup Guide for Mac</a></li>
+            <li><a href="/tutorial/Archipelago/commands_en">Server and Client Commands</a></li>
+            <li><a href="/tutorial/Archipelago/advanced_settings_en">Advanced YAML Guide</a></li>
+            <li><a href="/tutorial/Archipelago/triggers_en">Triggers Guide</a></li>
+            <li><a href="/tutorial/Archipelago/plando_en">Plando Guide</a></li>
         </ul>
 
         <h2>Game Info Pages</h2>


### PR DESCRIPTION
## What is this fixing or adding?
The tutorial links were 404s

## How was this tested?
I clicked some and they weren't 404s

## If this makes graphical changes, please attach screenshots.
