### PR TITLE
Sc2: [performance] change default options

### DIFF
--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -256,13 +256,13 @@ class EnabledCampaigns(OptionSet):
     Determines which campaign's missions will be used.
     Wings of Liberty, Prophecy, and Prologue are the only free-to-play campaigns.
     Valid campaign names:
-    - Wings of Liberty
-    - Prophecy
-    - Heart of the Swarm
-    - Whispers of Oblivion (Legacy of the Void: Prologue)
-    - Legacy of the Void
-    - Into the Void (Legacy of the Void: Epilogue)
-    - Nova Covert Ops
+    - 'Wings of Liberty'
+    - 'Prophecy'
+    - 'Heart of the Swarm'
+    - 'Whispers of Oblivion (Legacy of the Void: Prologue)'
+    - 'Legacy of the Void'
+    - 'Into the Void (Legacy of the Void: Epilogue)'
+    - 'Nova Covert Ops'
     """
     display_name = "Enabled Campaigns"
     valid_keys = {campaign.campaign_name for campaign in SC2Campaign if campaign != SC2Campaign.GLOBAL}

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -63,7 +63,7 @@ class Sc2MissionSet(OptionSet):
         return self.value.__len__()
 
 
-class SelectRaces(OptionSet):
+class SelectedRaces(OptionSet):
     """
     Pick which factions' missions and items can be shuffled into the world.
     """
@@ -152,6 +152,7 @@ class MissionOrder(Choice):
     option_golden_path = 10
     option_hopscotch = 11
     option_custom = 99
+    default = option_golden_path
 
 
 class MaximumCampaignSize(Range):
@@ -254,7 +255,7 @@ class EnabledCampaigns(OptionSet):
     """Determines which campaign's missions will be used"""
     display_name = "Enabled Campaigns"
     valid_keys = {campaign.campaign_name for campaign in SC2Campaign if campaign != SC2Campaign.GLOBAL}
-    default = valid_keys
+    default = set((SC2Campaign.WOL.campaign_name,))
 
 
 class EnableRaceSwapVariants(Choice):
@@ -1342,7 +1343,7 @@ class Starcraft2Options(PerGameCommonOptions):
     player_color_zerg: PlayerColorZerg
     player_color_zerg_primal: PlayerColorZergPrimal
     player_color_nova: PlayerColorNova
-    selected_races: SelectRaces
+    selected_races: SelectedRaces
     enabled_campaigns: EnabledCampaigns
     enable_race_swap: EnableRaceSwapVariants
     mission_race_balancing: EnableMissionRaceBalancing
@@ -1436,7 +1437,7 @@ option_groups = [
         ShuffleCampaigns,
         AllInMap,
         TwoStartPositions,
-        SelectRaces,
+        SelectedRaces,
         ExcludeVeryHardMissions,
         EnableMissionRaceBalancing,
     ]),
@@ -1548,7 +1549,7 @@ def get_option_value(world: Union['SC2World', None], name: str) -> int:
 
 
 def get_enabled_races(world: Optional['SC2World']) -> Set[SC2Race]:
-    race_names = world.options.selected_races.value if world and len(world.options.selected_races.value) > 0 else SelectRaces.valid_keys
+    race_names = world.options.selected_races.value if world and len(world.options.selected_races.value) > 0 else SelectedRaces.valid_keys
     return {race for race in SC2Race if race.get_title() in race_names}
 
 

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -252,7 +252,10 @@ class PlayerColorNova(ColorChoice):
 
 
 class EnabledCampaigns(OptionSet):
