### PR TITLE
setup: check if the sign host is on a local network

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -146,7 +146,16 @@ def download_SNI() -> None:
 
 signtool: str | None = None
 try:
-    with urllib.request.urlopen('http://192.168.206.4:12345/connector/status') as response:
+    import socket
+
+    sign_host, sign_port = "192.168.206.4", 12345
+    # check if the sign_host is on a local network
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.connect((sign_host, sign_port))
+    if s.getsockname()[0].rsplit(".", 1)[0] != sign_host.rsplit(".", 1)[0]:
+        raise ConnectionError()  # would go through default route
+    # configure signtool
+    with urllib.request.urlopen(f"http://{sign_host}:{sign_port}/connector/status") as response:
         html = response.read()
     if b"status=OK\n" in html:
         signtool = (r'signtool sign /sha1 6df76fe776b82869a5693ddcb1b04589cffa6faf /fd sha256 /td sha256 '


### PR DESCRIPTION
## What is this fixing or adding?

Fixes really bad timeout if 192.168.206.x goes through the default route and the default route drops the packet.

Works like this:
Creates a UDP socket and tells it to connect, which opens the socket, but doesn't actually send any packets. The outgoing address can then be used to detect if 192.168.206.0/24 is a local network or not.

## How was this tested?

By seeing that it properly compares the first 3 octets of sender and receiver address. And not seeing the timeout problem anymore.

I think berserker needs to test test with the sign tool.
