### PR TITLE
Pokemon Red and Blue: Don't add PC item to pre_fill_items pool if on key_items_only

### DIFF
--- a/worlds/pokemon_rb/__init__.py
+++ b/worlds/pokemon_rb/__init__.py
@@ -518,7 +518,8 @@ class PokemonRedBlueWorld(World):
 
     def get_pre_fill_items(self) -> typing.List["Item"]:
         pool = [self.create_item(mon) for mon in poke_data.pokemon_data]
-        pool.append(self.pc_item)
+        if not self.options.key_items_only:
+            pool.append(self.pc_item)
         return pool
 
     @classmethod


### PR DESCRIPTION
When using key_items_only, pc_item is just None, not an actual item.  Adding it to the pool here breaks generation if any item plando is used.

This was tested by taking a default PRB yaml, setting key_items_only to true, and a default DOOM 1993 yaml, and plandoing a Box of Bullets to Hangar (E1M1) - Mega Armor.  Before this change, generating a multiworld with those two yamls broke.  With this change, the generation succeeds.  I also verified that the patch file from that generation worked, and I could retrieve the PC item from the resulting game (not an AP item) and send checks to the multiworld.