### PR TITLE
LADX: fix local lvl 2 sword on the beach turning into a lvl 0 shield

### DIFF
--- a/worlds/ladx/LADXR/locations/beachSword.py
+++ b/worlds/ladx/LADXR/locations/beachSword.py
@@ -11,19 +11,18 @@ class BeachSword(DroppedKey):
         super().__init__(0x0F2)
 
     def patch(self, rom: ROM, option: str, *, multiworld: Optional[int] = None) -> None:
-        if option != SWORD or multiworld is not None:
-            # Set the heart piece data
-            super().patch(rom, option, multiworld=multiworld)
+        # Set the heart piece data
+        super().patch(rom, option, multiworld=multiworld)
 
-            # Patch the room to contain a heart piece instead of the sword on the beach
-            re = RoomEditor(rom, 0x0F2)
-            re.removeEntities(0x31)  # remove sword
-            re.addEntity(5, 5, 0x35)  # add heart piece
-            re.store(rom)
+        # Patch the room to contain a heart piece instead of the sword on the beach
+        re = RoomEditor(rom, 0x0F2)
+        re.removeEntities(0x31)  # remove sword
+        re.addEntity(5, 5, 0x35)  # add heart piece
+        re.store(rom)
 
-            # Prevent shield drops from the like-like from turning into swords.
-            rom.patch(0x03, 0x1B9C, ASM("ld a, [$DB4E]"), ASM("ld a, $01"), fill_nop=True)
-            rom.patch(0x03, 0x244D, ASM("ld a, [$DB4E]"), ASM("ld a, $01"), fill_nop=True)
+        # Prevent shield drops from the like-like from turning into swords.
+        rom.patch(0x03, 0x1B9C, ASM("ld a, [$DB4E]"), ASM("ld a, $01"), fill_nop=True)
+        rom.patch(0x03, 0x244D, ASM("ld a, [$DB4E]"), ASM("ld a, $01"), fill_nop=True)
 
     def read(self, rom: ROM) -> str:
         re = RoomEditor(rom, 0x0F2)


### PR DESCRIPTION
## What is this fixing or adding?
The sword is the vanilla beach item, it does a special pickup. This was previously left alone specifically if its your sword on the beach so you can still have the special pickup, but turns out in the rare case that you pick it up as your second level sword, it becomes a bugged shield instead. This is fixed by just always patching the location to a normal item pickup.

Upstream fixed this a while back, the fix here is the same:
https://github.com/daid/LADXR/commit/e3e49b16d6af03818d6820e14db8f2ba7f0a424d

Bug was reported here: https://discord.com/channels/731205301247803413/1090819435893362768/1405933901053956177

The user's patch file is a pretty easy way to test this, has a sword on tarin and second sword on beach.

This bug can make an unbeatable seed. Its rare, but L-2 sword sometimes matters in logic.

## How was this tested?
Patched with the fixes, playtested.