### PR TITLE
KH1: Fix a small error in option descriptions

### DIFF
--- a/worlds/kh1/Options.py
+++ b/worlds/kh1/Options.py
@@ -257,7 +257,7 @@ class KeybladeStats(Choice):
     """
     Determines whether Keyblade stats should be randomized.
     
-    Randomize: Randomly generates STR and MP bonuses for each keyblade between the defined minimums and maximums.
+    Randomize: Randomly generates stats for each keyblade between the defined minimums and maximums.
     
     Shuffle: Shuffles the stats of the vanilla keyblades amongst each other.
     


### PR DESCRIPTION
## What is this fixing or adding?
Noticed that the Keyblade Stats option description didn't get updated to reference the new stats in the big update

## How was this tested?
N/A

## If this makes graphical changes, please attach screenshots.
N/A