### PR TITLE
WebHost: enable numeric sort in tracker

### DIFF
--- a/WebHostLib/static/assets/trackerCommon.js
+++ b/WebHostLib/static/assets/trackerCommon.js
@@ -33,6 +33,12 @@ const secondsToHours = (seconds) => {
 };
 
 window.addEventListener('load', () => {
+    // Numeric sorting according to documentation on https://datatables.net/blog/2017/locale-based-sorting
+    const {compare} = new Intl.Collator('en', {numeric: true});
+    const types = $.fn.dataTable.ext.type;
+    delete types.order['string-pre'];
+    types.order['string-asc'] = compare;
+    types.order['string-desc'] = (a, b) => -compare(a, b);
     const tables = $(".table").DataTable({
         paging: false,
         info: false,


### PR DESCRIPTION
## What is this fixing or adding?

This is enabling numeric sort for tracker data tables. Consider a game like Pokemon Red - when showing locations, Route 11 is shown after Route 1, but before Route 2.

<img width="450" height="373" alt="image" src="https://github.com/user-attachments/assets/410f9e50-8441-43c4-b9cf-b49ba70ad871" />

After this change, Route 2 is directly after Route 1, as expected.

<img width="357" height="356" alt="image" src="https://github.com/user-attachments/assets/aa33a004-aa19-456b-9d99-47bf0a94c1aa" />

## How was this tested?

By starting a Pokemon Red single-player game, and looking at the tracker.