### PR TITLE
WebHost: fix log fetching extra characters when there is non-ascii

### DIFF
--- a/WebHostLib/misc.py
+++ b/WebHostLib/misc.py
@@ -271,9 +271,9 @@ def host_room(room: UUID):
                  or "Discordbot" in request.user_agent.string
                  or not any(browser_token in request.user_agent.string for browser_token in browser_tokens))
 
-    def get_log(max_size: int = 0 if automated else 1024000) -> str:
+    def get_log(max_size: int = 0 if automated else 1024000) -> Tuple[str, int]:
         if max_size == 0:
-            return "…"
+            return "…", 0
         try:
             with open(os.path.join("logs", str(room.id) + ".txt"), "rb") as log:
                 raw_size = 0
@@ -284,9 +284,9 @@ def host_room(room: UUID):
                         break
                     raw_size += len(block)
                     fragments.append(block.decode("utf-8"))
-                return "".join(fragments)
+                return "".join(fragments), raw_size
         except FileNotFoundError:
-            return ""
+            return "", 0
 
     return render_template("hostRoom.html", room=room, should_refresh=should_refresh, get_log=get_log)
 

--- a/WebHostLib/templates/hostRoom.html
+++ b/WebHostLib/templates/hostRoom.html
@@ -58,8 +58,7 @@
                     Open Log File...
                 </a>
             </div>
-        {%  set log = get_log() -%}
-        {%- set log_len = log | length - 1 if log.endswith("…") else log | length -%}
+        {%  set log, log_len = get_log() -%}
         <div id="logger" style="white-space: pre">{{ log }}</div>
         <script>
           let url = '{{ url_for('display_log', room = room.id) }}';


### PR DESCRIPTION
## What is this fixing or adding?

When loading a room, up to the first 1MB of log will be displayed inline and the client then starts polling for new data. The unit of this is bytes (UTF8), however the JS is currently populated with the string length, which does not match if there are any non-ASCII characters in the initial portion, which results in some repeated characters when first updating.

## How was this tested?

Hosting a room, sending some kanj as command/chat, hitting F5, seeing if the poll will repeat the last couple of characters.
