### PR TITLE
CV64 and CotM: Correct Archipleago

### DIFF
--- a/worlds/cv64/__init__.py
+++ b/worlds/cv64/__init__.py
@@ -37,7 +37,7 @@ class CV64Web(WebWorld):
 
     tutorials = [Tutorial(
         "Multiworld Setup Guide",
-        "A guide to setting up the Archipleago Castlevania 64 randomizer on your computer and connecting it to a "
+        "A guide to setting up the Archipelago Castlevania 64 randomizer on your computer and connecting it to a "
         "multiworld.",
         "English",
         "setup_en.md",

--- a/worlds/cvcotm/__init__.py
+++ b/worlds/cvcotm/__init__.py
@@ -41,7 +41,7 @@ class CVCotMWeb(WebWorld):
 
     tutorials = [Tutorial(
         "Multiworld Setup Guide",
-        "A guide to setting up the Archipleago Castlevania: Circle of the Moon randomizer on your computer and "
+        "A guide to setting up the Archipelago Castlevania: Circle of the Moon randomizer on your computer and "
         "connecting it to a multiworld.",
         "English",
         "setup_en.md",


### PR DESCRIPTION
## What is this fixing or adding?
Those pesky Flea Men evidently thought it would be so funny to plot an Archipelago takeover and call it Archipleago through both of my Castlevania worlds on the setup guides page! This restores the balance of the universe in said worlds.

## How was this tested?
Read the text after dowsing it in holy water to ensure they will never return...
