### PR TITLE
Core: Allow PlandoItems to be pickled

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -472,7 +472,7 @@ class RestrictedUnpickler(pickle.Unpickler):
                 mod = importlib.import_module(module)
             obj = getattr(mod, name)
             if issubclass(obj, (self.options_module.Option, self.options_module.PlandoConnection,
-                                self.options_module.PlandoText)):
+                                self.options_module.PlandoItem, self.options_module.PlandoText)):
                 return obj
         # Forbid everything else.
         raise pickle.UnpicklingError(f"global '{module}.{name}' is forbidden")


### PR DESCRIPTION
## What is this fixing or adding?
Apparently since #3046, `PlandoItems` can't be pickled since the `PlandoItem` class it contains (in `Options.py`, not worlds/generic) isn't included in `RestrictedUnpickler`. Example of issue [here](https://discord.com/channels/731205301247803413/1406036952494506096). This just adds it to the list of allowed classes in Options.

## How was this tested?
Running the failed YAML (which apparently has a non-existent item in the list and so still `KeyError`s even with local gen) and a small test YAML using an example from the plando guide through WebHost.