### PR TITLE
Core: require setuptools>=75

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY requirements.txt WebHostLib/requirements.txt
 
 RUN pip install --no-cache-dir -r \
     WebHostLib/requirements.txt \
-    "setuptools>=80,<81"
+    "setuptools>=75,<81"
 
 COPY _speedups.pyx .
 COPY intset.h .

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY requirements.txt WebHostLib/requirements.txt
 
 RUN pip install --no-cache-dir -r \
     WebHostLib/requirements.txt \
-    "setuptools<81"
+    "setuptools>=80,<81"
 
 COPY _speedups.pyx .
 COPY intset.h .

--- a/ModuleUpdate.py
+++ b/ModuleUpdate.py
@@ -78,7 +78,7 @@ def install_pkg_resources(yes=False):
         check_pip()
         if not yes:
             confirm("pkg_resources not found, press enter to install it")
-        subprocess.call([sys.executable, "-m", "pip", "install", "--upgrade", "setuptools<81"])
+        subprocess.call([sys.executable, "-m", "pip", "install", "--upgrade", "setuptools>=80,<81"])
 
 
 def update(yes: bool = False, force: bool = False) -> None:

--- a/ModuleUpdate.py
+++ b/ModuleUpdate.py
@@ -78,7 +78,7 @@ def install_pkg_resources(yes=False):
         check_pip()
         if not yes:
             confirm("pkg_resources not found, press enter to install it")
-        subprocess.call([sys.executable, "-m", "pip", "install", "--upgrade", "setuptools>=80,<81"])
+        subprocess.call([sys.executable, "-m", "pip", "install", "--upgrade", "setuptools>=75,<81"])
 
 
 def update(yes: bool = False, force: bool = False) -> None:

--- a/ModuleUpdate.py
+++ b/ModuleUpdate.py
@@ -74,7 +74,7 @@ def update_command():
 def install_pkg_resources(yes=False):
     try:
         import pkg_resources  # noqa: F401
-    except ImportError:
+    except (AttributeError, ImportError):
         check_pip()
         if not yes:
             confirm("pkg_resources not found, press enter to install it")

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ try:
         install_cx_freeze = False
     except pkg_resources.ResolutionError:
         install_cx_freeze = True
-except ImportError:
+except (AttributeError, ImportError):
     install_cx_freeze = True
     pkg_resources = None  # type: ignore[assignment]
 


### PR DESCRIPTION
## What is this fixing or adding?

setuptools ~~70.3.0~~ 65 seems to not work for us.

See whatever is happening here <https://discord.com/channels/731205301247803413/731214280439103580/1407239379814191164>;

cx_freeze has a requirement on setuptools, so we don't want to enforce the absolute latest version.

## How was this tested?

```bash
pip uninstall setuptools
pip install setuptools==65.5
python ModuleUpdate.py
```
and see it upgrade setuptools to 80.9.0
```bash
python setup.py
```
and see it downgrade setuptools to 75.8.0