### PR TITLE
[Webhost] API Fix - Rename player_timers to players in api/tracker.py

### DIFF
--- a/WebHostLib/api/tracker.py
+++ b/WebHostLib/api/tracker.py
@@ -112,7 +112,7 @@ def tracker_data(tracker: UUID) -> dict[str, Any]:
     client_activity_timers: tuple[tuple[int, int], float] = tracker_data._multisave.get("client_activity_timers", ())
     for (team, player), timestamp in client_activity_timers:
         # use index since we can rely on order
-        activity_timers[team]["player_timers"][player - 1]["time"] = datetime.fromtimestamp(timestamp, timezone.utc)
+        activity_timers[team]["players"][player - 1]["time"] = datetime.fromtimestamp(timestamp, timezone.utc)
 
     connection_timers: list[dict[str, int | list[PlayerTimer]]] = []
     """Time of last connection per player. Returned as RFC 1123 format and null if no connection has been made."""


### PR DESCRIPTION

`player_timers` doesn't exist as a key, rather it's `players` within the Activity_timer dict
Fixes #5378 



Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?

## How was this tested?
Localy, 500s are gone

## If this makes graphical changes, please attach screenshots.
