### PR TITLE
Raft: Add Zipline Tool requirement to Engine controls blueprint

### DIFF
--- a/worlds/raft/locations.json
+++ b/worlds/raft/locations.json
@@ -810,7 +810,10 @@
     {
         "id": 48105,
         "name": "Engine controls blueprint",
-        "region": "CaravanIsland"
+        "region": "CaravanIsland",
+        "requiresAccessToItems": [
+            "Zipline tool"
+        ]
     },
     {
         "id": 48106,


### PR DESCRIPTION
## What is this fixing or adding?
Engine controls blueprint requires the Zipline Tool to get to. [Discord bug report](https://discord.com/channels/731205301247803413/1416638503277695087)

## How was this tested?
Manually generated a few worlds

## If this makes graphical changes, please attach screenshots.
N/A