### PR TITLE
LADX: Fix quickswap

### DIFF
--- a/worlds/ladx/LADXR/generator.py
+++ b/worlds/ladx/LADXR/generator.py
@@ -242,9 +242,9 @@ def generateRom(base_rom: bytes, args, patch_data: Dict):
     #    patches.health.setStartHealth(rom, 1)
 
     patches.inventory.songSelectAfterOcarinaSelect(rom)
-    if options["quickswap"] == 'a':
+    if options["quickswap"] == Options.Quickswap.option_a:
         patches.core.quickswap(rom, 1)
-    elif options["quickswap"] == 'b':
+    elif options["quickswap"] == Options.Quickswap.option_b:
         patches.core.quickswap(rom, 0)
 
     patches.core.addBootsControls(rom, options["boots_controls"])


### PR DESCRIPTION
## What is this fixing or adding?
After the switch to APPP, the quickswap option was being checked wrong. Its reading the options after `as_dict`, so the string comparison doesn't work.

This results in the quickswap convenience setting never being enabled.

https://github.com/ArchipelagoMW/Archipelago/blob/6c2d68e38649c5d587933611b2dfd752fda1a7f3/worlds/ladx/Rom.py#L80

## How was this tested?
patching
