### PR TITLE
Pokemon Emerald: Set all abilities to Cacophony if all are blacklisted

### DIFF
--- a/worlds/pokemon_emerald/pokemon.py
+++ b/worlds/pokemon_emerald/pokemon.py
@@ -397,6 +397,10 @@ def randomize_abilities(world: "PokemonEmeraldWorld") -> None:
     ability_blacklist = {ability_label_to_value[label] for label in ability_blacklist_labels}
     ability_whitelist = [a.ability_id for a in data.abilities if a.ability_id not in ability_blacklist]
 
+    # If every ability is blacklisted, set all abilities to Cacophony, effectively disabling abilities
+    if len(ability_whitelist) == 0:
+        ability_whitelist = [data.constants["ABILITY_CACOPHONY"]]
+
     if world.options.abilities == RandomizeAbilities.option_follow_evolutions:
         already_modified: Set[int] = set()
 


### PR DESCRIPTION
## What is this fixing or adding?

Should address all instances of `IndexError: Cannot choose from an empty sequence` in #5368. The fuzzer managed to add every ability to the ability blacklist. Cacophony is an unimplemented ability, meaning blacklisting every ability will effectively disable abilities.

## How was this tested?

Generated with the yamls from the fuzzer output that encountered the problem. Generation succeeded. Did the same after removing an ability from the blacklist.
