### PR TITLE
sc2: Adding virtual item tracking for weapon/armour upgrades for performance

### DIFF
--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -869,8 +869,6 @@ def flag_user_excluded_item_sets(world: SC2World, item_list: List[FilterItem]) -
                     item.flags |= ItemFilterFlags.UserExcluded
                 vanilla_nonprogressive_count[item.name] += 1
 
-    excluded_count: Dict[str, int] = dict()
-
 
 def flag_war_council_items(world: SC2World, item_list: List[FilterItem]) -> None:
     """Excludes / start-inventories items based on `nerf_unit_baselines` option.

--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -30,7 +30,7 @@ from .options import (
 )
 from .rules import get_basic_units, SC2Logic
 from . import settings
-from .pool_filter import filter_items
+from .pool_filter import filter_items, after_add_item, after_remove_item
 from .mission_tables import SC2Campaign, SC2Mission, SC2Race, MissionFlag
 from .regions import create_mission_order
 from .mission_order import SC2MissionOrder
@@ -253,6 +253,18 @@ class SC2World(World):
             slot_data["enable_void_trade"] = EnableVoidTrade.option_false
 
         return slot_data
+    
+    def collect(self, state: CollectionState, item: Item) -> bool:
+        change = super().collect(state, item)
+        if change:
+            after_add_item(state.prog_items[item.player], item)
+        return change
+
+    def remove(self, state: CollectionState, item: Item) -> bool:
+        change = super().remove(state, item)
+        if change:
+            after_remove_item(state.prog_items[item.player], item)
+        return change
 
     def pre_fill(self) -> None:
         assert self.logic is not None

--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -12,8 +12,11 @@ from .item.item_tables import (
     get_full_item_list,
     not_balanced_starting_units, WEAPON_ARMOR_UPGRADE_MAX_LEVEL,
 )
-from .item import FilterItem, ItemFilterFlags, StarcraftItem, item_groups, item_names, item_tables, item_parents, \
+from .item import (
+    FilterItem, ItemFilterFlags, StarcraftItem, item_groups, item_names, item_tables, item_parents,
     ZergItemType, ProtossItemType, ItemData
+)
+from .item.virtual_items import after_add_item, after_remove_item
 from .locations import (
 	get_locations, DEFAULT_LOCATION_LIST, get_location_types, get_location_flags,
     get_plando_locations, LocationType, lookup_location_id_to_type
@@ -30,7 +33,7 @@ from .options import (
 )
 from .rules import get_basic_units, SC2Logic
 from . import settings
-from .pool_filter import filter_items, after_add_item, after_remove_item
+from .pool_filter import filter_items
 from .mission_tables import SC2Campaign, SC2Mission, SC2Race, MissionFlag
 from .regions import create_mission_order
 from .mission_order import SC2MissionOrder

--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -825,12 +825,11 @@ def flag_start_abilities(world: SC2World, item_list: List[FilterItem]) -> None:
 def flag_unused_upgrade_types(world: SC2World, item_list: List[FilterItem]) -> None:
     """Excludes +armour/attack upgrades based on generic upgrade strategy.
     Caps upgrade items based on `max_upgrade_level`."""
-    include_upgrades = world.options.generic_upgrade_missions == 0
     upgrade_items = world.options.generic_upgrade_items.value
     upgrade_included_counts: Dict[str, int] = {}
     for item in item_list:
         if item.data.type in item_tables.upgrade_item_types:
-            if not include_upgrades or (item.name not in upgrade_included_names[upgrade_items]):
+            if item.name not in upgrade_included_names[upgrade_items]:
                 item.flags |= ItemFilterFlags.Removed
             else:
                 included = upgrade_included_counts.get(item.name, 0)

--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -825,11 +825,14 @@ def flag_start_abilities(world: SC2World, item_list: List[FilterItem]) -> None:
 def flag_unused_upgrade_types(world: SC2World, item_list: List[FilterItem]) -> None:
     """Excludes +armour/attack upgrades based on generic upgrade strategy.
     Caps upgrade items based on `max_upgrade_level`."""
+    generic_upgrade_missions = world.options.generic_upgrade_missions.value > 0
     upgrade_items = world.options.generic_upgrade_items.value
     upgrade_included_counts: Dict[str, int] = {}
     for item in item_list:
         if item.data.type in item_tables.upgrade_item_types:
-            if item.name not in upgrade_included_names[upgrade_items]:
+            if (item.name not in upgrade_included_names[upgrade_items]
+                or (generic_upgrade_missions and ItemFilterFlags.StartInventory not in item.flags)
+            ):
                 item.flags |= ItemFilterFlags.Removed
             else:
                 included = upgrade_included_counts.get(item.name, 0)

--- a/worlds/sc2/item/item_tables.py
+++ b/worlds/sc2/item/item_tables.py
@@ -2154,30 +2154,7 @@ not_balanced_starting_units = {
 
 # Defense rating table
 # Commented defense ratings are handled in LogicMixin
-tvx_defense_ratings = {
-    item_names.SIEGE_TANK: 5,
-    # "Graduating Range": 1,
-    item_names.PLANETARY_FORTRESS: 3,
-    # Bunker w/ Marine/Marauder: 3,
-    item_names.PERDITION_TURRET: 2,
-    item_names.DEVASTATOR_TURRET: 2,
-    item_names.VULTURE: 1,
-    item_names.BANSHEE: 1,
-    item_names.BATTLECRUISER: 1,
-    item_names.LIBERATOR: 4,
-    item_names.WIDOW_MINE: 1,
-    # "Concealment (Widow Mine)": 1
-}
-tvz_defense_ratings = {
-    item_names.PERDITION_TURRET: 2,
-    # Bunker w/ Firebat: 2,
-    item_names.LIBERATOR: -2,
-    item_names.HIVE_MIND_EMULATOR: 3,
-    item_names.PSI_DISRUPTER: 3,
-}
-tvx_air_defense_ratings = {
-    item_names.MISSILE_TURRET: 2,
-}
+# Note(phaneros): Terran defense rating data moved to virtual_items.py
 zvx_defense_ratings = {
     # Note that this doesn't include Kerrigan because this is just for race swaps, which doesn't involve her (for now)
     item_names.SPINE_CRAWLER: 3,

--- a/worlds/sc2/item/virtual_items.py
+++ b/worlds/sc2/item/virtual_items.py
@@ -96,7 +96,7 @@ LOGIC_EFFECTS = {
     item_table[item_names.PLANETARY_FORTRESS].code: (LogicEffect.TERRAN_DEFENSE_RATING, 3),
     item_table[item_names.PERDITION_TURRET].code: (LogicEffect.TERRAN_DEFENSE_RATING|LogicEffect.TVZ_DEFENSE_RATING, 2),
     item_table[item_names.DEVASTATOR_TURRET].code: (LogicEffect.TERRAN_DEFENSE_RATING, 2),
-    item_table[item_names.LIBERATOR].code: (LogicEffect.TERRAN_DEFENSE_RATING, 3),
+    item_table[item_names.LIBERATOR].code: (LogicEffect.TERRAN_DEFENSE_RATING, 4),  # adjusted to 2 vs zerg
     item_table[item_names.WIDOW_MINE].code: (LogicEffect.TERRAN_DEFENSE_RATING, 1),
 
     item_table[item_names.HIVE_MIND_EMULATOR].code: (LogicEffect.TVZ_DEFENSE_RATING, 3),

--- a/worlds/sc2/item/virtual_items.py
+++ b/worlds/sc2/item/virtual_items.py
@@ -1,0 +1,164 @@
+
+from typing import TYPE_CHECKING, NamedTuple
+import enum
+from .item_tables import item_table
+from . import item_names
+
+if TYPE_CHECKING:
+    from BaseClasses import Item
+    from collections import Counter
+
+
+
+class LogicEffect(enum.IntFlag):
+    NONE = 0
+    TERRAN_INFANTRY_ARMOR = enum.auto()
+    TERRAN_INFANTRY_WEAPON = enum.auto()
+    TERRAN_VEHICLE_ARMOR = enum.auto()
+    TERRAN_VEHICLE_WEAPON = enum.auto()
+    TERRAN_SHIP_ARMOR = enum.auto()
+    TERRAN_SHIP_WEAPON = enum.auto()
+    ZERG_MELEE_ATTACK = enum.auto()
+    ZERG_RANGED_ATTACK = enum.auto()
+    ZERG_GROUND_ARMOR = enum.auto()
+    ZERG_AIR_ATTACK = enum.auto()
+    ZERG_AIR_ARMOR = enum.auto()
+    PROTOSS_GROUND_ARMOR = enum.auto()
+    PROTOSS_GROUND_WEAPON = enum.auto()
+    PROTOSS_AIR_ARMOR = enum.auto()
+    PROTOSS_AIR_WEAPON = enum.auto()
+    # Note(phaneros): shield tracking is incomplete when bundling by air/ground; not used by logic
+    PROTOSS_SHIELDS = enum.auto()
+
+    TERRAN_DEFENSE_RATING = enum.auto()
+    BUNKER_DEFENSE_RATING = enum.auto()
+    TVZ_DEFENSE_RATING = enum.auto()
+
+    TERRAN_UPGRADE = (
+         TERRAN_INFANTRY_WEAPON|TERRAN_INFANTRY_ARMOR
+        |TERRAN_VEHICLE_WEAPON|TERRAN_VEHICLE_ARMOR
+        |TERRAN_SHIP_WEAPON|TERRAN_SHIP_ARMOR
+    ),
+    ZERG_UPGRADE = (
+         ZERG_MELEE_ATTACK|ZERG_RANGED_ATTACK|ZERG_GROUND_ARMOR
+        |ZERG_AIR_ATTACK|ZERG_AIR_ARMOR
+    )
+    PROTOSS_UPGRADE = (
+         PROTOSS_GROUND_WEAPON|PROTOSS_GROUND_ARMOR
+        |PROTOSS_AIR_WEAPON|PROTOSS_AIR_ARMOR
+        # |PROTOSS_SHIELDS
+    )
+
+
+class LogicSet(NamedTuple):
+    """Represents a set of items that achieve a virtual item if combined"""
+    items: tuple[str, ...]
+    effect: LogicEffect
+
+
+LOGIC_EFFECTS = {
+    item_table[item_names.PROGRESSIVE_TERRAN_INFANTRY_WEAPON].code: (LogicEffect.TERRAN_INFANTRY_WEAPON, 1),
+    item_table[item_names.PROGRESSIVE_TERRAN_INFANTRY_ARMOR].code: (LogicEffect.TERRAN_INFANTRY_ARMOR, 1),
+    item_table[item_names.PROGRESSIVE_TERRAN_VEHICLE_WEAPON].code: (LogicEffect.TERRAN_VEHICLE_WEAPON, 1),
+    item_table[item_names.PROGRESSIVE_TERRAN_VEHICLE_ARMOR].code: (LogicEffect.TERRAN_VEHICLE_ARMOR, 1),
+    item_table[item_names.PROGRESSIVE_TERRAN_SHIP_WEAPON].code: (LogicEffect.TERRAN_SHIP_WEAPON, 1),
+    item_table[item_names.PROGRESSIVE_TERRAN_SHIP_ARMOR].code: (LogicEffect.TERRAN_SHIP_ARMOR, 1),
+    item_table[item_names.PROGRESSIVE_TERRAN_WEAPON_UPGRADE].code: (LogicEffect.TERRAN_INFANTRY_WEAPON|LogicEffect.TERRAN_VEHICLE_WEAPON|LogicEffect.TERRAN_SHIP_WEAPON, 1),
+    item_table[item_names.PROGRESSIVE_TERRAN_ARMOR_UPGRADE].code: (LogicEffect.TERRAN_INFANTRY_ARMOR|LogicEffect.TERRAN_VEHICLE_ARMOR|LogicEffect.TERRAN_SHIP_ARMOR, 1),
+    item_table[item_names.PROGRESSIVE_TERRAN_INFANTRY_UPGRADE].code: (LogicEffect.TERRAN_INFANTRY_WEAPON|LogicEffect.TERRAN_INFANTRY_ARMOR, 1),
+    item_table[item_names.PROGRESSIVE_TERRAN_VEHICLE_UPGRADE].code: (LogicEffect.TERRAN_VEHICLE_WEAPON|LogicEffect.TERRAN_VEHICLE_ARMOR, 1),
+    item_table[item_names.PROGRESSIVE_TERRAN_SHIP_UPGRADE].code: (LogicEffect.TERRAN_SHIP_WEAPON|LogicEffect.TERRAN_SHIP_ARMOR, 1),
+    item_table[item_names.PROGRESSIVE_TERRAN_WEAPON_ARMOR_UPGRADE].code: (LogicEffect.TERRAN_UPGRADE, 1),
+    item_table[item_names.PROGRESSIVE_ZERG_MELEE_ATTACK].code: (LogicEffect.ZERG_MELEE_ATTACK, 1),
+    item_table[item_names.PROGRESSIVE_ZERG_MISSILE_ATTACK].code: (LogicEffect.ZERG_RANGED_ATTACK, 1),
+    item_table[item_names.PROGRESSIVE_ZERG_GROUND_CARAPACE].code: (LogicEffect.ZERG_GROUND_ARMOR, 1),
+    item_table[item_names.PROGRESSIVE_ZERG_FLYER_ATTACK].code: (LogicEffect.ZERG_AIR_ATTACK, 1),
+    item_table[item_names.PROGRESSIVE_ZERG_FLYER_CARAPACE].code: (LogicEffect.ZERG_AIR_ARMOR, 1),
+    item_table[item_names.PROGRESSIVE_ZERG_WEAPON_UPGRADE].code: (LogicEffect.ZERG_MELEE_ATTACK|LogicEffect.ZERG_RANGED_ATTACK|LogicEffect.ZERG_AIR_ATTACK, 1),
+    item_table[item_names.PROGRESSIVE_ZERG_ARMOR_UPGRADE].code: (LogicEffect.ZERG_GROUND_ARMOR|LogicEffect.ZERG_AIR_ARMOR, 1),
+    item_table[item_names.PROGRESSIVE_ZERG_GROUND_UPGRADE].code: (LogicEffect.ZERG_MELEE_ATTACK|LogicEffect.ZERG_RANGED_ATTACK|LogicEffect.ZERG_GROUND_ARMOR, 1),
+    item_table[item_names.PROGRESSIVE_ZERG_FLYER_UPGRADE].code: (LogicEffect.ZERG_AIR_ATTACK|LogicEffect.ZERG_AIR_ARMOR, 1),
+    item_table[item_names.PROGRESSIVE_ZERG_WEAPON_ARMOR_UPGRADE].code: (LogicEffect.ZERG_UPGRADE, 1),
+    item_table[item_names.PROGRESSIVE_PROTOSS_GROUND_WEAPON].code: (LogicEffect.PROTOSS_GROUND_WEAPON, 1),
+    item_table[item_names.PROGRESSIVE_PROTOSS_GROUND_ARMOR].code: (LogicEffect.PROTOSS_GROUND_ARMOR, 1),
+    item_table[item_names.PROGRESSIVE_PROTOSS_SHIELDS].code: (LogicEffect.PROTOSS_SHIELDS, 1),
+    item_table[item_names.PROGRESSIVE_PROTOSS_AIR_WEAPON].code: (LogicEffect.PROTOSS_AIR_WEAPON, 1),
+    item_table[item_names.PROGRESSIVE_PROTOSS_AIR_ARMOR].code: (LogicEffect.PROTOSS_AIR_ARMOR, 1),
+    item_table[item_names.PROGRESSIVE_PROTOSS_WEAPON_UPGRADE].code: (LogicEffect.PROTOSS_GROUND_WEAPON|LogicEffect.PROTOSS_AIR_WEAPON, 1),
+    item_table[item_names.PROGRESSIVE_PROTOSS_ARMOR_UPGRADE].code: (LogicEffect.PROTOSS_GROUND_ARMOR|LogicEffect.PROTOSS_AIR_ARMOR, 1),
+    item_table[item_names.PROGRESSIVE_PROTOSS_GROUND_UPGRADE].code: (LogicEffect.PROTOSS_GROUND_WEAPON|LogicEffect.PROTOSS_GROUND_ARMOR, 1),
+    item_table[item_names.PROGRESSIVE_PROTOSS_AIR_UPGRADE].code: (LogicEffect.PROTOSS_AIR_WEAPON|LogicEffect.PROTOSS_AIR_ARMOR, 1),
+    item_table[item_names.PROGRESSIVE_PROTOSS_WEAPON_ARMOR_UPGRADE].code: (LogicEffect.PROTOSS_UPGRADE, 1),
+
+    item_table[item_names.SIEGE_TANK].code: (LogicEffect.TERRAN_DEFENSE_RATING, 5),
+    item_table[item_names.PLANETARY_FORTRESS].code: (LogicEffect.TERRAN_DEFENSE_RATING, 3),
+    item_table[item_names.PERDITION_TURRET].code: (LogicEffect.TERRAN_DEFENSE_RATING|LogicEffect.TVZ_DEFENSE_RATING, 2),
+    item_table[item_names.DEVASTATOR_TURRET].code: (LogicEffect.TERRAN_DEFENSE_RATING, 2),
+    item_table[item_names.LIBERATOR].code: (LogicEffect.TERRAN_DEFENSE_RATING, 3),
+    item_table[item_names.WIDOW_MINE].code: (LogicEffect.TERRAN_DEFENSE_RATING, 1),
+
+    item_table[item_names.MARINE].code: (LogicEffect.BUNKER_DEFENSE_RATING, 3),
+    item_table[item_names.DOMINION_TROOPER].code: (LogicEffect.BUNKER_DEFENSE_RATING, 3),
+    item_table[item_names.MARAUDER].code: (LogicEffect.BUNKER_DEFENSE_RATING, 3),
+    item_table[item_names.FIREBAT].code: (LogicEffect.BUNKER_DEFENSE_RATING, 1),
+    item_table[item_names.GHOST].code: (LogicEffect.BUNKER_DEFENSE_RATING, 2),
+    item_table[item_names.SPECTRE].code: (LogicEffect.BUNKER_DEFENSE_RATING, 2),
+
+    item_table[item_names.HIVE_MIND_EMULATOR].code: (LogicEffect.TVZ_DEFENSE_RATING, 3),
+    item_table[item_names.PSI_DISRUPTER].code: (LogicEffect.TVZ_DEFENSE_RATING, 3),
+}
+LOGIC_MINIMUM_COUNTERS = {
+    item_table[item_names.PROGRESSIVE_TERRAN_INFANTRY_WEAPON].code: LogicEffect.TERRAN_UPGRADE,
+    item_table[item_names.PROGRESSIVE_TERRAN_INFANTRY_ARMOR].code: LogicEffect.TERRAN_UPGRADE,
+    item_table[item_names.PROGRESSIVE_TERRAN_VEHICLE_WEAPON].code: LogicEffect.TERRAN_UPGRADE,
+    item_table[item_names.PROGRESSIVE_TERRAN_VEHICLE_ARMOR].code: LogicEffect.TERRAN_UPGRADE,
+    item_table[item_names.PROGRESSIVE_TERRAN_SHIP_WEAPON].code: LogicEffect.TERRAN_UPGRADE,
+    item_table[item_names.PROGRESSIVE_TERRAN_SHIP_ARMOR].code: LogicEffect.TERRAN_UPGRADE,
+    item_table[item_names.PROGRESSIVE_TERRAN_WEAPON_UPGRADE].code: LogicEffect.TERRAN_UPGRADE,
+    item_table[item_names.PROGRESSIVE_TERRAN_ARMOR_UPGRADE].code: LogicEffect.TERRAN_UPGRADE,
+    item_table[item_names.PROGRESSIVE_TERRAN_INFANTRY_UPGRADE].code: LogicEffect.TERRAN_UPGRADE,
+    item_table[item_names.PROGRESSIVE_TERRAN_VEHICLE_UPGRADE].code: LogicEffect.TERRAN_UPGRADE,
+    item_table[item_names.PROGRESSIVE_TERRAN_SHIP_UPGRADE].code: LogicEffect.TERRAN_UPGRADE,
+    item_table[item_names.PROGRESSIVE_TERRAN_WEAPON_ARMOR_UPGRADE].code: LogicEffect.TERRAN_UPGRADE,
+    item_table[item_names.PROGRESSIVE_ZERG_MELEE_ATTACK].code: LogicEffect.ZERG_UPGRADE,
+    item_table[item_names.PROGRESSIVE_ZERG_MISSILE_ATTACK].code: LogicEffect.ZERG_UPGRADE,
+    item_table[item_names.PROGRESSIVE_ZERG_GROUND_CARAPACE].code: LogicEffect.ZERG_UPGRADE,
+    item_table[item_names.PROGRESSIVE_ZERG_FLYER_ATTACK].code: LogicEffect.ZERG_UPGRADE,
+    item_table[item_names.PROGRESSIVE_ZERG_FLYER_CARAPACE].code: LogicEffect.ZERG_UPGRADE,
+    item_table[item_names.PROGRESSIVE_ZERG_WEAPON_UPGRADE].code: LogicEffect.ZERG_UPGRADE,
+    item_table[item_names.PROGRESSIVE_ZERG_ARMOR_UPGRADE].code: LogicEffect.ZERG_UPGRADE,
+    item_table[item_names.PROGRESSIVE_ZERG_GROUND_UPGRADE].code: LogicEffect.ZERG_UPGRADE,
+    item_table[item_names.PROGRESSIVE_ZERG_FLYER_UPGRADE].code: LogicEffect.ZERG_UPGRADE,
+    item_table[item_names.PROGRESSIVE_ZERG_WEAPON_ARMOR_UPGRADE].code: LogicEffect.ZERG_UPGRADE,
+    item_table[item_names.PROGRESSIVE_PROTOSS_GROUND_WEAPON].code: LogicEffect.PROTOSS_UPGRADE,
+    item_table[item_names.PROGRESSIVE_PROTOSS_GROUND_ARMOR].code: LogicEffect.PROTOSS_UPGRADE,
+    item_table[item_names.PROGRESSIVE_PROTOSS_AIR_WEAPON].code: LogicEffect.PROTOSS_UPGRADE,
+    item_table[item_names.PROGRESSIVE_PROTOSS_AIR_ARMOR].code: LogicEffect.PROTOSS_UPGRADE,
+    item_table[item_names.PROGRESSIVE_PROTOSS_WEAPON_UPGRADE].code: LogicEffect.PROTOSS_UPGRADE,
+    item_table[item_names.PROGRESSIVE_PROTOSS_ARMOR_UPGRADE].code: LogicEffect.PROTOSS_UPGRADE,
+    item_table[item_names.PROGRESSIVE_PROTOSS_GROUND_UPGRADE].code: LogicEffect.PROTOSS_UPGRADE,
+    item_table[item_names.PROGRESSIVE_PROTOSS_AIR_UPGRADE].code: LogicEffect.PROTOSS_UPGRADE,
+    item_table[item_names.PROGRESSIVE_PROTOSS_WEAPON_ARMOR_UPGRADE].code: LogicEffect.PROTOSS_UPGRADE,
+}
+
+
+def after_add_item(inventory: "Counter[str]", item: "Item") -> None:
+    effects, count = LOGIC_EFFECTS.get(item.code, (LogicEffect.NONE, 0))
+    if count:
+        for effect in effects:
+            inventory[effect.name] += count
+    min_counter = LOGIC_MINIMUM_COUNTERS.get(item.code)
+    if min_counter:
+        inventory[min_counter.name] = min(
+            inventory[effect.name] for effect in min_counter
+        )
+
+def after_remove_item(inventory: "Counter[str]", item: "Item") -> None:
+    effects, count = LOGIC_EFFECTS.get(item.code, (LogicEffect.NONE, 0))
+    if count:
+        for effect in effects:
+            inventory[effect.name] -= count
+    min_counter = LOGIC_MINIMUM_COUNTERS.get(item.code)
+    if min_counter:
+        if inventory[min_counter.name] > inventory[item.name]:
+            inventory[min_counter.name] = inventory[item.name]

--- a/worlds/sc2/item/virtual_items.py
+++ b/worlds/sc2/item/virtual_items.py
@@ -34,6 +34,12 @@ class LogicEffect(enum.IntFlag):
     BUNKER_DEFENSE_RATING = enum.auto()
     TVZ_DEFENSE_RATING = enum.auto()
 
+    ZERG_MUTALISK_RATING = enum.auto()
+    """
+    Checking against 10+N guarantees mutas + N powerful upgrades (+attack, glaives).
+    >=14 is competent mutas
+    """
+
     TERRAN_UPGRADE = (
          TERRAN_INFANTRY_WEAPON|TERRAN_INFANTRY_ARMOR
         |TERRAN_VEHICLE_WEAPON|TERRAN_VEHICLE_ARMOR
@@ -73,13 +79,13 @@ LOGIC_EFFECTS = {
     item_table[item_names.PROGRESSIVE_ZERG_MELEE_ATTACK].code: (LogicEffect.ZERG_MELEE_ATTACK, 1),
     item_table[item_names.PROGRESSIVE_ZERG_MISSILE_ATTACK].code: (LogicEffect.ZERG_RANGED_ATTACK, 1),
     item_table[item_names.PROGRESSIVE_ZERG_GROUND_CARAPACE].code: (LogicEffect.ZERG_GROUND_ARMOR, 1),
-    item_table[item_names.PROGRESSIVE_ZERG_FLYER_ATTACK].code: (LogicEffect.ZERG_AIR_ATTACK, 1),
+    item_table[item_names.PROGRESSIVE_ZERG_FLYER_ATTACK].code: (LogicEffect.ZERG_AIR_ATTACK|LogicEffect.ZERG_MUTALISK_RATING, 1),
     item_table[item_names.PROGRESSIVE_ZERG_FLYER_CARAPACE].code: (LogicEffect.ZERG_AIR_ARMOR, 1),
     item_table[item_names.PROGRESSIVE_ZERG_WEAPON_UPGRADE].code: (LogicEffect.ZERG_MELEE_ATTACK|LogicEffect.ZERG_RANGED_ATTACK|LogicEffect.ZERG_AIR_ATTACK, 1),
     item_table[item_names.PROGRESSIVE_ZERG_ARMOR_UPGRADE].code: (LogicEffect.ZERG_GROUND_ARMOR|LogicEffect.ZERG_AIR_ARMOR, 1),
     item_table[item_names.PROGRESSIVE_ZERG_GROUND_UPGRADE].code: (LogicEffect.ZERG_MELEE_ATTACK|LogicEffect.ZERG_RANGED_ATTACK|LogicEffect.ZERG_GROUND_ARMOR, 1),
-    item_table[item_names.PROGRESSIVE_ZERG_FLYER_UPGRADE].code: (LogicEffect.ZERG_AIR_ATTACK|LogicEffect.ZERG_AIR_ARMOR, 1),
-    item_table[item_names.PROGRESSIVE_ZERG_WEAPON_ARMOR_UPGRADE].code: (LogicEffect.ZERG_UPGRADE, 1),
+    item_table[item_names.PROGRESSIVE_ZERG_FLYER_UPGRADE].code: (LogicEffect.ZERG_AIR_ATTACK|LogicEffect.ZERG_AIR_ARMOR|LogicEffect.ZERG_MUTALISK_RATING, 1),
+    item_table[item_names.PROGRESSIVE_ZERG_WEAPON_ARMOR_UPGRADE].code: (LogicEffect.ZERG_UPGRADE|LogicEffect.ZERG_MUTALISK_RATING, 1),
     item_table[item_names.PROGRESSIVE_PROTOSS_GROUND_WEAPON].code: (LogicEffect.PROTOSS_GROUND_WEAPON, 1),
     item_table[item_names.PROGRESSIVE_PROTOSS_GROUND_ARMOR].code: (LogicEffect.PROTOSS_GROUND_ARMOR, 1),
     item_table[item_names.PROGRESSIVE_PROTOSS_SHIELDS].code: (LogicEffect.PROTOSS_SHIELDS, 1),
@@ -109,6 +115,12 @@ LOGIC_EFFECTS = {
     item_table[item_names.FIREBAT].code: (LogicEffect.BUNKER_DEFENSE_RATING, 1),
     item_table[item_names.GHOST].code: (LogicEffect.BUNKER_DEFENSE_RATING, 1),
     item_table[item_names.SPECTRE].code: (LogicEffect.BUNKER_DEFENSE_RATING, 1),
+
+    # Mutalisk rating
+    item_table[item_names.MUTALISK].code: (LogicEffect.ZERG_MUTALISK_RATING, 10),
+    item_table[item_names.MUTALISK_SEVERING_GLAIVE].code: (LogicEffect.ZERG_MUTALISK_RATING, 1),
+    item_table[item_names.MUTALISK_SUNDERING_GLAIVE].code: (LogicEffect.ZERG_MUTALISK_RATING, 1),
+    item_table[item_names.MUTALISK_VICIOUS_GLAIVE].code: (LogicEffect.ZERG_MUTALISK_RATING, 1),
 }
 LOGIC_MINIMUM_COUNTERS = {
     # When the key is added or removed,
@@ -125,16 +137,6 @@ LOGIC_MINIMUM_COUNTERS = {
     item_table[item_names.PROGRESSIVE_TERRAN_VEHICLE_UPGRADE].code: LogicEffect.TERRAN_UPGRADE,
     item_table[item_names.PROGRESSIVE_TERRAN_SHIP_UPGRADE].code: LogicEffect.TERRAN_UPGRADE,
     item_table[item_names.PROGRESSIVE_TERRAN_WEAPON_ARMOR_UPGRADE].code: LogicEffect.TERRAN_UPGRADE,
-    item_table[item_names.PROGRESSIVE_ZERG_MELEE_ATTACK].code: LogicEffect.ZERG_UPGRADE,
-    item_table[item_names.PROGRESSIVE_ZERG_MISSILE_ATTACK].code: LogicEffect.ZERG_UPGRADE,
-    item_table[item_names.PROGRESSIVE_ZERG_GROUND_CARAPACE].code: LogicEffect.ZERG_UPGRADE,
-    item_table[item_names.PROGRESSIVE_ZERG_FLYER_ATTACK].code: LogicEffect.ZERG_UPGRADE,
-    item_table[item_names.PROGRESSIVE_ZERG_FLYER_CARAPACE].code: LogicEffect.ZERG_UPGRADE,
-    item_table[item_names.PROGRESSIVE_ZERG_WEAPON_UPGRADE].code: LogicEffect.ZERG_UPGRADE,
-    item_table[item_names.PROGRESSIVE_ZERG_ARMOR_UPGRADE].code: LogicEffect.ZERG_UPGRADE,
-    item_table[item_names.PROGRESSIVE_ZERG_GROUND_UPGRADE].code: LogicEffect.ZERG_UPGRADE,
-    item_table[item_names.PROGRESSIVE_ZERG_FLYER_UPGRADE].code: LogicEffect.ZERG_UPGRADE,
-    item_table[item_names.PROGRESSIVE_ZERG_WEAPON_ARMOR_UPGRADE].code: LogicEffect.ZERG_UPGRADE,
     item_table[item_names.PROGRESSIVE_PROTOSS_GROUND_WEAPON].code: LogicEffect.PROTOSS_UPGRADE,
     item_table[item_names.PROGRESSIVE_PROTOSS_GROUND_ARMOR].code: LogicEffect.PROTOSS_UPGRADE,
     item_table[item_names.PROGRESSIVE_PROTOSS_AIR_WEAPON].code: LogicEffect.PROTOSS_UPGRADE,

--- a/worlds/sc2/item/virtual_items.py
+++ b/worlds/sc2/item/virtual_items.py
@@ -90,7 +90,6 @@ LOGIC_EFFECTS = {
     item_table[item_names.PROGRESSIVE_PROTOSS_GROUND_UPGRADE].code: (LogicEffect.PROTOSS_GROUND_WEAPON|LogicEffect.PROTOSS_GROUND_ARMOR, 1),
     item_table[item_names.PROGRESSIVE_PROTOSS_AIR_UPGRADE].code: (LogicEffect.PROTOSS_AIR_WEAPON|LogicEffect.PROTOSS_AIR_ARMOR, 1),
     item_table[item_names.PROGRESSIVE_PROTOSS_WEAPON_ARMOR_UPGRADE].code: (LogicEffect.PROTOSS_UPGRADE, 1),
-    item_table[item_names.QUATRO].code: (LogicEffect.PROTOSS_UPGRADE, 1),
 
     # General defense rating
     item_table[item_names.SIEGE_TANK].code: (LogicEffect.TERRAN_DEFENSE_RATING, 5),
@@ -145,7 +144,6 @@ LOGIC_MINIMUM_COUNTERS = {
     item_table[item_names.PROGRESSIVE_PROTOSS_GROUND_UPGRADE].code: LogicEffect.PROTOSS_UPGRADE,
     item_table[item_names.PROGRESSIVE_PROTOSS_AIR_UPGRADE].code: LogicEffect.PROTOSS_UPGRADE,
     item_table[item_names.PROGRESSIVE_PROTOSS_WEAPON_ARMOR_UPGRADE].code: LogicEffect.PROTOSS_UPGRADE,
-    item_table[item_names.QUATRO].code: LogicEffect.PROTOSS_UPGRADE,
 }
 
 
@@ -156,8 +154,9 @@ def after_add_item(inventory: "Counter[str]", item: "Item") -> None:
             inventory[effect.name] += count
     min_counter = LOGIC_MINIMUM_COUNTERS.get(item.code)
     if min_counter:
-        if inventory[min_counter.name] < inventory[item.name]:
-            inventory[min_counter.name] = inventory[item.name]
+        inventory[min_counter.name] = min(
+            inventory[effect.name] for effect in min_counter
+        )
 
 def after_remove_item(inventory: "Counter[str]", item: "Item") -> None:
     effects, count = LOGIC_EFFECTS.get(item.code, (LogicEffect.NONE, 0))
@@ -166,6 +165,5 @@ def after_remove_item(inventory: "Counter[str]", item: "Item") -> None:
             inventory[effect.name] -= count
     min_counter = LOGIC_MINIMUM_COUNTERS.get(item.code)
     if min_counter:
-        inventory[min_counter.name] = min(
-            inventory[effect.name] for effect in min_counter
-        )
+        if inventory[min_counter.name] > inventory[item.name]:
+            inventory[min_counter.name] = inventory[item.name]

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -2245,10 +2245,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Victory",
             SC2HOTS_LOC_ID_OFFSET + 100,
             LocationType.VICTORY,
-            lambda state: (
-                logic.zerg_common_unit
-                or state.has_any((item_names.ZERGLING, item_names.PYGALISK), player)
-            ),
+            logic.zerg_lab_rat_requirement,
         ),
         make_location_data(
             SC2Mission.LAB_RAT.mission_name,
@@ -2261,33 +2258,21 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "South Zergling Group",
             SC2HOTS_LOC_ID_OFFSET + 102,
             LocationType.VANILLA,
-            lambda state: adv_tactics
-            or (
-                logic.zerg_common_unit
-                or state.has_any((item_names.ZERGLING, item_names.PYGALISK), player)
-            ),
+            logic.zerg_lab_rat_requirement,
         ),
         make_location_data(
             SC2Mission.LAB_RAT.mission_name,
             "East Zergling Group",
             SC2HOTS_LOC_ID_OFFSET + 103,
             LocationType.VANILLA,
-            lambda state: adv_tactics
-            or (
-                logic.zerg_common_unit
-                or state.has_any((item_names.ZERGLING, item_names.PYGALISK), player)
-            ),
+            logic.zerg_lab_rat_requirement,
         ),
         make_location_data(
             SC2Mission.LAB_RAT.mission_name,
             "West Zergling Group",
             SC2HOTS_LOC_ID_OFFSET + 104,
             LocationType.VANILLA,
-            lambda state: adv_tactics
-            or (
-                logic.zerg_common_unit
-                or state.has_any((item_names.ZERGLING, item_names.PYGALISK), player)
-            ),
+            logic.zerg_lab_rat_requirement,
         ),
         make_location_data(
             SC2Mission.LAB_RAT.mission_name,
@@ -2306,11 +2291,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Gas Turrets",
             SC2HOTS_LOC_ID_OFFSET + 107,
             LocationType.EXTRA,
-            lambda state: adv_tactics
-            or (
-                logic.zerg_common_unit
-                or state.has_any((item_names.ZERGLING, item_names.PYGALISK), player)
-            ),
+            logic.zerg_lab_rat_requirement,
         ),
         make_location_data(
             SC2Mission.LAB_RAT.mission_name,
@@ -2318,7 +2299,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2HOTS_LOC_ID_OFFSET + 108,
             LocationType.CHALLENGE,
             lambda state: (
-                logic.zerg_common_unit
+                logic.zerg_common_unit(state)
                 or state.has_any((item_names.ZERGLING, item_names.PYGALISK), player)
             ),
             flags=LocationFlag.SPEEDRUN,
@@ -7240,7 +7221,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2_RACESWAP_LOC_ID_OFFSET + 1809,
             LocationType.MASTERY,
             lambda state: (
-                logic.protoss_anti_armor_anti_air
+                logic.protoss_anti_armor_anti_air(state)
                 and logic.protoss_defense_rating(state, False) >= 6
                 and logic.protoss_common_unit(state)
                 and logic.protoss_deathball(state)
@@ -9063,15 +9044,14 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Victory",
             SC2_RACESWAP_LOC_ID_OFFSET + 4800,
             LocationType.VICTORY,
-            lambda state: logic.zerg_common_unit(state)
-            and logic.zerg_competent_anti_air(state),
+            logic.zerg_common_unit_competent_aa,
         ),
         make_location_data(
             SC2Mission.ECHOES_OF_THE_FUTURE_Z.mission_name,
             "Close Obelisk",
             SC2_RACESWAP_LOC_ID_OFFSET + 4801,
             LocationType.VANILLA,
-            lambda state: adv_tactics or logic.zerg_common_unit,
+            lambda state: adv_tactics or logic.zerg_common_unit(state),
         ),
         make_location_data(
             SC2Mission.ECHOES_OF_THE_FUTURE_Z.mission_name,
@@ -11825,7 +11805,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Victory",
             SC2_RACESWAP_LOC_ID_OFFSET + 9600,
             LocationType.VICTORY,
-            lambda state: logic.protoss_deathball
+            lambda state: logic.protoss_deathball(state)
             or (adv_tactics and logic.protoss_competent_comp(state)),
         ),
         make_location_data(
@@ -11860,7 +11840,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Main Path Command Center",
             SC2_RACESWAP_LOC_ID_OFFSET + 9605,
             LocationType.EXTRA,
-            lambda state: logic.protoss_deathball
+            lambda state: logic.protoss_deathball(state)
             or (adv_tactics and logic.protoss_competent_comp(state)),
         ),
         make_location_data(
@@ -12010,7 +11990,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Victory",
             SC2_RACESWAP_LOC_ID_OFFSET + 10000,
             LocationType.VICTORY,
-            lambda state: logic.zerg_competent_comp
+            lambda state: logic.zerg_competent_comp(state)
             and logic.zerg_moderate_anti_air(state),
         ),
         make_location_data(
@@ -12018,7 +11998,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "First Prisoner Group",
             SC2_RACESWAP_LOC_ID_OFFSET + 10001,
             LocationType.VANILLA,
-            lambda state: logic.zerg_competent_comp
+            lambda state: logic.zerg_competent_comp(state)
             and logic.zerg_moderate_anti_air(state),
         ),
         make_location_data(
@@ -12026,7 +12006,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Second Prisoner Group",
             SC2_RACESWAP_LOC_ID_OFFSET + 10002,
             LocationType.VANILLA,
-            lambda state: logic.zerg_competent_comp
+            lambda state: logic.zerg_competent_comp(state)
             and logic.zerg_moderate_anti_air(state),
         ),
         make_location_data(
@@ -12034,7 +12014,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "First Pylon",
             SC2_RACESWAP_LOC_ID_OFFSET + 10003,
             LocationType.VANILLA,
-            lambda state: logic.zerg_competent_comp
+            lambda state: logic.zerg_competent_comp(state)
             and logic.zerg_moderate_anti_air(state),
         ),
         make_location_data(
@@ -12042,7 +12022,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Second Pylon",
             SC2_RACESWAP_LOC_ID_OFFSET + 10004,
             LocationType.VANILLA,
-            lambda state: logic.zerg_competent_comp
+            lambda state: logic.zerg_competent_comp(state)
             and logic.zerg_moderate_anti_air(state),
         ),
         make_location_data(
@@ -12645,7 +12625,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2_RACESWAP_LOC_ID_OFFSET + 11406,
             LocationType.CHALLENGE,
             lambda state: (
-                logic.zerg_brothers_in_arms_requirement
+                logic.zerg_brothers_in_arms_requirement(state)
                 and logic.zerg_base_buster(state)
                 and logic.zerg_power_rating(state) >= 8
             ),

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -734,51 +734,35 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Left Relic",
             SC2WOL_LOC_ID_OFFSET + 901,
             LocationType.VANILLA,
-            lambda state: (
-                logic.terran_defense_rating(state, False, False) >= 6
-                and logic.terran_common_unit(state)
-                and (logic.marine_medic_upgrade(state) or adv_tactics)
-            ),
+            logic.terran_the_dig_anti_ground_requirement,
         ),
         make_location_data(
             SC2Mission.THE_DIG.mission_name,
             "Right Ground Relic",
             SC2WOL_LOC_ID_OFFSET + 902,
             LocationType.VANILLA,
-            lambda state: (
-                logic.terran_defense_rating(state, False, False) >= 6
-                and logic.terran_common_unit(state)
-                and (logic.marine_medic_upgrade(state) or adv_tactics)
-            ),
+            logic.terran_the_dig_anti_ground_requirement,
         ),
         make_location_data(
             SC2Mission.THE_DIG.mission_name,
             "Right Cliff Relic",
             SC2WOL_LOC_ID_OFFSET + 903,
             LocationType.VANILLA,
-            lambda state: (
-                logic.terran_defense_rating(state, False, False) >= 6
-                and logic.terran_common_unit(state)
-                and (logic.marine_medic_upgrade(state) or adv_tactics)
-            ),
+            logic.terran_the_dig_anti_ground_requirement,
         ),
         make_location_data(
             SC2Mission.THE_DIG.mission_name,
             "Moebius Base",
             SC2WOL_LOC_ID_OFFSET + 904,
             LocationType.EXTRA,
-            lambda state: logic.marine_medic_upgrade(state) or adv_tactics,
+            logic.terran_the_dig_nobuild_requirement,
         ),
         make_location_data(
             SC2Mission.THE_DIG.mission_name,
             "Door Outer Layer",
             SC2WOL_LOC_ID_OFFSET + 905,
             LocationType.EXTRA,
-            lambda state: (
-                logic.terran_defense_rating(state, False, False) >= 6
-                and logic.terran_common_unit(state)
-                and (logic.marine_medic_upgrade(state) or adv_tactics)
-            ),
+            logic.terran_the_dig_anti_ground_requirement,
         ),
         make_location_data(
             SC2Mission.THE_DIG.mission_name,

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -2413,7 +2413,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2HOTS_LOC_ID_OFFSET + 305,
             LocationType.MASTERY,
             lambda state: (
-                logic.zerg_competent_comp(state)
+                logic.zerg_upgraded_competent_comp(state)
                 and logic.zerg_competent_anti_air(state)
                 and (logic.basic_kerrigan(state) or kerriganless)
                 and logic.zerg_defense_rating(state, False, False) >= 3
@@ -2751,7 +2751,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2HOTS_LOC_ID_OFFSET + 800,
             LocationType.VICTORY,
             lambda state: (
-                logic.zerg_competent_comp(state)
+                logic.zerg_upgraded_competent_comp(state)
                 and logic.zerg_moderate_anti_air(state)
                 and logic.spread_creep(state)
             ),
@@ -2768,7 +2768,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2HOTS_LOC_ID_OFFSET + 802,
             LocationType.VANILLA,
             lambda state: (
-                logic.zerg_competent_comp(state)
+                logic.zerg_upgraded_competent_comp(state)
                 and logic.zerg_moderate_anti_air(state)
                 and logic.spread_creep(state)
             ),
@@ -2779,7 +2779,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2HOTS_LOC_ID_OFFSET + 803,
             LocationType.VANILLA,
             lambda state: (
-                logic.zerg_competent_comp(state)
+                logic.zerg_upgraded_competent_comp(state)
                 and logic.zerg_moderate_anti_air(state)
                 and logic.spread_creep(state)
             ),
@@ -2790,7 +2790,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2HOTS_LOC_ID_OFFSET + 804,
             LocationType.EXTRA,
             lambda state: (
-                logic.zerg_competent_comp(state)
+                logic.zerg_upgraded_competent_comp(state)
                 and logic.zerg_moderate_anti_air(state)
                 and logic.spread_creep(state)
             ),
@@ -2814,7 +2814,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2HOTS_LOC_ID_OFFSET + 807,
             LocationType.EXTRA,
             lambda state: (
-                logic.zerg_competent_comp(state)
+                logic.zerg_upgraded_competent_comp(state)
                 and logic.zerg_moderate_anti_air(state)
                 and logic.spread_creep(state)
             ),
@@ -2825,7 +2825,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2HOTS_LOC_ID_OFFSET + 808,
             LocationType.EXTRA,
             lambda state: (
-                logic.zerg_competent_comp(state)
+                logic.zerg_upgraded_competent_comp(state)
                 and logic.zerg_moderate_anti_air(state)
                 and logic.spread_creep(state)
             ),
@@ -2836,7 +2836,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2HOTS_LOC_ID_OFFSET + 809,
             LocationType.EXTRA,
             lambda state: (
-                logic.zerg_competent_comp(state)
+                logic.zerg_upgraded_competent_comp(state)
                 and logic.zerg_moderate_anti_air(state)
                 and logic.spread_creep(state)
             ),
@@ -2847,7 +2847,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2HOTS_LOC_ID_OFFSET + 810,
             LocationType.CHALLENGE,
             lambda state: (
-                logic.zerg_competent_comp(state) and logic.zerg_moderate_anti_air(state)
+                logic.zerg_upgraded_competent_comp(state) and logic.zerg_moderate_anti_air(state)
             ),
             flags=LocationFlag.BASEBUST,
         ),
@@ -2857,7 +2857,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2HOTS_LOC_ID_OFFSET + 811,
             LocationType.CHALLENGE,
             lambda state: (
-                logic.zerg_competent_comp(state) and logic.zerg_moderate_anti_air(state)
+                logic.zerg_upgraded_competent_comp(state) and logic.zerg_moderate_anti_air(state)
             ),
             flags=LocationFlag.BASEBUST,
         ),
@@ -2867,7 +2867,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2HOTS_LOC_ID_OFFSET + 812,
             LocationType.CHALLENGE,
             lambda state: (
-                logic.zerg_competent_comp(state) and logic.zerg_moderate_anti_air(state)
+                logic.zerg_upgraded_competent_comp(state) and logic.zerg_moderate_anti_air(state)
             ),
             flags=LocationFlag.BASEBUST,
         ),
@@ -3350,7 +3350,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2HOTS_LOC_ID_OFFSET + 1500,
             LocationType.VICTORY,
             lambda state: (
-                logic.zerg_competent_comp(state)
+                logic.zerg_upgraded_competent_comp(state)
                 and (
                     logic.zerg_competent_anti_air(state)
                     or (adv_tactics and logic.zerg_moderate_anti_air(state))
@@ -3363,7 +3363,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2HOTS_LOC_ID_OFFSET + 1501,
             LocationType.VANILLA,
             lambda state: (
-                logic.zerg_competent_comp(state)
+                logic.zerg_upgraded_competent_comp(state)
                 and (
                     logic.zerg_competent_anti_air(state)
                     or (adv_tactics and logic.zerg_moderate_anti_air(state))
@@ -3376,7 +3376,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2HOTS_LOC_ID_OFFSET + 1502,
             LocationType.VANILLA,
             lambda state: (
-                logic.zerg_competent_comp(state)
+                logic.zerg_upgraded_competent_comp(state)
                 and (
                     logic.zerg_competent_anti_air(state)
                     or (adv_tactics and logic.zerg_moderate_anti_air(state))
@@ -3401,7 +3401,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2HOTS_LOC_ID_OFFSET + 1505,
             LocationType.EXTRA,
             lambda state: (
-                logic.zerg_competent_comp(state)
+                logic.zerg_upgraded_competent_comp(state)
                 and (
                     logic.zerg_competent_anti_air(state)
                     or (adv_tactics and logic.zerg_moderate_anti_air(state))
@@ -3414,7 +3414,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2HOTS_LOC_ID_OFFSET + 1506,
             LocationType.EXTRA,
             lambda state: (
-                logic.zerg_competent_comp(state)
+                logic.zerg_upgraded_competent_comp(state)
                 and (
                     logic.zerg_competent_anti_air(state)
                     or (adv_tactics and logic.zerg_moderate_anti_air(state))
@@ -3427,7 +3427,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2HOTS_LOC_ID_OFFSET + 1507,
             LocationType.EXTRA,
             lambda state: (
-                logic.zerg_competent_comp(state)
+                logic.zerg_upgraded_competent_comp(state)
                 and (
                     logic.zerg_competent_anti_air(state)
                     or (adv_tactics and logic.zerg_moderate_anti_air(state))
@@ -3440,7 +3440,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2HOTS_LOC_ID_OFFSET + 1508,
             LocationType.EXTRA,
             lambda state: (
-                logic.zerg_competent_comp(state)
+                logic.zerg_upgraded_competent_comp(state)
                 and (
                     logic.zerg_competent_anti_air(state)
                     or (adv_tactics and logic.zerg_moderate_anti_air(state))
@@ -3453,7 +3453,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2HOTS_LOC_ID_OFFSET + 1509,
             LocationType.EXTRA,
             lambda state: (
-                logic.zerg_competent_comp(state)
+                logic.zerg_upgraded_competent_comp(state)
                 and (
                     logic.zerg_competent_anti_air(state)
                     or (adv_tactics and logic.zerg_moderate_anti_air(state))
@@ -8905,7 +8905,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Victory",
             SC2_RACESWAP_LOC_ID_OFFSET + 4600,
             LocationType.VICTORY,
-            lambda state: logic.zerg_competent_comp(state)
+            lambda state: logic.zerg_upgraded_competent_comp(state)
             and logic.zerg_competent_anti_air(state),
         ),
         make_location_data(
@@ -8962,7 +8962,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Northwest Preserver",
             SC2_RACESWAP_LOC_ID_OFFSET + 4607,
             LocationType.EXTRA,
-            lambda state: logic.zerg_competent_comp(state)
+            lambda state: logic.zerg_upgraded_competent_comp(state)
             and logic.zerg_competent_anti_air(state),
         ),
         make_location_data(
@@ -8970,7 +8970,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Southwest Preserver",
             SC2_RACESWAP_LOC_ID_OFFSET + 4608,
             LocationType.EXTRA,
-            lambda state: logic.zerg_competent_comp(state)
+            lambda state: logic.zerg_upgraded_competent_comp(state)
             and logic.zerg_competent_anti_air(state),
         ),
         make_location_data(
@@ -8978,7 +8978,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "East Preserver",
             SC2_RACESWAP_LOC_ID_OFFSET + 4609,
             LocationType.EXTRA,
-            lambda state: logic.zerg_competent_comp(state)
+            lambda state: logic.zerg_upgraded_competent_comp(state)
             and logic.zerg_competent_anti_air(state),
         ),
         make_location_data(
@@ -11991,7 +11991,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Victory",
             SC2_RACESWAP_LOC_ID_OFFSET + 10000,
             LocationType.VICTORY,
-            lambda state: logic.zerg_competent_comp(state)
+            lambda state: logic.zerg_upgraded_competent_comp(state)
             and logic.zerg_moderate_anti_air(state),
         ),
         make_location_data(
@@ -11999,7 +11999,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "First Prisoner Group",
             SC2_RACESWAP_LOC_ID_OFFSET + 10001,
             LocationType.VANILLA,
-            lambda state: logic.zerg_competent_comp(state)
+            lambda state: logic.zerg_upgraded_competent_comp(state)
             and logic.zerg_moderate_anti_air(state),
         ),
         make_location_data(
@@ -12007,7 +12007,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Second Prisoner Group",
             SC2_RACESWAP_LOC_ID_OFFSET + 10002,
             LocationType.VANILLA,
-            lambda state: logic.zerg_competent_comp(state)
+            lambda state: logic.zerg_upgraded_competent_comp(state)
             and logic.zerg_moderate_anti_air(state),
         ),
         make_location_data(
@@ -12015,7 +12015,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "First Pylon",
             SC2_RACESWAP_LOC_ID_OFFSET + 10003,
             LocationType.VANILLA,
-            lambda state: logic.zerg_competent_comp(state)
+            lambda state: logic.zerg_upgraded_competent_comp(state)
             and logic.zerg_moderate_anti_air(state),
         ),
         make_location_data(
@@ -12023,7 +12023,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             "Second Pylon",
             SC2_RACESWAP_LOC_ID_OFFSET + 10004,
             LocationType.VANILLA,
-            lambda state: logic.zerg_competent_comp(state)
+            lambda state: logic.zerg_upgraded_competent_comp(state)
             and logic.zerg_moderate_anti_air(state),
         ),
         make_location_data(
@@ -12032,7 +12032,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2_RACESWAP_LOC_ID_OFFSET + 10005,
             LocationType.MASTERY,
             lambda state: (
-                logic.zerg_competent_comp(state)
+                logic.zerg_upgraded_competent_comp(state)
                 and logic.zerg_moderate_anti_air(state)
                 and logic.zerg_base_buster(state)
                 and logic.zerg_power_rating(state) >= 6
@@ -12086,7 +12086,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2_RACESWAP_LOC_ID_OFFSET + 10200,
             LocationType.VICTORY,
             lambda state: (
-                logic.zerg_competent_comp(state)
+                logic.zerg_upgraded_competent_comp(state)
                 and logic.zerg_competent_anti_air(state)
                 and logic.zerg_mineral_dump(state)
             ),
@@ -12097,7 +12097,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2_RACESWAP_LOC_ID_OFFSET + 10201,
             LocationType.VANILLA,
             lambda state: (
-                logic.zerg_competent_comp(state)
+                logic.zerg_upgraded_competent_comp(state)
                 and logic.zerg_competent_anti_air(state)
                 and logic.zerg_mineral_dump(state)
             ),
@@ -12108,7 +12108,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2_RACESWAP_LOC_ID_OFFSET + 10202,
             LocationType.VANILLA,
             lambda state: (
-                logic.zerg_competent_comp(state)
+                logic.zerg_upgraded_competent_comp(state)
                 and logic.zerg_competent_anti_air(state)
                 and logic.zerg_mineral_dump(state)
             ),
@@ -12119,7 +12119,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2_RACESWAP_LOC_ID_OFFSET + 10203,
             LocationType.VANILLA,
             lambda state: (
-                logic.zerg_competent_comp(state)
+                logic.zerg_upgraded_competent_comp(state)
                 and logic.zerg_competent_anti_air(state)
                 and logic.zerg_mineral_dump(state)
                 and logic.zerg_can_grab_ghosts_in_the_fog_east_rock_formation(state)
@@ -12693,7 +12693,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2_RACESWAP_LOC_ID_OFFSET + 11600,
             LocationType.VICTORY,
             lambda state: (
-                logic.zerg_competent_comp(state)
+                logic.zerg_upgraded_competent_comp(state)
                 and logic.zerg_basic_kerriganless_anti_air(state)
             ),
         ),
@@ -12709,7 +12709,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2_RACESWAP_LOC_ID_OFFSET + 11602,
             LocationType.VANILLA,
             lambda state: (
-                logic.zerg_competent_comp(state)
+                logic.zerg_upgraded_competent_comp(state)
                 and logic.zerg_basic_kerriganless_anti_air(state)
             ),
         ),
@@ -12719,7 +12719,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2_RACESWAP_LOC_ID_OFFSET + 11603,
             LocationType.VANILLA,
             lambda state: (
-                logic.zerg_competent_comp(state)
+                logic.zerg_upgraded_competent_comp(state)
                 and logic.zerg_basic_kerriganless_anti_air(state)
             ),
         ),
@@ -12729,7 +12729,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2_RACESWAP_LOC_ID_OFFSET + 11604,
             LocationType.EXTRA,
             lambda state: (
-                logic.zerg_competent_comp(state)
+                logic.zerg_upgraded_competent_comp(state)
                 and logic.zerg_basic_kerriganless_anti_air(state)
             ),
         ),
@@ -12739,7 +12739,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2_RACESWAP_LOC_ID_OFFSET + 11605,
             LocationType.EXTRA,
             lambda state: (
-                logic.zerg_competent_comp(state)
+                logic.zerg_upgraded_competent_comp(state)
                 and logic.zerg_basic_kerriganless_anti_air(state)
             ),
         ),
@@ -12749,7 +12749,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2_RACESWAP_LOC_ID_OFFSET + 11606,
             LocationType.EXTRA,
             lambda state: (
-                logic.zerg_competent_comp(state)
+                logic.zerg_upgraded_competent_comp(state)
                 and logic.zerg_basic_kerriganless_anti_air(state)
             ),
         ),
@@ -12759,7 +12759,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2_RACESWAP_LOC_ID_OFFSET + 11607,
             LocationType.EXTRA,
             lambda state: (
-                logic.zerg_competent_comp(state)
+                logic.zerg_upgraded_competent_comp(state)
                 and logic.zerg_basic_kerriganless_anti_air(state)
             ),
         ),

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -5125,7 +5125,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2NCO_LOC_ID_OFFSET + 100,
             LocationType.VICTORY,
             logic.the_escape_requirement,
-            hard_rule=logic.nova_any_weapon,
+            hard_rule=logic.nova_any_weapon_or_grenade,
         ),
         make_location_data(
             SC2Mission.THE_ESCAPE.mission_name,
@@ -5149,7 +5149,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2NCO_LOC_ID_OFFSET + 103,
             LocationType.VANILLA,
             logic.the_escape_requirement,
-            hard_rule=logic.nova_any_weapon,
+            hard_rule=logic.nova_any_weapon_or_grenade,
         ),
         make_location_data(
             SC2Mission.THE_ESCAPE.mission_name,
@@ -5157,7 +5157,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2NCO_LOC_ID_OFFSET + 104,
             LocationType.VANILLA,
             logic.the_escape_requirement,
-            hard_rule=logic.nova_any_weapon,
+            hard_rule=logic.nova_any_weapon_or_grenade,
         ),
         make_location_data(
             SC2Mission.THE_ESCAPE.mission_name,
@@ -5165,7 +5165,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2NCO_LOC_ID_OFFSET + 105,
             LocationType.VANILLA,
             logic.the_escape_requirement,
-            hard_rule=logic.nova_any_weapon,
+            hard_rule=logic.nova_any_weapon_or_grenade,
         ),
         make_location_data(
             SC2Mission.SUDDEN_STRIKE.mission_name,

--- a/worlds/sc2/locations.py
+++ b/worlds/sc2/locations.py
@@ -5125,7 +5125,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2NCO_LOC_ID_OFFSET + 100,
             LocationType.VICTORY,
             logic.the_escape_requirement,
-            hard_rule=logic.nova_any_nobuild_damage,
+            hard_rule=logic.nova_any_weapon,
         ),
         make_location_data(
             SC2Mission.THE_ESCAPE.mission_name,
@@ -5133,6 +5133,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2NCO_LOC_ID_OFFSET + 101,
             LocationType.VANILLA,
             logic.the_escape_first_stage_requirement,
+            hard_rule=logic.nova_any_nobuild_damage,
         ),
         make_location_data(
             SC2Mission.THE_ESCAPE.mission_name,
@@ -5148,7 +5149,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2NCO_LOC_ID_OFFSET + 103,
             LocationType.VANILLA,
             logic.the_escape_requirement,
-            hard_rule=logic.nova_any_nobuild_damage,
+            hard_rule=logic.nova_any_weapon,
         ),
         make_location_data(
             SC2Mission.THE_ESCAPE.mission_name,
@@ -5156,7 +5157,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2NCO_LOC_ID_OFFSET + 104,
             LocationType.VANILLA,
             logic.the_escape_requirement,
-            hard_rule=logic.nova_any_nobuild_damage,
+            hard_rule=logic.nova_any_weapon,
         ),
         make_location_data(
             SC2Mission.THE_ESCAPE.mission_name,
@@ -5164,7 +5165,7 @@ def get_locations(world: Optional["SC2World"]) -> Tuple[LocationData, ...]:
             SC2NCO_LOC_ID_OFFSET + 105,
             LocationType.VANILLA,
             logic.the_escape_requirement,
-            hard_rule=logic.nova_any_nobuild_damage,
+            hard_rule=logic.nova_any_weapon,
         ),
         make_location_data(
             SC2Mission.SUDDEN_STRIKE.mission_name,

--- a/worlds/sc2/pool_filter.py
+++ b/worlds/sc2/pool_filter.py
@@ -119,7 +119,7 @@ def after_add_item(inventory: Counter[str], item: "Item") -> None:
 
 def after_remove_item(inventory: Counter[str], item: "Item") -> None:
     for effect in LOGIC_EFFECTS.get(item.code, ()):
-        inventory[effect.name] += 1
+        inventory[effect.name] -= 1
     min_counter = LOGIC_MINIMUM_COUNTERS.get(item.code)
     if min_counter:
         if inventory[min_counter.name] > inventory[item.name]:

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -44,6 +44,13 @@ if TYPE_CHECKING:
     from . import SC2World
 
 
+def min2(left: int, right: int) -> int:
+    """A faster min() function that only takes two values. About twice as fast under timeit"""
+    if left < right:
+        return left
+    return right
+
+
 class SC2Logic:
     def __init__(self, world: Optional["SC2World"]) -> None:
         # Note: Don't store a reference to the world so we can cache this object on the world object
@@ -721,7 +728,7 @@ class SC2Logic:
         # General enemy-based rules
         if air_enemy:
             # Capped at 2
-            defense_score += min(sum((zvx_air_defense_ratings[item] for item in zvx_air_defense_ratings if state.has(item, self.player))), 2)
+            defense_score += min2(sum((zvx_air_defense_ratings[item] for item in zvx_air_defense_ratings if state.has(item, self.player))), 2)
         # Advanced Tactics bumps defense rating requirements down by 2
         if self.advanced_tactics:
             defense_score += 2
@@ -731,7 +738,7 @@ class SC2Logic:
         return self.weapon_armor_upgrade_count(LogicEffect.ZERG_UPGRADE.name, state)
 
     def zerg_melee_weapon_armor_upgrade_min_level(self, state: CollectionState) -> int:
-        result = min(
+        result = min2(
             state.count(LogicEffect.ZERG_MELEE_ATTACK.name, self.player),
             state.count(LogicEffect.ZERG_GROUND_ARMOR.name, self.player),
         )
@@ -740,7 +747,7 @@ class SC2Logic:
         return result
 
     def zerg_ranged_weapon_armor_upgrade_min_level(self, state: CollectionState) -> int:
-        result = min(
+        result = min2(
             state.count(LogicEffect.ZERG_RANGED_ATTACK.name, self.player),
             state.count(LogicEffect.ZERG_GROUND_ARMOR.name, self.player),
         )
@@ -749,7 +756,7 @@ class SC2Logic:
         return result
 
     def zerg_flyer_weapon_armor_upgrade_min_level(self, state: CollectionState) -> int:
-        result = min(
+        result = min2(
             state.count(LogicEffect.ZERG_AIR_ATTACK.name, self.player),
             state.count(LogicEffect.ZERG_AIR_ARMOR.name, self.player),
         )
@@ -1078,7 +1085,7 @@ class SC2Logic:
         # Levels from missions beaten
         levels = self.kerrigan_levels_per_mission_completed * state.count_group("Missions", self.player)
         if self.kerrigan_levels_per_mission_completed_cap != -1:
-            levels = min(levels, self.kerrigan_levels_per_mission_completed_cap)
+            levels = min2(levels, self.kerrigan_levels_per_mission_completed_cap)
         # Levels from items
         for kerrigan_level_item in kerrigan_levels:
             level_amount = item_table[kerrigan_level_item].number
@@ -1086,7 +1093,7 @@ class SC2Logic:
             levels += item_count * level_amount
         # Total level cap
         if self.kerrigan_total_level_cap != -1:
-            levels = min(levels, self.kerrigan_total_level_cap)
+            levels = min2(levels, self.kerrigan_total_level_cap)
 
         return levels >= target
 

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -117,6 +117,8 @@ class SC2Logic:
 
     def generic_upgrades_from_missions(self, state: CollectionState) -> int:
         if not self.total_mission_count:
+            # This flag should be 0 during item pool culling, so w/a checks will always pass.
+            # pre_fill sets total_mission_count to check if upgrade items need to be added to the starting inventory.
             return WEAPON_ARMOR_UPGRADE_MAX_LEVEL
         return (
             floor((100 / self.generic_upgrade_missions) * (state.count_group("Missions", self.player) / self.total_mission_count))

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -19,9 +19,6 @@ from .options import (
     get_enabled_races,
 )
 from .item.item_tables import (
-    tvx_defense_ratings,
-    tvz_defense_ratings,
-    tvx_air_defense_ratings,
     kerrigan_levels,
     item_table,
     zvx_air_defense_ratings,
@@ -31,7 +28,6 @@ from .item.item_tables import (
     no_logic_basic_units,
     advanced_basic_units,
     basic_units,
-    upgrade_bundle_inverted_lookup,
     WEAPON_ARMOR_UPGRADE_MAX_LEVEL,
     soa_ultimate_ratings,
     soa_energy_ratings,

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -576,30 +576,34 @@ class SC2Logic:
         )
 
     def nova_any_nobuild_damage(self, state: CollectionState) -> bool:
-        return state.has_any(
-            (
-                item_names.NOVA_C20A_CANISTER_RIFLE,
-                item_names.NOVA_HELLFIRE_SHOTGUN,
-                item_names.NOVA_PLASMA_RIFLE,
-                item_names.NOVA_MONOMOLECULAR_BLADE,
-                item_names.NOVA_BLAZEFIRE_GUNBLADE,
-                item_names.NOVA_PULSE_GRENADES,
-                item_names.NOVA_DOMINATION,
-            ),
-            self.player,
-        )
+        return state.has_any((
+            item_names.NOVA_C20A_CANISTER_RIFLE,
+            item_names.NOVA_HELLFIRE_SHOTGUN,
+            item_names.NOVA_PLASMA_RIFLE,
+            item_names.NOVA_MONOMOLECULAR_BLADE,
+            item_names.NOVA_BLAZEFIRE_GUNBLADE,
+            item_names.NOVA_PULSE_GRENADES,
+            item_names.NOVA_DOMINATION,
+        ), self.player)
 
     def nova_any_weapon(self, state: CollectionState) -> bool:
-        return state.has_any(
-            {
-                item_names.NOVA_C20A_CANISTER_RIFLE,
-                item_names.NOVA_HELLFIRE_SHOTGUN,
-                item_names.NOVA_PLASMA_RIFLE,
-                item_names.NOVA_MONOMOLECULAR_BLADE,
-                item_names.NOVA_BLAZEFIRE_GUNBLADE,
-            },
-            self.player,
-        )
+        return state.has_any((
+            item_names.NOVA_C20A_CANISTER_RIFLE,
+            item_names.NOVA_HELLFIRE_SHOTGUN,
+            item_names.NOVA_PLASMA_RIFLE,
+            item_names.NOVA_MONOMOLECULAR_BLADE,
+            item_names.NOVA_BLAZEFIRE_GUNBLADE,
+        ), self.player)
+    
+    def nova_any_weapon_or_grenade(self, state: CollectionState) -> bool:
+        return state.has_any((
+            item_names.NOVA_C20A_CANISTER_RIFLE,
+            item_names.NOVA_HELLFIRE_SHOTGUN,
+            item_names.NOVA_PLASMA_RIFLE,
+            item_names.NOVA_MONOMOLECULAR_BLADE,
+            item_names.NOVA_BLAZEFIRE_GUNBLADE,
+            item_names.NOVA_PULSE_GRENADES,
+        ), self.player)
 
     def nova_ranged_weapon(self, state: CollectionState) -> bool:
         return state.has_any({item_names.NOVA_C20A_CANISTER_RIFLE, item_names.NOVA_HELLFIRE_SHOTGUN, item_names.NOVA_PLASMA_RIFLE}, self.player)

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -2159,8 +2159,8 @@ class SC2Logic:
         if not self.terran_very_hard_mission_weapon_armor_level(state):
             return False
         beats_kerrigan = (
-            state.has_any({item_names.MARINE, item_names.DOMINION_TROOPER, item_names.BANSHEE}, self.player)
-            or state.has_all({item_names.REAPER, item_names.REAPER_RESOURCE_EFFICIENCY}, self.player)
+            state.has_any((item_names.MARINE, item_names.DOMINION_TROOPER, item_names.BANSHEE), self.player)
+            or state.has_all((item_names.REAPER, item_names.REAPER_RESOURCE_EFFICIENCY), self.player)
             or (self.all_in_map == AllInMap.option_air and state.has_all((item_names.VALKYRIE, item_names.VALKYRIE_FLECHETTE_MISSILES), self.player))
             or (self.advanced_tactics and state.has_all((item_names.GHOST, item_names.GHOST_EMP_ROUNDS), self.player))
         )
@@ -2171,7 +2171,7 @@ class SC2Logic:
         if self.all_in_map == AllInMap.option_ground:
             # Ground
             defense_rating = self.terran_defense_rating(state, True, False)
-            if state.has_any((item_names.BATTLECRUISER, item_names.BANSHEE, item_names.VALKYRIE), self.player):
+            if state.has_any((item_names.BATTLECRUISER, item_names.BANSHEE), self.player):
                 defense_rating += 2
             return defense_rating >= 13
         else:
@@ -2180,8 +2180,8 @@ class SC2Logic:
             return (
                 defense_rating >= 9
                 and self.terran_competent_anti_air(state)
-                and state.has_any({item_names.VIKING, item_names.BATTLECRUISER, item_names.VALKYRIE}, self.player)
-                and state.has_any({item_names.HIVE_MIND_EMULATOR, item_names.PSI_DISRUPTER, item_names.MISSILE_TURRET}, self.player)
+                and state.has_any((item_names.VIKING, item_names.BATTLECRUISER, item_names.VALKYRIE), self.player)
+                and state.has_any((item_names.HIVE_MIND_EMULATOR, item_names.PSI_DISRUPTER, item_names.MISSILE_TURRET), self.player)
             )
 
     def zerg_all_in_requirement(self, state: CollectionState):

--- a/worlds/sc2/test/test_base.py
+++ b/worlds/sc2/test/test_base.py
@@ -7,15 +7,7 @@ from Generate import get_seed_name
 from worlds import AutoWorld
 from test.general import gen_steps, call_all
 
-from test.bases import WorldTestBase
 from .. import SC2World
-from .. import client
-
-class Sc2TestBase(WorldTestBase):
-    game = client.SC2Context.game
-    world: SC2World
-    player: ClassVar[int] = 1
-    skip_long_tests: bool = True
 
 
 class Sc2SetupTestBase(unittest.TestCase):

--- a/worlds/sc2/test/test_generation.py
+++ b/worlds/sc2/test/test_generation.py
@@ -797,7 +797,6 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_kerrigan_levels_per_mission_and_generic_upgrades_both_triggering_pre_fill(self):
         world_options = {
-            # Vanilla WoL with all missions
             'mission_order': options.MissionOrder.option_custom,
             'custom_mission_order': {
                 'campaign': {
@@ -842,7 +841,52 @@ class TestItemFiltering(Sc2SetupTestBase):
         self.assertNotIn(item_names.KERRIGAN_LEVELS_70, itempool)
         self.assertNotIn(item_names.KERRIGAN_LEVELS_70, starting_inventory)
 
-
+    def test_wa_prefill_doesnt_trigger_if_upgrades_in_start_inventory(self) -> None:
+        world_options = {
+            'mission_order': options.MissionOrder.option_custom,
+            'custom_mission_order': {
+                'campaign': {
+                    'goal': True,
+                    'layout': {
+                        'type': 'column',
+                        'size': 3,
+                        'missions': [
+                            {
+                                'index': 0,
+                                'mission_pool': [SC2Mission.THE_DIG.mission_name]
+                            },
+                            {
+                                'index': 1,
+                                'mission_pool': [SC2Mission.WELCOME_TO_THE_JUNGLE.mission_name]
+                            },
+                            {
+                                'index': 2,
+                                'mission_pool': [SC2Mission.ALL_IN.mission_name]
+                            },
+                        ]
+                    }
+                }
+            },
+            'start_inventory': {
+                item_names.GOLIATH: 1,
+                item_groups.ItemGroupNames.TERRAN_GENERIC_UPGRADES: 3,
+            },
+            'selected_races': [SC2Race.TERRAN.get_title()],
+            'required_tactics': options.RequiredTactics.option_standard,
+            'generic_upgrade_items': options.GenericUpgradeItems.option_bundle_all,
+            'generic_upgrade_missions': 100, # Weapon / Armor upgrades
+        }
+        self.generate_world(world_options)
+        starting_inventory = [item.name for item in self.multiworld.precollected_items[self.player]]
+        starting_terran_upgrades = [
+            item_name
+            for item_name in starting_inventory
+            if item_tables.item_table[item_name].type == item_tables.TerranItemType.Upgrade
+        ]
+        self.assertEqual(
+            len(starting_terran_upgrades), 3,
+            msg=f"Unexpected Upgrades in start inventory (expected 3 terran upgrades): {starting_terran_upgrades}"
+        )
 
     def test_locking_required_items(self):
         world_options = {

--- a/worlds/sc2/test/test_regions.py
+++ b/worlds/sc2/test/test_regions.py
@@ -1,10 +1,9 @@
-import unittest
-from .test_base import Sc2TestBase
+from .test_base import Sc2SetupTestBase
 from .. import mission_tables, SC2Campaign
 from .. import options
 from ..mission_order.layout_types import Grid
 
-class TestGridsizes(unittest.TestCase):
+class TestGridsizes(Sc2SetupTestBase):
     def test_grid_sizes_meet_specs(self):
         self.assertTupleEqual((1, 2, 0), Grid.get_grid_dimensions(2))
         self.assertTupleEqual((1, 3, 0), Grid.get_grid_dimensions(3))
@@ -23,18 +22,16 @@ class TestGridsizes(unittest.TestCase):
         self.assertTupleEqual((5, 6, 1), Grid.get_grid_dimensions(29))
         self.assertTupleEqual((5, 7, 2), Grid.get_grid_dimensions(33))
 
-
-class TestGridGeneration(Sc2TestBase):
-    options = {
-        "mission_order": options.MissionOrder.option_grid,
-        "excluded_missions": [mission_tables.SC2Mission.ZERO_HOUR.mission_name,],
-        "enabled_campaigns": {
-            SC2Campaign.WOL.campaign_name,
-            SC2Campaign.PROPHECY.campaign_name,
-        }
-    }
-
     def test_size_matches_exclusions(self):
+        world_options = {
+            "mission_order": options.MissionOrder.option_grid,
+            "excluded_missions": [mission_tables.SC2Mission.ZERO_HOUR.mission_name,],
+            "enabled_campaigns": {
+                SC2Campaign.WOL.campaign_name,
+                SC2Campaign.PROPHECY.campaign_name,
+            }
+        }
+        self.generate_world(world_options)
         self.assertNotIn(mission_tables.SC2Mission.ZERO_HOUR.mission_name, self.multiworld.regions)
         # WoL has 29 missions. -1 for Zero Hour being excluded, +1 for the automatically-added menu location
         self.assertEqual(len(self.multiworld.regions), 29)

--- a/worlds/sc2/test/test_rules.py
+++ b/worlds/sc2/test/test_rules.py
@@ -8,8 +8,16 @@ from BaseClasses import ItemClassification, MultiWorld
 import Options as CoreOptions
 from .. import options, locations
 from ..item import item_tables
-from ..rules import SC2Logic
+from ..rules import SC2Logic, LogicEffect
 from ..mission_tables import SC2Race, MissionFlag, lookup_name_to_mission
+
+
+VIRTUAL_ITEM_NAMES = {
+    LogicEffect.TERRAN_UPGRADE.name,
+    LogicEffect.ZERG_UPGRADE.name,
+    LogicEffect.PROTOSS_UPGRADE.name,
+    *LogicEffect._member_names_,
+}
 
 
 class TestInventory:
@@ -18,10 +26,12 @@ class TestInventory:
     """
     def __init__(self) -> None:
         self.random: Random = Random()
