### PR TITLE
Stardew Valley: Fixed Traveling merchant flaky test

### DIFF
--- a/worlds/stardew_valley/rules.py
+++ b/worlds/stardew_valley/rules.py
@@ -206,7 +206,7 @@ def set_entrance_rules(logic: StardewLogic, multiworld, player, world_options: S
     set_entrance_rule(multiworld, player, Entrance.enter_skull_cavern, logic.received(Wallet.skull_key))
     set_entrance_rule(multiworld, player, LogicEntrance.talk_to_mines_dwarf,
                       logic.wallet.can_speak_dwarf() & logic.tool.has_tool(Tool.pickaxe, ToolMaterial.iron))
-    set_entrance_rule(multiworld, player, LogicEntrance.buy_from_traveling_merchant, logic.traveling_merchant.has_days() & logic.money.can_spend(1000))
+    set_entrance_rule(multiworld, player, LogicEntrance.buy_from_traveling_merchant, logic.traveling_merchant.has_days() & logic.money.can_spend(1200))
     set_entrance_rule(multiworld, player, LogicEntrance.buy_from_raccoon, logic.quest.has_raccoon_shop())
     set_entrance_rule(multiworld, player, LogicEntrance.fish_in_waterfall,
                       logic.skill.has_level(Skill.fishing, 5) & logic.tool.has_fishing_rod(2))

--- a/worlds/stardew_valley/test/rules/TestTravelingMerchant.py
+++ b/worlds/stardew_valley/test/rules/TestTravelingMerchant.py
@@ -1,8 +1,13 @@
 from ..bases import SVTestBase
+from ... import SeasonRandomization, EntranceRandomization
 from ...locations import location_table, LocationTags
 
 
 class TestTravelingMerchant(SVTestBase):
+    options = {
+        SeasonRandomization: SeasonRandomization.option_randomized_not_winter,
+        EntranceRandomization: EntranceRandomization.option_disabled,
+    }
 
     def test_purchase_from_traveling_merchant_requires_money(self):
         traveling_merchant_location_names = [l for l in self.get_real_location_names() if LocationTags.TRAVELING_MERCHANT in location_table[l].tags]


### PR DESCRIPTION
## What is this fixing or adding?
I discovered, during a rebase of the 7.x.x branch, that main had a flaky traveling merchant test.
It is fixed in the [7.x.x PR](https://github.com/ArchipelagoMW/Archipelago/pull/5432), and it would be better for me to merge it, instead of this, but obviously pushing through a 15k lines PR for such a small fix is unreasonable, so I cherry picked it in its own PR instead so it can get merged faster. I'll deal with the conflicts later.

The issue was simply that, depending on which cached worlds the test was grabbing (order of tests), it could land on settings that would invalidate its assumptions. Plus, the fact that, at 1000 cost, you only need to have pierre and start outside of winter to invalide the shipping bin, so I also increased the price a bit.

## How was this tested?
Ran the tests a couple times, not flaky anymore.

## If this makes graphical changes, please attach screenshots.
