### PR TITLE
Factorio: only show fluid boxes on assembling machine 1 when the selected recipe needs fluids

### DIFF
--- a/worlds/factorio/data/mod_template/data-final-fixes.lua
+++ b/worlds/factorio/data/mod_template/data-final-fixes.lua
@@ -130,6 +130,7 @@ end
 data.raw["assembling-machine"]["assembling-machine-1"].crafting_categories = table.deepcopy(data.raw["assembling-machine"]["assembling-machine-3"].crafting_categories)
 data.raw["assembling-machine"]["assembling-machine-2"].crafting_categories = table.deepcopy(data.raw["assembling-machine"]["assembling-machine-3"].crafting_categories)
 data.raw["assembling-machine"]["assembling-machine-1"].fluid_boxes = table.deepcopy(data.raw["assembling-machine"]["assembling-machine-2"].fluid_boxes)
+data.raw["assembling-machine"]["assembling-machine-1"].fluid_boxes_off_when_no_fluid_recipe = data.raw["assembling-machine"]["assembling-machine-2"].fluid_boxes_off_when_no_fluid_recipe
 if mods["factory-levels"] then
     -- Factory-Levels allows the assembling machines to get faster (and depending on settings), more productive at crafting products, the more the
     -- assembling machine crafts the product.  If the machine crafts enough, it may auto-upgrade to the next tier.


### PR DESCRIPTION
## What is this fixing or adding?

Small cosmetic change to only show the fluid boxes on assembling machine 1 when the selected recipe has a fluid ingredient instead of always showing them as soon as the machine is placed.

This align the behavior to the one assembling machines 2 and 3 have in the base game.

## How was this tested?

Generated a new seed and launched Factorio to see if the fluid box was present or not once placed.

## If this makes graphical changes, please attach screenshots.
