### PR TITLE
[TLOZ] Move completion condition to be before set_rules is complete

### DIFF
--- a/worlds/tloz/Rules.py
+++ b/worlds/tloz/Rules.py
@@ -13,6 +13,13 @@ def set_rules(tloz_world: "TLoZWorld"):
     options = tloz_world.options
 
     tloz_world.multiworld.completion_condition[player] = lambda state: state.has("Rescued Zelda!", player)
+    ganon = tloz_world.multiworld.get_location("Ganon", player)
+    ganon.place_locked_item(tloz_world.create_event("Triforce of Power"))
+    add_rule(ganon, lambda state: state.has("Silver Arrow", player) and state.has("Bow", player))
+
+    tloz_world.multiworld.get_location("Zelda", player).place_locked_item(tloz_world.create_event("Rescued Zelda!"))
+    add_rule(tloz_world.multiworld.get_location("Zelda", player),
+             lambda state: state.has("Triforce of Power", player))
 
     # Boss events for a nicer spoiler log play through
     for level in range(1, 9):

--- a/worlds/tloz/__init__.py
+++ b/worlds/tloz/__init__.py
@@ -188,13 +188,7 @@ class TLoZWorld(World):
     set_rules = set_rules
 
     def generate_basic(self):
-        ganon = self.multiworld.get_location("Ganon", self.player)
-        ganon.place_locked_item(self.create_event("Triforce of Power"))
-        add_rule(ganon, lambda state: state.has("Silver Arrow", self.player) and state.has("Bow", self.player))
-
-        self.multiworld.get_location("Zelda", self.player).place_locked_item(self.create_event("Rescued Zelda!"))
-        add_rule(self.multiworld.get_location("Zelda", self.player),
-                 lambda state: state.has("Triforce of Power", self.player))
+        pass
 
 
     def apply_base_patch(self, rom):


### PR DESCRIPTION
## What is this fixing or adding?
Moves setting of the completion condition from generate_basic to set_rules. Addresses #4566 and #4563.

## How was this tested?
Ran some generations, verified that generations completed successfully and that the game was still beatable with required items still showing up in the spoiler playthrough.

## If this makes graphical changes, please attach screenshots.
N/A