### PR TITLE
[FF1] Added Deep Dungeon locations to locations.json so they exist in the datapackage

### DIFF
--- a/worlds/ff1/data/locations.json
+++ b/worlds/ff1/data/locations.json
@@ -253,5 +253,17 @@
   "CubeBot": 529,
   "Sarda": 525,
   "Fairy": 531,
-  "Lefein": 527
+  "Lefein": 527,
+  "DeepDungeon32B_Chest144": 401,
+  "DeepDungeon30B_Chest145": 402,
+  "DeepDungeon29B_Chest146": 403,
+  "DeepDungeon29B_Chest147": 404,
+  "DeepDungeon40B_Chest186": 443,
+  "DeepDungeon38B_Chest188": 445,
+  "DeepDungeon36B_Chest189": 446,
+  "DeepDungeon33B_Chest190": 447,
+  "DeepDungeon40B_Chest191": 448,
+  "DeepDungeon41B_Chest192": 449,
+  "DeepDungeon34B_Chest193": 450,
+  "DeepDungeon39B_Chest194": 451
 }


### PR DESCRIPTION
## What is this fixing or adding?
What it says on the tin, really. In the Deep Dungeon mode of FF1R, extra treasure chests are added. These were being provided as locations in the YAML but didn't exist in the static data, resulting in errors when attempting to look up information about them in the world data. This PR fixes that, adding in those locations so they can be handled properly.

## How was this tested?
Ran generations with and without the added locations on a Deep Dungeon FF1R seed. Without the fix, locations appeared on the web tracker as Unknown Location with a parenthetical ID. With, they appear as the other locations do, with names entries.

## If this makes graphical changes, please attach screenshots.
N/A