### PR TITLE
SC2: Launcher bugfixes after content merge

### DIFF
--- a/worlds/sc2/client.py
+++ b/worlds/sc2/client.py
@@ -1304,11 +1304,11 @@ def parse_uri(uri: str) -> str:
     return uri.split('?', 1)[0]
 
 
-async def main():
+async def main(args: typing.Sequence[str] | None):
     multiprocessing.freeze_support()
     parser = get_base_parser()
     parser.add_argument('--name', default=None, help="Slot Name to connect as.")
-    args, uri = parser.parse_known_args()
+    args, uri = parser.parse_known_args(args)
 
     if uri and uri[0].startswith('archipelago://'):
         args.connect = parse_uri(' '.join(uri))
@@ -2346,7 +2346,7 @@ def force_settings_save_on_close() -> None:
     _has_forced_save = True
 
 
-def launch():
+def launch(*args: str):
     colorama.just_fix_windows_console()
-    asyncio.run(main())
+    asyncio.run(main(args))
     colorama.deinit()

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -170,7 +170,7 @@ class TwoStartPositions(Toggle):
     If turned on and 'grid', 'hopscotch', or 'golden_path' mission orders are selected,
     removes the first mission and allows both of the next two missions to be played from the start.
     """
-    display_name = "Start with two unlocked missions on grid"
+    display_name = "Two start missions"
     default = Toggle.option_false
 
 
@@ -1053,7 +1053,7 @@ class VictoryCache(Range):
     Controls how many additional checks are awarded for completing a mission.
     Goal missions are unaffected by this option.
     """
-    display_name = "Victory Checks"
+    display_name = "Victory Cache"
     range_start = 0
     range_end = 10
     default = 0


### PR DESCRIPTION
## What is this fixing or adding?
The big sc2 content merge PR #5312 was merged with a last-minute change that removed Starcraft2Client.py. Unfortunately, the replacement command-line functionality -- calling `Launcher.py "Starcraft 2 Client" -- <args>` doesn't work properly as the `launch()` function was set to read args straight from `sys.argv` but the plumbing was passing those arguments in as function arguments.

I also took the time to poke at the webhost as I wasn't sure if the URI handling was up to snuff and I remember not being able to test it locally. As it turns out, the precise component I wanted to test is still no testable purely locally, but I uncovered a few unupdated option names in the options page that I updated here as well.

## How was this tested?
* Generated+hosted locally, connected with `Launcher.py "Starcraft 2 Client" -- --connect localhost --name phaneros`
* Updated my old automated quickstart scripts with this new syntax; they all now work again

## If this makes graphical changes, please attach screenshots.
None