### PR TITLE
MultiServer: Validate CreateHints status arg

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1961,6 +1961,16 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
             if not locations:
                 await ctx.send_msgs(client, [{"cmd": "InvalidPacket", "type": "arguments",
                                               "text": "CreateHints: No locations specified.", "original_cmd": cmd}])
+                return
+
+            try:
+                status = HintStatus(status)
+            except ValueError as err:
+                await ctx.send_msgs(client,
+                                    [{"cmd": "InvalidPacket", "type": "arguments",
+                                      "text": f"Unknown Status: {err}",
+                                      "original_cmd": cmd}])
+                return
 
             hints = []
 


### PR DESCRIPTION
## What is this fixing or adding?
add check to status arg that it's a valid and known hintstatus

## How was this tested?
spun up multiserver, ran a createhints with status of `"0"`, `0`, missing, and `9999` and saw the invalid values error properly back to the client

also added a return to the other InvalidPacket response as it was probably intended

## If this makes graphical changes, please attach screenshots.
