### PR TITLE
core:  Add host.yaml setting to make !countdown configurable

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -179,6 +179,7 @@ class Context:
                       "release_mode": str,
                       "remaining_mode": str,
                       "collect_mode": str,
+                      "countdown_mode": str,
                       "item_cheat": bool,
                       "compatibility": int}
     # team -> slot id -> list of clients authenticated to slot.
@@ -208,8 +209,8 @@ class Context:
 
     def __init__(self, host: str, port: int, server_password: str, password: str, location_check_points: int,
                  hint_cost: int, item_cheat: bool, release_mode: str = "disabled", collect_mode="disabled",
-                 remaining_mode: str = "disabled", auto_shutdown: typing.SupportsFloat = 0, compatibility: int = 2,
-                 log_network: bool = False, logger: logging.Logger = logging.getLogger()):
+                 countdown_mode: str = "auto", remaining_mode: str = "disabled", auto_shutdown: typing.SupportsFloat = 0, 
+                 compatibility: int = 2, log_network: bool = False, logger: logging.Logger = logging.getLogger()):
         self.logger = logger
         super(Context, self).__init__()
         self.slot_info = {}
@@ -242,6 +243,7 @@ class Context:
         self.release_mode: str = release_mode
         self.remaining_mode: str = remaining_mode
         self.collect_mode: str = collect_mode
+        self.countdown_mode: str = countdown_mode
         self.item_cheat = item_cheat
         self.exit_event = asyncio.Event()
         self.client_activity_timers: typing.Dict[
@@ -1329,19 +1331,6 @@ class CommandProcessor(metaclass=CommandMeta):
 class CommonCommandProcessor(CommandProcessor):
     ctx: Context
 
-    def _cmd_countdown(self, seconds: str = "10") -> bool:
-        """Start a countdown in seconds"""
-        try:
-            timer = int(seconds, 10)
-        except ValueError:
-            timer = 10
-        else:
-            if timer > 60 * 60:
-                raise ValueError(f"{timer} is invalid. Maximum is 1 hour.")
-
-        async_start(countdown(self.ctx, timer))
-        return True
-
     def _cmd_options(self):
         """List all current options. Warning: lists password."""
         self.output("Current options:")
@@ -1482,6 +1471,23 @@ class ClientMessageProcessor(CommonCommandProcessor):
                     "Sorry, client collecting requires you to have beaten the game on this server."
                     " You can ask the server admin for a /collect")
                 return False
+
+    def _cmd_countdown(self, seconds: str = "10") -> bool:
+        """Start a countdown in seconds"""
+        if self.ctx.countdown_mode == "disabled" or \
+           self.ctx.countdown_mode == "auto" and len(self.ctx.player_names) >= 30:
+            self.output("Sorry, client countdowns have been disabled on this server. You can ask the server admin for a /countdown")
+            return False
+        try:
+            timer = int(seconds, 10)
+        except ValueError:
+            timer = 10
+        else:
+            if timer > 60 * 60:
+                raise ValueError(f"{timer} is invalid. Maximum is 1 hour.")
+
+        async_start(countdown(self.ctx, timer))
+        return True
 
     def _cmd_remaining(self) -> bool:
         """List remaining items in your game, but not their location or recipient"""
@@ -2228,6 +2234,19 @@ class ServerCommandProcessor(CommonCommandProcessor):
         self.output(f"Could not find player {player_name} to collect")
         return False
 
+    def _cmd_countdown(self, seconds: str = "10") -> bool:
+        """Start a countdown in seconds"""
+        try:
+            timer = int(seconds, 10)
+        except ValueError:
+            timer = 10
+        else:
+            if timer > 60 * 60:
+                raise ValueError(f"{timer} is invalid. Maximum is 1 hour.")
+
+        async_start(countdown(self.ctx, timer))
+        return True
+
     @mark_raw
     def _cmd_release(self, player_name: str) -> bool:
         """Send out the remaining items from a player to their intended recipients."""
