### PR TITLE
DS3: use yaml.safe_load

### DIFF
--- a/worlds/dark_souls_3/detailed_location_descriptions.py
+++ b/worlds/dark_souls_3/detailed_location_descriptions.py
@@ -22,7 +22,7 @@ if __name__ == '__main__':
     response = requests.get(url)
     if response.status_code != 200:
         raise Exception(f"Got {response.status_code} when downloading static randomizer locations")
-    annotations = yaml.load(response.text, Loader=yaml.Loader)
+    annotations = yaml.safe_load(response.text)
 
     static_to_archi_regions = {
         area['Name']: area['Archipelago']


### PR DESCRIPTION
## What is this fixing or adding?

Use a safe yaml loader in the locations help generator script in DS3.

It's unexpected that this script can execute code from nex3's github if it would get compromised, but also it's best practice to not use an unsafe loader if not required, especially when the data comes from the internet.

## How was this tested?

Wasn't