### PR TITLE
Core: Add a tab to default client for items sent/received for the active slot.

### DIFF
--- a/kvui.py
+++ b/kvui.py
@@ -916,7 +916,7 @@ class GameManager(ThemedApp):
                 self.add_client_tab(display_name, self.log_panels[display_name])
 
         self.my_log = UILog()
-        self.add_client_tab("My Checks", self.my_log)
+        self.add_client_tab("My Activity", self.my_log)
 
         self.hint_log = HintLog(self.json_to_kivy_parser)
         hint_panel = self.add_client_tab("Hints", HintLayout(self.hint_log))


### PR DESCRIPTION
## What is this fixing or adding?

In large multiworld games, players like to see their own checks which can get lost in the firehose of updates (citation: https://www.youtube.com/watch?v=uObaQEym8Js). This new tab only displays json messages for the local player and their team.

## How was this tested?
Running locally. I wrote some unit tests, but importing kvui imports kivy which crashes without UI:

```
INTERNALERROR>   File "/home/codespace/.local/lib/python3.12/site-packages/kivymd/__init__.py", line 62, in <module>
INTERNALERROR>     import kivymd.font_definitions  # NOQA
INTERNALERROR>     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/home/codespace/.local/lib/python3.12/site-packages/kivymd/font_definitions.py", line 58, in <module>
INTERNALERROR>     "font-size": sp(24),
INTERNALERROR>                  ^^^^^^
INTERNALERROR>   File "/home/codespace/.local/lib/python3.12/site-packages/kivy/metrics.py", line 168, in sp
INTERNALERROR>     return dpi2px(value, 'sp')
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "kivy/_metrics.pyx", line 55, in kivy._metrics.dpi2px
INTERNALERROR>   File "kivy/_metrics.pyx", line 59, in kivy._metrics.dpi2px
INTERNALERROR>   File "kivy/_metrics.pyx", line 35, in kivy._metrics.dispatch_pixel_scale
INTERNALERROR>   File "/home/codespace/.local/lib/python3.12/site-packages/kivy/context.py", line 36, in __getattribute__
INTERNALERROR>     return getattr(object.__getattribute__(self, '_obj'), name)
INTERNALERROR>            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "kivy/properties.pyx", line 531, in kivy.properties.Property.__get__
INTERNALERROR>   File "kivy/properties.pyx", line 1656, in kivy.properties.AliasProperty.get
INTERNALERROR>   File "/home/codespace/.local/lib/python3.12/site-packages/kivy/metrics.py", line 206, in get_dpi
INTERNALERROR>     EventLoop.ensure_window()
INTERNALERROR>   File "/home/codespace/.local/lib/python3.12/site-packages/kivy/base.py", line 139, in ensure_window
INTERNALERROR>     sys.exit(1)
INTERNALERROR> SystemExit: 1
mainloop: caught unexpected SystemExit!
```

Simple tests I can't run:
```py
from unittest import TestCase

from kvui import GameManager
from CommonClient import CommonContext

class GameManagerTest(TestCase):
    def test_gamemanager_print_json_filter_team(self):
        """Test that GameManager only emits relevant updates to the My Checks tab."""
        ctx = CommonContext()
        app = GameManager(ctx)
        app.build()
        ctx.slot = 1

        app.print_json([{"text": "Team message", "player": 1}])
        app.print_json([{"text": "Other message", "player": 2}])
        self.assertIn("Team message", app.team_log.data)
        self.assertNotIn("Other message", app.team_log.data)
```

## If this makes graphical changes, please attach screenshots.
<img width="788" height="115" alt="image" src="https://github.com/user-attachments/assets/7522487c-9de3-49b5-a9cb-4989a6c83102" />