@@ -2510,6 +2529,13 @@ def parse_args() -> argparse.Namespace:
                              goal:     !collect can be used after goal completion
                              auto-enabled: !collect is available and automatically triggered on goal completion
                              ''')
+    parser.add_argument('--countdown_mode', default=defaults["countdown_mode"], nargs='?',
+                        choices=['enabled', 'disabled', "auto"], help='''\
+                                Select !countdown Accessibility. (default: %(default)s)
+                                enabled:  !countdown is always available
+                                disabled: !countdown is never available
+                                auto:     !countdown is available for rooms with less than 30 players
+                                ''')
     parser.add_argument('--remaining_mode', default=defaults["remaining_mode"], nargs='?',
                         choices=['enabled', 'disabled', "goal"], help='''\
                              Select !remaining Accessibility. (default: %(default)s)
@@ -2575,7 +2601,7 @@ async def main(args: argparse.Namespace):
 
     ctx = Context(args.host, args.port, args.server_password, args.password, args.location_check_points,
                   args.hint_cost, not args.disable_item_cheat, args.release_mode, args.collect_mode,
-                  args.remaining_mode,
+                  args.countdown_mode, args.remaining_mode,
                   args.auto_shutdown, args.compatibility, args.log_network)
     data_filename = args.multidata
 

--- a/WebHostLib/generate.py
+++ b/WebHostLib/generate.py
@@ -34,6 +34,7 @@ def get_meta(options_source: dict, race: bool = False) -> dict[str, list[str] | 
         "release_mode": str(options_source.get("release_mode", ServerOptions.release_mode)),
         "remaining_mode": str(options_source.get("remaining_mode", ServerOptions.remaining_mode)),
         "collect_mode": str(options_source.get("collect_mode", ServerOptions.collect_mode)),
+        "countdown_mode": str(options_source.get("countdown_mode", ServerOptions.countdown_mode)),
         "item_cheat": bool(int(options_source.get("item_cheat", not ServerOptions.disable_item_cheat))),
         "server_password": str(options_source.get("server_password", None)),
     }

--- a/settings.py
+++ b/settings.py
@@ -579,6 +579,15 @@ class ServerOptions(Group):
         "goal" -> Client can ask for remaining items after goal completion
         """
 
+    class CountdownMode(str):
+        """
+        Countdown modes
+        Determines whether or not a player can initiate a countdown with !countdown
+        "enabled" -> Client can always initiate a countdown with !countdown.
+        "disabled" -> Client can never initiate a countdown with !countdown. /countdown is still available to the host.
+        "auto" -> !countdown will be available for any room with less than 30 slots.
+        """
+
     class AutoShutdown(int):
         """Automatically shut down the server after this many seconds without new location checks, 0 to keep running"""
 
@@ -613,6 +622,7 @@ class ServerOptions(Group):
     release_mode: ReleaseMode = ReleaseMode("auto")
     collect_mode: CollectMode = CollectMode("auto")
     remaining_mode: RemainingMode = RemainingMode("goal")
+    countdown_mode: CountdownMode = CountdownMode("auto")
     auto_shutdown: AutoShutdown = AutoShutdown(0)
     compatibility: Compatibility = Compatibility(2)
     log_network: LogNetwork = LogNetwork(0)


### PR DESCRIPTION
An alternative to #5463

## What is this fixing or adding?
There have been issues with players in large syncs using !countdown when they were not the host.   This is absolutely an issue.  

However, I feel that the proposed solution - which was to change it exclusively to an admin command - goes too far in the other direction, and prevents legitimate uses of !countdown when doing mid-game coordination, especially around things like deaths or releases.

This PR instead makes the ability to call !countdown a server setting, with three options:
- Always Enabled
- Never Enabled

- Enabled for small (<30 players) rooms. (Default)

This is available both as a host.yaml/CLI argument, and also something that can be set with `/option` at runtime.

I feel like this strikes a good balance between allowing novel uses of client-countdowns mid-run while also protecting large syncs from griefing during setup.

## How was this tested?
* Tested with host.yaml enabled
* Tested with host.yaml disabled
* Tested with host.yaml auto 25 players
* Tested with host.yaml auto 35 players
* Tested with various permutations of `!admin /option countdown_mode`

## If this makes graphical changes, please attach screenshots.

<img width="987" height="579" alt="Screenshot 2025-09-21 at 3 00 23 pm" src="https://github.com/user-attachments/assets/2afea0dc-eacf-4033-82c7-5bee096fe263" />