### PR TITLE
Launcher: run init_logging before importing from worlds

### DIFF
--- a/Launcher.py
+++ b/Launcher.py
@@ -31,6 +31,10 @@ import settings
 import Utils
 from Utils import (init_logging, is_frozen, is_linux, is_macos, is_windows, local_path, messagebox, open_filename,
                    user_path)
+
+if __name__ == "__main__":
+    init_logging('Launcher')
+
 from worlds.LauncherComponents import Component, components, icon_paths, SuffixIdentifier, Type
 
 
@@ -483,7 +487,6 @@ def main(args: argparse.Namespace | dict | None = None):
 
 
 if __name__ == '__main__':
-    init_logging('Launcher')
     multiprocessing.freeze_support()
     multiprocessing.set_start_method("spawn")  # if launched process uses kivy, fork won't work
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
## What is this fixing or adding?
If a broken apworld is present within an installation, the exception will not be printed out to the Launcher log file, complicating retrieving the exception for developers. This simply runs init_logging before we import anything from the worlds module.

## How was this tested?
Purposefully broke an apworld on my install, watched as the resulting exception was logged to file when running Launcher.

## If this makes graphical changes, please attach screenshots.
