### PR TITLE
Pokemon Emerald: Add manifest

### DIFF
--- a/worlds/pokemon_emerald/archipelago.json
+++ b/worlds/pokemon_emerald/archipelago.json
@@ -1,0 +1,6 @@
+{
+    "game": "Pokemon Emerald",
+    "world_version": "2.4.1",
+    "minimum_ap_version": "0.6.1",
+    "authors": ["Zunawe"]
+}


### PR DESCRIPTION
## What is this fixing or adding?

Adds a manifest file based on the docs in #5477. Minimum version is just set to the last time Emerald included any changes (other than a data file for the adjuster) in an AP release. It's probably compatible farther back, but whatever.

## How was this tested?

Ran the build apworlds component and checked the built manifest.
