### PR TITLE
Core: Make RestrictedUnpickler work with more options module naming schemes

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -467,7 +467,8 @@ class RestrictedUnpickler(pickle.Unpickler):
                 self.generic_properties_module = importlib.import_module("worlds.generic")
             return getattr(self.generic_properties_module, name)
         # pep 8 specifies that modules should have "all-lowercase names" (options, not Options)
-        if module.lower().endswith("options"):
+        # check if the end module contains the word "option" in it
+        if "option" in module.lower().rsplit('.', 1)[-1]:
             if module == "Options":
                 mod = self.options_module
             else:


### PR DESCRIPTION
## What is this?
This change will change the `RestrictedUnpickler` from requiring the options module name to end with the word "options" to instead require the options module to contain the word "option." Currently, if the module does not end with "options," then it will raise and error preventing generation on a WebHost.

### Backstory
I have a very modular options layout in my APWorld. The option classes are defined in the `options.optiondefs` module while the dataclass is defined in `options`. This works perfectly fine when I tested it. However, recently, there is the pickle dump unit test that was introduced which fails (and indicates that the WebHost would fail to generate the world). Regardless, the source of this issue is in this `RestrictedUnpickler` class where it expects the option classes to be in a module that ends with "options."

### Example what the changes do
The new changes make it so the module requires the word "option" somewhere in the end module.
For example, with module `options.optiondefs`, `optiondefs` contains the word "option," which means it is fine.
Other examples that would work with this fix would be `optiondefinitions`, `optionclasses`, `optionz`, etc.

### Another possibility
Another option is to instead check if the classes are defined in any submodule of a module called `options` on top of a module named `options`. It's cleaner logic and it could force an opinionated style for APWorlds (I am not here to force a specific style though).
Logic could be like `if "options" in module.lower().split('.')`, However, this idea would break purely Ocarina of Time based on the pickle dump Unit Test because the option module names are named like `xxOptions`.

## How was this tested?
Tested the pickle dump test in `tests/general/test_options.py` using PyTest, and generated worlds with the WebHost.
