### PR TITLE
Core: Remove lttp module requirement from generation

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -166,19 +166,10 @@ def main(args=None) -> tuple[argparse.Namespace, int]:
                         f"A mix is also permitted.")
 
     from worlds.AutoWorld import AutoWorldRegister
-    from worlds.alttp.EntranceRandomizer import parse_arguments
-    erargs = parse_arguments(['--multi', str(args.multi)])
-    erargs.seed = seed
-    erargs.plando_options = args.plando
-    erargs.spoiler = args.spoiler
-    erargs.race = args.race
-    erargs.outputname = seed_name
-    erargs.outputpath = args.outputpath
-    erargs.skip_prog_balancing = args.skip_prog_balancing
-    erargs.skip_output = args.skip_output
-    erargs.spoiler_only = args.spoiler_only
-    erargs.name = {}
-    erargs.csv_output = args.csv_output
+    args.outputname = seed_name
+    args.sprite = dict.fromkeys(range(1, args.multi+1), None)
+    args.sprite_pool = dict.fromkeys(range(1, args.multi+1), None)
+    args.name = {}
 
     settings_cache: dict[str, tuple[argparse.Namespace, ...]] = \
         {fname: (tuple(roll_settings(yaml, args.plando) for yaml in yamls) if args.sameoptions else None)
@@ -205,7 +196,7 @@ def main(args=None) -> tuple[argparse.Namespace, int]:
     for player in range(1, args.multi + 1):
         player_path_cache[player] = player_files.get(player, args.weights_file_path)
     name_counter = Counter()
-    erargs.player_options = {}
+    args.player_options = {}
 
     player = 1
     while player <= args.multi:
@@ -218,21 +209,21 @@ def main(args=None) -> tuple[argparse.Namespace, int]:
                     for k, v in vars(settingsObject).items():
                         if v is not None:
                             try:
-                                getattr(erargs, k)[player] = v
+                                getattr(args, k)[player] = v
                             except AttributeError:
-                                setattr(erargs, k, {player: v})
+                                setattr(args, k, {player: v})
                             except Exception as e:
                                 raise Exception(f"Error setting {k} to {v} for player {player}") from e
 
                     # name was not specified
-                    if player not in erargs.name:
+                    if player not in args.name:
                         if path == args.weights_file_path:
                             # weights file, so we need to make the name unique
-                            erargs.name[player] = f"Player{player}"
+                            args.name[player] = f"Player{player}"
                         else:
                             # use the filename
-                            erargs.name[player] = os.path.splitext(os.path.split(path)[-1])[0]
-                    erargs.name[player] = handle_name(erargs.name[player], player, name_counter)
+                            args.name[player] = os.path.splitext(os.path.split(path)[-1])[0]
+                    args.name[player] = handle_name(args.name[player], player, name_counter)
 
                     player += 1
             except Exception as e:
@@ -240,10 +231,10 @@ def main(args=None) -> tuple[argparse.Namespace, int]:
         else:
             raise RuntimeError(f'No weights specified for player {player}')
 
-    if len(set(name.lower() for name in erargs.name.values())) != len(erargs.name):
-        raise Exception(f"Names have to be unique. Names: {Counter(name.lower() for name in erargs.name.values())}")
+    if len(set(name.lower() for name in args.name.values())) != len(args.name):
+        raise Exception(f"Names have to be unique. Names: {Counter(name.lower() for name in args.name.values())}")
 
-    return erargs, seed
+    return args, seed
 
 
 def read_weights_yamls(path) -> tuple[Any, ...]:

--- a/Main.py
+++ b/Main.py
@@ -37,7 +37,7 @@ def main(args, seed=None, baked_server_options: dict[str, object] | None = None)
 
     logger = logging.getLogger()
     multiworld.set_seed(seed, args.race, str(args.outputname) if args.outputname else None)
-    multiworld.plando_options = args.plando_options
+    multiworld.plando_options = args.plando
     multiworld.game = args.game.copy()
     multiworld.player_name = args.name.copy()
     multiworld.sprite = args.sprite.copy()

--- a/WebHost.py
+++ b/WebHost.py
@@ -99,11 +99,11 @@ if __name__ == "__main__":
     multiprocessing.set_start_method('spawn')
     logging.basicConfig(format='[%(asctime)s] %(message)s', level=logging.INFO)
 
-    from WebHostLib.lttpsprites import update_sprites_lttp
     from WebHostLib.autolauncher import autohost, autogen, stop
     from WebHostLib.options import create as create_options_files
 
     try:
+        from WebHostLib.lttpsprites import update_sprites_lttp
         update_sprites_lttp()
     except Exception as e:
         logging.exception(e)

--- a/WebHostLib/lttpsprites.py
+++ b/WebHostLib/lttpsprites.py
@@ -3,10 +3,10 @@ import threading
 import json
 
 from Utils import local_path, user_path
-from worlds.alttp.Rom import Sprite
 
 
 def update_sprites_lttp():
+    from worlds.alttp.Rom import Sprite
     from tkinter import Tk
     from LttPAdjuster import get_image_for_sprite
     from LttPAdjuster import BackgroundTaskProgress

--- a/worlds/bumpstik/Items.py
+++ b/worlds/bumpstik/Items.py
@@ -6,7 +6,6 @@
 import typing
 
 from BaseClasses import Item, ItemClassification
-from worlds.alttp import ALTTPWorld
 
 
 class BumpStikLttPText(typing.NamedTuple):
@@ -117,13 +116,17 @@ item_table = {
     item: offset + x for x, item in enumerate(LttPCreditsText.keys())
 }
 
-ALTTPWorld.pedestal_credit_texts.update({item_table[name]: f"and the {texts.pedestal}"
-                                         for name, texts in LttPCreditsText.items()})
-ALTTPWorld.sickkid_credit_texts.update(
-    {item_table[name]: texts.sickkid for name, texts in LttPCreditsText.items()})
-ALTTPWorld.magicshop_credit_texts.update(
-    {item_table[name]: texts.magicshop for name, texts in LttPCreditsText.items()})
-ALTTPWorld.zora_credit_texts.update(
-    {item_table[name]: texts.zora for name, texts in LttPCreditsText.items()})
-ALTTPWorld.fluteboy_credit_texts.update(
-    {item_table[name]: texts.fluteboy for name, texts in LttPCreditsText.items()})
+try:
+    from worlds.alttp import ALTTPWorld
+    ALTTPWorld.pedestal_credit_texts.update({item_table[name]: f"and the {texts.pedestal}"
+                                             for name, texts in LttPCreditsText.items()})
+    ALTTPWorld.sickkid_credit_texts.update(
+        {item_table[name]: texts.sickkid for name, texts in LttPCreditsText.items()})
+    ALTTPWorld.magicshop_credit_texts.update(
+        {item_table[name]: texts.magicshop for name, texts in LttPCreditsText.items()})
+    ALTTPWorld.zora_credit_texts.update(
+        {item_table[name]: texts.zora for name, texts in LttPCreditsText.items()})
+    ALTTPWorld.fluteboy_credit_texts.update(
+        {item_table[name]: texts.fluteboy for name, texts in LttPCreditsText.items()})
+except ModuleNotFoundError:
+    pass

--- a/worlds/meritous/Items.py
+++ b/worlds/meritous/Items.py
@@ -6,7 +6,6 @@
 import typing
 
 from BaseClasses import Item, ItemClassification
-from worlds.alttp import ALTTPWorld
 
 
 class MeritousLttPText(typing.NamedTuple):
@@ -206,9 +205,13 @@ item_groups = {
     "Crystals": ["Crystals x500", "Crystals x1000", "Crystals x2000"]
 }
 
-ALTTPWorld.pedestal_credit_texts.update({item_table[name]: f"and the {texts.pedestal}"
-                                         for name, texts in LttPCreditsText.items()})
-ALTTPWorld.sickkid_credit_texts.update({item_table[name]: texts.sickkid for name, texts in LttPCreditsText.items()})
-ALTTPWorld.magicshop_credit_texts.update({item_table[name]: texts.magicshop for name, texts in LttPCreditsText.items()})
-ALTTPWorld.zora_credit_texts.update({item_table[name]: texts.zora for name, texts in LttPCreditsText.items()})
-ALTTPWorld.fluteboy_credit_texts.update({item_table[name]: texts.fluteboy for name, texts in LttPCreditsText.items()})
+try:
+    from worlds.alttp import ALTTPWorld
+    ALTTPWorld.pedestal_credit_texts.update({item_table[name]: f"and the {texts.pedestal}"
+                                             for name, texts in LttPCreditsText.items()})
+    ALTTPWorld.sickkid_credit_texts.update({item_table[name]: texts.sickkid for name, texts in LttPCreditsText.items()})
+    ALTTPWorld.magicshop_credit_texts.update({item_table[name]: texts.magicshop for name, texts in LttPCreditsText.items()})
+    ALTTPWorld.zora_credit_texts.update({item_table[name]: texts.zora for name, texts in LttPCreditsText.items()})
+    ALTTPWorld.fluteboy_credit_texts.update({item_table[name]: texts.fluteboy for name, texts in LttPCreditsText.items()})
+except ModuleNotFoundError:
+    pass


### PR DESCRIPTION
## What is this fixing or adding?
lazy import or try/catch some lttp imports, as well as remove the alttp.EntranceRandomizer call in generate/webhost and replace it with the literal defaults already being used

could also potentially come with a full deletion of `alttp.EntranceRandomizer`, but I didn't know if there was still a usecase for it that didn't have test coverage

## How was this tested?
ran unit tests, someone should gen lttp to make sure the patch files still work

also ran unit test with #5338 merged in and saw only the one expected error for the item group test noted in that ticket that uses lttp by game name, but nothing attempted to import the world that wasn't caught

## If this makes graphical changes, please attach screenshots.
