### PR TITLE
WebHost: Add Core Verified / Custom entry to glossary

### DIFF
--- a/WebHostLib/static/assets/glossary/en.md
+++ b/WebHostLib/static/assets/glossary/en.md
@@ -31,6 +31,12 @@ share a world that way, usually with only one player connected to the multiworld
 * On the programming side, a world typically represents the package that integrates Archipelago with a
 particular game. For example this could be the entire `worlds/factorio` directory.
 
+## Core Verified / Custom
+A Core Verified world is an integration that is included by default with Archipelago in the `worlds` folder,
+and able to be generated on the main archipelago.gg website. There are also many other games playable in
+Archipelago using separately installable "Custom" worlds. These types of worlds are also sometimes referred
+to as "Supported" and "Unsupported" respectively.
+
 ## RNG
 Acronym for "Random Number Generator." Archipelago uses its own custom Random object with a unique seed per generation,
 or, if running from source, a seed can be supplied and this seed will control all randomization during generation as all


### PR DESCRIPTION
## What is this fixing or adding?
Adds a short description of the "Core Verified" and "Custom" terminology to the glossary. I've kept it brief and stuck to the terminology itself without explaining much about the the use of each since that's probably better suited for #4490. I also figured it made most sense to have a single entry for both. I do think this plays somewhat weirdly with the use of "Supported" on the FAQ page though.
Small bit of discussion here. https://discord.com/channels/731205301247803413/731214280439103580/1404997525634678907

## How was this tested?
Looking at it in local webhost.

## If this makes graphical changes, please attach screenshots.
<img width="1595" height="277" alt="image" src="https://github.com/user-attachments/assets/96e6f6d8-5b59-4870-beef-b890d4348c62" />