### PR TITLE
CommonClient: Use Local Datapackage if Matching

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -108,6 +108,9 @@ class ClientCommandProcessor(CommandProcessor):
         if not self.ctx.game:
             return {}
         checksum = self.ctx.checksums[self.ctx.game]
+        if checksum == network_data_package["games"][self.ctx.game]["checksum"]:
+            # datapackages in local install may not be cached, so load them directly
+            return network_data_package["games"][self.ctx.game]
         return Utils.load_data_package_for_checksum(self.ctx.game, checksum)
 
     def _cmd_missing(self, filter_text = "") -> bool:


### PR DESCRIPTION
## What is this fixing or adding?
use local datapackage in cc commands if matching because we cannot trust they are in the cache if so

## How was this tested?
added a debug statement to the new if branch, opened up Undertale client, used /items, confirmed we were in the new code and that it returned the expected items

## If this makes graphical changes, please attach screenshots.
