### PR TITLE
Core: improve formatting on /help command

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1300,7 +1300,8 @@ class CommandProcessor(metaclass=CommandMeta):
                         argname += "=" + parameter.default
                 argtext += argname
                 argtext += " "
-            s += f"{self.marker}{command} {argtext}\n    {'\n    '.join(inspect.getdoc(method).split('\n'))}\n"
+            doctext = '\n    '.join(inspect.getdoc(method).split('\n'))
+            s += f"{self.marker}{command} {argtext}\n    {doctext}\n"
         return s
 
     def _cmd_help(self):


### PR DESCRIPTION
## What is this fixing or adding?
updates /help textgen to have a uniform 4 space indent and strip newlines from the start and end.

## How was this tested?
by looking at /help in textclient

## If this makes graphical changes, please attach screenshots.
Before on the left, after on the right.
Notable changes in /missing and /item_groups
<img width="1475" height="887" alt="image" src="https://github.com/user-attachments/assets/aca3ec92-bb39-465d-b028-e87ee0f3e8b0" />
