### PR TITLE
[Core] [Draft] Implement connection blocking to multiserver.py to prevent misuse

### DIFF
--- a/HOLDING
+++ b/HOLDING
@@ -1,0 +1,2 @@
+Archipelago-Dev
+DraftPR Holder :)


### PR DESCRIPTION
Looking into implementing rate-limiting connections to the multiserver to prevent misuse.
There are no guiderails in place currently, so I'd like to set them up. (Not because I'm the one breaking AP, but.. ok it's because I'm the one breaking AP. I figure if I'm the one who caused the issue, I can be one of the people to help stop it.)


Current plan;
1) If a haltable error occurs (invalid slot, password, etc), log connection details and issue, then add 1 to the connection's 'bonk' counter.
2) Intercept connection packets and compare connection to the 'bonk' counter.
  - We only bother with the Connect packet as if they pass this point they're allowed to be there.
3) If bonk counter is too high, sever the connection by preventing the websocket handshake from completing with process_request or process_response.
4) After the next successful connection, clear the bonk counter.

Thinking, 5 bonks within 15 minutes, triggers a block for 15minutes. If they try again within this 15 minutes, it'll reset the timer to 15min. Pretty standard rules that we use in the sysadmin world for Active Directory. Keeps baddies away by locking them away.
That's enough bonks to keep the end-users out of trouble, and still catch the nefarious bots.

Also may need/want a way to unblock via command in the console.
