### PR TITLE
Core: Pad version string in world printout

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -54,13 +54,16 @@ def main(args, seed=None, baked_server_options: dict[str, object] | None = None)
     logger.info(f"Found {len(AutoWorld.AutoWorldRegister.world_types)} World Types:")
     longest_name = max(len(text) for text in AutoWorld.AutoWorldRegister.world_types)
 
-    item_count = len(str(max(len(cls.item_names) for cls in AutoWorld.AutoWorldRegister.world_types.values())))
-    location_count = len(str(max(len(cls.location_names) for cls in AutoWorld.AutoWorldRegister.world_types.values())))
+    world_classes = AutoWorld.AutoWorldRegister.world_types.values()
+
+    version_count = max(len(cls.world_version.as_simple_string()) for cls in world_classes)
+    item_count = len(str(max(len(cls.item_names) for cls in world_classes)))
+    location_count = len(str(max(len(cls.location_names) for cls in world_classes)))
 
     for name, cls in AutoWorld.AutoWorldRegister.world_types.items():
         if not cls.hidden and len(cls.item_names) > 0:
             logger.info(f" {name:{longest_name}}: "
-                        f"v{cls.world_version.as_simple_string()} |"
+                        f"v{cls.world_version.as_simple_string():{version_count}} | "
                         f"Items: {len(cls.item_names):{item_count}} | "
                         f"Locations: {len(cls.location_names):{location_count}}")
 


### PR DESCRIPTION
## What is this fixing or adding?
Adds padding for world version added to the printout in #5484 since currently it gets shifted for version strings of different lengths and also has no space after the first bar (which I think was unintentional anyway since it wasn't in [this message](https://discord.com/channels/731205301247803413/731214280439103580/1420629227023110195)).
This does happen to raise the line length for core games from a perfect 80 columns to 83, although that was already broken by Muse Dash having an extra char in version and being 81 (and just like what the names/counts happened to be anyway).

Also do we like that the longest game's one doesn't have a space before the colon? That was already the case before the version was there but I think it looks kinda bad.

## How was this tested?
Looking at the output when generating.

## If this makes graphical changes, please attach screenshots.
```
...
 Mega Man 2                              : v0.3.2 |Items:   23 | Locations:    71
 MegaMan Battle Network 3                : v0.0.0 |Items:  224 | Locations:   263
 Muse Dash                               : v1.5.25 |Items:  682 | Locations:  1334
 Noita                                   : v1.4.0 |Items:   32 | Locations:   672
...
```

to

```
...
 Mega Man 2                              : v0.3.2  | Items:   23 | Locations:    71
 MegaMan Battle Network 3                : v0.0.0  | Items:  224 | Locations:   263
 Muse Dash                               : v1.5.25 | Items:  682 | Locations:  1334
 Noita                                   : v1.4.0  | Items:   32 | Locations:   672
...
```