### PR TITLE
Core: Cleanup unneeded use of `Version`/`tuplize_version`

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -1710,7 +1710,7 @@ def generate_yaml_templates(target_folder: typing.Union[str, "pathlib.Path"], ge
     from jinja2 import Template
 
     from worlds import AutoWorldRegister
-    from Utils import local_path, __version__, tuplize_version
+    from Utils import local_path, __version__
 
     full_path: str
 

--- a/Utils.py
+++ b/Utils.py
@@ -35,7 +35,7 @@ if typing.TYPE_CHECKING:
 
 
 def tuplize_version(version: str) -> Version:
-    return Version(*(int(piece, 10) for piece in version.split(".")))
+    return Version(*(int(piece) for piece in version.split(".")))
 
 
 class Version(typing.NamedTuple):
@@ -49,7 +49,6 @@ class Version(typing.NamedTuple):
 
 __version__ = "0.6.4"
 version_tuple = tuplize_version(__version__)
-version = Version(*version_tuple)
 
 is_linux = sys.platform.startswith("linux")
 is_macos = sys.platform == "darwin"

--- a/Utils.py
+++ b/Utils.py
@@ -48,7 +48,7 @@ class Version(typing.NamedTuple):
 
 
 __version__ = "0.6.4"
-version = version_tuple = tuplize_version(__version__)
+version_tuple = tuplize_version(__version__)
 
 is_linux = sys.platform.startswith("linux")
 is_macos = sys.platform == "darwin"

--- a/Utils.py
+++ b/Utils.py
@@ -48,7 +48,7 @@ class Version(typing.NamedTuple):
 
 
 __version__ = "0.6.4"
-version_tuple = tuplize_version(__version__)
+version = version_tuple = tuplize_version(__version__)
 
 is_linux = sys.platform.startswith("linux")
 is_macos = sys.platform == "darwin"

--- a/setup.py
+++ b/setup.py
@@ -372,7 +372,6 @@ class BuildExeCommand(cx_Freeze.command.build_exe.build_exe):
         from Options import generate_yaml_templates
         from worlds.AutoWorld import AutoWorldRegister
         from worlds.Files import APWorldContainer
-        from Utils import version
         assert not non_apworlds - set(AutoWorldRegister.world_types), \
             f"Unknown world {non_apworlds - set(AutoWorldRegister.world_types)} designated for .apworld"
         folders_to_remove: list[str] = []
@@ -398,8 +397,8 @@ class BuildExeCommand(cx_Freeze.command.build_exe.build_exe):
                 # which should be ok
                 zip_path = self.libfolder / "worlds" / (file_name + ".apworld")
                 apworld = APWorldContainer(str(zip_path))
-                apworld.minimum_ap_version = version
-                apworld.maximum_ap_version = version
+                apworld.minimum_ap_version = version_tuple
+                apworld.maximum_ap_version = version_tuple
                 apworld.game = worldtype.game
                 manifest.update(apworld.get_manifest())
                 apworld.manifest_path = f"{file_name}/archipelago.json"

--- a/worlds/Files.py
+++ b/worlds/Files.py
@@ -175,12 +175,12 @@ class APWorldContainer(APContainer):
     maximum_ap_version: "Version | None" = None
 
     def read_contents(self, opened_zipfile: zipfile.ZipFile) -> Dict[str, Any]:
-        from Utils import tuplize_version, Version
+        from Utils import tuplize_version
         manifest = super().read_contents(opened_zipfile)
         self.game = manifest["game"]
         for version_key in ("world_version", "minimum_ap_version", "maximum_ap_version"):
             if version_key in manifest:
-                setattr(self, version_key, Version(*tuplize_version(manifest[version_key])))
+                setattr(self, version_key, tuplize_version(manifest[version_key]))
         return manifest
 
     def get_manifest(self) -> Dict[str, Any]:

--- a/worlds/__init__.py
+++ b/worlds/__init__.py
@@ -128,8 +128,7 @@ for world_source in world_sources:
                 break
         game = manifest.get("game")
         if game in AutoWorldRegister.world_types:
-            AutoWorldRegister.world_types[game].world_version = Version(*tuplize_version(manifest.get("world_version",
-                                                                                                      "0.0.0")))
+            AutoWorldRegister.world_types[game].world_version = tuplize_version(manifest.get("world_version", "0.0.0"))
 
 if apworlds:
     # encapsulation for namespace / gc purposes


### PR DESCRIPTION
## What is this fixing or adding?
Cleans up a couple uses of `Version(*tuplize_version(...))`, which is redundant, an unused import and var, and an unneeded base parameter in `int`.

## How was this tested?
Running generation to make sure it doesn't somehow break it.