### PR TITLE
WebHost: redirect old tutorials to new URL

### DIFF
--- a/WebHostLib/misc.py
+++ b/WebHostLib/misc.py
@@ -133,6 +133,15 @@ def tutorial(game: str, file: str):
         return abort(404)
 
 
+@app.route('/tutorial/<string:game>/<string:file>/<string:lang>')
+def tutorial_redirect(game: str, file: str, lang: str):
+    """
+    Permanent redirect old tutorial URLs to new ones to keep search engines happy.
+    e.g. /Archipelago/setup/en -> /tutorial/Archipelago/setup_en
+    """
+    return redirect(url_for("tutorial", game=game, file=f"{file}_{lang}"), code=301)
+
+
 @app.route('/tutorial/')
 @cache.cached()
 def tutorial_landing():

--- a/WebHostLib/misc.py
+++ b/WebHostLib/misc.py
@@ -137,7 +137,7 @@ def tutorial(game: str, file: str):
 def tutorial_redirect(game: str, file: str, lang: str):
     """
     Permanent redirect old tutorial URLs to new ones to keep search engines happy.
-    e.g. /Archipelago/setup/en -> /tutorial/Archipelago/setup_en
+    e.g. /tutorial/Archipelago/setup/en -> /tutorial/Archipelago/setup_en
     """
     return redirect(url_for("tutorial", game=game, file=f"{file}_{lang}"), code=301)
 


### PR DESCRIPTION
## What is this fixing or adding?

Tutorial changed to use the actual markdown filename, so URLs indexed by search engines are wrong now.
This replaces the old URL scheme with permanent redirects, updating search indices when being crawled the next time.

As a side note: I think if we implement proper multi-language support, it should be `/tutorials/<lang>/...` or `/<lang>/tutorials/...`, so I don't think we need to change back the tutorial route at this point.

## How was this tested?

Clicking the broken sitemap links locally.