### PR TITLE
SC2: Update docs for Linux launch script to follow the core client migration

### DIFF
--- a/worlds/sc2/docs/setup_en.md
+++ b/worlds/sc2/docs/setup_en.md
@@ -247,7 +247,7 @@ PATH_TO_ARCHIPELAGO=
 ARCHIPELAGO="$(ls ${PATH_TO_ARCHIPELAGO:-$(dirname $0)}/Archipelago_*.AppImage | sort -r | head -1)"
 
 # Start the Archipelago client
-$ARCHIPELAGO Starcraft2Client
+$ARCHIPELAGO "Starcraft 2 Client"
 ```
 
 For Lutris installs, you can run `lutris -l` to get the numerical ID of your StarCraft II install, then run the command

--- a/worlds/sc2/docs/setup_fr.md
+++ b/worlds/sc2/docs/setup_fr.md
@@ -203,7 +203,7 @@ PATH_TO_ARCHIPELAGO=
 ARCHIPELAGO="$(ls ${PATH_TO_ARCHIPELAGO:-$(dirname $0)}/Archipelago_*.AppImage | sort -r | head -1)"
 
 # Lance le client de Archipelago
-$ARCHIPELAGO Starcraft2Client
+$ARCHIPELAGO "Starcraft 2 Client"
 ```
 
 Pour une installation via Lutris, vous pouvez exécuter `lutris -l` pour obtenir l'identifiant numérique de votre 


### PR DESCRIPTION
## What is this fixing or adding?
Updates the docs how to launch SC2 Client under Linux to follow the client migration away from the custom exe

## How was this tested?
Launched the client using AppImage

## If this makes graphical changes, please attach screenshots.
No