### PR TITLE
MultiServer: prevent GetDataPackage if PerMessageDeflate is not supported.

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -416,8 +416,6 @@ class Context:
     def notify_client_without_auth(self, client: Client, text: str, additional_arguments: dict = {}):
         if client.auth:
             return self.notify_client(client, text, additional_arguments)
-        if client.no_text:
-            return
         self.logger.info("Notice (Unauthenticated Player): " + text)
         async_start(self.send_msgs(client, [{"cmd": "PrintJSON", "data": [{ "text": text }], **additional_arguments}]))
 


### PR DESCRIPTION
## What is this fixing or adding?
Prevents GetDataPackage from giving the datapackage if the connection is not compressed.
This has several positive effects:
- encourages the use of compressed websockets
- the server sends less datapackage data
- encourages the use of IDs over names in clients
- encourages the use of the shared cache, so that proper clients can download the datapackage for non-compliant ones
- encourages clients to not crash when names are missing
- prevents this deathloop, which by now I've observed by two different clients in two different langs:
- 1. Client without pmd connects
- 2. Client requests datapackage
- 3. Client's incoming data buffer is too small to receive the incoming datapackage
- 4. Client throws an exception
- 5. Client automatically reconnects
- 6. goto 1

## How was this tested?
Minimally, CommonClient still works as expected.

