### PR TITLE
CI: test with py3.11.2

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -40,7 +40,7 @@ jobs:
         os: [ubuntu-latest]
         python:
           - {version: '3.10'}
-          - {version: '3.11.2'}
+          - {version: '3.11.2'}  # Change to '3.11' around 2026-06-10
           - {version: '3.12'}
         include:
           - python: {version: '3.10'}  # old compat

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -40,7 +40,7 @@ jobs:
         os: [ubuntu-latest]
         python:
           - {version: '3.10'}
-          - {version: '3.11'}
+          - {version: '3.11.2'}
           - {version: '3.12'}
         include:
           - python: {version: '3.10'}  # old compat


### PR DESCRIPTION
## What is this fixing or adding?

Uses the oldest python 3.11 in CI that is potentially wide spread.
This is the current python version on Debian 12 (oldstable).
The successor (Debian 13) was released only few days ago, so there is a good chance that Debian 12 will be around for a bit until people upgrade. Drop around 2026-06-10 when it reaches LTS?

Note: As long as we want to support 3.11.2, we have to keep the Utils.ByValue mixin and test with that version.

## How was this tested?

CI passing