### PR TITLE
WebHost: Handle blank values for OptionCounters

### DIFF
--- a/WebHostLib/options.py
+++ b/WebHostLib/options.py
@@ -231,7 +231,7 @@ def generate_yaml(game: str):
             if key_parts[-1] == "qty":
                 if key_parts[0] not in options:
                     options[key_parts[0]] = {}
-                if val != "0":
+                if val and val != "0":
                     options[key_parts[0]][key_parts[1]] = int(val)
                 del options[key]
 


### PR DESCRIPTION
## What is this fixing or adding?
Adds handling for empty string to the OptionCounter handling in `generate_yaml`. This doesn't change the weirdness of values of `0` getting cut out entirely but values of `00` making it into the yaml as 0, but it's probably good to at least not server error if it's empty.

It may also be good to handle non-empty but still non-int values in some way, currently we rely on browser-side validation on the input field that maybe won't always work.

## How was this tested?
Trying to export yaml with a couple different OptionCounter types having a blank value.

## If this makes graphical changes, please attach screenshots.
🚫💥