### PR TITLE
Core: Improved GER's caching of visited nodes during initialization

### DIFF
--- a/entrance_rando.py
+++ b/entrance_rando.py
@@ -74,7 +74,7 @@ class EntranceLookup:
         if entrance in self._expands_graph_cache:
             return self._expands_graph_cache[entrance]
 
-        visited = {entrance.connected_region}
+        seen = {entrance.connected_region}
         q: deque[Region] = deque()
         q.append(entrance.connected_region)
 
@@ -102,8 +102,8 @@ class EntranceLookup:
                         and exit_ in self._usable_exits):
                     self._expands_graph_cache[entrance] = True
                     return True
-                elif exit_.connected_region and exit_.connected_region not in visited:
-                    visited.add(exit_.connected_region)
+                elif exit_.connected_region and exit_.connected_region not in seen:
+                    seen.add(exit_.connected_region)
                     q.append(exit_.connected_region)
 
         self._expands_graph_cache[entrance] = False

--- a/entrance_rando.py
+++ b/entrance_rando.py
@@ -74,13 +74,12 @@ class EntranceLookup:
         if entrance in self._expands_graph_cache:
             return self._expands_graph_cache[entrance]
 
-        visited = set()
+        visited = {entrance.connected_region}
         q: deque[Region] = deque()
         q.append(entrance.connected_region)
 
         while q:
             region = q.popleft()
-            visited.add(region)
 
             # check if the region itself is progression
             if region in region.multiworld.indirect_connections:
@@ -104,6 +103,7 @@ class EntranceLookup:
                     self._expands_graph_cache[entrance] = True
                     return True
                 elif exit_.connected_region and exit_.connected_region not in visited:
+                    visited.add(exit_.connected_region)
                     q.append(exit_.connected_region)
 
         self._expands_graph_cache[entrance] = False


### PR DESCRIPTION
## What is this fixing or adding?
Currently, on densely packed regions with a lot of interconnectivity, regions are added several times to the queue, which leads to exponential times
### Small example:
Say we have 0 >1, 0>2, 0>3, 1>2,1>3 and 2>3. 0 will add 1, 2, 3 to the queue, then 1 on explore will add 2 and 3, then 2 will add 3 twice to the queue and now 3 is explored 4 times in this minimal example

## How was this tested?
On my Tilesanity branch, GER was still initializing after 10 minutes. After this fix, it was done in a second

## If this makes graphical changes, please attach screenshots.
