### PR TITLE
SC2: Fix Conviction logic for Grant Story Tech

### DIFF
--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -2345,8 +2345,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2HOTS_LOC_ID_OFFSET + 200,
             LocationType.VICTORY,
             lambda state: logic.basic_kerrigan(state)
-                or kerriganless
-                or logic.grant_story_tech == GrantStoryTech.option_grant,
+                or kerriganless,
             hard_rule=logic.zerg_any_units_back_in_the_saddle_requirement,
         ),
         make_location_data(
@@ -2355,8 +2354,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2HOTS_LOC_ID_OFFSET + 201,
             LocationType.EXTRA,
             lambda state: logic.basic_kerrigan(state)
-                or kerriganless
-                or logic.grant_story_tech == GrantStoryTech.option_grant,
+                or kerriganless,
             hard_rule=logic.zerg_any_units_back_in_the_saddle_requirement,
         ),
         make_location_data(
@@ -2383,8 +2381,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2HOTS_LOC_ID_OFFSET + 205,
             LocationType.EXTRA,
             lambda state: logic.basic_kerrigan(state)
-                or kerriganless
-                or logic.grant_story_tech == GrantStoryTech.option_grant,
+                or kerriganless,
             hard_rule=logic.zerg_any_units_back_in_the_saddle_requirement,
         ),
         make_location_data(
@@ -2450,7 +2447,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             lambda state: (
                 logic.zerg_competent_comp(state)
                 and logic.zerg_competent_anti_air(state)
-                and (logic.basic_kerrigan(state) or kerriganless)
+                and (logic.basic_kerrigan(state, False) or kerriganless)
                 and logic.zerg_defense_rating(state, False, False) >= 3
                 and logic.zerg_power_rating(state) >= 5
             ),
@@ -3533,11 +3530,8 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             lambda state: (
                 kerriganless
                 or (
-                    (
-                        logic.two_kerrigan_actives(state)
-                        and logic.basic_kerrigan(state)
-                        or logic.grant_story_tech == GrantStoryTech.option_grant
-                    )
+                    logic.two_kerrigan_actives(state)
+                    and logic.basic_kerrigan(state)
                     and logic.kerrigan_levels(state, 25)
                 )
             ),
@@ -3548,7 +3542,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2HOTS_LOC_ID_OFFSET + 1701,
             LocationType.VANILLA,
             lambda state: (
-                (logic.two_kerrigan_actives(state) or logic.grant_story_tech == GrantStoryTech.option_grant) and logic.kerrigan_levels(state, 25)
+                logic.two_kerrigan_actives(state) and logic.kerrigan_levels(state, 25)
             )
             or kerriganless,
         ),
@@ -3560,11 +3554,8 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             lambda state: (
                 kerriganless
                 or (
-                    (
-                        logic.two_kerrigan_actives(state)
-                        and logic.basic_kerrigan(state)
-                        or logic.grant_story_tech == GrantStoryTech.option_grant
-                    )
+                    logic.two_kerrigan_actives(state)
+                    and logic.basic_kerrigan(state)
                     and logic.kerrigan_levels(state, 25)
                 )
             ),
@@ -3575,7 +3566,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2HOTS_LOC_ID_OFFSET + 1703,
             LocationType.EXTRA,
             lambda state: (
-                (logic.two_kerrigan_actives(state) or logic.grant_story_tech == GrantStoryTech.option_grant) and logic.kerrigan_levels(state, 25)
+                logic.two_kerrigan_actives(state) and logic.kerrigan_levels(state, 25)
             )
             or kerriganless,
         ),
@@ -3585,7 +3576,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2HOTS_LOC_ID_OFFSET + 1704,
             LocationType.EXTRA,
             lambda state: (
-                (logic.two_kerrigan_actives(state) or logic.grant_story_tech == GrantStoryTech.option_grant) and logic.kerrigan_levels(state, 25)
+                logic.two_kerrigan_actives(state) and logic.kerrigan_levels(state, 25)
             )
             or kerriganless,
         ),

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -1123,8 +1123,10 @@ class SC2Logic:
 
         return levels >= target
 
