### PR TITLE
SC2: Region access rule speedups

### DIFF
--- a/worlds/sc2/mission_order/entry_rules.py
+++ b/worlds/sc2/mission_order/entry_rules.py
@@ -60,6 +60,11 @@ class EntryRule(ABC):
         """Used in the client to determine accessibility while playing and to populate tooltips."""
         pass
 
+    @abstractmethod
+    def find_mandatory_mission(self) -> SC2MOGenMission | None:
+        """Should return any mission that is mandatory to fulfill the entry rule, or `None` if there is no such mission."""
+        return None
+
 
 @dataclass
 class RuleData(ABC):
@@ -103,6 +108,11 @@ class BeatMissionsEntryRule(EntryRule):
             mission_ids,
             resolved_reqs
         )
+    
+    def find_mandatory_mission(self) -> SC2MOGenMission | None:
+        if len(self.missions_to_beat) > 0:
+            return self.missions_to_beat[0]
+        return None
 
 
 @dataclass
@@ -155,7 +165,20 @@ class CountMissionsEntryRule(EntryRule):
         return max(mission_depth, self.target_amount - 1) # -1 because depth is zero-based but amount is one-based
 
     def to_lambda(self, player: int) -> Callable[[CollectionState], bool]:
-        return lambda state: self.target_amount <= sum(state.has(mission.beat_item(), player) for mission in self.missions_to_count)
+        if self.target_amount == 0:
+            return lambda _: True
+        
+        beat_items = [mission.beat_item() for mission in self.missions_to_count]
+        def count_missions(state: CollectionState) -> bool:
+            count = 0
+            for mission in range(len(self.missions_to_count)):
+                if state.has(beat_items[mission], player):
+                    count += 1
+                    if count == self.target_amount:
+                        return True
+            return False
+        
+        return count_missions
     
     def to_slot_data(self) -> RuleData:
         resolved_reqs: List[Union[str, int]] = [req if isinstance(req, str) else req.mission.id for req in self.visual_reqs]
@@ -165,6 +188,11 @@ class CountMissionsEntryRule(EntryRule):
             self.target_amount,
             resolved_reqs
         )
+    
+    def find_mandatory_mission(self) -> SC2MOGenMission | None:
+        if self.target_amount > 0 and self.target_amount == len(self.missions_to_count):
+            return self.missions_to_count[0]
+        return None
 
 
 @dataclass
@@ -222,7 +250,15 @@ class SubRuleEntryRule(EntryRule):
             self.target_amount = target_amount
 
     def _is_fulfilled(self, beaten_missions: Set[SC2MOGenMission], in_region_check: bool) -> bool:
-        return self.target_amount <= sum(rule.is_fulfilled(beaten_missions, in_region_check) for rule in self.rules_to_check)
+        if len(self.rules_to_check) == 0:
+            return True
+        count = 0
+        for rule in self.rules_to_check:
+            if rule.is_fulfilled(beaten_missions, in_region_check):
+                count += 1
+                if count == self.target_amount:
+                    return True
+        return False
     
     def _get_depth(self, beaten_missions: Set[SC2MOGenMission]) -> int:
         if len(self.rules_to_check) == 0:
@@ -235,7 +271,21 @@ class SubRuleEntryRule(EntryRule):
 
     def to_lambda(self, player: int) -> Callable[[CollectionState], bool]:
         sub_lambdas = [rule.to_lambda(player) for rule in self.rules_to_check]
-        return lambda state, sub_lambdas=sub_lambdas: self.target_amount <= sum(sub_lambda(state) for sub_lambda in sub_lambdas)
+        if len(sub_lambdas) == 0 or self.target_amount == 0:
+            return lambda _: True
+        if len(sub_lambdas) == 1:
+            return sub_lambdas[0]
+        
+        def count_rules(state: CollectionState) -> bool:
+            count = 0
+            for sub_lambda in sub_lambdas:
+                if sub_lambda(state):
+                    count += 1
+                    if count == self.target_amount:
+                        return True
+            return False
+        
+        return count_rules
     
     def to_slot_data(self) -> SubRuleRuleData:
         sub_rules = [rule.to_slot_data() for rule in self.rules_to_check]
@@ -244,6 +294,14 @@ class SubRuleEntryRule(EntryRule):
             sub_rules,
             self.target_amount
         )
