### PR TITLE
[Docs] Update docs/network protocol.md/NetworkVersion to include class field

### DIFF
--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -647,7 +647,7 @@ class Version(NamedTuple):
     build: int
 ```
 
-If constructing version information as a Dict for a custom client rather than as a NamedTuple built into the CommonClient, you must use add the `class` key to allow Archipelago to compare version support.
+If constructing version information as a dict for a custom client rather than as a NamedTuple built into the CommonClient, you must add the `class` key to allow Archipelago to compare version support.
 ```
 "version": {
       "class": "Version",


### PR DESCRIPTION
In response to #4339

Tested with a custom client, removing `class` from the dict causes the Multiserver to throw a fit

`[2025-08-29 17:29:28,416]: '>' not supported between instances of 'Version' and 'dict'
Traceback (most recent call last):
  File "/Projects/Archipelago/MultiServer.py", line 861, in server
    await process_client_cmd(ctx, client, msg)
  File "/Projects/Archipelago/MultiServer.py", line 1809, in process_client_cmd
    if minver > args['version']:
       ^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '>' not supported between instances of 'Version' and 'dict'`

Re-adding `class` allowed the slot to keep the connection open.

------
Updating Network Protocol to reflect required fields with dict formatting