### PR TITLE
Webhost: Fix Tracker API

### DIFF
--- a/WebHostLib/api/tracker.py
+++ b/WebHostLib/api/tracker.py
@@ -4,7 +4,7 @@ from uuid import UUID
 
 from flask import abort
 
-from NetUtils import ClientStatus, Hint, NetworkItem, SlotType
+from NetUtils import ClientStatus, Hint, NetworkItem, SlotType, convert_to_base_types
 from WebHostLib import cache
 from WebHostLib.api import api_endpoints
 from WebHostLib.models import Room
@@ -112,7 +112,7 @@ def tracker_data(tracker: UUID) -> dict[str, Any]:
     client_activity_timers: tuple[tuple[int, int], float] = tracker_data._multisave.get("client_activity_timers", ())
     for (team, player), timestamp in client_activity_timers:
         # use index since we can rely on order
-        activity_timers[team]["player_timers"][player - 1]["time"] = datetime.fromtimestamp(timestamp, timezone.utc)
+        activity_timers[team]["players"][player - 1]["time"] = datetime.fromtimestamp(timestamp, timezone.utc)
 
     connection_timers: list[dict[str, int | list[PlayerTimer]]] = []
     """Time of last connection per player. Returned as RFC 1123 format and null if no connection has been made."""
@@ -226,5 +226,5 @@ def get_static_tracker_data(room: Room) -> dict[str, Any]:
 
     return {
         "groups": groups,
-        "slot_data": slot_data,
+        "slot_data": convert_to_base_types(slot_data),
     }


### PR DESCRIPTION
## What is this fixing or adding?
re-allow sets and fix missed player_timers rename
fixes #5378

## How was this tested?
ran webhost locally, sent one check, opened tracker api url for the room
happened to run it with a Celeste (Open World) room i had laying around which is what found the set issue

## If this makes graphical changes, please attach screenshots.
