### PR TITLE
Add a bunch of validation to AutoPatchRegister

### DIFF
--- a/worlds/Files.py
+++ b/worlds/Files.py
@@ -31,10 +31,19 @@ class AutoPatchRegister(abc.ABCMeta):
         if "game" in dct:
             AutoPatchRegister.patch_types[dct["game"]] = new_class
 
+            if not callable(getattr(new_class, "patch", None)):
+                raise ImproperlyConfiguredAutoPatchError(
+                    f"Container {new_class} uses metaclass AutoPatchRegister, but does not have a patch method defined."
+                )
+
             patch_file_ending = dct.get("patch_file_ending")
             if not patch_file_ending:
                 raise ImproperlyConfiguredAutoPatchError(
                     f"Need an expected file ending for auto patch container {new_class}"
+                )
+            if patch_file_ending == ".zip":
+                raise ImproperlyConfiguredAutoPatchError(
+                    f'Auto patch container {new_class} uses file ending ".zip", which is not allowed.'
                 )
 
             existing_handler = AutoPatchRegister.file_endings.get(patch_file_ending)
@@ -43,10 +52,7 @@ class AutoPatchRegister(abc.ABCMeta):
                     f"Two auto patch containers are using the same file extension: {new_class}, {existing_handler}"
                 )
 
-            if not callable(getattr(new_class, "patch", None)):
-                raise ImproperlyConfiguredAutoPatchError(
-                    f"Container {new_class} uses metaclass AutoPatchRegister, but does not have a patch method defined."
-                )
+
 
             AutoPatchRegister.file_endings[dct["patch_file_ending"]] = new_class
         return new_class

--- a/worlds/adventure/Rom.py
+++ b/worlds/adventure/Rom.py
@@ -8,7 +8,7 @@ import bsdiff4
 
 import Utils
 from settings import get_settings
-from worlds.Files import APPatch, AutoPatchRegister
+from worlds.Files import APPatch
 from .Locations import LocationData
 
 ADVENTUREHASH: str = "157bddb7192754a45372be196797f284"
@@ -78,7 +78,7 @@ class BatNoTouchLocation:
         return ret_dict
 
 
-class AdventureDeltaPatch(APPatch, metaclass=AutoPatchRegister):
+class AdventureDeltaPatch(APPatch):
     hash = ADVENTUREHASH
     game = "Adventure"
     patch_file_ending = ".apadvn"


### PR DESCRIPTION
Some games are using AutoPatchRegister wrong, or are using it when they shouldn't.
You can actually do quite a lot of damage with an improperly configured auto patch Container, so I decided we should have some validation.

1. Class actually has a `patch` method that can be called. Without a `patch` method, it is not an auto patch.
2. Patch file ending is not `.zip`. I'm not sure if this is necessary, but it seems like a no-brainer to me. If it's an auto patch, it should have a custom file ending linking it to a specific game.
3. Patch file ending is not already used by another Container.

Adventure actually fails #1. So, this PR removed AutoPatchRegister from Adventure's Container.