### PR TITLE
SC2: Restrict allow Orphan to missions that already require that

### DIFF
--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -654,8 +654,7 @@ def flag_mission_based_item_excludes(world: SC2World, item_list: List[FilterItem
 def flag_allowed_orphan_items(world: SC2World, item_list: List[FilterItem]) -> None:
     """Adds the `Allowed_Orphan` flag to items that shouldn't be filtered with their parents, like combat shield"""
     missions = get_all_missions(world.custom_mission_order)
-    terran_nobuild_missions = any((MissionFlag.Terran|MissionFlag.NoBuild) in mission.flags and mission.campaign != SC2Campaign.NCO for mission in missions)
-    if terran_nobuild_missions:
+    if SC2Mission.PIERCING_OF_THE_SHROUD in missions:
         for item in item_list:
             if item.name in (
                     item_names.MARINE_COMBAT_SHIELD, item_names.MARINE_PROGRESSIVE_STIMPACK, item_names.MARINE_MAGRAIL_MUNITIONS,
@@ -665,7 +664,11 @@ def flag_allowed_orphan_items(world: SC2World, item_list: List[FilterItem]) -> N
     # These rules only trigger on Standard tactics
     if SC2Mission.BELLY_OF_THE_BEAST in missions and world.options.required_tactics == RequiredTactics.option_standard:
         for item in item_list:
-            if item.name in (item_names.FIREBAT_NANO_PROJECTORS, item_names.FIREBAT_NANO_PROJECTORS, item_names.FIREBAT_PROGRESSIVE_STIMPACK):
+            if item.name in (
+                    item_names.MARINE_COMBAT_SHIELD, item_names.MARINE_PROGRESSIVE_STIMPACK, item_names.MARINE_MAGRAIL_MUNITIONS,
+                    item_names.MEDIC_STABILIZER_MEDPACKS, item_names.MEDIC_NANO_PROJECTOR, item_names.MARINE_LASER_TARGETING_SYSTEM,
+                    item_names.FIREBAT_NANO_PROJECTORS, item_names.FIREBAT_NANO_PROJECTORS, item_names.FIREBAT_PROGRESSIVE_STIMPACK
+            ):
                 item.flags |= ItemFilterFlags.AllowedOrphan
     if SC2Mission.EVIL_AWOKEN in missions and world.options.required_tactics == RequiredTactics.option_standard:
         for item in item_list:


### PR DESCRIPTION
## What is this fixing or adding?
Restricts setting allow orphan item flag only if a mission actually requiring that is rolled
Thus just having Liberation Day won't allow Medic upgrades as the player doesn't need that and Medics aren't even available in that mission

## How was this tested?
Unit Tests

## If this makes graphical changes, please attach screenshots.
No