### PR TITLE
Update language of ROM Setup Guides to reflect KivyMD Change

### DIFF
--- a/worlds/cv64/docs/setup_en.md
+++ b/worlds/cv64/docs/setup_en.md
@@ -14,9 +14,9 @@ Once you have installed BizHawk, open `EmuHawk.exe` and change the following set
 `NLua+KopiLua` to `Lua+LuaInterface`, then restart EmuHawk. (If you're using BizHawk 2.9, you can skip this step.)
 - Under `Config > Customize`, check the "Run in background" option to prevent disconnecting from the client while you're
 tabbed out of EmuHawk.
-- Open a `.z64` file in EmuHawk and go to `Config > Controllers…` to configure your inputs. If you can't click
+- Open a `.z64` file in EmuHawk and go to `Config > Controllers...` to configure your inputs. If you can't click
 `Controllers…`, load any `.z64` ROM first.
-- Consider clearing keybinds in `Config > Hotkeys…` if you don't intend to use them. Select the keybind and press Esc to
+- Consider clearing keybinds in `Config > Hotkeys...` if you don't intend to use them. Select the keybind and press Esc to
 clear it.
 - All non-Japanese versions of the N64 Castlevanias require a Controller Pak to save game data. To enable this, while
 you still have the `.z64` ROM loaded, go to `N64 > Controller Settings...`, click the dropdown by `Controller 1`, and
@@ -33,7 +33,7 @@ the White Jewels.
 2. Follow the general Archipelago instructions for [generating a game](../../Archipelago/setup/en#generating-a-game).
 This will generate an output file for you. Your patch file will have the `.apcv64` file extension.
 This patch file can also be downloaded off the multiworld room page if you [host your multiworld on the website](../../Archipelago/setup#hosting-on-the-website).
-3. Open `ArchipelagoLauncher.exe`
+3. Open `ArchipelagoLauncher.exe`.
 4. Select "Open Patch" from the initial list or under `Misc -> Open Patch` and select your patch file.
 5. If this is your first time patching, you will be prompted to locate your vanilla ROM.
 6. A patched `.z64` file will be created in the same place as the patch file.
@@ -53,7 +53,7 @@ in case you have to close and reopen a window mid-game for some reason.
 you can re-open it from the launcher.
 2. Ensure EmuHawk is running the patched ROM.
 3. In EmuHawk, go to `Tools > Lua Console`. This window must stay open while playing.
-4. In the Lua Console window, go to `Script > Open Script…`.
+4. In the Lua Console window, go to `Script > Open Script...`.
 5. Navigate to your Archipelago install folder and open `data/lua/connector_bizhawk_generic.lua`.
 6. The emulator may freeze every few seconds until it manages to connect to the client. This is expected. The BizHawk
 Client window should indicate that it connected and recognized Castlevania 64.

--- a/worlds/cv64/docs/setup_en.md
+++ b/worlds/cv64/docs/setup_en.md
@@ -32,8 +32,9 @@ the White Jewels.
 [Castlevania 64 options page](../../../games/Castlevania%2064/player-options).
 2. Follow the general Archipelago instructions for [generating a game](../../Archipelago/setup/en#generating-a-game).
 This will generate an output file for you. Your patch file will have the `.apcv64` file extension.
+This patch file can also be downloaded off the multiworld room page if you [host your multiworld on the website](../../Archipelago/setup#hosting-on-the-website).
 3. Open `ArchipelagoLauncher.exe`
-4. Select "Open Patch" on the left side and select your patch file.
+4. Select "Open Patch" from the initial list or under `Misc -> Open Patch` and select your patch file.
 5. If this is your first time patching, you will be prompted to locate your vanilla ROM.
 6. A patched `.z64` file will be created in the same place as the patch file.
 7. On your first time opening a patch with BizHawk Client, you will also be asked to locate `EmuHawk.exe` in your

--- a/worlds/cvcotm/docs/setup_en.md
+++ b/worlds/cvcotm/docs/setup_en.md
@@ -30,8 +30,9 @@ clear it.
 1. Create your settings file (YAML). You can make one on the [Castlevania: Circle of the Moon options page](../../../games/Castlevania%20-%20Circle%20of%20the%20Moon/player-options).
 2. Follow the general Archipelago instructions for [generating a game](../../Archipelago/setup/en#generating-a-game).
 This will generate an output file for you. Your patch file will have the `.apcvcotm` file extension.
-3. Open `ArchipelagoLauncher.exe`.
-4. Select "Open Patch" on the left side and select your patch file.
+This patch file can also be downloaded off the multiworld room page if you [host your multiworld on the website](../../Archipelago/setup#hosting-on-the-website).
+3. Open `ArchipelagoLauncher.exe`
+4. Select "Open Patch" from the initial list or under `Misc -> Open Patch` and select your patch file.
 5. If this is your first time patching, you will be prompted to locate your vanilla ROM.
 6. A patched `.gba` file will be created in the same place as the patch file.
 7. On your first time opening a patch with BizHawk Client, you will also be asked to locate `EmuHawk.exe` in your

--- a/worlds/cvcotm/docs/setup_en.md
+++ b/worlds/cvcotm/docs/setup_en.md
@@ -15,9 +15,9 @@ Once you have installed BizHawk, open `EmuHawk.exe` and change the following set
 `NLua+KopiLua` to `Lua+LuaInterface`, then restart EmuHawk. (If you're using BizHawk 2.9, you can skip this step.)
 - Under `Config > Customize`, check the "Run in background" option to prevent disconnecting from the client while you're
 tabbed out of EmuHawk.
-- Open a `.gba` file in EmuHawk and go to `Config > Controllers…` to configure your inputs. If you can't click
+- Open a `.gba` file in EmuHawk and go to `Config > Controllers...` to configure your inputs. If you can't click
 `Controllers…`, load any `.gba` ROM first.
-- Consider clearing keybinds in `Config > Hotkeys…` if you don't intend to use them. Select the keybind and press Esc to
+- Consider clearing keybinds in `Config > Hotkeys...` if you don't intend to use them. Select the keybind and press Esc to
 clear it.
 
 ## Optional Software
@@ -31,7 +31,7 @@ clear it.
 2. Follow the general Archipelago instructions for [generating a game](../../Archipelago/setup/en#generating-a-game).
 This will generate an output file for you. Your patch file will have the `.apcvcotm` file extension.
 This patch file can also be downloaded off the multiworld room page if you [host your multiworld on the website](../../Archipelago/setup#hosting-on-the-website).
-3. Open `ArchipelagoLauncher.exe`
+3. Open `ArchipelagoLauncher.exe`.
 4. Select "Open Patch" from the initial list or under `Misc -> Open Patch` and select your patch file.
 5. If this is your first time patching, you will be prompted to locate your vanilla ROM.
 6. A patched `.gba` file will be created in the same place as the patch file.
@@ -51,7 +51,7 @@ in case you have to close and reopen a window mid-game for some reason.
 you can re-open it from the launcher.
 2. Ensure EmuHawk is running the patched ROM.
 3. In EmuHawk, go to `Tools > Lua Console`. This window must stay open while playing.
-4. In the Lua Console window, go to `Script > Open Script…`.
+4. In the Lua Console window, go to `Script > Open Script...`.
 5. Navigate to your Archipelago install folder and open `data/lua/connector_bizhawk_generic.lua`.
 6. The emulator may freeze every few seconds until it manages to connect to the client. This is expected. The BizHawk
 Client window should indicate that it connected and recognized Castlevania: Circle of the Moon.

--- a/worlds/kh1/docs/kh1_en.md
+++ b/worlds/kh1/docs/kh1_en.md
@@ -40,7 +40,7 @@
 
 <h2 style="text-transform:none";>Connecting to your multiworld via the KH1 Client</h2>
 
-- Once your game is being hosted, open `ArchipelagoLauncher.exe`..
+- Once your game is being hosted, open `ArchipelagoLauncher.exe`.
 - Find `KH1 Client` and open it.
 - At the top, in the `Server:` bar, type in the host address and port.
 - Click the `Connect` button in the top right.

--- a/worlds/kh1/docs/kh1_en.md
+++ b/worlds/kh1/docs/kh1_en.md
@@ -19,7 +19,7 @@
 - When prompted, install Panacea, then click `Next`.
 - When prompted, check KH1 plus any other AP game you want to play, and click `Install and configure Lua backend`, then click `Next`.
 - Extract the data for KH1.
-- Click `Finish`
+- Click `Finish`.
 
 <h3 style="text-transform:none";>Kingdom Hearts 1FM Randomizer Software</h3>
 
@@ -40,7 +40,7 @@
 
 <h2 style="text-transform:none";>Connecting to your multiworld via the KH1 Client</h2>
 
-- Once your game is being hosted, open `ArchipelagoLauncher.exe`.
+- Once your game is being hosted, open `ArchipelagoLauncher.exe`..
 - Find `KH1 Client` and open it.
 - At the top, in the `Server:` bar, type in the host address and port.
 - Click the `Connect` button in the top right.

--- a/worlds/marioland2/docs/setup_en.md
+++ b/worlds/marioland2/docs/setup_en.md
@@ -46,8 +46,9 @@ You can generate a yaml or download a template by visiting the [Super Mario Land
 1. Create your options file (YAML).
 2. Follow the general Archipelago instructions for [generating a game](../../Archipelago/setup/en#generating-a-game).
 This will generate an output file for you. Your patch file will have a `.apsml2` file extension.
+This patch file can also be downloaded off the multiworld room page if you [host your multiworld on the website](../../Archipelago/setup#hosting-on-the-website).
 3. Open `ArchipelagoLauncher.exe`
-4. Select "Open Patch" on the left side and select your patch file.
+4. Select "Open Patch" from the initial list or under `Misc -> Open Patch` and select your patch file.
 5. If this is your first time patching, you will be prompted to locate your vanilla ROM.
 6. A patched `.gb` file will be created in the same place as the patch file.
 7. On your first time opening a patch with BizHawk Client, you will also be asked to locate `EmuHawk.exe` in your

--- a/worlds/marioland2/docs/setup_en.md
+++ b/worlds/marioland2/docs/setup_en.md
@@ -47,7 +47,7 @@ You can generate a yaml or download a template by visiting the [Super Mario Land
 2. Follow the general Archipelago instructions for [generating a game](../../Archipelago/setup/en#generating-a-game).
 This will generate an output file for you. Your patch file will have a `.apsml2` file extension.
 This patch file can also be downloaded off the multiworld room page if you [host your multiworld on the website](../../Archipelago/setup#hosting-on-the-website).
-3. Open `ArchipelagoLauncher.exe`
+3. Open `ArchipelagoLauncher.exe`.
 4. Select "Open Patch" from the initial list or under `Misc -> Open Patch` and select your patch file.
 5. If this is your first time patching, you will be prompted to locate your vanilla ROM.
 6. A patched `.gb` file will be created in the same place as the patch file.
@@ -65,7 +65,7 @@ in case you have to close and reopen a window mid-game for some reason.
 game, you can re-open it from the launcher.
 2. Ensure EmuHawk is running the patched ROM.
 3. In EmuHawk, go to `Tools > Lua Console`. This window must stay open while playing.
-4. In the Lua Console window, go to `Script > Open Script…`.
+4. In the Lua Console window, go to `Script > Open Script...`.
 5. Navigate to your Archipelago install folder and open `data/lua/connector_bizhawk_generic.lua`.
 6. The emulator may freeze every few seconds until it manages to connect to the client. This is expected. The BizHawk
 Client window should indicate that it connected and recognized Super Mario Land 2.

--- a/worlds/mm2/docs/setup_en.md
+++ b/worlds/mm2/docs/setup_en.md
@@ -25,8 +25,9 @@ clear it.
 [Mega Man 2 options page](../../../games/Mega%20Man%202/player-options).
 2. Follow the general Archipelago instructions for [generating a game](../../Archipelago/setup/en#generating-a-game).
 This will generate an output file for you. Your patch file will have the `.apmm2` file extension.
+This patch file can also be downloaded off the multiworld room page if you [host your multiworld on the website](../../Archipelago/setup#hosting-on-the-website).
 3. Open `ArchipelagoLauncher.exe`
-4. Select "Open Patch" on the left side and select your patch file.
+4. Select "Open Patch" from the initial list or under `Misc -> Open Patch` and select your patch file.
 5. If this is your first time patching, you will be prompted to locate your vanilla ROM. If you are using the Legacy 
 Collection, provide `Proteus.exe` in place of your rom.
 6. A patched `.nes` file will be created in the same place as the patch file.

--- a/worlds/mm2/docs/setup_en.md
+++ b/worlds/mm2/docs/setup_en.md
@@ -14,9 +14,9 @@ Once you have installed BizHawk, open `EmuHawk.exe` and change the following set
 `NLua+KopiLua` to `Lua+LuaInterface`, then restart EmuHawk. (If you're using BizHawk 2.9, you can skip this step.)
 - Under `Config > Customize`, check the "Run in background" option to prevent disconnecting from the client while you're
 tabbed out of EmuHawk.
-- Open a `.nes` file in EmuHawk and go to `Config > Controllers…` to configure your inputs. If you can't click
+- Open a `.nes` file in EmuHawk and go to `Config > Controllers...` to configure your inputs. If you can't click
 `Controllers…`, load any `.nes` ROM first.
-- Consider clearing keybinds in `Config > Hotkeys…` if you don't intend to use them. Select the keybind and press Esc to
+- Consider clearing keybinds in `Config > Hotkeys...` if you don't intend to use them. Select the keybind and press Esc to
 clear it.
 
 ## Generating and Patching a Game
@@ -26,7 +26,7 @@ clear it.
 2. Follow the general Archipelago instructions for [generating a game](../../Archipelago/setup/en#generating-a-game).
 This will generate an output file for you. Your patch file will have the `.apmm2` file extension.
 This patch file can also be downloaded off the multiworld room page if you [host your multiworld on the website](../../Archipelago/setup#hosting-on-the-website).
-3. Open `ArchipelagoLauncher.exe`
+3. Open `ArchipelagoLauncher.exe`.
 4. Select "Open Patch" from the initial list or under `Misc -> Open Patch` and select your patch file.
 5. If this is your first time patching, you will be prompted to locate your vanilla ROM. If you are using the Legacy 
 Collection, provide `Proteus.exe` in place of your rom.
@@ -43,7 +43,7 @@ in case you have to close and reopen a window mid-game for some reason.
 you can re-open it from the launcher.
 2. Ensure EmuHawk is running the patched ROM.
 3. In EmuHawk, go to `Tools > Lua Console`. This window must stay open while playing.
-4. In the Lua Console window, go to `Script > Open Script…`.
+4. In the Lua Console window, go to `Script > Open Script...`.
 5. Navigate to your Archipelago install folder and open `data/lua/connector_bizhawk_generic.lua`.
 6. The emulator and client will eventually connect to each other. The BizHawk Client window should indicate that it
 connected and recognized Mega Man 2.

--- a/worlds/pokemon_emerald/docs/setup_en.md
+++ b/worlds/pokemon_emerald/docs/setup_en.md
@@ -30,8 +30,9 @@ clear it.
 [Pokémon Emerald options page](../../../games/Pokemon%20Emerald/player-options).
 2. Follow the general Archipelago instructions for [generating a game](../../Archipelago/setup/en#generating-a-game).
 This will generate an output file for you. Your patch file will have the `.apemerald` file extension.
+This patch file can also be downloaded off the multiworld room page if you [host your multiworld on the website](../../Archipelago/setup#hosting-on-the-website).
 3. Open `ArchipelagoLauncher.exe`
-4. Select "Open Patch" on the left side and select your patch file.
+4. Select "Open Patch" from the initial list or under `Misc -> Open Patch` and select your patch file.
 5. If this is your first time patching, you will be prompted to locate your vanilla ROM.
 6. A patched `.gba` file will be created in the same place as the patch file.
 7. On your first time opening a patch with BizHawk Client, you will also be asked to locate `EmuHawk.exe` in your

--- a/worlds/pokemon_emerald/docs/setup_en.md
+++ b/worlds/pokemon_emerald/docs/setup_en.md
@@ -14,9 +14,9 @@ Once you have installed BizHawk, open `EmuHawk.exe` and change the following set
 `NLua+KopiLua` to `Lua+LuaInterface`, then restart EmuHawk. (If you're using BizHawk 2.9, you can skip this step.)
 - Under `Config > Customize`, check the "Run in background" option to prevent disconnecting from the client while you're
 tabbed out of EmuHawk.
-- Open a `.gba` file in EmuHawk and go to `Config > Controllers…` to configure your inputs. If you can't click
+- Open a `.gba` file in EmuHawk and go to `Config > Controllers...` to configure your inputs. If you can't click
 `Controllers…`, load any `.gba` ROM first.
-- Consider clearing keybinds in `Config > Hotkeys…` if you don't intend to use them. Select the keybind and press Esc to
+- Consider clearing keybinds in `Config > Hotkeys...` if you don't intend to use them. Select the keybind and press Esc to
 clear it.
 
 ## Optional Software
@@ -31,7 +31,7 @@ clear it.
 2. Follow the general Archipelago instructions for [generating a game](../../Archipelago/setup/en#generating-a-game).
 This will generate an output file for you. Your patch file will have the `.apemerald` file extension.
 This patch file can also be downloaded off the multiworld room page if you [host your multiworld on the website](../../Archipelago/setup#hosting-on-the-website).
-3. Open `ArchipelagoLauncher.exe`
+3. Open `ArchipelagoLauncher.exe`.
 4. Select "Open Patch" from the initial list or under `Misc -> Open Patch` and select your patch file.
 5. If this is your first time patching, you will be prompted to locate your vanilla ROM.
 6. A patched `.gba` file will be created in the same place as the patch file.
@@ -51,7 +51,7 @@ in case you have to close and reopen a window mid-game for some reason.
 you can re-open it from the launcher.
 2. Ensure EmuHawk is running the patched ROM.
 3. In EmuHawk, go to `Tools > Lua Console`. This window must stay open while playing.
-4. In the Lua Console window, go to `Script > Open Script…`.
+4. In the Lua Console window, go to `Script > Open Script...`.
 5. Navigate to your Archipelago install folder and open `data/lua/connector_bizhawk_generic.lua`.
 6. The emulator and client will eventually connect to each other. The BizHawk Client window should indicate that it
 connected and recognized Pokemon Emerald.

--- a/worlds/pokemon_emerald/docs/setup_es.md
+++ b/worlds/pokemon_emerald/docs/setup_es.md
@@ -14,9 +14,9 @@ Una vez que hayas instalado BizHawk, abre `EmuHawk.exe` y cambia las siguientes 
 `NLua+KopiLua` a `Lua+LuaInterface`, luego reinicia EmuHawk. (Si estás usando BizHawk 2.9, puedes saltar este paso.)
 - En `Config > Customize`, activa la opción "Run in background" para prevenir desconexiones del cliente mientras
 la aplicación activa no sea EmuHawk.
-- Abre el archivo `.gba` en EmuHawk y luego ve a `Config > Controllers…` para configurar los controles. Si no puedes
+- Abre el archivo `.gba` en EmuHawk y luego ve a `Config > Controllers...` para configurar los controles. Si no puedes
 hacer clic en `Controllers…`, debes abrir cualquier ROM `.gba` primeramente.
-- Considera limpiar tus macros y atajos en `Config > Hotkeys…` si no quieres usarlas de manera intencional. Para
+- Considera limpiar tus macros y atajos en `Config > Hotkeys...` si no quieres usarlas de manera intencional. Para
 limpiarlas, selecciona el atajo y presiona la tecla Esc.
 
 ## Software Opcional
@@ -32,7 +32,7 @@ con [PopTracker](https://github.com/black-sliver/PopTracker/releases)
 [Generar un juego](../../Archipelago/setup/en#generating-a-game). Esto generará un archivo de salida (output file) para
 ti. Tu archivo de parche tendrá la extensión de archivo `.apemerald`.
 Este parche también puede ser descargado desde la pagina de la sala del multiworld si tu [hosteas tu multiworld en el sitio web](../../Archipelago/setup#hosting-on-the-website).
-3. Abre `ArchipelagoLauncher.exe`.
+3. Abre `ArchipelagoLauncher.exe`..
 4. Selecciona "Open Patch" en la lista inicial o en Misc -> Open Patch y selecciona tu parche.
 5. Si esta es la primera vez que vas a parchear, se te pedirá que selecciones la ROM sin parchear.
 6. Un archivo parcheado con extensión `.gba` será creado en el mismo lugar que el archivo de parcheo.

--- a/worlds/pokemon_emerald/docs/setup_es.md
+++ b/worlds/pokemon_emerald/docs/setup_es.md
@@ -32,7 +32,7 @@ con [PopTracker](https://github.com/black-sliver/PopTracker/releases)
 [Generar un juego](../../Archipelago/setup/en#generating-a-game). Esto generará un archivo de salida (output file) para
 ti. Tu archivo de parche tendrá la extensión de archivo `.apemerald`.
 Este parche también puede ser descargado desde la pagina de la sala del multiworld si tu [hosteas tu multiworld en el sitio web](../../Archipelago/setup#hosting-on-the-website).
-3. Abre `ArchipelagoLauncher.exe`..
+3. Abre `ArchipelagoLauncher.exe`.
 4. Selecciona "Open Patch" en la lista inicial o en Misc -> Open Patch y selecciona tu parche.
 5. Si esta es la primera vez que vas a parchear, se te pedirá que selecciones la ROM sin parchear.
 6. Un archivo parcheado con extensión `.gba` será creado en el mismo lugar que el archivo de parcheo.

--- a/worlds/pokemon_emerald/docs/setup_es.md
+++ b/worlds/pokemon_emerald/docs/setup_es.md
@@ -31,7 +31,7 @@ con [PopTracker](https://github.com/black-sliver/PopTracker/releases)
 2. Sigue las instrucciones generales de Archipelago para
 [Generar un juego](../../Archipelago/setup/en#generating-a-game). Esto generará un archivo de salida (output file) para
 ti. Tu archivo de parche tendrá la extensión de archivo `.apemerald`.
-Este parche también puede ser descargado desde la pagina de la sala del multiworld si tu [hosteas tu multiworld en el sitio web](../../Archipelago/setup#hosting-on-the-website).
+Este parche también puede ser descargado desde la página de la sala del multiworld si tu [hosteas tu multiworld en el sitio web](../../Archipelago/setup#hosting-on-the-website).
 3. Abre `ArchipelagoLauncher.exe`.
 4. Selecciona "Open Patch" en la lista inicial o en Misc -> Open Patch y selecciona tu parche.
 5. Si esta es la primera vez que vas a parchear, se te pedirá que selecciones la ROM sin parchear.

--- a/worlds/pokemon_emerald/docs/setup_es.md
+++ b/worlds/pokemon_emerald/docs/setup_es.md
@@ -31,8 +31,9 @@ con [PopTracker](https://github.com/black-sliver/PopTracker/releases)
 2. Sigue las instrucciones generales de Archipelago para
 [Generar un juego](../../Archipelago/setup/en#generating-a-game). Esto generará un archivo de salida (output file) para
 ti. Tu archivo de parche tendrá la extensión de archivo `.apemerald`.
-3. Abre `ArchipelagoLauncher.exe`
-4. Selecciona "Open Patch" en el lado derecho y elige tu archivo de parcheo.
+Este parche también puede ser descargado desde la pagina de la sala del multiworld si tu [hosteas tu multiworld en el sitio web](../../Archipelago/setup#hosting-on-the-website).
+3. Abre `ArchipelagoLauncher.exe`.
+4. Selecciona "Open Patch" en la lista inicial o en Misc -> Open Patch y selecciona tu parche.
 5. Si esta es la primera vez que vas a parchear, se te pedirá que selecciones la ROM sin parchear.
 6. Un archivo parcheado con extensión `.gba` será creado en el mismo lugar que el archivo de parcheo.
 7. La primera vez que abras un archivo parcheado con el BizHawk Client, se te preguntará donde está localizado
@@ -51,7 +52,7 @@ siguiente en caso de que debas cerrar y volver a abrir la ventana en mitad de la
 parcheada, puedes volver a abrirlo desde el Archipelago Launcher.
 2. Asegúrate que EmuHawk está corriendo la ROM parcheada.
 3. En EmuHawk, ve a `Tools > Lua Console`. Debes tener esta ventana abierta mientras juegas.
-4. En la ventana de Lua Console, ve a `Script > Open Script…`.
+4. En la ventana de Lua Console, ve a `Script > Open Script...`.
 5. Ve a la carpeta donde está instalado Archipelago y abre `data/lua/connector_bizhawk_generic.lua`.
 6. El emulador y el cliente eventualmente se conectarán uno con el otro. La ventana de BizHawk Client indicará que te
 has conectado y reconocerá Pokémon Emerald.

--- a/worlds/pokemon_emerald/docs/setup_sv.md
+++ b/worlds/pokemon_emerald/docs/setup_sv.md
@@ -34,7 +34,7 @@ används tillsammans med
 Detta kommer generera en fil för dig. Din patchfil kommer ha `.apemerald` som sitt filnamnstillägg.
 Den här patch filen kan också laddas ner från multvärlds lobbyn om du [hostar din multivärld på hemsidan](../../Archipelago/setup#hosting-on-the-website).
 3. Öppna `ArchipelagoLauncher.exe`.
-Välj "Open Patch" från listan eller under `Misc -> Open Patch` och välj din patchfil.
+4. Välj "Open Patch" från listan eller under `Misc -> Open Patch` och välj din patchfil.
 5. Om detta är första gången du patchar, så kommer du behöva välja var ditt ursprungliga ROM är.
 6. En patchad `.gba` fil kommer skapas på samma plats som patchfilen.
 7. Första gången du öppnar en patch med BizHawk-klienten, kommer du också behöva bekräfta var `EmuHawk.exe` filen är

--- a/worlds/pokemon_emerald/docs/setup_sv.md
+++ b/worlds/pokemon_emerald/docs/setup_sv.md
@@ -14,9 +14,9 @@ När du har installerat BizHawk, öppna `EmuHawk.exe` och ändra följande inst�
 `NLua+KopiLua` till `Lua+LuaInterface`, starta om EmuHawk efteråt. (Använder du BizHawk 2.9, kan du skippa detta steg.)
 - Gå till `Config > Customize`. Markera "Run in background" inställningen för att förhindra bortkoppling från
 klienten om du alt-tabbar bort från EmuHawk.
-- Öppna en `.gba` fil i EmuHawk och gå till `Config > Controllers…` för att konfigurera dina inputs.
+- Öppna en `.gba` fil i EmuHawk och gå till `Config > Controllers...` för att konfigurera dina inputs.
 Om du inte hittar `Controllers…`, starta ett valfritt `.gba` ROM först.
-- Överväg att rensa keybinds i `Config > Hotkeys…` som du inte tänkt använda. Välj en keybind och tryck på ESC
+- Överväg att rensa keybinds i `Config > Hotkeys...` som du inte tänkt använda. Välj en keybind och tryck på ESC
 för att rensa bort den.
 
 ## Extra programvara
@@ -32,7 +32,7 @@ används tillsammans med
 2. Följ de allmänna Archipelago instruktionerna för att
 [Generera ett spel](../../Archipelago/setup/en#generating-a-game).
 Detta kommer generera en fil för dig. Din patchfil kommer ha `.apemerald` som sitt filnamnstillägg.
-3. Öppna `ArchipelagoLauncher.exe`
+3. Öppna `ArchipelagoLauncher.exe`.
 4. Välj "Open Patch" på vänstra sidan, och välj din patchfil.
 5. Om detta är första gången du patchar, så kommer du behöva välja var ditt ursprungliga ROM är.
 6. En patchad `.gba` fil kommer skapas på samma plats som patchfilen.
@@ -52,7 +52,7 @@ ifall du till exempel behöver stänga ner och starta om något medans du spelar
 så kan du bara öppna den igen från launchern.
 2. Dubbelkolla att EmuHawk faktiskt startat med den patchade ROM-filen.
 3. I EmuHawk, gå till `Tools > Lua Console`. Luakonsolen måste vara igång medans du spelar.
-4. I Luakonsolen, Tryck på `Script > Open Script…`.
+4. I Luakonsolen, Tryck på `Script > Open Script...`.
 5. Leta reda på din Archipelago-mapp och i den öppna `data/lua/connector_bizhawk_generic.lua`.
 6. Emulatorn och klienten kommer så småningom ansluta till varandra. I BizHawk-klienten kommer du kunna see om allt är
 anslutet och att Pokemon Emerald är igenkänt.

--- a/worlds/pokemon_emerald/docs/setup_sv.md
+++ b/worlds/pokemon_emerald/docs/setup_sv.md
@@ -32,8 +32,9 @@ används tillsammans med
 2. Följ de allmänna Archipelago instruktionerna för att
 [Generera ett spel](../../Archipelago/setup/en#generating-a-game).
 Detta kommer generera en fil för dig. Din patchfil kommer ha `.apemerald` som sitt filnamnstillägg.
+Den här patch filen kan också laddas ner från multvärlds lobbyn om du [hostar din multivärld på hemsidan](../../Archipelago/setup#hosting-on-the-website).
 3. Öppna `ArchipelagoLauncher.exe`.
-4. Välj "Open Patch" på vänstra sidan, och välj din patchfil.
+Välj "Open Patch" från listan eller under `Misc -> Open Patch` och välj din patchfil.
 5. Om detta är första gången du patchar, så kommer du behöva välja var ditt ursprungliga ROM är.
 6. En patchad `.gba` fil kommer skapas på samma plats som patchfilen.
 7. Första gången du öppnar en patch med BizHawk-klienten, kommer du också behöva bekräfta var `EmuHawk.exe` filen är

--- a/worlds/pokemon_emerald/docs/setup_sv.md
+++ b/worlds/pokemon_emerald/docs/setup_sv.md
@@ -32,7 +32,7 @@ används tillsammans med
 2. Följ de allmänna Archipelago instruktionerna för att
 [Generera ett spel](../../Archipelago/setup/en#generating-a-game).
 Detta kommer generera en fil för dig. Din patchfil kommer ha `.apemerald` som sitt filnamnstillägg.
-Den här patch filen kan också laddas ner från multvärlds lobbyn om du [hostar din multivärld på hemsidan](../../Archipelago/setup#hosting-on-the-website).
+Den här patch filen kan också laddas ner från multvärldslobbyn om du [hostar din multivärld på hemsidan](../../Archipelago/setup#hosting-on-the-website).
 3. Öppna `ArchipelagoLauncher.exe`.
 4. Välj "Open Patch" från listan eller under `Misc -> Open Patch` och välj din patchfil.
 5. Om detta är första gången du patchar, så kommer du behöva välja var ditt ursprungliga ROM är.

--- a/worlds/pokemon_rb/docs/setup_en.md
+++ b/worlds/pokemon_rb/docs/setup_en.md
@@ -76,7 +76,7 @@ And the following special characters (these each count as one character):
 2. Follow the general Archipelago instructions for [generating a game](../../Archipelago/setup/en#generating-a-game).
 This will generate an output file for you. Your patch file will have a `.apred` or `.apblue` file extension.
 This patch file can also be downloaded off the multiworld room page if you [host your multiworld on the website](../../Archipelago/setup#hosting-on-the-website).
-3. Open `ArchipelagoLauncher.exe`
+3. Open `ArchipelagoLauncher.exe`.
 4. Select "Open Patch" from the initial list or under `Misc -> Open Patch` and select your patch file.
 5. If this is your first time patching, you will be prompted to locate your vanilla ROM.
 6. A patched `.gb` file will be created in the same place as the patch file.
@@ -96,7 +96,7 @@ in case you have to close and reopen a window mid-game for some reason.
 game, you can re-open it from the launcher.
 2. Ensure EmuHawk is running the patched ROM.
 3. In EmuHawk, go to `Tools > Lua Console`. This window must stay open while playing.
-4. In the Lua Console window, go to `Script > Open Script…`.
+4. In the Lua Console window, go to `Script > Open Script...`.
 5. Navigate to your Archipelago install folder and open `data/lua/connector_bizhawk_generic.lua`.
 6. The emulator may freeze every few seconds until it manages to connect to the client. This is expected. The BizHawk
 Client window should indicate that it connected and recognized Pokémon Red/Blue.

--- a/worlds/pokemon_rb/docs/setup_en.md
+++ b/worlds/pokemon_rb/docs/setup_en.md
@@ -75,8 +75,9 @@ And the following special characters (these each count as one character):
 1. Create your options file (YAML).
 2. Follow the general Archipelago instructions for [generating a game](../../Archipelago/setup/en#generating-a-game).
 This will generate an output file for you. Your patch file will have a `.apred` or `.apblue` file extension.
+This patch file can also be downloaded off the multiworld room page if you [host your multiworld on the website](../../Archipelago/setup#hosting-on-the-website).
 3. Open `ArchipelagoLauncher.exe`
-4. Select "Open Patch" on the left side and select your patch file.
+4. Select "Open Patch" from the initial list or under `Misc -> Open Patch` and select your patch file.
 5. If this is your first time patching, you will be prompted to locate your vanilla ROM.
 6. A patched `.gb` file will be created in the same place as the patch file.
 7. On your first time opening a patch with BizHawk Client, you will also be asked to locate `EmuHawk.exe` in your

--- a/worlds/pokemon_rb/docs/setup_es.md
+++ b/worlds/pokemon_rb/docs/setup_es.md
@@ -79,8 +79,9 @@ Y los siguientes caracteres especiales (cada uno ocupa un carácter):
 1. Crea tu archivo de opciones (YAML).
 2. Sigue las instrucciones generales de Archipelago para [generar un juego](../../Archipelago/setup/en#generating-a-game).
 Haciendo esto se generará un archivo de salida. Tu parche tendrá la extensión de archivo `.apred` o `.apblue`.
-3. Abre `ArchipelagoLauncher.exe`
-4. Selecciona "Open Patch" en el lado izquierdo y selecciona tu parche.
+Este parche también puede ser descargado desde la pagina de la sala del multiworld si tu [hosteas tu multiworld en el sitio web](../../Archipelago/setup#hosting-on-the-website).
+3. Abre `ArchipelagoLauncher.exe`.
+4. Selecciona "Open Patch" en la lista inicial o en Misc -> Open Patch y selecciona tu parche.
 5. Si es tu primera vez parchando, se te pedirá que selecciones tu ROM original.
 6. Un archivo `.gb` parchado será creado en el mismo lugar donde está el parche.
 7. La primera vez que abras un parche con BizHawk Client, también se te pedira ubicar `EmuHawk.exe` en tu

--- a/worlds/pokemon_rb/docs/setup_es.md
+++ b/worlds/pokemon_rb/docs/setup_es.md
@@ -79,7 +79,7 @@ Y los siguientes caracteres especiales (cada uno ocupa un carácter):
 1. Crea tu archivo de opciones (YAML).
 2. Sigue las instrucciones generales de Archipelago para [generar un juego](../../Archipelago/setup/en#generating-a-game).
 Haciendo esto se generará un archivo de salida. Tu parche tendrá la extensión de archivo `.apred` o `.apblue`.
-Este parche también puede ser descargado desde la pagina de la sala del multiworld si tu [hosteas tu multiworld en el sitio web](../../Archipelago/setup#hosting-on-the-website).
+Este parche también puede ser descargado desde la página de la sala del multiworld si tu [hosteas tu multiworld en el sitio web](../../Archipelago/setup#hosting-on-the-website).
 3. Abre `ArchipelagoLauncher.exe`.
 4. Selecciona "Open Patch" en la lista inicial o en Misc -> Open Patch y selecciona tu parche.
 5. Si es tu primera vez parchando, se te pedirá que selecciones tu ROM original.

--- a/worlds/pokemon_rb/docs/setup_es.md
+++ b/worlds/pokemon_rb/docs/setup_es.md
@@ -80,7 +80,7 @@ Y los siguientes caracteres especiales (cada uno ocupa un carácter):
 2. Sigue las instrucciones generales de Archipelago para [generar un juego](../../Archipelago/setup/en#generating-a-game).
 Haciendo esto se generará un archivo de salida. Tu parche tendrá la extensión de archivo `.apred` o `.apblue`.
 Este parche también puede ser descargado desde la pagina de la sala del multiworld si tu [hosteas tu multiworld en el sitio web](../../Archipelago/setup#hosting-on-the-website).
-3. Abre `ArchipelagoLauncher.exe`.
+3. Abre `ArchipelagoLauncher.exe`..
 4. Selecciona "Open Patch" en la lista inicial o en Misc -> Open Patch y selecciona tu parche.
 5. Si es tu primera vez parchando, se te pedirá que selecciones tu ROM original.
 6. Un archivo `.gb` parchado será creado en el mismo lugar donde está el parche.
@@ -100,7 +100,7 @@ que tengas que cerrar y volver a abrir el juego por alguna razón.
 puedes volverlo a abrir desde el Launcher.
 2. Asegúrate que EmuHawk esta cargando el ROM parchado.
 3. En EmuHawk, ir a `Tools > Lua Console`. Esta ventana debe quedarse abierta mientras se juega.
-4. En la ventana de Lua Console, ir a `Script > Open Script…`.
+4. En la ventana de Lua Console, ir a `Script > Open Script...`.
 5. Navegar a tu carpeta de instalación de Archipelago y abrir `data/lua/connector_bizhawk_generic.lua`.
 6. El emulador se puede congelar por unos segundos hasta que logre conectarse al cliente. Esto es normal. La ventana del
 BizHawk Client debería indicar que se logro conectar y reconocer Pokémon Red/Blue.

--- a/worlds/pokemon_rb/docs/setup_es.md
+++ b/worlds/pokemon_rb/docs/setup_es.md
@@ -80,7 +80,7 @@ Y los siguientes caracteres especiales (cada uno ocupa un carácter):
 2. Sigue las instrucciones generales de Archipelago para [generar un juego](../../Archipelago/setup/en#generating-a-game).
 Haciendo esto se generará un archivo de salida. Tu parche tendrá la extensión de archivo `.apred` o `.apblue`.
 Este parche también puede ser descargado desde la pagina de la sala del multiworld si tu [hosteas tu multiworld en el sitio web](../../Archipelago/setup#hosting-on-the-website).
-3. Abre `ArchipelagoLauncher.exe`..
+3. Abre `ArchipelagoLauncher.exe`.
 4. Selecciona "Open Patch" en la lista inicial o en Misc -> Open Patch y selecciona tu parche.
 5. Si es tu primera vez parchando, se te pedirá que selecciones tu ROM original.
 6. Un archivo `.gb` parchado será creado en el mismo lugar donde está el parche.


### PR DESCRIPTION
## What is this fixing or adding?
This PR minorly updates some setup docs. It updates three things:
1. Missing punctuation (make it standardized to have a dot at the end of every sentence. Most "Open ArchipelagoLauncher.exe" were missing this).
2. Replace remaining "…" with "...". Most of the Guides were already using "..." Some guides used both. I fixed it so guides that use both use only "..."
3. Previously, "Open Patch" was on the left side of the AP Launcher. With the KivyMD change of... a version not long ago, it's now part of the giant list. I updated the Setup Guides of all ROM games that have instructions surrounding this button to reflect this change. I also added a line that the patch file can be acquired from the website. With the thanks of @ShinyNT and @Tsukino-uwu I updated the Spanish & Swedish guides with this as well.

## How was this tested?
It wasn't.

## If this makes graphical changes, please attach screenshots.
Does anybody ever do this?