### PR TITLE
Docs: update mac install instructions to reflect 3.13 support

### DIFF
--- a/worlds/generic/docs/mac_en.md
+++ b/worlds/generic/docs/mac_en.md
@@ -3,7 +3,7 @@ Archipelago does not have a compiled release on macOS. However, it is possible t
 ## Prerequisite Software
 Here is a list of software to install and source code to download.
 1. Python 3.11 "universal2" or newer from the [macOS Python downloads page](https://www.python.org/downloads/macos/).
-   **Python 3.13 is not supported yet.**
+   **Python 3.14 is not supported yet.**
 2. Xcode from the [macOS App Store](https://apps.apple.com/us/app/xcode/id497799835).
 3. The source code from the [Archipelago releases page](https://github.com/ArchipelagoMW/Archipelago/releases).
 4. The asset with darwin in the name from the [SNI Github releases page](https://github.com/alttpo/sni/releases).


### PR DESCRIPTION
## What is this fixing or adding?
3.13 is supported mac docs, keep up

## How was this tested?


## If this makes graphical changes, please attach screenshots.
