### PR TITLE
Core: Only error in playthrough generation if game is not beatable

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1720,7 +1720,7 @@ class Spoiler:
                     location.item.name, location.item.player, location.name, location.player) for location in
                                                                                sphere_candidates])
                 if not multiworld.has_beaten_game(state):
-                    raise RuntimeError("During playthrough generation, the game was determined not to be beatable. "
+                    raise RuntimeError("During playthrough generation, the game was determined to be unbeatable. "
                                        "Something went terribly wrong here. "
                                        f"Unreachable progression items: {sphere_candidates}")
                 else:


### PR DESCRIPTION
The current flow of accessibility works like this:

```
if fulfills_accessibility fails:
    if __debug__:
        raise Exception
    elif multiworld can be beaten:
        log a warning
    else:
        raise Exception

if playthrough is enabled:
    if any progression items are not reachable for "full" players:
        raise Exception

    ...
```

This means that if you do a generation on frozen (non-\_\_debug__), where the game is beatable but some full players' items are not reachable, it doesn't crash on accessibility check (only warns), but then crashes on playthrough. This means that **whether it crashes depends on whether you have playthrough enabled or not**.

Imo, erroring on something accessibility-related is outside of the scope of create_playthrough. Create_playthrough only needs to care about whether it can fulfill its own goal - Building a minimal playthrough to everyone's victory. Unrequired unreachables have no impact on create_playthrough. The actual [accessibility check](https://github.com/ArchipelagoMW/Archipelago/blob/main/Main.py#L355-L359) should be the place that takes care of the accessibility.