-    def basic_kerrigan(self, state: CollectionState) -> bool:
-        # One active ability that can be used to defeat enemies directly on Standard
+    def basic_kerrigan(self, state: CollectionState, story_tech_available=True) -> bool:
+        if story_tech_available and self.grant_story_tech == GrantStoryTech.option_grant:
+            return True
+        # One active ability that can be used to defeat enemies directly
         if not state.has_any(
             (
                 item_names.KERRIGAN_LEAPING_STRIKE,
@@ -1145,7 +1147,9 @@ class SC2Logic:
                 return True
         return False
 
-    def two_kerrigan_actives(self, state: CollectionState) -> bool:
+    def two_kerrigan_actives(self, state: CollectionState, story_tech_available=True) -> bool:
+        if story_tech_available and self.grant_story_tech == GrantStoryTech.option_grant:
+            return True
         count = 0
         for i in range(7):
             if state.has_any(kerrigan_logic_active_abilities, self.player):
@@ -2395,7 +2399,7 @@ class SC2Logic:
         return (
             self.zerg_competent_comp(state)
             and (self.zerg_competent_anti_air(state) or self.advanced_tactics and self.zerg_moderate_anti_air(state))
-            and (self.basic_kerrigan(state) or self.zerg_power_rating(state) >= 4)
+            and (self.basic_kerrigan(state, False) or self.zerg_power_rating(state) >= 4)
         )
 
     def protoss_hand_of_darkness_requirement(self, state: CollectionState) -> bool:
@@ -2411,7 +2415,7 @@ class SC2Logic:
         return self.protoss_deathball(state) and self.protoss_power_rating(state) >= 8
 
     def zerg_the_reckoning_requirement(self, state: CollectionState) -> bool:
-        if not (self.zerg_power_rating(state) >= 6 or self.basic_kerrigan(state)):
+        if not (self.zerg_power_rating(state) >= 6 or self.basic_kerrigan(state, False)):
             return False
         if self.take_over_ai_allies:
             return (
@@ -2461,20 +2465,22 @@ class SC2Logic:
 
     def the_infinite_cycle_requirement(self, state: CollectionState) -> bool:
         return (
-            self.grant_story_tech == GrantStoryTech.option_grant
-            or not self.kerrigan_unit_available
-            or (
-                state.has_any(
-                    (
-                        item_names.KERRIGAN_KINETIC_BLAST,
-                        item_names.KERRIGAN_SPAWN_BANELINGS,
-                        item_names.KERRIGAN_LEAPING_STRIKE,
-                        item_names.KERRIGAN_SPAWN_LEVIATHAN,
-                    ),
-                    self.player,
+            self.kerrigan_levels(state, 70)
+            and (
+                self.grant_story_tech == GrantStoryTech.option_grant
+                or not self.kerrigan_unit_available
+                or (
+                    state.has_any(
+                        (
+                            item_names.KERRIGAN_KINETIC_BLAST,
+                            item_names.KERRIGAN_SPAWN_BANELINGS,
+                            item_names.KERRIGAN_LEAPING_STRIKE,
+                            item_names.KERRIGAN_SPAWN_LEVIATHAN,
+                        ),
+                        self.player,
+                    )
+                    and self.basic_kerrigan(state)
                 )
-                and self.basic_kerrigan(state)
-                and self.kerrigan_levels(state, 70)
             )
         )
 

--- a/worlds/sc2/test/test_generation.py
+++ b/worlds/sc2/test/test_generation.py
@@ -3,20 +3,13 @@ Unit tests for world generation
 """
 from typing import *
 
-from Options import Accessibility
 from .test_base import Sc2SetupTestBase
 
-from .. import mission_groups, mission_tables, options, locations, SC2Mission, SC2Campaign, SC2Race, unreleased_items, \
-    StarterUnit, GrantStoryTech
+from .. import mission_groups, mission_tables, options, locations, SC2Mission, SC2Campaign, SC2Race, unreleased_items
 from ..item import item_groups, item_tables, item_names
 from .. import get_all_missions, get_random_first_mission
 from ..options import EnabledCampaigns, NovaGhostOfAChanceVariant, MissionOrder, ExcludeOverpoweredItems, \
-    VanillaItemsOnly, MaximumCampaignSize, AllInMap, KeyMode, EnableRaceSwapVariants, EnableMissionRaceBalancing, \
-    ShuffleCampaigns, ShuffleNoBuild, RequiredTactics, EnsureGenericItems, GenericUpgradeResearch, \
-    GenericUpgradeResearchSpeedup, GenericUpgradeItems, KerriganPresence, KerriganLevelItemDistribution, \
-    KerriganPrimalStatus, EnableMorphling, WarCouncilNerfs, SpearOfAdunPresence, SpearOfAdunPresentInNoBuild, \
-    SpearOfAdunPassiveAbilityPresence, SpearOfAdunPassivesPresentInNoBuild, GrantStoryLevels, TakeOverAIAllies, \
-    DifficultyCurve, ExcludeVeryHardMissions
+    VanillaItemsOnly, MaximumCampaignSize
 
 
 class TestItemFiltering(Sc2SetupTestBase):
@@ -1234,39 +1227,3 @@ class TestItemFiltering(Sc2SetupTestBase):
 
         # A unit nerf happens due to excluding OP items
         self.assertNotIn(item_names.MOTHERSHIP_INTEGRATED_POWER, starting_inventory)
-
-    def test_all_kerrigan_missions_are_nobuild_and_grant_story_tech_is_on(self) -> None:
-        # The actual situation the bug got caught
-        world_options = {
-            'mission_order': MissionOrder.option_vanilla_shuffled,
-            'selected_races': [
-                SC2Race.TERRAN.get_title(),
-                SC2Race.ZERG.get_title(),
-                SC2Race.PROTOSS.get_title(),
-            ],
-            'enabled_campaigns': [
-                SC2Campaign.WOL.campaign_name,
-                SC2Campaign.PROPHECY.campaign_name,
-                SC2Campaign.HOTS.campaign_name,
-                SC2Campaign.PROLOGUE.campaign_name,
-                SC2Campaign.LOTV.campaign_name,
-                SC2Campaign.EPILOGUE.campaign_name,
-                SC2Campaign.NCO.campaign_name,
-            ],
-            'enable_race_swap': EnableRaceSwapVariants.option_shuffle_all_non_vanilla, # Causes no build Kerrigan missions to be present, only nobuilds remain
-            'shuffle_campaigns': ShuffleCampaigns.option_true,
-            'shuffle_no_build': ShuffleNoBuild.option_true,
-            'starter_unit': StarterUnit.option_balanced,
-            'required_tactics': RequiredTactics.option_standard,
-            'kerrigan_presence': KerriganPresence.option_vanilla,
-            'kerrigan_levels_per_mission_completed': 0,
-            'kerrigan_levels_per_mission_completed_cap': -1,
-            'kerrigan_level_item_sum': 87,
-            'kerrigan_level_item_distribution': KerriganLevelItemDistribution.option_size_7,
-            'kerrigan_total_level_cap': -1,
-            'start_primary_abilities': 0,
-            'grant_story_tech': GrantStoryTech.option_grant,
-            'grant_story_levels': GrantStoryLevels.option_additive,
-        }
-        self.generate_world(world_options)
-        # Just check that the world itself generates under those rules and no exception is thrown

--- a/worlds/sc2/test/test_usecases.py
+++ b/worlds/sc2/test/test_usecases.py
@@ -6,7 +6,9 @@ from .test_base import Sc2SetupTestBase
 from .. import get_all_missions, mission_tables, options
 from ..item import item_groups, item_tables, item_names
 from ..mission_tables import SC2Race, SC2Mission, SC2Campaign, MissionFlag
-from ..options import EnabledCampaigns, MasteryLocations
+from ..options import EnabledCampaigns, MasteryLocations, MissionOrder, EnableRaceSwapVariants, ShuffleCampaigns, \
+    ShuffleNoBuild, StarterUnit, RequiredTactics, KerriganPresence, KerriganLevelItemDistribution, GrantStoryTech, \
+    GrantStoryLevels
 
 
 class TestSupportedUseCases(Sc2SetupTestBase):
@@ -490,3 +492,39 @@ class TestSupportedUseCases(Sc2SetupTestBase):
 
         self.assertTupleEqual(terran_nonmerc_units, ())
         self.assertTupleEqual(zerg_nonmerc_units, ())
+
+    def test_all_kerrigan_missions_are_nobuild_and_grant_story_tech_is_on(self) -> None:
+        # The actual situation the bug got caught
+        world_options = {
+            'mission_order': MissionOrder.option_vanilla_shuffled,
+            'selected_races': [
+                SC2Race.TERRAN.get_title(),
+                SC2Race.ZERG.get_title(),
+                SC2Race.PROTOSS.get_title(),
+            ],
+            'enabled_campaigns': [
+                SC2Campaign.WOL.campaign_name,
+                SC2Campaign.PROPHECY.campaign_name,
+                SC2Campaign.HOTS.campaign_name,
+                SC2Campaign.PROLOGUE.campaign_name,
+                SC2Campaign.LOTV.campaign_name,
+                SC2Campaign.EPILOGUE.campaign_name,
+                SC2Campaign.NCO.campaign_name,
+            ],
+            'enable_race_swap': EnableRaceSwapVariants.option_shuffle_all_non_vanilla, # Causes no build Kerrigan missions to be present, only nobuilds remain
+            'shuffle_campaigns': ShuffleCampaigns.option_true,
+            'shuffle_no_build': ShuffleNoBuild.option_true,
+            'starter_unit': StarterUnit.option_balanced,
+            'required_tactics': RequiredTactics.option_standard,
+            'kerrigan_presence': KerriganPresence.option_vanilla,
+            'kerrigan_levels_per_mission_completed': 0,
+            'kerrigan_levels_per_mission_completed_cap': -1,
+            'kerrigan_level_item_sum': 87,
+            'kerrigan_level_item_distribution': KerriganLevelItemDistribution.option_size_7,
+            'kerrigan_total_level_cap': -1,
+            'start_primary_abilities': 0,
+            'grant_story_tech': GrantStoryTech.option_grant,
+            'grant_story_levels': GrantStoryLevels.option_additive,
+        }
+        self.generate_world(world_options)
+        # Just check that the world itself generates under those rules and no exception is thrown


### PR DESCRIPTION
## What is this fixing or adding?
Fixes a case when Conviction logic causes generation failure if story tech is granted and no Kerrigan build missions are present

NOTE:
- Kinetic Blast and Crushing Grip is available for the mission if story tech is granted which are both Kerrigan's active abilities
## How was this tested?
Unit tests

## If this makes graphical changes, please attach screenshots.
No