### PR TITLE
Core: "Build APWorlds" cleanup

### DIFF
--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -295,8 +295,5 @@ if not is_frozen():
         open_folder(apworlds_folder)
 
 
-    def _run_build_apworlds(*args: str):
-        launch_subprocess(_build_apworlds, name="BuildAPWorlds", args=args)
-
-    components.append(Component('Build APWorlds', func=_run_build_apworlds, cli=True,
+    components.append(Component('Build APWorlds', func=_build_apworlds, cli=True,
                                 description="Build APWorlds from loose-file world folders."))


### PR DESCRIPTION
## What is this fixing or adding?
- Fixed capitalization on the component name and added a description
- Now runs as a subprocess; no longer hangs the Launcher while running
- Opens the build folder upon completion
- Added a command line arg for specifying a specific list of worlds to build.
- Changed the glob to include extensionless files; addresses #5506 

No Kivy integration yet, since I think the init for Kivy would take longer than the actual function for most systems. We'd need a way to link to the main Launcher.

## How was this tested?
Ran the Launcher and the Build APWorlds component.
Ran Launcher with the following args: `"Build APWorlds" "Kirby's Dream Land 3" "Mega Man 2" "Mega Man 3"`
Confirmed that the two extant worlds were built, while the third non-existent world was ignored with an error in the log.

## If this makes graphical changes, please attach screenshots.
