### PR TITLE
CV64: Fix Explosive DeathLink not working with Increase Shimmy Speed on

### DIFF
--- a/worlds/cv64/rom.py
+++ b/worlds/cv64/rom.py
@@ -609,8 +609,8 @@ class CV64PatchExtensions(APPatchExtension):
 
         # Shimmy speed increase hack
         if options["increase_shimmy_speed"]:
-            rom_data.write_int32(0x97EB4, 0x803FE9F0)
-            rom_data.write_int32s(0xBFE9F0, patches.shimmy_speed_modifier)
+            rom_data.write_int32(0x97EB4, 0x803FEA20)
+            rom_data.write_int32s(0xBFEA20, patches.shimmy_speed_modifier)
 
         # Disable landing fall damage
         if options["fall_guard"]:


### PR DESCRIPTION
## What is this fixing or adding?
With https://github.com/ArchipelagoMW/Archipelago/pull/4730, it turns out I made a mistake in deciding where in RDRAM the shimmy speed hack should lie; it was overlapping the hack specific to Explosive DeathLink that checks to see if you are in a valid explode-able state, causing the latter to be borked in all sorts of ways. Hahaha, ooops! This PR moves the shimmy speed hack to not overlap.

## How was this tested?
Enabled the two problematic options and made sure both were working at the same time.
