### PR TITLE
[Factorio]: Allow to reconnect a timed out RCON client connection.

### DIFF
--- a/worlds/factorio/Client.py
+++ b/worlds/factorio/Client.py
@@ -65,7 +65,7 @@ class FactorioCommandProcessor(ClientCommandProcessor):
         try:
             result = self.ctx.rcon_client.send_command("/help")
             if result:
-                self.output("RCON Client already connected")
+                self.output("RCON Client already connected.")
             return True
         except factorio_rcon.RCONNetworkError:
             self.ctx.rcon_client = factorio_rcon.RCONClient("localhost", self.ctx.rcon_port, self.ctx.rcon_password, timeout=5)

--- a/worlds/factorio/Client.py
+++ b/worlds/factorio/Client.py
@@ -59,6 +59,19 @@ class FactorioCommandProcessor(ClientCommandProcessor):
     def _cmd_toggle_chat(self):
         """Toggle sending of chat messages from players on the Factorio server to Archipelago."""
         self.ctx.toggle_bridge_chat_out()
+        
+    def _cmd_rcon_reconnect(self) -> bool:
+        """Reconnect the RCON client if its disconnected."""
+        try:
+            result = self.ctx.rcon_client.send_command("/help")
+            if result:
+                self.output("RCON Client already connected")
+            return True
+        except factorio_rcon.RCONNetworkError:
+            self.ctx.rcon_client = factorio_rcon.RCONClient("localhost", self.ctx.rcon_port, self.ctx.rcon_password, timeout=5)
+            self.output("RCON Client successfully reconnected")
+            return True
+        return False
 
 
 class FactorioContext(CommonContext):
@@ -242,7 +255,13 @@ async def game_watcher(ctx: FactorioContext):
             if ctx.rcon_client and time.perf_counter() > next_bridge:
                 next_bridge = time.perf_counter() + 1
                 ctx.awaiting_bridge = False
-                data = json.loads(ctx.rcon_client.send_command("/ap-sync"))
+                try:
+                    data = json.loads(ctx.rcon_client.send_command("/ap-sync"))
+                except factorio_rcon.RCONNotConnected:
+                    continue
+                except factorio_rcon.RCONNetworkError:
+                    bridge_logger.warning("RCON Client has unexpectedly lost connection. Please issue /rcon_reconnect")
+                    continue
                 if not ctx.auth:
                     pass  # auth failed, wait for new attempt
                 elif data["slot_name"] != ctx.auth:
@@ -294,9 +313,13 @@ async def game_watcher(ctx: FactorioContext):
                                     "cmd": "Set", "key": ctx.energylink_key, "operations":
                                         [{"operation": "add", "value": value}]
                                 }]))
-                                ctx.rcon_client.send_command(
-                                    f"/ap-energylink -{value}")
-                                logger.debug(f"EnergyLink: Sent {format_SI_prefix(value)}J")
+                                try:
+                                    ctx.rcon_client.send_command(
+                                        f"/ap-energylink -{value}")
+                                except factorio_rcon.RCONNetworkError:
+                                    bridge_logger.warning("RCON Client has unexpectedly lost connection. Please issue /rcon_reconnect")
+                                else:
+                                    logger.debug(f"EnergyLink: Sent {format_SI_prefix(value)}J")
 
             await asyncio.sleep(0.1)
 

--- a/worlds/factorio/Client.py
+++ b/worlds/factorio/Client.py
@@ -69,7 +69,7 @@ class FactorioCommandProcessor(ClientCommandProcessor):
             return True
         except factorio_rcon.RCONNetworkError:
             self.ctx.rcon_client = factorio_rcon.RCONClient("localhost", self.ctx.rcon_port, self.ctx.rcon_password, timeout=5)
-            self.output("RCON Client successfully reconnected")
+            self.output("RCON Client successfully reconnected.")
             return True
         return False
 
@@ -260,7 +260,7 @@ async def game_watcher(ctx: FactorioContext):
                 except factorio_rcon.RCONNotConnected:
                     continue
                 except factorio_rcon.RCONNetworkError:
-                    bridge_logger.warning("RCON Client has unexpectedly lost connection. Please issue /rcon_reconnect")
+                    bridge_logger.warning("RCON Client has unexpectedly lost connection. Please issue /rcon_reconnect.")
                     continue
                 if not ctx.auth:
                     pass  # auth failed, wait for new attempt
@@ -317,7 +317,7 @@ async def game_watcher(ctx: FactorioContext):
                                     ctx.rcon_client.send_command(
                                         f"/ap-energylink -{value}")
                                 except factorio_rcon.RCONNetworkError:
-                                    bridge_logger.warning("RCON Client has unexpectedly lost connection. Please issue /rcon_reconnect")
+                                    bridge_logger.warning("RCON Client has unexpectedly lost connection. Please issue /rcon_reconnect.")
                                 else:
                                     logger.debug(f"EnergyLink: Sent {format_SI_prefix(value)}J")
 


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?

The ability to reconnect the Factorio RCON client when it times out without needing to restart the Factorio client.

Game watcher no longer dies when RCON client connection is lost, it just waits for it to be restored.


## How was this tested?

Do things in factorio that causes the factorio server to take so long to process a request that the RCON client connection times out,  then when the factorio server is done processing whatever it was processing, issue /rcon_reconnect to the factorio ap client.


## If this makes graphical changes, please attach screenshots.

<img width="1728" height="988" alt="image" src="https://github.com/user-attachments/assets/6c4f03c1-1bfb-4111-9dcc-198d35e5e74b" />

<img width="1728" height="988" alt="image" src="https://github.com/user-attachments/assets/e04e05f7-8cf6-4bc7-84d1-face1021e805" />

<img width="1518" height="644" alt="image" src="https://github.com/user-attachments/assets/c1971e3f-5d63-428f-8b73-b161320d71f3" />


