### PR TITLE
Jak and Daxter: close Power Cell loophole in trades test

### DIFF
--- a/worlds/jakanddaxter/test/test_trades.py
+++ b/worlds/jakanddaxter/test/test_trades.py
@@ -6,7 +6,8 @@ class TradesCostNothingTest(JakAndDaxterTestBase):
         "enable_orbsanity": 2,
         "global_orbsanity_bundle_size": 10,
         "citizen_orb_trade_amount": 0,
-        "oracle_orb_trade_amount": 0
+        "oracle_orb_trade_amount": 0,
+        "start_inventory": {"Power Cell": 100},
     }
 
     def test_orb_items_are_filler(self):
@@ -24,7 +25,8 @@ class TradesCostEverythingTest(JakAndDaxterTestBase):
         "enable_orbsanity": 2,
         "global_orbsanity_bundle_size": 10,
         "citizen_orb_trade_amount": 120,
-        "oracle_orb_trade_amount": 150
+        "oracle_orb_trade_amount": 150,
+        "start_inventory": {"Power Cell": 100},
     }
 
     def test_orb_items_are_progression(self):


### PR DESCRIPTION
## What is this fixing or adding?
The test `TradesCostEverythingTest` fails randomly more often than we would like, which impacts other developers, worlds, and their unit tests. Examples [A](https://github.com/agilbert1412/Archipelago/actions/runs/17387737657/job/49356833708), [B](https://github.com/ArchipelagoMW/Archipelago/actions/runs/17415447817/job/49442655388?pr=5166), and [C](https://github.com/ArchipelagoMW/Archipelago/pull/5461).

These are fill errors due to being unable to place 20 Power Cells in Jak's first hub area. Under default options, this failure is extremely rare. However, this test increases the likelihood of failure because nearly all Orb items are marked as Progression during this test. Core is now flooded with more Orbs than Cells, and it cannot pick enough cells to put in hub 1.

Power Cells are not the system under test here, the NPC trading rules are. So we should eliminate cells as a variable during this test by providing all of them in the start_inventory. This should ensure that the access rules for all hub areas pass freely, allowing the test to focus solely on being able to trade with the NPC's.

## How was this tested?
Ran unit tests and they pass. This fill error is random however, so the passing tests only tell us there are no bugs in this change. Testing that the fill errors stop happening still requires a statistically significant number of runs.

## If this makes graphical changes, please attach screenshots.
N/A