### PR TITLE
WebHost: fix Internal Server Error if parallel access to /room/* happens

### DIFF
--- a/WebHostLib/misc.py
+++ b/WebHostLib/misc.py
@@ -260,7 +260,10 @@ def host_room(room: UUID):
     # indicate that the page should reload to get the assigned port
     should_refresh = ((not room.last_port and now - room.creation_time < datetime.timedelta(seconds=3))
                       or room.last_activity < now - datetime.timedelta(seconds=room.timeout))
-    with db_session:
+
+    if now - room.last_activity > datetime.timedelta(minutes=1):
+        # we only set last_activity if needed, otherwise parallel access on /room will cause an internal server error
+        # due to "pony.orm.core.OptimisticCheckError: Object Room was updated outside of current transaction"
         room.last_activity = now  # will trigger a spinup, if it's not already running
 
     browser_tokens = "Mozilla", "Chrome", "Safari"


### PR DESCRIPTION
## What is this fixing or adding?
https://discord.com/channels/731205301247803413/731213907380666488/1416427397993070715
In essence, setting Room.last_activity in parallel is bad. This reduces the chance of that happening to near enough zero that it should be effectively fixed.

## How was this tested?
I only tested regular spinup still works, I did not set up a swarm to test if the bug is truely fixed, though it should be,