-        self.progression_types: Set[ItemClassification] = {ItemClassification.progression, ItemClassification.progression_skip_balancing}
 
     def is_item_progression(self, item: str) -> bool:
-        return item_tables.item_table[item].classification in self.progression_types
+        return (
+            item in VIRTUAL_ITEM_NAMES
+            or (item_tables.item_table[item].classification & ItemClassification.progression)
+        )
 
     def random_boolean(self):
         return self.random.choice([True, False])


### PR DESCRIPTION
## What is this fixing or adding?
Beginning to address the large performance nosedive after PR #5312.

Reported by Mysteryem earlier today in [#ap-core-dev](https://discord.com/channels/731205301247803413/731214280439103580/1413578906912555038).

More can still be done to get the performance back in line, but I'll keep this PR focused on performance boosts from virtual items / overloading `collect()` / `remove()`. (Performance boost from options change now up on PR #5424).

### Weapon/Armour upgrades are now managed by a virtual item
Note there's a slight behavioural change on the logic here: Protoss shield upgrades are no longer covered by logic. As a player I'd say it's fine, shield upgrades are by far the least useful generic upgrades and it was only being checked for in places that were also checking for weapon/armour, so I'd say it's fine and shouldn't lead to any logic holes. The reason shields were left out was because I didn't want to add complexity to hot code to account for the behaviour when the upgrade bundling was set to air/ground -- in that situation, shield upgrades are set to the maximum value of the two upgrade packs.

### Terran defense rating is now regulated by a virtual item
After w/a upgrades were made into virtual functions, the next most expensive rules under the profiler were `terran_competent_comp` and `terran_defense_rating`. `competent_comp` is a far more complex beast, so I aimed for the lower-hanging fruit. I also simplified the logic around it somewhat as it wasn't really matching what I'd expect from a "defense rating". I ran this by the sc2-dev discord chat to make sure it wasn't coming out of left field. The new (and what I expected was old) focus is on specifically items that help you defend even if you F2 your army. This means buildings and units that deploy/siege somehow.

This meant some AA tools and splash tools were removed, like Banshees, splash vikings and valkyries. I looked through all the usages of the function to make sure they still made sense under the new rules and had a reasonable number of permissible combinations of units even under vanilla_items_only.

This refactor and simplification only saved about 2s out of ~220s in my 5-yaml setup under cProfile. There's a few other low-hanging fruit, like terran power level, but I think it's safe to say the payoff is probably too small to promise it as part of this PR.

## How was this tested?
* Ran all unit tests.
* Ran a test generation with 5 template yamls. Generation time went from ~89s to ~68 seconds
* Ran many generations with 5 template yamls under cProfile. Checked time savings were really coming from the functions that were refactored

## If this makes graphical changes, please attach screenshots.
None