### PR TITLE
SC2: Caching important complex logic rules

### DIFF
--- a/worlds/sc2/__init__.py
+++ b/worlds/sc2/__init__.py
@@ -356,8 +356,10 @@ class SC2World(World):
 
     def clear_logic_cache(self, state: "CollectionState", item: "Item", is_removal: bool) -> None:
         if item.player == self.player:
-            for consequent, rule in self.logic.cached_rules.items():
-                if item.name in rule.get_all_affecting_items():
+            if item.name in self.logic.cached_rules_affected_by_items.keys():
+                cached_rules = self.logic.cached_rules_affected_by_items[item.name]
+                for rule in cached_rules:
+                    consequent = rule.consequent
                     consequent_count = state.count(consequent, self.player)
                     if consequent_count > 0:
                         if isinstance(rule, BooleanCachedRule):

--- a/worlds/sc2/item/item_groups.py
+++ b/worlds/sc2/item/item_groups.py
@@ -23,7 +23,7 @@ For non-developers the following will be useful:
 item_name_groups: typing.Dict[str, typing.List[str]] = {}
 
 # Groups for use in world logic
-item_name_groups["Missions"] = ["Beat " + mission.mission_name for mission in SC2Mission]
+item_name_groups["Missions"] = BEAT_EVENTS = ["Beat " + mission.mission_name for mission in SC2Mission]
 item_name_groups["WoL Missions"] = ["Beat " + mission.mission_name for mission in campaign_mission_table[SC2Campaign.WOL]] + \
                                    ["Beat " + mission.mission_name for mission in campaign_mission_table[SC2Campaign.PROPHECY]]
 

--- a/worlds/sc2/rules.py
+++ b/worlds/sc2/rules.py
@@ -1,6 +1,6 @@
 from enum import StrEnum, auto
 from math import floor
-from typing import TYPE_CHECKING, Set, Optional, Callable, Dict, Tuple, Iterable, Any
+from typing import TYPE_CHECKING, Set, Optional, Callable, Dict, Tuple, Iterable, Any, List
 
 from BaseClasses import CollectionState, Location
 from .item.item_groups import kerrigan_non_ulimates, kerrigan_logic_active_abilities
@@ -125,7 +125,7 @@ class IntegerCachedRule(AbstractCachedRule):
             result = self.rule(state, *args, **kwargs)
             self.set_state_count(state, result + 1)
             return result
-        return consequent_count -1
+        return consequent_count - 1
 
 class BooleanCachedRule(AbstractCachedRule):
     def __init__(self, logic: "SC2Logic", consequent: LogicConsequent, antecedents: Iterable[str], rule: Callable[[CollectionState], bool]):
@@ -322,6 +322,13 @@ class SC2Logic:
             item_names.ZEALOT, item_names.ZEALOT_WHIRLWIND, item_names.DESTROYER,
             item_names.DESTROYER_REFORGED_BLOODSHARD_CORE, item_names.DESTROYER_RESOURCE_EFFICIENCY,
         ), self.protoss_basic_splash_impl)
+
+        self.cached_rules_affected_by_items: Dict[str, List[AbstractCachedRule]] = dict()
+        for rule in self.cached_rules.values():
+            for item in rule.get_all_affecting_items():
+                if item not in self.cached_rules_affected_by_items.keys():
+                    self.cached_rules_affected_by_items[item] = []
+                self.cached_rules_affected_by_items[item].append(rule)
 
 
 


### PR DESCRIPTION
## What is this fixing or adding?
Tries to speed up SC2 logic evaluation in a way, that's more easy to maintain than #5423

The real logic rules can maintain their inner complexity, the outcome is cached and the cache is reset if any item affecting the rule is collected or removed

For boolean rules, the result is caches as 1 event item when the rule is not fulfilled and as 2 event items when it is
For integer rules, the integer value + 1 is cached as an event item
0 means that no cache exists and standard rule must be evaluated (and gets cached afterwards)

Currently only fill stages use rule cache, not item pool filter (subject to future PR)

The antecedents of cached rules are validated using a unit test, therefore nothing can be missed, thus keeping the dev maintenance costs low

According to my tests, the gain is about to cutting 20% generation time.
After looking into profiler, now the most problematic performance-wise thing is counting missions in mission orders (for region navigation), but that's out of scope of this PR

Notes for future PRs:
Cache defensive score and power level
Use caching while doing item pool filtering

## How was this tested?
Unit tests, world generation, including 1000 randomized worlds.
The logic bottlenecks in the common functions from the profiler are gone, thus far less time is spent inside those functions without adding too much overhead.

## If this makes graphical changes, please attach screenshots.
No