### PR TITLE
Core: Fix `get_unique_identifier` failing on missing cache folder

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -414,11 +414,11 @@ def get_adjuster_settings(game_name: str) -> Namespace:
 @cache_argsless
 def get_unique_identifier():
     common_path = cache_path("common.json")
-    if os.path.exists(common_path):
+    try:
         with open(common_path) as f:
             common_file = json.load(f)
             uuid = common_file.get("uuid", None)
-    else:
+    except FileNotFoundError:
         common_file = {}
         uuid = None
 
@@ -428,6 +428,9 @@ def get_unique_identifier():
     from uuid import uuid4
     uuid = str(uuid4())
     common_file["uuid"] = uuid
+
+    cache_folder = os.path.dirname(common_path)
+    os.makedirs(cache_folder, exist_ok=True)
     with open(common_path, "w") as f:
         json.dump(common_file, f, separators=(",", ":"))
     return uuid


### PR DESCRIPTION
## What is this fixing or adding?
Error in #5088 which caused games to fail connection if the cache folder did not already exist.

## How was this tested?
Connecting to an AHiT slot with and without the cache dir already existing.

## If this makes graphical changes, please attach screenshots.
