### PR TITLE
WebHost: Fix Tracker API crashing when there are sets/etc. in slot data

### DIFF
--- a/WebHostLib/api/tracker.py
+++ b/WebHostLib/api/tracker.py
@@ -4,7 +4,7 @@ from uuid import UUID
 
 from flask import abort
 
-from NetUtils import ClientStatus, Hint, NetworkItem, SlotType
+from NetUtils import ClientStatus, Hint, NetworkItem, SlotType, _scan_for_TypedTuples
 from WebHostLib import cache
 from WebHostLib.api import api_endpoints
 from WebHostLib.models import Room
@@ -228,5 +228,5 @@ def get_static_tracker_data(room: Room) -> dict[str, Any]:
 
     return {
         "groups": groups,
-        "slot_data": slot_data,
+        "slot_data": _scan_for_TypedTuples(slot_data),
     }


### PR DESCRIPTION
https://github.com/ArchipelagoMW/Archipelago/pull/5380 aimed to fix two issues with the tracker api, one of which was that slot_data with sets or other non-json-encodable objects would crash.

Berserker closed this PR, claiming that these rooms are not playable anyway

That is just plain false.
MultiServer messages, including connect packets with slot_data, get dumped using this dumper: https://github.com/ArchipelagoMW/Archipelago/blob/main/MultiServer.py#L172
The `encode` function referenced here is this one: https://github.com/ArchipelagoMW/Archipelago/blob/main/NetUtils.py#L138-L139

And what do we see in this `_scan_for_typed_tuples` function?
https://github.com/ArchipelagoMW/Archipelago/blob/main/NetUtils.py#L103-L104
A conversion of sets to tuple.