### PR TITLE
Choo Choo Charles: Raise InvalidItemError instead of bare Exception

### DIFF
--- a/worlds/cccharles/__init__.py
+++ b/worlds/cccharles/__init__.py
@@ -4,7 +4,7 @@ from .Options import CCCharlesOptions
 from .Rules import set_rules
 from .Regions import create_regions
 from BaseClasses import Tutorial, ItemClassification
-from worlds.AutoWorld import World, WebWorld
+from worlds.AutoWorld import InvalidItemError, World, WebWorld
 
 
 class CCCharlesWeb(WebWorld):
@@ -157,7 +157,7 @@ class CCCharlesWorld(World):
             case "Bug Spray":
                 classification = ItemClassification.progression
             case _: # Should not occur
-                raise Exception("Unexpected case met: classification cannot be set for unknown item \"" + name + "\"")
+                raise InvalidItemError("Unexpected case met: classification cannot be set for unknown item \"" + name + "\"")
 
         return CCCharlesItem(name, classification, item_id, self.player)
 


### PR DESCRIPTION
Something I missed when reviewing Choo Choo Charles: We were trying to standardize the error thrown by create_item
