### PR TITLE
Webhost: Ignore Invalid Worlds in Webhost

### DIFF
--- a/WebHost.py
+++ b/WebHost.py
@@ -109,6 +109,10 @@ if __name__ == "__main__":
         logging.exception(e)
         logging.warning("Could not update LttP sprites.")
     app = get_app()
+    from worlds import AutoWorldRegister
+    # Update to only valid WebHost worlds
+    AutoWorldRegister.world_types = dict(filter(lambda item: hasattr(item[1].web, "tutorials"),
+                                                AutoWorldRegister.world_types.items()))
     create_options_files()
     copy_tutorials_files_to_static()
     if app.config["SELFLAUNCH"]:

--- a/WebHost.py
+++ b/WebHost.py
@@ -111,8 +111,11 @@ if __name__ == "__main__":
     app = get_app()
     from worlds import AutoWorldRegister
     # Update to only valid WebHost worlds
-    AutoWorldRegister.world_types = dict(filter(lambda item: hasattr(item[1].web, "tutorials"),
-                                                AutoWorldRegister.world_types.items()))
+    invalid_worlds = {name for name, world in AutoWorldRegister.world_types.items()
+                      if not hasattr(world.web, "tutorials")}
+    if invalid_worlds:
+        logging.error(f"Following worlds not loaded as they are invalid for WebHost: {invalid_worlds}")
+    AutoWorldRegister.world_types = {k: v for k, v in AutoWorldRegister.world_types.items() if k not in invalid_worlds}
     create_options_files()
     copy_tutorials_files_to_static()
     if app.config["SELFLAUNCH"]:


### PR DESCRIPTION
## What is this fixing or adding?
filter world types at top of webhost so worlds that aren't loadable in webhost are "uninstalled"
could also add more requirements if there are other known issues

alternatively webhost should have it's own register that it pulls from AutoWorld and filters down, but then every single file in webhostlib would need to be retargeted to use the other register

idk if the filter() is better or even looks better than a comprehension tbh

## How was this tested?
commented out the world.web declaration of a world and confirmed they were dropped from the /tutorial page (and that the page loaded at all)

## If this makes graphical changes, please attach screenshots.