-    """Determines which campaign's missions will be used"""
+    """
+    Determines which campaign's missions will be used.
+    Wings of Liberty, Prophecy, and Prologue are the only free-to-play campaigns.
+    """
     display_name = "Enabled Campaigns"
     valid_keys = {campaign.campaign_name for campaign in SC2Campaign if campaign != SC2Campaign.GLOBAL}
     default = set((SC2Campaign.WOL.campaign_name,))

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -255,6 +255,14 @@ class EnabledCampaigns(OptionSet):
     """
     Determines which campaign's missions will be used.
     Wings of Liberty, Prophecy, and Prologue are the only free-to-play campaigns.
+    Valid campaign names:
+    - Wings of Liberty
+    - Prophecy
+    - Heart of the Swarm
+    - Whispers of Oblivion (Legacy of the Void: Prologue)
+    - Legacy of the Void
+    - Into the Void (Legacy of the Void: Epilogue)
+    - Nova Covert Ops
     """
     display_name = "Enabled Campaigns"
     valid_keys = {campaign.campaign_name for campaign in SC2Campaign if campaign != SC2Campaign.GLOBAL}

--- a/worlds/sc2/test/test_base.py
+++ b/worlds/sc2/test/test_base.py
@@ -8,7 +8,7 @@ from worlds import AutoWorld
 from test.general import gen_steps, call_all
 
 from test.bases import WorldTestBase
-from .. import SC2World
+from .. import SC2World, SC2Campaign
 from .. import client
 from .. import options
 
@@ -27,6 +27,15 @@ class Sc2SetupTestBase(unittest.TestCase):
     """
     ALL_CAMPAIGNS = {
         'enabled_campaigns': options.EnabledCampaigns.valid_keys,
+    }
+    TERRAN_CAMPAIGNS = {
+        'enabled_campaigns': {SC2Campaign.WOL.campaign_name, SC2Campaign.NCO.campaign_name,}
+    }
+    ZERG_CAMPAIGNS = {
+        'enabled_campaigns': {SC2Campaign.HOTS.campaign_name,}
+    }
+    PROTOSS_CAMPAIGNS = {
+        'enabled_campaigns': {SC2Campaign.PROPHECY.campaign_name, SC2Campaign.PROLOGUE.campaign_name, SC2Campaign.LOTV.campaign_name,}
     }
     seed: Optional[int] = None
     game = SC2World.game

--- a/worlds/sc2/test/test_base.py
+++ b/worlds/sc2/test/test_base.py
@@ -10,6 +10,7 @@ from test.general import gen_steps, call_all
 from test.bases import WorldTestBase
 from .. import SC2World
 from .. import client
+from .. import options
 
 class Sc2TestBase(WorldTestBase):
     game = client.SC2Context.game
@@ -24,6 +25,9 @@ class Sc2SetupTestBase(unittest.TestCase):
     This allows potentially generating multiple worlds in one test case, useful for tracking down a rare / sporadic
     crash.
     """
+    ALL_CAMPAIGNS = {
+        'enabled_campaigns': options.EnabledCampaigns.valid_keys,
+    }
     seed: Optional[int] = None
     game = SC2World.game
     player = 1

--- a/worlds/sc2/test/test_custom_mission_orders.py
+++ b/worlds/sc2/test/test_custom_mission_orders.py
@@ -6,6 +6,7 @@ from .test_base import Sc2SetupTestBase
 from .. import MissionFlag
 from ..item import item_tables, item_names
 from BaseClasses import ItemClassification
+from .. import options
 
 class TestCustomMissionOrders(Sc2SetupTestBase):
     def test_mini_wol_generates(self):
