### PR TITLE
CVCotM: Add a client safeguard in case the player doesn't have Dash Boots

### DIFF
--- a/worlds/cvcotm/client.py
+++ b/worlds/cvcotm/client.py
@@ -247,6 +247,10 @@ class CastlevaniaCotMClient(BizHawkClient):
                 await bizhawk.write(ctx.bizhawk_ctx, [(QUEUED_TEXTBOX_1_ADDRESS, [0 for _ in range(12)], "EWRAM")])
                 return
 
+            # If the player doesn't have Dash Boots for whatever reason, put them in their inventory now.
+            if not magic_items_array[0]:
+                await bizhawk.write(ctx.bizhawk_ctx, [(MAGIC_ITEMS_ARRAY_START, [1], "EWRAM")])
+
             # Enable DeathLink if it's in our slot_data.
             if "DeathLink" not in ctx.tags and ctx.slot_data["death_link"]:
                 await ctx.update_death_link(True)


### PR DESCRIPTION
## What is this fixing or adding?
What the title says. If the client detects the player doesn't have Dash Boots for some reason, it will now give them on the spot. You should always have them in this rando no matter what. However, because they are being given through the in-game start inventory system, games patched on an AP version after https://github.com/ArchipelagoMW/Archipelago/pull/5132 using a patch file generated before it will not have their start inventory properly given by the game upon starting a new game, and therefore are permanently locked out of having the Dash Boots, which is not a thing fixable via !getitem or /send. So, I figured I'd implement this safeguard because it's simple.

## How was this tested?
Poked the game's memory to remove Dash Boots from the inventory, verified I didn't have them, connected, and verified I had them again.