### PR TITLE
Core: make countdown an "admin" only command

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1350,19 +1350,6 @@ class CommandProcessor(metaclass=CommandMeta):
 class CommonCommandProcessor(CommandProcessor):
     ctx: Context
 
-    def _cmd_countdown(self, seconds: str = "10") -> bool:
-        """Start a countdown in seconds"""
-        try:
-            timer = int(seconds, 10)
-        except ValueError:
-            timer = 10
-        else:
-            if timer > 60 * 60:
-                raise ValueError(f"{timer} is invalid. Maximum is 1 hour.")
-
-        async_start(countdown(self.ctx, timer))
-        return True
-
     def _cmd_options(self):
         """List all current options. Warning: lists password."""
         self.output("Current options:")
@@ -2258,6 +2245,19 @@ class ServerCommandProcessor(CommonCommandProcessor):
 
         self.output(f"Could not find player {player_name} to collect")
         return False
+
+    def _cmd_countdown(self, seconds: str = "10") -> bool:
+        """Start a countdown in seconds"""
+        try:
+            timer = int(seconds, 10)
+        except ValueError:
+            timer = 10
+        else:
+            if timer > 60 * 60:
+                raise ValueError(f"{timer} is invalid. Maximum is 1 hour.")
+
+        async_start(countdown(self.ctx, timer))
+        return True
 
     @mark_raw
     def _cmd_release(self, player_name: str) -> bool:


### PR DESCRIPTION
## What is this fixing or adding?
Apparently !countdown has been used for trolling too much by now. Originally, we didn't have !admin /countdown in the olden days, now that we do, it's probably for the best to make this a host/admin only command.

## How was this tested?
locally:
<img width="781" height="156" alt="image" src="https://github.com/user-attachments/assets/99825f65-6953-41bf-a584-ab564aff61ae" />
When I do it on the server:
<img width="351" height="225" alt="image" src="https://github.com/user-attachments/assets/ae1ecd88-34ed-409d-b3b0-1c4b7501b844" />
