### PR TITLE
LADX: Drop a marin text option that makes patching fail

### DIFF
--- a/worlds/ladx/LADXR/patches/marin.txt
+++ b/worlds/ladx/LADXR/patches/marin.txt
@@ -424,7 +424,6 @@ Oh, look at that. Link's Awakened.\nYou did it, you beat the game.
 Excellent armaments, #####. Please return - \nCOVERED IN BLOOD -\n...safe and sound.
 Pray return to the Link's Awakening Sands.
 This Marin dialogue was inspired by The Witness's audiologs.
-You're awake!\n....\nYou were warned.\nI'm now going to say every word beginning with Z!\nZA\nZABAGLIONE\nZABAGLIONES\nZABAIONE\nZABAIONES\nZABAJONE\nZABAJONES\nZABETA\nZABETAS\nZABRA\nZABRAS\nZABTIEH\nZABTIEHS\nZACATON\nZACATONS\nZACK\nZACKS\nZADDICK\nZADDIK\nZADDIKIM\nZADDIKS\nZAFFAR\nzAFFARS\nZAFFER\nZAFFERS\nZAFFIR\n....\n....\n....\nI'll let you off easy.\nThis time.
 Leave me alone, I'm Marinating.
 praise be to the tungsten cube
 If you play multiple seeds in a row, you can pretend that each run is the dream you awaken from in the next.


### PR DESCRIPTION
## What is this fixing or adding?
The fix for marin text line splitting (https://github.com/ArchipelagoMW/Archipelago/pull/5225) has revealed another bad marin text. The issue is number of line breaks on this one, rather than just length.

It makes patching fail and has a 1/460 chance of being selected.

## How was this tested?
patching
