### PR TITLE
KH1: Remove the top level client script

### DIFF
--- a/KH1Client.py
+++ b/KH1Client.py
@@ -1,9 +1,0 @@
-if __name__ == '__main__':
-    import ModuleUpdate
-    ModuleUpdate.update()
-
-    import Utils
-    Utils.init_logging("KH1Client", exception_logger="Client")
-
-    from worlds.kh1.Client import launch
-    launch()

--- a/worlds/kh1/__init__.py
+++ b/worlds/kh1/__init__.py
@@ -21,7 +21,7 @@ def launch_client():
     launch_component(launch, name="KH1 Client")
 
 
-components.append(Component("KH1 Client", "KH1Client", func=launch_client, component_type=Type.CLIENT, icon="kh1_heart"))
+components.append(Component("KH1 Client", func=launch_client, component_type=Type.CLIENT, icon="kh1_heart"))
 
 icon_paths["kh1_heart"] = f"ap:{__name__}/icons/kh1_heart.png"
 


### PR DESCRIPTION
The KH1 client was recently changed to using `func` in its component. It got a fancy new icon as well
However, it also still has a script_name and a top level script.

This breaks the part of setup.py that tries to resolve the icon.

This could *maybe* be considered some sort of core bug, but we're trying to move away from top level client scripts/.exes anyway and want to have everything in the Launcher.

Tested:
setup.py no longer errors ✅
KH1Client can still be launched through the Launcher ✅