### PR TITLE
Core/Manifest: Unify source world and .apworld loading

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -60,7 +60,7 @@ def main(args, seed=None, baked_server_options: dict[str, object] | None = None)
     item_count = len(str(max(len(cls.item_names) for cls in world_classes)))
     location_count = len(str(max(len(cls.location_names) for cls in world_classes)))
 
-    for name, cls in AutoWorld.AutoWorldRegister.world_types.items():
+    for name, cls in sorted(AutoWorld.AutoWorldRegister.world_types.items(), key=lambda it: it[0].casefold()):
         if not cls.hidden and len(cls.item_names) > 0:
             logger.info(f" {name:{longest_name}}: "
                         f"v{cls.world_version.as_simple_string():{version_count}} | "


### PR DESCRIPTION
## What is this fixing or adding?
Somewhat experimental. This changes world loading from loading loose worlds first and then apworlds to doing them simultaneously, and restructures some of the manifest handling to happen in world source (although there is kinda duplication going on from `APWorldContainer`). This means that `world_version` can be respected for source worlds as well now, and load the newest version in that case on source or for non-apworlds (which makes the process for installing alternate versions of worlds like explained in #5510 easier).

Since some world sources may not have a manifest/game name known, this sorts by version only instead of name so that earlier versions will always come first. I moved the sorting for the printout of world info to main itself.

## How was this tested?
Fairly lightly, I tried on source to have both a loose world in `worlds` and an .apworld in `custom_worlds`, and they load by newest version as desired. I also tried renaming a folder and it acted the same.

## If this makes graphical changes, please attach screenshots.
