### PR TITLE
Docker: Fix Dockerfile by updating dependant tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ COPY intset.h .
 RUN cythonize -b -i _speedups.pyx
 
 # Archipelago
-FROM python:3.12-slim AS archipelago
+FROM python:3.12-slim-bookworm AS archipelago
 ARG TARGETARCH
 ENV VIRTUAL_ENV=/opt/venv
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
## What is this fixing or adding?

Currently, the Dockerfile fails to build, as a dependant Docker Hub tag [`python:3.12-slim`](https://hub.docker.com/layers/library/python/3.12-slim/images/sha256-2a6671d21f2bf5a7e21e66baf3d502ce3242e587a5eeae1157f6e84f39c7a128) was updated to use the recently-released Debian 13.

This PR changes the Docker tag used to `python:3.12-slim-bookworm` to continue using Debian 12 as before.

I considered bumping package versions and using `python:3.12-slim-trixie` to update to Debian 13, as that also builds successfully, but I figured it'd be best to continue using an already-tested base.

## How was this tested?

Ensured the Docker image still built successfully.