### PR TITLE
The Witness: Add archipelago.json

### DIFF
--- a/worlds/witness/archipelago.json
+++ b/worlds/witness/archipelago.json
@@ -1,0 +1,5 @@
+{
+    "game": "The Witness",
+    "minimum_ap_version": "0.6.4",
+    "world_version": "8.0.0"
+}


### PR DESCRIPTION
I think technically this apworld is compatible with AP all the way back to 0.5.1, but since 0.6.4 is the first version that can actually *read* the manifest, I think this makes more sense.