@@ -138,6 +139,7 @@ class TestCustomMissionOrders(Sc2SetupTestBase):
         test_item = item_names.ZERGLING_METABOLIC_BOOST
         world_options = {
             'mission_order': 'custom',
+            'enabled_campaigns': set(options.EnabledCampaigns.valid_keys),
             'start_inventory': { test_item: 1 },
             'custom_mission_order': {
                 'test': {
@@ -165,6 +167,7 @@ class TestCustomMissionOrders(Sc2SetupTestBase):
         test_item = item_names.ZERGLING_METABOLIC_BOOST
         world_options = {
             'mission_order': 'custom',
+            'enabled_campaigns': set(options.EnabledCampaigns.valid_keys),
             'start_inventory': { test_item: 1 },
             'locked_items': { test_item: 1 },
             'custom_mission_order': {

--- a/worlds/sc2/test/test_custom_mission_orders.py
+++ b/worlds/sc2/test/test_custom_mission_orders.py
@@ -10,6 +10,7 @@ from BaseClasses import ItemClassification
 class TestCustomMissionOrders(Sc2SetupTestBase):
     def test_mini_wol_generates(self):
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'mission_order': 'custom',
             'custom_mission_order': {
                 'Mini Wings of Liberty': {
@@ -192,6 +193,7 @@ class TestCustomMissionOrders(Sc2SetupTestBase):
         test_item = item_names.ZERGLING
         test_amount = 3
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'mission_order': 'custom',
             'locked_items': { test_item: 1 }, # Make sure it is generated as normal
             'custom_mission_order': {

--- a/worlds/sc2/test/test_generation.py
+++ b/worlds/sc2/test/test_generation.py
@@ -15,6 +15,7 @@ from ..options import EnabledCampaigns, NovaGhostOfAChanceVariant, MissionOrder,
 class TestItemFiltering(Sc2SetupTestBase):
     def test_explicit_locks_excludes_interact_and_set_flags(self):
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'locked_items': {
                 item_names.MARINE: 0,
                 item_names.MARAUDER: 0,
@@ -115,6 +116,8 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_excluding_mission_groups_excludes_all_missions_in_group(self):
         world_options = {
+            **self.ZERG_CAMPAIGNS,
+            'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
             'excluded_missions': [
                 mission_groups.MissionGroupNames.HOTS_ZERUS_MISSIONS,
             ],
@@ -158,6 +161,7 @@ class TestItemFiltering(Sc2SetupTestBase):
     def test_excluding_all_terran_missions_excludes_all_terran_items(self) -> None:
         world_options = {
             **self.ALL_CAMPAIGNS,
+            'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
             'mission_order': options.MissionOrder.option_grid,
             'maximum_campaign_size': options.MaximumCampaignSize.range_end,
             'excluded_missions': [
@@ -173,6 +177,8 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_excluding_all_terran_build_missions_excludes_all_terran_units(self) -> None:
         world_options = {
+            **self.ALL_CAMPAIGNS,
+            'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
             'mission_order': options.MissionOrder.option_grid,
             'maximum_campaign_size': options.MaximumCampaignSize.range_end,
             'excluded_missions': [
@@ -191,6 +197,8 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_excluding_all_zerg_and_kerrigan_missions_excludes_all_zerg_items(self) -> None:
         world_options = {
+            **self.ALL_CAMPAIGNS,
+            'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
             'mission_order': options.MissionOrder.option_grid,
             'maximum_campaign_size': options.MaximumCampaignSize.range_end,
             'excluded_missions': [
@@ -206,6 +214,8 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_excluding_all_zerg_build_missions_excludes_zerg_units(self) -> None:
         world_options = {
+            **self.ALL_CAMPAIGNS,
+            'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
             'mission_order': options.MissionOrder.option_grid,
             'maximum_campaign_size': options.MaximumCampaignSize.range_end,
             'excluded_missions': [
@@ -225,6 +235,8 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_excluding_all_protoss_missions_excludes_all_protoss_items(self) -> None:
         world_options = {
+            **self.ALL_CAMPAIGNS,
+            'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
             'mission_order': options.MissionOrder.option_grid,
             'maximum_campaign_size': options.MaximumCampaignSize.range_end,
             'accessibility': 'locations',
@@ -242,6 +254,8 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_excluding_all_protoss_build_missions_excludes_protoss_units(self) -> None:
         world_options = {
+            **self.ALL_CAMPAIGNS,
+            'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
             'mission_order': options.MissionOrder.option_grid,
             'maximum_campaign_size': options.MaximumCampaignSize.range_end,
             'accessibility': 'locations',
@@ -287,6 +301,7 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_vanilla_items_only_includes_only_nova_equipment_and_vanilla_and_filler_items(self) -> None:
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'mission_order': options.MissionOrder.option_grid,
             'maximum_campaign_size': options.MaximumCampaignSize.range_end,
             # Avoid options that lock non-vanilla items for logic
@@ -758,7 +773,6 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_kerrigan_levels_per_mission_triggering_pre_fill(self):
         world_options = {
-            # Vanilla WoL with all missions
             **self.ALL_CAMPAIGNS,
             'mission_order': options.MissionOrder.option_custom,
             'custom_mission_order': {
@@ -800,7 +814,6 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_kerrigan_levels_per_mission_and_generic_upgrades_both_triggering_pre_fill(self):
         world_options = {
-            # Vanilla WoL with all missions
             **self.ALL_CAMPAIGNS,
             'mission_order': options.MissionOrder.option_custom,
             'custom_mission_order': {
@@ -926,6 +939,7 @@ class TestItemFiltering(Sc2SetupTestBase):
             },
             'max_number_of_upgrades': 2,
             'mission_order': options.MissionOrder.option_grid,
+            **self.ALL_CAMPAIGNS,
             'selected_races': {
                 SC2Race.TERRAN.get_title(),
             },
@@ -962,6 +976,7 @@ class TestItemFiltering(Sc2SetupTestBase):
             },
             'max_number_of_upgrades': 2,
             'mission_order': options.MissionOrder.option_grid,
+            **self.ALL_CAMPAIGNS,
             'selected_races': {
                 SC2Race.TERRAN.get_title(),
                 SC2Race.ZERG.get_title(),
@@ -992,6 +1007,7 @@ class TestItemFiltering(Sc2SetupTestBase):
             },
             'max_upgrade_level': MAX_LEVEL,
             'mission_order': options.MissionOrder.option_grid,
+            **self.ALL_CAMPAIGNS,
             'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
             'generic_upgrade_items': options.GenericUpgradeItems.option_bundle_weapon_and_armor
         }
@@ -1018,12 +1034,13 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_ghost_of_a_chance_generates_without_nco(self) -> None:
         world_options = {
+            **self.TERRAN_CAMPAIGNS,
             'mission_order': MissionOrder.option_custom,
             'nova_ghost_of_a_chance_variant': NovaGhostOfAChanceVariant.option_auto,
             'custom_mission_order': {
                 'test': {
                     'type': 'column',
-                    'size': 1, # Give the generator some space to place the key
+                    'size': 1,
                     'mission_pool': [
                         SC2Mission.GHOST_OF_A_CHANCE.mission_name
                     ]
@@ -1039,12 +1056,13 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_ghost_of_a_chance_generates_using_nco_nova(self) -> None:
         world_options = {
+            **self.TERRAN_CAMPAIGNS,
             'mission_order': MissionOrder.option_custom,
             'nova_ghost_of_a_chance_variant': NovaGhostOfAChanceVariant.option_nco,
             'custom_mission_order': {
                 'test': {
                     'type': 'column',
-                    'size': 2, # Give the generator some space to place the key
+                    'size': 2,
                     'mission_pool': [
                         SC2Mission.LIBERATION_DAY.mission_name, # Starter mission
                         SC2Mission.GHOST_OF_A_CHANCE.mission_name,
@@ -1060,13 +1078,13 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_ghost_of_a_chance_generates_with_nco(self) -> None:
         world_options = {
-            **self.ALL_CAMPAIGNS,
+            **self.TERRAN_CAMPAIGNS,
             'mission_order': MissionOrder.option_custom,
             'nova_ghost_of_a_chance_variant': NovaGhostOfAChanceVariant.option_auto,
             'custom_mission_order': {
                 'test': {
                     'type': 'column',
-                    'size': 3, # Give the generator some space to place the key
+                    'size': 3,
                     'mission_pool': [
                         SC2Mission.LIBERATION_DAY.mission_name, # Starter mission
                         SC2Mission.GHOST_OF_A_CHANCE.mission_name,
@@ -1085,6 +1103,7 @@ class TestItemFiltering(Sc2SetupTestBase):
         world_options = {
             **self.ALL_CAMPAIGNS,
             'mission_order': MissionOrder.option_grid,
+            'maximum_campaign_size': MaximumCampaignSize.range_end,
             'exclude_overpowered_items': ExcludeOverpoweredItems.option_true,
             'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
             'selected_races': [SC2Race.TERRAN.get_title()],
@@ -1102,6 +1121,7 @@ class TestItemFiltering(Sc2SetupTestBase):
         world_options = {
             **self.ALL_CAMPAIGNS,
             'mission_order': MissionOrder.option_grid,
+            'maximum_campaign_size': MaximumCampaignSize.range_end,
             'exclude_overpowered_items': ExcludeOverpoweredItems.option_false,
             'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
             'selected_races': [SC2Race.TERRAN.get_title()],
@@ -1117,7 +1137,9 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_exclude_overpowered_items_vanilla_only(self) -> None:
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'mission_order': MissionOrder.option_grid,
+            'maximum_campaign_size': MaximumCampaignSize.range_end,
             'exclude_overpowered_items': ExcludeOverpoweredItems.option_true,
             'vanilla_items_only': VanillaItemsOnly.option_true,
             'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
@@ -1134,7 +1156,9 @@ class TestItemFiltering(Sc2SetupTestBase):
     def test_exclude_locked_overpowered_items(self) -> None:
         locked_item = item_names.BATTLECRUISER_ATX_LASER_BATTERY
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'mission_order': MissionOrder.option_grid,
+            'maximum_campaign_size': MaximumCampaignSize.range_end,
             'exclude_overpowered_items': ExcludeOverpoweredItems.option_true,
             'locked_items': [locked_item],
             'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
@@ -1152,7 +1176,9 @@ class TestItemFiltering(Sc2SetupTestBase):
         Checks if all unreleased items are marked properly not to generate
         """
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'mission_order': MissionOrder.option_grid,
+            'maximum_campaign_size': MaximumCampaignSize.range_end,
             'exclude_overpowered_items': ExcludeOverpoweredItems.option_false,
             'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
         }
@@ -1170,7 +1196,9 @@ class TestItemFiltering(Sc2SetupTestBase):
         Locking overrides this behavior - if they're locked, they must appear
         """
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'mission_order': MissionOrder.option_grid,
+            'maximum_campaign_size': MaximumCampaignSize.range_end,
             'exclude_overpowered_items': ExcludeOverpoweredItems.option_false,
             'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
             'locked_items': {item_name: 0 for item_name in unreleased_items},
@@ -1185,10 +1213,12 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_merc_excluded_excludes_merc_upgrades(self) -> None:
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'mission_order': MissionOrder.option_grid,
             'maximum_campaign_size': MaximumCampaignSize.range_end,
             'excluded_items': [item_name for item_name in item_groups.terran_mercenaries],
             'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
+            'selected_races': [SC2Race.TERRAN.get_title()],
         }
 
         self.generate_world(world_options)
@@ -1204,6 +1234,7 @@ class TestItemFiltering(Sc2SetupTestBase):
             'exclude_overpowered_items': ExcludeOverpoweredItems.option_true,
             'unexcluded_items': [item_names.SOA_TIME_STOP],
             'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
+            'selected_races': [SC2Race.PROTOSS.get_title()],
         }
 
         self.generate_world(world_options)
@@ -1222,11 +1253,13 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_exclude_overpowered_items_and_not_allow_unit_nerfs(self) -> None:
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'mission_order': MissionOrder.option_grid,
             'maximum_campaign_size': MaximumCampaignSize.range_end,
             'exclude_overpowered_items': ExcludeOverpoweredItems.option_true,
             'war_council_nerfs': options.WarCouncilNerfs.option_false,
             'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
+            'selected_races': [SC2Race.PROTOSS.get_title()],
         }
 
         self.generate_world(world_options)

--- a/worlds/sc2/test/test_generation.py
+++ b/worlds/sc2/test/test_generation.py
@@ -759,6 +759,7 @@ class TestItemFiltering(Sc2SetupTestBase):
     def test_kerrigan_levels_per_mission_triggering_pre_fill(self):
         world_options = {
             # Vanilla WoL with all missions
+            **self.ALL_CAMPAIGNS,
             'mission_order': options.MissionOrder.option_custom,
             'custom_mission_order': {
                 'campaign': {

--- a/worlds/sc2/test/test_generation.py
+++ b/worlds/sc2/test/test_generation.py
@@ -1234,7 +1234,6 @@ class TestItemFiltering(Sc2SetupTestBase):
             'exclude_overpowered_items': ExcludeOverpoweredItems.option_true,
             'unexcluded_items': [item_names.SOA_TIME_STOP],
             'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
-            'selected_races': [SC2Race.PROTOSS.get_title()],
         }
 
         self.generate_world(world_options)

--- a/worlds/sc2/test/test_generation.py
+++ b/worlds/sc2/test/test_generation.py
@@ -157,6 +157,7 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_excluding_all_terran_missions_excludes_all_terran_items(self) -> None:
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'mission_order': options.MissionOrder.option_grid,
             'maximum_campaign_size': options.MaximumCampaignSize.range_end,
             'excluded_missions': [
@@ -515,6 +516,7 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_nco_and_wol_picks_correct_starting_mission(self):
         world_options = {
+            'mission_order': MissionOrder.option_vanilla,
             'enabled_campaigns': {
                 SC2Campaign.WOL.campaign_name,
                 SC2Campaign.NCO.campaign_name
@@ -529,7 +531,7 @@ class TestItemFiltering(Sc2SetupTestBase):
                 mission_tables.SC2Mission.ZERO_HOUR.mission_name.split(" (")[0]
             ],
             'mission_order': options.MissionOrder.option_grid,
-            'selected_races': options.SelectRaces.valid_keys,
+            'selected_races': options.SelectedRaces.valid_keys,
             'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
             'enabled_campaigns': {
                 SC2Campaign.WOL.campaign_name,
@@ -548,7 +550,7 @@ class TestItemFiltering(Sc2SetupTestBase):
                 mission_tables.SC2Mission.ZERO_HOUR.mission_name
             ],
             'mission_order': options.MissionOrder.option_grid,
-            'selected_races': options.SelectRaces.valid_keys,
+            'selected_races': options.SelectedRaces.valid_keys,
             'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
             'enabled_campaigns': {
                 SC2Campaign.WOL.campaign_name,
@@ -798,6 +800,7 @@ class TestItemFiltering(Sc2SetupTestBase):
     def test_kerrigan_levels_per_mission_and_generic_upgrades_both_triggering_pre_fill(self):
         world_options = {
             # Vanilla WoL with all missions
+            **self.ALL_CAMPAIGNS,
             'mission_order': options.MissionOrder.option_custom,
             'custom_mission_order': {
                 'campaign': {
@@ -842,10 +845,9 @@ class TestItemFiltering(Sc2SetupTestBase):
         self.assertNotIn(item_names.KERRIGAN_LEVELS_70, itempool)
         self.assertNotIn(item_names.KERRIGAN_LEVELS_70, starting_inventory)
 
-
-
     def test_locking_required_items(self):
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'mission_order': options.MissionOrder.option_custom,
             'custom_mission_order': {
                 'campaign': {
@@ -891,7 +893,7 @@ class TestItemFiltering(Sc2SetupTestBase):
             'mission_order': options.MissionOrder.option_grid,
             'maximum_campaign_size': campaign_size,
             'enabled_campaigns': EnabledCampaigns.valid_keys,
-            'selected_races': options.SelectRaces.valid_keys,
+            'selected_races': options.SelectedRaces.valid_keys,
             'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
             'mission_race_balancing': options.EnableMissionRaceBalancing.option_fully_balanced,
         }
@@ -1057,6 +1059,7 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_ghost_of_a_chance_generates_with_nco(self) -> None:
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'mission_order': MissionOrder.option_custom,
             'nova_ghost_of_a_chance_variant': NovaGhostOfAChanceVariant.option_auto,
             'custom_mission_order': {
@@ -1079,6 +1082,7 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_exclude_overpowered_items(self) -> None:
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'mission_order': MissionOrder.option_grid,
             'exclude_overpowered_items': ExcludeOverpoweredItems.option_true,
             'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
@@ -1095,6 +1099,7 @@ class TestItemFiltering(Sc2SetupTestBase):
 
     def test_exclude_overpowered_items_not_excluded(self) -> None:
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'mission_order': MissionOrder.option_grid,
             'exclude_overpowered_items': ExcludeOverpoweredItems.option_false,
             'enable_race_swap': options.EnableRaceSwapVariants.option_shuffle_all,
@@ -1192,6 +1197,7 @@ class TestItemFiltering(Sc2SetupTestBase):
     
     def test_unexcluded_items_applies_over_op_items(self) -> None:
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'mission_order': MissionOrder.option_grid,
             'maximum_campaign_size': MaximumCampaignSize.range_end,
             'exclude_overpowered_items': ExcludeOverpoweredItems.option_true,

--- a/worlds/sc2/test/test_item_filtering.py
+++ b/worlds/sc2/test/test_item_filtering.py
@@ -68,6 +68,7 @@ class ItemFilterTests(Sc2SetupTestBase):
 
     def test_excluding_all_items_in_multiparent_excludes_child_items(self) -> None:
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'excluded_items': {
                 item_names.ZEALOT: 1,
                 item_names.SENTINEL: 1,

--- a/worlds/sc2/test/test_item_filtering.py
+++ b/worlds/sc2/test/test_item_filtering.py
@@ -15,6 +15,7 @@ class ItemFilterTests(Sc2SetupTestBase):
             },
             'required_tactics': 'standard',
             'min_number_of_upgrades': 1,
+            **self.TERRAN_CAMPAIGNS,
             'selected_races': {
                 SC2Race.TERRAN.get_title()
             },
@@ -54,6 +55,7 @@ class ItemFilterTests(Sc2SetupTestBase):
             },
             'min_number_of_upgrades': 2,
             'required_tactics': 'standard',
+            **self.ALL_CAMPAIGNS,
             'selected_races': {
                 SC2Race.PROTOSS.get_title()
             },
@@ -68,7 +70,6 @@ class ItemFilterTests(Sc2SetupTestBase):
 
     def test_excluding_all_items_in_multiparent_excludes_child_items(self) -> None:
         world_options = {
-            **self.ALL_CAMPAIGNS,
             'excluded_items': {
                 item_names.ZEALOT: 1,
                 item_names.SENTINEL: 1,
@@ -76,6 +77,7 @@ class ItemFilterTests(Sc2SetupTestBase):
             },
             'min_number_of_upgrades': 2,
             'required_tactics': 'standard',
+            **self.PROTOSS_CAMPAIGNS,
             'selected_races': {
                 SC2Race.PROTOSS.get_title()
             },

--- a/worlds/sc2/test/test_rules.py
+++ b/worlds/sc2/test/test_rules.py
@@ -116,6 +116,7 @@ class TestRules(unittest.TestCase):
         test_world.options.take_over_ai_allies.value = take_over_ai_allies
         test_world.options.kerrigan_presence.value = kerrigan_presence
         test_world.options.spear_of_adun_passive_ability_presence.value = spear_of_adun_passive_presence
+        test_world.options.enabled_campaigns.value = set(options.EnabledCampaigns.valid_keys)
         test_world.logic = SC2Logic(test_world)  # type: ignore
         return test_world
 

--- a/worlds/sc2/test/test_usecases.py
+++ b/worlds/sc2/test/test_usecases.py
@@ -270,7 +270,7 @@ class TestSupportedUseCases(Sc2SetupTestBase):
 
     def test_race_swap_pick_one_has_correct_length_and_includes_swaps(self) -> None:
         world_options = {
-            'selected_races': options.SelectRaces.valid_keys,
+            'selected_races': options.SelectedRaces.valid_keys,
             'enable_race_swap': options.EnableRaceSwapVariants.option_pick_one,
             'enabled_campaigns': {
                 SC2Campaign.WOL.campaign_name,

--- a/worlds/sc2/test/test_usecases.py
+++ b/worlds/sc2/test/test_usecases.py
@@ -341,6 +341,7 @@ class TestSupportedUseCases(Sc2SetupTestBase):
     def test_kerrigan_max_active_abilities(self):
         target_number: int = 8
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'mission_order': options.MissionOrder.option_grid,
             'maximum_campaign_size': options.MaximumCampaignSize.range_end,
             'selected_races': {
@@ -359,6 +360,7 @@ class TestSupportedUseCases(Sc2SetupTestBase):
     def test_kerrigan_max_passive_abilities(self):
         target_number: int = 3
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'mission_order': options.MissionOrder.option_grid,
             'maximum_campaign_size': options.MaximumCampaignSize.range_end,
             'selected_races': {
@@ -377,6 +379,7 @@ class TestSupportedUseCases(Sc2SetupTestBase):
     def test_spear_of_adun_max_active_abilities(self):
         target_number: int = 8
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'mission_order': options.MissionOrder.option_grid,
             'maximum_campaign_size': options.MaximumCampaignSize.range_end,
             'selected_races': {
@@ -396,6 +399,7 @@ class TestSupportedUseCases(Sc2SetupTestBase):
     def test_spear_of_adun_max_autocasts(self):
         target_number: int = 2
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'mission_order': options.MissionOrder.option_grid,
             'maximum_campaign_size': options.MaximumCampaignSize.range_end,
             'selected_races': {
@@ -415,6 +419,7 @@ class TestSupportedUseCases(Sc2SetupTestBase):
     def test_nova_max_weapons(self):
         target_number: int = 3
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'mission_order': options.MissionOrder.option_grid,
             'maximum_campaign_size': options.MaximumCampaignSize.range_end,
             'selected_races': {
@@ -434,6 +439,7 @@ class TestSupportedUseCases(Sc2SetupTestBase):
     def test_nova_max_gadgets(self):
         target_number: int = 3
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'mission_order': options.MissionOrder.option_grid,
             'maximum_campaign_size': options.MaximumCampaignSize.range_end,
             'selected_races': {
@@ -451,6 +457,7 @@ class TestSupportedUseCases(Sc2SetupTestBase):
     
     def test_mercs_only(self) -> None:
         world_options = {
+            **self.ALL_CAMPAIGNS,
             'selected_races': [
                 SC2Race.TERRAN.get_title(),
                 SC2Race.ZERG.get_title(),


### PR DESCRIPTION
## What is this fixing or adding?
Following today's great big discussion on sc2 performance, an older topic was brought up relating to our default options. In particular, the default options for included campaigns list all campaigns (3 main campaigns + 1 mission pack + 3 subcampaigns that come with bigger campaigns). Of these, only 1 main campaign and 2 subcampaigns are actually free-to-play; the rest must be purchased before use.

It turns out that changing the default to only the free-to-play main campaign (Wings of Liberty) brings generation time for 5 default yamls from ~70s to around 10s. Doing all free campaigns (WoL+Prophecy+Prologue) is similarly fast, though would have an unbalanced pool of 25 terran missions to 9 protoss, so I'm making that non-default. Considering the developer experience (many core unit tests use default options), this seems like a more desirable change. However, this is still open to player feedback.

More of a user-facing change, but the default mission order was changed from vanilla to the new golden_path, which is a variable size "vanilla-like" order that should be more responsive to mission exclusions and changes to `maximum_campaign_size`. I made a poll in the sc2 dev discord chat to see how people feel, and golden path and vanilla shuffle were tied for best default, beating vanilla by a significant margin.

I also took this opportunity to do a minor cleanup in the options -- renaming the option class `SelectRaces` to `SelectedRaces` to match the yaml name `selected_races`.

## How was this tested?
Updated and ran all unit tests. Did several test generations with 5 template yamls.

## If this makes graphical changes, please attach screenshots.
None