### PR TITLE
include vendor into ignore_dirs for test_packages_have_init

### DIFF
--- a/test/general/test_packages.py
+++ b/test/general/test_packages.py
@@ -9,7 +9,7 @@ class TestPackages(unittest.TestCase):
         import Utils
 
         # Ignore directories with these names.
-        ignore_dirs = {".github"}
+        ignore_dirs = {".github", "vendor"}
 
         worlds_path = Utils.local_path("worlds")
         for dirpath, dirnames, filenames in os.walk(worlds_path):


### PR DESCRIPTION
vendored code may not have __init__.py in every directory.

Please format your title with what portion of the project this pull request is
targeting and what it's changing.

This was tested by... testing the test by testing.
