### PR TITLE
Core: Fix Priority Fill *not* crashing when it should, in cases where there is no deprioritized progression

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -549,10 +549,12 @@ def distribute_items_restrictive(multiworld: MultiWorld,
         if prioritylocations and regular_progression:
             # retry with one_item_per_player off because some priority fills can fail to fill with that optimization
             # deprioritized items are still not in the mix, so they need to be collected into state first.
+            # allow_partial should only be set if there is deprioritized progression to fall back on.
             priority_retry_state = sweep_from_pool(multiworld.state, deprioritized_progression)
             fill_restrictive(multiworld, priority_retry_state, prioritylocations, regular_progression,
                              single_player_placement=single_player, swap=False, on_place=mark_for_locking,
-                             name="Priority Retry", one_item_per_player=False, allow_partial=True)
+                             name="Priority Retry", one_item_per_player=False,
+                             allow_partial=bool(deprioritized_progression))
 
         if prioritylocations and deprioritized_progression:
             # There are no more regular progression items that can be placed on any priority locations.


### PR DESCRIPTION
Fixes an issue introduced in https://github.com/ArchipelagoMW/Archipelago/pull/4610

If there are regular progression items and deprioritized items, and there is no way to fill the priority locations with only regular progression, deprioritized progression will be used instead. If that also doesn't work, it crashes. So far, so good.

But: If there are regular progression items and *no* deprioritized items, it *doesn't* crash, because the place it would crash (the final attempt using allow_partial = True) never happens. Which is wrong. So this fixes that