### PR TITLE
Aquaria: Updating documentation to add latest clients informations

### DIFF
--- a/worlds/aquaria/docs/setup_en.md
+++ b/worlds/aquaria/docs/setup_en.md
@@ -23,7 +23,7 @@ game you play will make sure that every game has its own save game.
 Unzip the Aquaria randomizer release and copy all unzipped files in the Aquaria game folder. The unzipped files are:
 - aquaria_randomizer.exe
 - OpenAL32.dll
-- override (directory)
+- randomizer_files (directory)
 - SDL2.dll
 - usersettings.xml
 - wrap_oal.dll
@@ -32,7 +32,10 @@ Unzip the Aquaria randomizer release and copy all unzipped files in the Aquaria 
 If there is a conflict between files in the original game folder and the unzipped files, you should overwrite
 the original files with the ones from the unzipped randomizer.
 
-Finally, to launch the randomizer, you must use the command line interface (you can open the command line interface
+There is multiple way to start the game. The easiest one is using the launcher. To do that, just run
+the `aquaria_randomizer.exe` file.
+
+You can also launch the randomizer using the command line interface (you can open the command line interface
 by typing `cmd` in the address bar of the Windows File Explorer). Here is the command line used to start the
 randomizer:
 
@@ -49,15 +52,17 @@ aquaria_randomizer.exe  --name YourName --server theServer:thePort --password th
 ### Linux when using the AppImage
 
 If you use the AppImage, just copy it into the Aquaria game folder. You then have to make it executable. You
-can do that from command line by using:
+can do that from the command line by using:
 
 ```bash
 chmod +x Aquaria_Randomizer-*.AppImage
 ```
 
-or by using the Graphical Explorer of your system.
+or by using the Graphical file Explorer of your system (the permission est generally in the file properties).
 
-To launch the randomizer, just launch in command line:
+To launch the randomizer using the integrated launcher, just execute the AppImage file.
+
+You can also use command line arguments to set the server and slot of your game:
 
 ```bash
 ./Aquaria_Randomizer-*.AppImage --name YourName --server theServer:thePort
@@ -79,7 +84,7 @@ the original game will stop working. Copying the folder will guarantee that the 
 
 Untar the Aquaria randomizer release and copy all extracted files in the Aquaria game folder. The extracted files are:
 - aquaria_randomizer
-- override (directory)
+- randomizer_files (directory)
 - usersettings.xml
 - cacert.pem
 
@@ -87,7 +92,7 @@ If there is a conflict between files in the original game folder and the extract
 the original files with the ones from the extracted randomizer files.
 
 Then, you should use your system package manager to install `liblua5`, `libogg`, `libvorbis`, `libopenal` and `libsdl2`.
-On Debian base system (like Ubuntu), you can use the following command:
+On Debian base systems (like Ubuntu), you can use the following command:
 
 ```bash
 sudo apt install liblua5.1-0-dev libogg-dev libvorbis-dev libopenal-dev libsdl2-dev
@@ -97,7 +102,9 @@ Also, if there are certain `.so` files in the original Aquaria game folder (`lib
 `libSDL-1.2.so.0` and `libstdc++.so.6`), you should remove them from the Aquaria Randomizer game folder. Those are
 old libraries that will not work on the recent build of the randomizer.
 
-To launch the randomizer, just launch in command line:
+To launch the randomizer using the integrated launcher, just execute the `aquaria_randomizer` file.
+
+You can also use command line arguments to set the server and slot of your game:
 
 ```bash
 ./aquaria_randomizer --name YourName --server theServer:thePort
@@ -114,6 +121,20 @@ sure that your executable has executable permission:
 
 ```bash
 chmod +x aquaria_randomizer
+```
+### Steam deck
+
+On the Steamdeck, go in desktop mode and follow the same procedure as the Linux Appimage.
+
+
+### No sound on Linux/Steam deck
+
+If your game play without problems, but with no sound, the game probably does not use the correct
+driver for the sound system. To fix that, you can use `ALSOFT_DRIVERS=pulse` before your command
+line to make it work. Something like this (depending on the way you launch the randomizer):
+
+```bash
+ALSOFT_DRIVERS=pulse ./Aquaria_Randomizer-*.AppImage --name YourName --server theServer:thePort
 ```
 
 ## Auto-Tracking

--- a/worlds/aquaria/docs/setup_en.md
+++ b/worlds/aquaria/docs/setup_en.md
@@ -58,7 +58,7 @@ can do that from the command line by using:
 chmod +x Aquaria_Randomizer-*.AppImage
 ```
 
-or by using the Graphical file Explorer of your system (the permission est generally in the file properties).
+or by using the Graphical file Explorer of your system (the permission can generally be set in the file properties).
 
 To launch the randomizer using the integrated launcher, just execute the AppImage file.
 

--- a/worlds/aquaria/docs/setup_fr.md
+++ b/worlds/aquaria/docs/setup_fr.md
@@ -2,12 +2,12 @@
 
 ## Logiciels nécessaires
 
-- Une copie du jeu Aquaria non-modifiée (disponible sur la majorité des sites de ventes de jeux vidéos en ligne)
+- Une copie du jeu Aquaria non modifiée (disponible sur la majorité des sites de ventes de jeux vidéos en ligne)
 - Le client du Randomizer d'Aquaria [Aquaria randomizer](https://github.com/tioui/Aquaria_Randomizer/releases/latest)
 
 ## Logiciels optionnels
 
-- De manière optionnel, pour pouvoir envoyer des [commandes](/tutorial/Archipelago/commands/en) comme `!hint`: utilisez le client texte de [la version la plus récente d'Archipelago](https://github.com/ArchipelagoMW/Archipelago/releases/latest)
+- De manière optionnelle, pour pouvoir envoyer des [commandes](/tutorial/Archipelago/commands/en) comme `!hint`: utilisez le client texte de [la version la plus récente d'Archipelago](https://github.com/ArchipelagoMW/Archipelago/releases/latest)
 - [Aquaria AP Tracker](https://github.com/palex00/aquaria-ap-tracker/releases/latest), pour utiliser avec [PopTracker](https://github.com/black-sliver/PopTracker/releases/latest)
 
 ## Procédures d'installation et d'exécution
@@ -25,7 +25,7 @@ Désarchiver le randomizer d'Aquaria et copier tous les fichiers de l'archive da
 fichier d'archive devrait contenir les fichiers suivants:
 - aquaria_randomizer.exe
 - OpenAL32.dll
-- override (directory)
+- randomizer_files (directory)
 - SDL2.dll
 - usersettings.xml
 - wrap_oal.dll
@@ -34,7 +34,10 @@ fichier d'archive devrait contenir les fichiers suivants:
 S'il y a des conflits entre les fichiers de l'archive zip et les fichiers du jeu original, vous devez utiliser
 les fichiers contenus dans l'archive zip.
 
-Finalement, pour lancer le randomizer, vous devez utiliser la ligne de commande (vous pouvez ouvrir une interface de
+Il y a plusieurs manières de lancer le randomizer. Le plus simple consiste à utiliser le lanceur intégré en
+exécutant simplement le fichier `aquaria_randomizer.exe`.
+
+Il est également possible de lancer le randomizer en utilisant la ligne de commande (vous pouvez ouvrir une interface de
 ligne de commande, entrez l'adresse `cmd` dans la barre d'adresse de l'explorateur de fichier de Windows). Voici
 la ligne de commande à utiliser pour lancer le randomizer:
 
@@ -57,9 +60,12 @@ le mettre exécutable. Vous pouvez mettre le fichier exécutable avec la command
 chmod +x Aquaria_Randomizer-*.AppImage
 ```
 
-ou bien en utilisant l'explorateur graphique de votre système.
+ou bien en utilisant l'explorateur de fichier graphique de votre système (la permission d'exécution est
+généralement dans les propriétés du fichier).
 
-Pour lancer le randomizer, utiliser la commande suivante:
+Pour lancer le randomizer en utilisant le lanceur intégré, seulement exécuter le fichier AppImage.
+
+Vous pouvez également lancer le randomizer en spécifiant les informations de connexion dans les arguments de la ligne de commande:
 
 ```bash
 ./Aquaria_Randomizer-*.AppImage --name VotreNom --server LeServeur:LePort
@@ -83,7 +89,7 @@ avant de déposer le randomizer à l'intérieur permet de vous assurer de garder
 Désarchiver le fichier tar et copier tous les fichiers qu'il contient dans le répertoire du jeu d'origine d'Aquaria. Les
 fichiers extraient du fichier tar devraient être les suivants:
 - aquaria_randomizer
-- override (directory)
+- randomizer_files (directory)
 - usersettings.xml
 - cacert.pem
 
@@ -102,7 +108,10 @@ Notez également que s'il y a des fichiers ".so" dans le répertoire d'Aquaria (
 `libSDL-1.2.so.0` and `libstdc++.so.6`), vous devriez les retirer. Il s'agit de vieille version des librairies qui
 ne sont plus fonctionnelles dans les systèmes modernes et qui pourrait empêcher le randomizer de fonctionner.
 
-Pour lancer le randomizer, utiliser la commande suivante:
+Pour lancer le randomizer en utilisant le lanceur intégré, seulement exécuter le fichier `aquaria_randomizer`.
+
+Vous pouvez également lancer le randomizer en spécifiant les information de connexion dans les arguments de la
+ligne de commande:
 
 ```bash
 ./aquaria_randomizer --name VotreNom --server LeServeur:LePort
@@ -119,6 +128,21 @@ pour vous assurer que votre fichier est exécutable:
 
 ```bash
 chmod +x aquaria_randomizer
+```
+### Steam Deck
+
+Pour installer le randomizer sur la Steam Deck, seulement suivre la procédure pour les fichiers AppImage
+indiquée précédemment.
+
+### Aucun son sur Linux/Steam Deck
+
+Si le jeu fonctionne sans problème, mais qu'il n'y a aucun son, c'est probablement parce que le jeu
+n'arrive pas à utiliser le bon pilote de son. Généralement, le problème est réglé en ajoutant la
+variable d'environnement `ALSOFT_DRIVERS=pulse`. Voici un exemple (peut varier en fonction de la manière
+que le randomizer est lancé):
+
+```bash
+ALSOFT_DRIVERS=pulse ./Aquaria_Randomizer-*.AppImage --name VotreNom --server LeServeur:LePort
 ```
 
 ## Tracking automatique


### PR DESCRIPTION
## What is this fixing or adding?

Modifications of the game documentation to add some new information about the latest Aquaria client.

Also, a bug happens where there is not sound when running on the Steam Deck. So adding the workaround to fix it.

## How was this tested?

It is documentation. No test required... I think.
