### PR TITLE
AHIT: Fix death link timestamps being incorrect

### DIFF
--- a/worlds/ahit/Client.py
+++ b/worlds/ahit/Client.py
@@ -1,4 +1,6 @@
 import asyncio
+import time
+
 import Utils
 import websockets
 import functools
@@ -207,6 +209,9 @@ async def proxy(websocket, path: str = "/", ctx: AHITContext = None):
 
                     if not ctx.is_proxy_connected():
                         break
+
+                    if msg["cmd"] == "Bounce" and msg.get("tags") == ["DeathLink"] and "data" in msg:
+                        msg["data"]["time"] = time.time()
 
                     await ctx.send_msgs([msg])
 


### PR DESCRIPTION
## What is this fixing or adding?
Fixes the death link timestamps sent from A Hat in Time using an incorrect time, causing some games to not react to the death link.
This is something that has to be fixed in the Python client and not the mod because the timestamp functions in UnrealScript are evidently broken. So the fix here is to just update the time value in the death link packet before it gets sent.

## How was this tested?
Connecting to a slot with death link enabled, triggering a death link, and then printing the death link packet.

## If this makes graphical changes, please attach screenshots.
