### PR TITLE
Docs: APWorld documentation, make a distinction between APWorld and .apworld

### DIFF
--- a/docs/apworld specification.md
+++ b/docs/apworld specification.md
@@ -29,12 +29,6 @@ If the APWorld is a folder, the only required field is "game":
 }
 ```
 
-If the APWorld is packaged as an `.apworld` zip file, it also needs to have `version` and `compatible_version`,
-which refer to the version of the APContainer packaging scheme defined in [Files.py](../worlds/Files.py).  
-These get automatically added to the `archipelago.json` of an .apworld if it is packaged using the 
-["Build apworlds" launcher component](#build-apworlds-launcher-component),
-which is the correct way to package your `.apworld` as a world developer. Do not write these fields yourself.
-
 There are also the following optional fields:
 * `minimum_ap_version` and `maximum_ap_version` - which if present will each be compared against the current
   Archipelago version respectively to filter those files from being loaded.
@@ -43,6 +37,12 @@ There are also the following optional fields:
   (**Must** use exactly the format `"major.minor.build"`, e.g. `1.0.0`)
 * `authors` - a list of authors, to eventually be displayed in various user-facing places such as WebHost and
   package managers. Should always be a list of strings.
+
+If the APWorld is packaged as an `.apworld` zip file, it also needs to have `version` and `compatible_version`,
+which refer to the version of the APContainer packaging scheme defined in [Files.py](../worlds/Files.py).  
+These get automatically added to the `archipelago.json` of an .apworld if it is packaged using the 
+["Build apworlds" launcher component](#build-apworlds-launcher-component),
+which is the correct way to package your `.apworld` as a world developer. Do not write these fields yourself.
 
 ### "Build apworlds" Launcher Component
 


### PR DESCRIPTION
We've had some discussions in ap-core-dev and it seems that a lot of people use these two different spellings of APWorld/.apworld to mean different things.

This distinction also allows us to go a bit more into detail about how folder worlds differ from .apworld worlds, for example regarding the .apworld-only manifest fields.

Doing this as a separate PR to https://github.com/ArchipelagoMW/Archipelago/pull/5477, because that one is on core review so I wanna leave it, and the topic and changed lines are mostly different.