### PR TITLE
Launcher: Rework 

### DIFF
--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -5,7 +5,7 @@ import weakref
 from enum import Enum, auto
 from typing import Optional, Callable, List, Iterable, Tuple
 
-from Utils import local_path, open_filename, is_frozen
+from Utils import local_path, open_filename, is_frozen, is_kivy_running
 
 
 class Type(Enum):
@@ -177,10 +177,9 @@ def _install_apworld(apworld_src: str = "") -> Optional[Tuple[pathlib.Path, path
         if module_name == loaded_name:
             found_already_loaded = True
             break
-    if found_already_loaded:
-        raise Exception(f"Installed APWorld successfully, but '{module_name}' is already loaded,\n"
-                        "so a Launcher restart is required to use the new installation.\n"
-                        "If the Launcher is not open, no action needs to be taken.")
+    if found_already_loaded and is_kivy_running():
+        raise Exception(f"Installed APWorld successfully, but '{module_name}' is already loaded, "
+                        "so a Launcher restart is required to use the new installation.")
     world_source = worlds.WorldSource(str(target), is_zip=True)
     bisect.insort(worlds.world_sources, world_source)
     world_source.load()
@@ -197,7 +196,7 @@ def install_apworld(apworld_path: str = "") -> None:
         source, target = res
     except Exception as e:
         import Utils
-        Utils.messagebox(e.__class__.__name__, str(e), error=True)
+        Utils.messagebox("Notice", str(e), error=True)
         logging.exception(e)
     else:
         import Utils


### PR DESCRIPTION
## What is this fixing or adding?
reword message on install apworld popup when the launcher is open and the world is already loaded, and change the popup title to Notice to not make users think they cannot self-serve

in addition check to see if launcher (kivy) is open instead of telling the user to ignore the message if launcher isn't open

## How was this tested?
drag and dropping a lingo2 apworld into my source launcher and running launcher with the path to the apworld as the only arg, notifications showed up as expected

also checked one of the error paths by trying to install from own custom_worlds

## If this makes graphical changes, please attach screenshots.
<img width="408" height="152" alt="image" src="https://github.com/user-attachments/assets/9b7f056a-58e9-4071-8b67-5f7cece09524" />
<img width="394" height="168" alt="image" src="https://github.com/user-attachments/assets/5573153d-013f-4473-9c6f-0f2edbe3b7b7" />
<img width="397" height="136" alt="image" src="https://github.com/user-attachments/assets/bad5c4d8-7051-4898-b1b5-2352bf26d1a5" />
<img width="409" height="158" alt="image" src="https://github.com/user-attachments/assets/7f258a8a-36a1-41e9-9b8f-1fdbd15be68a" />