+    
+    def find_mandatory_mission(self) -> SC2MOGenMission | None:
+        if self.target_amount > 0 and self.target_amount == len(self.rules_to_check):
+            for sub_rule in self.rules_to_check:
+                mandatory_mission = sub_rule.find_mandatory_mission()
+                if mandatory_mission is not None:
+                    return mandatory_mission
+        return None
 
 
 @dataclass
@@ -362,6 +420,9 @@ class ItemEntryRule(EntryRule):
             item_ids,
             visual_reqs
         )
+    
+    def find_mandatory_mission(self) -> SC2MOGenMission | None:
+        return None
 
 
 @dataclass


### PR DESCRIPTION
## What is this fixing or adding?
These changes are in response to the reported slowdown of SC2's template YAML following the recent content merge, targeting issues with the region code. 

The steps taken were:
- Replacing `sum()` calls in lambdas with explicit list iterations and early return conditions
  - In one case a function call to create strings was moved out of the containing lambda
- Special-casing small entry rules to avoid creating lambdas that just call one other lambda
- Removing a lambda that was created for every access rule and would only ever call one other lambda
- Manually preventing lambdas that would only ever evaluate to `True` from being called in the final access rules
- Implementing a simple algorithm to find a mission that *must* be beaten to satisfy an entry rule, to reduce connections to `Menu` in the specific case of vanilla-like mission orders

## How was this tested?
Using cProfile to run test generations with 3 SC2 template YAMLs. I tested this incrementally to verify each step, but for brevity I'll only showcase a full comparison below. I don't know if this known or intended, but I found playthrough calculation to be a source of non-determinism with regards to total function calls, so I've included `update_reachable_regions` calls as a measure of how "lucky" the generation was, and have otherwise stripped code I haven't touched.

Before any changes:
```
Done. Enjoy. Total Time: 136.55459279986098
         229991172 function calls (225527525 primitive calls) in 143.492 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   157818    0.466    0.000   34.274    0.000 BaseClasses.py:748(update_reachable_regions)
3509784/3363821    2.402    0.000   24.627    0.000 entry_rules.py:238(<lambda>)
6585451/6147562    2.163    0.000   20.490    0.000 entry_rules.py:238(<genexpr>)
  1317925    0.602    0.000   13.965    0.000 generation.py:510(<lambda>)
  1317925    1.110    0.000   13.364    0.000 generation.py:499(<lambda>)
   809927    0.407    0.000   12.780    0.000 generation.py:506(<lambda>)
   986610    0.738    0.000   12.342    0.000 entry_rules.py:158(<lambda>)
  6931151    4.769    0.000   10.283    0.000 entry_rules.py:158(<genexpr>)
  8555102    2.539    0.000    2.539    0.000 nodes.py:567(beat_item)
 1050/966    0.001    0.000    0.004    0.000 entry_rules.py:224(_is_fulfilled)
        3    0.001    0.000    0.004    0.001 generation.py:486(make_connections)
```
Note that the `generation.py:510` and `generation.py:506` lambdas were pointless wrappers and thus removed. The `generation.py:499` lambda still exists, but the code to filter out functionally useless lambdas from access rules prevents this lambda from being created on the vanilla mission order, so it doesn't show up in the next profile.

With all changes:
```
Done. Enjoy. Total Time: 116.06302800029516
         188236306 function calls (186245313 primitive calls) in 122.774 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   157241    0.444    0.000   13.356    0.000 BaseClasses.py:748(update_reachable_regions)
   371752    0.463    0.000    4.816    0.000 entry_rules.py:279(count_rules) -- formerly entry_rules.py:238
   955152    2.395    0.000    4.424    0.000 entry_rules.py:172(count_missions) -- formerly entry_rules.py:158
  1204884    0.403    0.000    0.403    0.000 nodes.py:567(beat_item)
        3    0.001    0.000    0.005    0.002 generation.py:486(make_connections)
 1050/966    0.001    0.000    0.003    0.000 entry_rules.py:252(_is_fulfilled)
```
At first glance there's a discrepancy between the total 20s gain and the individual gains of `count_rules` (24s -> 4s) and `count_missions` (12s -> 4s), but this can be explained. As a guarantee of the system, all access rules have a `SubRuleEntryRule` as their top-most rule, so in the original code `entry_rules.py:238` includes the run time of `entry_rules.py:158`, but in the new code `count_missions` can bypass `count_rules` via a special case, so the gains of `count_rules` include a duplicate 8s gain from never being called.

To conclude, these changes come out to a ~20s or ~14% speedup on my machine.