### PR TITLE
AHIT: Add option to shuffle Battle of the Birds director tokens and time bonus pickups

### DIFF
--- a/worlds/ahit/Locations.py
+++ b/worlds/ahit/Locations.py
@@ -63,6 +63,9 @@ def is_location_valid(world: "HatInTimeWorld", location: str) -> bool:
     if not world.options.ShuffleStorybookPages and location in storybook_pages.keys():
         return False
 
+    if not world.options.ShuffleDirectorTokens and location in director_tokens.keys():
+        return False
+
     if not world.options.ShuffleActContracts and location in contract_locations.keys():
         return False
 
@@ -566,6 +569,34 @@ storybook_pages = {
     "Rumbi Factory - Page: Last Area": LocData(2000345883, "Time Rift - Rumbi Factory", dlc_flags=HatDLC.dlc2),
 }
 
+director_tokens = {
+    "Murder on the Owl Express - Conductor Token: Cafeteria": LocData(2001104767, "Murder on the Owl Express"),
+    "Murder on the Owl Express - Conductor Token: Recreational Room": LocData(2001104768, "Murder on the Owl Express"),
+    "Picture Perfect - DJ Grooves Token: Cardboard Puppy": LocData(2001203990, "Picture Perfect"),
+    "Picture Perfect - DJ Grooves Token: Card Guessing Game": LocData(2001203991, "Picture Perfect"),
+    "Picture Perfect - DJ Grooves Token: Back Alley": LocData(2001203992, "Picture Perfect"),
+    "Picture Perfect - DJ Grooves Token: Cooking Show": LocData(2001203993, "Picture Perfect"),
+    "Picture Perfect - DJ Grooves Token: Pon Cluster": LocData(2001203987, "Picture Perfect"),
+    "Train Rush - Time Bonus: 1st Room": LocData(2001305235, "Train Rush", hookshot=True),
+    "Train Rush - Time Bonus: Falling Platform": LocData(2001305189, "Train Rush", hookshot=True),
+    "Train Rush - Time Bonus: Acid Crates": LocData(2001305186, "Train Rush", hookshot=True),
+    "Train Rush - Time Bonus: Balloon": LocData(2001305239, "Train Rush", hookshot=True),
+    "Train Rush - Time Bonus: Ring of Fire": LocData(2001305237, "Train Rush", hookshot=True),
+    "Train Rush - Time Bonus: Blue Panels": LocData(2001305236, "Train Rush", hookshot=True),
+    "Train Rush - Time Bonus: Sinking Lava Platform": LocData(2001305234, "Train Rush", hookshot=True),
+    "Train Rush - Time Bonus: Lava Panels 1": LocData(2001305193, "Train Rush", hookshot=True),
+    "Train Rush - Time Bonus: Lava Panels 2": LocData(2001305190, "Train Rush", hookshot=True),
+    "Train Rush - Time Bonus: Lava Panels 3": LocData(2001305238, "Train Rush", hookshot=True),
+    "The Big Parade - DJ Grooves Token (1/8)": LocData(2001400000, "The Big Parade"),
+    "The Big Parade - DJ Grooves Token (2/8)": LocData(2001400001, "The Big Parade"),
+    "The Big Parade - DJ Grooves Token (3/8)": LocData(2001400002, "The Big Parade"),
+    "The Big Parade - DJ Grooves Token (4/8)": LocData(2001400003, "The Big Parade"),
+    "The Big Parade - DJ Grooves Token (5/8)": LocData(2001400004, "The Big Parade", hit_type=HitType.umbrella),
+    "The Big Parade - DJ Grooves Token (6/8)": LocData(2001400005, "The Big Parade", hit_type=HitType.umbrella),
+    "The Big Parade - DJ Grooves Token (7/8)": LocData(2001400006, "The Big Parade", hit_type=HitType.umbrella),
+    "The Big Parade - DJ Grooves Token (8/8)": LocData(2001400007, "The Big Parade", hit_type=HitType.umbrella),
+}
+
 shop_locations = {
     "Badge Seller - Item 1": LocData(2000301003, "Badge Seller"),
     "Badge Seller - Item 2": LocData(2000301004, "Badge Seller"),
@@ -1050,6 +1081,7 @@ location_table = {
     **ahit_locations,
     **act_completions,
     **storybook_pages,
+    **director_tokens,
     **contract_locations,
     **shop_locations,
 }

--- a/worlds/ahit/Options.py
+++ b/worlds/ahit/Options.py
@@ -72,6 +72,7 @@ def adjust_options(world: "HatInTimeWorld"):
         world.options.EndGoal.value = EndGoal.option_seal_the_deal
         world.options.ActRandomizer.value = 0
         world.options.ShuffleAlpineZiplines.value = 0
+        world.options.ShuffleDirectorTokens.value = 0
         world.options.ShuffleSubconPaintings.value = 0
         world.options.ShuffleStorybookPages.value = 0
         world.options.ShuffleActContracts.value = 0
@@ -217,6 +218,12 @@ class ShuffleStorybookPages(DefaultOnToggle):
     """If enabled, each storybook page in the purple Time Rifts is an item check.
     The Compass Badge can track these down for you."""
     display_name = "Shuffle Storybook Pages"
+
+
+class ShuffleDirectorTokens(Toggle):
+    """If enabled, causes the Conductor/DJ Grooves tokens found in Chapter 2 levels to become item checks.
+    NOTE: This also includes the time bonus pickups from Train Rush, since the level doesn't have any tokens."""
+    display_name = "Shuffle Director Tokens"
 
 
 class ShuffleActContracts(DefaultOnToggle):
@@ -623,23 +630,6 @@ class ParadeTrapWeight(Range):
     default = 20
 
 
-class DeathLinkAmnesty(Range):
-    """Amount of forgiven deaths before sending a Death Link.
-    0 means that every death will send a Death Link."""
-    display_name = "Death Link Amnesty"
-    range_start = 0
-    range_end = 20
-    default = 0
-
-
-class DWDeathLinkAmnesty(Range):
-    """Amount of forgiven deaths before sending a Death Link during Death Wish levels."""
-    display_name = "Death Wish Amnesty"
-    range_start = 0
-    range_end = 30
-    default = 5
-
-
 @dataclass
 class AHITOptions(PerGameCommonOptions):
     start_inventory_from_pool: StartInventoryPool
@@ -658,6 +648,7 @@ class AHITOptions(PerGameCommonOptions):
     StartWithCompassBadge:    StartWithCompassBadge
     CompassBadgeMode:         CompassBadgeMode
     ShuffleStorybookPages:    ShuffleStorybookPages
+    ShuffleDirectorTokens:    ShuffleDirectorTokens
     ShuffleActContracts:      ShuffleActContracts
     ShuffleSubconPaintings:   ShuffleSubconPaintings
     NoPaintingSkips:          NoPaintingSkips
@@ -717,12 +708,11 @@ class AHITOptions(PerGameCommonOptions):
     ParadeTrapWeight:         ParadeTrapWeight
 
     death_link:               DeathLink
-    death_link_amnesty:       DeathLinkAmnesty
-    dw_death_link_amnesty:    DWDeathLinkAmnesty
 
 
 ahit_option_groups: Dict[str, List[Any]] = {
-    "General Options": [EndGoal, ShuffleStorybookPages, ShuffleAlpineZiplines, ShuffleSubconPaintings,
+    "General Options": [EndGoal, ShuffleStorybookPages, ShuffleDirectorTokens,
+                        ShuffleAlpineZiplines, ShuffleSubconPaintings,
                         ShuffleActContracts, MinPonCost, MaxPonCost, BadgeSellerMinItems, BadgeSellerMaxItems,
                         LogicDifficulty, NoPaintingSkips, CTRLogic],
 
@@ -759,6 +749,7 @@ slot_data_options: List[str] = [
     "StartWithCompassBadge",
     "CompassBadgeMode",
     "ShuffleStorybookPages",
+    "ShuffleDirectorTokens",
     "ShuffleActContracts",
     "ShuffleSubconPaintings",
     "NoPaintingSkips",
@@ -788,6 +779,4 @@ slot_data_options: List[str] = [
     "MaxPonCost",
 
     "death_link",
-    "death_link_amnesty",
-    "dw_death_link_amnesty",
 ]

--- a/worlds/ahit/Regions.py
+++ b/worlds/ahit/Regions.py
@@ -1,7 +1,7 @@
 from BaseClasses import Region, Entrance, ItemClassification, Location, LocationProgressType
 from .Types import ChapterIndex, Difficulty, HatInTimeLocation, HatInTimeItem
 from .Locations import location_table, storybook_pages, event_locs, is_location_valid, \
-    shop_locations, TASKSANITY_START_ID, snatcher_coins, zero_jumps, zero_jumps_expert, zero_jumps_hard
+    shop_locations, TASKSANITY_START_ID, snatcher_coins, zero_jumps, zero_jumps_expert, zero_jumps_hard, director_tokens
 from typing import TYPE_CHECKING, List, Dict, Optional
 from .Rules import set_rift_rules, get_difficulty
 from .Options import ActRandomizer, EndGoal
@@ -857,6 +857,9 @@ def create_region(world: "HatInTimeWorld", name: str) -> Region:
 
         if data.region == name:
             if key in storybook_pages.keys() and not world.options.ShuffleStorybookPages:
+                continue
+
+            if key in director_tokens.keys() and not world.options.ShuffleDirectorTokens:
                 continue
 
             location = HatInTimeLocation(world.player, key, data.id, reg)


### PR DESCRIPTION
(reopened to fix the 200 commits)
## What is this fixing or adding?
Adds a new option to the A Hat in Time randomizer called `ShuffleDirectorTokens` that allows the director tokens and time bonuses from Battle of the Birds levels to become location checks.
I have updated the Steam Workshop mod already with the functionality necessary for this to work so once this PR is merged it will be enabled.

## How was this tested?
Generating a seed with the option enabled and sending out the checks from in-game.

## If this makes graphical changes, please attach screenshots.
