### PR TITLE
Pokemon Emerald: Remove base patch file from patch container

### DIFF
--- a/worlds/pokemon_emerald/CHANGELOG.md
+++ b/worlds/pokemon_emerald/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.5.0
+
+### Features
+
+- Changed patch file format to pull base patch from apworld instead of including it in the patch, significantly reducing
+patch file size.
+
 # 2.4.1
 
 ### Fixes

--- a/worlds/pokemon_emerald/archipelago.json
+++ b/worlds/pokemon_emerald/archipelago.json
@@ -1,6 +1,6 @@
 {
     "game": "Pokemon Emerald",
-    "world_version": "2.4.1",
+    "world_version": "2.5.0",
     "minimum_ap_version": "0.6.1",
     "authors": ["Zunawe"]
 }


### PR DESCRIPTION
## What is this fixing or adding?

Emerald patch files including the base patch is redundant. The only benefit it provides is the ability to patch a game regardless of whether there's a mismatch between the apworld version used to generate the patch file and the one used to patch it. But this is rendered useless anyway because if the base patch changes, the client will reject it anyway and prevent you from connecting.

So instead we can just check that the base patch used to generate is the same file as the one in our currently installed apworld and use that one. Reduces patch file size by about 85%.

Also a couple typing/attribute things that popped out while I was in `__init__`.

## How was this tested?

Patched an old patch file on this branch to make sure it still worked. Generated and patched on this branch. And then artificially modified the base patch file between generation and patching to see the error.
