### PR TITLE
Webhost: eagerly free resources in customserver

### DIFF
--- a/WebHostLib/customserver.py
+++ b/WebHostLib/customserver.py
@@ -97,6 +97,7 @@ class WebHostContext(Context):
                         self.main_loop.call_soon_threadsafe(cmdprocessor, command.commandtext)
                         command.delete()
                     commit()
+            del commands
             time.sleep(5)
 
     @db_session
@@ -146,13 +147,13 @@ class WebHostContext(Context):
             self.location_name_groups = static_location_name_groups
         return self._load(multidata, game_data_packages, True)
 
-    @db_session
     def init_save(self, enabled: bool = True):
         self.saving = enabled
         if self.saving:
-            savegame_data = Room.get(id=self.room_id).multisave
-            if savegame_data:
-                self.set_save(restricted_loads(Room.get(id=self.room_id).multisave))
+            with db_session:
+                savegame_data = Room.get(id=self.room_id).multisave
+                if savegame_data:
+                    self.set_save(restricted_loads(Room.get(id=self.room_id).multisave))
             self._start_async_saving(atexit_save=False)
         threading.Thread(target=self.listen_to_db_commands, daemon=True).start()
 
@@ -304,6 +305,7 @@ def run_server_process(name: str, ponyconfig: dict, static_server_data: dict,
                     with db_session:
                         room = Room.get(id=ctx.room_id)
                         room.last_port = port
+                    del room
                 else:
                     ctx.logger.exception("Could not determine port. Likely hosting failure.")
                 with db_session:
@@ -322,6 +324,7 @@ def run_server_process(name: str, ponyconfig: dict, static_server_data: dict,
                 with db_session:
                     room = Room.get(id=room_id)
                     room.last_port = -1
+                del room
                 logger.exception(e)
                 raise
             else:
@@ -333,11 +336,12 @@ def run_server_process(name: str, ponyconfig: dict, static_server_data: dict,
                     ctx.save_dirty = False  # make sure the saving thread does not write to DB after final wakeup
                     ctx.exit_event.set()  # make sure the saving thread stops at some point
                     # NOTE: async saving should probably be an async task and could be merged with shutdown_task
-                    with (db_session):
+                    with db_session:
                         # ensure the Room does not spin up again on its own, minute of safety buffer
                         room = Room.get(id=room_id)
                         room.last_activity = datetime.datetime.utcnow() - \
                                              datetime.timedelta(minutes=1, seconds=room.timeout)
+                    del room
                     logging.info(f"Shutting down room {room_id} on {name}.")
                 finally:
                     await asyncio.sleep(5)


### PR DESCRIPTION
## What is this fixing or adding?

Improve memory usage by freeing some resources in customserver eagerly:
* First `room` in `start_room()` is kept alive while running the room (awaiting `ctx.shutdown_task`) for no reason - also the other code path does not populate `room` at all.
* Second `room` in `start_room()` has the issue of last room (read below) if there was an exception while stopping the room
* Last `room` in `start_room()` is kept alive for 5 extra seconds
* `commands` in `listen_to_db_commands()` is kept for 5 extra seconds after it's been dealt with
* `init_save` would open the DB session even if saving is false and keeps it open after loading (when starting threads)
  * it might make sense to move the `set_save()` out as well, but I am unclear why the multisave is loaded twice, so I don't want to touch this

I'm not really clear what kind of resources a db row/entity holds after the session ended, but in case of commands it's at least all the strings and in case of room it's at least a hand full of objects and some bytes for the UUIDs, etc.

## How was this tested?

Only CI . test_hosting should cover all changes and I was hoping this could be tested on the RC test server.