### PR TITLE
TUNIC: Update name of a chest in the UT poptracker map integration

### DIFF
--- a/worlds/tunic/ut_stuff.py
+++ b/worlds/tunic/ut_stuff.py
@@ -96,6 +96,7 @@ poptracker_data: dict[str, int] = {
     "[Southwest] Chest Guarded By Turret/Behind the Trees": 509342519,
     "[Northwest] Shadowy Corner Chest/Dark Ramps Chest": 509342520,
     "[Southwest] Obscured In Tunnel To Beach/Deep in the Wall": 509342521,
+    "[Southwest] Obscured In Tunnel To Beach/Deep between the Trees": 509342521,
     "[Southwest] Grapple Chest Over Walkway/Jeffry": 509342522,
     "[Northwest] Chest Beneath Quarry Gate/Across the Bridge": 509342523,
     "[Southeast] Chest Near Swamp/Under the Bridge": 509342524,


### PR DESCRIPTION
## What is this fixing or adding?
Just adds the new name to the poptracker location list. There was no need to remove the old one, since it just sorta works with both, and would break back compat.

## How was this tested?
Launched UT and sent the location