### PR TITLE
[WebHost Docs] Updated and clarified new tracker endpoitns and misc fixes.

### DIFF
--- a/docs/webhost api.md
+++ b/docs/webhost api.md
@@ -4,7 +4,7 @@ Archipelago has a rudimentary API that can be queried by endpoints. The API is a
 
 The following API requests are formatted as: `https://<Archipelago URL>/api/<endpoint>`
 
-The returned data will be formated in a combination of JSON lists or dicts, with their keys or values being notated in `blocks` (if applicable)
+The returned data will be formatted in a combination of JSON lists or dicts, with their keys or values being notated in `blocks` (if applicable)
 
 Current endpoints:
 - Datapackage API
@@ -40,7 +40,7 @@ Each game will have:
 - Location name to AP ID dict `location_name_to_id`
 
 Example:
-```
+```json
 {
     "games": {
         ...
@@ -91,7 +91,7 @@ Its format will be identical to the whole-datapackage endpoint (`/datapackage`),
 Fetches the checksums of the current static datapackages on the WebHost.
 You'll receive a dict with `game:checksum` key-value pairs for all the current officially supported games.  
 Example:
-```
+```json
 {
 ...
 "Donkey Kong Country 3":"f90acedcd958213f483a6a4c238e2a3faf92165e",
@@ -116,7 +116,7 @@ Have your ZIP of yaml(s) or a single yaml, and submit a POST request to the `/ge
 If the options are valid, you'll be returned a successful generation response. (see [Generation Response](#generation-response))
 
 Example using the python requests library:
-```
+```python
 file = {'file': open('Games.zip', 'rb')}
 req = requests.post("https://archipelago.gg/api/generate", files=file)
 ```
@@ -127,7 +127,7 @@ Finally, submit a POST request to the `/generate` endpoint.
 If the weighted options are valid, you'll be returned a successful generation response (see [Generation Response](#generation-response))
 
 Example using the python requests library:
-```
+```python
 data = {"Test":{"game": "Factorio","name": "Test","Factorio": {}},}
 weights={"weights": data}
 req = requests.post("https://archipelago.gg/api/generate", json=weights)
@@ -143,7 +143,7 @@ Upon successful generation, you'll be sent a JSON dict response detailing the ge
 - The API status page of the generation `wait_api_url` (see [Status Endpoint](#status))
 
 Example:
-```
+```json
 {
     "detail": "19878f16-5a58-4b76-aab7-d6bf38be9463",
     "encoded": "GYePFlpYS3aqt9a_OL6UYw",
@@ -167,12 +167,12 @@ If the generation detects a issue in generation, you'll be sent a dict with two 
 - Detailed issue in `detail`
 
 In the event of an unhandled server exception, you'll be provided a dict with a single key `text`:
-- Exception, `Uncought Exception: <error>` with a 500 status code
+- Exception, `Uncaught Exception: <error>` with a 500 status code
 
 ### `/status/<suuid:seed>`
 <a name="status"></a>
 Retrieves the status of the seed's generation.  
-This endpoint will return a dict with a single key-vlaue pair. The key will always be `text`  
+This endpoint will return a dict with a single key-value pair. The key will always be `text`  
 The value will tell you the status of the generation:
 - Generation was completed: `Generation done` with a 201 status code
 - Generation request was not found: `Generation not found` with a 404 status code
@@ -192,10 +192,10 @@ Will provide a dict of room data with the following keys:
 - Last activity timestamp (`last_activity`)
 - The room timeout counter (`timeout`)
 - A list of downloads for files required for gameplay (`downloads`)
-    - Each item is a dict containings the download URL and slot (`slot`, `download`)
+    - Each item is a dict containing the download URL and slot (`slot`, `download`)
 
 Example:
-```
+```json
 {
     "downloads": [
         {
@@ -244,7 +244,7 @@ Example:
         ]
     ],
     "timeout": 7200,
-    "tracker": "cf6989c0-4703-45d7-a317-2e5158431171"
+    "tracker": "2gVkMQgISGScA8wsvDZg5A"
 }
 ```
 
@@ -256,15 +256,23 @@ can either be viewed while on a room tracker page, or from the [room's endpoint]
 <a name=tracker></a>
 Will provide a dict of tracker data with the following keys:
 
-- Each player's current alias (`aliases`)
-  - Will return the name if there is none
-- A list of items each player has received as a NetworkItem (`player_items_received`)
+- A list of players current alias data (`aliases`)
+  - Each item containing a dict with, their alias `alias`, their player number `player`, and their team `team`
+  - `alias` will return `null` if there is no alias set
+- A list of items each player has received as a [NetworkItem](network%20protocol.md#networkitem) (`player_items_received`)
+  - Each item containing a dict with, a list of NetworkItems `items`, their player number `player`, their team `team`
 - A list of checks done by each player as a list of the location id's (`player_checks_done`)
-- The total number of checks done by all players (`total_checks_done`)
-- Hints that players have used or received (`hints`)
-- The time of last activity of each player in RFC 1123 format (`activity_timers`)
-- The time of last active connection of each player in RFC 1123 format (`connection_timers`)
-- The current client status of each player (`player_status`)
+  - Each item containing a dict with, a list of checked location id's `locations`, their player number `player`, and their team `team`
+- A list of the total number of checks done by all players (`total_checks_done`)
+  - Each item will contain a dict with, the total checks done `checks_done`, and the team `team`  
+- A list of [Hints](network%20protocol.md#hint) data that players have used or received (`hints`)
+  - Each item containing a dict containing, a list of hint data `hints`, the player number `player`, and their team `team`
+- A list containing the last activity time for each player, formatted in RFC 1123 format (`activity_timers`)
+  - Each item containing, last activity time `time`, their player number `player`, and their team `team`
+- A list containing the last connection time for each player, formatted in RFC 1123 format (`connection_timers`)
+  - Each item containing, the time of their last connection `time`, their player number `player`, and their team `team`
+- A list of the current [ClientStatus](network%20protocol.md#clientstatus) of each player (`player_status`)
+  - Each item will contain, their status `status`, their player number `player`, and their team `team`
 
 Example:
 ```json
@@ -279,7 +287,12 @@ Example:
       "team": 0,
       "player": 2,
       "alias": "Slot_Name_2"
-    }
+    },
+    {
+      "team": 0,
+      "player": 3,
+      "alias": null
+    },
   ],
   "player_items_received": [
     {
@@ -380,8 +393,11 @@ Example:
 <a name=statictracker></a>
 Will provide a dict of static tracker data with the following keys:
 
-- item_link groups and their players (`groups`)
-- The datapackage hash for each game (`datapackage`)
+- A list of item_link groups and their member players (`groups`)
+  - Each item containing a dict with, the slot registering the group `slot`, the item_link name `name`, and a list of members `members`
+- A dict of datapackage hashes for each game (`datapackage`)
+  - Each item is a named dict of the game's name.
+    - Each game contains two keys, the datapackage's checksum hash `checksum`, and the version `version`
   - This hash can then be sent to the datapackage API to receive the appropriate datapackage as necessary
 
 Example:
@@ -408,9 +424,11 @@ Example:
   "datapackage": {
     "Archipelago": {
       "checksum": "ac9141e9ad0318df2fa27da5f20c50a842afeecb",
+      "version": 0
     },
     "The Messenger": {
       "checksum": "6991cbcda7316b65bcb072667f3ee4c4cae71c0b",
+      "version": 0
     }
   }
 }
@@ -419,6 +437,9 @@ Example:
 ### `/slot_data_tracker/<suuid:tracker>`
 <a name=slotdatatracker></a>
 Will provide a list of each player's slot_data.
+Each list item will contain a dict with the player's data:
+- player slot number `player`
+- A named dict `slot_data` containing any set slot data for that player
 
 Example:
 ```json
@@ -456,25 +477,25 @@ Each list item will contain a dict with the room's details:
 - Room tracker SUUID (`tracker`)
 
 Example:
-```
+```json
 [
     {
         "creation_time": "Fri, 18 Apr 2025 19:46:53 GMT",
         "last_activity": "Fri, 18 Apr 2025 21:16:02 GMT",
         "last_port": 52122,
-        "room_id": "90ae5f9b-177c-4df8-ac53-9629fc3bff7a",
-        "seed_id": "efbd62c2-aaeb-4dda-88c3-f461c029cef6",
+        "room_id": "0D30FgQaRcWivFsw9o8qzw",
+        "seed_id": "TFjiarBgTsCj5-Jbe8u33A",
         "timeout": 7200,
-        "tracker": "cf6989c0-4703-45d7-a317-2e5158431171"
+        "tracker": "52BycvJhRe6knrYH8v4bag"
     },
     {
         "creation_time": "Fri, 18 Apr 2025 20:36:42 GMT",
         "last_activity": "Fri, 18 Apr 2025 20:36:46 GMT",
         "last_port": 56884,
-        "room_id": "14465c05-d08e-4d28-96bd-916f994609d8",
-        "seed_id": "a528e34c-3b4f-42a9-9f8f-00a4fd40bacb",
+        "room_id": "LMCFchESSNyuqcY3GxkhwA",
+        "seed_id": "CENtJMXCTGmkIYCzjB5Csg",
         "timeout": 7200,
-        "tracker": "4e624bd8-32b6-42e4-9178-aa407f72751c"
+        "tracker": "2gVkMQgISGScA8wsvDZg5A"
     }
 ]
 ```
@@ -489,7 +510,7 @@ Each item in the list will contain a dict with the seed's details:
     - Each item in the list will contain a list of the slot name and game
 
 Example:
-```
+```json
 [
     {
         "creation_time": "Fri, 18 Apr 2025 19:46:52 GMT",
@@ -515,7 +536,7 @@ Example:
                 "Ocarina of Time"
             ]
         ],
-        "seed_id": "efbd62c2-aaeb-4dda-88c3-f461c029cef6"
+        "seed_id": "CENtJMXCTGmkIYCzjB5Csg"
     },
     {
         "creation_time": "Fri, 18 Apr 2025 20:36:39 GMT",
@@ -537,7 +558,7 @@ Example:
                 "Archipelago"
             ]
         ],
-        "seed_id": "a528e34c-3b4f-42a9-9f8f-00a4fd40bacb"
+        "seed_id": "TFjiarBgTsCj5-Jbe8u33A"
     }
 ]
 ```


### PR DESCRIPTION
Adding json/python to codeblocks to make it pretty
fixed spelling mistakes that somehow made it all this way (thanks AI, you're good for something at least)
swapped uuids for suuids in the examples to reflect production AP after merged changes
expanded on /tracker and /static_tracker, and /slot_data_tracker giving detail on the returned structure of the API endpoints



## What is this fixing or adding?
Docs

## How was this tested?
It wasn't :)

## If this makes graphical changes, please attach screenshots.
Nope.