### PR TITLE
The Witness: Use entity IDs as location IDs directly

### DIFF
--- a/worlds/witness/data/WitnessLogic.txt
+++ b/worlds/witness/data/WitnessLogic.txt
@@ -3,237 +3,237 @@
 Entry (Entry):
 
 Tutorial First Hallway (Tutorial First Hallway) - Entry - True - Tutorial First Hallway Room - 0x00064:
-158000 - 0x00064 (Straight) - True - True
-159510 - 0x01848 (EP) - 0x00064 - True
+0x00064 (Straight) - True - True
+0x01848 (EP) - 0x00064 - True
 
 Tutorial First Hallway Room (Tutorial First Hallway) - Tutorial - 0x00182:
-158001 - 0x00182 (Bend) - True - True
+0x00182 (Bend) - True - True
 
 Tutorial (Tutorial) - Outside Tutorial - 0x03629:
-158002 - 0x00293 (Front Center) - True - True
-158003 - 0x00295 (Center Left) - 0x00293 - True
-158004 - 0x002C2 (Front Left) - 0x00295 - True
-158005 - 0x0A3B5 (Back Left) - True - True
-158006 - 0x0A3B2 (Back Right) - True - True
-158007 - 0x03629 (Gate Open) - 0x002C2 & 0x0A3B5 & 0x0A3B2 - True
-158008 - 0x03505 (Gate Close) - 0x2FAF6 & 0x03629 - True
-158009 - 0x0C335 (Pillar) - True - Triangles
-158010 - 0x0C373 (Patio Floor) - 0x0C335 - Dots
-159512 - 0x33530 (Cloud EP) - True - True
-159513 - 0x33600 (Patio Flowers EP) - 0x0C373 - True
-159517 - 0x3352F (Gate EP) - 0x03505 - True
+0x00293 (Front Center) - True - True
+0x00295 (Center Left) - 0x00293 - True
+0x002C2 (Front Left) - 0x00295 - True
+0x0A3B5 (Back Left) - True - True
+0x0A3B2 (Back Right) - True - True
+0x03629 (Gate Open) - 0x002C2 & 0x0A3B5 & 0x0A3B2 - True
+0x03505 (Gate Close) - 0x2FAF6 & 0x03629 - True
+0x0C335 (Pillar) - True - Triangles
+0x0C373 (Patio Floor) - 0x0C335 - Dots
+0x33530 (Cloud EP) - True - True
+0x33600 (Patio Flowers EP) - 0x0C373 - True
+0x3352F (Gate EP) - 0x03505 - True
 
 ==Tutorial (Outside)==
 
 Outside Tutorial (Outside Tutorial) - Outside Tutorial Path To Outpost - 0x03BA2 - Outside Tutorial Vault - 0x033D0:
-158650 - 0x033D4 (Vault Panel) - True - Dots & Black/White Squares
+0x033D4 (Vault Panel) - True - Dots & Black/White Squares
 Door - 0x033D0 (Vault Door) - 0x033D4
-158013 - 0x0005D (Shed Row 1) - True - Dots
-158014 - 0x0005E (Shed Row 2) - 0x0005D - Dots
-158015 - 0x0005F (Shed Row 3) - 0x0005E - Dots
-158016 - 0x00060 (Shed Row 4) - 0x0005F - Dots
-158017 - 0x00061 (Shed Row 5) - 0x00060 - Dots
-158018 - 0x018AF (Tree Row 1) - True - Black/White Squares
-158019 - 0x0001B (Tree Row 2) - 0x018AF - Black/White Squares
-158020 - 0x012C9 (Tree Row 3) - 0x0001B - Black/White Squares
-158021 - 0x0001C (Tree Row 4) - 0x012C9 - Black/White Squares
-158022 - 0x0001D (Tree Row 5) - 0x0001C - Black/White Squares
-158023 - 0x0001E (Tree Row 6) - 0x0001D - Black/White Squares
-158024 - 0x0001F (Tree Row 7) - 0x0001E - Black/White Squares
-158025 - 0x00020 (Tree Row 8) - 0x0001F - Black/White Squares
-158026 - 0x00021 (Tree Row 9) - 0x00020 - Black/White Squares
+0x0005D (Shed Row 1) - True - Dots
+0x0005E (Shed Row 2) - 0x0005D - Dots
+0x0005F (Shed Row 3) - 0x0005E - Dots
+0x00060 (Shed Row 4) - 0x0005F - Dots
+0x00061 (Shed Row 5) - 0x00060 - Dots
+0x018AF (Tree Row 1) - True - Black/White Squares
+0x0001B (Tree Row 2) - 0x018AF - Black/White Squares
+0x012C9 (Tree Row 3) - 0x0001B - Black/White Squares
+0x0001C (Tree Row 4) - 0x012C9 - Black/White Squares
+0x0001D (Tree Row 5) - 0x0001C - Black/White Squares
+0x0001E (Tree Row 6) - 0x0001D - Black/White Squares
+0x0001F (Tree Row 7) - 0x0001E - Black/White Squares
+0x00020 (Tree Row 8) - 0x0001F - Black/White Squares
+0x00021 (Tree Row 9) - 0x00020 - Black/White Squares
 Door - 0x03BA2 (Outpost Path) - 0x0A3B5
-159511 - 0x03D06 (Garden EP) - True - True
-159514 - 0x28A2F (Town Sewer EP) - True - True
-159516 - 0x334A3 (Path EP) - True - True
-159500 - 0x035C7 (Tractor EP) - True - True
+0x03D06 (Garden EP) - True - True
+0x28A2F (Town Sewer EP) - True - True
+0x334A3 (Path EP) - True - True
+0x035C7 (Tractor EP) - True - True
 
 Outside Tutorial Vault (Outside Tutorial):
-158651 - 0x03481 (Vault Box) - True - True
+0x03481 (Vault Box) - True - True
 
 Outside Tutorial Path To Outpost (Outside Tutorial) - Outside Tutorial Outpost - 0x0A170:
-158011 - 0x0A171 (Outpost Entry Panel) - True - Full Dots
+0x0A171 (Outpost Entry Panel) - True - Full Dots
 Door - 0x0A170 (Outpost Entry) - 0x0A171
 
 Outside Tutorial Outpost (Outside Tutorial) - Outside Tutorial - 0x04CA3:
-158012 - 0x04CA4 (Outpost Exit Panel) - True - Black/White Squares & Full Dots
+0x04CA4 (Outpost Exit Panel) - True - Black/White Squares & Full Dots
 Door - 0x04CA3 (Outpost Exit) - 0x04CA4
-158600 - 0x17CFB (Discard) - True - Triangles
+0x17CFB (Discard) - True - Triangles
 
 Orchard (Orchard) - Main Island - True - Orchard Beyond First Gate - 0x03307:
-158071 - 0x00143 (Apple Tree 1) - True - True
-158072 - 0x0003B (Apple Tree 2) - 0x00143 - True
-158073 - 0x00055 (Apple Tree 3) - 0x0003B - True
+0x00143 (Apple Tree 1) - True - True
+0x0003B (Apple Tree 2) - 0x00143 - True
+0x00055 (Apple Tree 3) - 0x0003B - True
 Door - 0x03307 (First Gate) - 0x00055
 
 Orchard Beyond First Gate (Orchard) - Orchard End - 0x03313:
-158074 - 0x032F7 (Apple Tree 4) - 0x00055 - True
-158075 - 0x032FF (Apple Tree 5) - 0x032F7 - True
+0x032F7 (Apple Tree 4) - 0x00055 - True
+0x032FF (Apple Tree 5) - 0x032F7 - True
 Door - 0x03313 (Second Gate) - 0x032FF
 
 Orchard End (Orchard):
 
 Main Island (Main Island) - Outside Tutorial - True:
-159801 - 0xFFD00 (Reached Independently) - True - True
+0xFFD00 (Reached Independently) - True - True
 
 ==Glass Factory==
 
 Outside Glass Factory (Glass Factory) - Main Island - True - Inside Glass Factory - 0x01A29:
-158027 - 0x01A54 (Entry Panel) - True - Symmetry
+0x01A54 (Entry Panel) - True - Symmetry
 Door - 0x01A29 (Entry) - 0x01A54
-158601 - 0x3C12B (Discard) - True - Triangles
-159002 - 0x28B8A (Vase EP) - 0x01A54 - True
+0x3C12B (Discard) - True - Triangles
+0x28B8A (Vase EP) - 0x01A54 - True
 
 Inside Glass Factory (Glass Factory) - Inside Glass Factory Behind Back Wall - 0x0D7ED:
-158028 - 0x00086 (Back Wall 1) - True - Symmetry
-158029 - 0x00087 (Back Wall 2) - 0x00086 - Symmetry
-158030 - 0x00059 (Back Wall 3) - 0x00087 - Symmetry
-158031 - 0x00062 (Back Wall 4) - 0x00059 - Symmetry
-158032 - 0x0005C (Back Wall 5) - 0x00062 - Symmetry
-158033 - 0x0008D (Front 1) - 0x0005C - Symmetry
-158034 - 0x00081 (Front 2) - 0x0008D - Symmetry
-158035 - 0x00083 (Front 3) - 0x00081 - Symmetry
-158036 - 0x00084 (Melting 1) - 0x00083 - Symmetry
-158037 - 0x00082 (Melting 2) - 0x00084 - Symmetry
-158038 - 0x0343A (Melting 3) - 0x00082 - Symmetry
+0x00086 (Back Wall 1) - True - Symmetry
+0x00087 (Back Wall 2) - 0x00086 - Symmetry
+0x00059 (Back Wall 3) - 0x00087 - Symmetry
+0x00062 (Back Wall 4) - 0x00059 - Symmetry
+0x0005C (Back Wall 5) - 0x00062 - Symmetry
+0x0008D (Front 1) - 0x0005C - Symmetry
+0x00081 (Front 2) - 0x0008D - Symmetry
+0x00083 (Front 3) - 0x00081 - Symmetry
+0x00084 (Melting 1) - 0x00083 - Symmetry
+0x00082 (Melting 2) - 0x00084 - Symmetry
+0x0343A (Melting 3) - 0x00082 - Symmetry
 Door - 0x0D7ED (Back Wall) - 0x0005C
 
 Inside Glass Factory Behind Back Wall (Glass Factory) - The Ocean - 0x17CC8:
-158039 - 0x17CC8 (Boat Spawn) - 0x17CA6 | 0x17CDF | 0x09DB8 | 0x17C95 - Boat
+0x17CC8 (Boat Spawn) - 0x17CA6 | 0x17CDF | 0x09DB8 | 0x17C95 - Boat
 
 ==Symmetry Island==
 
 Outside Symmetry Island (Symmetry Island) - Main Island - True - Symmetry Island Lower - 0x17F3E:
-158040 - 0x000B0 (Lower Panel) - 0x0343A - Dots
+0x000B0 (Lower Panel) - 0x0343A - Dots
 Door - 0x17F3E (Lower) - 0x000B0
 
 Symmetry Island Lower (Symmetry Island) - Symmetry Island Upper - 0x18269:
-158041 - 0x00022 (Right 1) - True - Symmetry & Dots
-158042 - 0x00023 (Right 2) - 0x00022 - Symmetry & Dots
-158043 - 0x00024 (Right 3) - 0x00023 - Symmetry & Dots
-158044 - 0x00025 (Right 4) - 0x00024 - Symmetry & Dots
-158045 - 0x00026 (Right 5) - 0x00025 - Symmetry & Dots
-158046 - 0x0007C (Back 1) - 0x00026 - Symmetry & Colored Dots
-158047 - 0x0007E (Back 2) - 0x0007C - Symmetry & Colored Dots
-158048 - 0x00075 (Back 3) - 0x0007E - Symmetry & Colored Dots
-158049 - 0x00073 (Back 4) - 0x00075 - Symmetry & Colored Dots
-158050 - 0x00077 (Back 5) - 0x00073 - Symmetry & Colored Dots
-158051 - 0x00079 (Back 6) - 0x00077 - Symmetry & Colored Dots
-158052 - 0x00065 (Left 1) - 0x00079 - Symmetry & Colored Dots
-158053 - 0x0006D (Left 2) - 0x00065 - Symmetry & Colored Dots
-158054 - 0x00072 (Left 3) - 0x0006D - Symmetry & Colored Dots
-158055 - 0x0006F (Left 4) - 0x00072 - Symmetry & Colored Dots
-158056 - 0x00070 (Left 5) - 0x0006F - Symmetry & Colored Dots
-158057 - 0x00071 (Left 6) - 0x00070 - Symmetry & Colored Dots
-158058 - 0x00076 (Left 7) - 0x00071 - Symmetry & Colored Dots
-158059 - 0x009B8 (Scenery Outlines 1) - True - Symmetry
-158060 - 0x003E8 (Scenery Outlines 2) - 0x009B8 - Symmetry
-158061 - 0x00A15 (Scenery Outlines 3) - 0x003E8 - Symmetry
-158062 - 0x00B53 (Scenery Outlines 4) - 0x00A15 - Symmetry
-158063 - 0x00B8D (Scenery Outlines 5) - 0x00B53 - Symmetry
-158064 - 0x1C349 (Upper Panel) - 0x00076 - Symmetry & Dots
+0x00022 (Right 1) - True - Symmetry & Dots
+0x00023 (Right 2) - 0x00022 - Symmetry & Dots
+0x00024 (Right 3) - 0x00023 - Symmetry & Dots
+0x00025 (Right 4) - 0x00024 - Symmetry & Dots
+0x00026 (Right 5) - 0x00025 - Symmetry & Dots
+0x0007C (Back 1) - 0x00026 - Symmetry & Colored Dots
+0x0007E (Back 2) - 0x0007C - Symmetry & Colored Dots
+0x00075 (Back 3) - 0x0007E - Symmetry & Colored Dots
+0x00073 (Back 4) - 0x00075 - Symmetry & Colored Dots
+0x00077 (Back 5) - 0x00073 - Symmetry & Colored Dots
+0x00079 (Back 6) - 0x00077 - Symmetry & Colored Dots
+0x00065 (Left 1) - 0x00079 - Symmetry & Colored Dots
+0x0006D (Left 2) - 0x00065 - Symmetry & Colored Dots
+0x00072 (Left 3) - 0x0006D - Symmetry & Colored Dots
+0x0006F (Left 4) - 0x00072 - Symmetry & Colored Dots
+0x00070 (Left 5) - 0x0006F - Symmetry & Colored Dots
+0x00071 (Left 6) - 0x00070 - Symmetry & Colored Dots
+0x00076 (Left 7) - 0x00071 - Symmetry & Colored Dots
+0x009B8 (Scenery Outlines 1) - True - Symmetry
+0x003E8 (Scenery Outlines 2) - 0x009B8 - Symmetry
+0x00A15 (Scenery Outlines 3) - 0x003E8 - Symmetry
+0x00B53 (Scenery Outlines 4) - 0x00A15 - Symmetry
+0x00B8D (Scenery Outlines 5) - 0x00B53 - Symmetry
+0x1C349 (Upper Panel) - 0x00076 - Symmetry & Dots
 Door - 0x18269 (Upper) - 0x1C349
-159000 - 0x0332B (Glass Factory Black Line Reflection EP) - True - True
+0x0332B (Glass Factory Black Line Reflection EP) - True - True
 
 Symmetry Island Upper (Symmetry Island):
-158065 - 0x00A52 (Laser Yellow 1) - True - Colored Dots
-158066 - 0x00A57 (Laser Yellow 2) - 0x00A52 - Colored Dots
-158067 - 0x00A5B (Laser Yellow 3) - 0x00A57 - Colored Dots
-158068 - 0x00A61 (Laser Blue 1) - 0x00A52 - Colored Dots
-158069 - 0x00A64 (Laser Blue 2) - 0x00A61 & 0x00A57 - Colored Dots
-158070 - 0x00A68 (Laser Blue 3) - 0x00A64 & 0x00A5B - Colored Dots
-158700 - 0x0360D (Laser Panel) - 0x00A68 - True
+0x00A52 (Laser Yellow 1) - True - Colored Dots
+0x00A57 (Laser Yellow 2) - 0x00A52 - Colored Dots
+0x00A5B (Laser Yellow 3) - 0x00A57 - Colored Dots
+0x00A61 (Laser Blue 1) - 0x00A52 - Colored Dots
+0x00A64 (Laser Blue 2) - 0x00A61 & 0x00A57 - Colored Dots
+0x00A68 (Laser Blue 3) - 0x00A64 & 0x00A5B - Colored Dots
+0x0360D (Laser Panel) - 0x00A68 - True
 Laser - 0x00509 (Laser) - 0x0360D
-159001 - 0x03367 (Glass Factory Black Line EP) - True - True
+0x03367 (Glass Factory Black Line EP) - True - True
 
 ==Desert==
 
 Desert Obelisk (Desert) - Entry - True:
-159700 - 0xFFE00 (Obelisk Side 1) - 0x0332B & 0x03367 & 0x28B8A - True
-159701 - 0xFFE01 (Obelisk Side 2) - 0x037B6 & 0x037B2 & 0x000F7 - True
-159702 - 0xFFE02 (Obelisk Side 3) - 0x3351D - True
-159703 - 0xFFE03 (Obelisk Side 4) - 0x0053C & 0x00771 & 0x335C8 & 0x335C9 & 0x337F8 & 0x037BB & 0x220E4 & 0x220E5 - True
-159704 - 0xFFE04 (Obelisk Side 5) - 0x334B9 & 0x334BC & 0x22106 & 0x0A14C & 0x0A14D - True
-159709 - 0x00359 (Obelisk) - True - True
+0xFFE00 (Obelisk Side 1) - 0x0332B & 0x03367 & 0x28B8A - True
+0xFFE01 (Obelisk Side 2) - 0x037B6 & 0x037B2 & 0x000F7 - True
+0xFFE02 (Obelisk Side 3) - 0x3351D - True
+0xFFE03 (Obelisk Side 4) - 0x0053C & 0x00771 & 0x335C8 & 0x335C9 & 0x337F8 & 0x037BB & 0x220E4 & 0x220E5 - True
+0xFFE04 (Obelisk Side 5) - 0x334B9 & 0x334BC & 0x22106 & 0x0A14C & 0x0A14D - True
+0x00359 (Obelisk) - True - True
 
 Desert Outside (Desert) - Main Island - True - Desert Light Room - 0x09FEE - Desert Vault - 0x03444:
-158652 - 0x0CC7B (Vault Panel) - True - Shapers & Rotated Shapers & Negative Shapers & Full Dots
+0x0CC7B (Vault Panel) - True - Shapers & Rotated Shapers & Negative Shapers & Full Dots
 Door - 0x03444 (Vault Door) - 0x0CC7B
-158602 - 0x17CE7 (Discard) - True - Triangles
-158076 - 0x00698 (Surface 1) - True - True
-158077 - 0x0048F (Surface 2) - 0x00698 - True
-158078 - 0x09F92 (Surface 3) - 0x0048F & 0x09FA0 - True
-158079 - 0x09FA0 (Surface 3 Control) - 0x0048F - True
-158080 - 0x0A036 (Surface 4) - 0x09F92 - True
-158081 - 0x09DA6 (Surface 5) - 0x09F92 - True
-158082 - 0x0A049 (Surface 6) - 0x09F92 - True
-158083 - 0x0A053 (Surface 7) - 0x0A036 & 0x09DA6 & 0x0A049 - True
-158084 - 0x09F94 (Surface 8) - 0x0A053 & 0x09F86 - True
-158085 - 0x09F86 (Surface 8 Control) - 0x0A053 - True
-158086 - 0x0C339 (Light Room Entry Panel) - 0x09F94 - True
+0x17CE7 (Discard) - True - Triangles
+0x00698 (Surface 1) - True - True
+0x0048F (Surface 2) - 0x00698 - True
+0x09F92 (Surface 3) - 0x0048F & 0x09FA0 - True
+0x09FA0 (Surface 3 Control) - 0x0048F - True
+0x0A036 (Surface 4) - 0x09F92 - True
+0x09DA6 (Surface 5) - 0x09F92 - True
+0x0A049 (Surface 6) - 0x09F92 - True
+0x0A053 (Surface 7) - 0x0A036 & 0x09DA6 & 0x0A049 - True
+0x09F94 (Surface 8) - 0x0A053 & 0x09F86 - True
+0x09F86 (Surface 8 Control) - 0x0A053 - True
+0x0C339 (Light Room Entry Panel) - 0x09F94 - True
 Door - 0x09FEE (Light Room Entry) - 0x0C339
-158701 - 0x03608 (Laser Panel) - 0x012D7 & 0x0A15F - True
+0x03608 (Laser Panel) - 0x012D7 & 0x0A15F - True
 Laser - 0x012FB (Laser) - 0x03608
-159804 - 0xFFD03 (Laser Activated + Redirected) - 0x09F98 & 0x012FB - True
-159020 - 0x3351D (Sand Snake EP) - True - True
-159030 - 0x0053C (Facade Right EP) - True - True
-159031 - 0x00771 (Facade Left EP) - True - True
-159032 - 0x335C8 (Stairs Left EP) - True - True
-159033 - 0x335C9 (Stairs Right EP) - True - True
-159036 - 0x220E4 (Broken Wall Straight EP) - True - True
-159037 - 0x220E5 (Broken Wall Bend EP) - True - True
-159040 - 0x334B9 (Shore EP) - True - True
-159041 - 0x334BC (Island EP) - True - True
+0xFFD03 (Laser Activated + Redirected) - 0x09F98 & 0x012FB - True
+0x3351D (Sand Snake EP) - True - True
+0x0053C (Facade Right EP) - True - True
+0x00771 (Facade Left EP) - True - True
+0x335C8 (Stairs Left EP) - True - True
+0x335C9 (Stairs Right EP) - True - True
+0x220E4 (Broken Wall Straight EP) - True - True
+0x220E5 (Broken Wall Bend EP) - True - True
+0x334B9 (Shore EP) - True - True
+0x334BC (Island EP) - True - True
 
 Desert Vault (Desert):
-158653 - 0x0339E (Vault Box) - True - True
+0x0339E (Vault Box) - True - True
 
 Desert Light Room (Desert) - Desert Pond Room - 0x0C2C3:
-158087 - 0x09FAA (Light Control) - True - True
-158088 - 0x00422 (Light Room 1) - 0x09FAA - True
-158089 - 0x006E3 (Light Room 2) - 0x09FAA - True
-158090 - 0x0A02D (Light Room 3) - 0x09FAA & 0x00422 & 0x006E3 - True
+0x09FAA (Light Control) - True - True
+0x00422 (Light Room 1) - 0x09FAA - True
+0x006E3 (Light Room 2) - 0x09FAA - True
+0x0A02D (Light Room 3) - 0x09FAA & 0x00422 & 0x006E3 - True
 Door - 0x0C2C3 (Pond Room Entry) - 0x0A02D
 
 Desert Pond Room (Desert) - Desert Flood Room - 0x0A24B:
-158091 - 0x00C72 (Pond Room 1) - True - True
-158092 - 0x0129D (Pond Room 2) - 0x00C72 - True
-158093 - 0x008BB (Pond Room 3) - 0x0129D - True
-158094 - 0x0078D (Pond Room 4) - 0x008BB - True
-158095 - 0x18313 (Pond Room 5) - 0x0078D - True
-158096 - 0x0A249 (Flood Room Entry Panel) - 0x18313 - True
+0x00C72 (Pond Room 1) - True - True
+0x0129D (Pond Room 2) - 0x00C72 - True
+0x008BB (Pond Room 3) - 0x0129D - True
+0x0078D (Pond Room 4) - 0x008BB - True
+0x18313 (Pond Room 5) - 0x0078D - True
+0x0A249 (Flood Room Entry Panel) - 0x18313 - True
 Door - 0x0A24B (Flood Room Entry) - 0x0A249
-159043 - 0x0A14C (Pond Room Near Reflection EP) - True - True
-159044 - 0x0A14D (Pond Room Far Reflection EP) - True - True
+0x0A14C (Pond Room Near Reflection EP) - True - True
+0x0A14D (Pond Room Far Reflection EP) - True - True
 
 Desert Flood Room (Desert) - Desert Elevator Room - 0x0C316 - Desert Flood Room Underwater - 0x1C260:
-158097 - 0x1C2DF (Reduce Water Level Far Left) - True - True
-158098 - 0x1831E (Reduce Water Level Far Right) - True - True
-158099 - 0x1C260 (Reduce Water Level Near Left) - True - True
-158100 - 0x1831C (Reduce Water Level Near Right) - True - True
-158101 - 0x1C2F3 (Raise Water Level Far Left) - True - True
-158102 - 0x1831D (Raise Water Level Far Right) - True - True
-158103 - 0x1C2B1 (Raise Water Level Near Left) - True - True
-158104 - 0x1831B (Raise Water Level Near Right) - True - True
-158105 - 0x04D18 (Flood Room 1) - 0x1C260 & 0x1831C - True
-158106 - 0x01205 (Flood Room 2) - 0x04D18 & 0x1C260 & 0x1831C - True
-158107 - 0x181AB (Flood Room 3) - 0x01205 & 0x1C260 & 0x1831C - True
-158108 - 0x0117A (Flood Room 4) - 0x181AB & 0x1C260 & 0x1831C - True
-158109 - 0x17ECA (Flood Room 5) - 0x0117A & 0x1C260 & 0x1831C - True
-158110 - 0x18076 (Flood Room 6) - 0x17ECA & 0x1C260 & 0x1831C - True
+0x1C2DF (Reduce Water Level Far Left) - True - True
+0x1831E (Reduce Water Level Far Right) - True - True
+0x1C260 (Reduce Water Level Near Left) - True - True
+0x1831C (Reduce Water Level Near Right) - True - True
+0x1C2F3 (Raise Water Level Far Left) - True - True
+0x1831D (Raise Water Level Far Right) - True - True
+0x1C2B1 (Raise Water Level Near Left) - True - True
+0x1831B (Raise Water Level Near Right) - True - True
+0x04D18 (Flood Room 1) - 0x1C260 & 0x1831C - True
+0x01205 (Flood Room 2) - 0x04D18 & 0x1C260 & 0x1831C - True
+0x181AB (Flood Room 3) - 0x01205 & 0x1C260 & 0x1831C - True
+0x0117A (Flood Room 4) - 0x181AB & 0x1C260 & 0x1831C - True
+0x17ECA (Flood Room 5) - 0x0117A & 0x1C260 & 0x1831C - True
+0x18076 (Flood Room 6) - 0x17ECA & 0x1C260 & 0x1831C - True
 Door - 0x0C316 (Elevator Room Entry) - 0x18076
-159034 - 0x337F8 (Flood Room EP) - 0x1C2DF - True
+0x337F8 (Flood Room EP) - 0x1C2DF - True
 
 Desert Flood Room Underwater (Desert):
 
 Desert Elevator Room (Desert) - Desert Behind Elevator - 0x01317:
-158111 - 0x17C31 (Elevator Room Transparent) - True - True
-158113 - 0x012D7 (Elevator Room Hexagonal) - 0x17C31 & 0x0A015 - True
-158114 - 0x0A015 (Elevator Room Hexagonal Control) - 0x17C31 - True
-158115 - 0x0A15C (Elevator Room Bent 1) - True - True
-158116 - 0x09FFF (Elevator Room Bent 2) - 0x0A15C - True
-158117 - 0x0A15F (Elevator Room Bent 3) - 0x09FFF - True
-159035 - 0x037BB (Elevator EP) - 0x01317 - True
+0x17C31 (Elevator Room Transparent) - True - True
+0x012D7 (Elevator Room Hexagonal) - 0x17C31 & 0x0A015 - True
+0x0A015 (Elevator Room Hexagonal Control) - 0x17C31 - True
+0x0A15C (Elevator Room Bent 1) - True - True
+0x09FFF (Elevator Room Bent 2) - 0x0A15C - True
+0x0A15F (Elevator Room Bent 3) - 0x09FFF - True
+0x037BB (Elevator EP) - 0x01317 - True
 Door - 0x01317 (Elevator) - 0x03608
 
 Desert Behind Elevator (Desert):
@@ -241,277 +241,277 @@ Desert Behind Elevator (Desert):
 ==Quarry==
 
 Quarry Obelisk (Quarry) - Entry - True:
-159740 - 0xFFE40 (Obelisk Side 1) - 0x28A7B & 0x005F6 & 0x00859 & 0x17CB9 & 0x28A4A - True
-159741 - 0xFFE41 (Obelisk Side 2) - 0x334B6 & 0x00614 & 0x0069D & 0x28A4C - True
-159742 - 0xFFE42 (Obelisk Side 3) - 0x289CF & 0x289D1 - True
-159743 - 0xFFE43 (Obelisk Side 4) - 0x33692 - True
-159744 - 0xFFE44 (Obelisk Side 5) - 0x03E77 & 0x03E7C - True
-159749 - 0x22073 (Obelisk) - True - True
+0xFFE40 (Obelisk Side 1) - 0x28A7B & 0x005F6 & 0x00859 & 0x17CB9 & 0x28A4A - True
+0xFFE41 (Obelisk Side 2) - 0x334B6 & 0x00614 & 0x0069D & 0x28A4C - True
+0xFFE42 (Obelisk Side 3) - 0x289CF & 0x289D1 - True
+0xFFE43 (Obelisk Side 4) - 0x33692 - True
+0xFFE44 (Obelisk Side 5) - 0x03E77 & 0x03E7C - True
+0x22073 (Obelisk) - True - True
 
 Outside Quarry (Quarry) - Main Island - True - Quarry Between Entry Doors - 0x09D6F - Quarry Elevator - 0xFFD00 & 0xFFD01:
-158118 - 0x09E57 (Entry 1 Panel) - True - Black/White Squares
-158603 - 0x17CF0 (Discard) - True - Triangles
-158702 - 0x03612 (Laser Panel) - 0x0A3D0 & 0x0367C - Eraser & Shapers
+0x09E57 (Entry 1 Panel) - True - Black/White Squares
+0x17CF0 (Discard) - True - Triangles
+0x03612 (Laser Panel) - 0x0A3D0 & 0x0367C - Eraser & Shapers
 Laser - 0x01539 (Laser) - 0x03612
 Door - 0x09D6F (Entry 1) - 0x09E57
-159404 - 0x28A4A (Shore EP) - True - True
-159410 - 0x334B6 (Entrance Pipe EP) - True - True
-159412 - 0x28A4C (Sand Pile EP) - True - True
-159420 - 0x289CF (Rock Line EP) - True - True
-159421 - 0x289D1 (Rock Line Reflection EP) - True - True
+0x28A4A (Shore EP) - True - True
+0x334B6 (Entrance Pipe EP) - True - True
+0x28A4C (Sand Pile EP) - True - True
+0x289CF (Rock Line EP) - True - True
+0x289D1 (Rock Line Reflection EP) - True - True
 
 Quarry Elevator (Quarry) - Outside Quarry - 0x17CC4 - Quarry - 0x17CC4:
-158120 - 0x17CC4 (Elevator Control) - 0x0367C - Dots & Eraser
-159403 - 0x17CB9 (Railroad EP) - 0x17CC4 - True
+0x17CC4 (Elevator Control) - 0x0367C - Dots & Eraser
+0x17CB9 (Railroad EP) - 0x17CC4 - True
 
 Quarry Between Entry Doors (Quarry) - Quarry - 0x17C07:
-158119 - 0x17C09 (Entry 2 Panel) - True - Shapers
+0x17C09 (Entry 2 Panel) - True - Shapers
 Door - 0x17C07 (Entry 2) - 0x17C09
 
 Quarry (Quarry) - Quarry Stoneworks Ground Floor - 0x02010:
-159802 - 0xFFD01 (Inside Reached Independently) - True - True
-158121 - 0x01E5A (Stoneworks Entry Left Panel) - True - Black/White Squares
-158122 - 0x01E59 (Stoneworks Entry Right Panel) - True - Dots
+0xFFD01 (Inside Reached Independently) - True - True
+0x01E5A (Stoneworks Entry Left Panel) - True - Black/White Squares
+0x01E59 (Stoneworks Entry Right Panel) - True - Dots
 Door - 0x02010 (Stoneworks Entry) - 0x01E59 & 0x01E5A
 
 Quarry Stoneworks Ground Floor (Quarry Stoneworks) - Quarry - 0x275FF - Quarry Stoneworks Middle Floor - 0x03678 - Outside Quarry - 0x17CE8 - Quarry Stoneworks Lift - TrueOneWay:
-158123 - 0x275ED (Side Exit Panel) - True - True
+0x275ED (Side Exit Panel) - True - True
 Door - 0x275FF (Side Exit) - 0x275ED
-158124 - 0x03678 (Lower Ramp Control) - True - Dots & Eraser
-158145 - 0x17CAC (Roof Exit Panel) - True - True
+0x03678 (Lower Ramp Control) - True - Dots & Eraser
+0x17CAC (Roof Exit Panel) - True - True
 Door - 0x17CE8 (Roof Exit) - 0x17CAC
 
 Quarry Stoneworks Middle Floor (Quarry Stoneworks) - Quarry Stoneworks Lift - TrueOneWay:
-158125 - 0x00E0C (Lower Row 1) - True - Dots & Eraser
-158126 - 0x01489 (Lower Row 2) - 0x00E0C - Dots & Eraser
-158127 - 0x0148A (Lower Row 3) - 0x01489 - Dots & Eraser
-158128 - 0x014D9 (Lower Row 4) - 0x0148A - Dots & Eraser
-158129 - 0x014E7 (Lower Row 5) - 0x014D9 - Dots & Eraser
-158130 - 0x014E8 (Lower Row 6) - 0x014E7 - Dots & Eraser
+0x00E0C (Lower Row 1) - True - Dots & Eraser
+0x01489 (Lower Row 2) - 0x00E0C - Dots & Eraser
+0x0148A (Lower Row 3) - 0x01489 - Dots & Eraser
+0x014D9 (Lower Row 4) - 0x0148A - Dots & Eraser
+0x014E7 (Lower Row 5) - 0x014D9 - Dots & Eraser
+0x014E8 (Lower Row 6) - 0x014E7 - Dots & Eraser
 
 Quarry Stoneworks Lift (Quarry Stoneworks) - Quarry Stoneworks Middle Floor - 0x03679 - Quarry Stoneworks Ground Floor - 0x03679 - Quarry Stoneworks Upper Floor - 0x03679:
-158131 - 0x03679 (Lower Lift Control) - 0x014E8 - Dots & Eraser
+0x03679 (Lower Lift Control) - 0x014E8 - Dots & Eraser
 
 Quarry Stoneworks Upper Floor (Quarry Stoneworks) - Quarry Stoneworks Lift - 0x03675 - Quarry Stoneworks Ground Floor - 0x0368A:
-158132 - 0x03676 (Upper Ramp Control) - True - Dots & Eraser
-158133 - 0x03675 (Upper Lift Control) - True - Dots & Eraser
-158134 - 0x00557 (Upper Row 1) - True - Colored Squares & Eraser
-158135 - 0x005F1 (Upper Row 2) - 0x00557 - Colored Squares & Eraser
-158136 - 0x00620 (Upper Row 3) - 0x005F1 - Colored Squares & Eraser
-158137 - 0x009F5 (Upper Row 4) - 0x00620 - Colored Squares & Eraser
-158138 - 0x0146C (Upper Row 5) - 0x009F5 - Colored Squares & Eraser
-158139 - 0x3C12D (Upper Row 6) - 0x0146C - Colored Squares & Eraser
-158140 - 0x03686 (Upper Row 7) - 0x3C12D - Colored Squares & Eraser
-158141 - 0x014E9 (Upper Row 8) - 0x03686 - Colored Squares & Eraser
-158142 - 0x03677 (Stairs Panel) - True - Colored Squares & Eraser
+0x03676 (Upper Ramp Control) - True - Dots & Eraser
+0x03675 (Upper Lift Control) - True - Dots & Eraser
+0x00557 (Upper Row 1) - True - Colored Squares & Eraser
+0x005F1 (Upper Row 2) - 0x00557 - Colored Squares & Eraser
+0x00620 (Upper Row 3) - 0x005F1 - Colored Squares & Eraser
+0x009F5 (Upper Row 4) - 0x00620 - Colored Squares & Eraser
+0x0146C (Upper Row 5) - 0x009F5 - Colored Squares & Eraser
+0x3C12D (Upper Row 6) - 0x0146C - Colored Squares & Eraser
+0x03686 (Upper Row 7) - 0x3C12D - Colored Squares & Eraser
+0x014E9 (Upper Row 8) - 0x03686 - Colored Squares & Eraser
+0x03677 (Stairs Panel) - True - Colored Squares & Eraser
 Door - 0x0368A (Stairs) - 0x03677
-158143 - 0x3C125 (Control Room Left) - 0x014E9 - Black/White Squares & Dots & Eraser
-158144 - 0x0367C (Control Room Right) - 0x014E9 - Colored Squares & Dots & Eraser
-159411 - 0x0069D (Ramp EP) - 0x03676 & 0x275FF - True
-159413 - 0x00614 (Lift EP) - 0x275FF & 0x03675 - True
+0x3C125 (Control Room Left) - 0x014E9 - Black/White Squares & Dots & Eraser
+0x0367C (Control Room Right) - 0x014E9 - Colored Squares & Dots & Eraser
+0x0069D (Ramp EP) - 0x03676 & 0x275FF - True
+0x00614 (Lift EP) - 0x275FF & 0x03675 - True
 
 Quarry Boathouse (Quarry Boathouse) - Quarry - True - Quarry Boathouse Upper Front - 0x03852 - Quarry Boathouse Behind Staircase - 0x2769B:
-158146 - 0x034D4 (Intro Left) - True - Stars
-158147 - 0x021D5 (Intro Right) - True - Shapers & Rotated Shapers
-158148 - 0x03852 (Ramp Height Control) - 0x034D4 & 0x021D5 - Rotated Shapers
-158166 - 0x17CA6 (Boat Spawn) - True - Boat
+0x034D4 (Intro Left) - True - Stars
+0x021D5 (Intro Right) - True - Shapers & Rotated Shapers
+0x03852 (Ramp Height Control) - 0x034D4 & 0x021D5 - Rotated Shapers
+0x17CA6 (Boat Spawn) - True - Boat
 Door - 0x2769B (Dock) - 0x17CA6
 Door - 0x27163 (Dock Invis Barrier) - 0x17CA6
 
 Quarry Boathouse Behind Staircase (Quarry Boathouse) - The Ocean - 0x17CA6:
 
 Quarry Boathouse Upper Front (Quarry Boathouse) - Quarry Boathouse Upper Middle - 0x17C50:
-158149 - 0x021B3 (Front Row 1) - True - Shapers & Eraser
-158150 - 0x021B4 (Front Row 2) - 0x021B3 - Shapers & Eraser
-158151 - 0x021B0 (Front Row 3) - 0x021B4 - Shapers & Eraser
-158152 - 0x021AF (Front Row 4) - 0x021B0 - Shapers & Eraser
-158153 - 0x021AE (Front Row 5) - 0x021AF - Shapers & Eraser
+0x021B3 (Front Row 1) - True - Shapers & Eraser
+0x021B4 (Front Row 2) - 0x021B3 - Shapers & Eraser
+0x021B0 (Front Row 3) - 0x021B4 - Shapers & Eraser
+0x021AF (Front Row 4) - 0x021B0 - Shapers & Eraser
+0x021AE (Front Row 5) - 0x021AF - Shapers & Eraser
 Door - 0x17C50 (First Barrier) - 0x021AE
 
 Quarry Boathouse Upper Middle (Quarry Boathouse) - Quarry Boathouse Upper Back - 0x03858:
-158154 - 0x03858 (Ramp Horizontal Control) - True - Shapers & Eraser
-159402 - 0x00859 (Moving Ramp EP) - 0x03858 & 0x03852 & 0x3865F - True
+0x03858 (Ramp Horizontal Control) - True - Shapers & Eraser
+0x00859 (Moving Ramp EP) - 0x03858 & 0x03852 & 0x3865F - True
 
 Quarry Boathouse Upper Back (Quarry Boathouse) - Quarry Boathouse Upper Middle - 0x3865F:
-158155 - 0x38663 (Second Barrier Panel) - True - True
+0x38663 (Second Barrier Panel) - True - True
 Door - 0x3865F (Second Barrier) - 0x38663
-158156 - 0x021B5 (Back First Row 1) - True - Stars + Same Colored Symbol & Eraser
-158157 - 0x021B6 (Back First Row 2) - 0x021B5 - Stars + Same Colored Symbol & Eraser
-158158 - 0x021B7 (Back First Row 3) - 0x021B6 - Stars + Same Colored Symbol & Eraser
-158159 - 0x021BB (Back First Row 4) - 0x021B7 - Stars + Same Colored Symbol & Eraser
-158160 - 0x09DB5 (Back First Row 5) - 0x021BB - Stars + Same Colored Symbol & Eraser
-158161 - 0x09DB1 (Back First Row 6) - 0x09DB5 - Stars + Same Colored Symbol & Eraser
-158162 - 0x3C124 (Back First Row 7) - 0x09DB1 - Stars + Same Colored Symbol & Eraser
-158163 - 0x09DB3 (Back First Row 8) - 0x3C124 - Stars & Eraser & Shapers
-158164 - 0x09DB4 (Back First Row 9) - 0x09DB3 - Stars & Eraser & Shapers
-158165 - 0x275FA (Hook Control) - True - Shapers & Eraser
-158167 - 0x0A3CB (Back Second Row 1) - 0x09DB4 - Stars & Eraser & Shapers
-158168 - 0x0A3CC (Back Second Row 2) - 0x0A3CB - Stars & Eraser & Shapers
-158169 - 0x0A3D0 (Back Second Row 3) - 0x0A3CC - Stars & Eraser & Shapers
-159401 - 0x005F6 (Hook EP) - 0x275FA & 0x03852 & 0x3865F - True
+0x021B5 (Back First Row 1) - True - Stars + Same Colored Symbol & Eraser
+0x021B6 (Back First Row 2) - 0x021B5 - Stars + Same Colored Symbol & Eraser
+0x021B7 (Back First Row 3) - 0x021B6 - Stars + Same Colored Symbol & Eraser
+0x021BB (Back First Row 4) - 0x021B7 - Stars + Same Colored Symbol & Eraser
+0x09DB5 (Back First Row 5) - 0x021BB - Stars + Same Colored Symbol & Eraser
+0x09DB1 (Back First Row 6) - 0x09DB5 - Stars + Same Colored Symbol & Eraser
+0x3C124 (Back First Row 7) - 0x09DB1 - Stars + Same Colored Symbol & Eraser
+0x09DB3 (Back First Row 8) - 0x3C124 - Stars & Eraser & Shapers
+0x09DB4 (Back First Row 9) - 0x09DB3 - Stars & Eraser & Shapers
+0x275FA (Hook Control) - True - Shapers & Eraser
+0x0A3CB (Back Second Row 1) - 0x09DB4 - Stars & Eraser & Shapers
+0x0A3CC (Back Second Row 2) - 0x0A3CB - Stars & Eraser & Shapers
+0x0A3D0 (Back Second Row 3) - 0x0A3CC - Stars & Eraser & Shapers
+0x005F6 (Hook EP) - 0x275FA & 0x03852 & 0x3865F - True
 
 ==Shadows==
 
 Shadows (Shadows) - Main Island - True - Shadows Ledge - 0x19B24 - Shadows Laser Room - 0x194B2 | 0x19665:
-158170 - 0x334DB (Door Timer Outside) - True - True
+0x334DB (Door Timer Outside) - True - True
 Door - 0x19B24 (Timed Door) - 0x334DB | 0x334DC
-158171 - 0x0AC74 (Intro 6) - 0x0A8DC - True
-158172 - 0x0AC7A (Intro 7) - 0x0AC74 - True
-158173 - 0x0A8E0 (Intro 8) - 0x0AC7A - True
-158174 - 0x386FA (Far 1) - 0x0A8E0 - True
-158175 - 0x1C33F (Far 2) - 0x386FA - True
-158176 - 0x196E2 (Far 3) - 0x1C33F - True
-158177 - 0x1972A (Far 4) - 0x196E2 - True
-158178 - 0x19809 (Far 5) - 0x1972A - True
-158179 - 0x19806 (Far 6) - 0x19809 - True
-158180 - 0x196F8 (Far 7) - 0x19806 - True
-158181 - 0x1972F (Far 8) - 0x196F8 - True
+0x0AC74 (Intro 6) - 0x0A8DC - True
+0x0AC7A (Intro 7) - 0x0AC74 - True
+0x0A8E0 (Intro 8) - 0x0AC7A - True
+0x386FA (Far 1) - 0x0A8E0 - True
+0x1C33F (Far 2) - 0x386FA - True
+0x196E2 (Far 3) - 0x1C33F - True
+0x1972A (Far 4) - 0x196E2 - True
+0x19809 (Far 5) - 0x1972A - True
+0x19806 (Far 6) - 0x19809 - True
+0x196F8 (Far 7) - 0x19806 - True
+0x1972F (Far 8) - 0x196F8 - True
 Door - 0x194B2 (Laser Entry Right) - 0x1972F
-158182 - 0x19797 (Near 1) - 0x0A8E0 - True
-158183 - 0x1979A (Near 2) - 0x19797 - True
-158184 - 0x197E0 (Near 3) - 0x1979A - True
-158185 - 0x197E8 (Near 4) - 0x197E0 - True
-158186 - 0x197E5 (Near 5) - 0x197E8 - True
+0x19797 (Near 1) - 0x0A8E0 - True
+0x1979A (Near 2) - 0x19797 - True
+0x197E0 (Near 3) - 0x1979A - True
+0x197E8 (Near 4) - 0x197E0 - True
+0x197E5 (Near 5) - 0x197E8 - True
 Door - 0x19665 (Laser Entry Left) - 0x197E5
-159400 - 0x28A7B (Quarry Stoneworks Rooftop Vent EP) - True - True
+0x28A7B (Quarry Stoneworks Rooftop Vent EP) - True - True
 
 Shadows Ledge (Shadows) - Shadows - 0x1855B - Quarry - 0x19865 & 0x0A2DF:
-158187 - 0x334DC (Door Timer Inside) - True - True
-158188 - 0x198B5 (Intro 1) - True - True
-158189 - 0x198BD (Intro 2) - 0x198B5 - True
-158190 - 0x198BF (Intro 3) - 0x198BD & 0x19B24 - True
+0x334DC (Door Timer Inside) - True - True
+0x198B5 (Intro 1) - True - True
+0x198BD (Intro 2) - 0x198B5 - True
+0x198BF (Intro 3) - 0x198BD & 0x19B24 - True
 Door - 0x19865 (Quarry Barrier) - 0x198BF
 Door - 0x0A2DF (Quarry Barrier 2) - 0x198BF
-158191 - 0x19771 (Intro 4) - 0x198BF - True
-158192 - 0x0A8DC (Intro 5) - 0x19771 - True
+0x19771 (Intro 4) - 0x198BF - True
+0x0A8DC (Intro 5) - 0x19771 - True
 Door - 0x1855B (Ledge Barrier) - 0x0A8DC
 Door - 0x19ADE (Ledge Barrier 2) - 0x0A8DC
 
 Shadows Laser Room (Shadows):
-158703 - 0x19650 (Laser Panel) - 0x194B2 & 0x19665 - True
+0x19650 (Laser Panel) - 0x194B2 & 0x19665 - True
 Laser - 0x181B3 (Laser) - 0x19650
 
 ==Keep==
 
 Outside Keep (Keep) - Main Island - True:
-159430 - 0x03E77 (Red Flowers EP) - True - True
-159431 - 0x03E7C (Purple Flowers EP) - True - True
+0x03E77 (Red Flowers EP) - True - True
+0x03E7C (Purple Flowers EP) - True - True
 
 Keep (Keep) - Outside Keep - True - Keep 2nd Maze - 0x01954 - Keep 2nd Pressure Plate - 0x01BEC:
-158193 - 0x00139 (Hedge Maze 1) - True - True
-158197 - 0x0A3A8 (Reset Pressure Plates 1) - True - True
-158198 - 0x033EA (Pressure Plates 1) - 0x0A3A8 - Dots
+0x00139 (Hedge Maze 1) - True - True
+0x0A3A8 (Reset Pressure Plates 1) - True - True
+0x033EA (Pressure Plates 1) - 0x0A3A8 - Dots
 Door - 0x01954 (Hedge Maze 1 Exit) - 0x00139
 Door - 0x01BEC (Pressure Plates 1 Exit) - 0x033EA
 
 Keep 2nd Maze (Keep) - Keep - 0x018CE - Keep 3rd Maze - 0x019D8:
 Door - 0x018CE (Hedge Maze 2 Shortcut) - 0x00139
-158194 - 0x019DC (Hedge Maze 2) - True - True
+0x019DC (Hedge Maze 2) - True - True
 Door - 0x019D8 (Hedge Maze 2 Exit) - 0x019DC
 
 Keep 3rd Maze (Keep) - Keep - 0x019B5 - Keep 4th Maze - 0x019E6:
 Door - 0x019B5 (Hedge Maze 3 Shortcut) - 0x019DC
-158195 - 0x019E7 (Hedge Maze 3) - True - True
+0x019E7 (Hedge Maze 3) - True - True
 Door - 0x019E6 (Hedge Maze 3 Exit) - 0x019E7
 
 Keep 4th Maze (Keep) - Keep - 0x0199A - Keep Tower - 0x01A0E:
 Door - 0x0199A (Hedge Maze 4 Shortcut) - 0x019E7
-158196 - 0x01A0F (Hedge Maze 4) - True - True
+0x01A0F (Hedge Maze 4) - True - True
 Door - 0x01A0E (Hedge Maze 4 Exit) - 0x01A0F
 
 Keep 2nd Pressure Plate (Keep) - Keep 3rd Pressure Plate - True:
-158199 - 0x0A3B9 (Reset Pressure Plates 2) - True - True
-158200 - 0x01BE9 (Pressure Plates 2) - 0x0A3B9 - Stars + Same Colored Symbol & Black/White Squares
+0x0A3B9 (Reset Pressure Plates 2) - True - True
+0x01BE9 (Pressure Plates 2) - 0x0A3B9 - Stars + Same Colored Symbol & Black/White Squares
 Door - 0x01BEA (Pressure Plates 2 Exit) - 0x01BE9
 
 Keep 3rd Pressure Plate (Keep) - Keep 4th Pressure Plate - 0x01CD5:
-158201 - 0x0A3BB (Reset Pressure Plates 3) - True - True
-158202 - 0x01CD3 (Pressure Plates 3) - 0x0A3BB - Shapers & Black/White Squares & Colored Squares
+0x0A3BB (Reset Pressure Plates 3) - True - True
+0x01CD3 (Pressure Plates 3) - 0x0A3BB - Shapers & Black/White Squares & Colored Squares
 Door - 0x01CD5 (Pressure Plates 3 Exit) - 0x01CD3
 
 Keep 4th Pressure Plate (Keep) - Shadows - 0x09E3D - Keep Tower - 0x01D40:
-158203 - 0x0A3AD (Reset Pressure Plates 4) - True - True
-158204 - 0x01D3F (Pressure Plates 4) - 0x0A3AD - Shapers & Dots & Symmetry
+0x0A3AD (Reset Pressure Plates 4) - True - True
+0x01D3F (Pressure Plates 4) - 0x0A3AD - Shapers & Dots & Symmetry
 Door - 0x01D40 (Pressure Plates 4 Exit) - 0x01D3F
-158604 - 0x17D27 (Discard) - True - Triangles
-158205 - 0x09E49 (Shadows Shortcut Panel) - True - True
+0x17D27 (Discard) - True - Triangles
+0x09E49 (Shadows Shortcut Panel) - True - True
 Door - 0x09E3D (Shadows Shortcut) - 0x09E49
 
 Keep Tower (Keep) - Keep - 0x04F8F:
-158206 - 0x0361B (Tower Shortcut Panel) - True - True
+0x0361B (Tower Shortcut Panel) - True - True
 Door - 0x04F8F (Tower Shortcut) - 0x0361B
-158704 - 0x0360E (Laser Panel Hedges) - 0x01A0F & 0x019E7 & 0x019DC & 0x00139 - True
-158705 - 0x03317 (Laser Panel Pressure Plates) - 0x033EA & 0x01BE9 & 0x01CD3 & 0x01D3F - Shapers & Black/White Squares & Colored Squares & Stars + Same Colored Symbol & Dots
+0x0360E (Laser Panel Hedges) - 0x01A0F & 0x019E7 & 0x019DC & 0x00139 - True
+0x03317 (Laser Panel Pressure Plates) - 0x033EA & 0x01BE9 & 0x01CD3 & 0x01D3F - Shapers & Black/White Squares & Colored Squares & Stars + Same Colored Symbol & Dots
 Laser - 0x014BB (Laser) - 0x0360E | 0x03317
-159240 - 0x033BE (Pressure Plates 1 EP) - 0x033EA - True
-159241 - 0x033BF (Pressure Plates 2 EP) - 0x01BE9 - True
-159242 - 0x033DD (Pressure Plates 3 EP) - 0x01CD3 & 0x01CD5 - True
-159243 - 0x033E5 (Pressure Plates 4 Left Exit EP) - 0x01D3F - True
-159244 - 0x018B6 (Pressure Plates 4 Right Exit EP) - 0x01D3F - True
-159250 - 0x28AE9 (Path EP) - True - True
-159251 - 0x3348F (Hedges EP) - True - True
+0x033BE (Pressure Plates 1 EP) - 0x033EA - True
+0x033BF (Pressure Plates 2 EP) - 0x01BE9 - True
+0x033DD (Pressure Plates 3 EP) - 0x01CD3 & 0x01CD5 - True
+0x033E5 (Pressure Plates 4 Left Exit EP) - 0x01D3F - True
+0x018B6 (Pressure Plates 4 Right Exit EP) - 0x01D3F - True
+0x28AE9 (Path EP) - True - True
+0x3348F (Hedges EP) - True - True
 
 ==Shipwreck==
 
 Shipwreck (Shipwreck) - Keep 3rd Pressure Plate - True - Shipwreck Vault - 0x17BB4:
-158654 - 0x00AFB (Vault Panel) - True - Symmetry & Sound Dots & Colored Dots
+0x00AFB (Vault Panel) - True - Symmetry & Sound Dots & Colored Dots
 Door - 0x17BB4 (Vault Door) - 0x00AFB
-158605 - 0x17D28 (Discard) - True - Triangles
-159220 - 0x03B22 (Circle Far EP) - True - True
-159221 - 0x03B23 (Circle Left EP) - True - True
-159222 - 0x03B24 (Circle Near EP) - True - True
-159224 - 0x03A79 (Stern EP) - True - True
-159225 - 0x28ABD (Rope Inner EP) - True - True
-159226 - 0x28ABE (Rope Outer EP) - True - True
-159230 - 0x3388F (Couch EP) - 0x17CDF | 0x0A054 - True
+0x17D28 (Discard) - True - Triangles
+0x03B22 (Circle Far EP) - True - True
+0x03B23 (Circle Left EP) - True - True
+0x03B24 (Circle Near EP) - True - True
+0x03A79 (Stern EP) - True - True
+0x28ABD (Rope Inner EP) - True - True
+0x28ABE (Rope Outer EP) - True - True
+0x3388F (Couch EP) - 0x17CDF | 0x0A054 - True
 
 Shipwreck Vault (Shipwreck):
-158655 - 0x03535 (Vault Box) - True - True
+0x03535 (Vault Box) - True - True
 
 ==Monastery==
 
 Monastery Obelisk (Monastery) - Entry - True:
-159710 - 0xFFE10 (Obelisk Side 1) - 0x03ABC & 0x03ABE & 0x03AC0 & 0x03AC4 - True
-159711 - 0xFFE11 (Obelisk Side 2) - 0x03AC5 - True
-159712 - 0xFFE12 (Obelisk Side 3) - 0x03BE2 & 0x03BE3 & 0x0A409 - True
-159713 - 0xFFE13 (Obelisk Side 4) - 0x006E5 & 0x006E6 & 0x006E7 & 0x034A7 & 0x034AD & 0x034AF & 0x03DAB & 0x03DAC & 0x03DAD - True
-159714 - 0xFFE14 (Obelisk Side 5) - 0x03E01 - True
-159715 - 0xFFE15 (Obelisk Side 6) - 0x289F4 & 0x289F5 - True
-159719 - 0x00263 (Obelisk) - True - True
+0xFFE10 (Obelisk Side 1) - 0x03ABC & 0x03ABE & 0x03AC0 & 0x03AC4 - True
+0xFFE11 (Obelisk Side 2) - 0x03AC5 - True
+0xFFE12 (Obelisk Side 3) - 0x03BE2 & 0x03BE3 & 0x0A409 - True
+0xFFE13 (Obelisk Side 4) - 0x006E5 & 0x006E6 & 0x006E7 & 0x034A7 & 0x034AD & 0x034AF & 0x03DAB & 0x03DAC & 0x03DAD - True
+0xFFE14 (Obelisk Side 5) - 0x03E01 - True
+0xFFE15 (Obelisk Side 6) - 0x289F4 & 0x289F5 - True
+0x00263 (Obelisk) - True - True
 
 Outside Monastery (Monastery) - Main Island - True - Inside Monastery - 0x0C128 & 0x0C153 - Monastery Garden - 0x03750:
-158207 - 0x03713 (Laser Shortcut Panel) - True - True
+0x03713 (Laser Shortcut Panel) - True - True
 Door - 0x0364E (Laser Shortcut) - 0x03713
-158208 - 0x00B10 (Entry Left) - True - True
-158209 - 0x00C92 (Entry Right) - 0x00B10 - True
+0x00B10 (Entry Left) - True - True
+0x00C92 (Entry Right) - 0x00B10 - True
 Door - 0x0C128 (Entry Inner) - 0x00B10
 Door - 0x0C153 (Entry Outer) - 0x00C92
-158210 - 0x00290 (Outside 1) - 0x09D9B - True
-158211 - 0x00038 (Outside 2) - 0x09D9B & 0x00290 - True
-158212 - 0x00037 (Outside 3) - 0x09D9B & 0x00038 - True
+0x00290 (Outside 1) - 0x09D9B - True
+0x00038 (Outside 2) - 0x09D9B & 0x00290 - True
+0x00037 (Outside 3) - 0x09D9B & 0x00038 - True
 Door - 0x03750 (Garden Entry) - 0x00037
-158706 - 0x17CA4 (Laser Panel) - 0x193A6 - True
+0x17CA4 (Laser Panel) - 0x193A6 - True
 Laser - 0x17C65 (Laser) - 0x17CA4
-159130 - 0x006E5 (Facade Left Near EP) - True - True
-159131 - 0x006E6 (Facade Left Far Short EP) - True - True
-159132 - 0x006E7 (Facade Left Far Long EP) - True - True
-159136 - 0x03DAB (Facade Right Near EP) - True - True
-159137 - 0x03DAC (Facade Left Stairs EP) - True - True
-159138 - 0x03DAD (Facade Right Stairs EP) - True - True
-159140 - 0x03E01 (Grass Stairs EP) - True - True
-159120 - 0x03BE2 (Garden Left EP) - 0x03750 - True
-159121 - 0x03BE3 (Garden Right EP) - True - True
-159122 - 0x0A409 (Wall EP) - True - True
+0x006E5 (Facade Left Near EP) - True - True
+0x006E6 (Facade Left Far Short EP) - True - True
+0x006E7 (Facade Left Far Long EP) - True - True
+0x03DAB (Facade Right Near EP) - True - True
+0x03DAC (Facade Left Stairs EP) - True - True
+0x03DAD (Facade Right Stairs EP) - True - True
+0x03E01 (Grass Stairs EP) - True - True
+0x03BE2 (Garden Left EP) - 0x03750 - True
+0x03BE3 (Garden Right EP) - True - True
+0x0A409 (Wall EP) - True - True
 
 Inside Monastery (Monastery) - Monastery North Shutters - 0x09D9B:
-158213 - 0x09D9B (Shutters Control) - True - Dots
-158214 - 0x193A7 (Inside 1) - 0x00037 - True
-158215 - 0x193AA (Inside 2) - 0x193A7 - True
-158216 - 0x193AB (Inside 3) - 0x193AA - True
-158217 - 0x193A6 (Inside 4) - 0x193AB - True
-159133 - 0x034A7 (Left Shutter EP) - 0x09D9B - True
-159134 - 0x034AD (Middle Shutter EP) - 0x09D9B - True
-159135 - 0x034AF (Right Shutter EP) - 0x09D9B - True
+0x09D9B (Shutters Control) - True - Dots
+0x193A7 (Inside 1) - 0x00037 - True
+0x193AA (Inside 2) - 0x193A7 - True
+0x193AB (Inside 3) - 0x193AA - True
+0x193A6 (Inside 4) - 0x193AB - True
+0x034A7 (Left Shutter EP) - 0x09D9B - True
+0x034AD (Middle Shutter EP) - 0x09D9B - True
+0x034AF (Right Shutter EP) - 0x09D9B - True
 
 Monastery Garden (Monastery):
 
@@ -520,76 +520,76 @@ Monastery North Shutters (Monastery):
 ==Town==
 
 Town Obelisk (Town) - Entry - True:
-159750 - 0xFFE50 (Obelisk Side 1) - 0x035C7 - True
-159751 - 0xFFE51 (Obelisk Side 2) - 0x01848 & 0x03D06 & 0x33530 & 0x33600 & 0x28A2F & 0x28A37 & 0x334A3 & 0x3352F - True
-159752 - 0xFFE52 (Obelisk Side 3) - 0x33857 & 0x33879 & 0x03C19 - True
-159753 - 0xFFE53 (Obelisk Side 4) - 0x28B30 & 0x035C9 - True
-159754 - 0xFFE54 (Obelisk Side 5) - 0x03335 & 0x03412 & 0x038A6 & 0x038AA & 0x03E3F & 0x03E40 & 0x28B8E - True
-159755 - 0xFFE55 (Obelisk Side 6) - 0x28B91 & 0x03BCE & 0x03BCF & 0x03BD1 & 0x339B6 & 0x33A20 & 0x33A29 & 0x33A2A & 0x33B06 - True
-159759 - 0x0A16C (Obelisk) - True - True
+0xFFE50 (Obelisk Side 1) - 0x035C7 - True
+0xFFE51 (Obelisk Side 2) - 0x01848 & 0x03D06 & 0x33530 & 0x33600 & 0x28A2F & 0x28A37 & 0x334A3 & 0x3352F - True
+0xFFE52 (Obelisk Side 3) - 0x33857 & 0x33879 & 0x03C19 - True
+0xFFE53 (Obelisk Side 4) - 0x28B30 & 0x035C9 - True
+0xFFE54 (Obelisk Side 5) - 0x03335 & 0x03412 & 0x038A6 & 0x038AA & 0x03E3F & 0x03E40 & 0x28B8E - True
+0xFFE55 (Obelisk Side 6) - 0x28B91 & 0x03BCE & 0x03BCF & 0x03BD1 & 0x339B6 & 0x33A20 & 0x33A29 & 0x33A2A & 0x33B06 - True
+0x0A16C (Obelisk) - True - True
 
 Town (Town) - Main Island - True - The Ocean - 0x0A054 - Town Maze Rooftop - 0x28AA2 - Town Church - True - Town Wooden Rooftop - 0x034F5 - Town RGB House - 0x28A61 - Town Inside Cargo Box - 0x0A0C9 - Outside Windmill - True:
-158218 - 0x0A054 (Boat Spawn) - 0x17CA6 | 0x17CDF | 0x09DB8 | 0x17C95 - Boat
-158219 - 0x0A0C8 (Cargo Box Entry Panel) - True - Black/White Squares & Shapers
+0x0A054 (Boat Spawn) - 0x17CA6 | 0x17CDF | 0x09DB8 | 0x17C95 - Boat
+0x0A0C8 (Cargo Box Entry Panel) - True - Black/White Squares & Shapers
 Door - 0x0A0C9 (Cargo Box Entry) - 0x0A0C8
-158707 - 0x09F98 (Desert Laser Redirect Control) - True - True
-158220 - 0x18590 (Transparent) - True - Symmetry
-158221 - 0x28AE3 (Vines) - 0x18590 - True
-158222 - 0x28938 (Apple Tree) - 0x28AE3 - True
-158223 - 0x079DF (Triple Exit) - 0x28938 - True
-158235 - 0x2899C (Wooden Roof Lower Row 1) - True - Rotated Shapers & Full Dots
-158236 - 0x28A33 (Wooden Roof Lower Row 2) - 0x2899C - Shapers & Full Dots
-158237 - 0x28ABF (Wooden Roof Lower Row 3) - 0x28A33 - Shapers & Rotated Shapers & Full Dots
-158238 - 0x28AC0 (Wooden Roof Lower Row 4) - 0x28ABF - Rotated Shapers & Full Dots
-158239 - 0x28AC1 (Wooden Roof Lower Row 5) - 0x28AC0 - Rotated Shapers & Full Dots
+0x09F98 (Desert Laser Redirect Control) - True - True
+0x18590 (Transparent) - True - Symmetry
+0x28AE3 (Vines) - 0x18590 - True
+0x28938 (Apple Tree) - 0x28AE3 - True
+0x079DF (Triple Exit) - 0x28938 - True
+0x2899C (Wooden Roof Lower Row 1) - True - Rotated Shapers & Full Dots
+0x28A33 (Wooden Roof Lower Row 2) - 0x2899C - Shapers & Full Dots
+0x28ABF (Wooden Roof Lower Row 3) - 0x28A33 - Shapers & Rotated Shapers & Full Dots
+0x28AC0 (Wooden Roof Lower Row 4) - 0x28ABF - Rotated Shapers & Full Dots
+0x28AC1 (Wooden Roof Lower Row 5) - 0x28AC0 - Rotated Shapers & Full Dots
 Door - 0x034F5 (Wooden Roof Stairs) - 0x28AC1
-158225 - 0x28998 (RGB House Entry Panel) - True - Stars & Rotated Shapers
+0x28998 (RGB House Entry Panel) - True - Stars & Rotated Shapers
 Door - 0x28A61 (RGB House Entry) - 0x28998
-158226 - 0x28A0D (Church Entry Panel) - 0x28A61 - Stars
+0x28A0D (Church Entry Panel) - 0x28A61 - Stars
 Door - 0x03BB0 (Church Entry) - 0x28A0D
-158228 - 0x28A79 (Maze Panel) - True - True
+0x28A79 (Maze Panel) - True - True
 Door - 0x28AA2 (Maze Stairs) - 0x28A79
-159540 - 0x03335 (Tower Underside Third EP) - True - True
-159541 - 0x03412 (Tower Underside Fourth EP) - True - True
-159542 - 0x038A6 (Tower Underside First EP) - True - True
-159543 - 0x038AA (Tower Underside Second EP) - True - True
-159545 - 0x03E40 (RGB House Green EP) - 0x334D8 - True
-159546 - 0x28B8E (Maze Bridge Underside EP) - 0x2896A - True
-159552 - 0x03BCF (Black Line Redirect EP) - True - True
-159800 - 0xFFF80 (Pet the Dog) - True - True
+0x03335 (Tower Underside Third EP) - True - True
+0x03412 (Tower Underside Fourth EP) - True - True
+0x038A6 (Tower Underside First EP) - True - True
+0x038AA (Tower Underside Second EP) - True - True
+0x03E40 (RGB House Green EP) - 0x334D8 - True
+0x28B8E (Maze Bridge Underside EP) - 0x2896A - True
+0x03BCF (Black Line Redirect EP) - True - True
+0xFFF80 (Pet the Dog) - True - True
 
 Town Inside Cargo Box (Town):
-158606 - 0x17D01 (Cargo Box Discard) - True - Triangles
+0x17D01 (Cargo Box Discard) - True - Triangles
 
 Town Maze Rooftop (Town) - Town Red Rooftop - 0x2896A:
-158229 - 0x2896A (Maze Rooftop Bridge Control) - True - Shapers
-159544 - 0x03E3F (RGB House Red EP) - 0x334D8 - True
+0x2896A (Maze Rooftop Bridge Control) - True - Shapers
+0x03E3F (RGB House Red EP) - 0x334D8 - True
 
 Town Red Rooftop (Town):
-158607 - 0x17C71 (Rooftop Discard) - True - Triangles
-158230 - 0x28AC7 (Red Rooftop 1) - True - Symmetry & Black/White Squares
-158231 - 0x28AC8 (Red Rooftop 2) - 0x28AC7 - Symmetry & Black/White Squares
-158232 - 0x28ACA (Red Rooftop 3) - 0x28AC8 - Symmetry & Black/White Squares & Dots
-158233 - 0x28ACB (Red Rooftop 4) - 0x28ACA - Symmetry & Black/White Squares & Dots
-158234 - 0x28ACC (Red Rooftop 5) - 0x28ACB - Symmetry & Black/White Squares & Dots
-158224 - 0x28B39 (Tall Hexagonal) - 0x079DF - True
+0x17C71 (Rooftop Discard) - True - Triangles
+0x28AC7 (Red Rooftop 1) - True - Symmetry & Black/White Squares
+0x28AC8 (Red Rooftop 2) - 0x28AC7 - Symmetry & Black/White Squares
+0x28ACA (Red Rooftop 3) - 0x28AC8 - Symmetry & Black/White Squares & Dots
+0x28ACB (Red Rooftop 4) - 0x28ACA - Symmetry & Black/White Squares & Dots
+0x28ACC (Red Rooftop 5) - 0x28ACB - Symmetry & Black/White Squares & Dots
+0x28B39 (Tall Hexagonal) - 0x079DF - True
 
 Town Wooden Rooftop (Town):
-158240 - 0x28AD9 (Wooden Rooftop) - 0x28AC1 - Rotated Shapers & Eraser & Full Dots
+0x28AD9 (Wooden Rooftop) - 0x28AC1 - Rotated Shapers & Eraser & Full Dots
 
 Town Church (Town):
-158227 - 0x28A69 (Church Lattice) - 0x03BB0 - True
-159553 - 0x03BD1 (Black Line Church EP) - True - True
+0x28A69 (Church Lattice) - 0x03BB0 - True
+0x03BD1 (Black Line Church EP) - True - True
 
 Town RGB House (Town RGB House) - Town RGB House Upstairs - 0x2897B:
-158242 - 0x034E4 (Sound Room Left) - True - True
-158243 - 0x034E3 (Sound Room Right) - True - Sound Dots
+0x034E4 (Sound Room Left) - True - True
+0x034E3 (Sound Room Right) - True - Sound Dots
 Door - 0x2897B (Stairs) - 0x034E4 & 0x034E3
 
 Town RGB House Upstairs (Town RGB House Upstairs):
-158244 - 0x334D8 (RGB Control) - True - Rotated Shapers & Colored Squares
-158245 - 0x03C0C (Left) - 0x334D8 - Colored Squares & Black/White Squares
-158246 - 0x03C08 (Right) - 0x334D8 - Stars
+0x334D8 (RGB Control) - True - Rotated Shapers & Colored Squares
+0x03C0C (Left) - 0x334D8 - Colored Squares & Black/White Squares
+0x03C08 (Right) - 0x334D8 - Stars
 
 Town Tower Bottom (Town Tower) - Town - True - Town Tower After First Door - 0x27799:
 Door - 0x27799 (First Door) - 0x28A69
@@ -604,42 +604,42 @@ Town Tower After Third Door (Town Tower) - Town Tower Top - 0x2779A:
 Door - 0x2779A (Fourth Door) - 0x28B39
 
 Town Tower Top (Town):
-158708 - 0x032F5 (Laser Panel) - True - True
+0x032F5 (Laser Panel) - True - True
 Laser - 0x032F9 (Laser) - 0x032F5
-159422 - 0x33692 (Brown Bridge EP) - True - True
-159551 - 0x03BCE (Black Line Tower EP) - True - True
+0x33692 (Brown Bridge EP) - True - True
+0x03BCE (Black Line Tower EP) - True - True
 
 ==Windmill & Theater==
 
 Outside Windmill (Windmill) - Windmill Interior - 0x1845B:
-159010 - 0x037B6 (First Blade EP) - 0x17D02 - True
-159011 - 0x037B2 (Second Blade EP) - 0x17D02 - True
-159012 - 0x000F7 (Third Blade EP) - 0x17D02 - True
-158241 - 0x17F5F (Entry Panel) - True - Dots
+0x037B6 (First Blade EP) - 0x17D02 - True
+0x037B2 (Second Blade EP) - 0x17D02 - True
+0x000F7 (Third Blade EP) - 0x17D02 - True
+0x17F5F (Entry Panel) - True - Dots
 Door - 0x1845B (Entry) - 0x17F5F
 
 Windmill Interior (Windmill) - Theater - 0x17F88:
-158247 - 0x17D02 (Turn Control) - True - Dots
-158248 - 0x17F89 (Theater Entry Panel) - True - Black/White Squares
+0x17D02 (Turn Control) - True - Dots
+0x17F89 (Theater Entry Panel) - True - Black/White Squares
 Door - 0x17F88 (Theater Entry) - 0x17F89
 
 Theater (Theater) - Town - 0x0A16D | 0x3CCDF:
-158656 - 0x00815 (Video Input) - True - True
-158657 - 0x03553 (Tutorial Video) - 0x00815 & 0x03481 - True
-158658 - 0x03552 (Desert Video) - 0x00815 & 0x0339E - True
-158659 - 0x0354E (Jungle Video) - 0x00815 & 0x03702 - True
-158660 - 0x03549 (Challenge Video) - 0x00815 & 0x0356B - True
-158661 - 0x0354F (Shipwreck Video) - 0x00815 & 0x03535 - True
-158662 - 0x03545 (Mountain Video) - 0x00815 & 0x03542 - True
-158249 - 0x0A168 (Exit Left Panel) - True - Black/White Squares & Eraser
-158250 - 0x33AB2 (Exit Right Panel) - True - Black/White Squares & Shapers
+0x00815 (Video Input) - True - True
+0x03553 (Tutorial Video) - 0x00815 & 0x03481 - True
+0x03552 (Desert Video) - 0x00815 & 0x0339E - True
+0x0354E (Jungle Video) - 0x00815 & 0x03702 - True
+0x03549 (Challenge Video) - 0x00815 & 0x0356B - True
+0x0354F (Shipwreck Video) - 0x00815 & 0x03535 - True
+0x03545 (Mountain Video) - 0x00815 & 0x03542 - True
+0x0A168 (Exit Left Panel) - True - Black/White Squares & Eraser
+0x33AB2 (Exit Right Panel) - True - Black/White Squares & Shapers
 Door - 0x0A16D (Exit Left) - 0x0A168
 Door - 0x3CCDF (Exit Right) - 0x33AB2
-158608 - 0x17CF7 (Discard) - True - Triangles
-159554 - 0x339B6 (Eclipse EP) - 0x03549 & 0x0A16D & 0x3CCDF - True
-159555 - 0x33A29 (Window EP) - 0x03553 - True
-159556 - 0x33A2A (Door EP) - 0x03553 - True
-159558 - 0x33B06 (Church EP) - 0x0354E - True
+0x17CF7 (Discard) - True - Triangles
+0x339B6 (Eclipse EP) - 0x03549 & 0x0A16D & 0x3CCDF - True
+0x33A29 (Window EP) - 0x03553 - True
+0x33A2A (Door EP) - 0x03553 - True
+0x33B06 (Church EP) - 0x0354E - True
 
 ==Southern Peninsula==
 
@@ -648,595 +648,595 @@ Southern Peninsula (Southern Peninsula) - Main Island - True:
 ==Jungle==
 
 Jungle (Jungle) - Main Island - True - The Ocean - 0x17CDF - Jungle Under Popup Wall - 0x1475B:
-158251 - 0x17CDF (Shore Boat Spawn) - True - Boat
-158609 - 0x17F9B (Discard) - True - Triangles
-158252 - 0x002C4 (First Row 1) - True - True
-158253 - 0x00767 (First Row 2) - 0x002C4 - True
-158254 - 0x002C6 (First Row 3) - 0x00767 - True
-158255 - 0x0070E (Second Row 1) - 0x002C6 - True
-158256 - 0x0070F (Second Row 2) - 0x0070E - True
-158257 - 0x0087D (Second Row 3) - 0x0070F - True
-158258 - 0x002C7 (Second Row 4) - 0x0087D - True
-158259 - 0x17CAB (Popup Wall Control) - 0x002C7 - True
+0x17CDF (Shore Boat Spawn) - True - Boat
+0x17F9B (Discard) - True - Triangles
+0x002C4 (First Row 1) - True - True
+0x00767 (First Row 2) - 0x002C4 - True
+0x002C6 (First Row 3) - 0x00767 - True
+0x0070E (Second Row 1) - 0x002C6 - True
+0x0070F (Second Row 2) - 0x0070E - True
+0x0087D (Second Row 3) - 0x0070F - True
+0x002C7 (Second Row 4) - 0x0087D - True
+0x17CAB (Popup Wall Control) - 0x002C7 - True
 Door - 0x1475B (Popup Wall) - 0x17CAB
-158260 - 0x0026D (Popup Wall 1) - 0x1475B - Sound Dots
-158261 - 0x0026E (Popup Wall 2) - 0x0026D - Sound Dots
-158262 - 0x0026F (Popup Wall 3) - 0x0026E - Sound Dots
-158263 - 0x00C3F (Popup Wall 4) - 0x0026F - Sound Dots
-158264 - 0x00C41 (Popup Wall 5) - 0x00C3F - Sound Dots
-158265 - 0x014B2 (Popup Wall 6) - 0x00C41 - Sound Dots
-158709 - 0x03616 (Laser Panel) - 0x014B2 - True
+0x0026D (Popup Wall 1) - 0x1475B - Sound Dots
+0x0026E (Popup Wall 2) - 0x0026D - Sound Dots
+0x0026F (Popup Wall 3) - 0x0026E - Sound Dots
+0x00C3F (Popup Wall 4) - 0x0026F - Sound Dots
+0x00C41 (Popup Wall 5) - 0x00C3F - Sound Dots
+0x014B2 (Popup Wall 6) - 0x00C41 - Sound Dots
+0x03616 (Laser Panel) - 0x014B2 - True
 Laser - 0x00274 (Laser) - 0x03616
-158266 - 0x337FA (Laser Shortcut Panel) - True - True
+0x337FA (Laser Shortcut Panel) - True - True
 Door - 0x3873B (Laser Shortcut) - 0x337FA
-159100 - 0x03ABC (Long Arch Moss EP) - True - True
-159101 - 0x03ABE (Straight Left Moss EP) - True - True
-159102 - 0x03AC0 (Pop-up Wall Moss EP) - True - True
-159103 - 0x03AC4 (Short Arch Moss EP) - True - True
-159150 - 0x289F4 (Entrance EP) - True - True
-159151 - 0x289F5 (Tree Halo EP) - True - True
-159350 - 0x035CB (Bamboo CCW EP) - True - True
-159351 - 0x035CF (Bamboo CW EP) - True - True
+0x03ABC (Long Arch Moss EP) - True - True
+0x03ABE (Straight Left Moss EP) - True - True
+0x03AC0 (Pop-up Wall Moss EP) - True - True
+0x03AC4 (Short Arch Moss EP) - True - True
+0x289F4 (Entrance EP) - True - True
+0x289F5 (Tree Halo EP) - True - True
+0x035CB (Bamboo CCW EP) - True - True
+0x035CF (Bamboo CW EP) - True - True
 
 Jungle Under Popup Wall (Jungle):
 
 Outside Jungle River (Jungle) - Main Island - True - Monastery Garden - 0x0CF2A - Jungle Vault - 0x15287:
-158267 - 0x17CAA (Monastery Garden Shortcut Panel) - True - True
+0x17CAA (Monastery Garden Shortcut Panel) - True - True
 Door - 0x0CF2A (Monastery Garden Shortcut) - 0x17CAA
-158663 - 0x15ADD (Vault Panel) - True - Black/White Squares & Dots
+0x15ADD (Vault Panel) - True - Black/White Squares & Dots
 Door - 0x15287 (Vault Door) - 0x15ADD
-159110 - 0x03AC5 (Green Leaf Moss EP) - True - True
+0x03AC5 (Green Leaf Moss EP) - True - True
 
 Jungle Vault (Jungle):
-158664 - 0x03702 (Vault Box) - True - True
+0x03702 (Vault Box) - True - True
 
 ==Bunker==
 
 Outside Bunker (Bunker) - Main Island - True - Bunker - 0x0C2A4:
-158268 - 0x17C2E (Entry Panel) - True - Black/White Squares
+0x17C2E (Entry Panel) - True - Black/White Squares
 Door - 0x0C2A4 (Entry) - 0x17C2E
 
 Bunker (Bunker) - Bunker Glass Room - 0x17C79:
-158269 - 0x09F7D (Intro Left 1) - True - Colored Squares
-158270 - 0x09FDC (Intro Left 2) - 0x09F7D - Colored Squares & Black/White Squares
-158271 - 0x09FF7 (Intro Left 3) - 0x09FDC - Colored Squares & Black/White Squares
-158272 - 0x09F82 (Intro Left 4) - 0x09FF7 - Colored Squares & Black/White Squares
-158273 - 0x09FF8 (Intro Left 5) - 0x09F82 - Colored Squares & Black/White Squares
-158274 - 0x09D9F (Intro Back 1) - 0x09FF8 - Colored Squares & Black/White Squares
-158275 - 0x09DA1 (Intro Back 2) - 0x09D9F - Colored Squares
-158276 - 0x09DA2 (Intro Back 3) - 0x09DA1 - Colored Squares
-158277 - 0x09DAF (Intro Back 4) - 0x09DA2 - Colored Squares
-158278 - 0x0A099 (Tinted Glass Door Panel) - 0x09DAF - True
+0x09F7D (Intro Left 1) - True - Colored Squares
+0x09FDC (Intro Left 2) - 0x09F7D - Colored Squares & Black/White Squares
+0x09FF7 (Intro Left 3) - 0x09FDC - Colored Squares & Black/White Squares
+0x09F82 (Intro Left 4) - 0x09FF7 - Colored Squares & Black/White Squares
+0x09FF8 (Intro Left 5) - 0x09F82 - Colored Squares & Black/White Squares
+0x09D9F (Intro Back 1) - 0x09FF8 - Colored Squares & Black/White Squares
+0x09DA1 (Intro Back 2) - 0x09D9F - Colored Squares
+0x09DA2 (Intro Back 3) - 0x09DA1 - Colored Squares
+0x09DAF (Intro Back 4) - 0x09DA2 - Colored Squares
+0x0A099 (Tinted Glass Door Panel) - 0x09DAF - True
 Door - 0x17C79 (Tinted Glass Door) - 0x0A099
 
 Bunker Glass Room (Bunker) - Bunker Ultraviolet Room - 0x0C2A3:
-158279 - 0x0A010 (Glass Room 1) - 0x17C79 - Colored Squares
-158280 - 0x0A01B (Glass Room 2) - 0x17C79 & 0x0A010 - Colored Squares & Black/White Squares
-158281 - 0x0A01F (Glass Room 3) - 0x17C79 & 0x0A01B - Colored Squares & Black/White Squares
+0x0A010 (Glass Room 1) - 0x17C79 - Colored Squares
+0x0A01B (Glass Room 2) - 0x17C79 & 0x0A010 - Colored Squares & Black/White Squares
+0x0A01F (Glass Room 3) - 0x17C79 & 0x0A01B - Colored Squares & Black/White Squares
 Door - 0x0C2A3 (UV Room Entry) - 0x0A01F
 
 Bunker Ultraviolet Room (Bunker) - Bunker Elevator Section - 0x0A08D:
-158282 - 0x34BC5 (Drop-Down Door Open) - True - True
-158283 - 0x34BC6 (Drop-Down Door Close) - 0x34BC5 - True
-158284 - 0x17E63 (UV Room 1) - 0x34BC5 - Colored Squares
-158285 - 0x17E67 (UV Room 2) - 0x17E63 & 0x34BC6 - Colored Squares & Black/White Squares
+0x34BC5 (Drop-Down Door Open) - True - True
+0x34BC6 (Drop-Down Door Close) - 0x34BC5 - True
+0x17E63 (UV Room 1) - 0x34BC5 - Colored Squares
+0x17E67 (UV Room 2) - 0x17E63 & 0x34BC6 - Colored Squares & Black/White Squares
 Door - 0x0A08D (Elevator Room Entry) - 0x17E67
 
 Bunker Elevator Section (Bunker) - Bunker Elevator - TrueOneWay - Bunker Under Elevator - 0x0A079 | Bunker Green Room | Bunker Cyan Room | Bunker Laser Platform:
-159311 - 0x035F5 (Tinted Door EP) - 0x17C79 - True
+0x035F5 (Tinted Door EP) - 0x17C79 - True
 
 Bunker Under Elevator (Bunker):
 
 Bunker Elevator (Bunker) - Bunker Elevator Section - 0x0A079 - Bunker Cyan Room - 0x0A079 - Bunker Green Room - 0x0A079 - Bunker Laser Platform - 0x0A079 - Outside Bunker - 0x0A079:
-158286 - 0x0A079 (Elevator Control) - True - Colored Squares & Black/White Squares
+0x0A079 (Elevator Control) - True - Colored Squares & Black/White Squares
 
 Bunker Cyan Room (Bunker) - Bunker Elevator - TrueOneWay:
 
 Bunker Green Room (Bunker) - Bunker Elevator - TrueOneWay:
-159310 - 0x000D3 (Green Room Flowers EP) - True - True
+0x000D3 (Green Room Flowers EP) - True - True
 
 Bunker Laser Platform (Bunker) - Bunker Elevator - TrueOneWay:
-158710 - 0x09DE0 (Laser Panel) - True - True
+0x09DE0 (Laser Panel) - True - True
 Laser - 0x0C2B2 (Laser) - 0x09DE0
 
 ==Swamp==
 
 Outside Swamp (Swamp) - Swamp Entry Area - 0x00C1C - Main Island - True:
-158287 - 0x0056E (Entry Panel) - True - Shapers
+0x0056E (Entry Panel) - True - Shapers
 Door - 0x00C1C (Entry) - 0x0056E
-159321 - 0x03603 (Purple Sand Middle EP) - 0x17E2B - True
-159322 - 0x03601 (Purple Sand Top EP) - 0x17E2B - True
-159327 - 0x035DE (Purple Sand Bottom EP) - True - True
+0x03603 (Purple Sand Middle EP) - 0x17E2B - True
+0x03601 (Purple Sand Top EP) - 0x17E2B - True
+0x035DE (Purple Sand Bottom EP) - True - True
 
 Swamp Entry Area (Swamp) - Swamp Sliding Bridge - TrueOneWay:
-158288 - 0x00469 (Intro Front 1) - True - Shapers
-158289 - 0x00472 (Intro Front 2) - 0x00469 - Shapers
-158290 - 0x00262 (Intro Front 3) - 0x00472 - Shapers
-158291 - 0x00474 (Intro Front 4) - 0x00262 - Shapers
-158292 - 0x00553 (Intro Front 5) - 0x00474 - Shapers
-158293 - 0x0056F (Intro Front 6) - 0x00553 - Shapers
-158294 - 0x00390 (Intro Back 1) - 0x0056F - Shapers
-158295 - 0x010CA (Intro Back 2) - 0x00390 - Shapers
-158296 - 0x00983 (Intro Back 3) - 0x010CA - Shapers
-158297 - 0x00984 (Intro Back 4) - 0x00983 - Shapers
-158298 - 0x00986 (Intro Back 5) - 0x00984 - Shapers
-158299 - 0x00985 (Intro Back 6) - 0x00986 - Shapers
-158300 - 0x00987 (Intro Back 7) - 0x00985 - Shapers
-158301 - 0x181A9 (Intro Back 8) - 0x00987 - Shapers
+0x00469 (Intro Front 1) - True - Shapers
+0x00472 (Intro Front 2) - 0x00469 - Shapers
+0x00262 (Intro Front 3) - 0x00472 - Shapers
+0x00474 (Intro Front 4) - 0x00262 - Shapers
+0x00553 (Intro Front 5) - 0x00474 - Shapers
+0x0056F (Intro Front 6) - 0x00553 - Shapers
+0x00390 (Intro Back 1) - 0x0056F - Shapers
+0x010CA (Intro Back 2) - 0x00390 - Shapers
+0x00983 (Intro Back 3) - 0x010CA - Shapers
+0x00984 (Intro Back 4) - 0x00983 - Shapers
+0x00986 (Intro Back 5) - 0x00984 - Shapers
+0x00985 (Intro Back 6) - 0x00986 - Shapers
+0x00987 (Intro Back 7) - 0x00985 - Shapers
+0x181A9 (Intro Back 8) - 0x00987 - Shapers
 
 Swamp Sliding Bridge (Swamp) - Swamp Entry Area - 0x00609 - Swamp Platform - 0x00609:
-158302 - 0x00609 (Sliding Bridge) - True - Shapers
-159342 - 0x0105D (Sliding Bridge Left EP) - 0x00609 - True
-159343 - 0x0A304 (Sliding Bridge Right EP) - 0x00609 - True
+0x00609 (Sliding Bridge) - True - Shapers
+0x0105D (Sliding Bridge Left EP) - 0x00609 - True
+0x0A304 (Sliding Bridge Right EP) - 0x00609 - True
 
 Swamp Platform (Swamp) - Swamp Cyan Underwater - 0x04B7F - Swamp Near Boat - 0x38AE6 - Swamp Between Bridges Near - 0x184B7 - Swamp Sliding Bridge - TrueOneWay:
-158313 - 0x00982 (Platform Row 1) - True - Shapers
-158314 - 0x0097F (Platform Row 2) - 0x00982 - Shapers
-158315 - 0x0098F (Platform Row 3) - 0x0097F - Shapers
-158316 - 0x00990 (Platform Row 4) - 0x0098F - Shapers
+0x00982 (Platform Row 1) - True - Shapers
+0x0097F (Platform Row 2) - 0x00982 - Shapers
+0x0098F (Platform Row 3) - 0x0097F - Shapers
+0x00990 (Platform Row 4) - 0x0098F - Shapers
 Door - 0x184B7 (Between Bridges First Door) - 0x00990
-158317 - 0x17C0D (Platform Shortcut Left Panel) - True - Shapers
-158318 - 0x17C0E (Platform Shortcut Right Panel) - 0x17C0D - Shapers
+0x17C0D (Platform Shortcut Left Panel) - True - Shapers
+0x17C0E (Platform Shortcut Right Panel) - 0x17C0D - Shapers
 Door - 0x38AE6 (Platform Shortcut) - 0x17C0E
 Door - 0x04B7F (Cyan Water Pump) - 0x00006
 
 Swamp Cyan Underwater (Swamp):
-158307 - 0x00002 (Cyan Underwater 1) - True - Shapers & Negative Shapers
-158308 - 0x00004 (Cyan Underwater 2) - 0x00002 - Shapers & Negative Shapers
-158309 - 0x00005 (Cyan Underwater 3) - 0x00004 - Shapers & Negative Shapers
-158310 - 0x013E6 (Cyan Underwater 4) - 0x00005 - Shapers & Negative Shapers
-158311 - 0x00596 (Cyan Underwater 5) - 0x013E6 - Shapers & Negative Shapers
-158312 - 0x18488 (Cyan Underwater Sliding Bridge Control) - True - Shapers
-159340 - 0x03AA6 (Cyan Underwater Sliding Bridge EP) - 0x18488 - True
+0x00002 (Cyan Underwater 1) - True - Shapers & Negative Shapers
+0x00004 (Cyan Underwater 2) - 0x00002 - Shapers & Negative Shapers
+0x00005 (Cyan Underwater 3) - 0x00004 - Shapers & Negative Shapers
+0x013E6 (Cyan Underwater 4) - 0x00005 - Shapers & Negative Shapers
+0x00596 (Cyan Underwater 5) - 0x013E6 - Shapers & Negative Shapers
+0x18488 (Cyan Underwater Sliding Bridge Control) - True - Shapers
+0x03AA6 (Cyan Underwater Sliding Bridge EP) - 0x18488 - True
 
 Swamp Between Bridges Near (Swamp) - Swamp Between Bridges Far - 0x18507:
-158303 - 0x00999 (Between Bridges Near Row 1) - 0x00990 - Shapers
-158304 - 0x0099D (Between Bridges Near Row 2) - 0x00999 - Shapers
-158305 - 0x009A0 (Between Bridges Near Row 3) - 0x0099D - Shapers
-158306 - 0x009A1 (Between Bridges Near Row 4) - 0x009A0 - Shapers
+0x00999 (Between Bridges Near Row 1) - 0x00990 - Shapers
+0x0099D (Between Bridges Near Row 2) - 0x00999 - Shapers
+0x009A0 (Between Bridges Near Row 3) - 0x0099D - Shapers
+0x009A1 (Between Bridges Near Row 4) - 0x009A0 - Shapers
 Door - 0x18507 (Between Bridges Second Door) - 0x009A1
 
 Swamp Between Bridges Far (Swamp) - Swamp Red Underwater - 0x183F2 - Swamp Rotating Bridge - TrueOneWay:
-158319 - 0x00007 (Between Bridges Far Row 1) - 0x009A1 - Rotated Shapers
-158320 - 0x00008 (Between Bridges Far Row 2) - 0x00007 - Rotated Shapers & Shapers
-158321 - 0x00009 (Between Bridges Far Row 3) - 0x00008 - Rotated Shapers
-158322 - 0x0000A (Between Bridges Far Row 4) - 0x00009 - Rotated Shapers
+0x00007 (Between Bridges Far Row 1) - 0x009A1 - Rotated Shapers
+0x00008 (Between Bridges Far Row 2) - 0x00007 - Rotated Shapers & Shapers
+0x00009 (Between Bridges Far Row 3) - 0x00008 - Rotated Shapers
+0x0000A (Between Bridges Far Row 4) - 0x00009 - Rotated Shapers
 Door - 0x183F2 (Red Water Pump) - 0x00596
 
 Swamp Red Underwater (Swamp) - Swamp Maze - 0x305D5:
-158323 - 0x00001 (Red Underwater 1) - True - Shapers & Negative Shapers
-158324 - 0x014D2 (Red Underwater 2) - True - Shapers & Negative Shapers
-158325 - 0x014D4 (Red Underwater 3) - True - Shapers & Negative Shapers
-158326 - 0x014D1 (Red Underwater 4) - True - Shapers & Negative Shapers
+0x00001 (Red Underwater 1) - True - Shapers & Negative Shapers
+0x014D2 (Red Underwater 2) - True - Shapers & Negative Shapers
+0x014D4 (Red Underwater 3) - True - Shapers & Negative Shapers
+0x014D1 (Red Underwater 4) - True - Shapers & Negative Shapers
 Door - 0x305D5 (Red Underwater Exit) - 0x014D1
 
 Swamp Rotating Bridge (Swamp) - Swamp Between Bridges Far - 0x181F5 - Swamp Near Boat - 0x181F5 - Swamp Purple Area - 0x181F5:
-158327 - 0x181F5 (Rotating Bridge) - True - Rotated Shapers & Shapers
-159331 - 0x016B2 (Rotating Bridge CCW EP) - 0x181F5 - True
-159334 - 0x036CE (Rotating Bridge CW EP) - 0x181F5 - True
+0x181F5 (Rotating Bridge) - True - Rotated Shapers & Shapers
+0x016B2 (Rotating Bridge CCW EP) - 0x181F5 - True
+0x036CE (Rotating Bridge CW EP) - 0x181F5 - True
 
 Swamp Near Boat (Swamp) - Swamp Rotating Bridge - TrueOneWay - Swamp Blue Underwater - 0x18482 - Swamp Long Bridge - 0xFFD00 & 0xFFD02 - The Ocean - 0x09DB8:
-159803 - 0xFFD02 (Beyond Rotating Bridge Reached Independently) - True - True
-158328 - 0x09DB8 (Boat Spawn) - True - Boat
-158329 - 0x003B2 (Beyond Rotating Bridge 1) - 0x0000A - Rotated Shapers
-158330 - 0x00A1E (Beyond Rotating Bridge 2) - 0x003B2 - Rotated Shapers
-158331 - 0x00C2E (Beyond Rotating Bridge 3) - 0x00A1E - Rotated Shapers
-158332 - 0x00E3A (Beyond Rotating Bridge 4) - 0x00C2E - Rotated Shapers
+0xFFD02 (Beyond Rotating Bridge Reached Independently) - True - True
+0x09DB8 (Boat Spawn) - True - Boat
+0x003B2 (Beyond Rotating Bridge 1) - 0x0000A - Rotated Shapers
+0x00A1E (Beyond Rotating Bridge 2) - 0x003B2 - Rotated Shapers
+0x00C2E (Beyond Rotating Bridge 3) - 0x00A1E - Rotated Shapers
+0x00E3A (Beyond Rotating Bridge 4) - 0x00C2E - Rotated Shapers
 Door - 0x18482 (Blue Water Pump) - 0x00E3A
-159332 - 0x3365F (Boat EP) - 0x09DB8 - True
-159333 - 0x03731 (Long Bridge Side EP) - 0x17E2B - True
+0x3365F (Boat EP) - 0x09DB8 - True
+0x03731 (Long Bridge Side EP) - 0x17E2B - True
 
 Swamp Long Bridge (Swamp) - Swamp Near Boat - 0x17E2B - Outside Swamp - 0x17E2B:
-158339 - 0x17E2B (Long Bridge Control) - True - Rotated Shapers & Shapers
+0x17E2B (Long Bridge Control) - True - Rotated Shapers & Shapers
 
 Swamp Purple Area (Swamp) - Swamp Rotating Bridge - TrueOneWay - Swamp Purple Underwater - 0x0A1D6 - Swamp Near Boat - TrueOneWay:
 Door - 0x0A1D6 (Purple Water Pump) - 0x00E3A
 
 Swamp Purple Underwater (Swamp):
-158333 - 0x009A6 (Purple Underwater) - True - Shapers
-159330 - 0x03A9E (Purple Underwater Right EP) - True - True
-159336 - 0x03A93 (Purple Underwater Left EP) - True - True
+0x009A6 (Purple Underwater) - True - Shapers
+0x03A9E (Purple Underwater Right EP) - True - True
+0x03A93 (Purple Underwater Left EP) - True - True
 
 Swamp Blue Underwater (Swamp):
-158334 - 0x009AB (Blue Underwater 1) - True - Shapers & Negative Shapers
-158335 - 0x009AD (Blue Underwater 2) - 0x009AB - Shapers & Negative Shapers
-158336 - 0x009AE (Blue Underwater 3) - 0x009AD - Shapers & Negative Shapers
-158337 - 0x009AF (Blue Underwater 4) - 0x009AE - Shapers & Negative Shapers
-158338 - 0x00006 (Blue Underwater 5) - 0x009AF - Shapers & Negative Shapers
+0x009AB (Blue Underwater 1) - True - Shapers & Negative Shapers
+0x009AD (Blue Underwater 2) - 0x009AB - Shapers & Negative Shapers
+0x009AE (Blue Underwater 3) - 0x009AD - Shapers & Negative Shapers
+0x009AF (Blue Underwater 4) - 0x009AE - Shapers & Negative Shapers
+0x00006 (Blue Underwater 5) - 0x009AF - Shapers & Negative Shapers
 
 Swamp Maze (Swamp) - Swamp Laser Area - 0x17C0A & 0x17E07:
-158340 - 0x17C0A (Maze Control) - True - Shapers & Negative Shapers & Rotated Shapers
-158112 - 0x17E07 (Maze Control Other Side) - True - Shapers & Negative Shapers & Rotated Shapers
+0x17C0A (Maze Control) - True - Shapers & Negative Shapers & Rotated Shapers
+0x17E07 (Maze Control Other Side) - True - Shapers & Negative Shapers & Rotated Shapers
 
 Swamp Laser Area (Swamp) - Outside Swamp - 0x2D880:
-158711 - 0x03615 (Laser Panel) - True - True
+0x03615 (Laser Panel) - True - True
 Laser - 0x00BF6 (Laser) - 0x03615
-158341 - 0x17C05 (Laser Shortcut Left Panel) - True - Rotated Shapers
-158342 - 0x17C02 (Laser Shortcut Right Panel) - 0x17C05 - Shapers & Negative Shapers & Rotated Shapers
+0x17C05 (Laser Shortcut Left Panel) - True - Rotated Shapers
+0x17C02 (Laser Shortcut Right Panel) - 0x17C05 - Shapers & Negative Shapers & Rotated Shapers
 Door - 0x2D880 (Laser Shortcut) - 0x17C02
 
 ==Treehouse==
 
 Treehouse Obelisk (Treehouse) - Entry - True:
-159720 - 0xFFE20 (Obelisk Side 1) - 0x0053D & 0x0053E & 0x00769 - True
-159721 - 0xFFE21 (Obelisk Side 2) - 0x33721 & 0x220A7 & 0x220BD - True
-159722 - 0xFFE22 (Obelisk Side 3) - 0x03B22 & 0x03B23 & 0x03B24 & 0x03B25 & 0x03A79 & 0x28ABD & 0x28ABE - True
-159723 - 0xFFE23 (Obelisk Side 4) - 0x3388F & 0x28B29 & 0x28B2A - True
-159724 - 0xFFE24 (Obelisk Side 5) - 0x018B6 & 0x033BE & 0x033BF & 0x033DD & 0x033E5 - True
-159725 - 0xFFE25 (Obelisk Side 6) - 0x28AE9 & 0x3348F - True
-159729 - 0x00097 (Obelisk) - True - True
+0xFFE20 (Obelisk Side 1) - 0x0053D & 0x0053E & 0x00769 - True
+0xFFE21 (Obelisk Side 2) - 0x33721 & 0x220A7 & 0x220BD - True
+0xFFE22 (Obelisk Side 3) - 0x03B22 & 0x03B23 & 0x03B24 & 0x03B25 & 0x03A79 & 0x28ABD & 0x28ABE - True
+0xFFE23 (Obelisk Side 4) - 0x3388F & 0x28B29 & 0x28B2A - True
+0xFFE24 (Obelisk Side 5) - 0x018B6 & 0x033BE & 0x033BF & 0x033DD & 0x033E5 - True
+0xFFE25 (Obelisk Side 6) - 0x28AE9 & 0x3348F - True
+0x00097 (Obelisk) - True - True
 
 Treehouse Beach (Treehouse Beach) - Main Island - True:
-159200 - 0x0053D (Rock Shadow EP) - True - True
-159201 - 0x0053E (Sand Shadow EP) - True - True
-159212 - 0x220BD (Both Orange Bridges EP) - 0x17DA2 & 0x17DDB - True
+0x0053D (Rock Shadow EP) - True - True
+0x0053E (Sand Shadow EP) - True - True
+0x220BD (Both Orange Bridges EP) - 0x17DA2 & 0x17DDB - True
 
 Treehouse Entry Area (Treehouse) - Treehouse Between Entry Doors - 0x0C309 - The Ocean - 0x17C95:
-158343 - 0x17C95 (Boat Spawn) - True - Boat
-158344 - 0x0288C (First Door Panel) - True - Stars
+0x17C95 (Boat Spawn) - True - Boat
+0x0288C (First Door Panel) - True - Stars
 Door - 0x0C309 (First Door) - 0x0288C
-159210 - 0x33721 (Buoy EP) - 0x17C95 - True
+0x33721 (Buoy EP) - 0x17C95 - True
 
 Treehouse Between Entry Doors (Treehouse) - Treehouse Yellow Bridge - 0x0C310:
-158345 - 0x02886 (Second Door Panel) - True - Stars
+0x02886 (Second Door Panel) - True - Stars
 Door - 0x0C310 (Second Door) - 0x02886
 
 Treehouse Yellow Bridge (Treehouse) - Treehouse After Yellow Bridge - 0x17DC4:
-158346 - 0x17D72 (Yellow Bridge 1) - True - Stars
-158347 - 0x17D8F (Yellow Bridge 2) - 0x17D72 - Stars
-158348 - 0x17D74 (Yellow Bridge 3) - 0x17D8F - Stars
-158349 - 0x17DAC (Yellow Bridge 4) - 0x17D74 - Stars
-158350 - 0x17D9E (Yellow Bridge 5) - 0x17DAC - Stars
-158351 - 0x17DB9 (Yellow Bridge 6) - 0x17D9E - Stars
-158352 - 0x17D9C (Yellow Bridge 7) - 0x17DB9 - Stars
-158353 - 0x17DC2 (Yellow Bridge 8) - 0x17D9C - Stars
-158354 - 0x17DC4 (Yellow Bridge 9) - 0x17DC2 - Stars
+0x17D72 (Yellow Bridge 1) - True - Stars
+0x17D8F (Yellow Bridge 2) - 0x17D72 - Stars
+0x17D74 (Yellow Bridge 3) - 0x17D8F - Stars
+0x17DAC (Yellow Bridge 4) - 0x17D74 - Stars
+0x17D9E (Yellow Bridge 5) - 0x17DAC - Stars
+0x17DB9 (Yellow Bridge 6) - 0x17D9E - Stars
+0x17D9C (Yellow Bridge 7) - 0x17DB9 - Stars
+0x17DC2 (Yellow Bridge 8) - 0x17D9C - Stars
+0x17DC4 (Yellow Bridge 9) - 0x17DC2 - Stars
 
 Treehouse After Yellow Bridge (Treehouse) - Treehouse Junction - 0x0A181:
-158355 - 0x0A182 (Third Door Panel) - True - Stars
+0x0A182 (Third Door Panel) - True - Stars
 Door - 0x0A181 (Third Door) - 0x0A182
 
 Treehouse Junction (Treehouse) - Treehouse Right Orange Bridge - True - Treehouse First Purple Bridge - True - Treehouse Green Bridge - True:
-158356 - 0x2700B (Laser House Door Timer Outside) - True - True
+0x2700B (Laser House Door Timer Outside) - True - True
 
 Treehouse First Purple Bridge (Treehouse) - Treehouse Second Purple Bridge - 0x17D6C:
-158357 - 0x17DC8 (First Purple Bridge 1) - True - Stars & Dots
-158358 - 0x17DC7 (First Purple Bridge 2) - 0x17DC8 - Stars & Dots
-158359 - 0x17CE4 (First Purple Bridge 3) - 0x17DC7 - Stars & Dots
-158360 - 0x17D2D (First Purple Bridge 4) - 0x17CE4 - Stars & Dots
-158361 - 0x17D6C (First Purple Bridge 5) - 0x17D2D - Stars & Dots
+0x17DC8 (First Purple Bridge 1) - True - Stars & Dots
+0x17DC7 (First Purple Bridge 2) - 0x17DC8 - Stars & Dots
+0x17CE4 (First Purple Bridge 3) - 0x17DC7 - Stars & Dots
+0x17D2D (First Purple Bridge 4) - 0x17CE4 - Stars & Dots
+0x17D6C (First Purple Bridge 5) - 0x17D2D - Stars & Dots
 
 Treehouse Right Orange Bridge (Treehouse) - Treehouse Drawbridge Platform - 0x17DA2:
-158391 - 0x17D88 (Right Orange Bridge 1) - True - Stars
-158392 - 0x17DB4 (Right Orange Bridge 2) - 0x17D88 - Stars
-158393 - 0x17D8C (Right Orange Bridge 3) - 0x17DB4 - Stars
-158394 - 0x17CE3 (Right Orange Bridge 4 & Directional) - 0x17D8C - Stars
-158395 - 0x17DCD (Right Orange Bridge 5) - 0x17CE3 - Stars
-158396 - 0x17DB2 (Right Orange Bridge 6) - 0x17DCD - Stars
-158397 - 0x17DCC (Right Orange Bridge 7) - 0x17DB2 - Stars
-158398 - 0x17DCA (Right Orange Bridge 8) - 0x17DCC - Stars
-158399 - 0x17D8E (Right Orange Bridge 9) - 0x17DCA - Stars
-158400 - 0x17DB7 (Right Orange Bridge 10 & Directional) - 0x17D8E - Stars
-158401 - 0x17DB1 (Right Orange Bridge 11) - 0x17DB7 - Stars
-158402 - 0x17DA2 (Right Orange Bridge 12) - 0x17DB1 - Stars
+0x17D88 (Right Orange Bridge 1) - True - Stars
+0x17DB4 (Right Orange Bridge 2) - 0x17D88 - Stars
+0x17D8C (Right Orange Bridge 3) - 0x17DB4 - Stars
+0x17CE3 (Right Orange Bridge 4 & Directional) - 0x17D8C - Stars
+0x17DCD (Right Orange Bridge 5) - 0x17CE3 - Stars
+0x17DB2 (Right Orange Bridge 6) - 0x17DCD - Stars
+0x17DCC (Right Orange Bridge 7) - 0x17DB2 - Stars
+0x17DCA (Right Orange Bridge 8) - 0x17DCC - Stars
+0x17D8E (Right Orange Bridge 9) - 0x17DCA - Stars
+0x17DB7 (Right Orange Bridge 10 & Directional) - 0x17D8E - Stars
+0x17DB1 (Right Orange Bridge 11) - 0x17DB7 - Stars
+0x17DA2 (Right Orange Bridge 12) - 0x17DB1 - Stars
 
 Treehouse Drawbridge Platform (Treehouse) - Main Island - 0x0C32D:
-158404 - 0x037FF (Drawbridge Panel) - True - Stars
+0x037FF (Drawbridge Panel) - True - Stars
 Door - 0x0C32D (Drawbridge) - 0x037FF
 
 Treehouse Second Purple Bridge (Treehouse) - Treehouse Left Orange Bridge - 0x17DC6:
-158362 - 0x17D9B (Second Purple Bridge 1) - True - Stars & Black/White Squares
-158363 - 0x17D99 (Second Purple Bridge 2) - 0x17D9B - Stars & Black/White Squares
-158364 - 0x17DAA (Second Purple Bridge 3) - 0x17D99 - Stars & Black/White Squares
-158365 - 0x17D97 (Second Purple Bridge 4) - 0x17DAA - Stars & Black/White Squares & Colored Squares
-158366 - 0x17BDF (Second Purple Bridge 5) - 0x17D97 - Stars & Colored Squares
-158367 - 0x17D91 (Second Purple Bridge 6) - 0x17BDF - Stars & Colored Squares
-158368 - 0x17DC6 (Second Purple Bridge 7) - 0x17D91 - Stars & Colored Squares
+0x17D9B (Second Purple Bridge 1) - True - Stars & Black/White Squares
+0x17D99 (Second Purple Bridge 2) - 0x17D9B - Stars & Black/White Squares
+0x17DAA (Second Purple Bridge 3) - 0x17D99 - Stars & Black/White Squares
+0x17D97 (Second Purple Bridge 4) - 0x17DAA - Stars & Black/White Squares & Colored Squares
+0x17BDF (Second Purple Bridge 5) - 0x17D97 - Stars & Colored Squares
+0x17D91 (Second Purple Bridge 6) - 0x17BDF - Stars & Colored Squares
+0x17DC6 (Second Purple Bridge 7) - 0x17D91 - Stars & Colored Squares
 
 Treehouse Left Orange Bridge (Treehouse) - Treehouse Laser Room Front Platform - 0x17DDB - Treehouse Laser Room Back Platform - 0x17DDB - Treehouse Burned House - 0x17DDB:
-158376 - 0x17DB3 (Left Orange Bridge 1) - True - Black/White Squares & Stars + Same Colored Symbol
-158377 - 0x17DB5 (Left Orange Bridge 2) - 0x17DB3 - Black/White Squares & Stars + Same Colored Symbol
-158378 - 0x17DB6 (Left Orange Bridge 3) - 0x17DB5 - Black/White Squares & Stars + Same Colored Symbol
-158379 - 0x17DC0 (Left Orange Bridge 4) - 0x17DB6 - Black/White Squares & Stars + Same Colored Symbol
-158380 - 0x17DD7 (Left Orange Bridge 5) - 0x17DC0 - Black/White Squares & Colored Squares & Stars + Same Colored Symbol
-158381 - 0x17DD9 (Left Orange Bridge 6) - 0x17DD7 - Black/White Squares & Colored Squares & Stars + Same Colored Symbol
-158382 - 0x17DB8 (Left Orange Bridge 7) - 0x17DD9 - Black/White Squares & Colored Squares & Stars + Same Colored Symbol
-158383 - 0x17DDC (Left Orange Bridge 8) - 0x17DB8 - Colored Squares & Stars + Same Colored Symbol
-158384 - 0x17DD1 (Left Orange Bridge 9 & Directional) - 0x17DDC - Colored Squares & Stars + Same Colored Symbol
-158385 - 0x17DDE (Left Orange Bridge 10) - 0x17DD1 - Colored Squares & Stars + Same Colored Symbol
-158386 - 0x17DE3 (Left Orange Bridge 11) - 0x17DDE - Colored Squares & Stars + Same Colored Symbol
-158387 - 0x17DEC (Left Orange Bridge 12) - 0x17DE3 - Black/White Squares & Stars + Same Colored Symbol
-158388 - 0x17DAE (Left Orange Bridge 13) - 0x17DEC - Black/White Squares & Stars + Same Colored Symbol
-158389 - 0x17DB0 (Left Orange Bridge 14) - 0x17DAE - Black/White Squares & Stars + Same Colored Symbol
-158390 - 0x17DDB (Left Orange Bridge 15) - 0x17DB0 - Black/White Squares & Stars + Same Colored Symbol
+0x17DB3 (Left Orange Bridge 1) - True - Black/White Squares & Stars + Same Colored Symbol
+0x17DB5 (Left Orange Bridge 2) - 0x17DB3 - Black/White Squares & Stars + Same Colored Symbol
+0x17DB6 (Left Orange Bridge 3) - 0x17DB5 - Black/White Squares & Stars + Same Colored Symbol
+0x17DC0 (Left Orange Bridge 4) - 0x17DB6 - Black/White Squares & Stars + Same Colored Symbol
+0x17DD7 (Left Orange Bridge 5) - 0x17DC0 - Black/White Squares & Colored Squares & Stars + Same Colored Symbol
+0x17DD9 (Left Orange Bridge 6) - 0x17DD7 - Black/White Squares & Colored Squares & Stars + Same Colored Symbol
+0x17DB8 (Left Orange Bridge 7) - 0x17DD9 - Black/White Squares & Colored Squares & Stars + Same Colored Symbol
+0x17DDC (Left Orange Bridge 8) - 0x17DB8 - Colored Squares & Stars + Same Colored Symbol
+0x17DD1 (Left Orange Bridge 9 & Directional) - 0x17DDC - Colored Squares & Stars + Same Colored Symbol
+0x17DDE (Left Orange Bridge 10) - 0x17DD1 - Colored Squares & Stars + Same Colored Symbol
+0x17DE3 (Left Orange Bridge 11) - 0x17DDE - Colored Squares & Stars + Same Colored Symbol
+0x17DEC (Left Orange Bridge 12) - 0x17DE3 - Black/White Squares & Stars + Same Colored Symbol
+0x17DAE (Left Orange Bridge 13) - 0x17DEC - Black/White Squares & Stars + Same Colored Symbol
+0x17DB0 (Left Orange Bridge 14) - 0x17DAE - Black/White Squares & Stars + Same Colored Symbol
+0x17DDB (Left Orange Bridge 15) - 0x17DB0 - Black/White Squares & Stars + Same Colored Symbol
 
 Treehouse Green Bridge (Treehouse) - Treehouse Green Bridge Front House - 0x17E61 - Treehouse Green Bridge Left House - 0x17E61:
-158369 - 0x17E3C (Green Bridge 1) - True - Stars & Shapers
-158370 - 0x17E4D (Green Bridge 2) - 0x17E3C - Stars & Shapers
-158371 - 0x17E4F (Green Bridge 3) - 0x17E4D - Stars & Shapers & Rotated Shapers
-158372 - 0x17E52 (Green Bridge 4 & Directional) - 0x17E4F - Stars & Rotated Shapers
-158373 - 0x17E5B (Green Bridge 5) - 0x17E52 - Shapers & Stars + Same Colored Symbol
-158374 - 0x17E5F (Green Bridge 6) - 0x17E5B - Shapers & Negative Shapers & Stars + Same Colored Symbol
-158375 - 0x17E61 (Green Bridge 7) - 0x17E5F - Stars & Shapers & Rotated Shapers
+0x17E3C (Green Bridge 1) - True - Stars & Shapers
+0x17E4D (Green Bridge 2) - 0x17E3C - Stars & Shapers
+0x17E4F (Green Bridge 3) - 0x17E4D - Stars & Shapers & Rotated Shapers
+0x17E52 (Green Bridge 4 & Directional) - 0x17E4F - Stars & Rotated Shapers
+0x17E5B (Green Bridge 5) - 0x17E52 - Shapers & Stars + Same Colored Symbol
+0x17E5F (Green Bridge 6) - 0x17E5B - Shapers & Negative Shapers & Stars + Same Colored Symbol
+0x17E61 (Green Bridge 7) - 0x17E5F - Stars & Shapers & Rotated Shapers
 
 Treehouse Green Bridge Front House (Treehouse):
-158610 - 0x17FA9 (Green Bridge Discard) - True - Triangles
+0x17FA9 (Green Bridge Discard) - True - Triangles
 
 Treehouse Green Bridge Left House (Treehouse):
-159211 - 0x220A7 (Right Orange Bridge EP) - 0x17DA2 - True
+0x220A7 (Right Orange Bridge EP) - 0x17DA2 - True
 
 Treehouse Laser Room Front Platform (Treehouse) - Treehouse Laser Room - 0x0C323:
 Door - 0x0C323 (Laser House Entry) - 0x17DA2 & 0x2700B & 0x17DDB | 0x17CBC
 
 Treehouse Laser Room Back Platform (Treehouse):
-158611 - 0x17FA0 (Laser Discard) - True - Triangles
+0x17FA0 (Laser Discard) - True - Triangles
 
 Treehouse Burned House (Treehouse):
-159202 - 0x00769 (Burned House Beach EP) - True - True
+0x00769 (Burned House Beach EP) - True - True
 
 Treehouse Laser Room (Treehouse):
-158712 - 0x03613 (Laser Panel) - True - True
-158403 - 0x17CBC (Laser House Door Timer Inside) - True - True
+0x03613 (Laser Panel) - True - True
+0x17CBC (Laser House Door Timer Inside) - True - True
 Laser - 0x028A4 (Laser) - 0x03613
 
 ==Mountain (Outside)==
 
 Mountainside Obelisk (Mountainside) - Entry - True:
-159730 - 0xFFE30 (Obelisk Side 1) - 0x001A3 & 0x335AE - True
-159731 - 0xFFE31 (Obelisk Side 2) - 0x000D3 & 0x035F5 & 0x09D5D & 0x09D5E & 0x09D63 - True
-159732 - 0xFFE32 (Obelisk Side 3) - 0x3370E & 0x035DE & 0x03601 & 0x03603 & 0x03D0D & 0x3369A & 0x336C8 & 0x33505 - True
-159733 - 0xFFE33 (Obelisk Side 4) - 0x03A9E & 0x016B2 & 0x3365F & 0x03731 & 0x036CE & 0x03C07 & 0x03A93 - True
-159734 - 0xFFE34 (Obelisk Side 5) - 0x03AA6 & 0x3397C & 0x0105D & 0x0A304 - True
-159735 - 0xFFE35 (Obelisk Side 6) - 0x035CB & 0x035CF - True
-159739 - 0x00367 (Obelisk) - True - True
+0xFFE30 (Obelisk Side 1) - 0x001A3 & 0x335AE - True
+0xFFE31 (Obelisk Side 2) - 0x000D3 & 0x035F5 & 0x09D5D & 0x09D5E & 0x09D63 - True
+0xFFE32 (Obelisk Side 3) - 0x3370E & 0x035DE & 0x03601 & 0x03603 & 0x03D0D & 0x3369A & 0x336C8 & 0x33505 - True
+0xFFE33 (Obelisk Side 4) - 0x03A9E & 0x016B2 & 0x3365F & 0x03731 & 0x036CE & 0x03C07 & 0x03A93 - True
+0xFFE34 (Obelisk Side 5) - 0x03AA6 & 0x3397C & 0x0105D & 0x0A304 - True
+0xFFE35 (Obelisk Side 6) - 0x035CB & 0x035CF - True
+0x00367 (Obelisk) - True - True
 
 Mountainside (Mountainside) - Main Island - True - Mountaintop - True - Mountainside Vault - 0x00085:
-159550 - 0x28B91 (Thundercloud EP) - 0xFFD03 - True
-158612 - 0x17C42 (Discard) - True - Triangles
-158665 - 0x002A6 (Vault Panel) - True - Symmetry & Colored Dots & Black/White Squares & Dots
+0x28B91 (Thundercloud EP) - 0xFFD03 - True
+0x17C42 (Discard) - True - Triangles
+0x002A6 (Vault Panel) - True - Symmetry & Colored Dots & Black/White Squares & Dots
 Door - 0x00085 (Vault Door) - 0x002A6
-159301 - 0x335AE (Cloud Cycle EP) - True - True
-159325 - 0x33505 (Bush EP) - True - True
-159335 - 0x03C07 (Apparent River EP) - True - True
+0x335AE (Cloud Cycle EP) - True - True
+0x33505 (Bush EP) - True - True
+0x03C07 (Apparent River EP) - True - True
 
 Mountainside Vault (Mountainside):
-158666 - 0x03542 (Vault Box) - True - True
+0x03542 (Vault Box) - True - True
 
 Mountaintop (Mountaintop) - Mountain Floor 1 - 0x17C34:
-158405 - 0x0042D (River Shape) - True - True
-158406 - 0x09F7F (Box Short) - 7 Lasers + Redirect - True
-158407 - 0x17C34 (Mountain Entry Panel) - 0x09F7F - Black/White Squares & Stars + Same Colored Symbol
-158800 - 0xFFF00 (Box Long) - 11 Lasers + Redirect & 0x17C34 - True
-159300 - 0x001A3 (River Shape EP) - True - True
-159320 - 0x3370E (Arch Black EP) - True - True
-159324 - 0x336C8 (Arch White Right EP) - True - True
-159326 - 0x3369A (Arch White Left EP) - True - True
+0x0042D (River Shape) - True - True
+0x09F7F (Box Short) - 7 Lasers + Redirect - True
+0x17C34 (Mountain Entry Panel) - 0x09F7F - Black/White Squares & Stars + Same Colored Symbol
+0xFFF00 (Box Long) - 11 Lasers + Redirect & 0x17C34 - True
+0x001A3 (River Shape EP) - True - True
+0x3370E (Arch Black EP) - True - True
+0x336C8 (Arch White Right EP) - True - True
+0x3369A (Arch White Left EP) - True - True
 
 ==Mountain (Inside)==
 
 Mountain Floor 1 (Mountain Floor 1) - Mountain Floor 1 Bridge - 0x09E39:
-158408 - 0x09E39 (Light Bridge Controller) - True - Black/White Squares & Colored Squares & Eraser
+0x09E39 (Light Bridge Controller) - True - Black/White Squares & Colored Squares & Eraser
 
 Mountain Floor 1 Bridge (Mountain Floor 1) - Mountain Floor 1 At Door - TrueOneWay - Mountain Floor 1 Trash Pillar - TrueOneWay - Mountain Floor 1 Back Section - TrueOneWay:
-158409 - 0x09E7A (Right Row 1) - True - Black/White Squares & Dots
-158410 - 0x09E71 (Right Row 2) - 0x09E7A - Black/White Squares & Dots
-158411 - 0x09E72 (Right Row 3) - 0x09E71 - Black/White Squares & Shapers & Dots
-158412 - 0x09E69 (Right Row 4) - 0x09E72 - Black/White Squares & Dots
-158413 - 0x09E7B (Right Row 5) - 0x09E69 - Black/White Squares & Dots
-158414 - 0x09E73 (Left Row 1) - True - Black/White Squares & Stars + Same Colored Symbol
-158415 - 0x09E75 (Left Row 2) - 0x09E73 - Black/White Squares & Stars + Same Colored Symbol
-158416 - 0x09E78 (Left Row 3) - 0x09E75 - Shapers
-158417 - 0x09E79 (Left Row 4) - 0x09E78 - Shapers & Rotated Shapers
-158418 - 0x09E6C (Left Row 5) - 0x09E79 - Black/White Squares & Stars + Same Colored Symbol
-158419 - 0x09E6F (Left Row 6) - 0x09E6C - Stars & Rotated Shapers & Shapers
-158420 - 0x09E6B (Left Row 7) - 0x09E6F - Stars & Dots
-158424 - 0x09EAD (Trash Pillar 1) - True - Black/White Squares & Shapers
-158425 - 0x09EAF (Trash Pillar 2) - 0x09EAD - Black/White Squares & Shaper
+0x09E7A (Right Row 1) - True - Black/White Squares & Dots
+0x09E71 (Right Row 2) - 0x09E7A - Black/White Squares & Dots
+0x09E72 (Right Row 3) - 0x09E71 - Black/White Squares & Shapers & Dots
+0x09E69 (Right Row 4) - 0x09E72 - Black/White Squares & Dots
+0x09E7B (Right Row 5) - 0x09E69 - Black/White Squares & Dots
+0x09E73 (Left Row 1) - True - Black/White Squares & Stars + Same Colored Symbol
+0x09E75 (Left Row 2) - 0x09E73 - Black/White Squares & Stars + Same Colored Symbol
+0x09E78 (Left Row 3) - 0x09E75 - Shapers
+0x09E79 (Left Row 4) - 0x09E78 - Shapers & Rotated Shapers
+0x09E6C (Left Row 5) - 0x09E79 - Black/White Squares & Stars + Same Colored Symbol
+0x09E6F (Left Row 6) - 0x09E6C - Stars & Rotated Shapers & Shapers
+0x09E6B (Left Row 7) - 0x09E6F - Stars & Dots
+0x09EAD (Trash Pillar 1) - True - Black/White Squares & Shapers
+0x09EAF (Trash Pillar 2) - 0x09EAD - Black/White Squares & Shaper
 
 Mountain Floor 1 Trash Pillar (Mountain Floor 1):
 
 Mountain Floor 1 Back Section (Mountain Floor 1):
-158421 - 0x33AF5 (Back Row 1) - True - Black/White Squares & Symmetry
-158422 - 0x33AF7 (Back Row 2) - 0x33AF5 - Black/White Squares & Stars
-158423 - 0x09F6E (Back Row 3) - 0x33AF7 - Symmetry & Dots
+0x33AF5 (Back Row 1) - True - Black/White Squares & Symmetry
+0x33AF7 (Back Row 2) - 0x33AF5 - Black/White Squares & Stars
+0x09F6E (Back Row 3) - 0x33AF7 - Symmetry & Dots
 
 Mountain Floor 1 At Door (Mountain Floor 1) - Mountain Floor 2 - 0x09E54:
 Door - 0x09E54 (Exit) - 0x09EAF & 0x09F6E & 0x09E6B & 0x09E7B
 
 Mountain Floor 2 (Mountain Floor 2) - Mountain Floor 2 Light Bridge Room Near - 0x09FFB - Mountain Floor 2 Beyond Bridge - 0x09E86 - Mountain Floor 2 Above The Abyss - True - Mountain Pink Bridge EP - TrueOneWay:
-158426 - 0x09FD3 (Near Row 1) - True - Colored Squares & Stars + Same Colored Symbol
-158427 - 0x09FD4 (Near Row 2) - 0x09FD3 - Colored Squares & Stars + Same Colored Symbol
-158428 - 0x09FD6 (Near Row 3) - 0x09FD4 - Colored Squares & Stars + Same Colored Symbol
-158429 - 0x09FD7 (Near Row 4) - 0x09FD6 - Colored Squares & Stars + Same Colored Symbol & Shapers
-158430 - 0x09FD8 (Near Row 5) - 0x09FD7 - Symmetry & Colored Dots
+0x09FD3 (Near Row 1) - True - Colored Squares & Stars + Same Colored Symbol
+0x09FD4 (Near Row 2) - 0x09FD3 - Colored Squares & Stars + Same Colored Symbol
+0x09FD6 (Near Row 3) - 0x09FD4 - Colored Squares & Stars + Same Colored Symbol
+0x09FD7 (Near Row 4) - 0x09FD6 - Colored Squares & Stars + Same Colored Symbol & Shapers
+0x09FD8 (Near Row 5) - 0x09FD7 - Symmetry & Colored Dots
 Door - 0x09FFB (Staircase Near) - 0x09FD8
 
 Mountain Floor 2 Above The Abyss (Mountain Floor 2) - Mountain Floor 2 Elevator Room - 0x09EDD & 0x09ED8 & 0x09E86:
 Door - 0x09EDD (Elevator Room Entry) - 0x09ED8 & 0x09E86
 
 Mountain Floor 2 Light Bridge Room Near (Mountain Floor 2):
-158431 - 0x09E86 (Light Bridge Controller Near) - True - Stars + Same Colored Symbol & Rotated Shapers & Eraser
+0x09E86 (Light Bridge Controller Near) - True - Stars + Same Colored Symbol & Rotated Shapers & Eraser
 
 Mountain Floor 2 Beyond Bridge (Mountain Floor 2) - Mountain Floor 2 Light Bridge Room Far - 0x09E07 - Mountain Pink Bridge EP - TrueOneWay - Mountain Floor 2 - 0x09ED8:
-158432 - 0x09FCC (Far Row 1) - True - Dots
-158433 - 0x09FCE (Far Row 2) - 0x09FCC - Black/White Squares
-158434 - 0x09FCF (Far Row 3) - 0x09FCE - Stars
-158435 - 0x09FD0 (Far Row 4) - 0x09FCF - Rotated Shapers
-158436 - 0x09FD1 (Far Row 5) - 0x09FD0 - Colored Squares & Stars + Same Colored Symbol
-158437 - 0x09FD2 (Far Row 6) - 0x09FD1 - Shapers
+0x09FCC (Far Row 1) - True - Dots
+0x09FCE (Far Row 2) - 0x09FCC - Black/White Squares
+0x09FCF (Far Row 3) - 0x09FCE - Stars
+0x09FD0 (Far Row 4) - 0x09FCF - Rotated Shapers
+0x09FD1 (Far Row 5) - 0x09FD0 - Colored Squares & Stars + Same Colored Symbol
+0x09FD2 (Far Row 6) - 0x09FD1 - Shapers
 Door - 0x09E07 (Staircase Far) - 0x09FD2
 
 Mountain Floor 2 Light Bridge Room Far (Mountain Floor 2):
-158438 - 0x09ED8 (Light Bridge Controller Far) - True - Stars + Same Colored Symbol & Rotated Shapers & Eraser
+0x09ED8 (Light Bridge Controller Far) - True - Stars + Same Colored Symbol & Rotated Shapers & Eraser
 
 Mountain Floor 2 Elevator Room (Mountain Floor 2) - Mountain Floor 2 Elevator - TrueOneWay:
-158613 - 0x17F93 (Elevator Discard) - True - Triangles
+0x17F93 (Elevator Discard) - True - Triangles
 
 Mountain Floor 2 Elevator (Mountain Floor 2) - Mountain Floor 2 Elevator Room - 0x09EEB - Mountain Floor 3 - 0x09EEB:
-158439 - 0x09EEB (Elevator Control Panel) - True - Dots
+0x09EEB (Elevator Control Panel) - True - Dots
 
 Mountain Floor 3 (Mountain Bottom Floor) - Mountain Floor 2 Elevator - TrueOneWay - Mountain Bottom Floor - 0x09F89 - Mountain Pink Bridge EP - TrueOneWay:
-158440 - 0x09FC1 (Giant Puzzle Bottom Left) - True - Shapers & Eraser
-158441 - 0x09F8E (Giant Puzzle Bottom Right) - True - Shapers & Eraser
-158442 - 0x09F01 (Giant Puzzle Top Right) - True - Rotated Shapers
-158443 - 0x09EFF (Giant Puzzle Top Left) - True - Shapers & Eraser
-158444 - 0x09FDA (Giant Puzzle) - 0x09FC1 & 0x09F8E & 0x09F01 & 0x09EFF - Shapers & Symmetry
-159313 - 0x09D5D (Yellow Bridge EP) - 0x09E86 & 0x09ED8 - True
-159314 - 0x09D5E (Blue Bridge EP) - 0x09E86 & 0x09ED8 - True
+0x09FC1 (Giant Puzzle Bottom Left) - True - Shapers & Eraser
+0x09F8E (Giant Puzzle Bottom Right) - True - Shapers & Eraser
+0x09F01 (Giant Puzzle Top Right) - True - Rotated Shapers
+0x09EFF (Giant Puzzle Top Left) - True - Shapers & Eraser
+0x09FDA (Giant Puzzle) - 0x09FC1 & 0x09F8E & 0x09F01 & 0x09EFF - Shapers & Symmetry
+0x09D5D (Yellow Bridge EP) - 0x09E86 & 0x09ED8 - True
+0x09D5E (Blue Bridge EP) - 0x09E86 & 0x09ED8 - True
 Door - 0x09F89 (Exit) - 0x09FDA
 
 Mountain Bottom Floor (Mountain Bottom Floor) - Mountain Path to Caves - 0x17F33 - Mountain Bottom Floor Pillars Room - 0x0C141:
-158614 - 0x17FA2 (Discard) - 0xFFF00 - Triangles
-158445 - 0x01983 (Pillars Room Entry Left) - True - Shapers & Stars
-158446 - 0x01987 (Pillars Room Entry Right) - True - Colored Squares & Dots
+0x17FA2 (Discard) - 0xFFF00 - Triangles
+0x01983 (Pillars Room Entry Left) - True - Shapers & Stars
+0x01987 (Pillars Room Entry Right) - True - Colored Squares & Dots
 Door - 0x0C141 (Pillars Room Entry) - 0x01983 & 0x01987
 Door - 0x17F33 (Rock Open) - 0x17FA2 | 0x334E1
 
 Mountain Bottom Floor Pillars Room (Mountain Bottom Floor) - Elevator - 0x339BB & 0x33961:
-158522 - 0x0383A (Right Pillar 1) - True - Stars
-158523 - 0x09E56 (Right Pillar 2) - 0x0383A - Stars & Dots
-158524 - 0x09E5A (Right Pillar 3) - 0x09E56 - Full Dots
-158525 - 0x33961 (Right Pillar 4) - 0x09E5A - Dots & Symmetry
-158526 - 0x0383D (Left Pillar 1) - True - Dots
-158527 - 0x0383F (Left Pillar 2) - 0x0383D - Black/White Squares
-158528 - 0x03859 (Left Pillar 3) - 0x0383F - Shapers
-158529 - 0x339BB (Left Pillar 4) - 0x03859 - Black/White Squares & Stars & Symmetry
+0x0383A (Right Pillar 1) - True - Stars
+0x09E56 (Right Pillar 2) - 0x0383A - Stars & Dots
+0x09E5A (Right Pillar 3) - 0x09E56 - Full Dots
+0x33961 (Right Pillar 4) - 0x09E5A - Dots & Symmetry
+0x0383D (Left Pillar 1) - True - Dots
+0x0383F (Left Pillar 2) - 0x0383D - Black/White Squares
+0x03859 (Left Pillar 3) - 0x0383F - Shapers
+0x339BB (Left Pillar 4) - 0x03859 - Black/White Squares & Stars & Symmetry
 
 Elevator (Mountain Bottom Floor):
-158530 - 0x3D9A6 (Elevator Door Close Left) - True - True
-158531 - 0x3D9A7 (Elevator Door Close Right) - True - True
-158532 - 0x3C113 (Elevator Entry Left) - 0x3D9A6 | 0x3D9A7 - True
-158533 - 0x3C114 (Elevator Entry Right) - 0x3D9A6 | 0x3D9A7 - True
-158534 - 0x3D9AA (Back Wall Left) - 0x3D9A6 | 0x3D9A7 - True
-158535 - 0x3D9A8 (Back Wall Right) - 0x3D9A6 | 0x3D9A7 - True
-158536 - 0x3D9A9 (Elevator Start) - 0x3D9AA & 7 Lasers | 0x3D9A8 & 7 Lasers - True
+0x3D9A6 (Elevator Door Close Left) - True - True
+0x3D9A7 (Elevator Door Close Right) - True - True
+0x3C113 (Elevator Entry Left) - 0x3D9A6 | 0x3D9A7 - True
+0x3C114 (Elevator Entry Right) - 0x3D9A6 | 0x3D9A7 - True
+0x3D9AA (Back Wall Left) - 0x3D9A6 | 0x3D9A7 - True
+0x3D9A8 (Back Wall Right) - 0x3D9A6 | 0x3D9A7 - True
+0x3D9A9 (Elevator Start) - 0x3D9AA & 7 Lasers | 0x3D9A8 & 7 Lasers - True
 
 Mountain Pink Bridge EP (Mountain Floor 2):
-159312 - 0x09D63 (Pink Bridge EP) - 0x09E39 - True
+0x09D63 (Pink Bridge EP) - 0x09E39 - True
 
 Mountain Path to Caves (Mountain Bottom Floor) - Caves - 0x2D77D - Caves Entry Door - TrueOneWay:
-158447 - 0x00FF8 (Caves Entry Panel) - True - Triangles & Black/White Squares
+0x00FF8 (Caves Entry Panel) - True - Triangles & Black/White Squares
 Door - 0x2D77D (Caves Entry) - 0x00FF8
-158448 - 0x334E1 (Rock Control) - True - True
+0x334E1 (Rock Control) - True - True
 
 ==Caves==
 
 Caves Entry Door (Caves):
 
 Caves (Caves) - Main Island - 0x2D73F | 0x2D859 - Caves Path to Challenge - 0x019A5 - Caves Entry Door - TrueOneWay:
-158451 - 0x335AB (Elevator Inside Control) - True - Dots & Black/White Squares
-158452 - 0x335AC (Elevator Upper Outside Control) - 0x335AB - Black/White Squares
-158453 - 0x3369D (Elevator Lower Outside Control) - 0x335AB - Black/White Squares & Dots
-158454 - 0x00190 (Blue Tunnel Right First 1) - True - Triangles & Full Dots
-158455 - 0x00558 (Blue Tunnel Right First 2) - 0x00190 - Triangles & Full Dots
-158456 - 0x00567 (Blue Tunnel Right First 3) - 0x00558 - Triangles & Full Dots
-158457 - 0x006FE (Blue Tunnel Right First 4) - 0x00567 - Triangles & Full Dots
-158458 - 0x01A0D (Blue Tunnel Left First 1) - True - Symmetry & Triangles
-158459 - 0x008B8 (Blue Tunnel Left Second 1) - True - Black/White Squares & Triangles
-158460 - 0x00973 (Blue Tunnel Left Second 2) - 0x008B8 - Stars & Triangles
-158461 - 0x0097B (Blue Tunnel Left Second 3) - 0x00973 - Triangles & Stars + Same Colored Symbol
-158462 - 0x0097D (Blue Tunnel Left Second 4) - 0x0097B - Black/White Squares & Stars + Same Colored Symbol & Triangles
-158463 - 0x0097E (Blue Tunnel Left Second 5) - 0x0097D - Black/White Squares & Stars + Same Colored Symbol & Colored Squares
-158464 - 0x00994 (Blue Tunnel Right Second 1) - True - Rotated Shapers & Triangles
-158465 - 0x334D5 (Blue Tunnel Right Second 2) - 0x00994 - Rotated Shapers & Triangles
-158466 - 0x00995 (Blue Tunnel Right Second 3) - 0x334D5 - Rotated Shapers & Triangles
-158467 - 0x00996 (Blue Tunnel Right Second 4) - 0x00995 - Shapers & Triangles
-158468 - 0x00998 (Blue Tunnel Right Second 5) - 0x00996 - Shapers & Triangles
-158469 - 0x009A4 (Blue Tunnel Left Third 1) - True - Shapers
-158470 - 0x018A0 (Blue Tunnel Right Third 1) - True - Shapers & Symmetry
-158471 - 0x00A72 (Blue Tunnel Left Fourth 1) - True - Shapers & Negative Shapers
-158472 - 0x32962 (First Floor Left) - True - Rotated Shapers
-158473 - 0x32966 (First Floor Grounded) - True - Black/White Squares & Stars + Same Colored Symbol
-158474 - 0x01A31 (First Floor Middle) - True - Colored Squares
-158475 - 0x00B71 (First Floor Right) - True - Colored Squares & Stars + Same Colored Symbol & Eraser
-158478 - 0x288EA (First Wooden Beam) - True - Shapers
-158479 - 0x288FC (Second Wooden Beam) - True - Black/White Squares & Shapers & Rotated Shapers
-158480 - 0x289E7 (Third Wooden Beam) - True - Stars & Black/White Squares
-158481 - 0x288AA (Fourth Wooden Beam) - True - Stars & Shapers
-158482 - 0x17FB9 (Left Upstairs Single) - True - Shapers & Negative Shapers & Full Dots
-158483 - 0x0A16B (Left Upstairs Left Row 1) - True - Full Dots
-158484 - 0x0A2CE (Left Upstairs Left Row 2) - 0x0A16B - Stars & Full Dots
-158485 - 0x0A2D7 (Left Upstairs Left Row 3) - 0x0A2CE - Black/White Squares & Stars + Same Colored Symbol & Full Dots
-158486 - 0x0A2DD (Left Upstairs Left Row 4) - 0x0A2D7 - Shapers & Full Dots
-158487 - 0x0A2EA (Left Upstairs Left Row 5) - 0x0A2DD - Rotated Shapers & Full Dots
-158488 - 0x0008F (Right Upstairs Left Row 1) - True - Dots
-158489 - 0x0006B (Right Upstairs Left Row 2) - 0x0008F - Dots
-158490 - 0x0008B (Right Upstairs Left Row 3) - 0x0006B - Dots
-158491 - 0x0008C (Right Upstairs Left Row 4) - 0x0008B - Dots
-158492 - 0x0008A (Right Upstairs Left Row 5) - 0x0008C - Dots
-158493 - 0x00089 (Right Upstairs Left Row 6) - 0x0008A - Dots
-158494 - 0x0006A (Right Upstairs Left Row 7) - 0x00089 - Dots
-158495 - 0x0006C (Right Upstairs Left Row 8) - 0x0006A - Dots
-158496 - 0x00027 (Right Upstairs Right Row 1) - True - Dots & Symmetry
-158497 - 0x00028 (Right Upstairs Right Row 2) - 0x00027 - Dots & Symmetry
-158498 - 0x00029 (Right Upstairs Right Row 3) - 0x00028 - Dots & Symmetry
-158476 - 0x09DD5 (Lone Pillar) - True - Triangles
+0x335AB (Elevator Inside Control) - True - Dots & Black/White Squares
+0x335AC (Elevator Upper Outside Control) - 0x335AB - Black/White Squares
+0x3369D (Elevator Lower Outside Control) - 0x335AB - Black/White Squares & Dots
+0x00190 (Blue Tunnel Right First 1) - True - Triangles & Full Dots
+0x00558 (Blue Tunnel Right First 2) - 0x00190 - Triangles & Full Dots
+0x00567 (Blue Tunnel Right First 3) - 0x00558 - Triangles & Full Dots
+0x006FE (Blue Tunnel Right First 4) - 0x00567 - Triangles & Full Dots
+0x01A0D (Blue Tunnel Left First 1) - True - Symmetry & Triangles
+0x008B8 (Blue Tunnel Left Second 1) - True - Black/White Squares & Triangles
+0x00973 (Blue Tunnel Left Second 2) - 0x008B8 - Stars & Triangles
+0x0097B (Blue Tunnel Left Second 3) - 0x00973 - Triangles & Stars + Same Colored Symbol
+0x0097D (Blue Tunnel Left Second 4) - 0x0097B - Black/White Squares & Stars + Same Colored Symbol & Triangles
+0x0097E (Blue Tunnel Left Second 5) - 0x0097D - Black/White Squares & Stars + Same Colored Symbol & Colored Squares
+0x00994 (Blue Tunnel Right Second 1) - True - Rotated Shapers & Triangles
+0x334D5 (Blue Tunnel Right Second 2) - 0x00994 - Rotated Shapers & Triangles
+0x00995 (Blue Tunnel Right Second 3) - 0x334D5 - Rotated Shapers & Triangles
+0x00996 (Blue Tunnel Right Second 4) - 0x00995 - Shapers & Triangles
+0x00998 (Blue Tunnel Right Second 5) - 0x00996 - Shapers & Triangles
+0x009A4 (Blue Tunnel Left Third 1) - True - Shapers
+0x018A0 (Blue Tunnel Right Third 1) - True - Shapers & Symmetry
+0x00A72 (Blue Tunnel Left Fourth 1) - True - Shapers & Negative Shapers
+0x32962 (First Floor Left) - True - Rotated Shapers
+0x32966 (First Floor Grounded) - True - Black/White Squares & Stars + Same Colored Symbol
+0x01A31 (First Floor Middle) - True - Colored Squares
+0x00B71 (First Floor Right) - True - Colored Squares & Stars + Same Colored Symbol & Eraser
+0x288EA (First Wooden Beam) - True - Shapers
+0x288FC (Second Wooden Beam) - True - Black/White Squares & Shapers & Rotated Shapers
+0x289E7 (Third Wooden Beam) - True - Stars & Black/White Squares
+0x288AA (Fourth Wooden Beam) - True - Stars & Shapers
+0x17FB9 (Left Upstairs Single) - True - Shapers & Negative Shapers & Full Dots
+0x0A16B (Left Upstairs Left Row 1) - True - Full Dots
+0x0A2CE (Left Upstairs Left Row 2) - 0x0A16B - Stars & Full Dots
+0x0A2D7 (Left Upstairs Left Row 3) - 0x0A2CE - Black/White Squares & Stars + Same Colored Symbol & Full Dots
+0x0A2DD (Left Upstairs Left Row 4) - 0x0A2D7 - Shapers & Full Dots
+0x0A2EA (Left Upstairs Left Row 5) - 0x0A2DD - Rotated Shapers & Full Dots
+0x0008F (Right Upstairs Left Row 1) - True - Dots
+0x0006B (Right Upstairs Left Row 2) - 0x0008F - Dots
+0x0008B (Right Upstairs Left Row 3) - 0x0006B - Dots
+0x0008C (Right Upstairs Left Row 4) - 0x0008B - Dots
+0x0008A (Right Upstairs Left Row 5) - 0x0008C - Dots
+0x00089 (Right Upstairs Left Row 6) - 0x0008A - Dots
+0x0006A (Right Upstairs Left Row 7) - 0x00089 - Dots
+0x0006C (Right Upstairs Left Row 8) - 0x0006A - Dots
+0x00027 (Right Upstairs Right Row 1) - True - Dots & Symmetry
+0x00028 (Right Upstairs Right Row 2) - 0x00027 - Dots & Symmetry
+0x00029 (Right Upstairs Right Row 3) - 0x00028 - Dots & Symmetry
+0x09DD5 (Lone Pillar) - True - Triangles
 Door - 0x019A5 (Pillar Door) - 0x09DD5
-158449 - 0x021D7 (Mountain Shortcut Panel) - True - Triangles & Stars + Same Colored Symbol
+0x021D7 (Mountain Shortcut Panel) - True - Triangles & Stars + Same Colored Symbol
 Door - 0x2D73F (Mountain Shortcut Door) - 0x021D7
-158450 - 0x17CF2 (Swamp Shortcut Panel) - True - Triangles
+0x17CF2 (Swamp Shortcut Panel) - True - Triangles
 Door - 0x2D859 (Swamp Shortcut Door) - 0x17CF2
-159341 - 0x3397C (Skylight EP) - True - True
+0x3397C (Skylight EP) - True - True
 
 Caves Path to Challenge (Caves) - Challenge - 0x0A19A:
-158477 - 0x0A16E (Challenge Entry Panel) - True - Shapers & Stars + Same Colored Symbol
+0x0A16E (Challenge Entry Panel) - True - Shapers & Stars + Same Colored Symbol
 Door - 0x0A19A (Challenge Entry) - 0x0A16E
 
 ==Challenge==
 
 Challenge (Challenge) - Tunnels - 0x0348A - Challenge Vault - 0x04D75:
-158499 - 0x0A332 (Start Timer) - 11 Lasers - True
-158500 - 0x0088E (Small Basic) - 0x0A332 - True
-158501 - 0x00BAF (Big Basic) - 0x0088E - True
-158502 - 0x00BF3 (Square) - 0x00BAF - Black/White Squares
-158503 - 0x00C09 (Maze Map) - 0x00BF3 - Dots
-158504 - 0x00CDB (Stars and Dots) - 0x00C09 - Stars & Dots
-158505 - 0x0051F (Symmetry) - 0x00CDB - Symmetry & Colored Dots & Dots
-158506 - 0x00524 (Stars and Shapers) - 0x0051F - Stars & Shapers
-158507 - 0x00CD4 (Big Basic 2) - 0x00524 - True
-158508 - 0x00CB9 (Choice Squares Right) - 0x00CD4 - Black/White Squares
-158509 - 0x00CA1 (Choice Squares Middle) - 0x00CD4 - Black/White Squares
-158510 - 0x00C80 (Choice Squares Left) - 0x00CD4 - Black/White Squares
-158511 - 0x00C68 (Choice Squares 2 Right) - 0x00CB9 | 0x00CA1 | 0x00C80 - Black/White Squares & Colored Squares
-158512 - 0x00C59 (Choice Squares 2 Middle) - 0x00CB9 | 0x00CA1 | 0x00C80 - Black/White Squares & Colored Squares
-158513 - 0x00C22 (Choice Squares 2 Left) - 0x00CB9 | 0x00CA1 | 0x00C80 - Black/White Squares & Colored Squares
-158514 - 0x034F4 (Maze Hidden 1) - 0x00C68 | 0x00C59 | 0x00C22 - Triangles
-158515 - 0x034EC (Maze Hidden 2) - 0x00C68 | 0x00C59 | 0x00C22 - Triangles
-158516 - 0x1C31A (Dots Pillar) - 0x034F4 & 0x034EC - Dots & Symmetry
-158517 - 0x1C319 (Squares Pillar) - 0x034F4 & 0x034EC - Black/White Squares & Symmetry
+0x0A332 (Start Timer) - 11 Lasers - True
+0x0088E (Small Basic) - 0x0A332 - True
+0x00BAF (Big Basic) - 0x0088E - True
+0x00BF3 (Square) - 0x00BAF - Black/White Squares
+0x00C09 (Maze Map) - 0x00BF3 - Dots
+0x00CDB (Stars and Dots) - 0x00C09 - Stars & Dots
+0x0051F (Symmetry) - 0x00CDB - Symmetry & Colored Dots & Dots
+0x00524 (Stars and Shapers) - 0x0051F - Stars & Shapers
+0x00CD4 (Big Basic 2) - 0x00524 - True
+0x00CB9 (Choice Squares Right) - 0x00CD4 - Black/White Squares
+0x00CA1 (Choice Squares Middle) - 0x00CD4 - Black/White Squares
+0x00C80 (Choice Squares Left) - 0x00CD4 - Black/White Squares
+0x00C68 (Choice Squares 2 Right) - 0x00CB9 | 0x00CA1 | 0x00C80 - Black/White Squares & Colored Squares
+0x00C59 (Choice Squares 2 Middle) - 0x00CB9 | 0x00CA1 | 0x00C80 - Black/White Squares & Colored Squares
+0x00C22 (Choice Squares 2 Left) - 0x00CB9 | 0x00CA1 | 0x00C80 - Black/White Squares & Colored Squares
+0x034F4 (Maze Hidden 1) - 0x00C68 | 0x00C59 | 0x00C22 - Triangles
+0x034EC (Maze Hidden 2) - 0x00C68 | 0x00C59 | 0x00C22 - Triangles
+0x1C31A (Dots Pillar) - 0x034F4 & 0x034EC - Dots & Symmetry
+0x1C319 (Squares Pillar) - 0x034F4 & 0x034EC - Black/White Squares & Symmetry
 Door - 0x04D75 (Vault Door) - 0x1C31A & 0x1C319
-158518 - 0x039B4 (Tunnels Entry Panel) - True - Triangles
+0x039B4 (Tunnels Entry Panel) - True - Triangles
 Door - 0x0348A (Tunnels Entry) - 0x039B4
-159530 - 0x28B30 (Water EP) - True - True
+0x28B30 (Water EP) - True - True
 
 Challenge Vault (Challenge):
-158667 - 0x0356B (Vault Box) - 0x1C31A & 0x1C319 - True
+0x0356B (Vault Box) - 0x1C31A & 0x1C319 - True
 
 ==Tunnels==
 
 Tunnels (Tunnels) - Windmill Interior - 0x27739 - Desert Behind Elevator - 0x27263 - Town - 0x09E87:
-158668 - 0x2FAF6 (Vault Box) - True - True
-158519 - 0x27732 (Theater Shortcut Panel) - True - True
+0x2FAF6 (Vault Box) - True - True
+0x27732 (Theater Shortcut Panel) - True - True
 Door - 0x27739 (Theater Shortcut) - 0x27732
-158520 - 0x2773D (Desert Shortcut Panel) - True - True
+0x2773D (Desert Shortcut Panel) - True - True
 Door - 0x27263 (Desert Shortcut) - 0x2773D
-158521 - 0x09E85 (Town Shortcut Panel) - True - Triangles
+0x09E85 (Town Shortcut Panel) - True - Triangles
 Door - 0x09E87 (Town Shortcut) - 0x09E85
-159557 - 0x33A20 (Theater Flowers EP) - 0x03553 & Theater to Tunnels - True
+0x33A20 (Theater Flowers EP) - 0x03553 & Theater to Tunnels - True
 
 ==Boat==
 
 The Ocean (Boat) - Main Island - TrueOneWay - Swamp Near Boat - TrueOneWay - Treehouse Entry Area - TrueOneWay - Quarry Boathouse Behind Staircase - TrueOneWay - Inside Glass Factory Behind Back Wall - TrueOneWay:
-159042 - 0x22106 (Desert EP) - True - True
-159223 - 0x03B25 (Shipwreck CCW Underside EP) - True - True
-159231 - 0x28B29 (Shipwreck Green EP) - True - True
-159232 - 0x28B2A (Shipwreck CW Underside EP) - True - True
-159323 - 0x03D0D (Bunker Yellow Line EP) - True - True
-159515 - 0x28A37 (Town Long Sewer EP) - True - True
-159520 - 0x33857 (Tutorial EP) - True - True
-159521 - 0x33879 (Tutorial Reflection EP) - True - True
-159522 - 0x03C19 (Tutorial Moss EP) - True - True
-159531 - 0x035C9 (Cargo Box EP) - 0x0A0C9 - True
+0x22106 (Desert EP) - True - True
+0x03B25 (Shipwreck CCW Underside EP) - True - True
+0x28B29 (Shipwreck Green EP) - True - True
+0x28B2A (Shipwreck CW Underside EP) - True - True
+0x03D0D (Bunker Yellow Line EP) - True - True
+0x28A37 (Town Long Sewer EP) - True - True
+0x33857 (Tutorial EP) - True - True
+0x33879 (Tutorial Reflection EP) - True - True
+0x03C19 (Tutorial Moss EP) - True - True
+0x035C9 (Cargo Box EP) - 0x0A0C9 - True
 
 ==Easter Eggs==
 

--- a/worlds/witness/data/WitnessLogicExpert.txt
+++ b/worlds/witness/data/WitnessLogicExpert.txt
@@ -3,237 +3,237 @@
 Entry (Entry):
 
 Tutorial First Hallway (Tutorial First Hallway) - Entry - True - Tutorial First Hallway Room - 0x00064:
-158000 - 0x00064 (Straight) - True - True
-159510 - 0x01848 (EP) - 0x00064 - True
+0x00064 (Straight) - True - True
+0x01848 (EP) - 0x00064 - True
 
 Tutorial First Hallway Room (Tutorial First Hallway) - Tutorial - 0x00182:
-158001 - 0x00182 (Bend) - True - True
+0x00182 (Bend) - True - True
 
 Tutorial (Tutorial) - Outside Tutorial - True:
-158002 - 0x00293 (Front Center) - True - Dots
-158003 - 0x00295 (Center Left) - 0x00293 - Dots
-158004 - 0x002C2 (Front Left) - 0x00295 - Dots
-158005 - 0x0A3B5 (Back Left) - True - Full Dots
-158006 - 0x0A3B2 (Back Right) - True - Full Dots
-158007 - 0x03629 (Gate Open) - 0x002C2 - Symmetry & Dots
-158008 - 0x03505 (Gate Close) - 0x2FAF6 & 0x03629 - True
-158009 - 0x0C335 (Pillar) - True - Triangles
-158010 - 0x0C373 (Patio Floor) - 0x0C335 - Dots
-159512 - 0x33530 (Cloud EP) - True - True
-159513 - 0x33600 (Patio Flowers EP) - 0x0C373 - True
-159517 - 0x3352F (Gate EP) - 0x03505 - True
+0x00293 (Front Center) - True - Dots
+0x00295 (Center Left) - 0x00293 - Dots
+0x002C2 (Front Left) - 0x00295 - Dots
+0x0A3B5 (Back Left) - True - Full Dots
+0x0A3B2 (Back Right) - True - Full Dots
+0x03629 (Gate Open) - 0x002C2 - Symmetry & Dots
+0x03505 (Gate Close) - 0x2FAF6 & 0x03629 - True
+0x0C335 (Pillar) - True - Triangles
+0x0C373 (Patio Floor) - 0x0C335 - Dots
+0x33530 (Cloud EP) - True - True
+0x33600 (Patio Flowers EP) - 0x0C373 - True
+0x3352F (Gate EP) - 0x03505 - True
 
 ==Tutorial (Outside)==
 
 Outside Tutorial (Outside Tutorial) - Outside Tutorial Path To Outpost - 0x03BA2 - Outside Tutorial Vault - 0x033D0:
-158650 - 0x033D4 (Vault Panel) - True - Full Dots & Black/White Squares
+0x033D4 (Vault Panel) - True - Full Dots & Black/White Squares
 Door - 0x033D0 (Vault Door) - 0x033D4
-158013 - 0x0005D (Shed Row 1) - True - Full Dots
-158014 - 0x0005E (Shed Row 2) - 0x0005D - Full Dots
-158015 - 0x0005F (Shed Row 3) - 0x0005E - Full Dots
-158016 - 0x00060 (Shed Row 4) - 0x0005F - Full Dots
-158017 - 0x00061 (Shed Row 5) - 0x00060 - Full Dots
-158018 - 0x018AF (Tree Row 1) - True - Black/White Squares
-158019 - 0x0001B (Tree Row 2) - 0x018AF - Black/White Squares
-158020 - 0x012C9 (Tree Row 3) - 0x0001B - Black/White Squares
-158021 - 0x0001C (Tree Row 4) - 0x012C9 - Black/White Squares & Dots
-158022 - 0x0001D (Tree Row 5) - 0x0001C - Black/White Squares & Dots
-158023 - 0x0001E (Tree Row 6) - 0x0001D - Black/White Squares & Dots
-158024 - 0x0001F (Tree Row 7) - 0x0001E - Black/White Squares & Full Dots
-158025 - 0x00020 (Tree Row 8) - 0x0001F - Black/White Squares & Full Dots
-158026 - 0x00021 (Tree Row 9) - 0x00020 - Black/White Squares & Full Dots
+0x0005D (Shed Row 1) - True - Full Dots
+0x0005E (Shed Row 2) - 0x0005D - Full Dots
+0x0005F (Shed Row 3) - 0x0005E - Full Dots
+0x00060 (Shed Row 4) - 0x0005F - Full Dots
+0x00061 (Shed Row 5) - 0x00060 - Full Dots
+0x018AF (Tree Row 1) - True - Black/White Squares
+0x0001B (Tree Row 2) - 0x018AF - Black/White Squares
+0x012C9 (Tree Row 3) - 0x0001B - Black/White Squares
+0x0001C (Tree Row 4) - 0x012C9 - Black/White Squares & Dots
+0x0001D (Tree Row 5) - 0x0001C - Black/White Squares & Dots
+0x0001E (Tree Row 6) - 0x0001D - Black/White Squares & Dots
+0x0001F (Tree Row 7) - 0x0001E - Black/White Squares & Full Dots
+0x00020 (Tree Row 8) - 0x0001F - Black/White Squares & Full Dots
+0x00021 (Tree Row 9) - 0x00020 - Black/White Squares & Full Dots
 Door - 0x03BA2 (Outpost Path) - 0x0A3B5
-159511 - 0x03D06 (Garden EP) - True - True
-159514 - 0x28A2F (Town Sewer EP) - True - True
-159516 - 0x334A3 (Path EP) - True - True
-159500 - 0x035C7 (Tractor EP) - True - True
+0x03D06 (Garden EP) - True - True
+0x28A2F (Town Sewer EP) - True - True
+0x334A3 (Path EP) - True - True
+0x035C7 (Tractor EP) - True - True
 
 Outside Tutorial Vault (Outside Tutorial):
-158651 - 0x03481 (Vault Box) - True - True
+0x03481 (Vault Box) - True - True
 
 Outside Tutorial Path To Outpost (Outside Tutorial) - Outside Tutorial Outpost - 0x0A170:
-158011 - 0x0A171 (Outpost Entry Panel) - True - Full Dots & Triangles
+0x0A171 (Outpost Entry Panel) - True - Full Dots & Triangles
 Door - 0x0A170 (Outpost Entry) - 0x0A171
 
 Outside Tutorial Outpost (Outside Tutorial) - Outside Tutorial - 0x04CA3:
-158012 - 0x04CA4 (Outpost Exit Panel) - True - Full Dots & Shapers & Rotated Shapers
+0x04CA4 (Outpost Exit Panel) - True - Full Dots & Shapers & Rotated Shapers
 Door - 0x04CA3 (Outpost Exit) - 0x04CA4
-158600 - 0x17CFB (Discard) - True - Arrows
+0x17CFB (Discard) - True - Arrows
 
 Orchard (Orchard) - Main Island - True - Orchard Beyond First Gate - 0x03307:
-158071 - 0x00143 (Apple Tree 1) - True - True
-158072 - 0x0003B (Apple Tree 2) - 0x00143 - True
-158073 - 0x00055 (Apple Tree 3) - 0x0003B - True
+0x00143 (Apple Tree 1) - True - True
+0x0003B (Apple Tree 2) - 0x00143 - True
+0x00055 (Apple Tree 3) - 0x0003B - True
 Door - 0x03307 (First Gate) - 0x00055
 
 Orchard Beyond First Gate (Orchard) - Orchard End - 0x03313:
-158074 - 0x032F7 (Apple Tree 4) - 0x00055 - True
-158075 - 0x032FF (Apple Tree 5) - 0x032F7 - True
+0x032F7 (Apple Tree 4) - 0x00055 - True
+0x032FF (Apple Tree 5) - 0x032F7 - True
 Door - 0x03313 (Second Gate) - 0x032FF
 
 Orchard End (Orchard):
 
 Main Island (Main Island) - Outside Tutorial - True:
-159801 - 0xFFD00 (Reached Independently) - True - True
+0xFFD00 (Reached Independently) - True - True
 
 ==Glass Factory==
 
 Outside Glass Factory (Glass Factory) - Main Island - True - Inside Glass Factory - 0x01A29:
-158027 - 0x01A54 (Entry Panel) - True - Symmetry
+0x01A54 (Entry Panel) - True - Symmetry
 Door - 0x01A29 (Entry) - 0x01A54
-158601 - 0x3C12B (Discard) - True - Arrows
-159002 - 0x28B8A (Vase EP) - 0x01A54 - True
+0x3C12B (Discard) - True - Arrows
+0x28B8A (Vase EP) - 0x01A54 - True
 
 Inside Glass Factory (Glass Factory) - Inside Glass Factory Behind Back Wall - 0x0D7ED:
-158028 - 0x00086 (Back Wall 1) - True - Symmetry & Dots
-158029 - 0x00087 (Back Wall 2) - 0x00086 - Symmetry & Dots
-158030 - 0x00059 (Back Wall 3) - 0x00087 - Symmetry & Dots
-158031 - 0x00062 (Back Wall 4) - 0x00059 - Symmetry & Dots
-158032 - 0x0005C (Back Wall 5) - 0x00062 - Symmetry & Dots
-158033 - 0x0008D (Front 1) - 0x0005C - Symmetry
-158034 - 0x00081 (Front 2) - 0x0008D - Symmetry
-158035 - 0x00083 (Front 3) - 0x00081 - Symmetry
-158036 - 0x00084 (Melting 1) - 0x00083 - Symmetry & Dots
-158037 - 0x00082 (Melting 2) - 0x00084 - Symmetry & Dots
-158038 - 0x0343A (Melting 3) - 0x00082 - Symmetry & Dots
+0x00086 (Back Wall 1) - True - Symmetry & Dots
+0x00087 (Back Wall 2) - 0x00086 - Symmetry & Dots
+0x00059 (Back Wall 3) - 0x00087 - Symmetry & Dots
+0x00062 (Back Wall 4) - 0x00059 - Symmetry & Dots
+0x0005C (Back Wall 5) - 0x00062 - Symmetry & Dots
+0x0008D (Front 1) - 0x0005C - Symmetry
+0x00081 (Front 2) - 0x0008D - Symmetry
+0x00083 (Front 3) - 0x00081 - Symmetry
+0x00084 (Melting 1) - 0x00083 - Symmetry & Dots
+0x00082 (Melting 2) - 0x00084 - Symmetry & Dots
+0x0343A (Melting 3) - 0x00082 - Symmetry & Dots
 Door - 0x0D7ED (Back Wall) - 0x0005C
 
 Inside Glass Factory Behind Back Wall (Glass Factory) - The Ocean - 0x17CC8:
-158039 - 0x17CC8 (Boat Spawn) - 0x17CA6 | 0x17CDF | 0x09DB8 | 0x17C95 - Boat
+0x17CC8 (Boat Spawn) - 0x17CA6 | 0x17CDF | 0x09DB8 | 0x17C95 - Boat
 
 ==Symmetry Island==
 
 Outside Symmetry Island (Symmetry Island) - Main Island - True - Symmetry Island Lower - 0x17F3E:
-158040 - 0x000B0 (Lower Panel) - 0x0343A - Triangles
+0x000B0 (Lower Panel) - 0x0343A - Triangles
 Door - 0x17F3E (Lower) - 0x000B0
 
 Symmetry Island Lower (Symmetry Island) - Symmetry Island Upper - 0x18269:
-158041 - 0x00022 (Right 1) - True - Symmetry & Triangles
-158042 - 0x00023 (Right 2) - 0x00022 - Symmetry & Triangles
-158043 - 0x00024 (Right 3) - 0x00023 - Symmetry & Triangles
-158044 - 0x00025 (Right 4) - 0x00024 - Symmetry & Triangles
-158045 - 0x00026 (Right 5) - 0x00025 - Symmetry & Triangles
-158046 - 0x0007C (Back 1) - 0x00026 - Symmetry & Colored Dots & Dots
-158047 - 0x0007E (Back 2) - 0x0007C - Symmetry & Colored Squares
-158048 - 0x00075 (Back 3) - 0x0007E - Symmetry & Stars
-158049 - 0x00073 (Back 4) - 0x00075 - Symmetry & Shapers
-158050 - 0x00077 (Back 5) - 0x00073 - Symmetry & Triangles
-158051 - 0x00079 (Back 6) - 0x00077 - Symmetry & Dots & Colored Dots & Eraser
-158052 - 0x00065 (Left 1) - 0x00079 - Symmetry & Colored Dots & Triangles
-158053 - 0x0006D (Left 2) - 0x00065 - Symmetry & Colored Dots & Triangles
-158054 - 0x00072 (Left 3) - 0x0006D - Symmetry & Colored Dots & Triangles
-158055 - 0x0006F (Left 4) - 0x00072 - Symmetry & Colored Dots & Triangles
-158056 - 0x00070 (Left 5) - 0x0006F - Symmetry & Colored Dots & Triangles
-158057 - 0x00071 (Left 6) - 0x00070 - Symmetry & Triangles
-158058 - 0x00076 (Left 7) - 0x00071 - Symmetry & Triangles
-158059 - 0x009B8 (Scenery Outlines 1) - True - Symmetry
-158060 - 0x003E8 (Scenery Outlines 2) - 0x009B8 - Symmetry
-158061 - 0x00A15 (Scenery Outlines 3) - 0x003E8 - Symmetry
-158062 - 0x00B53 (Scenery Outlines 4) - 0x00A15 - Symmetry
-158063 - 0x00B8D (Scenery Outlines 5) - 0x00B53 - Symmetry
-158064 - 0x1C349 (Upper Panel) - 0x00076 - Symmetry & Triangles
+0x00022 (Right 1) - True - Symmetry & Triangles
+0x00023 (Right 2) - 0x00022 - Symmetry & Triangles
+0x00024 (Right 3) - 0x00023 - Symmetry & Triangles
+0x00025 (Right 4) - 0x00024 - Symmetry & Triangles
+0x00026 (Right 5) - 0x00025 - Symmetry & Triangles
+0x0007C (Back 1) - 0x00026 - Symmetry & Colored Dots & Dots
+0x0007E (Back 2) - 0x0007C - Symmetry & Colored Squares
+0x00075 (Back 3) - 0x0007E - Symmetry & Stars
+0x00073 (Back 4) - 0x00075 - Symmetry & Shapers
+0x00077 (Back 5) - 0x00073 - Symmetry & Triangles
+0x00079 (Back 6) - 0x00077 - Symmetry & Dots & Colored Dots & Eraser
+0x00065 (Left 1) - 0x00079 - Symmetry & Colored Dots & Triangles
+0x0006D (Left 2) - 0x00065 - Symmetry & Colored Dots & Triangles
+0x00072 (Left 3) - 0x0006D - Symmetry & Colored Dots & Triangles
+0x0006F (Left 4) - 0x00072 - Symmetry & Colored Dots & Triangles
+0x00070 (Left 5) - 0x0006F - Symmetry & Colored Dots & Triangles
+0x00071 (Left 6) - 0x00070 - Symmetry & Triangles
+0x00076 (Left 7) - 0x00071 - Symmetry & Triangles
+0x009B8 (Scenery Outlines 1) - True - Symmetry
+0x003E8 (Scenery Outlines 2) - 0x009B8 - Symmetry
+0x00A15 (Scenery Outlines 3) - 0x003E8 - Symmetry
+0x00B53 (Scenery Outlines 4) - 0x00A15 - Symmetry
+0x00B8D (Scenery Outlines 5) - 0x00B53 - Symmetry
+0x1C349 (Upper Panel) - 0x00076 - Symmetry & Triangles
 Door - 0x18269 (Upper) - 0x1C349
-159000 - 0x0332B (Glass Factory Black Line Reflection EP) - True - True
+0x0332B (Glass Factory Black Line Reflection EP) - True - True
 
 Symmetry Island Upper (Symmetry Island):
-158065 - 0x00A52 (Laser Yellow 1) - True - Colored Dots
-158066 - 0x00A57 (Laser Yellow 2) - 0x00A52 - Colored Dots
-158067 - 0x00A5B (Laser Yellow 3) - 0x00A57 - Colored Dots
-158068 - 0x00A61 (Laser Blue 1) - 0x00A52 - Colored Dots
-158069 - 0x00A64 (Laser Blue 2) - 0x00A61 & 0x00A57 - Colored Dots
-158070 - 0x00A68 (Laser Blue 3) - 0x00A64 & 0x00A5B - Colored Dots
-158700 - 0x0360D (Laser Panel) - 0x00A68 - True
+0x00A52 (Laser Yellow 1) - True - Colored Dots
+0x00A57 (Laser Yellow 2) - 0x00A52 - Colored Dots
+0x00A5B (Laser Yellow 3) - 0x00A57 - Colored Dots
+0x00A61 (Laser Blue 1) - 0x00A52 - Colored Dots
+0x00A64 (Laser Blue 2) - 0x00A61 & 0x00A57 - Colored Dots
+0x00A68 (Laser Blue 3) - 0x00A64 & 0x00A5B - Colored Dots
+0x0360D (Laser Panel) - 0x00A68 - True
 Laser - 0x00509 (Laser) - 0x0360D
-159001 - 0x03367 (Glass Factory Black Line EP) - True - True
+0x03367 (Glass Factory Black Line EP) - True - True
 
 ==Desert==
 
 Desert Obelisk (Desert) - Entry - True:
-159700 - 0xFFE00 (Obelisk Side 1) - 0x0332B & 0x03367 & 0x28B8A - True
-159701 - 0xFFE01 (Obelisk Side 2) - 0x037B6 & 0x037B2 & 0x000F7 - True
-159702 - 0xFFE02 (Obelisk Side 3) - 0x3351D - True
-159703 - 0xFFE03 (Obelisk Side 4) - 0x0053C & 0x00771 & 0x335C8 & 0x335C9 & 0x337F8 & 0x037BB & 0x220E4 & 0x220E5 - True
-159704 - 0xFFE04 (Obelisk Side 5) - 0x334B9 & 0x334BC & 0x22106 & 0x0A14C & 0x0A14D - True
-159709 - 0x00359 (Obelisk) - True - True
+0xFFE00 (Obelisk Side 1) - 0x0332B & 0x03367 & 0x28B8A - True
+0xFFE01 (Obelisk Side 2) - 0x037B6 & 0x037B2 & 0x000F7 - True
+0xFFE02 (Obelisk Side 3) - 0x3351D - True
+0xFFE03 (Obelisk Side 4) - 0x0053C & 0x00771 & 0x335C8 & 0x335C9 & 0x337F8 & 0x037BB & 0x220E4 & 0x220E5 - True
+0xFFE04 (Obelisk Side 5) - 0x334B9 & 0x334BC & 0x22106 & 0x0A14C & 0x0A14D - True
+0x00359 (Obelisk) - True - True
 
 Desert Outside (Desert) - Main Island - True - Desert Light Room - 0x09FEE - Desert Vault - 0x03444:
-158652 - 0x0CC7B (Vault Panel) - True - Full Dots & Stars + Same Colored Symbol & Eraser & Triangles & Shapers & Negative Shapers & Colored Squares
+0x0CC7B (Vault Panel) - True - Full Dots & Stars + Same Colored Symbol & Eraser & Triangles & Shapers & Negative Shapers & Colored Squares
 Door - 0x03444 (Vault Door) - 0x0CC7B
-158602 - 0x17CE7 (Discard) - True - Arrows
-158076 - 0x00698 (Surface 1) - True - True
-158077 - 0x0048F (Surface 2) - 0x00698 - True
-158078 - 0x09F92 (Surface 3) - 0x0048F & 0x09FA0 - True
-158079 - 0x09FA0 (Surface 3 Control) - 0x0048F - True
-158080 - 0x0A036 (Surface 4) - 0x09F92 - True
-158081 - 0x09DA6 (Surface 5) - 0x09F92 - True
-158082 - 0x0A049 (Surface 6) - 0x09F92 - True
-158083 - 0x0A053 (Surface 7) - 0x0A036 & 0x09DA6 & 0x0A049 - True
-158084 - 0x09F94 (Surface 8) - 0x0A053 & 0x09F86 - True
-158085 - 0x09F86 (Surface 8 Control) - 0x0A053 - True
-158086 - 0x0C339 (Light Room Entry Panel) - 0x09F94 - True
+0x17CE7 (Discard) - True - Arrows
+0x00698 (Surface 1) - True - True
+0x0048F (Surface 2) - 0x00698 - True
+0x09F92 (Surface 3) - 0x0048F & 0x09FA0 - True
+0x09FA0 (Surface 3 Control) - 0x0048F - True
+0x0A036 (Surface 4) - 0x09F92 - True
+0x09DA6 (Surface 5) - 0x09F92 - True
+0x0A049 (Surface 6) - 0x09F92 - True
+0x0A053 (Surface 7) - 0x0A036 & 0x09DA6 & 0x0A049 - True
+0x09F94 (Surface 8) - 0x0A053 & 0x09F86 - True
+0x09F86 (Surface 8 Control) - 0x0A053 - True
+0x0C339 (Light Room Entry Panel) - 0x09F94 - True
 Door - 0x09FEE (Light Room Entry) - 0x0C339
-158701 - 0x03608 (Laser Panel) - 0x012D7 & 0x0A15F - True
+0x03608 (Laser Panel) - 0x012D7 & 0x0A15F - True
 Laser - 0x012FB (Laser) - 0x03608
-159804 - 0xFFD03 (Laser Activated + Redirected) - 0x09F98 & 0x012FB - True
-159020 - 0x3351D (Sand Snake EP) - True - True
-159030 - 0x0053C (Facade Right EP) - True - True
-159031 - 0x00771 (Facade Left EP) - True - True
-159032 - 0x335C8 (Stairs Left EP) - True - True
-159033 - 0x335C9 (Stairs Right EP) - True - True
-159036 - 0x220E4 (Broken Wall Straight EP) - True - True
-159037 - 0x220E5 (Broken Wall Bend EP) - True - True
-159040 - 0x334B9 (Shore EP) - True - True
-159041 - 0x334BC (Island EP) - True - True
+0xFFD03 (Laser Activated + Redirected) - 0x09F98 & 0x012FB - True
+0x3351D (Sand Snake EP) - True - True
+0x0053C (Facade Right EP) - True - True
+0x00771 (Facade Left EP) - True - True
+0x335C8 (Stairs Left EP) - True - True
+0x335C9 (Stairs Right EP) - True - True
+0x220E4 (Broken Wall Straight EP) - True - True
+0x220E5 (Broken Wall Bend EP) - True - True
+0x334B9 (Shore EP) - True - True
+0x334BC (Island EP) - True - True
 
 Desert Vault (Desert):
-158653 - 0x0339E (Vault Box) - True - True
+0x0339E (Vault Box) - True - True
 
 Desert Light Room (Desert) - Desert Pond Room - 0x0C2C3:
-158087 - 0x09FAA (Light Control) - True - True
-158088 - 0x00422 (Light Room 1) - 0x09FAA - True
-158089 - 0x006E3 (Light Room 2) - 0x09FAA - True
-158090 - 0x0A02D (Light Room 3) - 0x09FAA & 0x00422 & 0x006E3 - True
+0x09FAA (Light Control) - True - True
+0x00422 (Light Room 1) - 0x09FAA - True
+0x006E3 (Light Room 2) - 0x09FAA - True
+0x0A02D (Light Room 3) - 0x09FAA & 0x00422 & 0x006E3 - True
 Door - 0x0C2C3 (Pond Room Entry) - 0x0A02D
 
 Desert Pond Room (Desert) - Desert Flood Room - 0x0A24B:
-158091 - 0x00C72 (Pond Room 1) - True - True
-158092 - 0x0129D (Pond Room 2) - 0x00C72 - True
-158093 - 0x008BB (Pond Room 3) - 0x0129D - True
-158094 - 0x0078D (Pond Room 4) - 0x008BB - True
-158095 - 0x18313 (Pond Room 5) - 0x0078D - True
-158096 - 0x0A249 (Flood Room Entry Panel) - 0x18313 - True
+0x00C72 (Pond Room 1) - True - True
+0x0129D (Pond Room 2) - 0x00C72 - True
+0x008BB (Pond Room 3) - 0x0129D - True
+0x0078D (Pond Room 4) - 0x008BB - True
+0x18313 (Pond Room 5) - 0x0078D - True
+0x0A249 (Flood Room Entry Panel) - 0x18313 - True
 Door - 0x0A24B (Flood Room Entry) - 0x0A249
-159043 - 0x0A14C (Pond Room Near Reflection EP) - True - True
-159044 - 0x0A14D (Pond Room Far Reflection EP) - True - True
+0x0A14C (Pond Room Near Reflection EP) - True - True
+0x0A14D (Pond Room Far Reflection EP) - True - True
 
 Desert Flood Room (Desert) - Desert Elevator Room - 0x0C316 - Desert Flood Room Underwater - 0x1C260:
-158097 - 0x1C2DF (Reduce Water Level Far Left) - True - True
-158098 - 0x1831E (Reduce Water Level Far Right) - True - True
-158099 - 0x1C260 (Reduce Water Level Near Left) - True - True
-158100 - 0x1831C (Reduce Water Level Near Right) - True - True
-158101 - 0x1C2F3 (Raise Water Level Far Left) - True - True
-158102 - 0x1831D (Raise Water Level Far Right) - True - True
-158103 - 0x1C2B1 (Raise Water Level Near Left) - True - True
-158104 - 0x1831B (Raise Water Level Near Right) - True - True
-158105 - 0x04D18 (Flood Room 1) - 0x1C260 & 0x1831C - True
-158106 - 0x01205 (Flood Room 2) - 0x04D18 & 0x1C260 & 0x1831C - True
-158107 - 0x181AB (Flood Room 3) - 0x01205 & 0x1C260 & 0x1831C - True
-158108 - 0x0117A (Flood Room 4) - 0x181AB & 0x1C260 & 0x1831C - True
-158109 - 0x17ECA (Flood Room 5) - 0x0117A & 0x1C260 & 0x1831C - True
-158110 - 0x18076 (Flood Room 6) - 0x17ECA & 0x1C260 & 0x1831C - True
+0x1C2DF (Reduce Water Level Far Left) - True - True
+0x1831E (Reduce Water Level Far Right) - True - True
+0x1C260 (Reduce Water Level Near Left) - True - True
+0x1831C (Reduce Water Level Near Right) - True - True
+0x1C2F3 (Raise Water Level Far Left) - True - True
+0x1831D (Raise Water Level Far Right) - True - True
+0x1C2B1 (Raise Water Level Near Left) - True - True
+0x1831B (Raise Water Level Near Right) - True - True
+0x04D18 (Flood Room 1) - 0x1C260 & 0x1831C - True
+0x01205 (Flood Room 2) - 0x04D18 & 0x1C260 & 0x1831C - True
+0x181AB (Flood Room 3) - 0x01205 & 0x1C260 & 0x1831C - True
+0x0117A (Flood Room 4) - 0x181AB & 0x1C260 & 0x1831C - True
+0x17ECA (Flood Room 5) - 0x0117A & 0x1C260 & 0x1831C - True
+0x18076 (Flood Room 6) - 0x17ECA & 0x1C260 & 0x1831C - True
 Door - 0x0C316 (Elevator Room Entry) - 0x18076
-159034 - 0x337F8 (Flood Room EP) - 0x1C2DF - True
+0x337F8 (Flood Room EP) - 0x1C2DF - True
 
 Desert Flood Room Underwater (Desert):
 
 Desert Elevator Room (Desert) - Desert Behind Elevator - 0x01317:
-158111 - 0x17C31 (Elevator Room Transparent) - True - True
-158113 - 0x012D7 (Elevator Room Hexagonal) - 0x17C31 & 0x0A015 - True
-158114 - 0x0A015 (Elevator Room Hexagonal Control) - 0x17C31 - True
-158115 - 0x0A15C (Elevator Room Bent 1) - True - True
-158116 - 0x09FFF (Elevator Room Bent 2) - 0x0A15C - True
-158117 - 0x0A15F (Elevator Room Bent 3) - 0x09FFF - True
-159035 - 0x037BB (Elevator EP) - 0x01317 - True
+0x17C31 (Elevator Room Transparent) - True - True
+0x012D7 (Elevator Room Hexagonal) - 0x17C31 & 0x0A015 - True
+0x0A015 (Elevator Room Hexagonal Control) - 0x17C31 - True
+0x0A15C (Elevator Room Bent 1) - True - True
+0x09FFF (Elevator Room Bent 2) - 0x0A15C - True
+0x0A15F (Elevator Room Bent 3) - 0x09FFF - True
+0x037BB (Elevator EP) - 0x01317 - True
 Door - 0x01317 (Elevator) - 0x03608
 
 Desert Behind Elevator (Desert):
@@ -241,277 +241,277 @@ Desert Behind Elevator (Desert):
 ==Quarry==
 
 Quarry Obelisk (Quarry) - Entry - True:
-159740 - 0xFFE40 (Obelisk Side 1) - 0x28A7B & 0x005F6 & 0x00859 & 0x17CB9 & 0x28A4A - True
-159741 - 0xFFE41 (Obelisk Side 2) - 0x334B6 & 0x00614 & 0x0069D & 0x28A4C - True
-159742 - 0xFFE42 (Obelisk Side 3) - 0x289CF & 0x289D1 - True
-159743 - 0xFFE43 (Obelisk Side 4) - 0x33692 - True
-159744 - 0xFFE44 (Obelisk Side 5) - 0x03E77 & 0x03E7C - True
-159749 - 0x22073 (Obelisk) - True - True
+0xFFE40 (Obelisk Side 1) - 0x28A7B & 0x005F6 & 0x00859 & 0x17CB9 & 0x28A4A - True
+0xFFE41 (Obelisk Side 2) - 0x334B6 & 0x00614 & 0x0069D & 0x28A4C - True
+0xFFE42 (Obelisk Side 3) - 0x289CF & 0x289D1 - True
+0xFFE43 (Obelisk Side 4) - 0x33692 - True
+0xFFE44 (Obelisk Side 5) - 0x03E77 & 0x03E7C - True
+0x22073 (Obelisk) - True - True
 
 Outside Quarry (Quarry) - Main Island - True - Quarry Between Entry Doors - 0x09D6F - Quarry Elevator - 0xFFD00 & 0xFFD01:
-158118 - 0x09E57 (Entry 1 Panel) - True - Black/White Squares & Triangles
-158603 - 0x17CF0 (Discard) - True - Arrows
-158702 - 0x03612 (Laser Panel) - 0x0A3D0 & 0x0367C - Eraser & Triangles & Stars + Same Colored Symbol
+0x09E57 (Entry 1 Panel) - True - Black/White Squares & Triangles
+0x17CF0 (Discard) - True - Arrows
+0x03612 (Laser Panel) - 0x0A3D0 & 0x0367C - Eraser & Triangles & Stars + Same Colored Symbol
 Laser - 0x01539 (Laser) - 0x03612
 Door - 0x09D6F (Entry 1) - 0x09E57
-159404 - 0x28A4A (Shore EP) - True - True
-159410 - 0x334B6 (Entrance Pipe EP) - True - True
-159412 - 0x28A4C (Sand Pile EP) - True - True
-159420 - 0x289CF (Rock Line EP) - True - True
-159421 - 0x289D1 (Rock Line Reflection EP) - True - True
+0x28A4A (Shore EP) - True - True
+0x334B6 (Entrance Pipe EP) - True - True
+0x28A4C (Sand Pile EP) - True - True
+0x289CF (Rock Line EP) - True - True
+0x289D1 (Rock Line Reflection EP) - True - True
 
 Quarry Elevator (Quarry) - Outside Quarry - 0x17CC4 - Quarry - 0x17CC4:
-158120 - 0x17CC4 (Elevator Control) - 0x0367C - Dots & Eraser
-159403 - 0x17CB9 (Railroad EP) - 0x17CC4 - True
+0x17CC4 (Elevator Control) - 0x0367C - Dots & Eraser
+0x17CB9 (Railroad EP) - 0x17CC4 - True
 
 Quarry Between Entry Doors (Quarry) - Quarry - 0x17C07:
-158119 - 0x17C09 (Entry 2 Panel) - True - Shapers & Triangles
+0x17C09 (Entry 2 Panel) - True - Shapers & Triangles
 Door - 0x17C07 (Entry 2) - 0x17C09
 
 Quarry (Quarry) - Quarry Stoneworks Ground Floor - 0x02010:
-159802 - 0xFFD01 (Inside Reached Independently) - True - True
-158121 - 0x01E5A (Stoneworks Entry Left Panel) - True - Black/White Squares & Stars + Same Colored Symbol
-158122 - 0x01E59 (Stoneworks Entry Right Panel) - True - Triangles
+0xFFD01 (Inside Reached Independently) - True - True
+0x01E5A (Stoneworks Entry Left Panel) - True - Black/White Squares & Stars + Same Colored Symbol
+0x01E59 (Stoneworks Entry Right Panel) - True - Triangles
 Door - 0x02010 (Stoneworks Entry) - 0x01E59 & 0x01E5A
 
 Quarry Stoneworks Ground Floor (Quarry Stoneworks) - Quarry - 0x275FF - Quarry Stoneworks Middle Floor - 0x03678 - Outside Quarry - 0x17CE8 - Quarry Stoneworks Lift - TrueOneWay:
-158123 - 0x275ED (Side Exit Panel) - True - True
+0x275ED (Side Exit Panel) - True - True
 Door - 0x275FF (Side Exit) - 0x275ED
-158124 - 0x03678 (Lower Ramp Control) - True - Dots & Eraser
-158145 - 0x17CAC (Roof Exit Panel) - True - True
+0x03678 (Lower Ramp Control) - True - Dots & Eraser
+0x17CAC (Roof Exit Panel) - True - True
 Door - 0x17CE8 (Roof Exit) - 0x17CAC
 
 Quarry Stoneworks Middle Floor (Quarry Stoneworks) - Quarry Stoneworks Lift - TrueOneWay:
-158125 - 0x00E0C (Lower Row 1) - True - Triangles & Eraser
-158126 - 0x01489 (Lower Row 2) - 0x00E0C - Triangles & Eraser
-158127 - 0x0148A (Lower Row 3) - 0x01489 - Triangles & Eraser
-158128 - 0x014D9 (Lower Row 4) - 0x0148A - Triangles & Eraser
-158129 - 0x014E7 (Lower Row 5) - 0x014D9 - Triangles & Eraser
-158130 - 0x014E8 (Lower Row 6) - 0x014E7 - Triangles & Eraser
+0x00E0C (Lower Row 1) - True - Triangles & Eraser
+0x01489 (Lower Row 2) - 0x00E0C - Triangles & Eraser
+0x0148A (Lower Row 3) - 0x01489 - Triangles & Eraser
+0x014D9 (Lower Row 4) - 0x0148A - Triangles & Eraser
+0x014E7 (Lower Row 5) - 0x014D9 - Triangles & Eraser
+0x014E8 (Lower Row 6) - 0x014E7 - Triangles & Eraser
 
 Quarry Stoneworks Lift (Quarry Stoneworks) - Quarry Stoneworks Middle Floor - 0x03679 - Quarry Stoneworks Ground Floor - 0x03679 - Quarry Stoneworks Upper Floor - 0x03679:
-158131 - 0x03679 (Lower Lift Control) - 0x014E8 - Dots & Eraser
+0x03679 (Lower Lift Control) - 0x014E8 - Dots & Eraser
 
 Quarry Stoneworks Upper Floor (Quarry Stoneworks) - Quarry Stoneworks Lift - 0x03675 - Quarry Stoneworks Ground Floor - 0x0368A:
-158132 - 0x03676 (Upper Ramp Control) - True - Dots & Eraser
-158133 - 0x03675 (Upper Lift Control) - True - Dots & Eraser
-158134 - 0x00557 (Upper Row 1) - True - Colored Squares & Eraser & Stars + Same Colored Symbol
-158135 - 0x005F1 (Upper Row 2) - 0x00557 - Colored Squares & Eraser & Stars + Same Colored Symbol
-158136 - 0x00620 (Upper Row 3) - 0x005F1 - Colored Squares & Eraser & Stars + Same Colored Symbol
-158137 - 0x009F5 (Upper Row 4) - 0x00620 - Colored Squares & Eraser & Stars + Same Colored Symbol
-158138 - 0x0146C (Upper Row 5) - 0x009F5 - Colored Squares & Eraser & Stars + Same Colored Symbol
-158139 - 0x3C12D (Upper Row 6) - 0x0146C - Colored Squares & Eraser & Stars + Same Colored Symbol
-158140 - 0x03686 (Upper Row 7) - 0x3C12D - Colored Squares & Eraser & Stars + Same Colored Symbol
-158141 - 0x014E9 (Upper Row 8) - 0x03686 - Colored Squares & Eraser & Stars + Same Colored Symbol
-158142 - 0x03677 (Stairs Panel) - True - Colored Squares & Eraser
+0x03676 (Upper Ramp Control) - True - Dots & Eraser
+0x03675 (Upper Lift Control) - True - Dots & Eraser
+0x00557 (Upper Row 1) - True - Colored Squares & Eraser & Stars + Same Colored Symbol
+0x005F1 (Upper Row 2) - 0x00557 - Colored Squares & Eraser & Stars + Same Colored Symbol
+0x00620 (Upper Row 3) - 0x005F1 - Colored Squares & Eraser & Stars + Same Colored Symbol
+0x009F5 (Upper Row 4) - 0x00620 - Colored Squares & Eraser & Stars + Same Colored Symbol
+0x0146C (Upper Row 5) - 0x009F5 - Colored Squares & Eraser & Stars + Same Colored Symbol
+0x3C12D (Upper Row 6) - 0x0146C - Colored Squares & Eraser & Stars + Same Colored Symbol
+0x03686 (Upper Row 7) - 0x3C12D - Colored Squares & Eraser & Stars + Same Colored Symbol
+0x014E9 (Upper Row 8) - 0x03686 - Colored Squares & Eraser & Stars + Same Colored Symbol
+0x03677 (Stairs Panel) - True - Colored Squares & Eraser
 Door - 0x0368A (Stairs) - 0x03677
-158143 - 0x3C125 (Control Room Left) - 0x014E9 - Black/White Squares & Full Dots & Eraser
-158144 - 0x0367C (Control Room Right) - 0x014E9 - Colored Squares & Triangles & Eraser & Stars + Same Colored Symbol
-159411 - 0x0069D (Ramp EP) - 0x03676 & 0x275FF - True
-159413 - 0x00614 (Lift EP) - 0x275FF & 0x03675 - True
+0x3C125 (Control Room Left) - 0x014E9 - Black/White Squares & Full Dots & Eraser
+0x0367C (Control Room Right) - 0x014E9 - Colored Squares & Triangles & Eraser & Stars + Same Colored Symbol
+0x0069D (Ramp EP) - 0x03676 & 0x275FF - True
+0x00614 (Lift EP) - 0x275FF & 0x03675 - True
 
 Quarry Boathouse (Quarry Boathouse) - Quarry - True - Quarry Boathouse Upper Front - 0x03852 - Quarry Boathouse Behind Staircase - 0x2769B:
-158146 - 0x034D4 (Intro Left) - True - Stars + Same Colored Symbol & Eraser
-158147 - 0x021D5 (Intro Right) - True - Shapers & Eraser
-158148 - 0x03852 (Ramp Height Control) - 0x034D4 & 0x021D5 - Rotated Shapers
-158166 - 0x17CA6 (Boat Spawn) - True - Boat
+0x034D4 (Intro Left) - True - Stars + Same Colored Symbol & Eraser
+0x021D5 (Intro Right) - True - Shapers & Eraser
+0x03852 (Ramp Height Control) - 0x034D4 & 0x021D5 - Rotated Shapers
+0x17CA6 (Boat Spawn) - True - Boat
 Door - 0x2769B (Dock) - 0x17CA6
 Door - 0x27163 (Dock Invis Barrier) - 0x17CA6
 
 Quarry Boathouse Behind Staircase (Quarry Boathouse) - The Ocean - 0x17CA6:
 
 Quarry Boathouse Upper Front (Quarry Boathouse) - Quarry Boathouse Upper Middle - 0x17C50:
-158149 - 0x021B3 (Front Row 1) - True - Shapers & Eraser & Negative Shapers
-158150 - 0x021B4 (Front Row 2) - 0x021B3 - Shapers & Eraser & Negative Shapers
-158151 - 0x021B0 (Front Row 3) - 0x021B4 - Shapers & Eraser & Negative Shapers
-158152 - 0x021AF (Front Row 4) - 0x021B0 - Shapers & Eraser & Negative Shapers
-158153 - 0x021AE (Front Row 5) - 0x021AF - Shapers & Eraser & Negative Shapers
+0x021B3 (Front Row 1) - True - Shapers & Eraser & Negative Shapers
+0x021B4 (Front Row 2) - 0x021B3 - Shapers & Eraser & Negative Shapers
+0x021B0 (Front Row 3) - 0x021B4 - Shapers & Eraser & Negative Shapers
+0x021AF (Front Row 4) - 0x021B0 - Shapers & Eraser & Negative Shapers
+0x021AE (Front Row 5) - 0x021AF - Shapers & Eraser & Negative Shapers
 Door - 0x17C50 (First Barrier) - 0x021AE
 
 Quarry Boathouse Upper Middle (Quarry Boathouse) - Quarry Boathouse Upper Back - 0x03858:
-158154 - 0x03858 (Ramp Horizontal Control) - True - Shapers & Eraser
-159402 - 0x00859 (Moving Ramp EP) - 0x03858 & 0x03852 & 0x3865F - True
+0x03858 (Ramp Horizontal Control) - True - Shapers & Eraser
+0x00859 (Moving Ramp EP) - 0x03858 & 0x03852 & 0x3865F - True
 
 Quarry Boathouse Upper Back (Quarry Boathouse) - Quarry Boathouse Upper Middle - 0x3865F:
-158155 - 0x38663 (Second Barrier Panel) - True - True
+0x38663 (Second Barrier Panel) - True - True
 Door - 0x3865F (Second Barrier) - 0x38663
-158156 - 0x021B5 (Back First Row 1) - True - Stars + Same Colored Symbol & Eraser
-158157 - 0x021B6 (Back First Row 2) - 0x021B5 - Stars + Same Colored Symbol & Eraser
-158158 - 0x021B7 (Back First Row 3) - 0x021B6 - Stars + Same Colored Symbol & Eraser
-158159 - 0x021BB (Back First Row 4) - 0x021B7 - Stars + Same Colored Symbol & Eraser
-158160 - 0x09DB5 (Back First Row 5) - 0x021BB - Stars + Same Colored Symbol & Eraser
-158161 - 0x09DB1 (Back First Row 6) - 0x09DB5 - Eraser & Shapers
-158162 - 0x3C124 (Back First Row 7) - 0x09DB1 - Eraser & Shapers
-158163 - 0x09DB3 (Back First Row 8) - 0x3C124 - Eraser & Shapers & Stars + Same Colored Symbol
-158164 - 0x09DB4 (Back First Row 9) - 0x09DB3 - Eraser & Shapers & Stars + Same Colored Symbol
-158165 - 0x275FA (Hook Control) - True - Shapers & Eraser
-158167 - 0x0A3CB (Back Second Row 1) - 0x09DB4 - Eraser & Shapers & Negative Shapers & Stars + Same Colored Symbol
-158168 - 0x0A3CC (Back Second Row 2) - 0x0A3CB - Eraser & Shapers & Negative Shapers & Stars + Same Colored Symbol
-158169 - 0x0A3D0 (Back Second Row 3) - 0x0A3CC - Eraser & Shapers & Negative Shapers & Stars + Same Colored Symbol
-159401 - 0x005F6 (Hook EP) - 0x275FA & 0x03852 & 0x3865F - True
+0x021B5 (Back First Row 1) - True - Stars + Same Colored Symbol & Eraser
+0x021B6 (Back First Row 2) - 0x021B5 - Stars + Same Colored Symbol & Eraser
+0x021B7 (Back First Row 3) - 0x021B6 - Stars + Same Colored Symbol & Eraser
+0x021BB (Back First Row 4) - 0x021B7 - Stars + Same Colored Symbol & Eraser
+0x09DB5 (Back First Row 5) - 0x021BB - Stars + Same Colored Symbol & Eraser
+0x09DB1 (Back First Row 6) - 0x09DB5 - Eraser & Shapers
+0x3C124 (Back First Row 7) - 0x09DB1 - Eraser & Shapers
+0x09DB3 (Back First Row 8) - 0x3C124 - Eraser & Shapers & Stars + Same Colored Symbol
+0x09DB4 (Back First Row 9) - 0x09DB3 - Eraser & Shapers & Stars + Same Colored Symbol
+0x275FA (Hook Control) - True - Shapers & Eraser
+0x0A3CB (Back Second Row 1) - 0x09DB4 - Eraser & Shapers & Negative Shapers & Stars + Same Colored Symbol
+0x0A3CC (Back Second Row 2) - 0x0A3CB - Eraser & Shapers & Negative Shapers & Stars + Same Colored Symbol
+0x0A3D0 (Back Second Row 3) - 0x0A3CC - Eraser & Shapers & Negative Shapers & Stars + Same Colored Symbol
+0x005F6 (Hook EP) - 0x275FA & 0x03852 & 0x3865F - True
 
 ==Shadows==
 
 Shadows (Shadows) - Main Island - True - Shadows Ledge - 0x19B24 - Shadows Laser Room - 0x194B2 | 0x19665:
-158170 - 0x334DB (Door Timer Outside) - True - True
+0x334DB (Door Timer Outside) - True - True
 Door - 0x19B24 (Timed Door) - 0x334DB | 0x334DC
-158171 - 0x0AC74 (Intro 6) - 0x0A8DC - True
-158172 - 0x0AC7A (Intro 7) - 0x0AC74 - True
-158173 - 0x0A8E0 (Intro 8) - 0x0AC7A - True
-158174 - 0x386FA (Far 1) - 0x0A8E0 - True
-158175 - 0x1C33F (Far 2) - 0x386FA - True
-158176 - 0x196E2 (Far 3) - 0x1C33F - True
-158177 - 0x1972A (Far 4) - 0x196E2 - True
-158178 - 0x19809 (Far 5) - 0x1972A - True
-158179 - 0x19806 (Far 6) - 0x19809 - True
-158180 - 0x196F8 (Far 7) - 0x19806 - True
-158181 - 0x1972F (Far 8) - 0x196F8 - True
+0x0AC74 (Intro 6) - 0x0A8DC - True
+0x0AC7A (Intro 7) - 0x0AC74 - True
+0x0A8E0 (Intro 8) - 0x0AC7A - True
+0x386FA (Far 1) - 0x0A8E0 - True
+0x1C33F (Far 2) - 0x386FA - True
+0x196E2 (Far 3) - 0x1C33F - True
+0x1972A (Far 4) - 0x196E2 - True
+0x19809 (Far 5) - 0x1972A - True
+0x19806 (Far 6) - 0x19809 - True
+0x196F8 (Far 7) - 0x19806 - True
+0x1972F (Far 8) - 0x196F8 - True
 Door - 0x194B2 (Laser Entry Right) - 0x1972F
-158182 - 0x19797 (Near 1) - 0x0A8E0 - True
-158183 - 0x1979A (Near 2) - 0x19797 - True
-158184 - 0x197E0 (Near 3) - 0x1979A - True
-158185 - 0x197E8 (Near 4) - 0x197E0 - True
-158186 - 0x197E5 (Near 5) - 0x197E8 - True
+0x19797 (Near 1) - 0x0A8E0 - True
+0x1979A (Near 2) - 0x19797 - True
+0x197E0 (Near 3) - 0x1979A - True
+0x197E8 (Near 4) - 0x197E0 - True
+0x197E5 (Near 5) - 0x197E8 - True
 Door - 0x19665 (Laser Entry Left) - 0x197E5
-159400 - 0x28A7B (Quarry Stoneworks Rooftop Vent EP) - True - True
+0x28A7B (Quarry Stoneworks Rooftop Vent EP) - True - True
 
 Shadows Ledge (Shadows) - Shadows - 0x1855B - Quarry - 0x19865 & 0x0A2DF:
-158187 - 0x334DC (Door Timer Inside) - True - True
-158188 - 0x198B5 (Intro 1) - True - True
-158189 - 0x198BD (Intro 2) - 0x198B5 - True
-158190 - 0x198BF (Intro 3) - 0x198BD & 0x19B24 - True
+0x334DC (Door Timer Inside) - True - True
+0x198B5 (Intro 1) - True - True
+0x198BD (Intro 2) - 0x198B5 - True
+0x198BF (Intro 3) - 0x198BD & 0x19B24 - True
 Door - 0x19865 (Quarry Barrier) - 0x198BF
 Door - 0x0A2DF (Quarry Barrier 2) - 0x198BF
-158191 - 0x19771 (Intro 4) - 0x198BF - True
-158192 - 0x0A8DC (Intro 5) - 0x19771 - True
+0x19771 (Intro 4) - 0x198BF - True
+0x0A8DC (Intro 5) - 0x19771 - True
 Door - 0x1855B (Ledge Barrier) - 0x0A8DC
 Door - 0x19ADE (Ledge Barrier 2) - 0x0A8DC
 
 Shadows Laser Room (Shadows):
-158703 - 0x19650 (Laser Panel) - 0x194B2 & 0x19665 - True
+0x19650 (Laser Panel) - 0x194B2 & 0x19665 - True
 Laser - 0x181B3 (Laser) - 0x19650
 
 ==Keep==
 
 Outside Keep (Keep) - Main Island - True:
-159430 - 0x03E77 (Red Flowers EP) - True - True
-159431 - 0x03E7C (Purple Flowers EP) - True - True
+0x03E77 (Red Flowers EP) - True - True
+0x03E7C (Purple Flowers EP) - True - True
 
 Keep (Keep) - Outside Keep - True - Keep 2nd Maze - 0x01954 - Keep 2nd Pressure Plate - 0x01BEC:
-158193 - 0x00139 (Hedge Maze 1) - True - True
-158197 - 0x0A3A8 (Reset Pressure Plates 1) - True - True
-158198 - 0x033EA (Pressure Plates 1) - 0x0A3A8 - Colored Squares & Triangles & Stars + Same Colored Symbol
+0x00139 (Hedge Maze 1) - True - True
+0x0A3A8 (Reset Pressure Plates 1) - True - True
+0x033EA (Pressure Plates 1) - 0x0A3A8 - Colored Squares & Triangles & Stars + Same Colored Symbol
 Door - 0x01954 (Hedge Maze 1 Exit) - 0x00139
 Door - 0x01BEC (Pressure Plates 1 Exit) - 0x033EA
 
 Keep 2nd Maze (Keep) - Keep - 0x018CE - Keep 3rd Maze - 0x019D8:
 Door - 0x018CE (Hedge Maze 2 Shortcut) - 0x00139
-158194 - 0x019DC (Hedge Maze 2) - True - True
+0x019DC (Hedge Maze 2) - True - True
 Door - 0x019D8 (Hedge Maze 2 Exit) - 0x019DC
 
 Keep 3rd Maze (Keep) - Keep - 0x019B5 - Keep 4th Maze - 0x019E6:
 Door - 0x019B5 (Hedge Maze 3 Shortcut) - 0x019DC
-158195 - 0x019E7 (Hedge Maze 3) - True - True
+0x019E7 (Hedge Maze 3) - True - True
 Door - 0x019E6 (Hedge Maze 3 Exit) - 0x019E7
 
 Keep 4th Maze (Keep) - Keep - 0x0199A - Keep Tower - 0x01A0E:
 Door - 0x0199A (Hedge Maze 4 Shortcut) - 0x019E7
-158196 - 0x01A0F (Hedge Maze 4) - True - True
+0x01A0F (Hedge Maze 4) - True - True
 Door - 0x01A0E (Hedge Maze 4 Exit) - 0x01A0F
 
 Keep 2nd Pressure Plate (Keep) - Keep 3rd Pressure Plate - True:
-158199 - 0x0A3B9 (Reset Pressure Plates 2) - True - True
-158200 - 0x01BE9 (Pressure Plates 2) - PP2 Weirdness - Stars + Same Colored Symbol & Black/White Squares & Shapers & Rotated Shapers
+0x0A3B9 (Reset Pressure Plates 2) - True - True
+0x01BE9 (Pressure Plates 2) - PP2 Weirdness - Stars + Same Colored Symbol & Black/White Squares & Shapers & Rotated Shapers
 Door - 0x01BEA (Pressure Plates 2 Exit) - 0x01BE9
 
 Keep 3rd Pressure Plate (Keep) - Keep 4th Pressure Plate - 0x01CD5:
-158201 - 0x0A3BB (Reset Pressure Plates 3) - True - True
-158202 - 0x01CD3 (Pressure Plates 3) - 0x0A3BB - Black/White Squares & Triangles & Shapers & Rotated Shapers
+0x0A3BB (Reset Pressure Plates 3) - True - True
+0x01CD3 (Pressure Plates 3) - 0x0A3BB - Black/White Squares & Triangles & Shapers & Rotated Shapers
 Door - 0x01CD5 (Pressure Plates 3 Exit) - 0x01CD3
 
 Keep 4th Pressure Plate (Keep) - Shadows - 0x09E3D - Keep Tower - 0x01D40:
-158203 - 0x0A3AD (Reset Pressure Plates 4) - True - True
-158204 - 0x01D3F (Pressure Plates 4) - 0x0A3AD - Shapers & Triangles & Stars + Same Colored Symbol
+0x0A3AD (Reset Pressure Plates 4) - True - True
+0x01D3F (Pressure Plates 4) - 0x0A3AD - Shapers & Triangles & Stars + Same Colored Symbol
 Door - 0x01D40 (Pressure Plates 4 Exit) - 0x01D3F
-158604 - 0x17D27 (Discard) - True - Arrows
-158205 - 0x09E49 (Shadows Shortcut Panel) - True - True
+0x17D27 (Discard) - True - Arrows
+0x09E49 (Shadows Shortcut Panel) - True - True
 Door - 0x09E3D (Shadows Shortcut) - 0x09E49
 
 Keep Tower (Keep) - Keep - 0x04F8F:
-158206 - 0x0361B (Tower Shortcut Panel) - True - True
+0x0361B (Tower Shortcut Panel) - True - True
 Door - 0x04F8F (Tower Shortcut) - 0x0361B
-158704 - 0x0360E (Laser Panel Hedges) - 0x01A0F & 0x019E7 & 0x019DC & 0x00139 - True
-158705 - 0x03317 (Laser Panel Pressure Plates) - 0x033EA & 0x01BE9 & 0x01CD3 & 0x01D3F - Shapers & Rotated Shapers & Triangles & Stars + Same Colored Symbol & Colored Squares & Black/White Squares
+0x0360E (Laser Panel Hedges) - 0x01A0F & 0x019E7 & 0x019DC & 0x00139 - True
+0x03317 (Laser Panel Pressure Plates) - 0x033EA & 0x01BE9 & 0x01CD3 & 0x01D3F - Shapers & Rotated Shapers & Triangles & Stars + Same Colored Symbol & Colored Squares & Black/White Squares
 Laser - 0x014BB (Laser) - 0x0360E | 0x03317
-159240 - 0x033BE (Pressure Plates 1 EP) - 0x033EA - True
-159241 - 0x033BF (Pressure Plates 2 EP) - 0x01BE9 - True
-159242 - 0x033DD (Pressure Plates 3 EP) - 0x01CD3 & 0x01CD5 - True
-159243 - 0x033E5 (Pressure Plates 4 Left Exit EP) - 0x01D3F - True
-159244 - 0x018B6 (Pressure Plates 4 Right Exit EP) - 0x01D3F - True
-159250 - 0x28AE9 (Path EP) - True - True
-159251 - 0x3348F (Hedges EP) - True - True
+0x033BE (Pressure Plates 1 EP) - 0x033EA - True
+0x033BF (Pressure Plates 2 EP) - 0x01BE9 - True
+0x033DD (Pressure Plates 3 EP) - 0x01CD3 & 0x01CD5 - True
+0x033E5 (Pressure Plates 4 Left Exit EP) - 0x01D3F - True
+0x018B6 (Pressure Plates 4 Right Exit EP) - 0x01D3F - True
+0x28AE9 (Path EP) - True - True
+0x3348F (Hedges EP) - True - True
 
 ==Shipwreck==
 
 Shipwreck (Shipwreck) - Keep 3rd Pressure Plate - True - Shipwreck Vault - 0x17BB4:
-158654 - 0x00AFB (Vault Panel) - True - Symmetry & Sound Dots & Colored Dots
+0x00AFB (Vault Panel) - True - Symmetry & Sound Dots & Colored Dots
 Door - 0x17BB4 (Vault Door) - 0x00AFB
-158605 - 0x17D28 (Discard) - True - Arrows
-159220 - 0x03B22 (Circle Far EP) - True - True
-159221 - 0x03B23 (Circle Left EP) - True - True
-159222 - 0x03B24 (Circle Near EP) - True - True
-159224 - 0x03A79 (Stern EP) - True - True
-159225 - 0x28ABD (Rope Inner EP) - True - True
-159226 - 0x28ABE (Rope Outer EP) - True - True
-159230 - 0x3388F (Couch EP) - 0x17CDF | 0x0A054 - True
+0x17D28 (Discard) - True - Arrows
+0x03B22 (Circle Far EP) - True - True
+0x03B23 (Circle Left EP) - True - True
+0x03B24 (Circle Near EP) - True - True
+0x03A79 (Stern EP) - True - True
+0x28ABD (Rope Inner EP) - True - True
+0x28ABE (Rope Outer EP) - True - True
+0x3388F (Couch EP) - 0x17CDF | 0x0A054 - True
 
 Shipwreck Vault (Shipwreck):
-158655 - 0x03535 (Vault Box) - True - True
+0x03535 (Vault Box) - True - True
 
 ==Monastery==
 
 Monastery Obelisk (Monastery) - Entry - True:
-159710 - 0xFFE10 (Obelisk Side 1) - 0x03ABC & 0x03ABE & 0x03AC0 & 0x03AC4 - True
-159711 - 0xFFE11 (Obelisk Side 2) - 0x03AC5 - True
-159712 - 0xFFE12 (Obelisk Side 3) - 0x03BE2 & 0x03BE3 & 0x0A409 - True
-159713 - 0xFFE13 (Obelisk Side 4) - 0x006E5 & 0x006E6 & 0x006E7 & 0x034A7 & 0x034AD & 0x034AF & 0x03DAB & 0x03DAC & 0x03DAD - True
-159714 - 0xFFE14 (Obelisk Side 5) - 0x03E01 - True
-159715 - 0xFFE15 (Obelisk Side 6) - 0x289F4 & 0x289F5 - True
-159719 - 0x00263 (Obelisk) - True - True
+0xFFE10 (Obelisk Side 1) - 0x03ABC & 0x03ABE & 0x03AC0 & 0x03AC4 - True
+0xFFE11 (Obelisk Side 2) - 0x03AC5 - True
+0xFFE12 (Obelisk Side 3) - 0x03BE2 & 0x03BE3 & 0x0A409 - True
+0xFFE13 (Obelisk Side 4) - 0x006E5 & 0x006E6 & 0x006E7 & 0x034A7 & 0x034AD & 0x034AF & 0x03DAB & 0x03DAC & 0x03DAD - True
+0xFFE14 (Obelisk Side 5) - 0x03E01 - True
+0xFFE15 (Obelisk Side 6) - 0x289F4 & 0x289F5 - True
+0x00263 (Obelisk) - True - True
 
 Outside Monastery (Monastery) - Main Island - True - Inside Monastery - 0x0C128 & 0x0C153 - Monastery Garden - 0x03750:
-158207 - 0x03713 (Laser Shortcut Panel) - True - True
+0x03713 (Laser Shortcut Panel) - True - True
 Door - 0x0364E (Laser Shortcut) - 0x03713
-158208 - 0x00B10 (Entry Left) - True - True
-158209 - 0x00C92 (Entry Right) - 0x00B10 - True
+0x00B10 (Entry Left) - True - True
+0x00C92 (Entry Right) - 0x00B10 - True
 Door - 0x0C128 (Entry Inner) - 0x00B10
 Door - 0x0C153 (Entry Outer) - 0x00C92
-158210 - 0x00290 (Outside 1) - 0x09D9B - True
-158211 - 0x00038 (Outside 2) - 0x09D9B & 0x00290 - True
-158212 - 0x00037 (Outside 3) - 0x09D9B & 0x00038 - True
+0x00290 (Outside 1) - 0x09D9B - True
+0x00038 (Outside 2) - 0x09D9B & 0x00290 - True
+0x00037 (Outside 3) - 0x09D9B & 0x00038 - True
 Door - 0x03750 (Garden Entry) - 0x00037
-158706 - 0x17CA4 (Laser Panel) - 0x193A6 - True
+0x17CA4 (Laser Panel) - 0x193A6 - True
 Laser - 0x17C65 (Laser) - 0x17CA4
-159130 - 0x006E5 (Facade Left Near EP) - True - True
-159131 - 0x006E6 (Facade Left Far Short EP) - True - True
-159132 - 0x006E7 (Facade Left Far Long EP) - True - True
-159136 - 0x03DAB (Facade Right Near EP) - True - True
-159137 - 0x03DAC (Facade Left Stairs EP) - True - True
-159138 - 0x03DAD (Facade Right Stairs EP) - True - True
-159140 - 0x03E01 (Grass Stairs EP) - True - True
-159120 - 0x03BE2 (Garden Left EP) - 0x03750 - True
-159121 - 0x03BE3 (Garden Right EP) - True - True
-159122 - 0x0A409 (Wall EP) - True - True
+0x006E5 (Facade Left Near EP) - True - True
+0x006E6 (Facade Left Far Short EP) - True - True
+0x006E7 (Facade Left Far Long EP) - True - True
+0x03DAB (Facade Right Near EP) - True - True
+0x03DAC (Facade Left Stairs EP) - True - True
+0x03DAD (Facade Right Stairs EP) - True - True
+0x03E01 (Grass Stairs EP) - True - True
+0x03BE2 (Garden Left EP) - 0x03750 - True
+0x03BE3 (Garden Right EP) - True - True
+0x0A409 (Wall EP) - True - True
 
 Inside Monastery (Monastery) - Monastery North Shutters - 0x09D9B:
-158213 - 0x09D9B (Shutters Control) - True - Dots
-158214 - 0x193A7 (Inside 1) - 0x00037 - True
-158215 - 0x193AA (Inside 2) - 0x193A7 - True
-158216 - 0x193AB (Inside 3) - 0x193AA - True
-158217 - 0x193A6 (Inside 4) - 0x193AB - True
-159133 - 0x034A7 (Left Shutter EP) - 0x09D9B - True
-159134 - 0x034AD (Middle Shutter EP) - 0x09D9B - True
-159135 - 0x034AF (Right Shutter EP) - 0x09D9B - True
+0x09D9B (Shutters Control) - True - Dots
+0x193A7 (Inside 1) - 0x00037 - True
+0x193AA (Inside 2) - 0x193A7 - True
+0x193AB (Inside 3) - 0x193AA - True
+0x193A6 (Inside 4) - 0x193AB - True
+0x034A7 (Left Shutter EP) - 0x09D9B - True
+0x034AD (Middle Shutter EP) - 0x09D9B - True
+0x034AF (Right Shutter EP) - 0x09D9B - True
 
 Monastery Garden (Monastery):
 
@@ -520,76 +520,76 @@ Monastery North Shutters (Monastery):
 ==Town==
 
 Town Obelisk (Town) - Entry - True:
-159750 - 0xFFE50 (Obelisk Side 1) - 0x035C7 - True
-159751 - 0xFFE51 (Obelisk Side 2) - 0x01848 & 0x03D06 & 0x33530 & 0x33600 & 0x28A2F & 0x28A37 & 0x334A3 & 0x3352F - True
-159752 - 0xFFE52 (Obelisk Side 3) - 0x33857 & 0x33879 & 0x03C19 - True
-159753 - 0xFFE53 (Obelisk Side 4) - 0x28B30 & 0x035C9 - True
-159754 - 0xFFE54 (Obelisk Side 5) - 0x03335 & 0x03412 & 0x038A6 & 0x038AA & 0x03E3F & 0x03E40 & 0x28B8E - True
-159755 - 0xFFE55 (Obelisk Side 6) - 0x28B91 & 0x03BCE & 0x03BCF & 0x03BD1 & 0x339B6 & 0x33A20 & 0x33A29 & 0x33A2A & 0x33B06 - True
-159759 - 0x0A16C (Obelisk) - True - True
+0xFFE50 (Obelisk Side 1) - 0x035C7 - True
+0xFFE51 (Obelisk Side 2) - 0x01848 & 0x03D06 & 0x33530 & 0x33600 & 0x28A2F & 0x28A37 & 0x334A3 & 0x3352F - True
+0xFFE52 (Obelisk Side 3) - 0x33857 & 0x33879 & 0x03C19 - True
+0xFFE53 (Obelisk Side 4) - 0x28B30 & 0x035C9 - True
+0xFFE54 (Obelisk Side 5) - 0x03335 & 0x03412 & 0x038A6 & 0x038AA & 0x03E3F & 0x03E40 & 0x28B8E - True
+0xFFE55 (Obelisk Side 6) - 0x28B91 & 0x03BCE & 0x03BCF & 0x03BD1 & 0x339B6 & 0x33A20 & 0x33A29 & 0x33A2A & 0x33B06 - True
+0x0A16C (Obelisk) - True - True
 
 Town (Town) - Main Island - True - The Ocean - 0x0A054 - Town Maze Rooftop - 0x28AA2 - Town Church - True - Town Wooden Rooftop - 0x034F5 - Town RGB House - 0x28A61 - Town Inside Cargo Box - 0x0A0C9 - Outside Windmill - True:
-158218 - 0x0A054 (Boat Spawn) - 0x17CA6 | 0x17CDF | 0x09DB8 | 0x17C95 - Boat
-158219 - 0x0A0C8 (Cargo Box Entry Panel) - True - Black/White Squares & Shapers & Triangles
+0x0A054 (Boat Spawn) - 0x17CA6 | 0x17CDF | 0x09DB8 | 0x17C95 - Boat
+0x0A0C8 (Cargo Box Entry Panel) - True - Black/White Squares & Shapers & Triangles
 Door - 0x0A0C9 (Cargo Box Entry) - 0x0A0C8
-158707 - 0x09F98 (Desert Laser Redirect Control) - True - True
-158220 - 0x18590 (Transparent) - True - Symmetry
-158221 - 0x28AE3 (Vines) - 0x18590 - True
-158222 - 0x28938 (Apple Tree) - 0x28AE3 - True
-158223 - 0x079DF (Triple Exit) - 0x28938 - True
-158235 - 0x2899C (Wooden Roof Lower Row 1) - True - Triangles & Full Dots
-158236 - 0x28A33 (Wooden Roof Lower Row 2) - 0x2899C - Triangles & Full Dots
-158237 - 0x28ABF (Wooden Roof Lower Row 3) - 0x28A33 - Triangles & Full Dots
-158238 - 0x28AC0 (Wooden Roof Lower Row 4) - 0x28ABF - Triangles & Full Dots
-158239 - 0x28AC1 (Wooden Roof Lower Row 5) - 0x28AC0 - Triangles & Full Dots
+0x09F98 (Desert Laser Redirect Control) - True - True
+0x18590 (Transparent) - True - Symmetry
+0x28AE3 (Vines) - 0x18590 - True
+0x28938 (Apple Tree) - 0x28AE3 - True
+0x079DF (Triple Exit) - 0x28938 - True
+0x2899C (Wooden Roof Lower Row 1) - True - Triangles & Full Dots
+0x28A33 (Wooden Roof Lower Row 2) - 0x2899C - Triangles & Full Dots
+0x28ABF (Wooden Roof Lower Row 3) - 0x28A33 - Triangles & Full Dots
+0x28AC0 (Wooden Roof Lower Row 4) - 0x28ABF - Triangles & Full Dots
+0x28AC1 (Wooden Roof Lower Row 5) - 0x28AC0 - Triangles & Full Dots
 Door - 0x034F5 (Wooden Roof Stairs) - 0x28AC1
-158225 - 0x28998 (RGB House Entry Panel) - True - Rotated Shapers & Stars + Same Colored Symbol
+0x28998 (RGB House Entry Panel) - True - Rotated Shapers & Stars + Same Colored Symbol
 Door - 0x28A61 (RGB House Entry) - 0x28A0D
-158226 - 0x28A0D (Church Entry Panel) - 0x28998 - Stars
+0x28A0D (Church Entry Panel) - 0x28998 - Stars
 Door - 0x03BB0 (Church Entry) - 0x03C08
-158228 - 0x28A79 (Maze Panel) - True - True
+0x28A79 (Maze Panel) - True - True
 Door - 0x28AA2 (Maze Stairs) - 0x28A79
-159540 - 0x03335 (Tower Underside Third EP) - True - True
-159541 - 0x03412 (Tower Underside Fourth EP) - True - True
-159542 - 0x038A6 (Tower Underside First EP) - True - True
-159543 - 0x038AA (Tower Underside Second EP) - True - True
-159545 - 0x03E40 (RGB House Green EP) - 0x334D8 - True
-159546 - 0x28B8E (Maze Bridge Underside EP) - 0x2896A - True
-159552 - 0x03BCF (Black Line Redirect EP) - True - True
-159800 - 0xFFF80 (Pet the Dog) - True - True
+0x03335 (Tower Underside Third EP) - True - True
+0x03412 (Tower Underside Fourth EP) - True - True
+0x038A6 (Tower Underside First EP) - True - True
+0x038AA (Tower Underside Second EP) - True - True
+0x03E40 (RGB House Green EP) - 0x334D8 - True
+0x28B8E (Maze Bridge Underside EP) - 0x2896A - True
+0x03BCF (Black Line Redirect EP) - True - True
+0xFFF80 (Pet the Dog) - True - True
 
 Town Inside Cargo Box (Town):
-158606 - 0x17D01 (Cargo Box Discard) - True - Arrows
+0x17D01 (Cargo Box Discard) - True - Arrows
 
 Town Maze Rooftop (Town) - Town Red Rooftop - 0x2896A:
-158229 - 0x2896A (Maze Rooftop Bridge Control) - True - Shapers
-159544 - 0x03E3F (RGB House Red EP) - 0x334D8 & 0x03C0C & 0x03C08 - True
+0x2896A (Maze Rooftop Bridge Control) - True - Shapers
+0x03E3F (RGB House Red EP) - 0x334D8 & 0x03C0C & 0x03C08 - True
 
 Town Red Rooftop (Town):
-158607 - 0x17C71 (Rooftop Discard) - True - Arrows
-158230 - 0x28AC7 (Red Rooftop 1) - True - Symmetry & Shapers
-158231 - 0x28AC8 (Red Rooftop 2) - 0x28AC7 - Symmetry & Shapers
-158232 - 0x28ACA (Red Rooftop 3) - 0x28AC8 - Symmetry & Shapers
-158233 - 0x28ACB (Red Rooftop 4) - 0x28ACA - Symmetry & Shapers
-158234 - 0x28ACC (Red Rooftop 5) - 0x28ACB - Symmetry & Shapers
-158224 - 0x28B39 (Tall Hexagonal) - 0x079DF - True
+0x17C71 (Rooftop Discard) - True - Arrows
+0x28AC7 (Red Rooftop 1) - True - Symmetry & Shapers
+0x28AC8 (Red Rooftop 2) - 0x28AC7 - Symmetry & Shapers
+0x28ACA (Red Rooftop 3) - 0x28AC8 - Symmetry & Shapers
+0x28ACB (Red Rooftop 4) - 0x28ACA - Symmetry & Shapers
+0x28ACC (Red Rooftop 5) - 0x28ACB - Symmetry & Shapers
+0x28B39 (Tall Hexagonal) - 0x079DF - True
 
 Town Wooden Rooftop (Town):
-158240 - 0x28AD9 (Wooden Rooftop) - 0x28AC1 - Triangles & Full Dots & Eraser
+0x28AD9 (Wooden Rooftop) - 0x28AC1 - Triangles & Full Dots & Eraser
 
 Town Church (Town):
-158227 - 0x28A69 (Church Lattice) - 0x03BB0 - True
-159553 - 0x03BD1 (Black Line Church EP) - True - True
+0x28A69 (Church Lattice) - 0x03BB0 - True
+0x03BD1 (Black Line Church EP) - True - True
 
 Town RGB House (Town RGB House) - Town RGB House Upstairs - 0x2897B:
-158242 - 0x034E4 (Sound Room Left) - True - True
-158243 - 0x034E3 (Sound Room Right) - True - Sound Dots
+0x034E4 (Sound Room Left) - True - True
+0x034E3 (Sound Room Right) - True - Sound Dots
 Door - 0x2897B (Stairs) - 0x034E4 & 0x034E3
 
 Town RGB House Upstairs (Town RGB House Upstairs):
-158244 - 0x334D8 (RGB Control) - True - Rotated Shapers & Colored Squares & Triangles
-158245 - 0x03C0C (Left) - 0x334D8 - Colored Squares & Black/White Squares & Eraser
-158246 - 0x03C08 (Right) - 0x334D8 & 0x03C0C - Symmetry & Dots & Colored Dots & Triangles
+0x334D8 (RGB Control) - True - Rotated Shapers & Colored Squares & Triangles
+0x03C0C (Left) - 0x334D8 - Colored Squares & Black/White Squares & Eraser
+0x03C08 (Right) - 0x334D8 & 0x03C0C - Symmetry & Dots & Colored Dots & Triangles
 
 Town Tower Bottom (Town Tower) - Town - True - Town Tower After First Door - 0x27799:
 Door - 0x27799 (First Door) - 0x28A69
@@ -604,42 +604,42 @@ Town Tower After Third Door (Town Tower) - Town Tower Top - 0x2779A:
 Door - 0x2779A (Fourth Door) - 0x28B39
 
 Town Tower Top (Town):
-158708 - 0x032F5 (Laser Panel) - True - True
+0x032F5 (Laser Panel) - True - True
 Laser - 0x032F9 (Laser) - 0x032F5
-159422 - 0x33692 (Brown Bridge EP) - True - True
-159551 - 0x03BCE (Black Line Tower EP) - True - True
+0x33692 (Brown Bridge EP) - True - True
+0x03BCE (Black Line Tower EP) - True - True
 
 ==Windmill & Theater==
 
 Outside Windmill (Windmill) - Windmill Interior - 0x1845B:
-159010 - 0x037B6 (First Blade EP) - 0x17D02 - True
-159011 - 0x037B2 (Second Blade EP) - 0x17D02 - True
-159012 - 0x000F7 (Third Blade EP) - 0x17D02 - True
-158241 - 0x17F5F (Entry Panel) - True - Dots
+0x037B6 (First Blade EP) - 0x17D02 - True
+0x037B2 (Second Blade EP) - 0x17D02 - True
+0x000F7 (Third Blade EP) - 0x17D02 - True
+0x17F5F (Entry Panel) - True - Dots
 Door - 0x1845B (Entry) - 0x17F5F
 
 Windmill Interior (Windmill) - Theater - 0x17F88:
-158247 - 0x17D02 (Turn Control) - True - Dots
-158248 - 0x17F89 (Theater Entry Panel) - True - Black/White Squares & Eraser & Triangles
+0x17D02 (Turn Control) - True - Dots
+0x17F89 (Theater Entry Panel) - True - Black/White Squares & Eraser & Triangles
 Door - 0x17F88 (Theater Entry) - 0x17F89
 
 Theater (Theater) - Town - 0x0A16D | 0x3CCDF:
-158656 - 0x00815 (Video Input) - True - True
-158657 - 0x03553 (Tutorial Video) - 0x00815 & 0x03481 - True
-158658 - 0x03552 (Desert Video) - 0x00815 & 0x0339E - True
-158659 - 0x0354E (Jungle Video) - 0x00815 & 0x03702 - True
-158660 - 0x03549 (Challenge Video) - 0x00815 & 0x0356B - True
-158661 - 0x0354F (Shipwreck Video) - 0x00815 & 0x03535 - True
-158662 - 0x03545 (Mountain Video) - 0x00815 & 0x03542 - True
-158249 - 0x0A168 (Exit Left Panel) - True - Black/White Squares & Stars + Same Colored Symbol & Eraser
-158250 - 0x33AB2 (Exit Right Panel) - True - Eraser & Triangles & Shapers
+0x00815 (Video Input) - True - True
+0x03553 (Tutorial Video) - 0x00815 & 0x03481 - True
+0x03552 (Desert Video) - 0x00815 & 0x0339E - True
+0x0354E (Jungle Video) - 0x00815 & 0x03702 - True
+0x03549 (Challenge Video) - 0x00815 & 0x0356B - True
+0x0354F (Shipwreck Video) - 0x00815 & 0x03535 - True
+0x03545 (Mountain Video) - 0x00815 & 0x03542 - True
+0x0A168 (Exit Left Panel) - True - Black/White Squares & Stars + Same Colored Symbol & Eraser
+0x33AB2 (Exit Right Panel) - True - Eraser & Triangles & Shapers
 Door - 0x0A16D (Exit Left) - 0x0A168
 Door - 0x3CCDF (Exit Right) - 0x33AB2
-158608 - 0x17CF7 (Discard) - True - Arrows
-159554 - 0x339B6 (Eclipse EP) - 0x03549 & 0x0A16D & 0x3CCDF - True
-159555 - 0x33A29 (Window EP) - 0x03553 - True
-159556 - 0x33A2A (Door EP) - 0x03553 - True
-159558 - 0x33B06 (Church EP) - 0x0354E - True
+0x17CF7 (Discard) - True - Arrows
+0x339B6 (Eclipse EP) - 0x03549 & 0x0A16D & 0x3CCDF - True
+0x33A29 (Window EP) - 0x03553 - True
+0x33A2A (Door EP) - 0x03553 - True
+0x33B06 (Church EP) - 0x0354E - True
 
 ==Southern Peninsula==
 
@@ -648,595 +648,595 @@ Southern Peninsula (Southern Peninsula) - Main Island - True:
 ==Jungle==
 
 Jungle (Jungle) - Main Island - True - The Ocean - 0x17CDF - Jungle Under Popup Wall - 0x1475B:
-158251 - 0x17CDF (Shore Boat Spawn) - True - Boat
-158609 - 0x17F9B (Discard) - True - Arrows
-158252 - 0x002C4 (First Row 1) - True - True
-158253 - 0x00767 (First Row 2) - 0x002C4 - True
-158254 - 0x002C6 (First Row 3) - 0x00767 - True
-158255 - 0x0070E (Second Row 1) - 0x002C6 - True
-158256 - 0x0070F (Second Row 2) - 0x0070E - True
-158257 - 0x0087D (Second Row 3) - 0x0070F - True
-158258 - 0x002C7 (Second Row 4) - 0x0087D - True
-158259 - 0x17CAB (Popup Wall Control) - 0x002C7 - True
+0x17CDF (Shore Boat Spawn) - True - Boat
+0x17F9B (Discard) - True - Arrows
+0x002C4 (First Row 1) - True - True
+0x00767 (First Row 2) - 0x002C4 - True
+0x002C6 (First Row 3) - 0x00767 - True
+0x0070E (Second Row 1) - 0x002C6 - True
+0x0070F (Second Row 2) - 0x0070E - True
+0x0087D (Second Row 3) - 0x0070F - True
+0x002C7 (Second Row 4) - 0x0087D - True
+0x17CAB (Popup Wall Control) - 0x002C7 - True
 Door - 0x1475B (Popup Wall) - 0x17CAB
-158260 - 0x0026D (Popup Wall 1) - 0x1475B - Sound Dots & Symmetry
-158261 - 0x0026E (Popup Wall 2) - 0x0026D - Sound Dots & Symmetry
-158262 - 0x0026F (Popup Wall 3) - 0x0026E - Sound Dots & Symmetry
-158263 - 0x00C3F (Popup Wall 4) - 0x0026F - Sound Dots & Symmetry
-158264 - 0x00C41 (Popup Wall 5) - 0x00C3F - Sound Dots & Symmetry
-158265 - 0x014B2 (Popup Wall 6) - 0x00C41 - Sound Dots & Symmetry
-158709 - 0x03616 (Laser Panel) - 0x014B2 - True
+0x0026D (Popup Wall 1) - 0x1475B - Sound Dots & Symmetry
+0x0026E (Popup Wall 2) - 0x0026D - Sound Dots & Symmetry
+0x0026F (Popup Wall 3) - 0x0026E - Sound Dots & Symmetry
+0x00C3F (Popup Wall 4) - 0x0026F - Sound Dots & Symmetry
+0x00C41 (Popup Wall 5) - 0x00C3F - Sound Dots & Symmetry
+0x014B2 (Popup Wall 6) - 0x00C41 - Sound Dots & Symmetry
+0x03616 (Laser Panel) - 0x014B2 - True
 Laser - 0x00274 (Laser) - 0x03616
-158266 - 0x337FA (Laser Shortcut Panel) - True - True
+0x337FA (Laser Shortcut Panel) - True - True
 Door - 0x3873B (Laser Shortcut) - 0x337FA
-159100 - 0x03ABC (Long Arch Moss EP) - True - True
-159101 - 0x03ABE (Straight Left Moss EP) - True - True
-159102 - 0x03AC0 (Pop-up Wall Moss EP) - True - True
-159103 - 0x03AC4 (Short Arch Moss EP) - True - True
-159150 - 0x289F4 (Entrance EP) - True - True
-159151 - 0x289F5 (Tree Halo EP) - True - True
-159350 - 0x035CB (Bamboo CCW EP) - True - True
-159351 - 0x035CF (Bamboo CW EP) - True - True
+0x03ABC (Long Arch Moss EP) - True - True
+0x03ABE (Straight Left Moss EP) - True - True
+0x03AC0 (Pop-up Wall Moss EP) - True - True
+0x03AC4 (Short Arch Moss EP) - True - True
+0x289F4 (Entrance EP) - True - True
+0x289F5 (Tree Halo EP) - True - True
+0x035CB (Bamboo CCW EP) - True - True
+0x035CF (Bamboo CW EP) - True - True
 
 Jungle Under Popup Wall (Jungle):
 
 Outside Jungle River (Jungle) - Main Island - True - Monastery Garden - 0x0CF2A - Jungle Vault - 0x15287:
-158267 - 0x17CAA (Monastery Garden Shortcut Panel) - True - True
+0x17CAA (Monastery Garden Shortcut Panel) - True - True
 Door - 0x0CF2A (Monastery Garden Shortcut) - 0x17CAA
-158663 - 0x15ADD (Vault Panel) - True - Black/White Squares & Dots
+0x15ADD (Vault Panel) - True - Black/White Squares & Dots
 Door - 0x15287 (Vault Door) - 0x15ADD
-159110 - 0x03AC5 (Green Leaf Moss EP) - True - True
+0x03AC5 (Green Leaf Moss EP) - True - True
 
 Jungle Vault (Jungle):
-158664 - 0x03702 (Vault Box) - True - True
+0x03702 (Vault Box) - True - True
 
 ==Bunker==
 
 Outside Bunker (Bunker) - Main Island - True - Bunker - 0x0C2A4:
-158268 - 0x17C2E (Entry Panel) - True - Black/White Squares
+0x17C2E (Entry Panel) - True - Black/White Squares
 Door - 0x0C2A4 (Entry) - 0x17C2E
 
 Bunker (Bunker) - Bunker Glass Room - 0x17C79:
-158269 - 0x09F7D (Intro Left 1) - True - Colored Squares
-158270 - 0x09FDC (Intro Left 2) - 0x09F7D - Colored Squares & Black/White Squares
-158271 - 0x09FF7 (Intro Left 3) - 0x09FDC - Colored Squares & Black/White Squares
-158272 - 0x09F82 (Intro Left 4) - 0x09FF7 - Colored Squares & Black/White Squares
-158273 - 0x09FF8 (Intro Left 5) - 0x09F82 - Colored Squares & Black/White Squares
-158274 - 0x09D9F (Intro Back 1) - 0x09FF8 - Colored Squares & Black/White Squares
-158275 - 0x09DA1 (Intro Back 2) - 0x09D9F - Colored Squares
-158276 - 0x09DA2 (Intro Back 3) - 0x09DA1 - Colored Squares
-158277 - 0x09DAF (Intro Back 4) - 0x09DA2 - Colored Squares
-158278 - 0x0A099 (Tinted Glass Door Panel) - 0x09DAF - True
+0x09F7D (Intro Left 1) - True - Colored Squares
+0x09FDC (Intro Left 2) - 0x09F7D - Colored Squares & Black/White Squares
+0x09FF7 (Intro Left 3) - 0x09FDC - Colored Squares & Black/White Squares
+0x09F82 (Intro Left 4) - 0x09FF7 - Colored Squares & Black/White Squares
+0x09FF8 (Intro Left 5) - 0x09F82 - Colored Squares & Black/White Squares
+0x09D9F (Intro Back 1) - 0x09FF8 - Colored Squares & Black/White Squares
+0x09DA1 (Intro Back 2) - 0x09D9F - Colored Squares
+0x09DA2 (Intro Back 3) - 0x09DA1 - Colored Squares
+0x09DAF (Intro Back 4) - 0x09DA2 - Colored Squares
+0x0A099 (Tinted Glass Door Panel) - 0x09DAF - True
 Door - 0x17C79 (Tinted Glass Door) - 0x0A099
 
 Bunker Glass Room (Bunker) - Bunker Ultraviolet Room - 0x0C2A3:
-158279 - 0x0A010 (Glass Room 1) - 0x17C79 - Colored Squares
-158280 - 0x0A01B (Glass Room 2) - 0x17C79 & 0x0A010 - Colored Squares & Black/White Squares
-158281 - 0x0A01F (Glass Room 3) - 0x17C79 & 0x0A01B - Colored Squares & Black/White Squares
+0x0A010 (Glass Room 1) - 0x17C79 - Colored Squares
+0x0A01B (Glass Room 2) - 0x17C79 & 0x0A010 - Colored Squares & Black/White Squares
+0x0A01F (Glass Room 3) - 0x17C79 & 0x0A01B - Colored Squares & Black/White Squares
 Door - 0x0C2A3 (UV Room Entry) - 0x0A01F
 
 Bunker Ultraviolet Room (Bunker) - Bunker Elevator Section - 0x0A08D:
-158282 - 0x34BC5 (Drop-Down Door Open) - True - True
-158283 - 0x34BC6 (Drop-Down Door Close) - 0x34BC5 - True
-158284 - 0x17E63 (UV Room 1) - 0x34BC5 - Colored Squares
-158285 - 0x17E67 (UV Room 2) - 0x17E63 & 0x34BC6 - Colored Squares & Black/White Squares
+0x34BC5 (Drop-Down Door Open) - True - True
+0x34BC6 (Drop-Down Door Close) - 0x34BC5 - True
+0x17E63 (UV Room 1) - 0x34BC5 - Colored Squares
+0x17E67 (UV Room 2) - 0x17E63 & 0x34BC6 - Colored Squares & Black/White Squares
 Door - 0x0A08D (Elevator Room Entry) - 0x17E67
 
 Bunker Elevator Section (Bunker) - Bunker Elevator - TrueOneWay - Bunker Under Elevator - 0x0A079 | Bunker Green Room | Bunker Cyan Room | Bunker Laser Platform:
-159311 - 0x035F5 (Tinted Door EP) - 0x17C79 - True
+0x035F5 (Tinted Door EP) - 0x17C79 - True
 
 Bunker Under Elevator (Bunker):
 
 Bunker Elevator (Bunker) - Bunker Elevator Section - 0x0A079 - Bunker Cyan Room - 0x0A079 - Bunker Green Room - 0x0A079 - Bunker Laser Platform - 0x0A079 - Outside Bunker - 0x0A079:
-158286 - 0x0A079 (Elevator Control) - True - Colored Squares & Black/White Squares
+0x0A079 (Elevator Control) - True - Colored Squares & Black/White Squares
 
 Bunker Cyan Room (Bunker) - Bunker Elevator - TrueOneWay:
 
 Bunker Green Room (Bunker) - Bunker Elevator - TrueOneWay:
-159310 - 0x000D3 (Green Room Flowers EP) - True - True
+0x000D3 (Green Room Flowers EP) - True - True
 
 Bunker Laser Platform (Bunker) - Bunker Elevator - TrueOneWay:
-158710 - 0x09DE0 (Laser Panel) - True - True
+0x09DE0 (Laser Panel) - True - True
 Laser - 0x0C2B2 (Laser) - 0x09DE0
 
 ==Swamp==
 
 Outside Swamp (Swamp) - Swamp Entry Area - 0x00C1C - Main Island - True:
-158287 - 0x0056E (Entry Panel) - True - Rotated Shapers & Black/White Squares & Triangles
+0x0056E (Entry Panel) - True - Rotated Shapers & Black/White Squares & Triangles
 Door - 0x00C1C (Entry) - 0x0056E
-159321 - 0x03603 (Purple Sand Middle EP) - 0x17E2B - True
-159322 - 0x03601 (Purple Sand Top EP) - 0x17E2B - True
-159327 - 0x035DE (Purple Sand Bottom EP) - True - True
+0x03603 (Purple Sand Middle EP) - 0x17E2B - True
+0x03601 (Purple Sand Top EP) - 0x17E2B - True
+0x035DE (Purple Sand Bottom EP) - True - True
 
 Swamp Entry Area (Swamp) - Swamp Sliding Bridge - TrueOneWay:
-158288 - 0x00469 (Intro Front 1) - True - Black/White Squares & Shapers
-158289 - 0x00472 (Intro Front 2) - 0x00469 - Black/White Squares & Shapers & Rotated Shapers
-158290 - 0x00262 (Intro Front 3) - 0x00472 - Black/White Squares & Rotated Shapers
-158291 - 0x00474 (Intro Front 4) - 0x00262 - Black/White Squares & Shapers & Rotated Shapers
-158292 - 0x00553 (Intro Front 5) - 0x00474 - Black/White Squares & Shapers & Rotated Shapers
-158293 - 0x0056F (Intro Front 6) - 0x00553 - Black/White Squares & Shapers & Rotated Shapers
-158294 - 0x00390 (Intro Back 1) - 0x0056F - Shapers & Triangles
-158295 - 0x010CA (Intro Back 2) - 0x00390 - Shapers & Rotated Shapers & Triangles
-158296 - 0x00983 (Intro Back 3) - 0x010CA - Rotated Shapers & Triangles
-158297 - 0x00984 (Intro Back 4) - 0x00983 - Shapers & Rotated Shapers & Triangles
-158298 - 0x00986 (Intro Back 5) - 0x00984 - Shapers & Rotated Shapers & Triangles
-158299 - 0x00985 (Intro Back 6) - 0x00986 - Rotated Shapers & Triangles & Black/White Squares
-158300 - 0x00987 (Intro Back 7) - 0x00985 - Shapers & Rotated Shapers & Triangles & Black/White Squares
-158301 - 0x181A9 (Intro Back 8) - 0x00987 - Rotated Shapers & Triangles & Black/White Squares
+0x00469 (Intro Front 1) - True - Black/White Squares & Shapers
+0x00472 (Intro Front 2) - 0x00469 - Black/White Squares & Shapers & Rotated Shapers
+0x00262 (Intro Front 3) - 0x00472 - Black/White Squares & Rotated Shapers
+0x00474 (Intro Front 4) - 0x00262 - Black/White Squares & Shapers & Rotated Shapers
+0x00553 (Intro Front 5) - 0x00474 - Black/White Squares & Shapers & Rotated Shapers
+0x0056F (Intro Front 6) - 0x00553 - Black/White Squares & Shapers & Rotated Shapers
+0x00390 (Intro Back 1) - 0x0056F - Shapers & Triangles
+0x010CA (Intro Back 2) - 0x00390 - Shapers & Rotated Shapers & Triangles
+0x00983 (Intro Back 3) - 0x010CA - Rotated Shapers & Triangles
+0x00984 (Intro Back 4) - 0x00983 - Shapers & Rotated Shapers & Triangles
+0x00986 (Intro Back 5) - 0x00984 - Shapers & Rotated Shapers & Triangles
+0x00985 (Intro Back 6) - 0x00986 - Rotated Shapers & Triangles & Black/White Squares
+0x00987 (Intro Back 7) - 0x00985 - Shapers & Rotated Shapers & Triangles & Black/White Squares
+0x181A9 (Intro Back 8) - 0x00987 - Rotated Shapers & Triangles & Black/White Squares
 
 Swamp Sliding Bridge (Swamp) - Swamp Entry Area - 0x00609 - Swamp Platform - 0x00609:
-158302 - 0x00609 (Sliding Bridge) - True - Shapers & Black/White Squares
-159342 - 0x0105D (Sliding Bridge Left EP) - 0x00609 - True
-159343 - 0x0A304 (Sliding Bridge Right EP) - 0x00609 - True
+0x00609 (Sliding Bridge) - True - Shapers & Black/White Squares
+0x0105D (Sliding Bridge Left EP) - 0x00609 - True
+0x0A304 (Sliding Bridge Right EP) - 0x00609 - True
 
 Swamp Platform (Swamp) - Swamp Cyan Underwater - 0x04B7F - Swamp Near Boat - 0x38AE6 - Swamp Between Bridges Near - 0x184B7 - Swamp Sliding Bridge - TrueOneWay:
-158313 - 0x00982 (Platform Row 1) - True - Rotated Shapers
-158314 - 0x0097F (Platform Row 2) - 0x00982 - Rotated Shapers
-158315 - 0x0098F (Platform Row 3) - 0x0097F - Rotated Shapers
-158316 - 0x00990 (Platform Row 4) - 0x0098F - Rotated Shapers
+0x00982 (Platform Row 1) - True - Rotated Shapers
+0x0097F (Platform Row 2) - 0x00982 - Rotated Shapers
+0x0098F (Platform Row 3) - 0x0097F - Rotated Shapers
+0x00990 (Platform Row 4) - 0x0098F - Rotated Shapers
 Door - 0x184B7 (Between Bridges First Door) - 0x00990
-158317 - 0x17C0D (Platform Shortcut Left Panel) - True - Rotated Shapers
-158318 - 0x17C0E (Platform Shortcut Right Panel) - 0x17C0D - Rotated Shapers
+0x17C0D (Platform Shortcut Left Panel) - True - Rotated Shapers
+0x17C0E (Platform Shortcut Right Panel) - 0x17C0D - Rotated Shapers
 Door - 0x38AE6 (Platform Shortcut) - 0x17C0E
 Door - 0x04B7F (Cyan Water Pump) - 0x00006
 
 Swamp Cyan Underwater (Swamp):
-158307 - 0x00002 (Cyan Underwater 1) - True - Shapers & Negative Shapers & Black/White Squares
-158308 - 0x00004 (Cyan Underwater 2) - 0x00002 - Shapers & Negative Shapers & Triangles
-158309 - 0x00005 (Cyan Underwater 3) - 0x00004 - Shapers & Negative Shapers & Triangles & Black/White Squares
-158310 - 0x013E6 (Cyan Underwater 4) - 0x00005 - Shapers & Negative Shapers & Triangles & Black/White Squares
-158311 - 0x00596 (Cyan Underwater 5) - 0x013E6 - Shapers & Negative Shapers & Triangles & Black/White Squares
-158312 - 0x18488 (Cyan Underwater Sliding Bridge Control) - True - Shapers & Black/White Squares
-159340 - 0x03AA6 (Cyan Underwater Sliding Bridge EP) - 0x18488 - True
+0x00002 (Cyan Underwater 1) - True - Shapers & Negative Shapers & Black/White Squares
+0x00004 (Cyan Underwater 2) - 0x00002 - Shapers & Negative Shapers & Triangles
+0x00005 (Cyan Underwater 3) - 0x00004 - Shapers & Negative Shapers & Triangles & Black/White Squares
+0x013E6 (Cyan Underwater 4) - 0x00005 - Shapers & Negative Shapers & Triangles & Black/White Squares
+0x00596 (Cyan Underwater 5) - 0x013E6 - Shapers & Negative Shapers & Triangles & Black/White Squares
+0x18488 (Cyan Underwater Sliding Bridge Control) - True - Shapers & Black/White Squares
+0x03AA6 (Cyan Underwater Sliding Bridge EP) - 0x18488 - True
 
 Swamp Between Bridges Near (Swamp) - Swamp Between Bridges Far - 0x18507:
-158303 - 0x00999 (Between Bridges Near Row 1) - 0x00990 - Rotated Shapers
-158304 - 0x0099D (Between Bridges Near Row 2) - 0x00999 - Rotated Shapers
-158305 - 0x009A0 (Between Bridges Near Row 3) - 0x0099D - Rotated Shapers
-158306 - 0x009A1 (Between Bridges Near Row 4) - 0x009A0 - Rotated Shapers
+0x00999 (Between Bridges Near Row 1) - 0x00990 - Rotated Shapers
+0x0099D (Between Bridges Near Row 2) - 0x00999 - Rotated Shapers
+0x009A0 (Between Bridges Near Row 3) - 0x0099D - Rotated Shapers
+0x009A1 (Between Bridges Near Row 4) - 0x009A0 - Rotated Shapers
 Door - 0x18507 (Between Bridges Second Door) - 0x009A1
 
 Swamp Between Bridges Far (Swamp) - Swamp Red Underwater - 0x183F2 - Swamp Rotating Bridge - TrueOneWay:
-158319 - 0x00007 (Between Bridges Far Row 1) - 0x009A1 - Rotated Shapers & Full Dots
-158320 - 0x00008 (Between Bridges Far Row 2) - 0x00007 - Rotated Shapers & Full Dots
-158321 - 0x00009 (Between Bridges Far Row 3) - 0x00008 - Rotated Shapers & Shapers & Full Dots
-158322 - 0x0000A (Between Bridges Far Row 4) - 0x00009 - Rotated Shapers & Shapers & Full Dots
+0x00007 (Between Bridges Far Row 1) - 0x009A1 - Rotated Shapers & Full Dots
+0x00008 (Between Bridges Far Row 2) - 0x00007 - Rotated Shapers & Full Dots
+0x00009 (Between Bridges Far Row 3) - 0x00008 - Rotated Shapers & Shapers & Full Dots
+0x0000A (Between Bridges Far Row 4) - 0x00009 - Rotated Shapers & Shapers & Full Dots
 Door - 0x183F2 (Red Water Pump) - 0x00596
 
 Swamp Red Underwater (Swamp) - Swamp Maze - 0x305D5:
-158323 - 0x00001 (Red Underwater 1) - True - Shapers & Negative Shapers & Full Dots
-158324 - 0x014D2 (Red Underwater 2) - True - Shapers & Negative Shapers & Full Dots
-158325 - 0x014D4 (Red Underwater 3) - True - Shapers & Negative Shapers & Full Dots
-158326 - 0x014D1 (Red Underwater 4) - True - Shapers & Negative Shapers & Full Dots
+0x00001 (Red Underwater 1) - True - Shapers & Negative Shapers & Full Dots
+0x014D2 (Red Underwater 2) - True - Shapers & Negative Shapers & Full Dots
+0x014D4 (Red Underwater 3) - True - Shapers & Negative Shapers & Full Dots
+0x014D1 (Red Underwater 4) - True - Shapers & Negative Shapers & Full Dots
 Door - 0x305D5 (Red Underwater Exit) - 0x014D1
 
 Swamp Rotating Bridge (Swamp) - Swamp Between Bridges Far - 0x181F5 - Swamp Near Boat - 0x181F5 - Swamp Purple Area - 0x181F5:
-158327 - 0x181F5 (Rotating Bridge) - True - Rotated Shapers & Shapers & Colored Squares & Triangles & Stars + Same Colored Symbol
-159331 - 0x016B2 (Rotating Bridge CCW EP) - 0x181F5 - True
-159334 - 0x036CE (Rotating Bridge CW EP) - 0x181F5 - True
+0x181F5 (Rotating Bridge) - True - Rotated Shapers & Shapers & Colored Squares & Triangles & Stars + Same Colored Symbol
+0x016B2 (Rotating Bridge CCW EP) - 0x181F5 - True
+0x036CE (Rotating Bridge CW EP) - 0x181F5 - True
 
 Swamp Near Boat (Swamp) - Swamp Rotating Bridge - TrueOneWay - Swamp Blue Underwater - 0x18482 - Swamp Long Bridge - 0xFFD00 & 0xFFD02 - The Ocean - 0x09DB8:
-159803 - 0xFFD02 (Beyond Rotating Bridge Reached Independently) - True - True
-158328 - 0x09DB8 (Boat Spawn) - True - Boat
-158329 - 0x003B2 (Beyond Rotating Bridge 1) - 0x0000A - Shapers & Full Dots
-158330 - 0x00A1E (Beyond Rotating Bridge 2) - 0x003B2 - Rotated Shapers & Shapers & Full Dots
-158331 - 0x00C2E (Beyond Rotating Bridge 3) - 0x00A1E - Shapers & Full Dots
-158332 - 0x00E3A (Beyond Rotating Bridge 4) - 0x00C2E - Shapers & Full Dots
+0xFFD02 (Beyond Rotating Bridge Reached Independently) - True - True
+0x09DB8 (Boat Spawn) - True - Boat
+0x003B2 (Beyond Rotating Bridge 1) - 0x0000A - Shapers & Full Dots
+0x00A1E (Beyond Rotating Bridge 2) - 0x003B2 - Rotated Shapers & Shapers & Full Dots
+0x00C2E (Beyond Rotating Bridge 3) - 0x00A1E - Shapers & Full Dots
+0x00E3A (Beyond Rotating Bridge 4) - 0x00C2E - Shapers & Full Dots
 Door - 0x18482 (Blue Water Pump) - 0x00E3A
-159332 - 0x3365F (Boat EP) - 0x09DB8 - True
-159333 - 0x03731 (Long Bridge Side EP) - 0x17E2B - True
+0x3365F (Boat EP) - 0x09DB8 - True
+0x03731 (Long Bridge Side EP) - 0x17E2B - True
 
 Swamp Long Bridge (Swamp) - Swamp Near Boat - 0x17E2B - Outside Swamp - 0x17E2B:
-158339 - 0x17E2B (Long Bridge Control) - True - Rotated Shapers & Shapers
+0x17E2B (Long Bridge Control) - True - Rotated Shapers & Shapers
 
 Swamp Purple Area (Swamp) - Swamp Rotating Bridge - TrueOneWay - Swamp Purple Underwater - 0x0A1D6 - Swamp Near Boat - TrueOneWay:
 Door - 0x0A1D6 (Purple Water Pump) - 0x00E3A
 
 Swamp Purple Underwater (Swamp):
-158333 - 0x009A6 (Purple Underwater) - True - Shapers & Triangles & Black/White Squares & Rotated Shapers & Full Dots
-159330 - 0x03A9E (Purple Underwater Right EP) - True - True
-159336 - 0x03A93 (Purple Underwater Left EP) - True - True
+0x009A6 (Purple Underwater) - True - Shapers & Triangles & Black/White Squares & Rotated Shapers & Full Dots
+0x03A9E (Purple Underwater Right EP) - True - True
+0x03A93 (Purple Underwater Left EP) - True - True
 
 Swamp Blue Underwater (Swamp):
-158334 - 0x009AB (Blue Underwater 1) - True - Shapers & Negative Shapers
-158335 - 0x009AD (Blue Underwater 2) - 0x009AB - Shapers & Negative Shapers
-158336 - 0x009AE (Blue Underwater 3) - 0x009AD - Shapers & Negative Shapers
-158337 - 0x009AF (Blue Underwater 4) - 0x009AE - Shapers & Negative Shapers
-158338 - 0x00006 (Blue Underwater 5) - 0x009AF - Shapers & Negative Shapers
+0x009AB (Blue Underwater 1) - True - Shapers & Negative Shapers
+0x009AD (Blue Underwater 2) - 0x009AB - Shapers & Negative Shapers
+0x009AE (Blue Underwater 3) - 0x009AD - Shapers & Negative Shapers
+0x009AF (Blue Underwater 4) - 0x009AE - Shapers & Negative Shapers
+0x00006 (Blue Underwater 5) - 0x009AF - Shapers & Negative Shapers
 
 Swamp Maze (Swamp) - Swamp Laser Area - 0x17C0A & 0x17E07:
-158340 - 0x17C0A (Maze Control) - True - Shapers & Negative Shapers & Rotated Shapers
-158112 - 0x17E07 (Maze Control Other Side) - True - Shapers & Negative Shapers & Rotated Shapers
+0x17C0A (Maze Control) - True - Shapers & Negative Shapers & Rotated Shapers
+0x17E07 (Maze Control Other Side) - True - Shapers & Negative Shapers & Rotated Shapers
 
 Swamp Laser Area (Swamp) - Outside Swamp - 0x2D880:
-158711 - 0x03615 (Laser Panel) - True - True
+0x03615 (Laser Panel) - True - True
 Laser - 0x00BF6 (Laser) - 0x03615
-158341 - 0x17C05 (Laser Shortcut Left Panel) - True - Shapers & Negative Shapers & Stars + Same Colored Symbol
-158342 - 0x17C02 (Laser Shortcut Right Panel) - 0x17C05 - Shapers & Negative Shapers & Stars + Same Colored Symbol
+0x17C05 (Laser Shortcut Left Panel) - True - Shapers & Negative Shapers & Stars + Same Colored Symbol
+0x17C02 (Laser Shortcut Right Panel) - 0x17C05 - Shapers & Negative Shapers & Stars + Same Colored Symbol
 Door - 0x2D880 (Laser Shortcut) - 0x17C02
 
 ==Treehouse==
 
 Treehouse Obelisk (Treehouse) - Entry - True:
-159720 - 0xFFE20 (Obelisk Side 1) - 0x0053D & 0x0053E & 0x00769 - True
-159721 - 0xFFE21 (Obelisk Side 2) - 0x33721 & 0x220A7 & 0x220BD - True
-159722 - 0xFFE22 (Obelisk Side 3) - 0x03B22 & 0x03B23 & 0x03B24 & 0x03B25 & 0x03A79 & 0x28ABD & 0x28ABE - True
-159723 - 0xFFE23 (Obelisk Side 4) - 0x3388F & 0x28B29 & 0x28B2A - True
-159724 - 0xFFE24 (Obelisk Side 5) - 0x018B6 & 0x033BE & 0x033BF & 0x033DD & 0x033E5 - True
-159725 - 0xFFE25 (Obelisk Side 6) - 0x28AE9 & 0x3348F - True
-159729 - 0x00097 (Obelisk) - True - True
+0xFFE20 (Obelisk Side 1) - 0x0053D & 0x0053E & 0x00769 - True
+0xFFE21 (Obelisk Side 2) - 0x33721 & 0x220A7 & 0x220BD - True
+0xFFE22 (Obelisk Side 3) - 0x03B22 & 0x03B23 & 0x03B24 & 0x03B25 & 0x03A79 & 0x28ABD & 0x28ABE - True
+0xFFE23 (Obelisk Side 4) - 0x3388F & 0x28B29 & 0x28B2A - True
+0xFFE24 (Obelisk Side 5) - 0x018B6 & 0x033BE & 0x033BF & 0x033DD & 0x033E5 - True
+0xFFE25 (Obelisk Side 6) - 0x28AE9 & 0x3348F - True
+0x00097 (Obelisk) - True - True
 
 Treehouse Beach (Treehouse Beach) - Main Island - True:
-159200 - 0x0053D (Rock Shadow EP) - True - True
-159201 - 0x0053E (Sand Shadow EP) - True - True
-159212 - 0x220BD (Both Orange Bridges EP) - 0x17DA2 & 0x17DDB - True
+0x0053D (Rock Shadow EP) - True - True
+0x0053E (Sand Shadow EP) - True - True
+0x220BD (Both Orange Bridges EP) - 0x17DA2 & 0x17DDB - True
 
 Treehouse Entry Area (Treehouse) - Treehouse Between Entry Doors - 0x0C309 - The Ocean - 0x17C95:
-158343 - 0x17C95 (Boat Spawn) - True - Boat
-158344 - 0x0288C (First Door Panel) - True - Stars + Same Colored Symbol & Triangles
+0x17C95 (Boat Spawn) - True - Boat
+0x0288C (First Door Panel) - True - Stars + Same Colored Symbol & Triangles
 Door - 0x0C309 (First Door) - 0x0288C
-159210 - 0x33721 (Buoy EP) - 0x17C95 - True
+0x33721 (Buoy EP) - 0x17C95 - True
 
 Treehouse Between Entry Doors (Treehouse) - Treehouse Yellow Bridge - 0x0C310:
-158345 - 0x02886 (Second Door Panel) - True - Stars + Same Colored Symbol & Triangles
+0x02886 (Second Door Panel) - True - Stars + Same Colored Symbol & Triangles
 Door - 0x0C310 (Second Door) - 0x02886
 
 Treehouse Yellow Bridge (Treehouse) - Treehouse After Yellow Bridge - 0x17DC4:
-158346 - 0x17D72 (Yellow Bridge 1) - True - Stars + Same Colored Symbol & Triangles
-158347 - 0x17D8F (Yellow Bridge 2) - 0x17D72 - Stars + Same Colored Symbol & Triangles
-158348 - 0x17D74 (Yellow Bridge 3) - 0x17D8F - Stars + Same Colored Symbol & Triangles
-158349 - 0x17DAC (Yellow Bridge 4) - 0x17D74 - Stars + Same Colored Symbol & Triangles
-158350 - 0x17D9E (Yellow Bridge 5) - 0x17DAC - Stars + Same Colored Symbol & Triangles
-158351 - 0x17DB9 (Yellow Bridge 6) - 0x17D9E - Stars + Same Colored Symbol & Triangles
-158352 - 0x17D9C (Yellow Bridge 7) - 0x17DB9 - Stars + Same Colored Symbol & Triangles
-158353 - 0x17DC2 (Yellow Bridge 8) - 0x17D9C - Stars + Same Colored Symbol & Triangles
-158354 - 0x17DC4 (Yellow Bridge 9) - 0x17DC2 - Stars + Same Colored Symbol & Triangles
+0x17D72 (Yellow Bridge 1) - True - Stars + Same Colored Symbol & Triangles
+0x17D8F (Yellow Bridge 2) - 0x17D72 - Stars + Same Colored Symbol & Triangles
+0x17D74 (Yellow Bridge 3) - 0x17D8F - Stars + Same Colored Symbol & Triangles
+0x17DAC (Yellow Bridge 4) - 0x17D74 - Stars + Same Colored Symbol & Triangles
+0x17D9E (Yellow Bridge 5) - 0x17DAC - Stars + Same Colored Symbol & Triangles
+0x17DB9 (Yellow Bridge 6) - 0x17D9E - Stars + Same Colored Symbol & Triangles
+0x17D9C (Yellow Bridge 7) - 0x17DB9 - Stars + Same Colored Symbol & Triangles
+0x17DC2 (Yellow Bridge 8) - 0x17D9C - Stars + Same Colored Symbol & Triangles
+0x17DC4 (Yellow Bridge 9) - 0x17DC2 - Stars + Same Colored Symbol & Triangles
 
 Treehouse After Yellow Bridge (Treehouse) - Treehouse Junction - 0x0A181:
-158355 - 0x0A182 (Third Door Panel) - True - Stars + Same Colored Symbol & Triangles & Colored Squares
+0x0A182 (Third Door Panel) - True - Stars + Same Colored Symbol & Triangles & Colored Squares
 Door - 0x0A181 (Third Door) - 0x0A182
 
 Treehouse Junction (Treehouse) - Treehouse Right Orange Bridge - True - Treehouse First Purple Bridge - True - Treehouse Green Bridge - True:
-158356 - 0x2700B (Laser House Door Timer Outside) - True - True
+0x2700B (Laser House Door Timer Outside) - True - True
 
 Treehouse First Purple Bridge (Treehouse) - Treehouse Second Purple Bridge - 0x17D6C:
-158357 - 0x17DC8 (First Purple Bridge 1) - True - Stars & Full Dots
-158358 - 0x17DC7 (First Purple Bridge 2) - 0x17DC8 - Stars & Full Dots
-158359 - 0x17CE4 (First Purple Bridge 3) - 0x17DC7 - Stars & Full Dots
-158360 - 0x17D2D (First Purple Bridge 4) - 0x17CE4 - Stars & Full Dots
-158361 - 0x17D6C (First Purple Bridge 5) - 0x17D2D - Stars & Full Dots
+0x17DC8 (First Purple Bridge 1) - True - Stars & Full Dots
+0x17DC7 (First Purple Bridge 2) - 0x17DC8 - Stars & Full Dots
+0x17CE4 (First Purple Bridge 3) - 0x17DC7 - Stars & Full Dots
+0x17D2D (First Purple Bridge 4) - 0x17CE4 - Stars & Full Dots
+0x17D6C (First Purple Bridge 5) - 0x17D2D - Stars & Full Dots
 
 Treehouse Right Orange Bridge (Treehouse) - Treehouse Drawbridge Platform - 0x17DA2:
-158391 - 0x17D88 (Right Orange Bridge 1) - True - Stars + Same Colored Symbol & Triangles
-158392 - 0x17DB4 (Right Orange Bridge 2) - 0x17D88 - Stars + Same Colored Symbol & Triangles
-158393 - 0x17D8C (Right Orange Bridge 3) - 0x17DB4 - Stars + Same Colored Symbol & Triangles
-158394 - 0x17CE3 (Right Orange Bridge 4 & Directional) - 0x17D8C - Triangles
-158395 - 0x17DCD (Right Orange Bridge 5) - 0x17CE3 - Stars + Same Colored Symbol & Triangles
-158396 - 0x17DB2 (Right Orange Bridge 6) - 0x17DCD - Stars + Same Colored Symbol & Triangles
-158397 - 0x17DCC (Right Orange Bridge 7) - 0x17DB2 - Stars + Same Colored Symbol & Triangles
-158398 - 0x17DCA (Right Orange Bridge 8) - 0x17DCC - Stars + Same Colored Symbol & Triangles
-158399 - 0x17D8E (Right Orange Bridge 9) - 0x17DCA - Stars + Same Colored Symbol & Triangles
-158400 - 0x17DB7 (Right Orange Bridge 10 & Directional) - 0x17D8E - Triangles
-158401 - 0x17DB1 (Right Orange Bridge 11) - 0x17DB7 - Stars + Same Colored Symbol & Triangles
-158402 - 0x17DA2 (Right Orange Bridge 12) - 0x17DB1 - Stars + Same Colored Symbol & Triangles
+0x17D88 (Right Orange Bridge 1) - True - Stars + Same Colored Symbol & Triangles
+0x17DB4 (Right Orange Bridge 2) - 0x17D88 - Stars + Same Colored Symbol & Triangles
+0x17D8C (Right Orange Bridge 3) - 0x17DB4 - Stars + Same Colored Symbol & Triangles
+0x17CE3 (Right Orange Bridge 4 & Directional) - 0x17D8C - Triangles
+0x17DCD (Right Orange Bridge 5) - 0x17CE3 - Stars + Same Colored Symbol & Triangles
+0x17DB2 (Right Orange Bridge 6) - 0x17DCD - Stars + Same Colored Symbol & Triangles
+0x17DCC (Right Orange Bridge 7) - 0x17DB2 - Stars + Same Colored Symbol & Triangles
+0x17DCA (Right Orange Bridge 8) - 0x17DCC - Stars + Same Colored Symbol & Triangles
+0x17D8E (Right Orange Bridge 9) - 0x17DCA - Stars + Same Colored Symbol & Triangles
+0x17DB7 (Right Orange Bridge 10 & Directional) - 0x17D8E - Triangles
+0x17DB1 (Right Orange Bridge 11) - 0x17DB7 - Stars + Same Colored Symbol & Triangles
+0x17DA2 (Right Orange Bridge 12) - 0x17DB1 - Stars + Same Colored Symbol & Triangles
 
 Treehouse Drawbridge Platform (Treehouse) - Main Island - 0x0C32D:
-158404 - 0x037FF (Drawbridge Panel) - True - Stars
+0x037FF (Drawbridge Panel) - True - Stars
 Door - 0x0C32D (Drawbridge) - 0x037FF
 
 Treehouse Second Purple Bridge (Treehouse) - Treehouse Left Orange Bridge - 0x17DC6:
-158362 - 0x17D9B (Second Purple Bridge 1) - True - Black/White Squares & Triangles & Stars + Same Colored Symbol
-158363 - 0x17D99 (Second Purple Bridge 2) - 0x17D9B - Black/White Squares & Triangles & Stars + Same Colored Symbol
-158364 - 0x17DAA (Second Purple Bridge 3) - 0x17D99 - Black/White Squares & Triangles & Stars + Same Colored Symbol
-158365 - 0x17D97 (Second Purple Bridge 4) - 0x17DAA - Black/White Squares & Colored Squares & Triangles & Stars + Same Colored Symbol
-158366 - 0x17BDF (Second Purple Bridge 5) - 0x17D97 - Colored Squares & Triangles & Stars + Same Colored Symbol
-158367 - 0x17D91 (Second Purple Bridge 6) - 0x17BDF - Colored Squares & Triangles & Stars + Same Colored Symbol
-158368 - 0x17DC6 (Second Purple Bridge 7) - 0x17D91 - Colored Squares & Triangles & Stars + Same Colored Symbol
+0x17D9B (Second Purple Bridge 1) - True - Black/White Squares & Triangles & Stars + Same Colored Symbol
+0x17D99 (Second Purple Bridge 2) - 0x17D9B - Black/White Squares & Triangles & Stars + Same Colored Symbol
+0x17DAA (Second Purple Bridge 3) - 0x17D99 - Black/White Squares & Triangles & Stars + Same Colored Symbol
+0x17D97 (Second Purple Bridge 4) - 0x17DAA - Black/White Squares & Colored Squares & Triangles & Stars + Same Colored Symbol
+0x17BDF (Second Purple Bridge 5) - 0x17D97 - Colored Squares & Triangles & Stars + Same Colored Symbol
+0x17D91 (Second Purple Bridge 6) - 0x17BDF - Colored Squares & Triangles & Stars + Same Colored Symbol
+0x17DC6 (Second Purple Bridge 7) - 0x17D91 - Colored Squares & Triangles & Stars + Same Colored Symbol
 
 Treehouse Left Orange Bridge (Treehouse) - Treehouse Laser Room Front Platform - 0x17DDE - Treehouse Laser Room Back Platform - 0x17DDB - Treehouse Burned House - 0x17DDB:
-158376 - 0x17DB3 (Left Orange Bridge 1) - True - Black/White Squares & Stars + Same Colored Symbol & Shapers & Rotated Shapers
-158377 - 0x17DB5 (Left Orange Bridge 2) - 0x17DB3 - Black/White Squares & Stars + Same Colored Symbol & Shapers & Rotated Shapers
-158378 - 0x17DB6 (Left Orange Bridge 3) - 0x17DB5 - Black/White Squares & Stars + Same Colored Symbol & Shapers & Rotated Shapers
-158379 - 0x17DC0 (Left Orange Bridge 4) - 0x17DB6 - Black/White Squares & Stars + Same Colored Symbol & Shapers & Rotated Shapers
-158380 - 0x17DD7 (Left Orange Bridge 5) - 0x17DC0 - Colored Squares & Stars + Same Colored Symbol & Shapers & Rotated Shapers
-158381 - 0x17DD9 (Left Orange Bridge 6) - 0x17DD7 - Colored Squares & Stars + Same Colored Symbol & Shapers & Rotated Shapers
-158382 - 0x17DB8 (Left Orange Bridge 7) - 0x17DD9 - Colored Squares & Stars + Same Colored Symbol & Shapers & Rotated Shapers
-158383 - 0x17DDC (Left Orange Bridge 8) - 0x17DB8 - Colored Squares & Stars + Same Colored Symbol & Shapers & Rotated Shapers
-158384 - 0x17DD1 (Left Orange Bridge 9 & Directional) - 0x17DDC - Colored Squares & Stars + Same Colored Symbol & Shapers & Rotated Shapers & Black/White Squares
-158385 - 0x17DDE (Left Orange Bridge 10) - 0x17DD1 - Colored Squares & Stars + Same Colored Symbol & Shapers & Rotated Shapers & Black/White Squares
-158386 - 0x17DE3 (Left Orange Bridge 11) - 0x17DDE - Colored Squares & Stars + Same Colored Symbol & Shapers & Rotated Shapers & Black/White Squares
-158387 - 0x17DEC (Left Orange Bridge 12) - 0x17DE3 - Colored Squares & Stars + Same Colored Symbol & Shapers & Rotated Shapers & Black/White Squares
-158388 - 0x17DAE (Left Orange Bridge 13) - 0x17DEC & 0x03613 - Black/White Squares & Stars + Same Colored Symbol & Shapers & Rotated Shapers & Triangles
-158389 - 0x17DB0 (Left Orange Bridge 14) - 0x17DAE - Black/White Squares & Stars + Same Colored Symbol
-158390 - 0x17DDB (Left Orange Bridge 15) - 0x17DB0 - Black/White Squares & Stars + Same Colored Symbol
+0x17DB3 (Left Orange Bridge 1) - True - Black/White Squares & Stars + Same Colored Symbol & Shapers & Rotated Shapers
+0x17DB5 (Left Orange Bridge 2) - 0x17DB3 - Black/White Squares & Stars + Same Colored Symbol & Shapers & Rotated Shapers
+0x17DB6 (Left Orange Bridge 3) - 0x17DB5 - Black/White Squares & Stars + Same Colored Symbol & Shapers & Rotated Shapers
+0x17DC0 (Left Orange Bridge 4) - 0x17DB6 - Black/White Squares & Stars + Same Colored Symbol & Shapers & Rotated Shapers
+0x17DD7 (Left Orange Bridge 5) - 0x17DC0 - Colored Squares & Stars + Same Colored Symbol & Shapers & Rotated Shapers
+0x17DD9 (Left Orange Bridge 6) - 0x17DD7 - Colored Squares & Stars + Same Colored Symbol & Shapers & Rotated Shapers
+0x17DB8 (Left Orange Bridge 7) - 0x17DD9 - Colored Squares & Stars + Same Colored Symbol & Shapers & Rotated Shapers
+0x17DDC (Left Orange Bridge 8) - 0x17DB8 - Colored Squares & Stars + Same Colored Symbol & Shapers & Rotated Shapers
+0x17DD1 (Left Orange Bridge 9 & Directional) - 0x17DDC - Colored Squares & Stars + Same Colored Symbol & Shapers & Rotated Shapers & Black/White Squares
+0x17DDE (Left Orange Bridge 10) - 0x17DD1 - Colored Squares & Stars + Same Colored Symbol & Shapers & Rotated Shapers & Black/White Squares
+0x17DE3 (Left Orange Bridge 11) - 0x17DDE - Colored Squares & Stars + Same Colored Symbol & Shapers & Rotated Shapers & Black/White Squares
+0x17DEC (Left Orange Bridge 12) - 0x17DE3 - Colored Squares & Stars + Same Colored Symbol & Shapers & Rotated Shapers & Black/White Squares
+0x17DAE (Left Orange Bridge 13) - 0x17DEC & 0x03613 - Black/White Squares & Stars + Same Colored Symbol & Shapers & Rotated Shapers & Triangles
+0x17DB0 (Left Orange Bridge 14) - 0x17DAE - Black/White Squares & Stars + Same Colored Symbol
+0x17DDB (Left Orange Bridge 15) - 0x17DB0 - Black/White Squares & Stars + Same Colored Symbol
 
 Treehouse Green Bridge (Treehouse) - Treehouse Green Bridge Front House - 0x17E61 - Treehouse Green Bridge Left House - 0x17E61:
-158369 - 0x17E3C (Green Bridge 1) - True - Shapers & Negative Shapers & Stars + Same Colored Symbol
-158370 - 0x17E4D (Green Bridge 2) - 0x17E3C - Shapers & Negative Shapers & Stars + Same Colored Symbol
-158371 - 0x17E4F (Green Bridge 3) - 0x17E4D - Shapers & Negative Shapers & Stars + Same Colored Symbol
-158372 - 0x17E52 (Green Bridge 4 & Directional) - 0x17E4F - Shapers & Negative Shapers & Stars + Same Colored Symbol
-158373 - 0x17E5B (Green Bridge 5) - 0x17E52 - Shapers & Negative Shapers & Stars + Same Colored Symbol
-158374 - 0x17E5F (Green Bridge 6) - 0x17E5B - Shapers & Negative Shapers & Stars + Same Colored Symbol & Triangles
-158375 - 0x17E61 (Green Bridge 7) - 0x17E5F - Shapers & Negative Shapers & Stars + Same Colored Symbol & Triangles
+0x17E3C (Green Bridge 1) - True - Shapers & Negative Shapers & Stars + Same Colored Symbol
+0x17E4D (Green Bridge 2) - 0x17E3C - Shapers & Negative Shapers & Stars + Same Colored Symbol
+0x17E4F (Green Bridge 3) - 0x17E4D - Shapers & Negative Shapers & Stars + Same Colored Symbol
+0x17E52 (Green Bridge 4 & Directional) - 0x17E4F - Shapers & Negative Shapers & Stars + Same Colored Symbol
+0x17E5B (Green Bridge 5) - 0x17E52 - Shapers & Negative Shapers & Stars + Same Colored Symbol
+0x17E5F (Green Bridge 6) - 0x17E5B - Shapers & Negative Shapers & Stars + Same Colored Symbol & Triangles
+0x17E61 (Green Bridge 7) - 0x17E5F - Shapers & Negative Shapers & Stars + Same Colored Symbol & Triangles
 
 Treehouse Green Bridge Front House (Treehouse):
-158610 - 0x17FA9 (Green Bridge Discard) - True - Arrows
+0x17FA9 (Green Bridge Discard) - True - Arrows
 
 Treehouse Green Bridge Left House (Treehouse):
-159211 - 0x220A7 (Right Orange Bridge EP) - 0x17DA2 - True
+0x220A7 (Right Orange Bridge EP) - 0x17DA2 - True
 
 Treehouse Laser Room Front Platform (Treehouse) - Treehouse Laser Room - 0x0C323:
 Door - 0x0C323 (Laser House Entry) - 0x17DA2 & 0x2700B & 0x17DEC | 0x17CBC
 
 Treehouse Laser Room Back Platform (Treehouse):
-158611 - 0x17FA0 (Laser Discard) - True - Arrows
+0x17FA0 (Laser Discard) - True - Arrows
 
 Treehouse Burned House (Treehouse):
-159202 - 0x00769 (Burned House Beach EP) - True - True
+0x00769 (Burned House Beach EP) - True - True
 
 Treehouse Laser Room (Treehouse):
-158712 - 0x03613 (Laser Panel) - True - True
-158403 - 0x17CBC (Laser House Door Timer Inside) - True - True
+0x03613 (Laser Panel) - True - True
+0x17CBC (Laser House Door Timer Inside) - True - True
 Laser - 0x028A4 (Laser) - 0x03613
 
 ==Mountain (Outside)==
 
 Mountainside Obelisk (Mountainside) - Entry - True:
-159730 - 0xFFE30 (Obelisk Side 1) - 0x001A3 & 0x335AE - True
-159731 - 0xFFE31 (Obelisk Side 2) - 0x000D3 & 0x035F5 & 0x09D5D & 0x09D5E & 0x09D63 - True
-159732 - 0xFFE32 (Obelisk Side 3) - 0x3370E & 0x035DE & 0x03601 & 0x03603 & 0x03D0D & 0x3369A & 0x336C8 & 0x33505 - True
-159733 - 0xFFE33 (Obelisk Side 4) - 0x03A9E & 0x016B2 & 0x3365F & 0x03731 & 0x036CE & 0x03C07 & 0x03A93 - True
-159734 - 0xFFE34 (Obelisk Side 5) - 0x03AA6 & 0x3397C & 0x0105D & 0x0A304 - True
-159735 - 0xFFE35 (Obelisk Side 6) - 0x035CB & 0x035CF - True
-159739 - 0x00367 (Obelisk) - True - True
+0xFFE30 (Obelisk Side 1) - 0x001A3 & 0x335AE - True
+0xFFE31 (Obelisk Side 2) - 0x000D3 & 0x035F5 & 0x09D5D & 0x09D5E & 0x09D63 - True
+0xFFE32 (Obelisk Side 3) - 0x3370E & 0x035DE & 0x03601 & 0x03603 & 0x03D0D & 0x3369A & 0x336C8 & 0x33505 - True
+0xFFE33 (Obelisk Side 4) - 0x03A9E & 0x016B2 & 0x3365F & 0x03731 & 0x036CE & 0x03C07 & 0x03A93 - True
+0xFFE34 (Obelisk Side 5) - 0x03AA6 & 0x3397C & 0x0105D & 0x0A304 - True
+0xFFE35 (Obelisk Side 6) - 0x035CB & 0x035CF - True
+0x00367 (Obelisk) - True - True
 
 Mountainside (Mountainside) - Main Island - True - Mountaintop - True - Mountainside Vault - 0x00085:
-159550 - 0x28B91 (Thundercloud EP) - 0xFFD03 - True
-158612 - 0x17C42 (Discard) - True - Arrows
-158665 - 0x002A6 (Vault Panel) - True - Symmetry & Colored Squares & Triangles & Stars + Same Colored Symbol
+0x28B91 (Thundercloud EP) - 0xFFD03 - True
+0x17C42 (Discard) - True - Arrows
+0x002A6 (Vault Panel) - True - Symmetry & Colored Squares & Triangles & Stars + Same Colored Symbol
 Door - 0x00085 (Vault Door) - 0x002A6
-159301 - 0x335AE (Cloud Cycle EP) - True - True
-159325 - 0x33505 (Bush EP) - True - True
-159335 - 0x03C07 (Apparent River EP) - True - True
+0x335AE (Cloud Cycle EP) - True - True
+0x33505 (Bush EP) - True - True
+0x03C07 (Apparent River EP) - True - True
 
 Mountainside Vault (Mountainside):
-158666 - 0x03542 (Vault Box) - True - True
+0x03542 (Vault Box) - True - True
 
 Mountaintop (Mountaintop) - Mountain Floor 1 - 0x17C34:
-158405 - 0x0042D (River Shape) - True - True
-158406 - 0x09F7F (Box Short) - 7 Lasers + Redirect - True
-158407 - 0x17C34 (Mountain Entry Panel) - 0x09F7F - Black/White Squares & Stars + Same Colored Symbol & Triangles
-158800 - 0xFFF00 (Box Long) - 11 Lasers + Redirect & 0x17C34 - True
-159300 - 0x001A3 (River Shape EP) - True - True
-159320 - 0x3370E (Arch Black EP) - True - True
-159324 - 0x336C8 (Arch White Right EP) - True - True
-159326 - 0x3369A (Arch White Left EP) - True - True
+0x0042D (River Shape) - True - True
+0x09F7F (Box Short) - 7 Lasers + Redirect - True
+0x17C34 (Mountain Entry Panel) - 0x09F7F - Black/White Squares & Stars + Same Colored Symbol & Triangles
+0xFFF00 (Box Long) - 11 Lasers + Redirect & 0x17C34 - True
+0x001A3 (River Shape EP) - True - True
+0x3370E (Arch Black EP) - True - True
+0x336C8 (Arch White Right EP) - True - True
+0x3369A (Arch White Left EP) - True - True
 
 ==Mountain (Inside)==
 
 Mountain Floor 1 (Mountain Floor 1) - Mountain Floor 1 Bridge - 0x09E39:
-158408 - 0x09E39 (Light Bridge Controller) - True - Eraser & Triangles
+0x09E39 (Light Bridge Controller) - True - Eraser & Triangles
 
 Mountain Floor 1 Bridge (Mountain Floor 1) - Mountain Floor 1 At Door - TrueOneWay - Mountain Floor 1 Trash Pillar - TrueOneWay - Mountain Floor 1 Back Section - TrueOneWay:
-158409 - 0x09E7A (Right Row 1) - True - Black/White Squares & Dots & Stars + Same Colored Symbol
-158410 - 0x09E71 (Right Row 2) - 0x09E7A - Black/White Squares & Triangles
-158411 - 0x09E72 (Right Row 3) - 0x09E71 - Black/White Squares & Shapers & Stars + Same Colored Symbol
-158412 - 0x09E69 (Right Row 4) - 0x09E72 - Black/White Squares & Stars + Same Colored Symbol & Rotated Shapers
-158413 - 0x09E7B (Right Row 5) - 0x09E69 - Black/White Squares & Stars + Same Colored Symbol & Eraser & Dots & Triangles & Shapers
-158414 - 0x09E73 (Left Row 1) - True - Dots & Black/White Squares & Triangles
-158415 - 0x09E75 (Left Row 2) - 0x09E73 - Dots & Black/White Squares & Shapers & Rotated Shapers
-158416 - 0x09E78 (Left Row 3) - 0x09E75 - Triangles & Stars + Same Colored Symbol & Shapers & Rotated Shapers
-158417 - 0x09E79 (Left Row 4) - 0x09E78 - Colored Squares & Stars + Same Colored Symbol & Triangles & Eraser
-158418 - 0x09E6C (Left Row 5) - 0x09E79 - Shapers & Negative Shapers & Stars + Same Colored Symbol
-158419 - 0x09E6F (Left Row 6) - 0x09E6C - Symmetry & Colored Squares & Black/White Squares & Stars + Same Colored Symbol & Symmetry & Eraser
-158420 - 0x09E6B (Left Row 7) - 0x09E6F - Symmetry & Full Dots & Triangles
-158424 - 0x09EAD (Trash Pillar 1) - True - Rotated Shapers & Stars
-158425 - 0x09EAF (Trash Pillar 2) - 0x09EAD - Rotated Shapers & Triangles
+0x09E7A (Right Row 1) - True - Black/White Squares & Dots & Stars + Same Colored Symbol
+0x09E71 (Right Row 2) - 0x09E7A - Black/White Squares & Triangles
+0x09E72 (Right Row 3) - 0x09E71 - Black/White Squares & Shapers & Stars + Same Colored Symbol
+0x09E69 (Right Row 4) - 0x09E72 - Black/White Squares & Stars + Same Colored Symbol & Rotated Shapers
+0x09E7B (Right Row 5) - 0x09E69 - Black/White Squares & Stars + Same Colored Symbol & Eraser & Dots & Triangles & Shapers
+0x09E73 (Left Row 1) - True - Dots & Black/White Squares & Triangles
+0x09E75 (Left Row 2) - 0x09E73 - Dots & Black/White Squares & Shapers & Rotated Shapers
+0x09E78 (Left Row 3) - 0x09E75 - Triangles & Stars + Same Colored Symbol & Shapers & Rotated Shapers
+0x09E79 (Left Row 4) - 0x09E78 - Colored Squares & Stars + Same Colored Symbol & Triangles & Eraser
+0x09E6C (Left Row 5) - 0x09E79 - Shapers & Negative Shapers & Stars + Same Colored Symbol
+0x09E6F (Left Row 6) - 0x09E6C - Symmetry & Colored Squares & Black/White Squares & Stars + Same Colored Symbol & Symmetry & Eraser
+0x09E6B (Left Row 7) - 0x09E6F - Symmetry & Full Dots & Triangles
+0x09EAD (Trash Pillar 1) - True - Rotated Shapers & Stars
+0x09EAF (Trash Pillar 2) - 0x09EAD - Rotated Shapers & Triangles
 
 Mountain Floor 1 Trash Pillar (Mountain Floor 1):
 
 Mountain Floor 1 Back Section (Mountain Floor 1):
-158421 - 0x33AF5 (Back Row 1) - True - Symmetry & Black/White Squares & Triangles
-158422 - 0x33AF7 (Back Row 2) - 0x33AF5 - Symmetry & Triangles & Stars + Same Colored Symbol
-158423 - 0x09F6E (Back Row 3) - 0x33AF7 - Symmetry & Shapers & Stars + Same Colored Symbol
+0x33AF5 (Back Row 1) - True - Symmetry & Black/White Squares & Triangles
+0x33AF7 (Back Row 2) - 0x33AF5 - Symmetry & Triangles & Stars + Same Colored Symbol
+0x09F6E (Back Row 3) - 0x33AF7 - Symmetry & Shapers & Stars + Same Colored Symbol
 
 Mountain Floor 1 At Door (Mountain Floor 1) - Mountain Floor 2 - 0x09E54:
 Door - 0x09E54 (Exit) - 0x09EAF & 0x09F6E & 0x09E6B & 0x09E7B
 
 Mountain Floor 2 (Mountain Floor 2) - Mountain Floor 2 Light Bridge Room Near - 0x09FFB - Mountain Floor 2 Beyond Bridge - 0x09E86 - Mountain Floor 2 Above The Abyss - True - Mountain Pink Bridge EP - TrueOneWay:
-158426 - 0x09FD3 (Near Row 1) - True - Colored Squares & Stars + Same Colored Symbol
-158427 - 0x09FD4 (Near Row 2) - 0x09FD3 - Triangles & Stars + Same Colored Symbol
-158428 - 0x09FD6 (Near Row 3) - 0x09FD4 - Shapers & Negative Shapers & Stars + Same Colored Symbol
-158429 - 0x09FD7 (Near Row 4) - 0x09FD6 - Stars
-158430 - 0x09FD8 (Near Row 5) - 0x09FD7 - Stars + Same Colored Symbol & Rotated Shapers & Eraser
+0x09FD3 (Near Row 1) - True - Colored Squares & Stars + Same Colored Symbol
+0x09FD4 (Near Row 2) - 0x09FD3 - Triangles & Stars + Same Colored Symbol
+0x09FD6 (Near Row 3) - 0x09FD4 - Shapers & Negative Shapers & Stars + Same Colored Symbol
+0x09FD7 (Near Row 4) - 0x09FD6 - Stars
+0x09FD8 (Near Row 5) - 0x09FD7 - Stars + Same Colored Symbol & Rotated Shapers & Eraser
 Door - 0x09FFB (Staircase Near) - 0x09FD8
 
 Mountain Floor 2 Above The Abyss (Mountain Floor 2) - Mountain Floor 2 Elevator Room - 0x09EDD & 0x09ED8 & 0x09E86:
 Door - 0x09EDD (Elevator Room Entry) - 0x09ED8 & 0x09E86
 
 Mountain Floor 2 Light Bridge Room Near (Mountain Floor 2):
-158431 - 0x09E86 (Light Bridge Controller Near) - True - Shapers & Dots
+0x09E86 (Light Bridge Controller Near) - True - Shapers & Dots
 
 Mountain Floor 2 Beyond Bridge (Mountain Floor 2) - Mountain Floor 2 Light Bridge Room Far - 0x09E07 - Mountain Pink Bridge EP - TrueOneWay - Mountain Floor 2 - 0x09ED8:
-158432 - 0x09FCC (Far Row 1) - True - Triangles
-158433 - 0x09FCE (Far Row 2) - 0x09FCC - Black/White Squares & Stars + Same Colored Symbol
-158434 - 0x09FCF (Far Row 3) - 0x09FCE - Triangles & Stars + Same Colored Symbol
-158435 - 0x09FD0 (Far Row 4) - 0x09FCF - Rotated Shapers & Negative Shapers
-158436 - 0x09FD1 (Far Row 5) - 0x09FD0 - Dots
-158437 - 0x09FD2 (Far Row 6) - 0x09FD1 - Rotated Shapers
+0x09FCC (Far Row 1) - True - Triangles
+0x09FCE (Far Row 2) - 0x09FCC - Black/White Squares & Stars + Same Colored Symbol
+0x09FCF (Far Row 3) - 0x09FCE - Triangles & Stars + Same Colored Symbol
+0x09FD0 (Far Row 4) - 0x09FCF - Rotated Shapers & Negative Shapers
+0x09FD1 (Far Row 5) - 0x09FD0 - Dots
+0x09FD2 (Far Row 6) - 0x09FD1 - Rotated Shapers
 Door - 0x09E07 (Staircase Far) - 0x09FD2
 
 Mountain Floor 2 Light Bridge Room Far (Mountain Floor 2):
-158438 - 0x09ED8 (Light Bridge Controller Far) - True - Shapers & Dots
+0x09ED8 (Light Bridge Controller Far) - True - Shapers & Dots
 
 Mountain Floor 2 Elevator Room (Mountain Floor 2) - Mountain Floor 2 Elevator - TrueOneWay:
-158613 - 0x17F93 (Elevator Discard) - True - Arrows
+0x17F93 (Elevator Discard) - True - Arrows
 
 Mountain Floor 2 Elevator (Mountain Floor 2) - Mountain Floor 2 Elevator Room - 0x09EEB - Mountain Floor 3 - 0x09EEB:
-158439 - 0x09EEB (Elevator Control Panel) - True - Dots
+0x09EEB (Elevator Control Panel) - True - Dots
 
 Mountain Floor 3 (Mountain Bottom Floor) - Mountain Floor 2 Elevator - TrueOneWay - Mountain Bottom Floor - 0x09F89 - Mountain Pink Bridge EP - TrueOneWay:
-158440 - 0x09FC1 (Giant Puzzle Bottom Left) - True - Shapers & Eraser & Negative Shapers
-158441 - 0x09F8E (Giant Puzzle Bottom Right) - True - Shapers & Eraser & Negative Shapers
-158442 - 0x09F01 (Giant Puzzle Top Right) - True - Shapers & Eraser & Negative Shapers
-158443 - 0x09EFF (Giant Puzzle Top Left) - True - Shapers & Eraser & Negative Shapers
-158444 - 0x09FDA (Giant Puzzle) - 0x09FC1 & 0x09F8E & 0x09F01 & 0x09EFF - Shapers & Symmetry
-159313 - 0x09D5D (Yellow Bridge EP) - 0x09E86 & 0x09ED8 - True
-159314 - 0x09D5E (Blue Bridge EP) - 0x09E86 & 0x09ED8 - True
+0x09FC1 (Giant Puzzle Bottom Left) - True - Shapers & Eraser & Negative Shapers
+0x09F8E (Giant Puzzle Bottom Right) - True - Shapers & Eraser & Negative Shapers
+0x09F01 (Giant Puzzle Top Right) - True - Shapers & Eraser & Negative Shapers
+0x09EFF (Giant Puzzle Top Left) - True - Shapers & Eraser & Negative Shapers
+0x09FDA (Giant Puzzle) - 0x09FC1 & 0x09F8E & 0x09F01 & 0x09EFF - Shapers & Symmetry
+0x09D5D (Yellow Bridge EP) - 0x09E86 & 0x09ED8 - True
+0x09D5E (Blue Bridge EP) - 0x09E86 & 0x09ED8 - True
 Door - 0x09F89 (Exit) - 0x09FDA
 
 Mountain Bottom Floor (Mountain Bottom Floor) - Mountain Path to Caves - 0x17F33 - Mountain Bottom Floor Pillars Room - 0x0C141:
-158614 - 0x17FA2 (Discard) - 0xFFF00 - Arrows
-158445 - 0x01983 (Pillars Room Entry Left) - True - Shapers & Stars
-158446 - 0x01987 (Pillars Room Entry Right) - True - Colored Squares & Dots
+0x17FA2 (Discard) - 0xFFF00 - Arrows
+0x01983 (Pillars Room Entry Left) - True - Shapers & Stars
+0x01987 (Pillars Room Entry Right) - True - Colored Squares & Dots
 Door - 0x0C141 (Pillars Room Entry) - 0x01983 & 0x01987
 Door - 0x17F33 (Rock Open) - 0x17FA2 | 0x334E1
 
 Mountain Bottom Floor Pillars Room (Mountain Bottom Floor) - Elevator - 0x339BB & 0x33961:
-158522 - 0x0383A (Right Pillar 1) - True - Eraser & Triangles & Stars + Same Colored Symbol
-158523 - 0x09E56 (Right Pillar 2) - 0x0383A - Full Dots & Triangles & Symmetry
-158524 - 0x09E5A (Right Pillar 3) - 0x09E56 - Dots & Shapers & Negative Shapers & Stars + Same Colored Symbol & Symmetry
-158525 - 0x33961 (Right Pillar 4) - 0x09E5A - Eraser & Symmetry & Stars + Same Colored Symbol & Negative Shapers & Shapers
-158526 - 0x0383D (Left Pillar 1) - True - Black/White Squares & Stars + Same Colored Symbol
-158527 - 0x0383F (Left Pillar 2) - 0x0383D - Triangles & Symmetry
-158528 - 0x03859 (Left Pillar 3) - 0x0383F - Symmetry & Shapers & Black/White Squares
-158529 - 0x339BB (Left Pillar 4) - 0x03859 - Symmetry & Black/White Squares & Stars + Same Colored Symbol & Triangles & Colored Dots
+0x0383A (Right Pillar 1) - True - Eraser & Triangles & Stars + Same Colored Symbol
+0x09E56 (Right Pillar 2) - 0x0383A - Full Dots & Triangles & Symmetry
+0x09E5A (Right Pillar 3) - 0x09E56 - Dots & Shapers & Negative Shapers & Stars + Same Colored Symbol & Symmetry
+0x33961 (Right Pillar 4) - 0x09E5A - Eraser & Symmetry & Stars + Same Colored Symbol & Negative Shapers & Shapers
+0x0383D (Left Pillar 1) - True - Black/White Squares & Stars + Same Colored Symbol
+0x0383F (Left Pillar 2) - 0x0383D - Triangles & Symmetry
+0x03859 (Left Pillar 3) - 0x0383F - Symmetry & Shapers & Black/White Squares
+0x339BB (Left Pillar 4) - 0x03859 - Symmetry & Black/White Squares & Stars + Same Colored Symbol & Triangles & Colored Dots
 
 Elevator (Mountain Bottom Floor):
-158530 - 0x3D9A6 (Elevator Door Close Left) - True - True
-158531 - 0x3D9A7 (Elevator Door Close Right) - True - True
-158532 - 0x3C113 (Elevator Entry Left) - 0x3D9A6 | 0x3D9A7 - True
-158533 - 0x3C114 (Elevator Entry Right) - 0x3D9A6 | 0x3D9A7 - True
-158534 - 0x3D9AA (Back Wall Left) - 0x3D9A6 | 0x3D9A7 - True
-158535 - 0x3D9A8 (Back Wall Right) - 0x3D9A6 | 0x3D9A7 - True
-158536 - 0x3D9A9 (Elevator Start) - 0x3D9AA & 7 Lasers | 0x3D9A8 & 7 Lasers - True
+0x3D9A6 (Elevator Door Close Left) - True - True
+0x3D9A7 (Elevator Door Close Right) - True - True
+0x3C113 (Elevator Entry Left) - 0x3D9A6 | 0x3D9A7 - True
+0x3C114 (Elevator Entry Right) - 0x3D9A6 | 0x3D9A7 - True
+0x3D9AA (Back Wall Left) - 0x3D9A6 | 0x3D9A7 - True
+0x3D9A8 (Back Wall Right) - 0x3D9A6 | 0x3D9A7 - True
+0x3D9A9 (Elevator Start) - 0x3D9AA & 7 Lasers | 0x3D9A8 & 7 Lasers - True
 
 Mountain Pink Bridge EP (Mountain Floor 2):
-159312 - 0x09D63 (Pink Bridge EP) - 0x09E39 - True
+0x09D63 (Pink Bridge EP) - 0x09E39 - True
 
 Mountain Path to Caves (Mountain Bottom Floor) - Caves - 0x2D77D - Caves Entry Door - TrueOneWay:
-158447 - 0x00FF8 (Caves Entry Panel) - True - Arrows & Black/White Squares
+0x00FF8 (Caves Entry Panel) - True - Arrows & Black/White Squares
 Door - 0x2D77D (Caves Entry) - 0x00FF8
-158448 - 0x334E1 (Rock Control) - True - True
+0x334E1 (Rock Control) - True - True
 
 ==Caves==
 
 Caves Entry Door (Caves):
 
 Caves (Caves) - Main Island - 0x2D73F | 0x2D859 - Caves Path to Challenge - 0x019A5 - Caves Entry Door - TrueOneWay:
-158451 - 0x335AB (Elevator Inside Control) - True - Dots & Black/White Squares
-158452 - 0x335AC (Elevator Upper Outside Control) - 0x335AB - Black/White Squares
-158453 - 0x3369D (Elevator Lower Outside Control) - 0x335AB - Black/White Squares & Dots
-158454 - 0x00190 (Blue Tunnel Right First 1) - True - Arrows
-158455 - 0x00558 (Blue Tunnel Right First 2) - 0x00190 - Arrows
-158456 - 0x00567 (Blue Tunnel Right First 3) - 0x00558 - Arrows
-158457 - 0x006FE (Blue Tunnel Right First 4) - 0x00567 - Arrows
-158458 - 0x01A0D (Blue Tunnel Left First 1) - True - Arrows & Symmetry
-158459 - 0x008B8 (Blue Tunnel Left Second 1) - True - Arrows & Triangles
-158460 - 0x00973 (Blue Tunnel Left Second 2) - 0x008B8 - Arrows & Triangles
-158461 - 0x0097B (Blue Tunnel Left Second 3) - 0x00973 - Arrows & Triangles
-158462 - 0x0097D (Blue Tunnel Left Second 4) - 0x0097B - Arrows & Triangles
-158463 - 0x0097E (Blue Tunnel Left Second 5) - 0x0097D - Arrows & Triangles
-158464 - 0x00994 (Blue Tunnel Right Second 1) - True - Arrows & Shapers & Rotated Shapers
-158465 - 0x334D5 (Blue Tunnel Right Second 2) - 0x00994 - Arrows & Rotated Shapers
-158466 - 0x00995 (Blue Tunnel Right Second 3) - 0x334D5 - Arrows & Shapers & Rotated Shapers
-158467 - 0x00996 (Blue Tunnel Right Second 4) - 0x00995 - Arrows & Shapers & Rotated Shapers
-158468 - 0x00998 (Blue Tunnel Right Second 5) - 0x00996 - Arrows & Shapers
-158469 - 0x009A4 (Blue Tunnel Left Third 1) - True - Arrows & Stars
-158470 - 0x018A0 (Blue Tunnel Right Third 1) - True - Arrows & Symmetry
-158471 - 0x00A72 (Blue Tunnel Left Fourth 1) - True - Arrows & Shapers & Negative Shapers
-158472 - 0x32962 (First Floor Left) - True - Full Dots & Rotated Shapers
-158473 - 0x32966 (First Floor Grounded) - True - Triangles & Rotated Shapers & Black/White Squares & Stars + Same Colored Symbol
-158474 - 0x01A31 (First Floor Middle) - True - Stars
-158475 - 0x00B71 (First Floor Right) - True - Full Dots & Eraser & Stars + Same Colored Symbol & Colored Squares & Shapers & Negative Shapers
-158478 - 0x288EA (First Wooden Beam) - True - Stars
-158479 - 0x288FC (Second Wooden Beam) - True - Shapers & Eraser
-158480 - 0x289E7 (Third Wooden Beam) - True - Eraser & Triangles
-158481 - 0x288AA (Fourth Wooden Beam) - True - Full Dots & Negative Shapers & Shapers
-158482 - 0x17FB9 (Left Upstairs Single) - True - Full Dots & Arrows & Black/White Squares
-158483 - 0x0A16B (Left Upstairs Left Row 1) - True - Full Dots & Arrows
-158484 - 0x0A2CE (Left Upstairs Left Row 2) - 0x0A16B - Full Dots & Arrows
-158485 - 0x0A2D7 (Left Upstairs Left Row 3) - 0x0A2CE - Full Dots & Arrows
-158486 - 0x0A2DD (Left Upstairs Left Row 4) - 0x0A2D7 - Full Dots & Arrows
-158487 - 0x0A2EA (Left Upstairs Left Row 5) - 0x0A2DD - Full Dots & Arrows
-158488 - 0x0008F (Right Upstairs Left Row 1) - True - Dots & Black/White Squares & Colored Squares
-158489 - 0x0006B (Right Upstairs Left Row 2) - 0x0008F - Black/White Squares & Colored Squares & Stars + Same Colored Symbol
-158490 - 0x0008B (Right Upstairs Left Row 3) - 0x0006B - Black/White Squares & Colored Squares & Stars + Same Colored Symbol & Triangles
-158491 - 0x0008C (Right Upstairs Left Row 4) - 0x0008B - Stars + Same Colored Symbol & Shapers & Rotated Shapers
-158492 - 0x0008A (Right Upstairs Left Row 5) - 0x0008C - Stars + Same Colored Symbol & Shapers & Rotated Shapers & Eraser & Triangles
-158493 - 0x00089 (Right Upstairs Left Row 6) - 0x0008A - Shapers & Negative Shapers & Dots
-158494 - 0x0006A (Right Upstairs Left Row 7) - 0x00089 - Stars & Dots
-158495 - 0x0006C (Right Upstairs Left Row 8) - 0x0006A - Dots & Stars + Same Colored Symbol & Eraser
-158496 - 0x00027 (Right Upstairs Right Row 1) - True - Colored Squares & Black/White Squares & Eraser
-158497 - 0x00028 (Right Upstairs Right Row 2) - 0x00027 - Shapers & Symmetry
-158498 - 0x00029 (Right Upstairs Right Row 3) - 0x00028 - Symmetry & Triangles & Eraser
-158476 - 0x09DD5 (Lone Pillar) - True - Arrows
+0x335AB (Elevator Inside Control) - True - Dots & Black/White Squares
+0x335AC (Elevator Upper Outside Control) - 0x335AB - Black/White Squares
+0x3369D (Elevator Lower Outside Control) - 0x335AB - Black/White Squares & Dots
+0x00190 (Blue Tunnel Right First 1) - True - Arrows
+0x00558 (Blue Tunnel Right First 2) - 0x00190 - Arrows
+0x00567 (Blue Tunnel Right First 3) - 0x00558 - Arrows
+0x006FE (Blue Tunnel Right First 4) - 0x00567 - Arrows
+0x01A0D (Blue Tunnel Left First 1) - True - Arrows & Symmetry
+0x008B8 (Blue Tunnel Left Second 1) - True - Arrows & Triangles
+0x00973 (Blue Tunnel Left Second 2) - 0x008B8 - Arrows & Triangles
+0x0097B (Blue Tunnel Left Second 3) - 0x00973 - Arrows & Triangles
+0x0097D (Blue Tunnel Left Second 4) - 0x0097B - Arrows & Triangles
+0x0097E (Blue Tunnel Left Second 5) - 0x0097D - Arrows & Triangles
+0x00994 (Blue Tunnel Right Second 1) - True - Arrows & Shapers & Rotated Shapers
+0x334D5 (Blue Tunnel Right Second 2) - 0x00994 - Arrows & Rotated Shapers
+0x00995 (Blue Tunnel Right Second 3) - 0x334D5 - Arrows & Shapers & Rotated Shapers
+0x00996 (Blue Tunnel Right Second 4) - 0x00995 - Arrows & Shapers & Rotated Shapers
+0x00998 (Blue Tunnel Right Second 5) - 0x00996 - Arrows & Shapers
+0x009A4 (Blue Tunnel Left Third 1) - True - Arrows & Stars
+0x018A0 (Blue Tunnel Right Third 1) - True - Arrows & Symmetry
+0x00A72 (Blue Tunnel Left Fourth 1) - True - Arrows & Shapers & Negative Shapers
+0x32962 (First Floor Left) - True - Full Dots & Rotated Shapers
+0x32966 (First Floor Grounded) - True - Triangles & Rotated Shapers & Black/White Squares & Stars + Same Colored Symbol
+0x01A31 (First Floor Middle) - True - Stars
+0x00B71 (First Floor Right) - True - Full Dots & Eraser & Stars + Same Colored Symbol & Colored Squares & Shapers & Negative Shapers
+0x288EA (First Wooden Beam) - True - Stars
+0x288FC (Second Wooden Beam) - True - Shapers & Eraser
+0x289E7 (Third Wooden Beam) - True - Eraser & Triangles
+0x288AA (Fourth Wooden Beam) - True - Full Dots & Negative Shapers & Shapers
+0x17FB9 (Left Upstairs Single) - True - Full Dots & Arrows & Black/White Squares
+0x0A16B (Left Upstairs Left Row 1) - True - Full Dots & Arrows
+0x0A2CE (Left Upstairs Left Row 2) - 0x0A16B - Full Dots & Arrows
+0x0A2D7 (Left Upstairs Left Row 3) - 0x0A2CE - Full Dots & Arrows
+0x0A2DD (Left Upstairs Left Row 4) - 0x0A2D7 - Full Dots & Arrows
+0x0A2EA (Left Upstairs Left Row 5) - 0x0A2DD - Full Dots & Arrows
+0x0008F (Right Upstairs Left Row 1) - True - Dots & Black/White Squares & Colored Squares
+0x0006B (Right Upstairs Left Row 2) - 0x0008F - Black/White Squares & Colored Squares & Stars + Same Colored Symbol
+0x0008B (Right Upstairs Left Row 3) - 0x0006B - Black/White Squares & Colored Squares & Stars + Same Colored Symbol & Triangles
+0x0008C (Right Upstairs Left Row 4) - 0x0008B - Stars + Same Colored Symbol & Shapers & Rotated Shapers
+0x0008A (Right Upstairs Left Row 5) - 0x0008C - Stars + Same Colored Symbol & Shapers & Rotated Shapers & Eraser & Triangles
+0x00089 (Right Upstairs Left Row 6) - 0x0008A - Shapers & Negative Shapers & Dots
+0x0006A (Right Upstairs Left Row 7) - 0x00089 - Stars & Dots
+0x0006C (Right Upstairs Left Row 8) - 0x0006A - Dots & Stars + Same Colored Symbol & Eraser
+0x00027 (Right Upstairs Right Row 1) - True - Colored Squares & Black/White Squares & Eraser
+0x00028 (Right Upstairs Right Row 2) - 0x00027 - Shapers & Symmetry
+0x00029 (Right Upstairs Right Row 3) - 0x00028 - Symmetry & Triangles & Eraser
+0x09DD5 (Lone Pillar) - True - Arrows
 Door - 0x019A5 (Pillar Door) - 0x09DD5
-158449 - 0x021D7 (Mountain Shortcut Panel) - True - Stars + Same Colored Symbol & Triangles & Eraser
+0x021D7 (Mountain Shortcut Panel) - True - Stars + Same Colored Symbol & Triangles & Eraser
 Door - 0x2D73F (Mountain Shortcut Door) - 0x021D7
-158450 - 0x17CF2 (Swamp Shortcut Panel) - True - Arrows
+0x17CF2 (Swamp Shortcut Panel) - True - Arrows
 Door - 0x2D859 (Swamp Shortcut Door) - 0x17CF2
-159341 - 0x3397C (Skylight EP) - True - True
+0x3397C (Skylight EP) - True - True
 
 Caves Path to Challenge (Caves) - Challenge - 0x0A19A:
-158477 - 0x0A16E (Challenge Entry Panel) - True - Arrows & Stars + Same Colored Symbol
+0x0A16E (Challenge Entry Panel) - True - Arrows & Stars + Same Colored Symbol
 Door - 0x0A19A (Challenge Entry) - 0x0A16E
 
 ==Challenge==
 
 Challenge (Challenge) - Tunnels - 0x0348A - Challenge Vault - 0x04D75:
-158499 - 0x0A332 (Start Timer) - 11 Lasers - True
-158500 - 0x0088E (Small Basic) - 0x0A332 - True
-158501 - 0x00BAF (Big Basic) - 0x0088E - True
-158502 - 0x00BF3 (Square) - 0x00BAF - Black/White Squares
-158503 - 0x00C09 (Maze Map) - 0x00BF3 - Dots
-158504 - 0x00CDB (Stars and Dots) - 0x00C09 - Stars & Dots
-158505 - 0x0051F (Symmetry) - 0x00CDB - Symmetry & Colored Dots & Dots
-158506 - 0x00524 (Stars and Shapers) - 0x0051F - Stars & Shapers
-158507 - 0x00CD4 (Big Basic 2) - 0x00524 - True
-158508 - 0x00CB9 (Choice Squares Right) - 0x00CD4 - Black/White Squares
-158509 - 0x00CA1 (Choice Squares Middle) - 0x00CD4 - Black/White Squares
-158510 - 0x00C80 (Choice Squares Left) - 0x00CD4 - Black/White Squares
-158511 - 0x00C68 (Choice Squares 2 Right) - 0x00CB9 | 0x00CA1 | 0x00C80 - Black/White Squares & Colored Squares
-158512 - 0x00C59 (Choice Squares 2 Middle) - 0x00CB9 | 0x00CA1 | 0x00C80 - Black/White Squares & Colored Squares
-158513 - 0x00C22 (Choice Squares 2 Left) - 0x00CB9 | 0x00CA1 | 0x00C80 - Black/White Squares & Colored Squares
-158514 - 0x034F4 (Maze Hidden 1) - 0x00C68 | 0x00C59 | 0x00C22 - Triangles
-158515 - 0x034EC (Maze Hidden 2) - 0x00C68 | 0x00C59 | 0x00C22 - Triangles
-158516 - 0x1C31A (Dots Pillar) - 0x034F4 & 0x034EC - Dots & Symmetry
-158517 - 0x1C319 (Squares Pillar) - 0x034F4 & 0x034EC - Black/White Squares & Symmetry
+0x0A332 (Start Timer) - 11 Lasers - True
+0x0088E (Small Basic) - 0x0A332 - True
+0x00BAF (Big Basic) - 0x0088E - True
+0x00BF3 (Square) - 0x00BAF - Black/White Squares
+0x00C09 (Maze Map) - 0x00BF3 - Dots
+0x00CDB (Stars and Dots) - 0x00C09 - Stars & Dots
+0x0051F (Symmetry) - 0x00CDB - Symmetry & Colored Dots & Dots
+0x00524 (Stars and Shapers) - 0x0051F - Stars & Shapers
+0x00CD4 (Big Basic 2) - 0x00524 - True
+0x00CB9 (Choice Squares Right) - 0x00CD4 - Black/White Squares
+0x00CA1 (Choice Squares Middle) - 0x00CD4 - Black/White Squares
+0x00C80 (Choice Squares Left) - 0x00CD4 - Black/White Squares
+0x00C68 (Choice Squares 2 Right) - 0x00CB9 | 0x00CA1 | 0x00C80 - Black/White Squares & Colored Squares
+0x00C59 (Choice Squares 2 Middle) - 0x00CB9 | 0x00CA1 | 0x00C80 - Black/White Squares & Colored Squares
+0x00C22 (Choice Squares 2 Left) - 0x00CB9 | 0x00CA1 | 0x00C80 - Black/White Squares & Colored Squares
+0x034F4 (Maze Hidden 1) - 0x00C68 | 0x00C59 | 0x00C22 - Triangles
+0x034EC (Maze Hidden 2) - 0x00C68 | 0x00C59 | 0x00C22 - Triangles
+0x1C31A (Dots Pillar) - 0x034F4 & 0x034EC - Dots & Symmetry
+0x1C319 (Squares Pillar) - 0x034F4 & 0x034EC - Black/White Squares & Symmetry
 Door - 0x04D75 (Vault Door) - 0x1C31A & 0x1C319
-158518 - 0x039B4 (Tunnels Entry Panel) - True - Arrows
+0x039B4 (Tunnels Entry Panel) - True - Arrows
 Door - 0x0348A (Tunnels Entry) - 0x039B4
-159530 - 0x28B30 (Water EP) - True - True
+0x28B30 (Water EP) - True - True
 
 Challenge Vault (Challenge):
-158667 - 0x0356B (Vault Box) - 0x1C31A & 0x1C319 - True
+0x0356B (Vault Box) - 0x1C31A & 0x1C319 - True
 
 ==Tunnels==
 
 Tunnels (Tunnels) - Windmill Interior - 0x27739 - Desert Behind Elevator - 0x27263 - Town - 0x09E87:
-158668 - 0x2FAF6 (Vault Box) - True - True
-158519 - 0x27732 (Theater Shortcut Panel) - True - True
+0x2FAF6 (Vault Box) - True - True
+0x27732 (Theater Shortcut Panel) - True - True
 Door - 0x27739 (Theater Shortcut) - 0x27732
-158520 - 0x2773D (Desert Shortcut Panel) - True - True
+0x2773D (Desert Shortcut Panel) - True - True
 Door - 0x27263 (Desert Shortcut) - 0x2773D
-158521 - 0x09E85 (Town Shortcut Panel) - True - Arrows
+0x09E85 (Town Shortcut Panel) - True - Arrows
 Door - 0x09E87 (Town Shortcut) - 0x09E85
-159557 - 0x33A20 (Theater Flowers EP) - 0x03553 & Theater to Tunnels - True
+0x33A20 (Theater Flowers EP) - 0x03553 & Theater to Tunnels - True
 
 ==Boat==
 
 The Ocean (Boat) - Main Island - TrueOneWay - Swamp Near Boat - TrueOneWay - Treehouse Entry Area - TrueOneWay - Quarry Boathouse Behind Staircase - TrueOneWay - Inside Glass Factory Behind Back Wall - TrueOneWay:
-159042 - 0x22106 (Desert EP) - True - True
-159223 - 0x03B25 (Shipwreck CCW Underside EP) - True - True
-159231 - 0x28B29 (Shipwreck Green EP) - True - True
-159232 - 0x28B2A (Shipwreck CW Underside EP) - True - True
-159323 - 0x03D0D (Bunker Yellow Line EP) - True - True
-159515 - 0x28A37 (Town Long Sewer EP) - True - True
-159520 - 0x33857 (Tutorial EP) - True - True
-159521 - 0x33879 (Tutorial Reflection EP) - True - True
-159522 - 0x03C19 (Tutorial Moss EP) - True - True
-159531 - 0x035C9 (Cargo Box EP) - 0x0A0C9 - True
+0x22106 (Desert EP) - True - True
+0x03B25 (Shipwreck CCW Underside EP) - True - True
+0x28B29 (Shipwreck Green EP) - True - True
+0x28B2A (Shipwreck CW Underside EP) - True - True
+0x03D0D (Bunker Yellow Line EP) - True - True
+0x28A37 (Town Long Sewer EP) - True - True
+0x33857 (Tutorial EP) - True - True
+0x33879 (Tutorial Reflection EP) - True - True
+0x03C19 (Tutorial Moss EP) - True - True
+0x035C9 (Cargo Box EP) - 0x0A0C9 - True
 
 ==Easter Eggs==
 

--- a/worlds/witness/data/WitnessLogicVanilla.txt
+++ b/worlds/witness/data/WitnessLogicVanilla.txt
@@ -3,237 +3,237 @@
 Entry (Entry):
 
 Tutorial First Hallway (Tutorial First Hallway) - Entry - True - Tutorial First Hallway Room - 0x00064:
-158000 - 0x00064 (Straight) - True - True
-159510 - 0x01848 (EP) - 0x00064 - True
+0x00064 (Straight) - True - True
+0x01848 (EP) - 0x00064 - True
 
 Tutorial First Hallway Room (Tutorial First Hallway) - Tutorial - 0x00182:
-158001 - 0x00182 (Bend) - True - True
+0x00182 (Bend) - True - True
 
 Tutorial (Tutorial) - Outside Tutorial - 0x03629:
-158002 - 0x00293 (Front Center) - True - True
-158003 - 0x00295 (Center Left) - 0x00293 - True
-158004 - 0x002C2 (Front Left) - 0x00295 - True
-158005 - 0x0A3B5 (Back Left) - True - True
-158006 - 0x0A3B2 (Back Right) - True - True
-158007 - 0x03629 (Gate Open) - 0x002C2 & 0x0A3B5 & 0x0A3B2 - True
-158008 - 0x03505 (Gate Close) - 0x2FAF6 & 0x03629 - True
-158009 - 0x0C335 (Pillar) - True - Triangles
-158010 - 0x0C373 (Patio Floor) - 0x0C335 - Dots
-159512 - 0x33530 (Cloud EP) - True - True
-159513 - 0x33600 (Patio Flowers EP) - 0x0C373 - True
-159517 - 0x3352F (Gate EP) - 0x03505 - True
+0x00293 (Front Center) - True - True
+0x00295 (Center Left) - 0x00293 - True
+0x002C2 (Front Left) - 0x00295 - True
+0x0A3B5 (Back Left) - True - True
+0x0A3B2 (Back Right) - True - True
+0x03629 (Gate Open) - 0x002C2 & 0x0A3B5 & 0x0A3B2 - True
+0x03505 (Gate Close) - 0x2FAF6 & 0x03629 - True
+0x0C335 (Pillar) - True - Triangles
+0x0C373 (Patio Floor) - 0x0C335 - Dots
+0x33530 (Cloud EP) - True - True
+0x33600 (Patio Flowers EP) - 0x0C373 - True
+0x3352F (Gate EP) - 0x03505 - True
 
 ==Tutorial (Outside)==
 
 Outside Tutorial (Outside Tutorial) - Outside Tutorial Path To Outpost - 0x03BA2 - Outside Tutorial Vault - 0x033D0:
-158650 - 0x033D4 (Vault Panel) - True - Dots & Black/White Squares
+0x033D4 (Vault Panel) - True - Dots & Black/White Squares
 Door - 0x033D0 (Vault Door) - 0x033D4
-158013 - 0x0005D (Shed Row 1) - True - Dots
-158014 - 0x0005E (Shed Row 2) - 0x0005D - Dots
-158015 - 0x0005F (Shed Row 3) - 0x0005E - Dots
-158016 - 0x00060 (Shed Row 4) - 0x0005F - Dots
-158017 - 0x00061 (Shed Row 5) - 0x00060 - Dots
-158018 - 0x018AF (Tree Row 1) - True - Black/White Squares
-158019 - 0x0001B (Tree Row 2) - 0x018AF - Black/White Squares
-158020 - 0x012C9 (Tree Row 3) - 0x0001B - Black/White Squares
-158021 - 0x0001C (Tree Row 4) - 0x012C9 - Black/White Squares
-158022 - 0x0001D (Tree Row 5) - 0x0001C - Black/White Squares
-158023 - 0x0001E (Tree Row 6) - 0x0001D - Black/White Squares
-158024 - 0x0001F (Tree Row 7) - 0x0001E - Black/White Squares
-158025 - 0x00020 (Tree Row 8) - 0x0001F - Black/White Squares
-158026 - 0x00021 (Tree Row 9) - 0x00020 - Black/White Squares
+0x0005D (Shed Row 1) - True - Dots
+0x0005E (Shed Row 2) - 0x0005D - Dots
+0x0005F (Shed Row 3) - 0x0005E - Dots
+0x00060 (Shed Row 4) - 0x0005F - Dots
+0x00061 (Shed Row 5) - 0x00060 - Dots
+0x018AF (Tree Row 1) - True - Black/White Squares
+0x0001B (Tree Row 2) - 0x018AF - Black/White Squares
+0x012C9 (Tree Row 3) - 0x0001B - Black/White Squares
+0x0001C (Tree Row 4) - 0x012C9 - Black/White Squares
+0x0001D (Tree Row 5) - 0x0001C - Black/White Squares
+0x0001E (Tree Row 6) - 0x0001D - Black/White Squares
+0x0001F (Tree Row 7) - 0x0001E - Black/White Squares
+0x00020 (Tree Row 8) - 0x0001F - Black/White Squares
+0x00021 (Tree Row 9) - 0x00020 - Black/White Squares
 Door - 0x03BA2 (Outpost Path) - 0x0A3B5
-159511 - 0x03D06 (Garden EP) - True - True
-159514 - 0x28A2F (Town Sewer EP) - True - True
-159516 - 0x334A3 (Path EP) - True - True
-159500 - 0x035C7 (Tractor EP) - True - True
+0x03D06 (Garden EP) - True - True
+0x28A2F (Town Sewer EP) - True - True
+0x334A3 (Path EP) - True - True
+0x035C7 (Tractor EP) - True - True
 
 Outside Tutorial Vault (Outside Tutorial):
-158651 - 0x03481 (Vault Box) - True - True
+0x03481 (Vault Box) - True - True
 
 Outside Tutorial Path To Outpost (Outside Tutorial) - Outside Tutorial Outpost - 0x0A170:
-158011 - 0x0A171 (Outpost Entry Panel) - True - Full Dots
+0x0A171 (Outpost Entry Panel) - True - Full Dots
 Door - 0x0A170 (Outpost Entry) - 0x0A171
 
 Outside Tutorial Outpost (Outside Tutorial) - Outside Tutorial - 0x04CA3:
-158012 - 0x04CA4 (Outpost Exit Panel) - True - Full Dots
+0x04CA4 (Outpost Exit Panel) - True - Full Dots
 Door - 0x04CA3 (Outpost Exit) - 0x04CA4
-158600 - 0x17CFB (Discard) - True - Triangles
+0x17CFB (Discard) - True - Triangles
 
 Orchard (Orchard) - Main Island - True - Orchard Beyond First Gate - 0x03307:
-158071 - 0x00143 (Apple Tree 1) - True - True
-158072 - 0x0003B (Apple Tree 2) - 0x00143 - True
-158073 - 0x00055 (Apple Tree 3) - 0x0003B - True
+0x00143 (Apple Tree 1) - True - True
+0x0003B (Apple Tree 2) - 0x00143 - True
+0x00055 (Apple Tree 3) - 0x0003B - True
 Door - 0x03307 (First Gate) - 0x00055
 
 Orchard Beyond First Gate (Orchard) - Orchard End - 0x03313:
-158074 - 0x032F7 (Apple Tree 4) - 0x00055 - True
-158075 - 0x032FF (Apple Tree 5) - 0x032F7 - True
+0x032F7 (Apple Tree 4) - 0x00055 - True
+0x032FF (Apple Tree 5) - 0x032F7 - True
 Door - 0x03313 (Second Gate) - 0x032FF
 
 Orchard End (Orchard):
 
 Main Island (Main Island) - Outside Tutorial - True:
-159801 - 0xFFD00 (Reached Independently) - True - True
+0xFFD00 (Reached Independently) - True - True
 
 ==Glass Factory==
 
 Outside Glass Factory (Glass Factory) - Main Island - True - Inside Glass Factory - 0x01A29:
-158027 - 0x01A54 (Entry Panel) - True - Symmetry
+0x01A54 (Entry Panel) - True - Symmetry
 Door - 0x01A29 (Entry) - 0x01A54
-158601 - 0x3C12B (Discard) - True - Triangles
-159002 - 0x28B8A (Vase EP) - 0x01A54 - True
+0x3C12B (Discard) - True - Triangles
+0x28B8A (Vase EP) - 0x01A54 - True
 
 Inside Glass Factory (Glass Factory) - Inside Glass Factory Behind Back Wall - 0x0D7ED:
-158028 - 0x00086 (Back Wall 1) - True - Symmetry
-158029 - 0x00087 (Back Wall 2) - 0x00086 - Symmetry
-158030 - 0x00059 (Back Wall 3) - 0x00087 - Symmetry
-158031 - 0x00062 (Back Wall 4) - 0x00059 - Symmetry
-158032 - 0x0005C (Back Wall 5) - 0x00062 - Symmetry
-158033 - 0x0008D (Front 1) - 0x0005C - Symmetry
-158034 - 0x00081 (Front 2) - 0x0008D - Symmetry
-158035 - 0x00083 (Front 3) - 0x00081 - Symmetry
-158036 - 0x00084 (Melting 1) - 0x00083 - Symmetry
-158037 - 0x00082 (Melting 2) - 0x00084 - Symmetry
-158038 - 0x0343A (Melting 3) - 0x00082 - Symmetry
+0x00086 (Back Wall 1) - True - Symmetry
+0x00087 (Back Wall 2) - 0x00086 - Symmetry
+0x00059 (Back Wall 3) - 0x00087 - Symmetry
+0x00062 (Back Wall 4) - 0x00059 - Symmetry
+0x0005C (Back Wall 5) - 0x00062 - Symmetry
+0x0008D (Front 1) - 0x0005C - Symmetry
+0x00081 (Front 2) - 0x0008D - Symmetry
+0x00083 (Front 3) - 0x00081 - Symmetry
+0x00084 (Melting 1) - 0x00083 - Symmetry
+0x00082 (Melting 2) - 0x00084 - Symmetry
+0x0343A (Melting 3) - 0x00082 - Symmetry
 Door - 0x0D7ED (Back Wall) - 0x0005C
 
 Inside Glass Factory Behind Back Wall (Glass Factory) - The Ocean - 0x17CC8:
-158039 - 0x17CC8 (Boat Spawn) - 0x17CA6 | 0x17CDF | 0x09DB8 | 0x17C95 - Boat
+0x17CC8 (Boat Spawn) - 0x17CA6 | 0x17CDF | 0x09DB8 | 0x17C95 - Boat
 
 ==Symmetry Island==
 
 Outside Symmetry Island (Symmetry Island) - Main Island - True - Symmetry Island Lower - 0x17F3E:
-158040 - 0x000B0 (Lower Panel) - 0x0343A - Dots
+0x000B0 (Lower Panel) - 0x0343A - Dots
 Door - 0x17F3E (Lower) - 0x000B0
 
 Symmetry Island Lower (Symmetry Island) - Symmetry Island Upper - 0x18269:
-158041 - 0x00022 (Right 1) - True - Symmetry & Dots
-158042 - 0x00023 (Right 2) - 0x00022 - Symmetry & Dots
-158043 - 0x00024 (Right 3) - 0x00023 - Symmetry & Dots
-158044 - 0x00025 (Right 4) - 0x00024 - Symmetry & Dots
-158045 - 0x00026 (Right 5) - 0x00025 - Symmetry & Dots
-158046 - 0x0007C (Back 1) - 0x00026 - Symmetry & Colored Dots
-158047 - 0x0007E (Back 2) - 0x0007C - Symmetry & Colored Dots
-158048 - 0x00075 (Back 3) - 0x0007E - Symmetry & Colored Dots
-158049 - 0x00073 (Back 4) - 0x00075 - Symmetry & Dots & Colored Dots
-158050 - 0x00077 (Back 5) - 0x00073 - Symmetry & Dots & Colored Dots
-158051 - 0x00079 (Back 6) - 0x00077 - Symmetry & Dots & Colored Dots
-158052 - 0x00065 (Left 1) - 0x00079 - Symmetry & Colored Dots
-158053 - 0x0006D (Left 2) - 0x00065 - Symmetry & Colored Dots
-158054 - 0x00072 (Left 3) - 0x0006D - Symmetry & Colored Dots
-158055 - 0x0006F (Left 4) - 0x00072 - Symmetry & Colored Dots
-158056 - 0x00070 (Left 5) - 0x0006F - Symmetry & Colored Dots
-158057 - 0x00071 (Left 6) - 0x00070 - Symmetry & Colored Dots
-158058 - 0x00076 (Left 7) - 0x00071 - Symmetry & Colored Dots
-158059 - 0x009B8 (Scenery Outlines 1) - True - Symmetry
-158060 - 0x003E8 (Scenery Outlines 2) - 0x009B8 - Symmetry
-158061 - 0x00A15 (Scenery Outlines 3) - 0x003E8 - Symmetry
-158062 - 0x00B53 (Scenery Outlines 4) - 0x00A15 - Symmetry
-158063 - 0x00B8D (Scenery Outlines 5) - 0x00B53 - Symmetry
-158064 - 0x1C349 (Upper Panel) - 0x00076 - Symmetry & Dots
+0x00022 (Right 1) - True - Symmetry & Dots
+0x00023 (Right 2) - 0x00022 - Symmetry & Dots
+0x00024 (Right 3) - 0x00023 - Symmetry & Dots
+0x00025 (Right 4) - 0x00024 - Symmetry & Dots
+0x00026 (Right 5) - 0x00025 - Symmetry & Dots
+0x0007C (Back 1) - 0x00026 - Symmetry & Colored Dots
+0x0007E (Back 2) - 0x0007C - Symmetry & Colored Dots
+0x00075 (Back 3) - 0x0007E - Symmetry & Colored Dots
+0x00073 (Back 4) - 0x00075 - Symmetry & Dots & Colored Dots
+0x00077 (Back 5) - 0x00073 - Symmetry & Dots & Colored Dots
+0x00079 (Back 6) - 0x00077 - Symmetry & Dots & Colored Dots
+0x00065 (Left 1) - 0x00079 - Symmetry & Colored Dots
+0x0006D (Left 2) - 0x00065 - Symmetry & Colored Dots
+0x00072 (Left 3) - 0x0006D - Symmetry & Colored Dots
+0x0006F (Left 4) - 0x00072 - Symmetry & Colored Dots
+0x00070 (Left 5) - 0x0006F - Symmetry & Colored Dots
+0x00071 (Left 6) - 0x00070 - Symmetry & Colored Dots
+0x00076 (Left 7) - 0x00071 - Symmetry & Colored Dots
+0x009B8 (Scenery Outlines 1) - True - Symmetry
+0x003E8 (Scenery Outlines 2) - 0x009B8 - Symmetry
+0x00A15 (Scenery Outlines 3) - 0x003E8 - Symmetry
+0x00B53 (Scenery Outlines 4) - 0x00A15 - Symmetry
+0x00B8D (Scenery Outlines 5) - 0x00B53 - Symmetry
+0x1C349 (Upper Panel) - 0x00076 - Symmetry & Dots
 Door - 0x18269 (Upper) - 0x1C349
-159000 - 0x0332B (Glass Factory Black Line Reflection EP) - True - True
+0x0332B (Glass Factory Black Line Reflection EP) - True - True
 
 Symmetry Island Upper (Symmetry Island):
-158065 - 0x00A52 (Laser Yellow 1) - True - Colored Dots
-158066 - 0x00A57 (Laser Yellow 2) - 0x00A52 - Colored Dots
-158067 - 0x00A5B (Laser Yellow 3) - 0x00A57 - Colored Dots
-158068 - 0x00A61 (Laser Blue 1) - 0x00A52 - Colored Dots
-158069 - 0x00A64 (Laser Blue 2) - 0x00A61 & 0x00A57 - Colored Dots
-158070 - 0x00A68 (Laser Blue 3) - 0x00A64 & 0x00A5B - Colored Dots
-158700 - 0x0360D (Laser Panel) - 0x00A68 - True
+0x00A52 (Laser Yellow 1) - True - Colored Dots
+0x00A57 (Laser Yellow 2) - 0x00A52 - Colored Dots
+0x00A5B (Laser Yellow 3) - 0x00A57 - Colored Dots
+0x00A61 (Laser Blue 1) - 0x00A52 - Colored Dots
+0x00A64 (Laser Blue 2) - 0x00A61 & 0x00A57 - Colored Dots
+0x00A68 (Laser Blue 3) - 0x00A64 & 0x00A5B - Colored Dots
+0x0360D (Laser Panel) - 0x00A68 - True
 Laser - 0x00509 (Laser) - 0x0360D
-159001 - 0x03367 (Glass Factory Black Line EP) - True - True
+0x03367 (Glass Factory Black Line EP) - True - True
 
 ==Desert==
 
 Desert Obelisk (Desert) - Entry - True:
-159700 - 0xFFE00 (Obelisk Side 1) - 0x0332B & 0x03367 & 0x28B8A - True
-159701 - 0xFFE01 (Obelisk Side 2) - 0x037B6 & 0x037B2 & 0x000F7 - True
-159702 - 0xFFE02 (Obelisk Side 3) - 0x3351D - True
-159703 - 0xFFE03 (Obelisk Side 4) - 0x0053C & 0x00771 & 0x335C8 & 0x335C9 & 0x337F8 & 0x037BB & 0x220E4 & 0x220E5 - True
-159704 - 0xFFE04 (Obelisk Side 5) - 0x334B9 & 0x334BC & 0x22106 & 0x0A14C & 0x0A14D - True
-159709 - 0x00359 (Obelisk) - True - True
+0xFFE00 (Obelisk Side 1) - 0x0332B & 0x03367 & 0x28B8A - True
+0xFFE01 (Obelisk Side 2) - 0x037B6 & 0x037B2 & 0x000F7 - True
+0xFFE02 (Obelisk Side 3) - 0x3351D - True
+0xFFE03 (Obelisk Side 4) - 0x0053C & 0x00771 & 0x335C8 & 0x335C9 & 0x337F8 & 0x037BB & 0x220E4 & 0x220E5 - True
+0xFFE04 (Obelisk Side 5) - 0x334B9 & 0x334BC & 0x22106 & 0x0A14C & 0x0A14D - True
+0x00359 (Obelisk) - True - True
 
 Desert Outside (Desert) - Main Island - True - Desert Light Room - 0x09FEE - Desert Vault - 0x03444:
-158652 - 0x0CC7B (Vault Panel) - True - Shapers & Rotated Shapers & Negative Shapers & Full Dots
+0x0CC7B (Vault Panel) - True - Shapers & Rotated Shapers & Negative Shapers & Full Dots
 Door - 0x03444 (Vault Door) - 0x0CC7B
-158602 - 0x17CE7 (Discard) - True - Triangles
-158076 - 0x00698 (Surface 1) - True - True
-158077 - 0x0048F (Surface 2) - 0x00698 - True
-158078 - 0x09F92 (Surface 3) - 0x0048F & 0x09FA0 - True
-158079 - 0x09FA0 (Surface 3 Control) - 0x0048F - True
-158080 - 0x0A036 (Surface 4) - 0x09F92 - True
-158081 - 0x09DA6 (Surface 5) - 0x09F92 - True
-158082 - 0x0A049 (Surface 6) - 0x09F92 - True
-158083 - 0x0A053 (Surface 7) - 0x0A036 & 0x09DA6 & 0x0A049 - True
-158084 - 0x09F94 (Surface 8) - 0x0A053 & 0x09F86 - True
-158085 - 0x09F86 (Surface 8 Control) - 0x0A053 - True
-158086 - 0x0C339 (Light Room Entry Panel) - 0x09F94 - True
+0x17CE7 (Discard) - True - Triangles
+0x00698 (Surface 1) - True - True
+0x0048F (Surface 2) - 0x00698 - True
+0x09F92 (Surface 3) - 0x0048F & 0x09FA0 - True
+0x09FA0 (Surface 3 Control) - 0x0048F - True
+0x0A036 (Surface 4) - 0x09F92 - True
+0x09DA6 (Surface 5) - 0x09F92 - True
+0x0A049 (Surface 6) - 0x09F92 - True
+0x0A053 (Surface 7) - 0x0A036 & 0x09DA6 & 0x0A049 - True
+0x09F94 (Surface 8) - 0x0A053 & 0x09F86 - True
+0x09F86 (Surface 8 Control) - 0x0A053 - True
+0x0C339 (Light Room Entry Panel) - 0x09F94 - True
 Door - 0x09FEE (Light Room Entry) - 0x0C339
-158701 - 0x03608 (Laser Panel) - 0x012D7 & 0x0A15F - True
+0x03608 (Laser Panel) - 0x012D7 & 0x0A15F - True
 Laser - 0x012FB (Laser) - 0x03608
-159804 - 0xFFD03 (Laser Activated + Redirected) - 0x09F98 & 0x012FB - True
-159020 - 0x3351D (Sand Snake EP) - True - True
-159030 - 0x0053C (Facade Right EP) - True - True
-159031 - 0x00771 (Facade Left EP) - True - True
-159032 - 0x335C8 (Stairs Left EP) - True - True
-159033 - 0x335C9 (Stairs Right EP) - True - True
-159036 - 0x220E4 (Broken Wall Straight EP) - True - True
-159037 - 0x220E5 (Broken Wall Bend EP) - True - True
-159040 - 0x334B9 (Shore EP) - True - True
-159041 - 0x334BC (Island EP) - True - True
+0xFFD03 (Laser Activated + Redirected) - 0x09F98 & 0x012FB - True
+0x3351D (Sand Snake EP) - True - True
+0x0053C (Facade Right EP) - True - True
+0x00771 (Facade Left EP) - True - True
+0x335C8 (Stairs Left EP) - True - True
+0x335C9 (Stairs Right EP) - True - True
+0x220E4 (Broken Wall Straight EP) - True - True
+0x220E5 (Broken Wall Bend EP) - True - True
+0x334B9 (Shore EP) - True - True
+0x334BC (Island EP) - True - True
 
 Desert Vault (Desert):
-158653 - 0x0339E (Vault Box) - True - True
+0x0339E (Vault Box) - True - True
 
 Desert Light Room (Desert) - Desert Pond Room - 0x0C2C3:
-158087 - 0x09FAA (Light Control) - True - True
-158088 - 0x00422 (Light Room 1) - 0x09FAA - True
-158089 - 0x006E3 (Light Room 2) - 0x09FAA - True
-158090 - 0x0A02D (Light Room 3) - 0x09FAA & 0x00422 & 0x006E3 - True
+0x09FAA (Light Control) - True - True
+0x00422 (Light Room 1) - 0x09FAA - True
+0x006E3 (Light Room 2) - 0x09FAA - True
+0x0A02D (Light Room 3) - 0x09FAA & 0x00422 & 0x006E3 - True
 Door - 0x0C2C3 (Pond Room Entry) - 0x0A02D
 
 Desert Pond Room (Desert) - Desert Flood Room - 0x0A24B:
-158091 - 0x00C72 (Pond Room 1) - True - True
-158092 - 0x0129D (Pond Room 2) - 0x00C72 - True
-158093 - 0x008BB (Pond Room 3) - 0x0129D - True
-158094 - 0x0078D (Pond Room 4) - 0x008BB - True
-158095 - 0x18313 (Pond Room 5) - 0x0078D - True
-158096 - 0x0A249 (Flood Room Entry Panel) - 0x18313 - True
+0x00C72 (Pond Room 1) - True - True
+0x0129D (Pond Room 2) - 0x00C72 - True
+0x008BB (Pond Room 3) - 0x0129D - True
+0x0078D (Pond Room 4) - 0x008BB - True
+0x18313 (Pond Room 5) - 0x0078D - True
+0x0A249 (Flood Room Entry Panel) - 0x18313 - True
 Door - 0x0A24B (Flood Room Entry) - 0x0A249
-159043 - 0x0A14C (Pond Room Near Reflection EP) - True - True
-159044 - 0x0A14D (Pond Room Far Reflection EP) - True - True
+0x0A14C (Pond Room Near Reflection EP) - True - True
+0x0A14D (Pond Room Far Reflection EP) - True - True
 
 Desert Flood Room (Desert) - Desert Elevator Room - 0x0C316 - Desert Flood Room Underwater - 0x1C260:
-158097 - 0x1C2DF (Reduce Water Level Far Left) - True - True
-158098 - 0x1831E (Reduce Water Level Far Right) - True - True
-158099 - 0x1C260 (Reduce Water Level Near Left) - True - True
-158100 - 0x1831C (Reduce Water Level Near Right) - True - True
-158101 - 0x1C2F3 (Raise Water Level Far Left) - True - True
-158102 - 0x1831D (Raise Water Level Far Right) - True - True
-158103 - 0x1C2B1 (Raise Water Level Near Left) - True - True
-158104 - 0x1831B (Raise Water Level Near Right) - True - True
-158105 - 0x04D18 (Flood Room 1) - 0x1C260 & 0x1831C - True
-158106 - 0x01205 (Flood Room 2) - 0x04D18 & 0x1C260 & 0x1831C - True
-158107 - 0x181AB (Flood Room 3) - 0x01205 & 0x1C260 & 0x1831C - True
-158108 - 0x0117A (Flood Room 4) - 0x181AB & 0x1C260 & 0x1831C - True
-158109 - 0x17ECA (Flood Room 5) - 0x0117A & 0x1C260 & 0x1831C - True
-158110 - 0x18076 (Flood Room 6) - 0x17ECA & 0x1C260 & 0x1831C - True
+0x1C2DF (Reduce Water Level Far Left) - True - True
+0x1831E (Reduce Water Level Far Right) - True - True
+0x1C260 (Reduce Water Level Near Left) - True - True
+0x1831C (Reduce Water Level Near Right) - True - True
+0x1C2F3 (Raise Water Level Far Left) - True - True
+0x1831D (Raise Water Level Far Right) - True - True
+0x1C2B1 (Raise Water Level Near Left) - True - True
+0x1831B (Raise Water Level Near Right) - True - True
+0x04D18 (Flood Room 1) - 0x1C260 & 0x1831C - True
+0x01205 (Flood Room 2) - 0x04D18 & 0x1C260 & 0x1831C - True
+0x181AB (Flood Room 3) - 0x01205 & 0x1C260 & 0x1831C - True
+0x0117A (Flood Room 4) - 0x181AB & 0x1C260 & 0x1831C - True
+0x17ECA (Flood Room 5) - 0x0117A & 0x1C260 & 0x1831C - True
+0x18076 (Flood Room 6) - 0x17ECA & 0x1C260 & 0x1831C - True
 Door - 0x0C316 (Elevator Room Entry) - 0x18076
-159034 - 0x337F8 (Flood Room EP) - 0x1C2DF - True
+0x337F8 (Flood Room EP) - 0x1C2DF - True
 
 Desert Flood Room Underwater (Desert):
 
 Desert Elevator Room (Desert) - Desert Behind Elevator - 0x01317:
-158111 - 0x17C31 (Elevator Room Transparent) - True - True
-158113 - 0x012D7 (Elevator Room Hexagonal) - 0x17C31 & 0x0A015 - True
-158114 - 0x0A015 (Elevator Room Hexagonal Control) - 0x17C31 - True
-158115 - 0x0A15C (Elevator Room Bent 1) - True - True
-158116 - 0x09FFF (Elevator Room Bent 2) - 0x0A15C - True
-158117 - 0x0A15F (Elevator Room Bent 3) - 0x09FFF - True
-159035 - 0x037BB (Elevator EP) - 0x01317 - True
+0x17C31 (Elevator Room Transparent) - True - True
+0x012D7 (Elevator Room Hexagonal) - 0x17C31 & 0x0A015 - True
+0x0A015 (Elevator Room Hexagonal Control) - 0x17C31 - True
+0x0A15C (Elevator Room Bent 1) - True - True
+0x09FFF (Elevator Room Bent 2) - 0x0A15C - True
+0x0A15F (Elevator Room Bent 3) - 0x09FFF - True
+0x037BB (Elevator EP) - 0x01317 - True
 Door - 0x01317 (Elevator) - 0x03608
 
 Desert Behind Elevator (Desert):
@@ -241,277 +241,277 @@ Desert Behind Elevator (Desert):
 ==Quarry==
 
 Quarry Obelisk (Quarry) - Entry - True:
-159740 - 0xFFE40 (Obelisk Side 1) - 0x28A7B & 0x005F6 & 0x00859 & 0x17CB9 & 0x28A4A - True
-159741 - 0xFFE41 (Obelisk Side 2) - 0x334B6 & 0x00614 & 0x0069D & 0x28A4C - True
-159742 - 0xFFE42 (Obelisk Side 3) - 0x289CF & 0x289D1 - True
-159743 - 0xFFE43 (Obelisk Side 4) - 0x33692 - True
-159744 - 0xFFE44 (Obelisk Side 5) - 0x03E77 & 0x03E7C - True
-159749 - 0x22073 (Obelisk) - True - True
+0xFFE40 (Obelisk Side 1) - 0x28A7B & 0x005F6 & 0x00859 & 0x17CB9 & 0x28A4A - True
+0xFFE41 (Obelisk Side 2) - 0x334B6 & 0x00614 & 0x0069D & 0x28A4C - True
+0xFFE42 (Obelisk Side 3) - 0x289CF & 0x289D1 - True
+0xFFE43 (Obelisk Side 4) - 0x33692 - True
+0xFFE44 (Obelisk Side 5) - 0x03E77 & 0x03E7C - True
+0x22073 (Obelisk) - True - True
 
 Outside Quarry (Quarry) - Main Island - True - Quarry Between Entry Doors - 0x09D6F - Quarry Elevator - 0xFFD00 & 0xFFD01:
-158118 - 0x09E57 (Entry 1 Panel) - True - Black/White Squares
-158603 - 0x17CF0 (Discard) - True - Triangles
-158702 - 0x03612 (Laser Panel) - 0x0A3D0 & 0x0367C - Eraser & Shapers
+0x09E57 (Entry 1 Panel) - True - Black/White Squares
+0x17CF0 (Discard) - True - Triangles
+0x03612 (Laser Panel) - 0x0A3D0 & 0x0367C - Eraser & Shapers
 Laser - 0x01539 (Laser) - 0x03612
 Door - 0x09D6F (Entry 1) - 0x09E57
-159404 - 0x28A4A (Shore EP) - True - True
-159410 - 0x334B6 (Entrance Pipe EP) - True - True
-159412 - 0x28A4C (Sand Pile EP) - True - True
-159420 - 0x289CF (Rock Line EP) - True - True
-159421 - 0x289D1 (Rock Line Reflection EP) - True - True
+0x28A4A (Shore EP) - True - True
+0x334B6 (Entrance Pipe EP) - True - True
+0x28A4C (Sand Pile EP) - True - True
+0x289CF (Rock Line EP) - True - True
+0x289D1 (Rock Line Reflection EP) - True - True
 
 Quarry Elevator (Quarry) - Outside Quarry - 0x17CC4 - Quarry - 0x17CC4:
-158120 - 0x17CC4 (Elevator Control) - 0x0367C - Dots & Eraser
-159403 - 0x17CB9 (Railroad EP) - 0x17CC4 - True
+0x17CC4 (Elevator Control) - 0x0367C - Dots & Eraser
+0x17CB9 (Railroad EP) - 0x17CC4 - True
 
 Quarry Between Entry Doors (Quarry) - Quarry - 0x17C07:
-158119 - 0x17C09 (Entry 2 Panel) - True - Shapers
+0x17C09 (Entry 2 Panel) - True - Shapers
 Door - 0x17C07 (Entry 2) - 0x17C09
 
 Quarry (Quarry) - Quarry Stoneworks Ground Floor - 0x02010:
-159802 - 0xFFD01 (Inside Reached Independently) - True - True
-158121 - 0x01E5A (Stoneworks Entry Left Panel) - True - Black/White Squares
-158122 - 0x01E59 (Stoneworks Entry Right Panel) - True - Dots
+0xFFD01 (Inside Reached Independently) - True - True
+0x01E5A (Stoneworks Entry Left Panel) - True - Black/White Squares
+0x01E59 (Stoneworks Entry Right Panel) - True - Dots
 Door - 0x02010 (Stoneworks Entry) - 0x01E59 & 0x01E5A
 
 Quarry Stoneworks Ground Floor (Quarry Stoneworks) - Quarry - 0x275FF - Quarry Stoneworks Middle Floor - 0x03678 - Outside Quarry - 0x17CE8 - Quarry Stoneworks Lift - TrueOneWay:
-158123 - 0x275ED (Side Exit Panel) - True - True
+0x275ED (Side Exit Panel) - True - True
 Door - 0x275FF (Side Exit) - 0x275ED
-158124 - 0x03678 (Lower Ramp Control) - True - Dots & Eraser
-158145 - 0x17CAC (Roof Exit Panel) - True - True
+0x03678 (Lower Ramp Control) - True - Dots & Eraser
+0x17CAC (Roof Exit Panel) - True - True
 Door - 0x17CE8 (Roof Exit) - 0x17CAC
 
 Quarry Stoneworks Middle Floor (Quarry Stoneworks) - Quarry Stoneworks Lift - TrueOneWay:
-158125 - 0x00E0C (Lower Row 1) - True - Dots & Eraser
-158126 - 0x01489 (Lower Row 2) - 0x00E0C - Dots & Eraser
-158127 - 0x0148A (Lower Row 3) - 0x01489 - Dots & Eraser
-158128 - 0x014D9 (Lower Row 4) - 0x0148A - Full Dots & Eraser
-158129 - 0x014E7 (Lower Row 5) - 0x014D9 - Dots
-158130 - 0x014E8 (Lower Row 6) - 0x014E7 - Dots & Eraser
+0x00E0C (Lower Row 1) - True - Dots & Eraser
+0x01489 (Lower Row 2) - 0x00E0C - Dots & Eraser
+0x0148A (Lower Row 3) - 0x01489 - Dots & Eraser
+0x014D9 (Lower Row 4) - 0x0148A - Full Dots & Eraser
+0x014E7 (Lower Row 5) - 0x014D9 - Dots
+0x014E8 (Lower Row 6) - 0x014E7 - Dots & Eraser
 
 Quarry Stoneworks Lift (Quarry Stoneworks) - Quarry Stoneworks Middle Floor - 0x03679 - Quarry Stoneworks Ground Floor - 0x03679 - Quarry Stoneworks Upper Floor - 0x03679:
-158131 - 0x03679 (Lower Lift Control) - 0x014E8 - Dots & Eraser
+0x03679 (Lower Lift Control) - 0x014E8 - Dots & Eraser
 
 Quarry Stoneworks Upper Floor (Quarry Stoneworks) - Quarry Stoneworks Lift - 0x03675 - Quarry Stoneworks Ground Floor - 0x0368A:
-158132 - 0x03676 (Upper Ramp Control) - True - Dots & Eraser
-158133 - 0x03675 (Upper Lift Control) - True - Dots & Eraser
-158134 - 0x00557 (Upper Row 1) - True - Colored Squares & Eraser
-158135 - 0x005F1 (Upper Row 2) - 0x00557 - Colored Squares & Eraser
-158136 - 0x00620 (Upper Row 3) - 0x005F1 - Colored Squares & Eraser
-158137 - 0x009F5 (Upper Row 4) - 0x00620 - Colored Squares & Eraser
-158138 - 0x0146C (Upper Row 5) - 0x009F5 - Colored Squares & Eraser
-158139 - 0x3C12D (Upper Row 6) - 0x0146C - Colored Squares & Eraser
-158140 - 0x03686 (Upper Row 7) - 0x3C12D - Colored Squares & Eraser
-158141 - 0x014E9 (Upper Row 8) - 0x03686 - Colored Squares & Eraser
-158142 - 0x03677 (Stairs Panel) - True - Colored Squares & Eraser
+0x03676 (Upper Ramp Control) - True - Dots & Eraser
+0x03675 (Upper Lift Control) - True - Dots & Eraser
+0x00557 (Upper Row 1) - True - Colored Squares & Eraser
+0x005F1 (Upper Row 2) - 0x00557 - Colored Squares & Eraser
+0x00620 (Upper Row 3) - 0x005F1 - Colored Squares & Eraser
+0x009F5 (Upper Row 4) - 0x00620 - Colored Squares & Eraser
+0x0146C (Upper Row 5) - 0x009F5 - Colored Squares & Eraser
+0x3C12D (Upper Row 6) - 0x0146C - Colored Squares & Eraser
+0x03686 (Upper Row 7) - 0x3C12D - Colored Squares & Eraser
+0x014E9 (Upper Row 8) - 0x03686 - Colored Squares & Eraser
+0x03677 (Stairs Panel) - True - Colored Squares & Eraser
 Door - 0x0368A (Stairs) - 0x03677
-158143 - 0x3C125 (Control Room Left) - 0x014E9 - Black/White Squares & Dots & Eraser
-158144 - 0x0367C (Control Room Right) - 0x014E9 - Colored Squares & Dots & Eraser
-159411 - 0x0069D (Ramp EP) - 0x03676 & 0x275FF - True
-159413 - 0x00614 (Lift EP) - 0x275FF & 0x03675 - True
+0x3C125 (Control Room Left) - 0x014E9 - Black/White Squares & Dots & Eraser
+0x0367C (Control Room Right) - 0x014E9 - Colored Squares & Dots & Eraser
+0x0069D (Ramp EP) - 0x03676 & 0x275FF - True
+0x00614 (Lift EP) - 0x275FF & 0x03675 - True
 
 Quarry Boathouse (Quarry Boathouse) - Quarry - True - Quarry Boathouse Upper Front - 0x03852 - Quarry Boathouse Behind Staircase - 0x2769B:
-158146 - 0x034D4 (Intro Left) - True - Stars
-158147 - 0x021D5 (Intro Right) - True - Shapers & Rotated Shapers
-158148 - 0x03852 (Ramp Height Control) - 0x034D4 & 0x021D5 - Rotated Shapers
-158166 - 0x17CA6 (Boat Spawn) - True - Boat
+0x034D4 (Intro Left) - True - Stars
+0x021D5 (Intro Right) - True - Shapers & Rotated Shapers
+0x03852 (Ramp Height Control) - 0x034D4 & 0x021D5 - Rotated Shapers
+0x17CA6 (Boat Spawn) - True - Boat
 Door - 0x2769B (Dock) - 0x17CA6
 Door - 0x27163 (Dock Invis Barrier) - 0x17CA6
 
 Quarry Boathouse Behind Staircase (Quarry Boathouse) - The Ocean - 0x17CA6:
 
 Quarry Boathouse Upper Front (Quarry Boathouse) - Quarry Boathouse Upper Middle - 0x17C50:
-158149 - 0x021B3 (Front Row 1) - True - Shapers & Eraser
-158150 - 0x021B4 (Front Row 2) - 0x021B3 - Shapers & Eraser
-158151 - 0x021B0 (Front Row 3) - 0x021B4 - Shapers & Eraser
-158152 - 0x021AF (Front Row 4) - 0x021B0 - Shapers & Eraser
-158153 - 0x021AE (Front Row 5) - 0x021AF - Shapers & Eraser
+0x021B3 (Front Row 1) - True - Shapers & Eraser
+0x021B4 (Front Row 2) - 0x021B3 - Shapers & Eraser
+0x021B0 (Front Row 3) - 0x021B4 - Shapers & Eraser
+0x021AF (Front Row 4) - 0x021B0 - Shapers & Eraser
+0x021AE (Front Row 5) - 0x021AF - Shapers & Eraser
 Door - 0x17C50 (First Barrier) - 0x021AE
 
 Quarry Boathouse Upper Middle (Quarry Boathouse) - Quarry Boathouse Upper Back - 0x03858:
-158154 - 0x03858 (Ramp Horizontal Control) - True - Shapers & Eraser
-159402 - 0x00859 (Moving Ramp EP) - 0x03858 & 0x03852 & 0x3865F - True
+0x03858 (Ramp Horizontal Control) - True - Shapers & Eraser
+0x00859 (Moving Ramp EP) - 0x03858 & 0x03852 & 0x3865F - True
 
 Quarry Boathouse Upper Back (Quarry Boathouse) - Quarry Boathouse Upper Middle - 0x3865F:
-158155 - 0x38663 (Second Barrier Panel) - True - True
+0x38663 (Second Barrier Panel) - True - True
 Door - 0x3865F (Second Barrier) - 0x38663
-158156 - 0x021B5 (Back First Row 1) - True - Stars & Eraser
-158157 - 0x021B6 (Back First Row 2) - 0x021B5 - Stars + Same Colored Symbol & Eraser
-158158 - 0x021B7 (Back First Row 3) - 0x021B6 - Stars & Eraser
-158159 - 0x021BB (Back First Row 4) - 0x021B7 - Stars + Same Colored Symbol & Eraser
-158160 - 0x09DB5 (Back First Row 5) - 0x021BB - Stars + Same Colored Symbol & Eraser
-158161 - 0x09DB1 (Back First Row 6) - 0x09DB5 - Stars + Same Colored Symbol & Eraser
-158162 - 0x3C124 (Back First Row 7) - 0x09DB1 - Stars + Same Colored Symbol & Eraser
-158163 - 0x09DB3 (Back First Row 8) - 0x3C124 - Stars & Eraser & Shapers
-158164 - 0x09DB4 (Back First Row 9) - 0x09DB3 - Stars & Eraser & Shapers
-158165 - 0x275FA (Hook Control) - True - Shapers & Eraser
-158167 - 0x0A3CB (Back Second Row 1) - 0x09DB4 - Stars & Eraser & Shapers
-158168 - 0x0A3CC (Back Second Row 2) - 0x0A3CB - Stars & Eraser & Shapers
-158169 - 0x0A3D0 (Back Second Row 3) - 0x0A3CC - Stars & Eraser & Shapers
-159401 - 0x005F6 (Hook EP) - 0x275FA & 0x03852 & 0x3865F - True
+0x021B5 (Back First Row 1) - True - Stars & Eraser
+0x021B6 (Back First Row 2) - 0x021B5 - Stars + Same Colored Symbol & Eraser
+0x021B7 (Back First Row 3) - 0x021B6 - Stars & Eraser
+0x021BB (Back First Row 4) - 0x021B7 - Stars + Same Colored Symbol & Eraser
+0x09DB5 (Back First Row 5) - 0x021BB - Stars + Same Colored Symbol & Eraser
+0x09DB1 (Back First Row 6) - 0x09DB5 - Stars + Same Colored Symbol & Eraser
+0x3C124 (Back First Row 7) - 0x09DB1 - Stars + Same Colored Symbol & Eraser
+0x09DB3 (Back First Row 8) - 0x3C124 - Stars & Eraser & Shapers
+0x09DB4 (Back First Row 9) - 0x09DB3 - Stars & Eraser & Shapers
+0x275FA (Hook Control) - True - Shapers & Eraser
+0x0A3CB (Back Second Row 1) - 0x09DB4 - Stars & Eraser & Shapers
+0x0A3CC (Back Second Row 2) - 0x0A3CB - Stars & Eraser & Shapers
+0x0A3D0 (Back Second Row 3) - 0x0A3CC - Stars & Eraser & Shapers
+0x005F6 (Hook EP) - 0x275FA & 0x03852 & 0x3865F - True
 
 ==Shadows==
 
 Shadows (Shadows) - Main Island - True - Shadows Ledge - 0x19B24 - Shadows Laser Room - 0x194B2 | 0x19665:
-158170 - 0x334DB (Door Timer Outside) - True - True
+0x334DB (Door Timer Outside) - True - True
 Door - 0x19B24 (Timed Door) - 0x334DB | 0x334DC
-158171 - 0x0AC74 (Intro 6) - 0x0A8DC - True
-158172 - 0x0AC7A (Intro 7) - 0x0AC74 - True
-158173 - 0x0A8E0 (Intro 8) - 0x0AC7A - True
-158174 - 0x386FA (Far 1) - 0x0A8E0 - True
-158175 - 0x1C33F (Far 2) - 0x386FA - True
-158176 - 0x196E2 (Far 3) - 0x1C33F - True
-158177 - 0x1972A (Far 4) - 0x196E2 - True
-158178 - 0x19809 (Far 5) - 0x1972A - True
-158179 - 0x19806 (Far 6) - 0x19809 - True
-158180 - 0x196F8 (Far 7) - 0x19806 - True
-158181 - 0x1972F (Far 8) - 0x196F8 - True
+0x0AC74 (Intro 6) - 0x0A8DC - True
+0x0AC7A (Intro 7) - 0x0AC74 - True
+0x0A8E0 (Intro 8) - 0x0AC7A - True
+0x386FA (Far 1) - 0x0A8E0 - True
+0x1C33F (Far 2) - 0x386FA - True
+0x196E2 (Far 3) - 0x1C33F - True
+0x1972A (Far 4) - 0x196E2 - True
+0x19809 (Far 5) - 0x1972A - True
+0x19806 (Far 6) - 0x19809 - True
+0x196F8 (Far 7) - 0x19806 - True
+0x1972F (Far 8) - 0x196F8 - True
 Door - 0x194B2 (Laser Entry Right) - 0x1972F
-158182 - 0x19797 (Near 1) - 0x0A8E0 - True
-158183 - 0x1979A (Near 2) - 0x19797 - True
-158184 - 0x197E0 (Near 3) - 0x1979A - True
-158185 - 0x197E8 (Near 4) - 0x197E0 - True
-158186 - 0x197E5 (Near 5) - 0x197E8 - True
+0x19797 (Near 1) - 0x0A8E0 - True
+0x1979A (Near 2) - 0x19797 - True
+0x197E0 (Near 3) - 0x1979A - True
+0x197E8 (Near 4) - 0x197E0 - True
+0x197E5 (Near 5) - 0x197E8 - True
 Door - 0x19665 (Laser Entry Left) - 0x197E5
-159400 - 0x28A7B (Quarry Stoneworks Rooftop Vent EP) - True - True
+0x28A7B (Quarry Stoneworks Rooftop Vent EP) - True - True
 
 Shadows Ledge (Shadows) - Shadows - 0x1855B - Quarry - 0x19865 & 0x0A2DF:
-158187 - 0x334DC (Door Timer Inside) - True - True
-158188 - 0x198B5 (Intro 1) - True - True
-158189 - 0x198BD (Intro 2) - 0x198B5 - True
-158190 - 0x198BF (Intro 3) - 0x198BD & 0x19B24 - True
+0x334DC (Door Timer Inside) - True - True
+0x198B5 (Intro 1) - True - True
+0x198BD (Intro 2) - 0x198B5 - True
+0x198BF (Intro 3) - 0x198BD & 0x19B24 - True
 Door - 0x19865 (Quarry Barrier) - 0x198BF
 Door - 0x0A2DF (Quarry Barrier 2) - 0x198BF
-158191 - 0x19771 (Intro 4) - 0x198BF - True
-158192 - 0x0A8DC (Intro 5) - 0x19771 - True
+0x19771 (Intro 4) - 0x198BF - True
+0x0A8DC (Intro 5) - 0x19771 - True
 Door - 0x1855B (Ledge Barrier) - 0x0A8DC
 Door - 0x19ADE (Ledge Barrier 2) - 0x0A8DC
 
 Shadows Laser Room (Shadows):
-158703 - 0x19650 (Laser Panel) - 0x194B2 & 0x19665 - True
+0x19650 (Laser Panel) - 0x194B2 & 0x19665 - True
 Laser - 0x181B3 (Laser) - 0x19650
 
 ==Keep==
 
 Outside Keep (Keep) - Main Island - True:
-159430 - 0x03E77 (Red Flowers EP) - True - True
-159431 - 0x03E7C (Purple Flowers EP) - True - True
+0x03E77 (Red Flowers EP) - True - True
+0x03E7C (Purple Flowers EP) - True - True
 
 Keep (Keep) - Outside Keep - True - Keep 2nd Maze - 0x01954 - Keep 2nd Pressure Plate - 0x01BEC:
-158193 - 0x00139 (Hedge Maze 1) - True - True
-158197 - 0x0A3A8 (Reset Pressure Plates 1) - True - True
-158198 - 0x033EA (Pressure Plates 1) - 0x0A3A8 - Dots
+0x00139 (Hedge Maze 1) - True - True
+0x0A3A8 (Reset Pressure Plates 1) - True - True
+0x033EA (Pressure Plates 1) - 0x0A3A8 - Dots
 Door - 0x01954 (Hedge Maze 1 Exit) - 0x00139
 Door - 0x01BEC (Pressure Plates 1 Exit) - 0x033EA
 
 Keep 2nd Maze (Keep) - Keep - 0x018CE - Keep 3rd Maze - 0x019D8:
 Door - 0x018CE (Hedge Maze 2 Shortcut) - 0x00139
-158194 - 0x019DC (Hedge Maze 2) - True - True
+0x019DC (Hedge Maze 2) - True - True
 Door - 0x019D8 (Hedge Maze 2 Exit) - 0x019DC
 
 Keep 3rd Maze (Keep) - Keep - 0x019B5 - Keep 4th Maze - 0x019E6:
 Door - 0x019B5 (Hedge Maze 3 Shortcut) - 0x019DC
-158195 - 0x019E7 (Hedge Maze 3) - True - True
+0x019E7 (Hedge Maze 3) - True - True
 Door - 0x019E6 (Hedge Maze 3 Exit) - 0x019E7
 
 Keep 4th Maze (Keep) - Keep - 0x0199A - Keep Tower - 0x01A0E:
 Door - 0x0199A (Hedge Maze 4 Shortcut) - 0x019E7
-158196 - 0x01A0F (Hedge Maze 4) - True - True
+0x01A0F (Hedge Maze 4) - True - True
 Door - 0x01A0E (Hedge Maze 4 Exit) - 0x01A0F
 
 Keep 2nd Pressure Plate (Keep) - Keep 3rd Pressure Plate - True:
-158199 - 0x0A3B9 (Reset Pressure Plates 2) - True - True
-158200 - 0x01BE9 (Pressure Plates 2) - 0x0A3B9 - Black/White Squares
+0x0A3B9 (Reset Pressure Plates 2) - True - True
+0x01BE9 (Pressure Plates 2) - 0x0A3B9 - Black/White Squares
 Door - 0x01BEA (Pressure Plates 2 Exit) - 0x01BE9
 
 Keep 3rd Pressure Plate (Keep) - Keep 4th Pressure Plate - 0x01CD5:
-158201 - 0x0A3BB (Reset Pressure Plates 3) - True - True
-158202 - 0x01CD3 (Pressure Plates 3) - 0x0A3BB - Shapers
+0x0A3BB (Reset Pressure Plates 3) - True - True
+0x01CD3 (Pressure Plates 3) - 0x0A3BB - Shapers
 Door - 0x01CD5 (Pressure Plates 3 Exit) - 0x01CD3
 
 Keep 4th Pressure Plate (Keep) - Shadows - 0x09E3D - Keep Tower - 0x01D40:
-158203 - 0x0A3AD (Reset Pressure Plates 4) - True - True
-158204 - 0x01D3F (Pressure Plates 4) - 0x0A3AD - Rotated Shapers & Symmetry
+0x0A3AD (Reset Pressure Plates 4) - True - True
+0x01D3F (Pressure Plates 4) - 0x0A3AD - Rotated Shapers & Symmetry
 Door - 0x01D40 (Pressure Plates 4 Exit) - 0x01D3F
-158604 - 0x17D27 (Discard) - True - Triangles
-158205 - 0x09E49 (Shadows Shortcut Panel) - True - True
+0x17D27 (Discard) - True - Triangles
+0x09E49 (Shadows Shortcut Panel) - True - True
 Door - 0x09E3D (Shadows Shortcut) - 0x09E49
 
 Keep Tower (Keep) - Keep - 0x04F8F:
-158206 - 0x0361B (Tower Shortcut Panel) - True - True
+0x0361B (Tower Shortcut Panel) - True - True
 Door - 0x04F8F (Tower Shortcut) - 0x0361B
-158704 - 0x0360E (Laser Panel Hedges) - 0x01A0F & 0x019E7 & 0x019DC & 0x00139 - True
-158705 - 0x03317 (Laser Panel Pressure Plates) - 0x033EA & 0x01BE9 & 0x01CD3 & 0x01D3F - Dots & Shapers & Black/White Squares & Rotated Shapers
+0x0360E (Laser Panel Hedges) - 0x01A0F & 0x019E7 & 0x019DC & 0x00139 - True
+0x03317 (Laser Panel Pressure Plates) - 0x033EA & 0x01BE9 & 0x01CD3 & 0x01D3F - Dots & Shapers & Black/White Squares & Rotated Shapers
 Laser - 0x014BB (Laser) - 0x0360E | 0x03317
-159240 - 0x033BE (Pressure Plates 1 EP) - 0x033EA - True
-159241 - 0x033BF (Pressure Plates 2 EP) - 0x01BE9 & 0x01BEA - True
-159242 - 0x033DD (Pressure Plates 3 EP) - 0x01CD3 & 0x01CD5 - True
-159243 - 0x033E5 (Pressure Plates 4 Left Exit EP) - 0x01D3F - True
-159244 - 0x018B6 (Pressure Plates 4 Right Exit EP) - 0x01D3F - True
-159250 - 0x28AE9 (Path EP) - True - True
-159251 - 0x3348F (Hedges EP) - True - True
+0x033BE (Pressure Plates 1 EP) - 0x033EA - True
+0x033BF (Pressure Plates 2 EP) - 0x01BE9 & 0x01BEA - True
+0x033DD (Pressure Plates 3 EP) - 0x01CD3 & 0x01CD5 - True
+0x033E5 (Pressure Plates 4 Left Exit EP) - 0x01D3F - True
+0x018B6 (Pressure Plates 4 Right Exit EP) - 0x01D3F - True
+0x28AE9 (Path EP) - True - True
+0x3348F (Hedges EP) - True - True
 
 ==Shipwreck==
 
 Shipwreck (Shipwreck) - Keep 3rd Pressure Plate - True - Shipwreck Vault - 0x17BB4:
-158654 - 0x00AFB (Vault Panel) - True - Symmetry & Sound Dots & Colored Dots
+0x00AFB (Vault Panel) - True - Symmetry & Sound Dots & Colored Dots
 Door - 0x17BB4 (Vault Door) - 0x00AFB
-158605 - 0x17D28 (Discard) - True - Triangles
-159220 - 0x03B22 (Circle Far EP) - True - True
-159221 - 0x03B23 (Circle Left EP) - True - True
-159222 - 0x03B24 (Circle Near EP) - True - True
-159224 - 0x03A79 (Stern EP) - True - True
-159225 - 0x28ABD (Rope Inner EP) - True - True
-159226 - 0x28ABE (Rope Outer EP) - True - True
-159230 - 0x3388F (Couch EP) - 0x17CDF | 0x0A054 - True
+0x17D28 (Discard) - True - Triangles
+0x03B22 (Circle Far EP) - True - True
+0x03B23 (Circle Left EP) - True - True
+0x03B24 (Circle Near EP) - True - True
+0x03A79 (Stern EP) - True - True
+0x28ABD (Rope Inner EP) - True - True
+0x28ABE (Rope Outer EP) - True - True
+0x3388F (Couch EP) - 0x17CDF | 0x0A054 - True
 
 Shipwreck Vault (Shipwreck):
-158655 - 0x03535 (Vault Box) - True - True
+0x03535 (Vault Box) - True - True
 
 ==Monastery==
 
 Monastery Obelisk (Monastery) - Entry - True:
-159710 - 0xFFE10 (Obelisk Side 1) - 0x03ABC & 0x03ABE & 0x03AC0 & 0x03AC4 - True
-159711 - 0xFFE11 (Obelisk Side 2) - 0x03AC5 - True
-159712 - 0xFFE12 (Obelisk Side 3) - 0x03BE2 & 0x03BE3 & 0x0A409 - True
-159713 - 0xFFE13 (Obelisk Side 4) - 0x006E5 & 0x006E6 & 0x006E7 & 0x034A7 & 0x034AD & 0x034AF & 0x03DAB & 0x03DAC & 0x03DAD - True
-159714 - 0xFFE14 (Obelisk Side 5) - 0x03E01 - True
-159715 - 0xFFE15 (Obelisk Side 6) - 0x289F4 & 0x289F5 - True
-159719 - 0x00263 (Obelisk) - True - True
+0xFFE10 (Obelisk Side 1) - 0x03ABC & 0x03ABE & 0x03AC0 & 0x03AC4 - True
+0xFFE11 (Obelisk Side 2) - 0x03AC5 - True
+0xFFE12 (Obelisk Side 3) - 0x03BE2 & 0x03BE3 & 0x0A409 - True
+0xFFE13 (Obelisk Side 4) - 0x006E5 & 0x006E6 & 0x006E7 & 0x034A7 & 0x034AD & 0x034AF & 0x03DAB & 0x03DAC & 0x03DAD - True
+0xFFE14 (Obelisk Side 5) - 0x03E01 - True
+0xFFE15 (Obelisk Side 6) - 0x289F4 & 0x289F5 - True
+0x00263 (Obelisk) - True - True
 
 Outside Monastery (Monastery) - Main Island - True - Inside Monastery - 0x0C128 & 0x0C153 - Monastery Garden - 0x03750:
-158207 - 0x03713 (Laser Shortcut Panel) - True - True
+0x03713 (Laser Shortcut Panel) - True - True
 Door - 0x0364E (Laser Shortcut) - 0x03713
-158208 - 0x00B10 (Entry Left) - True - True
-158209 - 0x00C92 (Entry Right) - 0x00B10 - True
+0x00B10 (Entry Left) - True - True
+0x00C92 (Entry Right) - 0x00B10 - True
 Door - 0x0C128 (Entry Inner) - 0x00B10
 Door - 0x0C153 (Entry Outer) - 0x00C92
-158210 - 0x00290 (Outside 1) - 0x09D9B - True
-158211 - 0x00038 (Outside 2) - 0x09D9B & 0x00290 - True
-158212 - 0x00037 (Outside 3) - 0x09D9B & 0x00038 - True
+0x00290 (Outside 1) - 0x09D9B - True
+0x00038 (Outside 2) - 0x09D9B & 0x00290 - True
+0x00037 (Outside 3) - 0x09D9B & 0x00038 - True
 Door - 0x03750 (Garden Entry) - 0x00037
-158706 - 0x17CA4 (Laser Panel) - 0x193A6 - True
+0x17CA4 (Laser Panel) - 0x193A6 - True
 Laser - 0x17C65 (Laser) - 0x17CA4
-159130 - 0x006E5 (Facade Left Near EP) - True - True
-159131 - 0x006E6 (Facade Left Far Short EP) - True - True
-159132 - 0x006E7 (Facade Left Far Long EP) - True - True
-159136 - 0x03DAB (Facade Right Near EP) - True - True
-159137 - 0x03DAC (Facade Left Stairs EP) - True - True
-159138 - 0x03DAD (Facade Right Stairs EP) - True - True
-159140 - 0x03E01 (Grass Stairs EP) - True - True
-159120 - 0x03BE2 (Garden Left EP) - 0x03750 - True
-159121 - 0x03BE3 (Garden Right EP) - True - True
-159122 - 0x0A409 (Wall EP) - True - True
+0x006E5 (Facade Left Near EP) - True - True
+0x006E6 (Facade Left Far Short EP) - True - True
+0x006E7 (Facade Left Far Long EP) - True - True
+0x03DAB (Facade Right Near EP) - True - True
+0x03DAC (Facade Left Stairs EP) - True - True
+0x03DAD (Facade Right Stairs EP) - True - True
+0x03E01 (Grass Stairs EP) - True - True
+0x03BE2 (Garden Left EP) - 0x03750 - True
+0x03BE3 (Garden Right EP) - True - True
+0x0A409 (Wall EP) - True - True
 
 Inside Monastery (Monastery) - Monastery North Shutters - 0x09D9B:
-158213 - 0x09D9B (Shutters Control) - True - Dots
-158214 - 0x193A7 (Inside 1) - 0x00037 - True
-158215 - 0x193AA (Inside 2) - 0x193A7 - True
-158216 - 0x193AB (Inside 3) - 0x193AA - True
-158217 - 0x193A6 (Inside 4) - 0x193AB - True
-159133 - 0x034A7 (Left Shutter EP) - 0x09D9B - True
-159134 - 0x034AD (Middle Shutter EP) - 0x09D9B - True
-159135 - 0x034AF (Right Shutter EP) - 0x09D9B - True
+0x09D9B (Shutters Control) - True - Dots
+0x193A7 (Inside 1) - 0x00037 - True
+0x193AA (Inside 2) - 0x193A7 - True
+0x193AB (Inside 3) - 0x193AA - True
+0x193A6 (Inside 4) - 0x193AB - True
+0x034A7 (Left Shutter EP) - 0x09D9B - True
+0x034AD (Middle Shutter EP) - 0x09D9B - True
+0x034AF (Right Shutter EP) - 0x09D9B - True
 
 Monastery Garden (Monastery):
 
@@ -520,76 +520,76 @@ Monastery North Shutters (Monastery):
 ==Town==
 
 Town Obelisk (Town) - Entry - True:
-159750 - 0xFFE50 (Obelisk Side 1) - 0x035C7 - True
-159751 - 0xFFE51 (Obelisk Side 2) - 0x01848 & 0x03D06 & 0x33530 & 0x33600 & 0x28A2F & 0x28A37 & 0x334A3 & 0x3352F - True
-159752 - 0xFFE52 (Obelisk Side 3) - 0x33857 & 0x33879 & 0x03C19 - True
-159753 - 0xFFE53 (Obelisk Side 4) - 0x28B30 & 0x035C9 - True
-159754 - 0xFFE54 (Obelisk Side 5) - 0x03335 & 0x03412 & 0x038A6 & 0x038AA & 0x03E3F & 0x03E40 & 0x28B8E - True
-159755 - 0xFFE55 (Obelisk Side 6) - 0x28B91 & 0x03BCE & 0x03BCF & 0x03BD1 & 0x339B6 & 0x33A20 & 0x33A29 & 0x33A2A & 0x33B06 - True
-159759 - 0x0A16C (Obelisk) - True - True
+0xFFE50 (Obelisk Side 1) - 0x035C7 - True
+0xFFE51 (Obelisk Side 2) - 0x01848 & 0x03D06 & 0x33530 & 0x33600 & 0x28A2F & 0x28A37 & 0x334A3 & 0x3352F - True
+0xFFE52 (Obelisk Side 3) - 0x33857 & 0x33879 & 0x03C19 - True
+0xFFE53 (Obelisk Side 4) - 0x28B30 & 0x035C9 - True
+0xFFE54 (Obelisk Side 5) - 0x03335 & 0x03412 & 0x038A6 & 0x038AA & 0x03E3F & 0x03E40 & 0x28B8E - True
+0xFFE55 (Obelisk Side 6) - 0x28B91 & 0x03BCE & 0x03BCF & 0x03BD1 & 0x339B6 & 0x33A20 & 0x33A29 & 0x33A2A & 0x33B06 - True
+0x0A16C (Obelisk) - True - True
 
 Town (Town) - Main Island - True - The Ocean - 0x0A054 - Town Maze Rooftop - 0x28AA2 - Town Church - True - Town Wooden Rooftop - 0x034F5 - Town RGB House - 0x28A61 - Town Inside Cargo Box - 0x0A0C9 - Outside Windmill - True:
-158218 - 0x0A054 (Boat Spawn) - 0x17CA6 | 0x17CDF | 0x09DB8 | 0x17C95 - Boat
-158219 - 0x0A0C8 (Cargo Box Entry Panel) - True - Black/White Squares & Shapers
+0x0A054 (Boat Spawn) - 0x17CA6 | 0x17CDF | 0x09DB8 | 0x17C95 - Boat
+0x0A0C8 (Cargo Box Entry Panel) - True - Black/White Squares & Shapers
 Door - 0x0A0C9 (Cargo Box Entry) - 0x0A0C8
-158707 - 0x09F98 (Desert Laser Redirect Control) - True - True
-158220 - 0x18590 (Transparent) - True - Symmetry
-158221 - 0x28AE3 (Vines) - 0x18590 - True
-158222 - 0x28938 (Apple Tree) - 0x28AE3 - True
-158223 - 0x079DF (Triple Exit) - 0x28938 - True
-158235 - 0x2899C (Wooden Roof Lower Row 1) - True - Rotated Shapers & Full Dots
-158236 - 0x28A33 (Wooden Roof Lower Row 2) - 0x2899C - Shapers & Rotated Shapers & Full Dots
-158237 - 0x28ABF (Wooden Roof Lower Row 3) - 0x28A33 - Shapers & Rotated Shapers & Full Dots
-158238 - 0x28AC0 (Wooden Roof Lower Row 4) - 0x28ABF - Rotated Shapers & Full Dots
-158239 - 0x28AC1 (Wooden Roof Lower Row 5) - 0x28AC0 - Rotated Shapers & Full Dots
+0x09F98 (Desert Laser Redirect Control) - True - True
+0x18590 (Transparent) - True - Symmetry
+0x28AE3 (Vines) - 0x18590 - True
+0x28938 (Apple Tree) - 0x28AE3 - True
+0x079DF (Triple Exit) - 0x28938 - True
+0x2899C (Wooden Roof Lower Row 1) - True - Rotated Shapers & Full Dots
+0x28A33 (Wooden Roof Lower Row 2) - 0x2899C - Shapers & Rotated Shapers & Full Dots
+0x28ABF (Wooden Roof Lower Row 3) - 0x28A33 - Shapers & Rotated Shapers & Full Dots
+0x28AC0 (Wooden Roof Lower Row 4) - 0x28ABF - Rotated Shapers & Full Dots
+0x28AC1 (Wooden Roof Lower Row 5) - 0x28AC0 - Rotated Shapers & Full Dots
 Door - 0x034F5 (Wooden Roof Stairs) - 0x28AC1
-158225 - 0x28998 (RGB House Entry Panel) - True - Stars & Rotated Shapers
+0x28998 (RGB House Entry Panel) - True - Stars & Rotated Shapers
 Door - 0x28A61 (RGB House Entry) - 0x28998
-158226 - 0x28A0D (Church Entry Panel) - 0x28A61 - Stars
+0x28A0D (Church Entry Panel) - 0x28A61 - Stars
 Door - 0x03BB0 (Church Entry) - 0x28A0D
-158228 - 0x28A79 (Maze Panel) - True - True
+0x28A79 (Maze Panel) - True - True
 Door - 0x28AA2 (Maze Stairs) - 0x28A79
-159540 - 0x03335 (Tower Underside Third EP) - True - True
-159541 - 0x03412 (Tower Underside Fourth EP) - True - True
-159542 - 0x038A6 (Tower Underside First EP) - True - True
-159543 - 0x038AA (Tower Underside Second EP) - True - True
-159545 - 0x03E40 (RGB House Green EP) - 0x334D8 - True
-159546 - 0x28B8E (Maze Bridge Underside EP) - 0x2896A - True
-159552 - 0x03BCF (Black Line Redirect EP) - True - True
-159800 - 0xFFF80 (Pet the Dog) - True - True
+0x03335 (Tower Underside Third EP) - True - True
+0x03412 (Tower Underside Fourth EP) - True - True
+0x038A6 (Tower Underside First EP) - True - True
+0x038AA (Tower Underside Second EP) - True - True
+0x03E40 (RGB House Green EP) - 0x334D8 - True
+0x28B8E (Maze Bridge Underside EP) - 0x2896A - True
+0x03BCF (Black Line Redirect EP) - True - True
+0xFFF80 (Pet the Dog) - True - True
 
 Town Inside Cargo Box (Town):
-158606 - 0x17D01 (Cargo Box Discard) - True - Triangles
+0x17D01 (Cargo Box Discard) - True - Triangles
 
 Town Maze Rooftop (Town) - Town Red Rooftop - 0x2896A:
-158229 - 0x2896A (Maze Rooftop Bridge Control) - True - Shapers
-159544 - 0x03E3F (RGB House Red EP) - 0x334D8 - True
+0x2896A (Maze Rooftop Bridge Control) - True - Shapers
+0x03E3F (RGB House Red EP) - 0x334D8 - True
 
 Town Red Rooftop (Town):
-158607 - 0x17C71 (Rooftop Discard) - True - Triangles
-158230 - 0x28AC7 (Red Rooftop 1) - True - Symmetry & Black/White Squares
-158231 - 0x28AC8 (Red Rooftop 2) - 0x28AC7 - Symmetry & Black/White Squares
-158232 - 0x28ACA (Red Rooftop 3) - 0x28AC8 - Symmetry & Black/White Squares
-158233 - 0x28ACB (Red Rooftop 4) - 0x28ACA - Symmetry & Black/White Squares & Dots
-158234 - 0x28ACC (Red Rooftop 5) - 0x28ACB - Symmetry & Black/White Squares & Dots
-158224 - 0x28B39 (Tall Hexagonal) - 0x079DF - True
+0x17C71 (Rooftop Discard) - True - Triangles
+0x28AC7 (Red Rooftop 1) - True - Symmetry & Black/White Squares
+0x28AC8 (Red Rooftop 2) - 0x28AC7 - Symmetry & Black/White Squares
+0x28ACA (Red Rooftop 3) - 0x28AC8 - Symmetry & Black/White Squares
+0x28ACB (Red Rooftop 4) - 0x28ACA - Symmetry & Black/White Squares & Dots
+0x28ACC (Red Rooftop 5) - 0x28ACB - Symmetry & Black/White Squares & Dots
+0x28B39 (Tall Hexagonal) - 0x079DF - True
 
 Town Wooden Rooftop (Town):
-158240 - 0x28AD9 (Wooden Rooftop) - 0x28AC1 - Shapers & Eraser & Full Dots
+0x28AD9 (Wooden Rooftop) - 0x28AC1 - Shapers & Eraser & Full Dots
 
 Town Church (Town):
-158227 - 0x28A69 (Church Lattice) - 0x03BB0 - True
-159553 - 0x03BD1 (Black Line Church EP) - True - True
+0x28A69 (Church Lattice) - 0x03BB0 - True
+0x03BD1 (Black Line Church EP) - True - True
 
 Town RGB House (Town RGB House) - Town RGB House Upstairs - 0x2897B:
-158242 - 0x034E4 (Sound Room Left) - True - True
-158243 - 0x034E3 (Sound Room Right) - True - Sound Dots
+0x034E4 (Sound Room Left) - True - True
+0x034E3 (Sound Room Right) - True - Sound Dots
 Door - 0x2897B (Stairs) - 0x034E4 & 0x034E3
 
 Town RGB House Upstairs (Town RGB House Upstairs):
-158244 - 0x334D8 (RGB Control) - True - Rotated Shapers & Colored Squares
-158245 - 0x03C0C (Left) - 0x334D8 - Colored Squares & Black/White Squares
-158246 - 0x03C08 (Right) - 0x334D8 - Stars
+0x334D8 (RGB Control) - True - Rotated Shapers & Colored Squares
+0x03C0C (Left) - 0x334D8 - Colored Squares & Black/White Squares
+0x03C08 (Right) - 0x334D8 - Stars
 
 Town Tower Bottom (Town Tower) - Town - True - Town Tower After First Door - 0x27799:
 Door - 0x27799 (First Door) - 0x28A69
@@ -604,42 +604,42 @@ Town Tower After Third Door (Town Tower) - Town Tower Top - 0x2779A:
 Door - 0x2779A (Fourth Door) - 0x28B39
 
 Town Tower Top (Town):
-158708 - 0x032F5 (Laser Panel) - True - True
+0x032F5 (Laser Panel) - True - True
 Laser - 0x032F9 (Laser) - 0x032F5
-159422 - 0x33692 (Brown Bridge EP) - True - True
-159551 - 0x03BCE (Black Line Tower EP) - True - True
+0x33692 (Brown Bridge EP) - True - True
+0x03BCE (Black Line Tower EP) - True - True
 
 ==Windmill & Theater==
 
 Outside Windmill (Windmill) - Windmill Interior - 0x1845B:
-159010 - 0x037B6 (First Blade EP) - 0x17D02 - True
-159011 - 0x037B2 (Second Blade EP) - 0x17D02 - True
-159012 - 0x000F7 (Third Blade EP) - 0x17D02 - True
-158241 - 0x17F5F (Entry Panel) - True - Dots
+0x037B6 (First Blade EP) - 0x17D02 - True
+0x037B2 (Second Blade EP) - 0x17D02 - True
+0x000F7 (Third Blade EP) - 0x17D02 - True
+0x17F5F (Entry Panel) - True - Dots
 Door - 0x1845B (Entry) - 0x17F5F
 
 Windmill Interior (Windmill) - Theater - 0x17F88:
-158247 - 0x17D02 (Turn Control) - True - Dots
-158248 - 0x17F89 (Theater Entry Panel) - True - Black/White Squares
+0x17D02 (Turn Control) - True - Dots
+0x17F89 (Theater Entry Panel) - True - Black/White Squares
 Door - 0x17F88 (Theater Entry) - 0x17F89
 
 Theater (Theater) - Town - 0x0A16D | 0x3CCDF:
-158656 - 0x00815 (Video Input) - True - True
-158657 - 0x03553 (Tutorial Video) - 0x00815 & 0x03481 - True
-158658 - 0x03552 (Desert Video) - 0x00815 & 0x0339E - True
-158659 - 0x0354E (Jungle Video) - 0x00815 & 0x03702 - True
-158660 - 0x03549 (Challenge Video) - 0x00815 & 0x0356B - True
-158661 - 0x0354F (Shipwreck Video) - 0x00815 & 0x03535 - True
-158662 - 0x03545 (Mountain Video) - 0x00815 & 0x03542 - True
-158249 - 0x0A168 (Exit Left Panel) - True - Black/White Squares & Eraser
-158250 - 0x33AB2 (Exit Right Panel) - True - Black/White Squares & Shapers
+0x00815 (Video Input) - True - True
+0x03553 (Tutorial Video) - 0x00815 & 0x03481 - True
+0x03552 (Desert Video) - 0x00815 & 0x0339E - True
+0x0354E (Jungle Video) - 0x00815 & 0x03702 - True
+0x03549 (Challenge Video) - 0x00815 & 0x0356B - True
+0x0354F (Shipwreck Video) - 0x00815 & 0x03535 - True
+0x03545 (Mountain Video) - 0x00815 & 0x03542 - True
+0x0A168 (Exit Left Panel) - True - Black/White Squares & Eraser
+0x33AB2 (Exit Right Panel) - True - Black/White Squares & Shapers
 Door - 0x0A16D (Exit Left) - 0x0A168
 Door - 0x3CCDF (Exit Right) - 0x33AB2
-158608 - 0x17CF7 (Discard) - True - Triangles
-159554 - 0x339B6 (Eclipse EP) - 0x03549 & 0x0A16D & 0x3CCDF - True
-159555 - 0x33A29 (Window EP) - 0x03553 - True
-159556 - 0x33A2A (Door EP) - 0x03553 - True
-159558 - 0x33B06 (Church EP) - 0x0354E - True
+0x17CF7 (Discard) - True - Triangles
+0x339B6 (Eclipse EP) - 0x03549 & 0x0A16D & 0x3CCDF - True
+0x33A29 (Window EP) - 0x03553 - True
+0x33A2A (Door EP) - 0x03553 - True
+0x33B06 (Church EP) - 0x0354E - True
 
 ==Southern Peninsula==
 
@@ -648,595 +648,595 @@ Southern Peninsula (Southern Peninsula) - Main Island - True:
 ==Jungle==
 
 Jungle (Jungle) - Main Island - True - The Ocean - 0x17CDF - Jungle Under Popup Wall - 0x1475B:
-158251 - 0x17CDF (Shore Boat Spawn) - True - Boat
-158609 - 0x17F9B (Discard) - True - Triangles
-158252 - 0x002C4 (First Row 1) - True - True
-158253 - 0x00767 (First Row 2) - 0x002C4 - True
-158254 - 0x002C6 (First Row 3) - 0x00767 - True
-158255 - 0x0070E (Second Row 1) - 0x002C6 - True
-158256 - 0x0070F (Second Row 2) - 0x0070E - True
-158257 - 0x0087D (Second Row 3) - 0x0070F - True
-158258 - 0x002C7 (Second Row 4) - 0x0087D - True
-158259 - 0x17CAB (Popup Wall Control) - 0x002C7 - True
+0x17CDF (Shore Boat Spawn) - True - Boat
+0x17F9B (Discard) - True - Triangles
+0x002C4 (First Row 1) - True - True
+0x00767 (First Row 2) - 0x002C4 - True
+0x002C6 (First Row 3) - 0x00767 - True
+0x0070E (Second Row 1) - 0x002C6 - True
+0x0070F (Second Row 2) - 0x0070E - True
+0x0087D (Second Row 3) - 0x0070F - True
+0x002C7 (Second Row 4) - 0x0087D - True
+0x17CAB (Popup Wall Control) - 0x002C7 - True
 Door - 0x1475B (Popup Wall) - 0x17CAB
-158260 - 0x0026D (Popup Wall 1) - 0x1475B - Sound Dots
-158261 - 0x0026E (Popup Wall 2) - 0x0026D - Sound Dots
-158262 - 0x0026F (Popup Wall 3) - 0x0026E - Sound Dots
-158263 - 0x00C3F (Popup Wall 4) - 0x0026F - Sound Dots
-158264 - 0x00C41 (Popup Wall 5) - 0x00C3F - Sound Dots
-158265 - 0x014B2 (Popup Wall 6) - 0x00C41 - Sound Dots
-158709 - 0x03616 (Laser Panel) - 0x014B2 - True
+0x0026D (Popup Wall 1) - 0x1475B - Sound Dots
+0x0026E (Popup Wall 2) - 0x0026D - Sound Dots
+0x0026F (Popup Wall 3) - 0x0026E - Sound Dots
+0x00C3F (Popup Wall 4) - 0x0026F - Sound Dots
+0x00C41 (Popup Wall 5) - 0x00C3F - Sound Dots
+0x014B2 (Popup Wall 6) - 0x00C41 - Sound Dots
+0x03616 (Laser Panel) - 0x014B2 - True
 Laser - 0x00274 (Laser) - 0x03616
-158266 - 0x337FA (Laser Shortcut Panel) - True - True
+0x337FA (Laser Shortcut Panel) - True - True
 Door - 0x3873B (Laser Shortcut) - 0x337FA
-159100 - 0x03ABC (Long Arch Moss EP) - True - True
-159101 - 0x03ABE (Straight Left Moss EP) - True - True
-159102 - 0x03AC0 (Pop-up Wall Moss EP) - True - True
-159103 - 0x03AC4 (Short Arch Moss EP) - True - True
-159150 - 0x289F4 (Entrance EP) - True - True
-159151 - 0x289F5 (Tree Halo EP) - True - True
-159350 - 0x035CB (Bamboo CCW EP) - True - True
-159351 - 0x035CF (Bamboo CW EP) - True - True
+0x03ABC (Long Arch Moss EP) - True - True
+0x03ABE (Straight Left Moss EP) - True - True
+0x03AC0 (Pop-up Wall Moss EP) - True - True
+0x03AC4 (Short Arch Moss EP) - True - True
+0x289F4 (Entrance EP) - True - True
+0x289F5 (Tree Halo EP) - True - True
+0x035CB (Bamboo CCW EP) - True - True
+0x035CF (Bamboo CW EP) - True - True
 
 Jungle Under Popup Wall (Jungle):
 
 Outside Jungle River (Jungle) - Main Island - True - Monastery Garden - 0x0CF2A - Jungle Vault - 0x15287:
-158267 - 0x17CAA (Monastery Garden Shortcut Panel) - True - True
+0x17CAA (Monastery Garden Shortcut Panel) - True - True
 Door - 0x0CF2A (Monastery Garden Shortcut) - 0x17CAA
-158663 - 0x15ADD (Vault Panel) - True - Black/White Squares & Dots
+0x15ADD (Vault Panel) - True - Black/White Squares & Dots
 Door - 0x15287 (Vault Door) - 0x15ADD
-159110 - 0x03AC5 (Green Leaf Moss EP) - True - True
+0x03AC5 (Green Leaf Moss EP) - True - True
 
 Jungle Vault (Jungle):
-158664 - 0x03702 (Vault Box) - True - True
+0x03702 (Vault Box) - True - True
 
 ==Bunker==
 
 Outside Bunker (Bunker) - Main Island - True - Bunker - 0x0C2A4:
-158268 - 0x17C2E (Entry Panel) - True - Black/White Squares
+0x17C2E (Entry Panel) - True - Black/White Squares
 Door - 0x0C2A4 (Entry) - 0x17C2E
 
 Bunker (Bunker) - Bunker Glass Room - 0x17C79:
-158269 - 0x09F7D (Intro Left 1) - True - Colored Squares
-158270 - 0x09FDC (Intro Left 2) - 0x09F7D - Colored Squares & Black/White Squares
-158271 - 0x09FF7 (Intro Left 3) - 0x09FDC - Colored Squares & Black/White Squares
-158272 - 0x09F82 (Intro Left 4) - 0x09FF7 - Colored Squares & Black/White Squares
-158273 - 0x09FF8 (Intro Left 5) - 0x09F82 - Colored Squares & Black/White Squares
-158274 - 0x09D9F (Intro Back 1) - 0x09FF8 - Colored Squares & Black/White Squares
-158275 - 0x09DA1 (Intro Back 2) - 0x09D9F - Colored Squares
-158276 - 0x09DA2 (Intro Back 3) - 0x09DA1 - Colored Squares
-158277 - 0x09DAF (Intro Back 4) - 0x09DA2 - Colored Squares
-158278 - 0x0A099 (Tinted Glass Door Panel) - 0x09DAF - True
+0x09F7D (Intro Left 1) - True - Colored Squares
+0x09FDC (Intro Left 2) - 0x09F7D - Colored Squares & Black/White Squares
+0x09FF7 (Intro Left 3) - 0x09FDC - Colored Squares & Black/White Squares
+0x09F82 (Intro Left 4) - 0x09FF7 - Colored Squares & Black/White Squares
+0x09FF8 (Intro Left 5) - 0x09F82 - Colored Squares & Black/White Squares
+0x09D9F (Intro Back 1) - 0x09FF8 - Colored Squares & Black/White Squares
+0x09DA1 (Intro Back 2) - 0x09D9F - Colored Squares
+0x09DA2 (Intro Back 3) - 0x09DA1 - Colored Squares
+0x09DAF (Intro Back 4) - 0x09DA2 - Colored Squares
+0x0A099 (Tinted Glass Door Panel) - 0x09DAF - True
 Door - 0x17C79 (Tinted Glass Door) - 0x0A099
 
 Bunker Glass Room (Bunker) - Bunker Ultraviolet Room - 0x0C2A3:
-158279 - 0x0A010 (Glass Room 1) - 0x17C79 - Colored Squares
-158280 - 0x0A01B (Glass Room 2) - 0x17C79 & 0x0A010 - Colored Squares & Black/White Squares
-158281 - 0x0A01F (Glass Room 3) - 0x17C79 & 0x0A01B - Colored Squares & Black/White Squares
+0x0A010 (Glass Room 1) - 0x17C79 - Colored Squares
+0x0A01B (Glass Room 2) - 0x17C79 & 0x0A010 - Colored Squares & Black/White Squares
+0x0A01F (Glass Room 3) - 0x17C79 & 0x0A01B - Colored Squares & Black/White Squares
 Door - 0x0C2A3 (UV Room Entry) - 0x0A01F
 
 Bunker Ultraviolet Room (Bunker) - Bunker Elevator Section - 0x0A08D:
-158282 - 0x34BC5 (Drop-Down Door Open) - True - True
-158283 - 0x34BC6 (Drop-Down Door Close) - 0x34BC5 - True
-158284 - 0x17E63 (UV Room 1) - 0x34BC5 - Colored Squares
-158285 - 0x17E67 (UV Room 2) - 0x17E63 & 0x34BC6 - Colored Squares & Black/White Squares
+0x34BC5 (Drop-Down Door Open) - True - True
+0x34BC6 (Drop-Down Door Close) - 0x34BC5 - True
+0x17E63 (UV Room 1) - 0x34BC5 - Colored Squares
+0x17E67 (UV Room 2) - 0x17E63 & 0x34BC6 - Colored Squares & Black/White Squares
 Door - 0x0A08D (Elevator Room Entry) - 0x17E67
 
 Bunker Elevator Section (Bunker) - Bunker Elevator - TrueOneWay - Bunker Under Elevator - 0x0A079 | Bunker Green Room | Bunker Cyan Room | Bunker Laser Platform:
-159311 - 0x035F5 (Tinted Door EP) - 0x17C79 - True
+0x035F5 (Tinted Door EP) - 0x17C79 - True
 
 Bunker Under Elevator (Bunker):
 
 Bunker Elevator (Bunker) - Bunker Elevator Section - 0x0A079 - Bunker Cyan Room - 0x0A079 - Bunker Green Room - 0x0A079 - Bunker Laser Platform - 0x0A079 - Outside Bunker - 0x0A079:
-158286 - 0x0A079 (Elevator Control) - True - Colored Squares & Black/White Squares
+0x0A079 (Elevator Control) - True - Colored Squares & Black/White Squares
 
 Bunker Cyan Room (Bunker) - Bunker Elevator - TrueOneWay:
 
 Bunker Green Room (Bunker) - Bunker Elevator - TrueOneWay:
-159310 - 0x000D3 (Green Room Flowers EP) - True - True
+0x000D3 (Green Room Flowers EP) - True - True
 
 Bunker Laser Platform (Bunker) - Bunker Elevator - TrueOneWay:
-158710 - 0x09DE0 (Laser Panel) - True - True
+0x09DE0 (Laser Panel) - True - True
 Laser - 0x0C2B2 (Laser) - 0x09DE0
 
 ==Swamp==
 
 Outside Swamp (Swamp) - Swamp Entry Area - 0x00C1C - Main Island - True:
-158287 - 0x0056E (Entry Panel) - True - Shapers
+0x0056E (Entry Panel) - True - Shapers
 Door - 0x00C1C (Entry) - 0x0056E
-159321 - 0x03603 (Purple Sand Middle EP) - 0x17E2B - True
-159322 - 0x03601 (Purple Sand Top EP) - 0x17E2B - True
-159327 - 0x035DE (Purple Sand Bottom EP) - True - True
+0x03603 (Purple Sand Middle EP) - 0x17E2B - True
+0x03601 (Purple Sand Top EP) - 0x17E2B - True
+0x035DE (Purple Sand Bottom EP) - True - True
 
 Swamp Entry Area (Swamp) - Swamp Sliding Bridge - TrueOneWay:
-158288 - 0x00469 (Intro Front 1) - True - Shapers
-158289 - 0x00472 (Intro Front 2) - 0x00469 - Shapers
-158290 - 0x00262 (Intro Front 3) - 0x00472 - Shapers
-158291 - 0x00474 (Intro Front 4) - 0x00262 - Shapers
-158292 - 0x00553 (Intro Front 5) - 0x00474 - Shapers
-158293 - 0x0056F (Intro Front 6) - 0x00553 - Shapers
-158294 - 0x00390 (Intro Back 1) - 0x0056F - Shapers
-158295 - 0x010CA (Intro Back 2) - 0x00390 - Shapers
-158296 - 0x00983 (Intro Back 3) - 0x010CA - Shapers
-158297 - 0x00984 (Intro Back 4) - 0x00983 - Shapers
-158298 - 0x00986 (Intro Back 5) - 0x00984 - Shapers
-158299 - 0x00985 (Intro Back 6) - 0x00986 - Shapers
-158300 - 0x00987 (Intro Back 7) - 0x00985 - Shapers
-158301 - 0x181A9 (Intro Back 8) - 0x00987 - Shapers
+0x00469 (Intro Front 1) - True - Shapers
+0x00472 (Intro Front 2) - 0x00469 - Shapers
+0x00262 (Intro Front 3) - 0x00472 - Shapers
+0x00474 (Intro Front 4) - 0x00262 - Shapers
+0x00553 (Intro Front 5) - 0x00474 - Shapers
+0x0056F (Intro Front 6) - 0x00553 - Shapers
+0x00390 (Intro Back 1) - 0x0056F - Shapers
+0x010CA (Intro Back 2) - 0x00390 - Shapers
+0x00983 (Intro Back 3) - 0x010CA - Shapers
+0x00984 (Intro Back 4) - 0x00983 - Shapers
+0x00986 (Intro Back 5) - 0x00984 - Shapers
+0x00985 (Intro Back 6) - 0x00986 - Shapers
+0x00987 (Intro Back 7) - 0x00985 - Shapers
+0x181A9 (Intro Back 8) - 0x00987 - Shapers
 
 Swamp Sliding Bridge (Swamp) - Swamp Entry Area - 0x00609 - Swamp Platform - 0x00609:
-158302 - 0x00609 (Sliding Bridge) - True - Shapers
-159342 - 0x0105D (Sliding Bridge Left EP) - 0x00609 - True
-159343 - 0x0A304 (Sliding Bridge Right EP) - 0x00609 - True
+0x00609 (Sliding Bridge) - True - Shapers
+0x0105D (Sliding Bridge Left EP) - 0x00609 - True
+0x0A304 (Sliding Bridge Right EP) - 0x00609 - True
 
 Swamp Platform (Swamp) - Swamp Cyan Underwater - 0x04B7F - Swamp Near Boat - 0x38AE6 - Swamp Between Bridges Near - 0x184B7 - Swamp Sliding Bridge - TrueOneWay:
-158313 - 0x00982 (Platform Row 1) - True - Shapers
-158314 - 0x0097F (Platform Row 2) - 0x00982 - Shapers
-158315 - 0x0098F (Platform Row 3) - 0x0097F - Shapers
-158316 - 0x00990 (Platform Row 4) - 0x0098F - Shapers
+0x00982 (Platform Row 1) - True - Shapers
+0x0097F (Platform Row 2) - 0x00982 - Shapers
+0x0098F (Platform Row 3) - 0x0097F - Shapers
+0x00990 (Platform Row 4) - 0x0098F - Shapers
 Door - 0x184B7 (Between Bridges First Door) - 0x00990
-158317 - 0x17C0D (Platform Shortcut Left Panel) - True - Shapers
-158318 - 0x17C0E (Platform Shortcut Right Panel) - 0x17C0D - Shapers
+0x17C0D (Platform Shortcut Left Panel) - True - Shapers
+0x17C0E (Platform Shortcut Right Panel) - 0x17C0D - Shapers
 Door - 0x38AE6 (Platform Shortcut) - 0x17C0E
 Door - 0x04B7F (Cyan Water Pump) - 0x00006
 
 Swamp Cyan Underwater (Swamp):
-158307 - 0x00002 (Cyan Underwater 1) - True - Shapers & Negative Shapers
-158308 - 0x00004 (Cyan Underwater 2) - 0x00002 - Shapers & Negative Shapers
-158309 - 0x00005 (Cyan Underwater 3) - 0x00004 - Shapers & Negative Shapers
-158310 - 0x013E6 (Cyan Underwater 4) - 0x00005 - Shapers & Negative Shapers
-158311 - 0x00596 (Cyan Underwater 5) - 0x013E6 - Shapers & Negative Shapers
-158312 - 0x18488 (Cyan Underwater Sliding Bridge Control) - True - Shapers
-159340 - 0x03AA6 (Cyan Underwater Sliding Bridge EP) - 0x18488 - True
+0x00002 (Cyan Underwater 1) - True - Shapers & Negative Shapers
+0x00004 (Cyan Underwater 2) - 0x00002 - Shapers & Negative Shapers
+0x00005 (Cyan Underwater 3) - 0x00004 - Shapers & Negative Shapers
+0x013E6 (Cyan Underwater 4) - 0x00005 - Shapers & Negative Shapers
+0x00596 (Cyan Underwater 5) - 0x013E6 - Shapers & Negative Shapers
+0x18488 (Cyan Underwater Sliding Bridge Control) - True - Shapers
+0x03AA6 (Cyan Underwater Sliding Bridge EP) - 0x18488 - True
 
 Swamp Between Bridges Near (Swamp) - Swamp Between Bridges Far - 0x18507:
-158303 - 0x00999 (Between Bridges Near Row 1) - 0x00990 - Shapers
-158304 - 0x0099D (Between Bridges Near Row 2) - 0x00999 - Shapers
-158305 - 0x009A0 (Between Bridges Near Row 3) - 0x0099D - Shapers
-158306 - 0x009A1 (Between Bridges Near Row 4) - 0x009A0 - Shapers
+0x00999 (Between Bridges Near Row 1) - 0x00990 - Shapers
+0x0099D (Between Bridges Near Row 2) - 0x00999 - Shapers
+0x009A0 (Between Bridges Near Row 3) - 0x0099D - Shapers
+0x009A1 (Between Bridges Near Row 4) - 0x009A0 - Shapers
 Door - 0x18507 (Between Bridges Second Door) - 0x009A1
 
 Swamp Between Bridges Far (Swamp) - Swamp Red Underwater - 0x183F2 - Swamp Rotating Bridge - TrueOneWay:
-158319 - 0x00007 (Between Bridges Far Row 1) - 0x009A1 - Rotated Shapers
-158320 - 0x00008 (Between Bridges Far Row 2) - 0x00007 - Rotated Shapers
-158321 - 0x00009 (Between Bridges Far Row 3) - 0x00008 - Rotated Shapers
-158322 - 0x0000A (Between Bridges Far Row 4) - 0x00009 - Rotated Shapers
+0x00007 (Between Bridges Far Row 1) - 0x009A1 - Rotated Shapers
+0x00008 (Between Bridges Far Row 2) - 0x00007 - Rotated Shapers
+0x00009 (Between Bridges Far Row 3) - 0x00008 - Rotated Shapers
+0x0000A (Between Bridges Far Row 4) - 0x00009 - Rotated Shapers
 Door - 0x183F2 (Red Water Pump) - 0x00596
 
 Swamp Red Underwater (Swamp) - Swamp Maze - 0x305D5:
-158323 - 0x00001 (Red Underwater 1) - True - Shapers & Negative Shapers
-158324 - 0x014D2 (Red Underwater 2) - True - Shapers & Negative Shapers
-158325 - 0x014D4 (Red Underwater 3) - True - Shapers & Negative Shapers
-158326 - 0x014D1 (Red Underwater 4) - True - Shapers & Negative Shapers
+0x00001 (Red Underwater 1) - True - Shapers & Negative Shapers
+0x014D2 (Red Underwater 2) - True - Shapers & Negative Shapers
+0x014D4 (Red Underwater 3) - True - Shapers & Negative Shapers
+0x014D1 (Red Underwater 4) - True - Shapers & Negative Shapers
 Door - 0x305D5 (Red Underwater Exit) - 0x014D1
 
 Swamp Rotating Bridge (Swamp) - Swamp Between Bridges Far - 0x181F5 - Swamp Near Boat - 0x181F5 - Swamp Purple Area - 0x181F5:
-158327 - 0x181F5 (Rotating Bridge) - True - Rotated Shapers & Shapers
-159331 - 0x016B2 (Rotating Bridge CCW EP) - 0x181F5 - True
-159334 - 0x036CE (Rotating Bridge CW EP) - 0x181F5 - True
+0x181F5 (Rotating Bridge) - True - Rotated Shapers & Shapers
+0x016B2 (Rotating Bridge CCW EP) - 0x181F5 - True
+0x036CE (Rotating Bridge CW EP) - 0x181F5 - True
 
 Swamp Near Boat (Swamp) - Swamp Rotating Bridge - TrueOneWay - Swamp Blue Underwater - 0x18482 - Swamp Long Bridge - 0xFFD00 & 0xFFD02 - The Ocean - 0x09DB8:
-159803 - 0xFFD02 (Beyond Rotating Bridge Reached Independently) - True - True
-158328 - 0x09DB8 (Boat Spawn) - True - Boat
-158329 - 0x003B2 (Beyond Rotating Bridge 1) - 0x0000A - Rotated Shapers
-158330 - 0x00A1E (Beyond Rotating Bridge 2) - 0x003B2 - Rotated Shapers
-158331 - 0x00C2E (Beyond Rotating Bridge 3) - 0x00A1E - Rotated Shapers & Shapers
-158332 - 0x00E3A (Beyond Rotating Bridge 4) - 0x00C2E - Rotated Shapers & Shapers
+0xFFD02 (Beyond Rotating Bridge Reached Independently) - True - True
+0x09DB8 (Boat Spawn) - True - Boat
+0x003B2 (Beyond Rotating Bridge 1) - 0x0000A - Rotated Shapers
+0x00A1E (Beyond Rotating Bridge 2) - 0x003B2 - Rotated Shapers
+0x00C2E (Beyond Rotating Bridge 3) - 0x00A1E - Rotated Shapers & Shapers
+0x00E3A (Beyond Rotating Bridge 4) - 0x00C2E - Rotated Shapers & Shapers
 Door - 0x18482 (Blue Water Pump) - 0x00E3A
-159332 - 0x3365F (Boat EP) - 0x09DB8 - True
-159333 - 0x03731 (Long Bridge Side EP) - 0x17E2B - True
+0x3365F (Boat EP) - 0x09DB8 - True
+0x03731 (Long Bridge Side EP) - 0x17E2B - True
 
 Swamp Long Bridge (Swamp) - Swamp Near Boat - 0x17E2B - Outside Swamp - 0x17E2B:
-158339 - 0x17E2B (Long Bridge Control) - True - Rotated Shapers & Shapers
+0x17E2B (Long Bridge Control) - True - Rotated Shapers & Shapers
 
 Swamp Purple Area (Swamp) - Swamp Rotating Bridge - TrueOneWay - Swamp Purple Underwater - 0x0A1D6 - Swamp Near Boat - TrueOneWay:
 Door - 0x0A1D6 (Purple Water Pump) - 0x00E3A
 
 Swamp Purple Underwater (Swamp):
-158333 - 0x009A6 (Purple Underwater) - True - Shapers
-159330 - 0x03A9E (Purple Underwater Right EP) - True - True
-159336 - 0x03A93 (Purple Underwater Left EP) - True - True
+0x009A6 (Purple Underwater) - True - Shapers
+0x03A9E (Purple Underwater Right EP) - True - True
+0x03A93 (Purple Underwater Left EP) - True - True
 
 Swamp Blue Underwater (Swamp):
-158334 - 0x009AB (Blue Underwater 1) - True - Shapers & Negative Shapers
-158335 - 0x009AD (Blue Underwater 2) - 0x009AB - Shapers & Negative Shapers
-158336 - 0x009AE (Blue Underwater 3) - 0x009AD - Shapers & Negative Shapers
-158337 - 0x009AF (Blue Underwater 4) - 0x009AE - Shapers & Negative Shapers
-158338 - 0x00006 (Blue Underwater 5) - 0x009AF - Shapers & Negative Shapers
+0x009AB (Blue Underwater 1) - True - Shapers & Negative Shapers
+0x009AD (Blue Underwater 2) - 0x009AB - Shapers & Negative Shapers
+0x009AE (Blue Underwater 3) - 0x009AD - Shapers & Negative Shapers
+0x009AF (Blue Underwater 4) - 0x009AE - Shapers & Negative Shapers
+0x00006 (Blue Underwater 5) - 0x009AF - Shapers & Negative Shapers
 
 Swamp Maze (Swamp) - Swamp Laser Area - 0x17C0A & 0x17E07:
-158340 - 0x17C0A (Maze Control) - True - Shapers & Negative Shapers & Rotated Shapers
-158112 - 0x17E07 (Maze Control Other Side) - True - Shapers & Negative Shapers & Rotated Shapers
+0x17C0A (Maze Control) - True - Shapers & Negative Shapers & Rotated Shapers
+0x17E07 (Maze Control Other Side) - True - Shapers & Negative Shapers & Rotated Shapers
 
 Swamp Laser Area (Swamp) - Outside Swamp - 0x2D880:
-158711 - 0x03615 (Laser Panel) - True - True
+0x03615 (Laser Panel) - True - True
 Laser - 0x00BF6 (Laser) - 0x03615
-158341 - 0x17C05 (Laser Shortcut Left Panel) - True - Rotated Shapers
-158342 - 0x17C02 (Laser Shortcut Right Panel) - 0x17C05 - Shapers & Negative Shapers & Rotated Shapers
+0x17C05 (Laser Shortcut Left Panel) - True - Rotated Shapers
+0x17C02 (Laser Shortcut Right Panel) - 0x17C05 - Shapers & Negative Shapers & Rotated Shapers
 Door - 0x2D880 (Laser Shortcut) - 0x17C02
 
 ==Treehouse==
 
 Treehouse Obelisk (Treehouse) - Entry - True:
-159720 - 0xFFE20 (Obelisk Side 1) - 0x0053D & 0x0053E & 0x00769 - True
-159721 - 0xFFE21 (Obelisk Side 2) - 0x33721 & 0x220A7 & 0x220BD - True
-159722 - 0xFFE22 (Obelisk Side 3) - 0x03B22 & 0x03B23 & 0x03B24 & 0x03B25 & 0x03A79 & 0x28ABD & 0x28ABE - True
-159723 - 0xFFE23 (Obelisk Side 4) - 0x3388F & 0x28B29 & 0x28B2A - True
-159724 - 0xFFE24 (Obelisk Side 5) - 0x018B6 & 0x033BE & 0x033BF & 0x033DD & 0x033E5 - True
-159725 - 0xFFE25 (Obelisk Side 6) - 0x28AE9 & 0x3348F - True
-159729 - 0x00097 (Obelisk) - True - True
+0xFFE20 (Obelisk Side 1) - 0x0053D & 0x0053E & 0x00769 - True
+0xFFE21 (Obelisk Side 2) - 0x33721 & 0x220A7 & 0x220BD - True
+0xFFE22 (Obelisk Side 3) - 0x03B22 & 0x03B23 & 0x03B24 & 0x03B25 & 0x03A79 & 0x28ABD & 0x28ABE - True
+0xFFE23 (Obelisk Side 4) - 0x3388F & 0x28B29 & 0x28B2A - True
+0xFFE24 (Obelisk Side 5) - 0x018B6 & 0x033BE & 0x033BF & 0x033DD & 0x033E5 - True
+0xFFE25 (Obelisk Side 6) - 0x28AE9 & 0x3348F - True
+0x00097 (Obelisk) - True - True
 
 Treehouse Beach (Treehouse Beach) - Main Island - True:
-159200 - 0x0053D (Rock Shadow EP) - True - True
-159201 - 0x0053E (Sand Shadow EP) - True - True
-159212 - 0x220BD (Both Orange Bridges EP) - 0x17DA2 & 0x17DDB - True
+0x0053D (Rock Shadow EP) - True - True
+0x0053E (Sand Shadow EP) - True - True
+0x220BD (Both Orange Bridges EP) - 0x17DA2 & 0x17DDB - True
 
 Treehouse Entry Area (Treehouse) - Treehouse Between Entry Doors - 0x0C309 - The Ocean - 0x17C95:
-158343 - 0x17C95 (Boat Spawn) - True - Boat
-158344 - 0x0288C (First Door Panel) - True - Stars
+0x17C95 (Boat Spawn) - True - Boat
+0x0288C (First Door Panel) - True - Stars
 Door - 0x0C309 (First Door) - 0x0288C
-159210 - 0x33721 (Buoy EP) - 0x17C95 - True
+0x33721 (Buoy EP) - 0x17C95 - True
 
 Treehouse Between Entry Doors (Treehouse) - Treehouse Yellow Bridge - 0x0C310:
-158345 - 0x02886 (Second Door Panel) - True - Stars
+0x02886 (Second Door Panel) - True - Stars
 Door - 0x0C310 (Second Door) - 0x02886
 
 Treehouse Yellow Bridge (Treehouse) - Treehouse After Yellow Bridge - 0x17DC4:
-158346 - 0x17D72 (Yellow Bridge 1) - True - Stars
-158347 - 0x17D8F (Yellow Bridge 2) - 0x17D72 - Stars
-158348 - 0x17D74 (Yellow Bridge 3) - 0x17D8F - Stars
-158349 - 0x17DAC (Yellow Bridge 4) - 0x17D74 - Stars
-158350 - 0x17D9E (Yellow Bridge 5) - 0x17DAC - Stars
-158351 - 0x17DB9 (Yellow Bridge 6) - 0x17D9E - Stars
-158352 - 0x17D9C (Yellow Bridge 7) - 0x17DB9 - Stars
-158353 - 0x17DC2 (Yellow Bridge 8) - 0x17D9C - Stars
-158354 - 0x17DC4 (Yellow Bridge 9) - 0x17DC2 - Stars
+0x17D72 (Yellow Bridge 1) - True - Stars
+0x17D8F (Yellow Bridge 2) - 0x17D72 - Stars
+0x17D74 (Yellow Bridge 3) - 0x17D8F - Stars
+0x17DAC (Yellow Bridge 4) - 0x17D74 - Stars
+0x17D9E (Yellow Bridge 5) - 0x17DAC - Stars
+0x17DB9 (Yellow Bridge 6) - 0x17D9E - Stars
+0x17D9C (Yellow Bridge 7) - 0x17DB9 - Stars
+0x17DC2 (Yellow Bridge 8) - 0x17D9C - Stars
+0x17DC4 (Yellow Bridge 9) - 0x17DC2 - Stars
 
 Treehouse After Yellow Bridge (Treehouse) - Treehouse Junction - 0x0A181:
-158355 - 0x0A182 (Third Door Panel) - True - Stars
+0x0A182 (Third Door Panel) - True - Stars
 Door - 0x0A181 (Third Door) - 0x0A182
 
 Treehouse Junction (Treehouse) - Treehouse Right Orange Bridge - True - Treehouse First Purple Bridge - True - Treehouse Green Bridge - True:
-158356 - 0x2700B (Laser House Door Timer Outside) - True - True
+0x2700B (Laser House Door Timer Outside) - True - True
 
 Treehouse First Purple Bridge (Treehouse) - Treehouse Second Purple Bridge - 0x17D6C:
-158357 - 0x17DC8 (First Purple Bridge 1) - True - Stars & Dots
-158358 - 0x17DC7 (First Purple Bridge 2) - 0x17DC8 - Stars & Dots
-158359 - 0x17CE4 (First Purple Bridge 3) - 0x17DC7 - Stars & Dots
-158360 - 0x17D2D (First Purple Bridge 4) - 0x17CE4 - Stars & Dots
-158361 - 0x17D6C (First Purple Bridge 5) - 0x17D2D - Stars & Dots
+0x17DC8 (First Purple Bridge 1) - True - Stars & Dots
+0x17DC7 (First Purple Bridge 2) - 0x17DC8 - Stars & Dots
+0x17CE4 (First Purple Bridge 3) - 0x17DC7 - Stars & Dots
+0x17D2D (First Purple Bridge 4) - 0x17CE4 - Stars & Dots
+0x17D6C (First Purple Bridge 5) - 0x17D2D - Stars & Dots
 
 Treehouse Right Orange Bridge (Treehouse) - Treehouse Drawbridge Platform - 0x17DA2:
-158391 - 0x17D88 (Right Orange Bridge 1) - True - Stars
-158392 - 0x17DB4 (Right Orange Bridge 2) - 0x17D88 - Stars
-158393 - 0x17D8C (Right Orange Bridge 3) - 0x17DB4 - Stars
-158394 - 0x17CE3 (Right Orange Bridge 4 & Directional) - 0x17D8C - Stars
-158395 - 0x17DCD (Right Orange Bridge 5) - 0x17CE3 - Stars
-158396 - 0x17DB2 (Right Orange Bridge 6) - 0x17DCD - Stars
-158397 - 0x17DCC (Right Orange Bridge 7) - 0x17DB2 - Stars
-158398 - 0x17DCA (Right Orange Bridge 8) - 0x17DCC - Stars
-158399 - 0x17D8E (Right Orange Bridge 9) - 0x17DCA - Stars
-158400 - 0x17DB7 (Right Orange Bridge 10 & Directional) - 0x17D8E - Stars
-158401 - 0x17DB1 (Right Orange Bridge 11) - 0x17DB7 - Stars
-158402 - 0x17DA2 (Right Orange Bridge 12) - 0x17DB1 - Stars
+0x17D88 (Right Orange Bridge 1) - True - Stars
+0x17DB4 (Right Orange Bridge 2) - 0x17D88 - Stars
+0x17D8C (Right Orange Bridge 3) - 0x17DB4 - Stars
+0x17CE3 (Right Orange Bridge 4 & Directional) - 0x17D8C - Stars
+0x17DCD (Right Orange Bridge 5) - 0x17CE3 - Stars
+0x17DB2 (Right Orange Bridge 6) - 0x17DCD - Stars
+0x17DCC (Right Orange Bridge 7) - 0x17DB2 - Stars
+0x17DCA (Right Orange Bridge 8) - 0x17DCC - Stars
+0x17D8E (Right Orange Bridge 9) - 0x17DCA - Stars
+0x17DB7 (Right Orange Bridge 10 & Directional) - 0x17D8E - Stars
+0x17DB1 (Right Orange Bridge 11) - 0x17DB7 - Stars
+0x17DA2 (Right Orange Bridge 12) - 0x17DB1 - Stars
 
 Treehouse Drawbridge Platform (Treehouse) - Main Island - 0x0C32D:
-158404 - 0x037FF (Drawbridge Panel) - True - Stars
+0x037FF (Drawbridge Panel) - True - Stars
 Door - 0x0C32D (Drawbridge) - 0x037FF
 
 Treehouse Second Purple Bridge (Treehouse) - Treehouse Left Orange Bridge - 0x17DC6:
-158362 - 0x17D9B (Second Purple Bridge 1) - True - Stars & Black/White Squares
-158363 - 0x17D99 (Second Purple Bridge 2) - 0x17D9B - Stars & Black/White Squares
-158364 - 0x17DAA (Second Purple Bridge 3) - 0x17D99 - Stars & Black/White Squares
-158365 - 0x17D97 (Second Purple Bridge 4) - 0x17DAA - Stars & Black/White Squares & Colored Squares
-158366 - 0x17BDF (Second Purple Bridge 5) - 0x17D97 - Stars & Colored Squares
-158367 - 0x17D91 (Second Purple Bridge 6) - 0x17BDF - Stars & Colored Squares
-158368 - 0x17DC6 (Second Purple Bridge 7) - 0x17D91 - Stars & Colored Squares
+0x17D9B (Second Purple Bridge 1) - True - Stars & Black/White Squares
+0x17D99 (Second Purple Bridge 2) - 0x17D9B - Stars & Black/White Squares
+0x17DAA (Second Purple Bridge 3) - 0x17D99 - Stars & Black/White Squares
+0x17D97 (Second Purple Bridge 4) - 0x17DAA - Stars & Black/White Squares & Colored Squares
+0x17BDF (Second Purple Bridge 5) - 0x17D97 - Stars & Colored Squares
+0x17D91 (Second Purple Bridge 6) - 0x17BDF - Stars & Colored Squares
+0x17DC6 (Second Purple Bridge 7) - 0x17D91 - Stars & Colored Squares
 
 Treehouse Left Orange Bridge (Treehouse) - Treehouse Laser Room Front Platform - 0x17DDB - Treehouse Laser Room Back Platform - 0x17DDB - Treehouse Burned House - 0x17DDB:
-158376 - 0x17DB3 (Left Orange Bridge 1) - True - Black/White Squares & Stars + Same Colored Symbol
-158377 - 0x17DB5 (Left Orange Bridge 2) - 0x17DB3 - Stars & Black/White Squares
-158378 - 0x17DB6 (Left Orange Bridge 3) - 0x17DB5 - Black/White Squares & Stars + Same Colored Symbol
-158379 - 0x17DC0 (Left Orange Bridge 4) - 0x17DB6 - Black/White Squares & Stars + Same Colored Symbol
-158380 - 0x17DD7 (Left Orange Bridge 5) - 0x17DC0 - Black/White Squares & Stars + Same Colored Symbol
-158381 - 0x17DD9 (Left Orange Bridge 6) - 0x17DD7 - Black/White Squares & Colored Squares & Stars + Same Colored Symbol
-158382 - 0x17DB8 (Left Orange Bridge 7) - 0x17DD9 - Black/White Squares & Colored Squares & Stars + Same Colored Symbol
-158383 - 0x17DDC (Left Orange Bridge 8) - 0x17DB8 - Colored Squares & Stars + Same Colored Symbol
-158384 - 0x17DD1 (Left Orange Bridge 9 & Directional) - 0x17DDC - Colored Squares & Stars + Same Colored Symbol
-158385 - 0x17DDE (Left Orange Bridge 10) - 0x17DD1 - Colored Squares & Stars + Same Colored Symbol
-158386 - 0x17DE3 (Left Orange Bridge 11) - 0x17DDE - Colored Squares & Stars + Same Colored Symbol
-158387 - 0x17DEC (Left Orange Bridge 12) - 0x17DE3 - Black/White Squares & Stars + Same Colored Symbol
-158388 - 0x17DAE (Left Orange Bridge 13) - 0x17DEC - Black/White Squares & Stars + Same Colored Symbol
-158389 - 0x17DB0 (Left Orange Bridge 14) - 0x17DAE - Black/White Squares & Stars + Same Colored Symbol
-158390 - 0x17DDB (Left Orange Bridge 15) - 0x17DB0 - Black/White Squares & Stars + Same Colored Symbol
+0x17DB3 (Left Orange Bridge 1) - True - Black/White Squares & Stars + Same Colored Symbol
+0x17DB5 (Left Orange Bridge 2) - 0x17DB3 - Stars & Black/White Squares
+0x17DB6 (Left Orange Bridge 3) - 0x17DB5 - Black/White Squares & Stars + Same Colored Symbol
+0x17DC0 (Left Orange Bridge 4) - 0x17DB6 - Black/White Squares & Stars + Same Colored Symbol
+0x17DD7 (Left Orange Bridge 5) - 0x17DC0 - Black/White Squares & Stars + Same Colored Symbol
+0x17DD9 (Left Orange Bridge 6) - 0x17DD7 - Black/White Squares & Colored Squares & Stars + Same Colored Symbol
+0x17DB8 (Left Orange Bridge 7) - 0x17DD9 - Black/White Squares & Colored Squares & Stars + Same Colored Symbol
+0x17DDC (Left Orange Bridge 8) - 0x17DB8 - Colored Squares & Stars + Same Colored Symbol
+0x17DD1 (Left Orange Bridge 9 & Directional) - 0x17DDC - Colored Squares & Stars + Same Colored Symbol
+0x17DDE (Left Orange Bridge 10) - 0x17DD1 - Colored Squares & Stars + Same Colored Symbol
+0x17DE3 (Left Orange Bridge 11) - 0x17DDE - Colored Squares & Stars + Same Colored Symbol
+0x17DEC (Left Orange Bridge 12) - 0x17DE3 - Black/White Squares & Stars + Same Colored Symbol
+0x17DAE (Left Orange Bridge 13) - 0x17DEC - Black/White Squares & Stars + Same Colored Symbol
+0x17DB0 (Left Orange Bridge 14) - 0x17DAE - Black/White Squares & Stars + Same Colored Symbol
+0x17DDB (Left Orange Bridge 15) - 0x17DB0 - Black/White Squares & Stars + Same Colored Symbol
 
 Treehouse Green Bridge (Treehouse) - Treehouse Green Bridge Front House - 0x17E61 - Treehouse Green Bridge Left House - 0x17E61:
-158369 - 0x17E3C (Green Bridge 1) - True - Stars & Shapers
-158370 - 0x17E4D (Green Bridge 2) - 0x17E3C - Stars & Shapers
-158371 - 0x17E4F (Green Bridge 3) - 0x17E4D - Stars & Shapers & Rotated Shapers
-158372 - 0x17E52 (Green Bridge 4 & Directional) - 0x17E4F - Stars & Rotated Shapers
-158373 - 0x17E5B (Green Bridge 5) - 0x17E52 - Shapers & Stars + Same Colored Symbol
-158374 - 0x17E5F (Green Bridge 6) - 0x17E5B - Stars & Negative Shapers & Rotated Shapers
-158375 - 0x17E61 (Green Bridge 7) - 0x17E5F - Stars & Shapers & Rotated Shapers
+0x17E3C (Green Bridge 1) - True - Stars & Shapers
+0x17E4D (Green Bridge 2) - 0x17E3C - Stars & Shapers
+0x17E4F (Green Bridge 3) - 0x17E4D - Stars & Shapers & Rotated Shapers
+0x17E52 (Green Bridge 4 & Directional) - 0x17E4F - Stars & Rotated Shapers
+0x17E5B (Green Bridge 5) - 0x17E52 - Shapers & Stars + Same Colored Symbol
+0x17E5F (Green Bridge 6) - 0x17E5B - Stars & Negative Shapers & Rotated Shapers
+0x17E61 (Green Bridge 7) - 0x17E5F - Stars & Shapers & Rotated Shapers
 
 Treehouse Green Bridge Front House (Treehouse):
-158610 - 0x17FA9 (Green Bridge Discard) - True - Triangles
+0x17FA9 (Green Bridge Discard) - True - Triangles
 
 Treehouse Green Bridge Left House (Treehouse):
-159211 - 0x220A7 (Right Orange Bridge EP) - 0x17DA2 - True
+0x220A7 (Right Orange Bridge EP) - 0x17DA2 - True
 
 Treehouse Laser Room Front Platform (Treehouse) - Treehouse Laser Room - 0x0C323:
 Door - 0x0C323 (Laser House Entry) - 0x17DA2 & 0x2700B & 0x17DDB | 0x17CBC
 
 Treehouse Laser Room Back Platform (Treehouse):
-158611 - 0x17FA0 (Laser Discard) - True - Triangles
+0x17FA0 (Laser Discard) - True - Triangles
 
 Treehouse Burned House (Treehouse):
-159202 - 0x00769 (Burned House Beach EP) - True - True
+0x00769 (Burned House Beach EP) - True - True
 
 Treehouse Laser Room (Treehouse):
-158712 - 0x03613 (Laser Panel) - True - True
-158403 - 0x17CBC (Laser House Door Timer Inside) - True - True
+0x03613 (Laser Panel) - True - True
+0x17CBC (Laser House Door Timer Inside) - True - True
 Laser - 0x028A4 (Laser) - 0x03613
 
 ==Mountain (Outside)==
 
 Mountainside Obelisk (Mountainside) - Entry - True:
-159730 - 0xFFE30 (Obelisk Side 1) - 0x001A3 & 0x335AE - True
-159731 - 0xFFE31 (Obelisk Side 2) - 0x000D3 & 0x035F5 & 0x09D5D & 0x09D5E & 0x09D63 - True
-159732 - 0xFFE32 (Obelisk Side 3) - 0x3370E & 0x035DE & 0x03601 & 0x03603 & 0x03D0D & 0x3369A & 0x336C8 & 0x33505 - True
-159733 - 0xFFE33 (Obelisk Side 4) - 0x03A9E & 0x016B2 & 0x3365F & 0x03731 & 0x036CE & 0x03C07 & 0x03A93 - True
-159734 - 0xFFE34 (Obelisk Side 5) - 0x03AA6 & 0x3397C & 0x0105D & 0x0A304 - True
-159735 - 0xFFE35 (Obelisk Side 6) - 0x035CB & 0x035CF - True
-159739 - 0x00367 (Obelisk) - True - True
+0xFFE30 (Obelisk Side 1) - 0x001A3 & 0x335AE - True
+0xFFE31 (Obelisk Side 2) - 0x000D3 & 0x035F5 & 0x09D5D & 0x09D5E & 0x09D63 - True
+0xFFE32 (Obelisk Side 3) - 0x3370E & 0x035DE & 0x03601 & 0x03603 & 0x03D0D & 0x3369A & 0x336C8 & 0x33505 - True
+0xFFE33 (Obelisk Side 4) - 0x03A9E & 0x016B2 & 0x3365F & 0x03731 & 0x036CE & 0x03C07 & 0x03A93 - True
+0xFFE34 (Obelisk Side 5) - 0x03AA6 & 0x3397C & 0x0105D & 0x0A304 - True
+0xFFE35 (Obelisk Side 6) - 0x035CB & 0x035CF - True
+0x00367 (Obelisk) - True - True
 
 Mountainside (Mountainside) - Main Island - True - Mountaintop - True - Mountainside Vault - 0x00085:
-159550 - 0x28B91 (Thundercloud EP) - 0xFFD03 - True
-158612 - 0x17C42 (Discard) - True - Triangles
-158665 - 0x002A6 (Vault Panel) - True - Symmetry & Colored Dots & Black/White Squares
+0x28B91 (Thundercloud EP) - 0xFFD03 - True
+0x17C42 (Discard) - True - Triangles
+0x002A6 (Vault Panel) - True - Symmetry & Colored Dots & Black/White Squares
 Door - 0x00085 (Vault Door) - 0x002A6
-159301 - 0x335AE (Cloud Cycle EP) - True - True
-159325 - 0x33505 (Bush EP) - True - True
-159335 - 0x03C07 (Apparent River EP) - True - True
+0x335AE (Cloud Cycle EP) - True - True
+0x33505 (Bush EP) - True - True
+0x03C07 (Apparent River EP) - True - True
 
 Mountainside Vault (Mountainside):
-158666 - 0x03542 (Vault Box) - True - True
+0x03542 (Vault Box) - True - True
 
 Mountaintop (Mountaintop) - Mountain Floor 1 - 0x17C34:
-158405 - 0x0042D (River Shape) - True - True
-158406 - 0x09F7F (Box Short) - 7 Lasers + Redirect - True
-158407 - 0x17C34 (Mountain Entry Panel) - 0x09F7F - Black/White Squares
-158800 - 0xFFF00 (Box Long) - 11 Lasers + Redirect & 0x17C34 - True
-159300 - 0x001A3 (River Shape EP) - True - True
-159320 - 0x3370E (Arch Black EP) - True - True
-159324 - 0x336C8 (Arch White Right EP) - True - True
-159326 - 0x3369A (Arch White Left EP) - True - True
+0x0042D (River Shape) - True - True
+0x09F7F (Box Short) - 7 Lasers + Redirect - True
+0x17C34 (Mountain Entry Panel) - 0x09F7F - Black/White Squares
+0xFFF00 (Box Long) - 11 Lasers + Redirect & 0x17C34 - True
+0x001A3 (River Shape EP) - True - True
+0x3370E (Arch Black EP) - True - True
+0x336C8 (Arch White Right EP) - True - True
+0x3369A (Arch White Left EP) - True - True
 
 ==Mountain (Inside)==
 
 Mountain Floor 1 (Mountain Floor 1) - Mountain Floor 1 Bridge - 0x09E39:
-158408 - 0x09E39 (Light Bridge Controller) - True - Black/White Squares & Rotated Shapers
+0x09E39 (Light Bridge Controller) - True - Black/White Squares & Rotated Shapers
 
 Mountain Floor 1 Bridge (Mountain Floor 1) - Mountain Floor 1 At Door - TrueOneWay - Mountain Floor 1 Trash Pillar - TrueOneWay - Mountain Floor 1 Back Section - TrueOneWay:
-158409 - 0x09E7A (Right Row 1) - True - Black/White Squares & Dots
-158410 - 0x09E71 (Right Row 2) - 0x09E7A - Black/White Squares & Dots
-158411 - 0x09E72 (Right Row 3) - 0x09E71 - Black/White Squares & Shapers
-158412 - 0x09E69 (Right Row 4) - 0x09E72 - Black/White Squares & Dots
-158413 - 0x09E7B (Right Row 5) - 0x09E69 - Black/White Squares & Dots
-158414 - 0x09E73 (Left Row 1) - True - Black/White Squares & Dots
-158415 - 0x09E75 (Left Row 2) - 0x09E73 - Black/White Squares & Dots
-158416 - 0x09E78 (Left Row 3) - 0x09E75 - Dots & Shapers
-158417 - 0x09E79 (Left Row 4) - 0x09E78 - Shapers & Rotated Shapers
-158418 - 0x09E6C (Left Row 5) - 0x09E79 - Stars & Black/White Squares
-158419 - 0x09E6F (Left Row 6) - 0x09E6C - Shapers & Dots
-158420 - 0x09E6B (Left Row 7) - 0x09E6F - Dots
-158424 - 0x09EAD (Trash Pillar 1) - True - Black/White Squares & Shapers
-158425 - 0x09EAF (Trash Pillar 2) - 0x09EAD - Black/White Squares & Shapers
+0x09E7A (Right Row 1) - True - Black/White Squares & Dots
+0x09E71 (Right Row 2) - 0x09E7A - Black/White Squares & Dots
+0x09E72 (Right Row 3) - 0x09E71 - Black/White Squares & Shapers
+0x09E69 (Right Row 4) - 0x09E72 - Black/White Squares & Dots
+0x09E7B (Right Row 5) - 0x09E69 - Black/White Squares & Dots
+0x09E73 (Left Row 1) - True - Black/White Squares & Dots
+0x09E75 (Left Row 2) - 0x09E73 - Black/White Squares & Dots
+0x09E78 (Left Row 3) - 0x09E75 - Dots & Shapers
+0x09E79 (Left Row 4) - 0x09E78 - Shapers & Rotated Shapers
+0x09E6C (Left Row 5) - 0x09E79 - Stars & Black/White Squares
+0x09E6F (Left Row 6) - 0x09E6C - Shapers & Dots
+0x09E6B (Left Row 7) - 0x09E6F - Dots
+0x09EAD (Trash Pillar 1) - True - Black/White Squares & Shapers
+0x09EAF (Trash Pillar 2) - 0x09EAD - Black/White Squares & Shapers
 
 Mountain Floor 1 Trash Pillar (Mountain Floor 1):
 
 Mountain Floor 1 Back Section (Mountain Floor 1):
-158421 - 0x33AF5 (Back Row 1) - True - Black/White Squares & Symmetry
-158422 - 0x33AF7 (Back Row 2) - 0x33AF5 - Black/White Squares
-158423 - 0x09F6E (Back Row 3) - 0x33AF7 - Symmetry & Dots
+0x33AF5 (Back Row 1) - True - Black/White Squares & Symmetry
+0x33AF7 (Back Row 2) - 0x33AF5 - Black/White Squares
+0x09F6E (Back Row 3) - 0x33AF7 - Symmetry & Dots
 
 Mountain Floor 1 At Door (Mountain Floor 1) - Mountain Floor 2 - 0x09E54:
 Door - 0x09E54 (Exit) - 0x09EAF & 0x09F6E & 0x09E6B & 0x09E7B
 
 Mountain Floor 2 (Mountain Floor 2) - Mountain Floor 2 Light Bridge Room Near - 0x09FFB - Mountain Floor 2 Beyond Bridge - 0x09E86 - Mountain Floor 2 Above The Abyss - True - Mountain Pink Bridge EP - TrueOneWay:
-158426 - 0x09FD3 (Near Row 1) - True - Colored Squares
-158427 - 0x09FD4 (Near Row 2) - 0x09FD3 - Colored Squares & Dots
-158428 - 0x09FD6 (Near Row 3) - 0x09FD4 - Colored Squares & Stars + Same Colored Symbol
-158429 - 0x09FD7 (Near Row 4) - 0x09FD6 - Colored Squares & Stars + Same Colored Symbol & Shapers
-158430 - 0x09FD8 (Near Row 5) - 0x09FD7 - Colored Squares
+0x09FD3 (Near Row 1) - True - Colored Squares
+0x09FD4 (Near Row 2) - 0x09FD3 - Colored Squares & Dots
+0x09FD6 (Near Row 3) - 0x09FD4 - Colored Squares & Stars + Same Colored Symbol
+0x09FD7 (Near Row 4) - 0x09FD6 - Colored Squares & Stars + Same Colored Symbol & Shapers
+0x09FD8 (Near Row 5) - 0x09FD7 - Colored Squares
 Door - 0x09FFB (Staircase Near) - 0x09FD8
 
 Mountain Floor 2 Above The Abyss (Mountain Floor 2) - Mountain Floor 2 Elevator Room - 0x09EDD & 0x09ED8 & 0x09E86:
 Door - 0x09EDD (Elevator Room Entry) - 0x09ED8 & 0x09E86
 
 Mountain Floor 2 Light Bridge Room Near (Mountain Floor 2):
-158431 - 0x09E86 (Light Bridge Controller Near) - True - Stars & Black/White Squares
+0x09E86 (Light Bridge Controller Near) - True - Stars & Black/White Squares
 
 Mountain Floor 2 Beyond Bridge (Mountain Floor 2) - Mountain Floor 2 Light Bridge Room Far - 0x09E07 - Mountain Pink Bridge EP - TrueOneWay - Mountain Floor 2 - 0x09ED8:
-158432 - 0x09FCC (Far Row 1) - True - Dots
-158433 - 0x09FCE (Far Row 2) - 0x09FCC - Black/White Squares
-158434 - 0x09FCF (Far Row 3) - 0x09FCE - Shapers
-158435 - 0x09FD0 (Far Row 4) - 0x09FCF - Stars
-158436 - 0x09FD1 (Far Row 5) - 0x09FD0 - Black/White Squares
-158437 - 0x09FD2 (Far Row 6) - 0x09FD1 - Shapers
+0x09FCC (Far Row 1) - True - Dots
+0x09FCE (Far Row 2) - 0x09FCC - Black/White Squares
+0x09FCF (Far Row 3) - 0x09FCE - Shapers
+0x09FD0 (Far Row 4) - 0x09FCF - Stars
+0x09FD1 (Far Row 5) - 0x09FD0 - Black/White Squares
+0x09FD2 (Far Row 6) - 0x09FD1 - Shapers
 Door - 0x09E07 (Staircase Far) - 0x09FD2
 
 Mountain Floor 2 Light Bridge Room Far (Mountain Floor 2):
-158438 - 0x09ED8 (Light Bridge Controller Far) - True - Stars & Black/White Squares
+0x09ED8 (Light Bridge Controller Far) - True - Stars & Black/White Squares
 
 Mountain Floor 2 Elevator Room (Mountain Floor 2) - Mountain Floor 2 Elevator - TrueOneWay:
-158613 - 0x17F93 (Elevator Discard) - True - Triangles
+0x17F93 (Elevator Discard) - True - Triangles
 
 Mountain Floor 2 Elevator (Mountain Floor 2) - Mountain Floor 2 Elevator Room - 0x09EEB - Mountain Floor 3 - 0x09EEB:
-158439 - 0x09EEB (Elevator Control Panel) - True - Dots
+0x09EEB (Elevator Control Panel) - True - Dots
 
 Mountain Floor 3 (Mountain Bottom Floor) - Mountain Floor 2 Elevator - TrueOneWay - Mountain Bottom Floor - 0x09F89 - Mountain Pink Bridge EP - TrueOneWay:
-158440 - 0x09FC1 (Giant Puzzle Bottom Left) - True - Shapers & Eraser
-158441 - 0x09F8E (Giant Puzzle Bottom Right) - True - Rotated Shapers & Eraser
-158442 - 0x09F01 (Giant Puzzle Top Right) - True - Shapers & Eraser
-158443 - 0x09EFF (Giant Puzzle Top Left) - True - Shapers & Eraser
-158444 - 0x09FDA (Giant Puzzle) - 0x09FC1 & 0x09F8E & 0x09F01 & 0x09EFF - Shapers & Symmetry
-159313 - 0x09D5D (Yellow Bridge EP) - 0x09E86 & 0x09ED8 - True
-159314 - 0x09D5E (Blue Bridge EP) - 0x09E86 & 0x09ED8 - True
+0x09FC1 (Giant Puzzle Bottom Left) - True - Shapers & Eraser
+0x09F8E (Giant Puzzle Bottom Right) - True - Rotated Shapers & Eraser
+0x09F01 (Giant Puzzle Top Right) - True - Shapers & Eraser
+0x09EFF (Giant Puzzle Top Left) - True - Shapers & Eraser
+0x09FDA (Giant Puzzle) - 0x09FC1 & 0x09F8E & 0x09F01 & 0x09EFF - Shapers & Symmetry
+0x09D5D (Yellow Bridge EP) - 0x09E86 & 0x09ED8 - True
+0x09D5E (Blue Bridge EP) - 0x09E86 & 0x09ED8 - True
 Door - 0x09F89 (Exit) - 0x09FDA
 
 Mountain Bottom Floor (Mountain Bottom Floor) - Mountain Path to Caves - 0x17F33 - Mountain Bottom Floor Pillars Room - 0x0C141:
-158614 - 0x17FA2 (Discard) - 0xFFF00 - Triangles
-158445 - 0x01983 (Pillars Room Entry Left) - True - Shapers & Stars
-158446 - 0x01987 (Pillars Room Entry Right) - True - Colored Squares & Dots
+0x17FA2 (Discard) - 0xFFF00 - Triangles
+0x01983 (Pillars Room Entry Left) - True - Shapers & Stars
+0x01987 (Pillars Room Entry Right) - True - Colored Squares & Dots
 Door - 0x0C141 (Pillars Room Entry) - 0x01983 & 0x01987
 Door - 0x17F33 (Rock Open) - 0x17FA2 | 0x334E1
 
 Mountain Bottom Floor Pillars Room (Mountain Bottom Floor) - Elevator - 0x339BB & 0x33961:
-158522 - 0x0383A (Right Pillar 1) - True - Stars
-158523 - 0x09E56 (Right Pillar 2) - 0x0383A - Stars & Dots
-158524 - 0x09E5A (Right Pillar 3) - 0x09E56 - Full Dots
-158525 - 0x33961 (Right Pillar 4) - 0x09E5A - Dots & Symmetry
-158526 - 0x0383D (Left Pillar 1) - True - Full Dots
-158527 - 0x0383F (Left Pillar 2) - 0x0383D - Black/White Squares
-158528 - 0x03859 (Left Pillar 3) - 0x0383F - Shapers
-158529 - 0x339BB (Left Pillar 4) - 0x03859 - Black/White Squares & Stars & Symmetry
+0x0383A (Right Pillar 1) - True - Stars
+0x09E56 (Right Pillar 2) - 0x0383A - Stars & Dots
+0x09E5A (Right Pillar 3) - 0x09E56 - Full Dots
+0x33961 (Right Pillar 4) - 0x09E5A - Dots & Symmetry
+0x0383D (Left Pillar 1) - True - Full Dots
+0x0383F (Left Pillar 2) - 0x0383D - Black/White Squares
+0x03859 (Left Pillar 3) - 0x0383F - Shapers
+0x339BB (Left Pillar 4) - 0x03859 - Black/White Squares & Stars & Symmetry
 
 Elevator (Mountain Bottom Floor):
-158530 - 0x3D9A6 (Elevator Door Close Left) - True - True
-158531 - 0x3D9A7 (Elevator Door Close Right) - True - True
-158532 - 0x3C113 (Elevator Entry Left) - 0x3D9A6 | 0x3D9A7 - True
-158533 - 0x3C114 (Elevator Entry Right) - 0x3D9A6 | 0x3D9A7 - True
-158534 - 0x3D9AA (Back Wall Left) - 0x3D9A6 | 0x3D9A7 - True
-158535 - 0x3D9A8 (Back Wall Right) - 0x3D9A6 | 0x3D9A7 - True
-158536 - 0x3D9A9 (Elevator Start) - 0x3D9AA & 7 Lasers | 0x3D9A8 & 7 Lasers - True
+0x3D9A6 (Elevator Door Close Left) - True - True
+0x3D9A7 (Elevator Door Close Right) - True - True
+0x3C113 (Elevator Entry Left) - 0x3D9A6 | 0x3D9A7 - True
+0x3C114 (Elevator Entry Right) - 0x3D9A6 | 0x3D9A7 - True
+0x3D9AA (Back Wall Left) - 0x3D9A6 | 0x3D9A7 - True
+0x3D9A8 (Back Wall Right) - 0x3D9A6 | 0x3D9A7 - True
+0x3D9A9 (Elevator Start) - 0x3D9AA & 7 Lasers | 0x3D9A8 & 7 Lasers - True
 
 Mountain Pink Bridge EP (Mountain Floor 2):
-159312 - 0x09D63 (Pink Bridge EP) - 0x09E39 - True
+0x09D63 (Pink Bridge EP) - 0x09E39 - True
 
 Mountain Path to Caves (Mountain Bottom Floor) - Caves - 0x2D77D - Caves Entry Door - TrueOneWay:
-158447 - 0x00FF8 (Caves Entry Panel) - True - Black/White Squares
+0x00FF8 (Caves Entry Panel) - True - Black/White Squares
 Door - 0x2D77D (Caves Entry) - 0x00FF8
-158448 - 0x334E1 (Rock Control) - True - True
+0x334E1 (Rock Control) - True - True
 
 ==Caves==
 
 Caves Entry Door (Caves):
 
 Caves (Caves) - Main Island - 0x2D73F | 0x2D859 - Caves Path to Challenge - 0x019A5 - Caves Entry Door - TrueOneWay:
-158451 - 0x335AB (Elevator Inside Control) - True - Dots & Black/White Squares
-158452 - 0x335AC (Elevator Upper Outside Control) - 0x335AB - Black/White Squares
-158453 - 0x3369D (Elevator Lower Outside Control) - 0x335AB - Black/White Squares & Dots
-158454 - 0x00190 (Blue Tunnel Right First 1) - True - Shapers
-158455 - 0x00558 (Blue Tunnel Right First 2) - 0x00190 - Shapers
-158456 - 0x00567 (Blue Tunnel Right First 3) - 0x00558 - Shapers
-158457 - 0x006FE (Blue Tunnel Right First 4) - 0x00567 - Shapers
-158458 - 0x01A0D (Blue Tunnel Left First 1) - True - Symmetry & Shapers
-158459 - 0x008B8 (Blue Tunnel Left Second 1) - True - Shapers
-158460 - 0x00973 (Blue Tunnel Left Second 2) - 0x008B8 - Shapers
-158461 - 0x0097B (Blue Tunnel Left Second 3) - 0x00973 - Shapers
-158462 - 0x0097D (Blue Tunnel Left Second 4) - 0x0097B - Shapers
-158463 - 0x0097E (Blue Tunnel Left Second 5) - 0x0097D - Shapers
-158464 - 0x00994 (Blue Tunnel Right Second 1) - True - Shapers
-158465 - 0x334D5 (Blue Tunnel Right Second 2) - 0x00994 - Shapers
-158466 - 0x00995 (Blue Tunnel Right Second 3) - 0x334D5 - Shapers
-158467 - 0x00996 (Blue Tunnel Right Second 4) - 0x00995 - Shapers
-158468 - 0x00998 (Blue Tunnel Right Second 5) - 0x00996 - Shapers
-158469 - 0x009A4 (Blue Tunnel Left Third 1) - True - Shapers
-158470 - 0x018A0 (Blue Tunnel Right Third 1) - True - Shapers & Symmetry
-158471 - 0x00A72 (Blue Tunnel Left Fourth 1) - True - Shapers & Negative Shapers
-158472 - 0x32962 (First Floor Left) - True - Rotated Shapers & Shapers
-158473 - 0x32966 (First Floor Grounded) - True - Stars & Black/White Squares
-158474 - 0x01A31 (First Floor Middle) - True - Colored Squares
-158475 - 0x00B71 (First Floor Right) - True - Colored Squares & Stars + Same Colored Symbol & Eraser
-158478 - 0x288EA (First Wooden Beam) - True - Rotated Shapers
-158479 - 0x288FC (Second Wooden Beam) - True - Black/White Squares & Shapers & Rotated Shapers
-158480 - 0x289E7 (Third Wooden Beam) - True - Black/White Squares
-158481 - 0x288AA (Fourth Wooden Beam) - True - Black/White Squares & Shapers
-158482 - 0x17FB9 (Left Upstairs Single) - True - Dots
-158483 - 0x0A16B (Left Upstairs Left Row 1) - True - Full Dots
-158484 - 0x0A2CE (Left Upstairs Left Row 2) - 0x0A16B - Full Dots
-158485 - 0x0A2D7 (Left Upstairs Left Row 3) - 0x0A2CE - Full Dots
-158486 - 0x0A2DD (Left Upstairs Left Row 4) - 0x0A2D7 - Full Dots
-158487 - 0x0A2EA (Left Upstairs Left Row 5) - 0x0A2DD - Full Dots
-158488 - 0x0008F (Right Upstairs Left Row 1) - True - Dots
-158489 - 0x0006B (Right Upstairs Left Row 2) - 0x0008F - Dots
-158490 - 0x0008B (Right Upstairs Left Row 3) - 0x0006B - Dots
-158491 - 0x0008C (Right Upstairs Left Row 4) - 0x0008B - Dots
-158492 - 0x0008A (Right Upstairs Left Row 5) - 0x0008C - Dots
-158493 - 0x00089 (Right Upstairs Left Row 6) - 0x0008A - Dots
-158494 - 0x0006A (Right Upstairs Left Row 7) - 0x00089 - Dots
-158495 - 0x0006C (Right Upstairs Left Row 8) - 0x0006A - Dots
-158496 - 0x00027 (Right Upstairs Right Row 1) - True - Dots & Symmetry
-158497 - 0x00028 (Right Upstairs Right Row 2) - 0x00027 - Dots & Symmetry
-158498 - 0x00029 (Right Upstairs Right Row 3) - 0x00028 - Dots & Symmetry
-158476 - 0x09DD5 (Lone Pillar) - True - Triangles
+0x335AB (Elevator Inside Control) - True - Dots & Black/White Squares
+0x335AC (Elevator Upper Outside Control) - 0x335AB - Black/White Squares
+0x3369D (Elevator Lower Outside Control) - 0x335AB - Black/White Squares & Dots
+0x00190 (Blue Tunnel Right First 1) - True - Shapers
+0x00558 (Blue Tunnel Right First 2) - 0x00190 - Shapers
+0x00567 (Blue Tunnel Right First 3) - 0x00558 - Shapers
+0x006FE (Blue Tunnel Right First 4) - 0x00567 - Shapers
+0x01A0D (Blue Tunnel Left First 1) - True - Symmetry & Shapers
+0x008B8 (Blue Tunnel Left Second 1) - True - Shapers
+0x00973 (Blue Tunnel Left Second 2) - 0x008B8 - Shapers
+0x0097B (Blue Tunnel Left Second 3) - 0x00973 - Shapers
+0x0097D (Blue Tunnel Left Second 4) - 0x0097B - Shapers
+0x0097E (Blue Tunnel Left Second 5) - 0x0097D - Shapers
+0x00994 (Blue Tunnel Right Second 1) - True - Shapers
+0x334D5 (Blue Tunnel Right Second 2) - 0x00994 - Shapers
+0x00995 (Blue Tunnel Right Second 3) - 0x334D5 - Shapers
+0x00996 (Blue Tunnel Right Second 4) - 0x00995 - Shapers
+0x00998 (Blue Tunnel Right Second 5) - 0x00996 - Shapers
+0x009A4 (Blue Tunnel Left Third 1) - True - Shapers
+0x018A0 (Blue Tunnel Right Third 1) - True - Shapers & Symmetry
+0x00A72 (Blue Tunnel Left Fourth 1) - True - Shapers & Negative Shapers
+0x32962 (First Floor Left) - True - Rotated Shapers & Shapers
+0x32966 (First Floor Grounded) - True - Stars & Black/White Squares
+0x01A31 (First Floor Middle) - True - Colored Squares
+0x00B71 (First Floor Right) - True - Colored Squares & Stars + Same Colored Symbol & Eraser
+0x288EA (First Wooden Beam) - True - Rotated Shapers
+0x288FC (Second Wooden Beam) - True - Black/White Squares & Shapers & Rotated Shapers
+0x289E7 (Third Wooden Beam) - True - Black/White Squares
+0x288AA (Fourth Wooden Beam) - True - Black/White Squares & Shapers
+0x17FB9 (Left Upstairs Single) - True - Dots
+0x0A16B (Left Upstairs Left Row 1) - True - Full Dots
+0x0A2CE (Left Upstairs Left Row 2) - 0x0A16B - Full Dots
+0x0A2D7 (Left Upstairs Left Row 3) - 0x0A2CE - Full Dots
+0x0A2DD (Left Upstairs Left Row 4) - 0x0A2D7 - Full Dots
+0x0A2EA (Left Upstairs Left Row 5) - 0x0A2DD - Full Dots
+0x0008F (Right Upstairs Left Row 1) - True - Dots
+0x0006B (Right Upstairs Left Row 2) - 0x0008F - Dots
+0x0008B (Right Upstairs Left Row 3) - 0x0006B - Dots
+0x0008C (Right Upstairs Left Row 4) - 0x0008B - Dots
+0x0008A (Right Upstairs Left Row 5) - 0x0008C - Dots
+0x00089 (Right Upstairs Left Row 6) - 0x0008A - Dots
+0x0006A (Right Upstairs Left Row 7) - 0x00089 - Dots
+0x0006C (Right Upstairs Left Row 8) - 0x0006A - Dots
+0x00027 (Right Upstairs Right Row 1) - True - Dots & Symmetry
+0x00028 (Right Upstairs Right Row 2) - 0x00027 - Dots & Symmetry
+0x00029 (Right Upstairs Right Row 3) - 0x00028 - Dots & Symmetry
+0x09DD5 (Lone Pillar) - True - Triangles
 Door - 0x019A5 (Pillar Door) - 0x09DD5
-158449 - 0x021D7 (Mountain Shortcut Panel) - True - Stars
+0x021D7 (Mountain Shortcut Panel) - True - Stars
 Door - 0x2D73F (Mountain Shortcut Door) - 0x021D7
-158450 - 0x17CF2 (Swamp Shortcut Panel) - True - Triangles
+0x17CF2 (Swamp Shortcut Panel) - True - Triangles
 Door - 0x2D859 (Swamp Shortcut Door) - 0x17CF2
-159341 - 0x3397C (Skylight EP) - True - True
+0x3397C (Skylight EP) - True - True
 
 Caves Path to Challenge (Caves) - Challenge - 0x0A19A:
-158477 - 0x0A16E (Challenge Entry Panel) - True - Shapers & Stars + Same Colored Symbol
+0x0A16E (Challenge Entry Panel) - True - Shapers & Stars + Same Colored Symbol
 Door - 0x0A19A (Challenge Entry) - 0x0A16E
 
 ==Challenge==
 
 Challenge (Challenge) - Tunnels - 0x0348A - Challenge Vault - 0x04D75:
-158499 - 0x0A332 (Start Timer) - 11 Lasers - True
-158500 - 0x0088E (Small Basic) - 0x0A332 - True
-158501 - 0x00BAF (Big Basic) - 0x0088E - True
-158502 - 0x00BF3 (Square) - 0x00BAF - Black/White Squares
-158503 - 0x00C09 (Maze Map) - 0x00BF3 - Dots
-158504 - 0x00CDB (Stars and Dots) - 0x00C09 - Stars & Dots
-158505 - 0x0051F (Symmetry) - 0x00CDB - Symmetry & Colored Dots & Dots
-158506 - 0x00524 (Stars and Shapers) - 0x0051F - Stars & Shapers
-158507 - 0x00CD4 (Big Basic 2) - 0x00524 - True
-158508 - 0x00CB9 (Choice Squares Right) - 0x00CD4 - Black/White Squares
-158509 - 0x00CA1 (Choice Squares Middle) - 0x00CD4 - Black/White Squares
-158510 - 0x00C80 (Choice Squares Left) - 0x00CD4 - Black/White Squares
-158511 - 0x00C68 (Choice Squares 2 Right) - 0x00CB9 | 0x00CA1 | 0x00C80 - Black/White Squares & Colored Squares
-158512 - 0x00C59 (Choice Squares 2 Middle) - 0x00CB9 | 0x00CA1 | 0x00C80 - Black/White Squares & Colored Squares
-158513 - 0x00C22 (Choice Squares 2 Left) - 0x00CB9 | 0x00CA1 | 0x00C80 - Black/White Squares & Colored Squares
-158514 - 0x034F4 (Maze Hidden 1) - 0x00C68 | 0x00C59 | 0x00C22 - Triangles
-158515 - 0x034EC (Maze Hidden 2) - 0x00C68 | 0x00C59 | 0x00C22 - Triangles
-158516 - 0x1C31A (Dots Pillar) - 0x034F4 & 0x034EC - Dots & Symmetry
-158517 - 0x1C319 (Squares Pillar) - 0x034F4 & 0x034EC - Black/White Squares & Symmetry
+0x0A332 (Start Timer) - 11 Lasers - True
+0x0088E (Small Basic) - 0x0A332 - True
+0x00BAF (Big Basic) - 0x0088E - True
+0x00BF3 (Square) - 0x00BAF - Black/White Squares
+0x00C09 (Maze Map) - 0x00BF3 - Dots
+0x00CDB (Stars and Dots) - 0x00C09 - Stars & Dots
+0x0051F (Symmetry) - 0x00CDB - Symmetry & Colored Dots & Dots
+0x00524 (Stars and Shapers) - 0x0051F - Stars & Shapers
+0x00CD4 (Big Basic 2) - 0x00524 - True
+0x00CB9 (Choice Squares Right) - 0x00CD4 - Black/White Squares
+0x00CA1 (Choice Squares Middle) - 0x00CD4 - Black/White Squares
+0x00C80 (Choice Squares Left) - 0x00CD4 - Black/White Squares
+0x00C68 (Choice Squares 2 Right) - 0x00CB9 | 0x00CA1 | 0x00C80 - Black/White Squares & Colored Squares
+0x00C59 (Choice Squares 2 Middle) - 0x00CB9 | 0x00CA1 | 0x00C80 - Black/White Squares & Colored Squares
+0x00C22 (Choice Squares 2 Left) - 0x00CB9 | 0x00CA1 | 0x00C80 - Black/White Squares & Colored Squares
+0x034F4 (Maze Hidden 1) - 0x00C68 | 0x00C59 | 0x00C22 - Triangles
+0x034EC (Maze Hidden 2) - 0x00C68 | 0x00C59 | 0x00C22 - Triangles
+0x1C31A (Dots Pillar) - 0x034F4 & 0x034EC - Dots & Symmetry
+0x1C319 (Squares Pillar) - 0x034F4 & 0x034EC - Black/White Squares & Symmetry
 Door - 0x04D75 (Vault Door) - 0x1C31A & 0x1C319
-158518 - 0x039B4 (Tunnels Entry Panel) - True - Triangles
+0x039B4 (Tunnels Entry Panel) - True - Triangles
 Door - 0x0348A (Tunnels Entry) - 0x039B4
-159530 - 0x28B30 (Water EP) - True - True
+0x28B30 (Water EP) - True - True
 
 Challenge Vault (Challenge):
-158667 - 0x0356B (Vault Box) - 0x1C31A & 0x1C319 - True
+0x0356B (Vault Box) - 0x1C31A & 0x1C319 - True
 
 ==Tunnels==
 
 Tunnels (Tunnels) - Windmill Interior - 0x27739 - Desert Behind Elevator - 0x27263 - Town - 0x09E87:
-158668 - 0x2FAF6 (Vault Box) - True - True
-158519 - 0x27732 (Theater Shortcut Panel) - True - True
+0x2FAF6 (Vault Box) - True - True
+0x27732 (Theater Shortcut Panel) - True - True
 Door - 0x27739 (Theater Shortcut) - 0x27732
-158520 - 0x2773D (Desert Shortcut Panel) - True - True
+0x2773D (Desert Shortcut Panel) - True - True
 Door - 0x27263 (Desert Shortcut) - 0x2773D
-158521 - 0x09E85 (Town Shortcut Panel) - True - Triangles
+0x09E85 (Town Shortcut Panel) - True - Triangles
 Door - 0x09E87 (Town Shortcut) - 0x09E85
-159557 - 0x33A20 (Theater Flowers EP) - 0x03553 & Theater to Tunnels - True
+0x33A20 (Theater Flowers EP) - 0x03553 & Theater to Tunnels - True
 
 ==Boat==
 
 The Ocean (Boat) - Main Island - TrueOneWay - Swamp Near Boat - TrueOneWay - Treehouse Entry Area - TrueOneWay - Quarry Boathouse Behind Staircase - TrueOneWay - Inside Glass Factory Behind Back Wall - TrueOneWay:
-159042 - 0x22106 (Desert EP) - True - True
-159223 - 0x03B25 (Shipwreck CCW Underside EP) - True - True
-159231 - 0x28B29 (Shipwreck Green EP) - True - True
-159232 - 0x28B2A (Shipwreck CW Underside EP) - True - True
-159323 - 0x03D0D (Bunker Yellow Line EP) - True - True
-159515 - 0x28A37 (Town Long Sewer EP) - True - True
-159520 - 0x33857 (Tutorial EP) - True - True
-159521 - 0x33879 (Tutorial Reflection EP) - True - True
-159522 - 0x03C19 (Tutorial Moss EP) - True - True
-159531 - 0x035C9 (Cargo Box EP) - 0x0A0C9 - True
+0x22106 (Desert EP) - True - True
+0x03B25 (Shipwreck CCW Underside EP) - True - True
+0x28B29 (Shipwreck Green EP) - True - True
+0x28B2A (Shipwreck CW Underside EP) - True - True
+0x03D0D (Bunker Yellow Line EP) - True - True
+0x28A37 (Town Long Sewer EP) - True - True
+0x33857 (Tutorial EP) - True - True
+0x33879 (Tutorial Reflection EP) - True - True
+0x03C19 (Tutorial Moss EP) - True - True
+0x035C9 (Cargo Box EP) - 0x0A0C9 - True
 
 ==Easter Eggs==
 

--- a/worlds/witness/data/WitnessLogicVariety.txt
+++ b/worlds/witness/data/WitnessLogicVariety.txt
@@ -3,237 +3,237 @@
 Entry (Entry):
 
 Tutorial First Hallway (Tutorial First Hallway) - Entry - True - Tutorial First Hallway Room - 0x00064:
-158000 - 0x00064 (Straight) - True - True
-159510 - 0x01848 (EP) - 0x00064 - True
+0x00064 (Straight) - True - True
+0x01848 (EP) - 0x00064 - True
 
 Tutorial First Hallway Room (Tutorial First Hallway) - Tutorial - 0x00182:
-158001 - 0x00182 (Bend) - True - True
+0x00182 (Bend) - True - True
 
 Tutorial (Tutorial) - Outside Tutorial - True:
-158002 - 0x00293 (Front Center) - True - Dots
-158003 - 0x00295 (Center Left) - 0x00293 - Black/White Squares & Colored Squares
-158004 - 0x002C2 (Front Left) - 0x00295 - Stars
-158005 - 0x0A3B5 (Back Left) - True - True
-158006 - 0x0A3B2 (Back Right) - True - True
-158007 - 0x03629 (Gate Open) - 0x002C2 & 0x0A3B5 & 0x0A3B2 - True
-158008 - 0x03505 (Gate Close) - 0x2FAF6 & 0x03629 - True
-158009 - 0x0C335 (Pillar) - True - Triangles
-158010 - 0x0C373 (Patio Floor) - 0x0C335 - Dots
-159512 - 0x33530 (Cloud EP) - True - True
-159513 - 0x33600 (Patio Flowers EP) - 0x0C373 - True
-159517 - 0x3352F (Gate EP) - 0x03505 - True
+0x00293 (Front Center) - True - Dots
+0x00295 (Center Left) - 0x00293 - Black/White Squares & Colored Squares
+0x002C2 (Front Left) - 0x00295 - Stars
+0x0A3B5 (Back Left) - True - True
+0x0A3B2 (Back Right) - True - True
+0x03629 (Gate Open) - 0x002C2 & 0x0A3B5 & 0x0A3B2 - True
+0x03505 (Gate Close) - 0x2FAF6 & 0x03629 - True
+0x0C335 (Pillar) - True - Triangles
+0x0C373 (Patio Floor) - 0x0C335 - Dots
+0x33530 (Cloud EP) - True - True
+0x33600 (Patio Flowers EP) - 0x0C373 - True
+0x3352F (Gate EP) - 0x03505 - True
 
 ==Tutorial (Outside)==
 
 Outside Tutorial (Outside Tutorial) - Outside Tutorial Path To Outpost - 0x03BA2 - Outside Tutorial Vault - 0x033D0:
-158650 - 0x033D4 (Vault Panel) - True - Dots & Black/White Squares & Colored Squares & Symmetry
+0x033D4 (Vault Panel) - True - Dots & Black/White Squares & Colored Squares & Symmetry
 Door - 0x033D0 (Vault Door) - 0x033D4
-158013 - 0x0005D (Shed Row 1) - True - Full Dots & Black/White Squares & Colored Squares
-158014 - 0x0005E (Shed Row 2) - 0x0005D - Full Dots & Stars
-158015 - 0x0005F (Shed Row 3) - 0x0005E - Full Dots & Shapers & Negative Shapers
-158016 - 0x00060 (Shed Row 4) - 0x0005F - Full Dots & Black/White Squares & Stars + Same Colored Symbol & Eraser
-158017 - 0x00061 (Shed Row 5) - 0x00060 - Full Dots & Triangles
-158018 - 0x018AF (Tree Row 1) - True - Arrows
-158019 - 0x0001B (Tree Row 2) - 0x018AF - Arrows
-158020 - 0x012C9 (Tree Row 3) - 0x0001B - Arrows
-158021 - 0x0001C (Tree Row 4) - 0x012C9 - Arrows & Black/White Squares & Colored Squares
-158022 - 0x0001D (Tree Row 5) - 0x0001C - Arrows & Black/White Squares & Colored Squares
-158023 - 0x0001E (Tree Row 6) - 0x0001D - Arrows & Black/White Squares & Colored Squares
-158024 - 0x0001F (Tree Row 7) - 0x0001E - Arrows & Black/White Squares & Colored Squares
-158025 - 0x00020 (Tree Row 8) - 0x0001F - Arrows & Black/White Squares & Colored Squares
-158026 - 0x00021 (Tree Row 9) - 0x00020 - Arrows & Black/White Squares & Colored Squares
+0x0005D (Shed Row 1) - True - Full Dots & Black/White Squares & Colored Squares
+0x0005E (Shed Row 2) - 0x0005D - Full Dots & Stars
+0x0005F (Shed Row 3) - 0x0005E - Full Dots & Shapers & Negative Shapers
+0x00060 (Shed Row 4) - 0x0005F - Full Dots & Black/White Squares & Stars + Same Colored Symbol & Eraser
+0x00061 (Shed Row 5) - 0x00060 - Full Dots & Triangles
+0x018AF (Tree Row 1) - True - Arrows
+0x0001B (Tree Row 2) - 0x018AF - Arrows
+0x012C9 (Tree Row 3) - 0x0001B - Arrows
+0x0001C (Tree Row 4) - 0x012C9 - Arrows & Black/White Squares & Colored Squares
+0x0001D (Tree Row 5) - 0x0001C - Arrows & Black/White Squares & Colored Squares
+0x0001E (Tree Row 6) - 0x0001D - Arrows & Black/White Squares & Colored Squares
+0x0001F (Tree Row 7) - 0x0001E - Arrows & Black/White Squares & Colored Squares
+0x00020 (Tree Row 8) - 0x0001F - Arrows & Black/White Squares & Colored Squares
+0x00021 (Tree Row 9) - 0x00020 - Arrows & Black/White Squares & Colored Squares
 Door - 0x03BA2 (Outpost Path) - 0x0A3B5
-159511 - 0x03D06 (Garden EP) - True - True
-159514 - 0x28A2F (Town Sewer EP) - True - True
-159516 - 0x334A3 (Path EP) - True - True
-159500 - 0x035C7 (Tractor EP) - True - True
+0x03D06 (Garden EP) - True - True
+0x28A2F (Town Sewer EP) - True - True
+0x334A3 (Path EP) - True - True
+0x035C7 (Tractor EP) - True - True
 
 Outside Tutorial Vault (Outside Tutorial):
-158651 - 0x03481 (Vault Box) - True - True
+0x03481 (Vault Box) - True - True
 
 Outside Tutorial Path To Outpost (Outside Tutorial) - Outside Tutorial Outpost - 0x0A170:
-158011 - 0x0A171 (Outpost Entry Panel) - True - Full Dots & Triangles & Black/White Squares
+0x0A171 (Outpost Entry Panel) - True - Full Dots & Triangles & Black/White Squares
 Door - 0x0A170 (Outpost Entry) - 0x0A171
 
 Outside Tutorial Outpost (Outside Tutorial) - Outside Tutorial - 0x04CA3:
-158012 - 0x04CA4 (Outpost Exit Panel) - True - Full Dots & Triangles & Black/White Squares
+0x04CA4 (Outpost Exit Panel) - True - Full Dots & Triangles & Black/White Squares
 Door - 0x04CA3 (Outpost Exit) - 0x04CA4
-158600 - 0x17CFB (Discard) - True - Arrows & Triangles
+0x17CFB (Discard) - True - Arrows & Triangles
 
 Orchard (Orchard) - Main Island - True - Orchard Beyond First Gate - 0x03307:
-158071 - 0x00143 (Apple Tree 1) - True - True
-158072 - 0x0003B (Apple Tree 2) - 0x00143 - True
-158073 - 0x00055 (Apple Tree 3) - 0x0003B - True
+0x00143 (Apple Tree 1) - True - True
+0x0003B (Apple Tree 2) - 0x00143 - True
+0x00055 (Apple Tree 3) - 0x0003B - True
 Door - 0x03307 (First Gate) - 0x00055
 
 Orchard Beyond First Gate (Orchard) - Orchard End - 0x03313:
-158074 - 0x032F7 (Apple Tree 4) - 0x00055 - True
-158075 - 0x032FF (Apple Tree 5) - 0x032F7 - True
+0x032F7 (Apple Tree 4) - 0x00055 - True
+0x032FF (Apple Tree 5) - 0x032F7 - True
 Door - 0x03313 (Second Gate) - 0x032FF
 
 Orchard End (Orchard):
 
 Main Island (Main Island) - Outside Tutorial - True:
-159801 - 0xFFD00 (Reached Independently) - True - True
+0xFFD00 (Reached Independently) - True - True
 
 ==Glass Factory==
 
 Outside Glass Factory (Glass Factory) - Main Island - True - Inside Glass Factory - 0x01A29:
-158027 - 0x01A54 (Entry Panel) - True - Symmetry
+0x01A54 (Entry Panel) - True - Symmetry
 Door - 0x01A29 (Entry) - 0x01A54
-158601 - 0x3C12B (Discard) - True - Arrows & Triangles
-159002 - 0x28B8A (Vase EP) - 0x01A54 - True
+0x3C12B (Discard) - True - Arrows & Triangles
+0x28B8A (Vase EP) - 0x01A54 - True
 
 Inside Glass Factory (Glass Factory) - Inside Glass Factory Behind Back Wall - 0x0D7ED:
-158028 - 0x00086 (Back Wall 1) - True - Symmetry
-158029 - 0x00087 (Back Wall 2) - 0x00086 - Symmetry
-158030 - 0x00059 (Back Wall 3) - 0x00087 - Symmetry
-158031 - 0x00062 (Back Wall 4) - 0x00059 - Symmetry
-158032 - 0x0005C (Back Wall 5) - 0x00062 - Symmetry
-158033 - 0x0008D (Front 1) - 0x0005C - Symmetry & Dots
-158034 - 0x00081 (Front 2) - 0x0008D - Symmetry & Dots
-158035 - 0x00083 (Front 3) - 0x00081 - Symmetry & Dots
-158036 - 0x00084 (Melting 1) - 0x00083 - Symmetry & Dots
-158037 - 0x00082 (Melting 2) - 0x00084 - Symmetry & Dots
-158038 - 0x0343A (Melting 3) - 0x00082 - Symmetry & Dots
+0x00086 (Back Wall 1) - True - Symmetry
+0x00087 (Back Wall 2) - 0x00086 - Symmetry
+0x00059 (Back Wall 3) - 0x00087 - Symmetry
+0x00062 (Back Wall 4) - 0x00059 - Symmetry
+0x0005C (Back Wall 5) - 0x00062 - Symmetry
+0x0008D (Front 1) - 0x0005C - Symmetry & Dots
+0x00081 (Front 2) - 0x0008D - Symmetry & Dots
+0x00083 (Front 3) - 0x00081 - Symmetry & Dots
+0x00084 (Melting 1) - 0x00083 - Symmetry & Dots
+0x00082 (Melting 2) - 0x00084 - Symmetry & Dots
+0x0343A (Melting 3) - 0x00082 - Symmetry & Dots
 Door - 0x0D7ED (Back Wall) - 0x0005C
 
 Inside Glass Factory Behind Back Wall (Glass Factory) - The Ocean - 0x17CC8:
-158039 - 0x17CC8 (Boat Spawn) - 0x17CA6 | 0x17CDF | 0x09DB8 | 0x17C95 - Boat
+0x17CC8 (Boat Spawn) - 0x17CA6 | 0x17CDF | 0x09DB8 | 0x17C95 - Boat
 
 ==Symmetry Island==
 
 Outside Symmetry Island (Symmetry Island) - Main Island - True - Symmetry Island Lower - 0x17F3E:
-158040 - 0x000B0 (Lower Panel) - 0x0343A - Dots
+0x000B0 (Lower Panel) - 0x0343A - Dots
 Door - 0x17F3E (Lower) - 0x000B0
 
 Symmetry Island Lower (Symmetry Island) - Symmetry Island Upper - 0x18269:
-158041 - 0x00022 (Right 1) - True - Symmetry & Full Dots & Triangles
-158042 - 0x00023 (Right 2) - 0x00022 - Symmetry & Full Dots & Triangles
-158043 - 0x00024 (Right 3) - 0x00023 - Symmetry & Full Dots & Triangles
-158044 - 0x00025 (Right 4) - 0x00024 - Symmetry & Full Dots & Triangles
-158045 - 0x00026 (Right 5) - 0x00025 - Symmetry & Full Dots & Triangles
-158046 - 0x0007C (Back 1) - 0x00026 - Symmetry & Dots & Colored Dots
-158047 - 0x0007E (Back 2) - 0x0007C - Symmetry & Dots & Colored Dots
-158048 - 0x00075 (Back 3) - 0x0007E - Symmetry & Dots & Colored Dots
-158049 - 0x00073 (Back 4) - 0x00075 - Symmetry & Dots & Colored Dots & Eraser
-158050 - 0x00077 (Back 5) - 0x00073 - Symmetry & Dots & Colored Dots & Eraser
-158051 - 0x00079 (Back 6) - 0x00077 - Symmetry & Dots & Colored Dots & Eraser
-158052 - 0x00065 (Left 1) - 0x00079 - Symmetry & Dots & Colored Dots
-158053 - 0x0006D (Left 2) - 0x00065 - Symmetry & Colored Squares
-158054 - 0x00072 (Left 3) - 0x0006D - Symmetry & Stars
-158055 - 0x0006F (Left 4) - 0x00072 - Symmetry & Stars + Same Colored Symbol & Colored Squares
-158056 - 0x00070 (Left 5) - 0x0006F - Symmetry & Stars + Same Colored Symbol & Colored Squares
-158057 - 0x00071 (Left 6) - 0x00070 - Symmetry & Colored Dots & Eraser
-158058 - 0x00076 (Left 7) - 0x00071 - Symmetry & Dots & Eraser
-158059 - 0x009B8 (Scenery Outlines 1) - True - Symmetry
-158060 - 0x003E8 (Scenery Outlines 2) - 0x009B8 - Symmetry
-158061 - 0x00A15 (Scenery Outlines 3) - 0x003E8 - Symmetry
-158062 - 0x00B53 (Scenery Outlines 4) - 0x00A15 - Symmetry
-158063 - 0x00B8D (Scenery Outlines 5) - 0x00B53 - Symmetry
-158064 - 0x1C349 (Upper Panel) - 0x00076 - Symmetry & Dots
+0x00022 (Right 1) - True - Symmetry & Full Dots & Triangles
+0x00023 (Right 2) - 0x00022 - Symmetry & Full Dots & Triangles
+0x00024 (Right 3) - 0x00023 - Symmetry & Full Dots & Triangles
+0x00025 (Right 4) - 0x00024 - Symmetry & Full Dots & Triangles
+0x00026 (Right 5) - 0x00025 - Symmetry & Full Dots & Triangles
+0x0007C (Back 1) - 0x00026 - Symmetry & Dots & Colored Dots
+0x0007E (Back 2) - 0x0007C - Symmetry & Dots & Colored Dots
+0x00075 (Back 3) - 0x0007E - Symmetry & Dots & Colored Dots
+0x00073 (Back 4) - 0x00075 - Symmetry & Dots & Colored Dots & Eraser
+0x00077 (Back 5) - 0x00073 - Symmetry & Dots & Colored Dots & Eraser
+0x00079 (Back 6) - 0x00077 - Symmetry & Dots & Colored Dots & Eraser
+0x00065 (Left 1) - 0x00079 - Symmetry & Dots & Colored Dots
+0x0006D (Left 2) - 0x00065 - Symmetry & Colored Squares
+0x00072 (Left 3) - 0x0006D - Symmetry & Stars
+0x0006F (Left 4) - 0x00072 - Symmetry & Stars + Same Colored Symbol & Colored Squares
+0x00070 (Left 5) - 0x0006F - Symmetry & Stars + Same Colored Symbol & Colored Squares
+0x00071 (Left 6) - 0x00070 - Symmetry & Colored Dots & Eraser
+0x00076 (Left 7) - 0x00071 - Symmetry & Dots & Eraser
+0x009B8 (Scenery Outlines 1) - True - Symmetry
+0x003E8 (Scenery Outlines 2) - 0x009B8 - Symmetry
+0x00A15 (Scenery Outlines 3) - 0x003E8 - Symmetry
+0x00B53 (Scenery Outlines 4) - 0x00A15 - Symmetry
+0x00B8D (Scenery Outlines 5) - 0x00B53 - Symmetry
+0x1C349 (Upper Panel) - 0x00076 - Symmetry & Dots
 Door - 0x18269 (Upper) - 0x1C349
-159000 - 0x0332B (Glass Factory Black Line Reflection EP) - True - True
+0x0332B (Glass Factory Black Line Reflection EP) - True - True
 
 Symmetry Island Upper (Symmetry Island):
-158065 - 0x00A52 (Laser Yellow 1) - True - Colored Dots
-158066 - 0x00A57 (Laser Yellow 2) - 0x00A52 - Colored Dots
-158067 - 0x00A5B (Laser Yellow 3) - 0x00A57 - Colored Dots
-158068 - 0x00A61 (Laser Blue 1) - 0x00A52 - Colored Dots
-158069 - 0x00A64 (Laser Blue 2) - 0x00A61 & 0x00A57 - Colored Dots
-158070 - 0x00A68 (Laser Blue 3) - 0x00A64 & 0x00A5B - Colored Dots
-158700 - 0x0360D (Laser Panel) - 0x00A68 - True
+0x00A52 (Laser Yellow 1) - True - Colored Dots
+0x00A57 (Laser Yellow 2) - 0x00A52 - Colored Dots
+0x00A5B (Laser Yellow 3) - 0x00A57 - Colored Dots
+0x00A61 (Laser Blue 1) - 0x00A52 - Colored Dots
+0x00A64 (Laser Blue 2) - 0x00A61 & 0x00A57 - Colored Dots
+0x00A68 (Laser Blue 3) - 0x00A64 & 0x00A5B - Colored Dots
+0x0360D (Laser Panel) - 0x00A68 - True
 Laser - 0x00509 (Laser) - 0x0360D
-159001 - 0x03367 (Glass Factory Black Line EP) - True - True
+0x03367 (Glass Factory Black Line EP) - True - True
 
 ==Desert==
 
 Desert Obelisk (Desert) - Entry - True:
-159700 - 0xFFE00 (Obelisk Side 1) - 0x0332B & 0x03367 & 0x28B8A - True
-159701 - 0xFFE01 (Obelisk Side 2) - 0x037B6 & 0x037B2 & 0x000F7 - True
-159702 - 0xFFE02 (Obelisk Side 3) - 0x3351D - True
-159703 - 0xFFE03 (Obelisk Side 4) - 0x0053C & 0x00771 & 0x335C8 & 0x335C9 & 0x337F8 & 0x037BB & 0x220E4 & 0x220E5 - True
-159704 - 0xFFE04 (Obelisk Side 5) - 0x334B9 & 0x334BC & 0x22106 & 0x0A14C & 0x0A14D - True
-159709 - 0x00359 (Obelisk) - True - True
+0xFFE00 (Obelisk Side 1) - 0x0332B & 0x03367 & 0x28B8A - True
+0xFFE01 (Obelisk Side 2) - 0x037B6 & 0x037B2 & 0x000F7 - True
+0xFFE02 (Obelisk Side 3) - 0x3351D - True
+0xFFE03 (Obelisk Side 4) - 0x0053C & 0x00771 & 0x335C8 & 0x335C9 & 0x337F8 & 0x037BB & 0x220E4 & 0x220E5 - True
+0xFFE04 (Obelisk Side 5) - 0x334B9 & 0x334BC & 0x22106 & 0x0A14C & 0x0A14D - True
+0x00359 (Obelisk) - True - True
 
 Desert Outside (Desert) - Main Island - True - Desert Light Room - 0x09FEE - Desert Vault - 0x03444:
-158652 - 0x0CC7B (Vault Panel) - True - Full Dots & Rotated Shapers & Negative Shapers & Stars + Same Colored Symbol
+0x0CC7B (Vault Panel) - True - Full Dots & Rotated Shapers & Negative Shapers & Stars + Same Colored Symbol
 Door - 0x03444 (Vault Door) - 0x0CC7B
-158602 - 0x17CE7 (Discard) - True - Arrows & Triangles
-158076 - 0x00698 (Surface 1) - True - True
-158077 - 0x0048F (Surface 2) - 0x00698 - True
-158078 - 0x09F92 (Surface 3) - 0x0048F & 0x09FA0 - True
-158079 - 0x09FA0 (Surface 3 Control) - 0x0048F - True
-158080 - 0x0A036 (Surface 4) - 0x09F92 - True
-158081 - 0x09DA6 (Surface 5) - 0x09F92 - True
-158082 - 0x0A049 (Surface 6) - 0x09F92 - True
-158083 - 0x0A053 (Surface 7) - 0x0A036 & 0x09DA6 & 0x0A049 - True
-158084 - 0x09F94 (Surface 8) - 0x0A053 & 0x09F86 - True
-158085 - 0x09F86 (Surface 8 Control) - 0x0A053 - True
-158086 - 0x0C339 (Light Room Entry Panel) - 0x09F94 - True
+0x17CE7 (Discard) - True - Arrows & Triangles
+0x00698 (Surface 1) - True - True
+0x0048F (Surface 2) - 0x00698 - True
+0x09F92 (Surface 3) - 0x0048F & 0x09FA0 - True
+0x09FA0 (Surface 3 Control) - 0x0048F - True
+0x0A036 (Surface 4) - 0x09F92 - True
+0x09DA6 (Surface 5) - 0x09F92 - True
+0x0A049 (Surface 6) - 0x09F92 - True
+0x0A053 (Surface 7) - 0x0A036 & 0x09DA6 & 0x0A049 - True
+0x09F94 (Surface 8) - 0x0A053 & 0x09F86 - True
+0x09F86 (Surface 8 Control) - 0x0A053 - True
+0x0C339 (Light Room Entry Panel) - 0x09F94 - True
 Door - 0x09FEE (Light Room Entry) - 0x0C339
-158701 - 0x03608 (Laser Panel) - 0x012D7 & 0x0A15F - True
+0x03608 (Laser Panel) - 0x012D7 & 0x0A15F - True
 Laser - 0x012FB (Laser) - 0x03608
-159804 - 0xFFD03 (Laser Activated + Redirected) - 0x09F98 & 0x012FB - True
-159020 - 0x3351D (Sand Snake EP) - True - True
-159030 - 0x0053C (Facade Right EP) - True - True
-159031 - 0x00771 (Facade Left EP) - True - True
-159032 - 0x335C8 (Stairs Left EP) - True - True
-159033 - 0x335C9 (Stairs Right EP) - True - True
-159036 - 0x220E4 (Broken Wall Straight EP) - True - True
-159037 - 0x220E5 (Broken Wall Bend EP) - True - True
-159040 - 0x334B9 (Shore EP) - True - True
-159041 - 0x334BC (Island EP) - True - True
+0xFFD03 (Laser Activated + Redirected) - 0x09F98 & 0x012FB - True
+0x3351D (Sand Snake EP) - True - True
+0x0053C (Facade Right EP) - True - True
+0x00771 (Facade Left EP) - True - True
+0x335C8 (Stairs Left EP) - True - True
+0x335C9 (Stairs Right EP) - True - True
+0x220E4 (Broken Wall Straight EP) - True - True
+0x220E5 (Broken Wall Bend EP) - True - True
+0x334B9 (Shore EP) - True - True
+0x334BC (Island EP) - True - True
 
 Desert Vault (Desert):
-158653 - 0x0339E (Vault Box) - True - True
+0x0339E (Vault Box) - True - True
 
 Desert Light Room (Desert) - Desert Pond Room - 0x0C2C3:
-158087 - 0x09FAA (Light Control) - True - True
-158088 - 0x00422 (Light Room 1) - 0x09FAA - True
-158089 - 0x006E3 (Light Room 2) - 0x09FAA - True
-158090 - 0x0A02D (Light Room 3) - 0x09FAA & 0x00422 & 0x006E3 - True
+0x09FAA (Light Control) - True - True
+0x00422 (Light Room 1) - 0x09FAA - True
+0x006E3 (Light Room 2) - 0x09FAA - True
+0x0A02D (Light Room 3) - 0x09FAA & 0x00422 & 0x006E3 - True
 Door - 0x0C2C3 (Pond Room Entry) - 0x0A02D
 
 Desert Pond Room (Desert) - Desert Flood Room - 0x0A24B:
-158091 - 0x00C72 (Pond Room 1) - True - True
-158092 - 0x0129D (Pond Room 2) - 0x00C72 - True
-158093 - 0x008BB (Pond Room 3) - 0x0129D - True
-158094 - 0x0078D (Pond Room 4) - 0x008BB - True
-158095 - 0x18313 (Pond Room 5) - 0x0078D - True
-158096 - 0x0A249 (Flood Room Entry Panel) - 0x18313 - True
+0x00C72 (Pond Room 1) - True - True
+0x0129D (Pond Room 2) - 0x00C72 - True
+0x008BB (Pond Room 3) - 0x0129D - True
+0x0078D (Pond Room 4) - 0x008BB - True
+0x18313 (Pond Room 5) - 0x0078D - True
+0x0A249 (Flood Room Entry Panel) - 0x18313 - True
 Door - 0x0A24B (Flood Room Entry) - 0x0A249
-159043 - 0x0A14C (Pond Room Near Reflection EP) - True - True
-159044 - 0x0A14D (Pond Room Far Reflection EP) - True - True
+0x0A14C (Pond Room Near Reflection EP) - True - True
+0x0A14D (Pond Room Far Reflection EP) - True - True
 
 Desert Flood Room (Desert) - Desert Elevator Room - 0x0C316 - Desert Flood Room Underwater - 0x1C260:
-158097 - 0x1C2DF (Reduce Water Level Far Left) - True - True
-158098 - 0x1831E (Reduce Water Level Far Right) - True - True
-158099 - 0x1C260 (Reduce Water Level Near Left) - True - True
-158100 - 0x1831C (Reduce Water Level Near Right) - True - True
-158101 - 0x1C2F3 (Raise Water Level Far Left) - True - True
-158102 - 0x1831D (Raise Water Level Far Right) - True - True
-158103 - 0x1C2B1 (Raise Water Level Near Left) - True - True
-158104 - 0x1831B (Raise Water Level Near Right) - True - True
-158105 - 0x04D18 (Flood Room 1) - 0x1C260 & 0x1831C - True
-158106 - 0x01205 (Flood Room 2) - 0x04D18 & 0x1C260 & 0x1831C - True
-158107 - 0x181AB (Flood Room 3) - 0x01205 & 0x1C260 & 0x1831C - True
-158108 - 0x0117A (Flood Room 4) - 0x181AB & 0x1C260 & 0x1831C - True
-158109 - 0x17ECA (Flood Room 5) - 0x0117A & 0x1C260 & 0x1831C - True
-158110 - 0x18076 (Flood Room 6) - 0x17ECA & 0x1C260 & 0x1831C - True
+0x1C2DF (Reduce Water Level Far Left) - True - True
+0x1831E (Reduce Water Level Far Right) - True - True
+0x1C260 (Reduce Water Level Near Left) - True - True
+0x1831C (Reduce Water Level Near Right) - True - True
+0x1C2F3 (Raise Water Level Far Left) - True - True
+0x1831D (Raise Water Level Far Right) - True - True
+0x1C2B1 (Raise Water Level Near Left) - True - True
+0x1831B (Raise Water Level Near Right) - True - True
+0x04D18 (Flood Room 1) - 0x1C260 & 0x1831C - True
+0x01205 (Flood Room 2) - 0x04D18 & 0x1C260 & 0x1831C - True
+0x181AB (Flood Room 3) - 0x01205 & 0x1C260 & 0x1831C - True
+0x0117A (Flood Room 4) - 0x181AB & 0x1C260 & 0x1831C - True
+0x17ECA (Flood Room 5) - 0x0117A & 0x1C260 & 0x1831C - True
+0x18076 (Flood Room 6) - 0x17ECA & 0x1C260 & 0x1831C - True
 Door - 0x0C316 (Elevator Room Entry) - 0x18076
-159034 - 0x337F8 (Flood Room EP) - 0x1C2DF - True
+0x337F8 (Flood Room EP) - 0x1C2DF - True
 
 Desert Flood Room Underwater (Desert):
 
 Desert Elevator Room (Desert) - Desert Behind Elevator - 0x01317:
-158111 - 0x17C31 (Elevator Room Transparent) - True - True
-158113 - 0x012D7 (Elevator Room Hexagonal) - 0x17C31 & 0x0A015 - True
-158114 - 0x0A015 (Elevator Room Hexagonal Control) - 0x17C31 - True
-158115 - 0x0A15C (Elevator Room Bent 1) - True - True
-158116 - 0x09FFF (Elevator Room Bent 2) - 0x0A15C - True
-158117 - 0x0A15F (Elevator Room Bent 3) - 0x09FFF - True
-159035 - 0x037BB (Elevator EP) - 0x01317 - True
+0x17C31 (Elevator Room Transparent) - True - True
+0x012D7 (Elevator Room Hexagonal) - 0x17C31 & 0x0A015 - True
+0x0A015 (Elevator Room Hexagonal Control) - 0x17C31 - True
+0x0A15C (Elevator Room Bent 1) - True - True
+0x09FFF (Elevator Room Bent 2) - 0x0A15C - True
+0x0A15F (Elevator Room Bent 3) - 0x09FFF - True
+0x037BB (Elevator EP) - 0x01317 - True
 Door - 0x01317 (Elevator) - 0x03608
 
 Desert Behind Elevator (Desert):
@@ -241,277 +241,277 @@ Desert Behind Elevator (Desert):
 ==Quarry==
 
 Quarry Obelisk (Quarry) - Entry - True:
-159740 - 0xFFE40 (Obelisk Side 1) - 0x28A7B & 0x005F6 & 0x00859 & 0x17CB9 & 0x28A4A - True
-159741 - 0xFFE41 (Obelisk Side 2) - 0x334B6 & 0x00614 & 0x0069D & 0x28A4C - True
-159742 - 0xFFE42 (Obelisk Side 3) - 0x289CF & 0x289D1 - True
-159743 - 0xFFE43 (Obelisk Side 4) - 0x33692 - True
-159744 - 0xFFE44 (Obelisk Side 5) - 0x03E77 & 0x03E7C - True
-159749 - 0x22073 (Obelisk) - True - True
+0xFFE40 (Obelisk Side 1) - 0x28A7B & 0x005F6 & 0x00859 & 0x17CB9 & 0x28A4A - True
+0xFFE41 (Obelisk Side 2) - 0x334B6 & 0x00614 & 0x0069D & 0x28A4C - True
+0xFFE42 (Obelisk Side 3) - 0x289CF & 0x289D1 - True
+0xFFE43 (Obelisk Side 4) - 0x33692 - True
+0xFFE44 (Obelisk Side 5) - 0x03E77 & 0x03E7C - True
+0x22073 (Obelisk) - True - True
 
 Outside Quarry (Quarry) - Main Island - True - Quarry Between Entry Doors - 0x09D6F - Quarry Elevator - 0xFFD00 & 0xFFD01:
-158118 - 0x09E57 (Entry 1 Panel) - True - Black/White Squares & Dots
-158603 - 0x17CF0 (Discard) - True - Arrows & Triangles
-158702 - 0x03612 (Laser Panel) - 0x0A3D0 & 0x0367C - Eraser & Shapers
+0x09E57 (Entry 1 Panel) - True - Black/White Squares & Dots
+0x17CF0 (Discard) - True - Arrows & Triangles
+0x03612 (Laser Panel) - 0x0A3D0 & 0x0367C - Eraser & Shapers
 Laser - 0x01539 (Laser) - 0x03612
 Door - 0x09D6F (Entry 1) - 0x09E57
-159404 - 0x28A4A (Shore EP) - True - True
-159410 - 0x334B6 (Entrance Pipe EP) - True - True
-159412 - 0x28A4C (Sand Pile EP) - True - True
-159420 - 0x289CF (Rock Line EP) - True - True
-159421 - 0x289D1 (Rock Line Reflection EP) - True - True
+0x28A4A (Shore EP) - True - True
+0x334B6 (Entrance Pipe EP) - True - True
+0x28A4C (Sand Pile EP) - True - True
+0x289CF (Rock Line EP) - True - True
+0x289D1 (Rock Line Reflection EP) - True - True
 
 Quarry Elevator (Quarry) - Outside Quarry - 0x17CC4 - Quarry - 0x17CC4:
-158120 - 0x17CC4 (Elevator Control) - 0x0367C - Dots & Eraser
-159403 - 0x17CB9 (Railroad EP) - 0x17CC4 - True
+0x17CC4 (Elevator Control) - 0x0367C - Dots & Eraser
+0x17CB9 (Railroad EP) - 0x17CC4 - True
 
 Quarry Between Entry Doors (Quarry) - Quarry - 0x17C07:
-158119 - 0x17C09 (Entry 2 Panel) - True - Shapers & Eraser
+0x17C09 (Entry 2 Panel) - True - Shapers & Eraser
 Door - 0x17C07 (Entry 2) - 0x17C09
 
 Quarry (Quarry) - Quarry Stoneworks Ground Floor - 0x02010:
-159802 - 0xFFD01 (Inside Reached Independently) - True - True
-158121 - 0x01E5A (Stoneworks Entry Left Panel) - True - Stars + Same Colored Symbol & Eraser
-158122 - 0x01E59 (Stoneworks Entry Right Panel) - True - Triangles
+0xFFD01 (Inside Reached Independently) - True - True
+0x01E5A (Stoneworks Entry Left Panel) - True - Stars + Same Colored Symbol & Eraser
+0x01E59 (Stoneworks Entry Right Panel) - True - Triangles
 Door - 0x02010 (Stoneworks Entry) - 0x01E59 & 0x01E5A
 
 Quarry Stoneworks Ground Floor (Quarry Stoneworks) - Quarry - 0x275FF - Quarry Stoneworks Middle Floor - 0x03678 - Outside Quarry - 0x17CE8 - Quarry Stoneworks Lift - TrueOneWay:
-158123 - 0x275ED (Side Exit Panel) - True - True
+0x275ED (Side Exit Panel) - True - True
 Door - 0x275FF (Side Exit) - 0x275ED
-158124 - 0x03678 (Lower Ramp Control) - True - Dots & Eraser
-158145 - 0x17CAC (Roof Exit Panel) - True - True
+0x03678 (Lower Ramp Control) - True - Dots & Eraser
+0x17CAC (Roof Exit Panel) - True - True
 Door - 0x17CE8 (Roof Exit) - 0x17CAC
 
 Quarry Stoneworks Middle Floor (Quarry Stoneworks) - Quarry Stoneworks Lift - TrueOneWay:
-158125 - 0x00E0C (Lower Row 1) - True - Dots & Eraser
-158126 - 0x01489 (Lower Row 2) - 0x00E0C - Dots & Eraser
-158127 - 0x0148A (Lower Row 3) - 0x01489 - Dots & Eraser
-158128 - 0x014D9 (Lower Row 4) - 0x0148A - Dots & Eraser
-158129 - 0x014E7 (Lower Row 5) - 0x014D9 - Dots & Eraser
-158130 - 0x014E8 (Lower Row 6) - 0x014E7 - Dots & Eraser
+0x00E0C (Lower Row 1) - True - Dots & Eraser
+0x01489 (Lower Row 2) - 0x00E0C - Dots & Eraser
+0x0148A (Lower Row 3) - 0x01489 - Dots & Eraser
+0x014D9 (Lower Row 4) - 0x0148A - Dots & Eraser
+0x014E7 (Lower Row 5) - 0x014D9 - Dots & Eraser
+0x014E8 (Lower Row 6) - 0x014E7 - Dots & Eraser
 
 Quarry Stoneworks Lift (Quarry Stoneworks) - Quarry Stoneworks Middle Floor - 0x03679 - Quarry Stoneworks Ground Floor - 0x03679 - Quarry Stoneworks Upper Floor - 0x03679:
-158131 - 0x03679 (Lower Lift Control) - 0x014E8 - Dots & Eraser
+0x03679 (Lower Lift Control) - 0x014E8 - Dots & Eraser
 
 Quarry Stoneworks Upper Floor (Quarry Stoneworks) - Quarry Stoneworks Lift - 0x03675 - Quarry Stoneworks Ground Floor - 0x0368A:
-158132 - 0x03676 (Upper Ramp Control) - True - Dots & Eraser
-158133 - 0x03675 (Upper Lift Control) - True - Dots & Eraser
-158134 - 0x00557 (Upper Row 1) - True - Colored Squares & Eraser
-158135 - 0x005F1 (Upper Row 2) - 0x00557 - Colored Squares & Eraser
-158136 - 0x00620 (Upper Row 3) - 0x005F1 - Colored Squares & Eraser
-158137 - 0x009F5 (Upper Row 4) - 0x00620 - Colored Squares & Eraser
-158138 - 0x0146C (Upper Row 5) - 0x009F5 - Stars + Same Colored Symbol & Eraser
-158139 - 0x3C12D (Upper Row 6) - 0x0146C - Stars + Same Colored Symbol & Eraser
-158140 - 0x03686 (Upper Row 7) - 0x3C12D - Stars + Same Colored Symbol & Eraser
-158141 - 0x014E9 (Upper Row 8) - 0x03686 - Stars + Same Colored Symbol & Eraser
-158142 - 0x03677 (Stairs Panel) - True - Colored Squares & Eraser
+0x03676 (Upper Ramp Control) - True - Dots & Eraser
+0x03675 (Upper Lift Control) - True - Dots & Eraser
+0x00557 (Upper Row 1) - True - Colored Squares & Eraser
+0x005F1 (Upper Row 2) - 0x00557 - Colored Squares & Eraser
+0x00620 (Upper Row 3) - 0x005F1 - Colored Squares & Eraser
+0x009F5 (Upper Row 4) - 0x00620 - Colored Squares & Eraser
+0x0146C (Upper Row 5) - 0x009F5 - Stars + Same Colored Symbol & Eraser
+0x3C12D (Upper Row 6) - 0x0146C - Stars + Same Colored Symbol & Eraser
+0x03686 (Upper Row 7) - 0x3C12D - Stars + Same Colored Symbol & Eraser
+0x014E9 (Upper Row 8) - 0x03686 - Stars + Same Colored Symbol & Eraser
+0x03677 (Stairs Panel) - True - Colored Squares & Eraser
 Door - 0x0368A (Stairs) - 0x03677
-158143 - 0x3C125 (Control Room Left) - 0x014E9 - Black/White Squares & Dots & Eraser & Symmetry
-158144 - 0x0367C (Control Room Right) - 0x014E9 - Colored Squares & Dots & Eraser & Stars + Same Colored Symbol
-159411 - 0x0069D (Ramp EP) - 0x03676 & 0x275FF - True
-159413 - 0x00614 (Lift EP) - 0x275FF & 0x03675 - True
+0x3C125 (Control Room Left) - 0x014E9 - Black/White Squares & Dots & Eraser & Symmetry
+0x0367C (Control Room Right) - 0x014E9 - Colored Squares & Dots & Eraser & Stars + Same Colored Symbol
+0x0069D (Ramp EP) - 0x03676 & 0x275FF - True
+0x00614 (Lift EP) - 0x275FF & 0x03675 - True
 
 Quarry Boathouse (Quarry Boathouse) - Quarry - True - Quarry Boathouse Upper Front - 0x03852 - Quarry Boathouse Behind Staircase - 0x2769B:
-158146 - 0x034D4 (Intro Left) - True - Stars
-158147 - 0x021D5 (Intro Right) - True - Shapers & Rotated Shapers & Triangles
-158148 - 0x03852 (Ramp Height Control) - 0x034D4 & 0x021D5 - Rotated Shapers
-158166 - 0x17CA6 (Boat Spawn) - True - Boat
+0x034D4 (Intro Left) - True - Stars
+0x021D5 (Intro Right) - True - Shapers & Rotated Shapers & Triangles
+0x03852 (Ramp Height Control) - 0x034D4 & 0x021D5 - Rotated Shapers
+0x17CA6 (Boat Spawn) - True - Boat
 Door - 0x2769B (Dock) - 0x17CA6
 Door - 0x27163 (Dock Invis Barrier) - 0x17CA6
 
 Quarry Boathouse Behind Staircase (Quarry Boathouse) - The Ocean - 0x17CA6:
 
 Quarry Boathouse Upper Front (Quarry Boathouse) - Quarry Boathouse Upper Middle - 0x17C50:
-158149 - 0x021B3 (Front Row 1) - True - Shapers & Eraser
-158150 - 0x021B4 (Front Row 2) - 0x021B3 - Shapers & Eraser
-158151 - 0x021B0 (Front Row 3) - 0x021B4 - Shapers & Eraser
-158152 - 0x021AF (Front Row 4) - 0x021B0 - Shapers & Eraser
-158153 - 0x021AE (Front Row 5) - 0x021AF - Shapers & Eraser
+0x021B3 (Front Row 1) - True - Shapers & Eraser
+0x021B4 (Front Row 2) - 0x021B3 - Shapers & Eraser
+0x021B0 (Front Row 3) - 0x021B4 - Shapers & Eraser
+0x021AF (Front Row 4) - 0x021B0 - Shapers & Eraser
+0x021AE (Front Row 5) - 0x021AF - Shapers & Eraser
 Door - 0x17C50 (First Barrier) - 0x021AE
 
 Quarry Boathouse Upper Middle (Quarry Boathouse) - Quarry Boathouse Upper Back - 0x03858:
-158154 - 0x03858 (Ramp Horizontal Control) - True - Shapers & Eraser
-159402 - 0x00859 (Moving Ramp EP) - 0x03858 & 0x03852 & 0x3865F - True
+0x03858 (Ramp Horizontal Control) - True - Shapers & Eraser
+0x00859 (Moving Ramp EP) - 0x03858 & 0x03852 & 0x3865F - True
 
 Quarry Boathouse Upper Back (Quarry Boathouse) - Quarry Boathouse Upper Middle - 0x3865F:
-158155 - 0x38663 (Second Barrier Panel) - True - True
+0x38663 (Second Barrier Panel) - True - True
 Door - 0x3865F (Second Barrier) - 0x38663
-158156 - 0x021B5 (Back First Row 1) - True - Shapers & Negative Shapers & Eraser
-158157 - 0x021B6 (Back First Row 2) - 0x021B5 - Shapers & Negative Shapers & Eraser
-158158 - 0x021B7 (Back First Row 3) - 0x021B6 - Shapers & Negative Shapers & Eraser
-158159 - 0x021BB (Back First Row 4) - 0x021B7 - Shapers & Negative Shapers & Eraser
-158160 - 0x09DB5 (Back First Row 5) - 0x021BB - Shapers & Negative Shapers & Eraser
-158161 - 0x09DB1 (Back First Row 6) - 0x09DB5 - Stars + Same Colored Symbol & Eraser & Colored Squares
-158162 - 0x3C124 (Back First Row 7) - 0x09DB1 - Stars + Same Colored Symbol & Eraser & Colored Squares
-158163 - 0x09DB3 (Back First Row 8) - 0x3C124 - Stars + Same Colored Symbol & Eraser & Colored Squares & Triangles
-158164 - 0x09DB4 (Back First Row 9) - 0x09DB3 - Stars + Same Colored Symbol & Eraser & Colored Squares & Triangles
-158165 - 0x275FA (Hook Control) - True - Shapers & Eraser
-158167 - 0x0A3CB (Back Second Row 1) - 0x09DB4 - Black/White Squares & Colored Squares & Eraser & Shapers
-158168 - 0x0A3CC (Back Second Row 2) - 0x0A3CB - Stars + Same Colored Symbol & Eraser & Shapers
-158169 - 0x0A3D0 (Back Second Row 3) - 0x0A3CC - Triangles & Eraser & Shapers
-159401 - 0x005F6 (Hook EP) - 0x275FA & 0x03852 & 0x3865F - True
+0x021B5 (Back First Row 1) - True - Shapers & Negative Shapers & Eraser
+0x021B6 (Back First Row 2) - 0x021B5 - Shapers & Negative Shapers & Eraser
+0x021B7 (Back First Row 3) - 0x021B6 - Shapers & Negative Shapers & Eraser
+0x021BB (Back First Row 4) - 0x021B7 - Shapers & Negative Shapers & Eraser
+0x09DB5 (Back First Row 5) - 0x021BB - Shapers & Negative Shapers & Eraser
+0x09DB1 (Back First Row 6) - 0x09DB5 - Stars + Same Colored Symbol & Eraser & Colored Squares
+0x3C124 (Back First Row 7) - 0x09DB1 - Stars + Same Colored Symbol & Eraser & Colored Squares
+0x09DB3 (Back First Row 8) - 0x3C124 - Stars + Same Colored Symbol & Eraser & Colored Squares & Triangles
+0x09DB4 (Back First Row 9) - 0x09DB3 - Stars + Same Colored Symbol & Eraser & Colored Squares & Triangles
+0x275FA (Hook Control) - True - Shapers & Eraser
+0x0A3CB (Back Second Row 1) - 0x09DB4 - Black/White Squares & Colored Squares & Eraser & Shapers
+0x0A3CC (Back Second Row 2) - 0x0A3CB - Stars + Same Colored Symbol & Eraser & Shapers
+0x0A3D0 (Back Second Row 3) - 0x0A3CC - Triangles & Eraser & Shapers
+0x005F6 (Hook EP) - 0x275FA & 0x03852 & 0x3865F - True
 
 ==Shadows==
 
 Shadows (Shadows) - Main Island - True - Shadows Ledge - 0x19B24 - Shadows Laser Room - 0x194B2 | 0x19665:
-158170 - 0x334DB (Door Timer Outside) - True - True
+0x334DB (Door Timer Outside) - True - True
 Door - 0x19B24 (Timed Door) - 0x334DB | 0x334DC
-158171 - 0x0AC74 (Intro 6) - 0x0A8DC - True
-158172 - 0x0AC7A (Intro 7) - 0x0AC74 - True
-158173 - 0x0A8E0 (Intro 8) - 0x0AC7A - True
-158174 - 0x386FA (Far 1) - 0x0A8E0 - True
-158175 - 0x1C33F (Far 2) - 0x386FA - True
-158176 - 0x196E2 (Far 3) - 0x1C33F - True
-158177 - 0x1972A (Far 4) - 0x196E2 - True
-158178 - 0x19809 (Far 5) - 0x1972A - True
-158179 - 0x19806 (Far 6) - 0x19809 - True
-158180 - 0x196F8 (Far 7) - 0x19806 - True
-158181 - 0x1972F (Far 8) - 0x196F8 - True
+0x0AC74 (Intro 6) - 0x0A8DC - True
+0x0AC7A (Intro 7) - 0x0AC74 - True
+0x0A8E0 (Intro 8) - 0x0AC7A - True
+0x386FA (Far 1) - 0x0A8E0 - True
+0x1C33F (Far 2) - 0x386FA - True
+0x196E2 (Far 3) - 0x1C33F - True
+0x1972A (Far 4) - 0x196E2 - True
+0x19809 (Far 5) - 0x1972A - True
+0x19806 (Far 6) - 0x19809 - True
+0x196F8 (Far 7) - 0x19806 - True
+0x1972F (Far 8) - 0x196F8 - True
 Door - 0x194B2 (Laser Entry Right) - 0x1972F
-158182 - 0x19797 (Near 1) - 0x0A8E0 - True
-158183 - 0x1979A (Near 2) - 0x19797 - True
-158184 - 0x197E0 (Near 3) - 0x1979A - True
-158185 - 0x197E8 (Near 4) - 0x197E0 - True
-158186 - 0x197E5 (Near 5) - 0x197E8 - True
+0x19797 (Near 1) - 0x0A8E0 - True
+0x1979A (Near 2) - 0x19797 - True
+0x197E0 (Near 3) - 0x1979A - True
+0x197E8 (Near 4) - 0x197E0 - True
+0x197E5 (Near 5) - 0x197E8 - True
 Door - 0x19665 (Laser Entry Left) - 0x197E5
-159400 - 0x28A7B (Quarry Stoneworks Rooftop Vent EP) - True - True
+0x28A7B (Quarry Stoneworks Rooftop Vent EP) - True - True
 
 Shadows Ledge (Shadows) - Shadows - 0x1855B - Quarry - 0x19865 & 0x0A2DF:
-158187 - 0x334DC (Door Timer Inside) - True - True
-158188 - 0x198B5 (Intro 1) - True - True
-158189 - 0x198BD (Intro 2) - 0x198B5 - True
-158190 - 0x198BF (Intro 3) - 0x198BD & 0x19B24 - True
+0x334DC (Door Timer Inside) - True - True
+0x198B5 (Intro 1) - True - True
+0x198BD (Intro 2) - 0x198B5 - True
+0x198BF (Intro 3) - 0x198BD & 0x19B24 - True
 Door - 0x19865 (Quarry Barrier) - 0x198BF
 Door - 0x0A2DF (Quarry Barrier 2) - 0x198BF
-158191 - 0x19771 (Intro 4) - 0x198BF - True
-158192 - 0x0A8DC (Intro 5) - 0x19771 - True
+0x19771 (Intro 4) - 0x198BF - True
+0x0A8DC (Intro 5) - 0x19771 - True
 Door - 0x1855B (Ledge Barrier) - 0x0A8DC
 Door - 0x19ADE (Ledge Barrier 2) - 0x0A8DC
 
 Shadows Laser Room (Shadows):
-158703 - 0x19650 (Laser Panel) - 0x194B2 & 0x19665 - True
+0x19650 (Laser Panel) - 0x194B2 & 0x19665 - True
 Laser - 0x181B3 (Laser) - 0x19650
 
 ==Keep==
 
 Outside Keep (Keep) - Main Island - True:
-159430 - 0x03E77 (Red Flowers EP) - True - True
-159431 - 0x03E7C (Purple Flowers EP) - True - True
+0x03E77 (Red Flowers EP) - True - True
+0x03E7C (Purple Flowers EP) - True - True
 
 Keep (Keep) - Outside Keep - True - Keep 2nd Maze - 0x01954 - Keep 2nd Pressure Plate - 0x01BEC:
-158193 - 0x00139 (Hedge Maze 1) - True - True
-158197 - 0x0A3A8 (Reset Pressure Plates 1) - True - True
-158198 - 0x033EA (Pressure Plates 1) - 0x0A3A8 - Dots & Triangles
+0x00139 (Hedge Maze 1) - True - True
+0x0A3A8 (Reset Pressure Plates 1) - True - True
+0x033EA (Pressure Plates 1) - 0x0A3A8 - Dots & Triangles
 Door - 0x01954 (Hedge Maze 1 Exit) - 0x00139
 Door - 0x01BEC (Pressure Plates 1 Exit) - 0x033EA
 
 Keep 2nd Maze (Keep) - Keep - 0x018CE - Keep 3rd Maze - 0x019D8:
 Door - 0x018CE (Hedge Maze 2 Shortcut) - 0x00139
-158194 - 0x019DC (Hedge Maze 2) - True - True
+0x019DC (Hedge Maze 2) - True - True
 Door - 0x019D8 (Hedge Maze 2 Exit) - 0x019DC
 
 Keep 3rd Maze (Keep) - Keep - 0x019B5 - Keep 4th Maze - 0x019E6:
 Door - 0x019B5 (Hedge Maze 3 Shortcut) - 0x019DC
-158195 - 0x019E7 (Hedge Maze 3) - True - True
+0x019E7 (Hedge Maze 3) - True - True
 Door - 0x019E6 (Hedge Maze 3 Exit) - 0x019E7
 
 Keep 4th Maze (Keep) - Keep - 0x0199A - Keep Tower - 0x01A0E:
 Door - 0x0199A (Hedge Maze 4 Shortcut) - 0x019E7
-158196 - 0x01A0F (Hedge Maze 4) - True - True
+0x01A0F (Hedge Maze 4) - True - True
 Door - 0x01A0E (Hedge Maze 4 Exit) - 0x01A0F
 
 Keep 2nd Pressure Plate (Keep) - Keep 3rd Pressure Plate - True:
-158199 - 0x0A3B9 (Reset Pressure Plates 2) - True - True
-158200 - 0x01BE9 (Pressure Plates 2) - 0x0A3B9 - Stars + Same Colored Symbol & Triangles
+0x0A3B9 (Reset Pressure Plates 2) - True - True
+0x01BE9 (Pressure Plates 2) - 0x0A3B9 - Stars + Same Colored Symbol & Triangles
 Door - 0x01BEA (Pressure Plates 2 Exit) - 0x01BE9
 
 Keep 3rd Pressure Plate (Keep) - Keep 4th Pressure Plate - 0x01CD5:
-158201 - 0x0A3BB (Reset Pressure Plates 3) - True - True
-158202 - 0x01CD3 (Pressure Plates 3) - 0x0A3BB - Shapers & Stars
+0x0A3BB (Reset Pressure Plates 3) - True - True
+0x01CD3 (Pressure Plates 3) - 0x0A3BB - Shapers & Stars
 Door - 0x01CD5 (Pressure Plates 3 Exit) - 0x01CD3
 
 Keep 4th Pressure Plate (Keep) - Shadows - 0x09E3D - Keep Tower - 0x01D40:
-158203 - 0x0A3AD (Reset Pressure Plates 4) - True - True
-158204 - 0x01D3F (Pressure Plates 4) - 0x0A3AD - Shapers & Rotated Shapers & Negative Shapers & Symmetry & Dots
+0x0A3AD (Reset Pressure Plates 4) - True - True
+0x01D3F (Pressure Plates 4) - 0x0A3AD - Shapers & Rotated Shapers & Negative Shapers & Symmetry & Dots
 Door - 0x01D40 (Pressure Plates 4 Exit) - 0x01D3F
-158604 - 0x17D27 (Discard) - True - Arrows & Triangles
-158205 - 0x09E49 (Shadows Shortcut Panel) - True - True
+0x17D27 (Discard) - True - Arrows & Triangles
+0x09E49 (Shadows Shortcut Panel) - True - True
 Door - 0x09E3D (Shadows Shortcut) - 0x09E49
 
 Keep Tower (Keep) - Keep - 0x04F8F:
-158206 - 0x0361B (Tower Shortcut Panel) - True - True
+0x0361B (Tower Shortcut Panel) - True - True
 Door - 0x04F8F (Tower Shortcut) - 0x0361B
-158704 - 0x0360E (Laser Panel Hedges) - 0x01A0F & 0x019E7 & 0x019DC & 0x00139 - True
-158705 - 0x03317 (Laser Panel Pressure Plates) - 0x033EA & 0x01BE9 & 0x01CD3 & 0x01D3F - Dots & Shapers & Black/White Squares & Colored Squares & Stars + Same Colored Symbol
+0x0360E (Laser Panel Hedges) - 0x01A0F & 0x019E7 & 0x019DC & 0x00139 - True
+0x03317 (Laser Panel Pressure Plates) - 0x033EA & 0x01BE9 & 0x01CD3 & 0x01D3F - Dots & Shapers & Black/White Squares & Colored Squares & Stars + Same Colored Symbol
 Laser - 0x014BB (Laser) - 0x0360E | 0x03317
-159240 - 0x033BE (Pressure Plates 1 EP) - 0x033EA - True
-159241 - 0x033BF (Pressure Plates 2 EP) - 0x01BE9 - True
-159242 - 0x033DD (Pressure Plates 3 EP) - 0x01CD3 & 0x01CD5 - True
-159243 - 0x033E5 (Pressure Plates 4 Left Exit EP) - 0x01D3F - True
-159244 - 0x018B6 (Pressure Plates 4 Right Exit EP) - 0x01D3F - True
-159250 - 0x28AE9 (Path EP) - True - True
-159251 - 0x3348F (Hedges EP) - True - True
+0x033BE (Pressure Plates 1 EP) - 0x033EA - True
+0x033BF (Pressure Plates 2 EP) - 0x01BE9 - True
+0x033DD (Pressure Plates 3 EP) - 0x01CD3 & 0x01CD5 - True
+0x033E5 (Pressure Plates 4 Left Exit EP) - 0x01D3F - True
+0x018B6 (Pressure Plates 4 Right Exit EP) - 0x01D3F - True
+0x28AE9 (Path EP) - True - True
+0x3348F (Hedges EP) - True - True
 
 ==Shipwreck==
 
 Shipwreck (Shipwreck) - Keep 3rd Pressure Plate - True - Shipwreck Vault - 0x17BB4:
-158654 - 0x00AFB (Vault Panel) - True - Symmetry & Sound Dots & Colored Dots
+0x00AFB (Vault Panel) - True - Symmetry & Sound Dots & Colored Dots
 Door - 0x17BB4 (Vault Door) - 0x00AFB
-158605 - 0x17D28 (Discard) - True - Arrows & Triangles
-159220 - 0x03B22 (Circle Far EP) - True - True
-159221 - 0x03B23 (Circle Left EP) - True - True
-159222 - 0x03B24 (Circle Near EP) - True - True
-159224 - 0x03A79 (Stern EP) - True - True
-159225 - 0x28ABD (Rope Inner EP) - True - True
-159226 - 0x28ABE (Rope Outer EP) - True - True
-159230 - 0x3388F (Couch EP) - 0x17CDF | 0x0A054 - True
+0x17D28 (Discard) - True - Arrows & Triangles
+0x03B22 (Circle Far EP) - True - True
+0x03B23 (Circle Left EP) - True - True
+0x03B24 (Circle Near EP) - True - True
+0x03A79 (Stern EP) - True - True
+0x28ABD (Rope Inner EP) - True - True
+0x28ABE (Rope Outer EP) - True - True
+0x3388F (Couch EP) - 0x17CDF | 0x0A054 - True
 
 Shipwreck Vault (Shipwreck):
-158655 - 0x03535 (Vault Box) - True - True
+0x03535 (Vault Box) - True - True
 
 ==Monastery==
 
 Monastery Obelisk (Monastery) - Entry - True:
-159710 - 0xFFE10 (Obelisk Side 1) - 0x03ABC & 0x03ABE & 0x03AC0 & 0x03AC4 - True
-159711 - 0xFFE11 (Obelisk Side 2) - 0x03AC5 - True
-159712 - 0xFFE12 (Obelisk Side 3) - 0x03BE2 & 0x03BE3 & 0x0A409 - True
-159713 - 0xFFE13 (Obelisk Side 4) - 0x006E5 & 0x006E6 & 0x006E7 & 0x034A7 & 0x034AD & 0x034AF & 0x03DAB & 0x03DAC & 0x03DAD - True
-159714 - 0xFFE14 (Obelisk Side 5) - 0x03E01 - True
-159715 - 0xFFE15 (Obelisk Side 6) - 0x289F4 & 0x289F5 - True
-159719 - 0x00263 (Obelisk) - True - True
+0xFFE10 (Obelisk Side 1) - 0x03ABC & 0x03ABE & 0x03AC0 & 0x03AC4 - True
+0xFFE11 (Obelisk Side 2) - 0x03AC5 - True
+0xFFE12 (Obelisk Side 3) - 0x03BE2 & 0x03BE3 & 0x0A409 - True
+0xFFE13 (Obelisk Side 4) - 0x006E5 & 0x006E6 & 0x006E7 & 0x034A7 & 0x034AD & 0x034AF & 0x03DAB & 0x03DAC & 0x03DAD - True
+0xFFE14 (Obelisk Side 5) - 0x03E01 - True
+0xFFE15 (Obelisk Side 6) - 0x289F4 & 0x289F5 - True
+0x00263 (Obelisk) - True - True
 
 Outside Monastery (Monastery) - Main Island - True - Inside Monastery - 0x0C128 & 0x0C153 - Monastery Garden - 0x03750:
-158207 - 0x03713 (Laser Shortcut Panel) - True - True
+0x03713 (Laser Shortcut Panel) - True - True
 Door - 0x0364E (Laser Shortcut) - 0x03713
-158208 - 0x00B10 (Entry Left) - True - True
-158209 - 0x00C92 (Entry Right) - 0x00B10 - True
+0x00B10 (Entry Left) - True - True
+0x00C92 (Entry Right) - 0x00B10 - True
 Door - 0x0C128 (Entry Inner) - 0x00B10
 Door - 0x0C153 (Entry Outer) - 0x00C92
-158210 - 0x00290 (Outside 1) - 0x09D9B - True
-158211 - 0x00038 (Outside 2) - 0x09D9B & 0x00290 - True
-158212 - 0x00037 (Outside 3) - 0x09D9B & 0x00038 - True
+0x00290 (Outside 1) - 0x09D9B - True
+0x00038 (Outside 2) - 0x09D9B & 0x00290 - True
+0x00037 (Outside 3) - 0x09D9B & 0x00038 - True
 Door - 0x03750 (Garden Entry) - 0x00037
-158706 - 0x17CA4 (Laser Panel) - 0x193A6 - True
+0x17CA4 (Laser Panel) - 0x193A6 - True
 Laser - 0x17C65 (Laser) - 0x17CA4
-159130 - 0x006E5 (Facade Left Near EP) - True - True
-159131 - 0x006E6 (Facade Left Far Short EP) - True - True
-159132 - 0x006E7 (Facade Left Far Long EP) - True - True
-159136 - 0x03DAB (Facade Right Near EP) - True - True
-159137 - 0x03DAC (Facade Left Stairs EP) - True - True
-159138 - 0x03DAD (Facade Right Stairs EP) - True - True
-159140 - 0x03E01 (Grass Stairs EP) - True - True
-159120 - 0x03BE2 (Garden Left EP) - 0x03750 - True
-159121 - 0x03BE3 (Garden Right EP) - True - True
-159122 - 0x0A409 (Wall EP) - True - True
+0x006E5 (Facade Left Near EP) - True - True
+0x006E6 (Facade Left Far Short EP) - True - True
+0x006E7 (Facade Left Far Long EP) - True - True
+0x03DAB (Facade Right Near EP) - True - True
+0x03DAC (Facade Left Stairs EP) - True - True
+0x03DAD (Facade Right Stairs EP) - True - True
+0x03E01 (Grass Stairs EP) - True - True
+0x03BE2 (Garden Left EP) - 0x03750 - True
+0x03BE3 (Garden Right EP) - True - True
+0x0A409 (Wall EP) - True - True
 
 Inside Monastery (Monastery) - Monastery North Shutters - 0x09D9B:
-158213 - 0x09D9B (Shutters Control) - True - Dots
-158214 - 0x193A7 (Inside 1) - 0x00037 - True
-158215 - 0x193AA (Inside 2) - 0x193A7 - True
-158216 - 0x193AB (Inside 3) - 0x193AA - True
-158217 - 0x193A6 (Inside 4) - 0x193AB - True
-159133 - 0x034A7 (Left Shutter EP) - 0x09D9B - True
-159134 - 0x034AD (Middle Shutter EP) - 0x09D9B - True
-159135 - 0x034AF (Right Shutter EP) - 0x09D9B - True
+0x09D9B (Shutters Control) - True - Dots
+0x193A7 (Inside 1) - 0x00037 - True
+0x193AA (Inside 2) - 0x193A7 - True
+0x193AB (Inside 3) - 0x193AA - True
+0x193A6 (Inside 4) - 0x193AB - True
+0x034A7 (Left Shutter EP) - 0x09D9B - True
+0x034AD (Middle Shutter EP) - 0x09D9B - True
+0x034AF (Right Shutter EP) - 0x09D9B - True
 
 Monastery Garden (Monastery):
 
@@ -520,76 +520,76 @@ Monastery North Shutters (Monastery):
 ==Town==
 
 Town Obelisk (Town) - Entry - True:
-159750 - 0xFFE50 (Obelisk Side 1) - 0x035C7 - True
-159751 - 0xFFE51 (Obelisk Side 2) - 0x01848 & 0x03D06 & 0x33530 & 0x33600 & 0x28A2F & 0x28A37 & 0x334A3 & 0x3352F - True
-159752 - 0xFFE52 (Obelisk Side 3) - 0x33857 & 0x33879 & 0x03C19 - True
-159753 - 0xFFE53 (Obelisk Side 4) - 0x28B30 & 0x035C9 - True
-159754 - 0xFFE54 (Obelisk Side 5) - 0x03335 & 0x03412 & 0x038A6 & 0x038AA & 0x03E3F & 0x03E40 & 0x28B8E - True
-159755 - 0xFFE55 (Obelisk Side 6) - 0x28B91 & 0x03BCE & 0x03BCF & 0x03BD1 & 0x339B6 & 0x33A20 & 0x33A29 & 0x33A2A & 0x33B06 - True
-159759 - 0x0A16C (Obelisk) - True - True
+0xFFE50 (Obelisk Side 1) - 0x035C7 - True
+0xFFE51 (Obelisk Side 2) - 0x01848 & 0x03D06 & 0x33530 & 0x33600 & 0x28A2F & 0x28A37 & 0x334A3 & 0x3352F - True
+0xFFE52 (Obelisk Side 3) - 0x33857 & 0x33879 & 0x03C19 - True
+0xFFE53 (Obelisk Side 4) - 0x28B30 & 0x035C9 - True
+0xFFE54 (Obelisk Side 5) - 0x03335 & 0x03412 & 0x038A6 & 0x038AA & 0x03E3F & 0x03E40 & 0x28B8E - True
+0xFFE55 (Obelisk Side 6) - 0x28B91 & 0x03BCE & 0x03BCF & 0x03BD1 & 0x339B6 & 0x33A20 & 0x33A29 & 0x33A2A & 0x33B06 - True
+0x0A16C (Obelisk) - True - True
 
 Town (Town) - Main Island - True - The Ocean - 0x0A054 - Town Maze Rooftop - 0x28AA2 - Town Church - True - Town Wooden Rooftop - 0x034F5 - Town RGB House - 0x28A61 - Town Inside Cargo Box - 0x0A0C9 - Outside Windmill - True:
-158218 - 0x0A054 (Boat Spawn) - 0x17CA6 | 0x17CDF | 0x09DB8 | 0x17C95 - Boat
-158219 - 0x0A0C8 (Cargo Box Entry Panel) - True - Triangles
+0x0A054 (Boat Spawn) - 0x17CA6 | 0x17CDF | 0x09DB8 | 0x17C95 - Boat
+0x0A0C8 (Cargo Box Entry Panel) - True - Triangles
 Door - 0x0A0C9 (Cargo Box Entry) - 0x0A0C8
-158707 - 0x09F98 (Desert Laser Redirect Control) - True - True
-158220 - 0x18590 (Transparent) - True - Symmetry
-158221 - 0x28AE3 (Vines) - 0x18590 - True
-158222 - 0x28938 (Apple Tree) - 0x28AE3 - True
-158223 - 0x079DF (Triple Exit) - 0x28938 - True
-158235 - 0x2899C (Wooden Roof Lower Row 1) - True - Rotated Shapers & Full Dots & Colored Squares
-158236 - 0x28A33 (Wooden Roof Lower Row 2) - 0x2899C - Rotated Shapers & Full Dots & Stars
-158237 - 0x28ABF (Wooden Roof Lower Row 3) - 0x28A33 - Shapers & Negative Shapers & Full Dots
-158238 - 0x28AC0 (Wooden Roof Lower Row 4) - 0x28ABF - Rotated Shapers & Full Dots
-158239 - 0x28AC1 (Wooden Roof Lower Row 5) - 0x28AC0 - Rotated Shapers & Full Dots & Triangles
+0x09F98 (Desert Laser Redirect Control) - True - True
+0x18590 (Transparent) - True - Symmetry
+0x28AE3 (Vines) - 0x18590 - True
+0x28938 (Apple Tree) - 0x28AE3 - True
+0x079DF (Triple Exit) - 0x28938 - True
+0x2899C (Wooden Roof Lower Row 1) - True - Rotated Shapers & Full Dots & Colored Squares
+0x28A33 (Wooden Roof Lower Row 2) - 0x2899C - Rotated Shapers & Full Dots & Stars
+0x28ABF (Wooden Roof Lower Row 3) - 0x28A33 - Shapers & Negative Shapers & Full Dots
+0x28AC0 (Wooden Roof Lower Row 4) - 0x28ABF - Rotated Shapers & Full Dots
+0x28AC1 (Wooden Roof Lower Row 5) - 0x28AC0 - Rotated Shapers & Full Dots & Triangles
 Door - 0x034F5 (Wooden Roof Stairs) - 0x28AC1
-158225 - 0x28998 (RGB House Entry Panel) - True - Stars & Rotated Shapers
+0x28998 (RGB House Entry Panel) - True - Stars & Rotated Shapers
 Door - 0x28A61 (RGB House Entry) - 0x28998
-158226 - 0x28A0D (Church Entry Panel) - 0x28A61 - Stars
+0x28A0D (Church Entry Panel) - 0x28A61 - Stars
 Door - 0x03BB0 (Church Entry) - 0x28A0D
-158228 - 0x28A79 (Maze Panel) - True - True
+0x28A79 (Maze Panel) - True - True
 Door - 0x28AA2 (Maze Stairs) - 0x28A79
-159540 - 0x03335 (Tower Underside Third EP) - True - True
-159541 - 0x03412 (Tower Underside Fourth EP) - True - True
-159542 - 0x038A6 (Tower Underside First EP) - True - True
-159543 - 0x038AA (Tower Underside Second EP) - True - True
-159545 - 0x03E40 (RGB House Green EP) - 0x334D8 - True
-159546 - 0x28B8E (Maze Bridge Underside EP) - 0x2896A - True
-159552 - 0x03BCF (Black Line Redirect EP) - True - True
-159800 - 0xFFF80 (Pet the Dog) - True - True
+0x03335 (Tower Underside Third EP) - True - True
+0x03412 (Tower Underside Fourth EP) - True - True
+0x038A6 (Tower Underside First EP) - True - True
+0x038AA (Tower Underside Second EP) - True - True
+0x03E40 (RGB House Green EP) - 0x334D8 - True
+0x28B8E (Maze Bridge Underside EP) - 0x2896A - True
+0x03BCF (Black Line Redirect EP) - True - True
+0xFFF80 (Pet the Dog) - True - True
 
 Town Inside Cargo Box (Town):
-158606 - 0x17D01 (Cargo Box Discard) - True - Arrows & Triangles
+0x17D01 (Cargo Box Discard) - True - Arrows & Triangles
 
 Town Maze Rooftop (Town) - Town Red Rooftop - 0x2896A:
-158229 - 0x2896A (Maze Rooftop Bridge Control) - True - Shapers
-159544 - 0x03E3F (RGB House Red EP) - 0x334D8 - True
+0x2896A (Maze Rooftop Bridge Control) - True - Shapers
+0x03E3F (RGB House Red EP) - 0x334D8 - True
 
 Town Red Rooftop (Town):
-158607 - 0x17C71 (Rooftop Discard) - True - Arrows & Triangles
-158230 - 0x28AC7 (Red Rooftop 1) - True - Symmetry & Dots
-158231 - 0x28AC8 (Red Rooftop 2) - 0x28AC7 - Symmetry & Black/White Squares
-158232 - 0x28ACA (Red Rooftop 3) - 0x28AC8 - Symmetry & Stars
-158233 - 0x28ACB (Red Rooftop 4) - 0x28ACA - Symmetry & Shapers
-158234 - 0x28ACC (Red Rooftop 5) - 0x28ACB - Symmetry & Triangles
-158224 - 0x28B39 (Tall Hexagonal) - 0x079DF - True
+0x17C71 (Rooftop Discard) - True - Arrows & Triangles
+0x28AC7 (Red Rooftop 1) - True - Symmetry & Dots
+0x28AC8 (Red Rooftop 2) - 0x28AC7 - Symmetry & Black/White Squares
+0x28ACA (Red Rooftop 3) - 0x28AC8 - Symmetry & Stars
+0x28ACB (Red Rooftop 4) - 0x28ACA - Symmetry & Shapers
+0x28ACC (Red Rooftop 5) - 0x28ACB - Symmetry & Triangles
+0x28B39 (Tall Hexagonal) - 0x079DF - True
 
 Town Wooden Rooftop (Town):
-158240 - 0x28AD9 (Wooden Rooftop) - 0x28AC1 - Rotated Shapers & Eraser & Full Dots
+0x28AD9 (Wooden Rooftop) - 0x28AC1 - Rotated Shapers & Eraser & Full Dots
 
 Town Church (Town):
-158227 - 0x28A69 (Church Lattice) - 0x03BB0 - True
-159553 - 0x03BD1 (Black Line Church EP) - True - True
+0x28A69 (Church Lattice) - 0x03BB0 - True
+0x03BD1 (Black Line Church EP) - True - True
 
 Town RGB House (Town RGB House) - Town RGB House Upstairs - 0x2897B:
-158242 - 0x034E4 (Sound Room Left) - True - True
-158243 - 0x034E3 (Sound Room Right) - True - Sound Dots
+0x034E4 (Sound Room Left) - True - True
+0x034E3 (Sound Room Right) - True - Sound Dots
 Door - 0x2897B (Stairs) - 0x034E4 & 0x034E3
 
 Town RGB House Upstairs (Town RGB House Upstairs):
-158244 - 0x334D8 (RGB Control) - True - Rotated Shapers & Colored Squares
-158245 - 0x03C0C (Left) - 0x334D8 - Stars
-158246 - 0x03C08 (Right) - 0x334D8 - Dots & Symmetry & Colored Dots
+0x334D8 (RGB Control) - True - Rotated Shapers & Colored Squares
+0x03C0C (Left) - 0x334D8 - Stars
+0x03C08 (Right) - 0x334D8 - Dots & Symmetry & Colored Dots
 
 Town Tower Bottom (Town Tower) - Town - True - Town Tower After First Door - 0x27799:
 Door - 0x27799 (First Door) - 0x28A69
@@ -604,42 +604,42 @@ Town Tower After Third Door (Town Tower) - Town Tower Top - 0x2779A:
 Door - 0x2779A (Fourth Door) - 0x28B39
 
 Town Tower Top (Town):
-158708 - 0x032F5 (Laser Panel) - True - True
+0x032F5 (Laser Panel) - True - True
 Laser - 0x032F9 (Laser) - 0x032F5
-159422 - 0x33692 (Brown Bridge EP) - True - True
-159551 - 0x03BCE (Black Line Tower EP) - True - True
+0x33692 (Brown Bridge EP) - True - True
+0x03BCE (Black Line Tower EP) - True - True
 
 ==Windmill & Theater==
 
 Outside Windmill (Windmill) - Windmill Interior - 0x1845B:
-159010 - 0x037B6 (First Blade EP) - 0x17D02 - True
-159011 - 0x037B2 (Second Blade EP) - 0x17D02 - True
-159012 - 0x000F7 (Third Blade EP) - 0x17D02 - True
-158241 - 0x17F5F (Entry Panel) - True - Dots
+0x037B6 (First Blade EP) - 0x17D02 - True
+0x037B2 (Second Blade EP) - 0x17D02 - True
+0x000F7 (Third Blade EP) - 0x17D02 - True
+0x17F5F (Entry Panel) - True - Dots
 Door - 0x1845B (Entry) - 0x17F5F
 
 Windmill Interior (Windmill) - Theater - 0x17F88:
-158247 - 0x17D02 (Turn Control) - True - Dots
-158248 - 0x17F89 (Theater Entry Panel) - True - Black/White Squares & Triangles
+0x17D02 (Turn Control) - True - Dots
+0x17F89 (Theater Entry Panel) - True - Black/White Squares & Triangles
 Door - 0x17F88 (Theater Entry) - 0x17F89
 
 Theater (Theater) - Town - 0x0A16D | 0x3CCDF:
-158656 - 0x00815 (Video Input) - True - True
-158657 - 0x03553 (Tutorial Video) - 0x00815 & 0x03481 - True
-158658 - 0x03552 (Desert Video) - 0x00815 & 0x0339E - True
-158659 - 0x0354E (Jungle Video) - 0x00815 & 0x03702 - True
-158660 - 0x03549 (Challenge Video) - 0x00815 & 0x0356B - True
-158661 - 0x0354F (Shipwreck Video) - 0x00815 & 0x03535 - True
-158662 - 0x03545 (Mountain Video) - 0x00815 & 0x03542 - True
-158249 - 0x0A168 (Exit Left Panel) - True - Black/White Squares & Stars + Same Colored Symbol & Shapers
-158250 - 0x33AB2 (Exit Right Panel) - True - Black/White Squares & Stars + Same Colored Symbol & Shapers
+0x00815 (Video Input) - True - True
+0x03553 (Tutorial Video) - 0x00815 & 0x03481 - True
+0x03552 (Desert Video) - 0x00815 & 0x0339E - True
+0x0354E (Jungle Video) - 0x00815 & 0x03702 - True
+0x03549 (Challenge Video) - 0x00815 & 0x0356B - True
+0x0354F (Shipwreck Video) - 0x00815 & 0x03535 - True
+0x03545 (Mountain Video) - 0x00815 & 0x03542 - True
+0x0A168 (Exit Left Panel) - True - Black/White Squares & Stars + Same Colored Symbol & Shapers
+0x33AB2 (Exit Right Panel) - True - Black/White Squares & Stars + Same Colored Symbol & Shapers
 Door - 0x0A16D (Exit Left) - 0x0A168
 Door - 0x3CCDF (Exit Right) - 0x33AB2
-158608 - 0x17CF7 (Discard) - True - Arrows & Triangles
-159554 - 0x339B6 (Eclipse EP) - 0x03549 & 0x0A16D & 0x3CCDF - True
-159555 - 0x33A29 (Window EP) - 0x03553 - True
-159556 - 0x33A2A (Door EP) - 0x03553 - True
-159558 - 0x33B06 (Church EP) - 0x0354E - True
+0x17CF7 (Discard) - True - Arrows & Triangles
+0x339B6 (Eclipse EP) - 0x03549 & 0x0A16D & 0x3CCDF - True
+0x33A29 (Window EP) - 0x03553 - True
+0x33A2A (Door EP) - 0x03553 - True
+0x33B06 (Church EP) - 0x0354E - True
 
 ==Southern Peninsula==
 
@@ -648,595 +648,595 @@ Southern Peninsula (Southern Peninsula) - Main Island - True:
 ==Jungle==
 
 Jungle (Jungle) - Main Island - True - The Ocean - 0x17CDF - Jungle Under Popup Wall - 0x1475B:
-158251 - 0x17CDF (Shore Boat Spawn) - True - Boat
-158609 - 0x17F9B (Discard) - True - Arrows & Triangles
-158252 - 0x002C4 (First Row 1) - True - True
-158253 - 0x00767 (First Row 2) - 0x002C4 - True
-158254 - 0x002C6 (First Row 3) - 0x00767 - True
-158255 - 0x0070E (Second Row 1) - 0x002C6 - True
-158256 - 0x0070F (Second Row 2) - 0x0070E - True
-158257 - 0x0087D (Second Row 3) - 0x0070F - True
-158258 - 0x002C7 (Second Row 4) - 0x0087D - True
-158259 - 0x17CAB (Popup Wall Control) - 0x002C7 - True
+0x17CDF (Shore Boat Spawn) - True - Boat
+0x17F9B (Discard) - True - Arrows & Triangles
+0x002C4 (First Row 1) - True - True
+0x00767 (First Row 2) - 0x002C4 - True
+0x002C6 (First Row 3) - 0x00767 - True
+0x0070E (Second Row 1) - 0x002C6 - True
+0x0070F (Second Row 2) - 0x0070E - True
+0x0087D (Second Row 3) - 0x0070F - True
+0x002C7 (Second Row 4) - 0x0087D - True
+0x17CAB (Popup Wall Control) - 0x002C7 - True
 Door - 0x1475B (Popup Wall) - 0x17CAB
-158260 - 0x0026D (Popup Wall 1) - 0x1475B - Sound Dots
-158261 - 0x0026E (Popup Wall 2) - 0x0026D - Sound Dots
-158262 - 0x0026F (Popup Wall 3) - 0x0026E - Sound Dots
-158263 - 0x00C3F (Popup Wall 4) - 0x0026F - Sound Dots
-158264 - 0x00C41 (Popup Wall 5) - 0x00C3F - Sound Dots
-158265 - 0x014B2 (Popup Wall 6) - 0x00C41 - Sound Dots
-158709 - 0x03616 (Laser Panel) - 0x014B2 - True
+0x0026D (Popup Wall 1) - 0x1475B - Sound Dots
+0x0026E (Popup Wall 2) - 0x0026D - Sound Dots
+0x0026F (Popup Wall 3) - 0x0026E - Sound Dots
+0x00C3F (Popup Wall 4) - 0x0026F - Sound Dots
+0x00C41 (Popup Wall 5) - 0x00C3F - Sound Dots
+0x014B2 (Popup Wall 6) - 0x00C41 - Sound Dots
+0x03616 (Laser Panel) - 0x014B2 - True
 Laser - 0x00274 (Laser) - 0x03616
-158266 - 0x337FA (Laser Shortcut Panel) - True - True
+0x337FA (Laser Shortcut Panel) - True - True
 Door - 0x3873B (Laser Shortcut) - 0x337FA
-159100 - 0x03ABC (Long Arch Moss EP) - True - True
-159101 - 0x03ABE (Straight Left Moss EP) - True - True
-159102 - 0x03AC0 (Pop-up Wall Moss EP) - True - True
-159103 - 0x03AC4 (Short Arch Moss EP) - True - True
-159150 - 0x289F4 (Entrance EP) - True - True
-159151 - 0x289F5 (Tree Halo EP) - True - True
-159350 - 0x035CB (Bamboo CCW EP) - True - True
-159351 - 0x035CF (Bamboo CW EP) - True - True
+0x03ABC (Long Arch Moss EP) - True - True
+0x03ABE (Straight Left Moss EP) - True - True
+0x03AC0 (Pop-up Wall Moss EP) - True - True
+0x03AC4 (Short Arch Moss EP) - True - True
+0x289F4 (Entrance EP) - True - True
+0x289F5 (Tree Halo EP) - True - True
+0x035CB (Bamboo CCW EP) - True - True
+0x035CF (Bamboo CW EP) - True - True
 
 Jungle Under Popup Wall (Jungle):
 
 Outside Jungle River (Jungle) - Main Island - True - Monastery Garden - 0x0CF2A - Jungle Vault - 0x15287:
-158267 - 0x17CAA (Monastery Garden Shortcut Panel) - True - True
+0x17CAA (Monastery Garden Shortcut Panel) - True - True
 Door - 0x0CF2A (Monastery Garden Shortcut) - 0x17CAA
-158663 - 0x15ADD (Vault Panel) - True - Black/White Squares & Dots
+0x15ADD (Vault Panel) - True - Black/White Squares & Dots
 Door - 0x15287 (Vault Door) - 0x15ADD
-159110 - 0x03AC5 (Green Leaf Moss EP) - True - True
+0x03AC5 (Green Leaf Moss EP) - True - True
 
 Jungle Vault (Jungle):
-158664 - 0x03702 (Vault Box) - True - True
+0x03702 (Vault Box) - True - True
 
 ==Bunker==
 
 Outside Bunker (Bunker) - Main Island - True - Bunker - 0x0C2A4:
-158268 - 0x17C2E (Entry Panel) - True - Black/White Squares
+0x17C2E (Entry Panel) - True - Black/White Squares
 Door - 0x0C2A4 (Entry) - 0x17C2E
 
 Bunker (Bunker) - Bunker Glass Room - 0x17C79:
-158269 - 0x09F7D (Intro Left 1) - True - Colored Squares
-158270 - 0x09FDC (Intro Left 2) - 0x09F7D - Colored Squares & Black/White Squares
-158271 - 0x09FF7 (Intro Left 3) - 0x09FDC - Colored Squares & Black/White Squares
-158272 - 0x09F82 (Intro Left 4) - 0x09FF7 - Colored Squares & Black/White Squares
-158273 - 0x09FF8 (Intro Left 5) - 0x09F82 - Colored Squares & Black/White Squares
-158274 - 0x09D9F (Intro Back 1) - 0x09FF8 - Colored Squares & Black/White Squares
-158275 - 0x09DA1 (Intro Back 2) - 0x09D9F - Colored Squares
-158276 - 0x09DA2 (Intro Back 3) - 0x09DA1 - Colored Squares
-158277 - 0x09DAF (Intro Back 4) - 0x09DA2 - Colored Squares
-158278 - 0x0A099 (Tinted Glass Door Panel) - 0x09DAF - True
+0x09F7D (Intro Left 1) - True - Colored Squares
+0x09FDC (Intro Left 2) - 0x09F7D - Colored Squares & Black/White Squares
+0x09FF7 (Intro Left 3) - 0x09FDC - Colored Squares & Black/White Squares
+0x09F82 (Intro Left 4) - 0x09FF7 - Colored Squares & Black/White Squares
+0x09FF8 (Intro Left 5) - 0x09F82 - Colored Squares & Black/White Squares
+0x09D9F (Intro Back 1) - 0x09FF8 - Colored Squares & Black/White Squares
+0x09DA1 (Intro Back 2) - 0x09D9F - Colored Squares
+0x09DA2 (Intro Back 3) - 0x09DA1 - Colored Squares
+0x09DAF (Intro Back 4) - 0x09DA2 - Colored Squares
+0x0A099 (Tinted Glass Door Panel) - 0x09DAF - True
 Door - 0x17C79 (Tinted Glass Door) - 0x0A099
 
 Bunker Glass Room (Bunker) - Bunker Ultraviolet Room - 0x0C2A3:
-158279 - 0x0A010 (Glass Room 1) - 0x17C79 - Colored Squares
-158280 - 0x0A01B (Glass Room 2) - 0x17C79 & 0x0A010 - Colored Squares & Black/White Squares
-158281 - 0x0A01F (Glass Room 3) - 0x17C79 & 0x0A01B - Colored Squares & Black/White Squares
+0x0A010 (Glass Room 1) - 0x17C79 - Colored Squares
+0x0A01B (Glass Room 2) - 0x17C79 & 0x0A010 - Colored Squares & Black/White Squares
+0x0A01F (Glass Room 3) - 0x17C79 & 0x0A01B - Colored Squares & Black/White Squares
 Door - 0x0C2A3 (UV Room Entry) - 0x0A01F
 
 Bunker Ultraviolet Room (Bunker) - Bunker Elevator Section - 0x0A08D:
-158282 - 0x34BC5 (Drop-Down Door Open) - True - True
-158283 - 0x34BC6 (Drop-Down Door Close) - 0x34BC5 - True
-158284 - 0x17E63 (UV Room 1) - 0x34BC5 - Colored Squares
-158285 - 0x17E67 (UV Room 2) - 0x17E63 & 0x34BC6 - Colored Squares & Black/White Squares
+0x34BC5 (Drop-Down Door Open) - True - True
+0x34BC6 (Drop-Down Door Close) - 0x34BC5 - True
+0x17E63 (UV Room 1) - 0x34BC5 - Colored Squares
+0x17E67 (UV Room 2) - 0x17E63 & 0x34BC6 - Colored Squares & Black/White Squares
 Door - 0x0A08D (Elevator Room Entry) - 0x17E67
 
 Bunker Elevator Section (Bunker) - Bunker Elevator - TrueOneWay - Bunker Under Elevator - 0x0A079 | Bunker Green Room | Bunker Cyan Room | Bunker Laser Platform:
-159311 - 0x035F5 (Tinted Door EP) - 0x17C79 - True
+0x035F5 (Tinted Door EP) - 0x17C79 - True
 
 Bunker Under Elevator (Bunker):
 
 Bunker Elevator (Bunker) - Bunker Elevator Section - 0x0A079 - Bunker Cyan Room - 0x0A079 - Bunker Green Room - 0x0A079 - Bunker Laser Platform - 0x0A079 - Outside Bunker - 0x0A079:
-158286 - 0x0A079 (Elevator Control) - True - Colored Squares & Black/White Squares
+0x0A079 (Elevator Control) - True - Colored Squares & Black/White Squares
 
 Bunker Cyan Room (Bunker) - Bunker Elevator - TrueOneWay:
 
 Bunker Green Room (Bunker) - Bunker Elevator - TrueOneWay:
-159310 - 0x000D3 (Green Room Flowers EP) - True - True
+0x000D3 (Green Room Flowers EP) - True - True
 
 Bunker Laser Platform (Bunker) - Bunker Elevator - TrueOneWay:
-158710 - 0x09DE0 (Laser Panel) - True - True
+0x09DE0 (Laser Panel) - True - True
 Laser - 0x0C2B2 (Laser) - 0x09DE0
 
 ==Swamp==
 
 Outside Swamp (Swamp) - Swamp Entry Area - 0x00C1C - Main Island - True:
-158287 - 0x0056E (Entry Panel) - True - Shapers & Black/White Squares
+0x0056E (Entry Panel) - True - Shapers & Black/White Squares
 Door - 0x00C1C (Entry) - 0x0056E
-159321 - 0x03603 (Purple Sand Middle EP) - 0x17E2B - True
-159322 - 0x03601 (Purple Sand Top EP) - 0x17E2B - True
-159327 - 0x035DE (Purple Sand Bottom EP) - True - True
+0x03603 (Purple Sand Middle EP) - 0x17E2B - True
+0x03601 (Purple Sand Top EP) - 0x17E2B - True
+0x035DE (Purple Sand Bottom EP) - True - True
 
 Swamp Entry Area (Swamp) - Swamp Sliding Bridge - TrueOneWay:
-158288 - 0x00469 (Intro Front 1) - True - Shapers
-158289 - 0x00472 (Intro Front 2) - 0x00469 - Shapers
-158290 - 0x00262 (Intro Front 3) - 0x00472 - Shapers
-158291 - 0x00474 (Intro Front 4) - 0x00262 - Shapers
-158292 - 0x00553 (Intro Front 5) - 0x00474 - Shapers
-158293 - 0x0056F (Intro Front 6) - 0x00553 - Shapers
-158294 - 0x00390 (Intro Back 1) - 0x0056F - Shapers & Black/White Squares
-158295 - 0x010CA (Intro Back 2) - 0x00390 - Shapers & Black/White Squares
-158296 - 0x00983 (Intro Back 3) - 0x010CA - Shapers & Rotated Shapers & Black/White Squares
-158297 - 0x00984 (Intro Back 4) - 0x00983 - Shapers & Rotated Shapers & Black/White Squares
-158298 - 0x00986 (Intro Back 5) - 0x00984 - Shapers & Triangles
-158299 - 0x00985 (Intro Back 6) - 0x00986 - Shapers & Triangles
-158300 - 0x00987 (Intro Back 7) - 0x00985 - Rotated Shapers & Triangles
-158301 - 0x181A9 (Intro Back 8) - 0x00987 - Shapers & Triangles
+0x00469 (Intro Front 1) - True - Shapers
+0x00472 (Intro Front 2) - 0x00469 - Shapers
+0x00262 (Intro Front 3) - 0x00472 - Shapers
+0x00474 (Intro Front 4) - 0x00262 - Shapers
+0x00553 (Intro Front 5) - 0x00474 - Shapers
+0x0056F (Intro Front 6) - 0x00553 - Shapers
+0x00390 (Intro Back 1) - 0x0056F - Shapers & Black/White Squares
+0x010CA (Intro Back 2) - 0x00390 - Shapers & Black/White Squares
+0x00983 (Intro Back 3) - 0x010CA - Shapers & Rotated Shapers & Black/White Squares
+0x00984 (Intro Back 4) - 0x00983 - Shapers & Rotated Shapers & Black/White Squares
+0x00986 (Intro Back 5) - 0x00984 - Shapers & Triangles
+0x00985 (Intro Back 6) - 0x00986 - Shapers & Triangles
+0x00987 (Intro Back 7) - 0x00985 - Rotated Shapers & Triangles
+0x181A9 (Intro Back 8) - 0x00987 - Shapers & Triangles
 
 Swamp Sliding Bridge (Swamp) - Swamp Entry Area - 0x00609 - Swamp Platform - 0x00609:
-158302 - 0x00609 (Sliding Bridge) - True - Shapers
-159342 - 0x0105D (Sliding Bridge Left EP) - 0x00609 - True
-159343 - 0x0A304 (Sliding Bridge Right EP) - 0x00609 - True
+0x00609 (Sliding Bridge) - True - Shapers
+0x0105D (Sliding Bridge Left EP) - 0x00609 - True
+0x0A304 (Sliding Bridge Right EP) - 0x00609 - True
 
 Swamp Platform (Swamp) - Swamp Cyan Underwater - 0x04B7F - Swamp Near Boat - 0x38AE6 - Swamp Between Bridges Near - 0x184B7 - Swamp Sliding Bridge - TrueOneWay:
-158313 - 0x00982 (Platform Row 1) - True - Shapers
-158314 - 0x0097F (Platform Row 2) - 0x00982 - Shapers
-158315 - 0x0098F (Platform Row 3) - 0x0097F - Shapers
-158316 - 0x00990 (Platform Row 4) - 0x0098F - Shapers
+0x00982 (Platform Row 1) - True - Shapers
+0x0097F (Platform Row 2) - 0x00982 - Shapers
+0x0098F (Platform Row 3) - 0x0097F - Shapers
+0x00990 (Platform Row 4) - 0x0098F - Shapers
 Door - 0x184B7 (Between Bridges First Door) - 0x00990
-158317 - 0x17C0D (Platform Shortcut Left Panel) - True - Shapers
-158318 - 0x17C0E (Platform Shortcut Right Panel) - 0x17C0D - Shapers
+0x17C0D (Platform Shortcut Left Panel) - True - Shapers
+0x17C0E (Platform Shortcut Right Panel) - 0x17C0D - Shapers
 Door - 0x38AE6 (Platform Shortcut) - 0x17C0E
 Door - 0x04B7F (Cyan Water Pump) - 0x00006
 
 Swamp Cyan Underwater (Swamp):
-158307 - 0x00002 (Cyan Underwater 1) - True - Shapers & Negative Shapers & Black/White Squares
-158308 - 0x00004 (Cyan Underwater 2) - 0x00002 - Shapers & Negative Shapers & Black/White Squares
-158309 - 0x00005 (Cyan Underwater 3) - 0x00004 - Shapers & Negative Shapers & Stars
-158310 - 0x013E6 (Cyan Underwater 4) - 0x00005 - Shapers & Negative Shapers & Stars
-158311 - 0x00596 (Cyan Underwater 5) - 0x013E6 - Shapers & Negative Shapers & Dots
-158312 - 0x18488 (Cyan Underwater Sliding Bridge Control) - True - Shapers
-159340 - 0x03AA6 (Cyan Underwater Sliding Bridge EP) - 0x18488 - True
+0x00002 (Cyan Underwater 1) - True - Shapers & Negative Shapers & Black/White Squares
+0x00004 (Cyan Underwater 2) - 0x00002 - Shapers & Negative Shapers & Black/White Squares
+0x00005 (Cyan Underwater 3) - 0x00004 - Shapers & Negative Shapers & Stars
+0x013E6 (Cyan Underwater 4) - 0x00005 - Shapers & Negative Shapers & Stars
+0x00596 (Cyan Underwater 5) - 0x013E6 - Shapers & Negative Shapers & Dots
+0x18488 (Cyan Underwater Sliding Bridge Control) - True - Shapers
+0x03AA6 (Cyan Underwater Sliding Bridge EP) - 0x18488 - True
 
 Swamp Between Bridges Near (Swamp) - Swamp Between Bridges Far - 0x18507:
-158303 - 0x00999 (Between Bridges Near Row 1) - 0x00990 - Shapers
-158304 - 0x0099D (Between Bridges Near Row 2) - 0x00999 - Shapers
-158305 - 0x009A0 (Between Bridges Near Row 3) - 0x0099D - Shapers
-158306 - 0x009A1 (Between Bridges Near Row 4) - 0x009A0 - Shapers
+0x00999 (Between Bridges Near Row 1) - 0x00990 - Shapers
+0x0099D (Between Bridges Near Row 2) - 0x00999 - Shapers
+0x009A0 (Between Bridges Near Row 3) - 0x0099D - Shapers
+0x009A1 (Between Bridges Near Row 4) - 0x009A0 - Shapers
 Door - 0x18507 (Between Bridges Second Door) - 0x009A1
 
 Swamp Between Bridges Far (Swamp) - Swamp Red Underwater - 0x183F2 - Swamp Rotating Bridge - TrueOneWay:
-158319 - 0x00007 (Between Bridges Far Row 1) - 0x009A1 - Rotated Shapers & Dots
-158320 - 0x00008 (Between Bridges Far Row 2) - 0x00007 - Rotated Shapers & Dots
-158321 - 0x00009 (Between Bridges Far Row 3) - 0x00008 - Rotated Shapers & Dots
-158322 - 0x0000A (Between Bridges Far Row 4) - 0x00009 - Rotated Shapers & Dots
+0x00007 (Between Bridges Far Row 1) - 0x009A1 - Rotated Shapers & Dots
+0x00008 (Between Bridges Far Row 2) - 0x00007 - Rotated Shapers & Dots
+0x00009 (Between Bridges Far Row 3) - 0x00008 - Rotated Shapers & Dots
+0x0000A (Between Bridges Far Row 4) - 0x00009 - Rotated Shapers & Dots
 Door - 0x183F2 (Red Water Pump) - 0x00596
 
 Swamp Red Underwater (Swamp) - Swamp Maze - 0x305D5:
-158323 - 0x00001 (Red Underwater 1) - True - Symmetry & Shapers & Negative Shapers
-158324 - 0x014D2 (Red Underwater 2) - True - Symmetry & Shapers & Negative Shapers
-158325 - 0x014D4 (Red Underwater 3) - True - Symmetry & Shapers & Negative Shapers & Eraser
-158326 - 0x014D1 (Red Underwater 4) - True - Symmetry & Shapers & Negative Shapers & Eraser
+0x00001 (Red Underwater 1) - True - Symmetry & Shapers & Negative Shapers
+0x014D2 (Red Underwater 2) - True - Symmetry & Shapers & Negative Shapers
+0x014D4 (Red Underwater 3) - True - Symmetry & Shapers & Negative Shapers & Eraser
+0x014D1 (Red Underwater 4) - True - Symmetry & Shapers & Negative Shapers & Eraser
 Door - 0x305D5 (Red Underwater Exit) - 0x014D1
 
 Swamp Rotating Bridge (Swamp) - Swamp Between Bridges Far - 0x181F5 - Swamp Near Boat - 0x181F5 - Swamp Purple Area - 0x181F5:
-158327 - 0x181F5 (Rotating Bridge) - True - Rotated Shapers & Shapers
-159331 - 0x016B2 (Rotating Bridge CCW EP) - 0x181F5 - True
-159334 - 0x036CE (Rotating Bridge CW EP) - 0x181F5 - True
+0x181F5 (Rotating Bridge) - True - Rotated Shapers & Shapers
+0x016B2 (Rotating Bridge CCW EP) - 0x181F5 - True
+0x036CE (Rotating Bridge CW EP) - 0x181F5 - True
 
 Swamp Near Boat (Swamp) - Swamp Rotating Bridge - TrueOneWay - Swamp Blue Underwater - 0x18482 - Swamp Long Bridge - 0xFFD00 & 0xFFD02 - The Ocean - 0x09DB8:
-159803 - 0xFFD02 (Beyond Rotating Bridge Reached Independently) - True - True
-158328 - 0x09DB8 (Boat Spawn) - True - Boat
-158329 - 0x003B2 (Beyond Rotating Bridge 1) - 0x0000A - Rotated Shapers & Dots
-158330 - 0x00A1E (Beyond Rotating Bridge 2) - 0x003B2 - Rotated Shapers & Dots
-158331 - 0x00C2E (Beyond Rotating Bridge 3) - 0x00A1E - Rotated Shapers & Dots
-158332 - 0x00E3A (Beyond Rotating Bridge 4) - 0x00C2E - Rotated Shapers & Dots
+0xFFD02 (Beyond Rotating Bridge Reached Independently) - True - True
+0x09DB8 (Boat Spawn) - True - Boat
+0x003B2 (Beyond Rotating Bridge 1) - 0x0000A - Rotated Shapers & Dots
+0x00A1E (Beyond Rotating Bridge 2) - 0x003B2 - Rotated Shapers & Dots
+0x00C2E (Beyond Rotating Bridge 3) - 0x00A1E - Rotated Shapers & Dots
+0x00E3A (Beyond Rotating Bridge 4) - 0x00C2E - Rotated Shapers & Dots
 Door - 0x18482 (Blue Water Pump) - 0x00E3A
-159332 - 0x3365F (Boat EP) - 0x09DB8 - True
-159333 - 0x03731 (Long Bridge Side EP) - 0x17E2B - True
+0x3365F (Boat EP) - 0x09DB8 - True
+0x03731 (Long Bridge Side EP) - 0x17E2B - True
 
 Swamp Long Bridge (Swamp) - Swamp Near Boat - 0x17E2B - Outside Swamp - 0x17E2B:
-158339 - 0x17E2B (Long Bridge Control) - True - Rotated Shapers & Shapers
+0x17E2B (Long Bridge Control) - True - Rotated Shapers & Shapers
 
 Swamp Purple Area (Swamp) - Swamp Rotating Bridge - TrueOneWay - Swamp Purple Underwater - 0x0A1D6 - Swamp Near Boat - TrueOneWay:
 Door - 0x0A1D6 (Purple Water Pump) - 0x00E3A
 
 Swamp Purple Underwater (Swamp):
-158333 - 0x009A6 (Purple Underwater) - True - Shapers & Dots
-159330 - 0x03A9E (Purple Underwater Right EP) - True - True
-159336 - 0x03A93 (Purple Underwater Left EP) - True - True
+0x009A6 (Purple Underwater) - True - Shapers & Dots
+0x03A9E (Purple Underwater Right EP) - True - True
+0x03A93 (Purple Underwater Left EP) - True - True
 
 Swamp Blue Underwater (Swamp):
-158334 - 0x009AB (Blue Underwater 1) - True - Shapers & Negative Shapers
-158335 - 0x009AD (Blue Underwater 2) - 0x009AB - Shapers & Negative Shapers
-158336 - 0x009AE (Blue Underwater 3) - 0x009AD - Shapers & Negative Shapers
-158337 - 0x009AF (Blue Underwater 4) - 0x009AE - Shapers & Negative Shapers
-158338 - 0x00006 (Blue Underwater 5) - 0x009AF - Shapers & Negative Shapers
+0x009AB (Blue Underwater 1) - True - Shapers & Negative Shapers
+0x009AD (Blue Underwater 2) - 0x009AB - Shapers & Negative Shapers
+0x009AE (Blue Underwater 3) - 0x009AD - Shapers & Negative Shapers
+0x009AF (Blue Underwater 4) - 0x009AE - Shapers & Negative Shapers
+0x00006 (Blue Underwater 5) - 0x009AF - Shapers & Negative Shapers
 
 Swamp Maze (Swamp) - Swamp Laser Area - 0x17C0A & 0x17E07:
-158340 - 0x17C0A (Maze Control) - True - Shapers & Negative Shapers & Rotated Shapers
-158112 - 0x17E07 (Maze Control Other Side) - True - Shapers & Negative Shapers & Rotated Shapers
+0x17C0A (Maze Control) - True - Shapers & Negative Shapers & Rotated Shapers
+0x17E07 (Maze Control Other Side) - True - Shapers & Negative Shapers & Rotated Shapers
 
 Swamp Laser Area (Swamp) - Outside Swamp - 0x2D880:
-158711 - 0x03615 (Laser Panel) - True - True
+0x03615 (Laser Panel) - True - True
 Laser - 0x00BF6 (Laser) - 0x03615
-158341 - 0x17C05 (Laser Shortcut Left Panel) - True - Shapers & Colored Squares & Stars + Same Colored Symbol
-158342 - 0x17C02 (Laser Shortcut Right Panel) - 0x17C05 - Shapers & Colored Squares & Stars + Same Colored Symbol
+0x17C05 (Laser Shortcut Left Panel) - True - Shapers & Colored Squares & Stars + Same Colored Symbol
+0x17C02 (Laser Shortcut Right Panel) - 0x17C05 - Shapers & Colored Squares & Stars + Same Colored Symbol
 Door - 0x2D880 (Laser Shortcut) - 0x17C02
 
 ==Treehouse==
 
 Treehouse Obelisk (Treehouse) - Entry - True:
-159720 - 0xFFE20 (Obelisk Side 1) - 0x0053D & 0x0053E & 0x00769 - True
-159721 - 0xFFE21 (Obelisk Side 2) - 0x33721 & 0x220A7 & 0x220BD - True
-159722 - 0xFFE22 (Obelisk Side 3) - 0x03B22 & 0x03B23 & 0x03B24 & 0x03B25 & 0x03A79 & 0x28ABD & 0x28ABE - True
-159723 - 0xFFE23 (Obelisk Side 4) - 0x3388F & 0x28B29 & 0x28B2A - True
-159724 - 0xFFE24 (Obelisk Side 5) - 0x018B6 & 0x033BE & 0x033BF & 0x033DD & 0x033E5 - True
-159725 - 0xFFE25 (Obelisk Side 6) - 0x28AE9 & 0x3348F - True
-159729 - 0x00097 (Obelisk) - True - True
+0xFFE20 (Obelisk Side 1) - 0x0053D & 0x0053E & 0x00769 - True
+0xFFE21 (Obelisk Side 2) - 0x33721 & 0x220A7 & 0x220BD - True
+0xFFE22 (Obelisk Side 3) - 0x03B22 & 0x03B23 & 0x03B24 & 0x03B25 & 0x03A79 & 0x28ABD & 0x28ABE - True
+0xFFE23 (Obelisk Side 4) - 0x3388F & 0x28B29 & 0x28B2A - True
+0xFFE24 (Obelisk Side 5) - 0x018B6 & 0x033BE & 0x033BF & 0x033DD & 0x033E5 - True
+0xFFE25 (Obelisk Side 6) - 0x28AE9 & 0x3348F - True
+0x00097 (Obelisk) - True - True
 
 Treehouse Beach (Treehouse Beach) - Main Island - True:
-159200 - 0x0053D (Rock Shadow EP) - True - True
-159201 - 0x0053E (Sand Shadow EP) - True - True
-159212 - 0x220BD (Both Orange Bridges EP) - 0x17DA2 & 0x17DDB - True
+0x0053D (Rock Shadow EP) - True - True
+0x0053E (Sand Shadow EP) - True - True
+0x220BD (Both Orange Bridges EP) - 0x17DA2 & 0x17DDB - True
 
 Treehouse Entry Area (Treehouse) - Treehouse Between Entry Doors - 0x0C309 - The Ocean - 0x17C95:
-158343 - 0x17C95 (Boat Spawn) - True - Boat
-158344 - 0x0288C (First Door Panel) - True - Stars
+0x17C95 (Boat Spawn) - True - Boat
+0x0288C (First Door Panel) - True - Stars
 Door - 0x0C309 (First Door) - 0x0288C
-159210 - 0x33721 (Buoy EP) - 0x17C95 - True
+0x33721 (Buoy EP) - 0x17C95 - True
 
 Treehouse Between Entry Doors (Treehouse) - Treehouse Yellow Bridge - 0x0C310:
-158345 - 0x02886 (Second Door Panel) - True - Stars + Same Colored Symbol & Triangles
+0x02886 (Second Door Panel) - True - Stars + Same Colored Symbol & Triangles
 Door - 0x0C310 (Second Door) - 0x02886
 
 Treehouse Yellow Bridge (Treehouse) - Treehouse After Yellow Bridge - 0x17DC4:
-158346 - 0x17D72 (Yellow Bridge 1) - True - Stars
-158347 - 0x17D8F (Yellow Bridge 2) - 0x17D72 - Stars
-158348 - 0x17D74 (Yellow Bridge 3) - 0x17D8F - Stars
-158349 - 0x17DAC (Yellow Bridge 4) - 0x17D74 - Stars
-158350 - 0x17D9E (Yellow Bridge 5) - 0x17DAC - Stars
-158351 - 0x17DB9 (Yellow Bridge 6) - 0x17D9E - Stars
-158352 - 0x17D9C (Yellow Bridge 7) - 0x17DB9 - Stars
-158353 - 0x17DC2 (Yellow Bridge 8) - 0x17D9C - Stars
-158354 - 0x17DC4 (Yellow Bridge 9) - 0x17DC2 - Stars
+0x17D72 (Yellow Bridge 1) - True - Stars
+0x17D8F (Yellow Bridge 2) - 0x17D72 - Stars
+0x17D74 (Yellow Bridge 3) - 0x17D8F - Stars
+0x17DAC (Yellow Bridge 4) - 0x17D74 - Stars
+0x17D9E (Yellow Bridge 5) - 0x17DAC - Stars
+0x17DB9 (Yellow Bridge 6) - 0x17D9E - Stars
+0x17D9C (Yellow Bridge 7) - 0x17DB9 - Stars
+0x17DC2 (Yellow Bridge 8) - 0x17D9C - Stars
+0x17DC4 (Yellow Bridge 9) - 0x17DC2 - Stars
 
 Treehouse After Yellow Bridge (Treehouse) - Treehouse Junction - 0x0A181:
-158355 - 0x0A182 (Third Door Panel) - True - Stars
+0x0A182 (Third Door Panel) - True - Stars
 Door - 0x0A181 (Third Door) - 0x0A182
 
 Treehouse Junction (Treehouse) - Treehouse Right Orange Bridge - True - Treehouse First Purple Bridge - True - Treehouse Green Bridge - True:
-158356 - 0x2700B (Laser House Door Timer Outside) - True - True
+0x2700B (Laser House Door Timer Outside) - True - True
 
 Treehouse First Purple Bridge (Treehouse) - Treehouse Second Purple Bridge - 0x17D6C:
-158357 - 0x17DC8 (First Purple Bridge 1) - True - Stars & Dots & Triangles
-158358 - 0x17DC7 (First Purple Bridge 2) - 0x17DC8 - Stars & Dots & Triangles
-158359 - 0x17CE4 (First Purple Bridge 3) - 0x17DC7 - Stars & Dots & Triangles
-158360 - 0x17D2D (First Purple Bridge 4) - 0x17CE4 - Stars & Dots & Triangles
-158361 - 0x17D6C (First Purple Bridge 5) - 0x17D2D - Stars & Dots & Triangles
+0x17DC8 (First Purple Bridge 1) - True - Stars & Dots & Triangles
+0x17DC7 (First Purple Bridge 2) - 0x17DC8 - Stars & Dots & Triangles
+0x17CE4 (First Purple Bridge 3) - 0x17DC7 - Stars & Dots & Triangles
+0x17D2D (First Purple Bridge 4) - 0x17CE4 - Stars & Dots & Triangles
+0x17D6C (First Purple Bridge 5) - 0x17D2D - Stars & Dots & Triangles
 
 Treehouse Right Orange Bridge (Treehouse) - Treehouse Drawbridge Platform - 0x17DA2:
-158391 - 0x17D88 (Right Orange Bridge 1) - True - Stars + Same Colored Symbol & Colored Squares
-158392 - 0x17DB4 (Right Orange Bridge 2) - 0x17D88 - Stars + Same Colored Symbol & Colored Squares
-158393 - 0x17D8C (Right Orange Bridge 3) - 0x17DB4 - Stars + Same Colored Symbol & Colored Squares
-158394 - 0x17CE3 (Right Orange Bridge 4 & Directional) - 0x17D8C - Stars + Same Colored Symbol & Colored Squares
-158395 - 0x17DCD (Right Orange Bridge 5) - 0x17CE3 - Stars + Same Colored Symbol & Colored Squares
-158396 - 0x17DB2 (Right Orange Bridge 6) - 0x17DCD - Stars + Same Colored Symbol & Colored Squares
-158397 - 0x17DCC (Right Orange Bridge 7) - 0x17DB2 - Stars + Same Colored Symbol & Colored Squares
-158398 - 0x17DCA (Right Orange Bridge 8) - 0x17DCC - Stars + Same Colored Symbol & Colored Squares
-158399 - 0x17D8E (Right Orange Bridge 9) - 0x17DCA - Stars + Same Colored Symbol & Colored Squares
-158400 - 0x17DB7 (Right Orange Bridge 10 & Directional) - 0x17D8E - Stars + Same Colored Symbol & Colored Squares
-158401 - 0x17DB1 (Right Orange Bridge 11) - 0x17DB7 - Stars + Same Colored Symbol & Colored Squares
-158402 - 0x17DA2 (Right Orange Bridge 12) - 0x17DB1 - Stars + Same Colored Symbol & Colored Squares
+0x17D88 (Right Orange Bridge 1) - True - Stars + Same Colored Symbol & Colored Squares
+0x17DB4 (Right Orange Bridge 2) - 0x17D88 - Stars + Same Colored Symbol & Colored Squares
+0x17D8C (Right Orange Bridge 3) - 0x17DB4 - Stars + Same Colored Symbol & Colored Squares
+0x17CE3 (Right Orange Bridge 4 & Directional) - 0x17D8C - Stars + Same Colored Symbol & Colored Squares
+0x17DCD (Right Orange Bridge 5) - 0x17CE3 - Stars + Same Colored Symbol & Colored Squares
+0x17DB2 (Right Orange Bridge 6) - 0x17DCD - Stars + Same Colored Symbol & Colored Squares
+0x17DCC (Right Orange Bridge 7) - 0x17DB2 - Stars + Same Colored Symbol & Colored Squares
+0x17DCA (Right Orange Bridge 8) - 0x17DCC - Stars + Same Colored Symbol & Colored Squares
+0x17D8E (Right Orange Bridge 9) - 0x17DCA - Stars + Same Colored Symbol & Colored Squares
+0x17DB7 (Right Orange Bridge 10 & Directional) - 0x17D8E - Stars + Same Colored Symbol & Colored Squares
+0x17DB1 (Right Orange Bridge 11) - 0x17DB7 - Stars + Same Colored Symbol & Colored Squares
+0x17DA2 (Right Orange Bridge 12) - 0x17DB1 - Stars + Same Colored Symbol & Colored Squares
 
 Treehouse Drawbridge Platform (Treehouse) - Main Island - 0x0C32D:
-158404 - 0x037FF (Drawbridge Panel) - True - Stars
+0x037FF (Drawbridge Panel) - True - Stars
 Door - 0x0C32D (Drawbridge) - 0x037FF
 
 Treehouse Second Purple Bridge (Treehouse) - Treehouse Left Orange Bridge - 0x17DC6:
-158362 - 0x17D9B (Second Purple Bridge 1) - True - Stars + Same Colored Symbol & Black/White Squares & Colored Squares
-158363 - 0x17D99 (Second Purple Bridge 2) - 0x17D9B - Stars + Same Colored Symbol & Black/White Squares & Colored Squares
-158364 - 0x17DAA (Second Purple Bridge 3) - 0x17D99 - Stars + Same Colored Symbol & Black/White Squares & Colored Squares
-158365 - 0x17D97 (Second Purple Bridge 4) - 0x17DAA - Stars + Same Colored Symbol & Black/White Squares & Colored Squares
-158366 - 0x17BDF (Second Purple Bridge 5) - 0x17D97 - Stars + Same Colored Symbol & Colored Squares
-158367 - 0x17D91 (Second Purple Bridge 6) - 0x17BDF - Stars + Same Colored Symbol & Black/White Squares & Colored Squares
-158368 - 0x17DC6 (Second Purple Bridge 7) - 0x17D91 - Stars + Same Colored Symbol & Colored Squares
+0x17D9B (Second Purple Bridge 1) - True - Stars + Same Colored Symbol & Black/White Squares & Colored Squares
+0x17D99 (Second Purple Bridge 2) - 0x17D9B - Stars + Same Colored Symbol & Black/White Squares & Colored Squares
+0x17DAA (Second Purple Bridge 3) - 0x17D99 - Stars + Same Colored Symbol & Black/White Squares & Colored Squares
+0x17D97 (Second Purple Bridge 4) - 0x17DAA - Stars + Same Colored Symbol & Black/White Squares & Colored Squares
+0x17BDF (Second Purple Bridge 5) - 0x17D97 - Stars + Same Colored Symbol & Colored Squares
+0x17D91 (Second Purple Bridge 6) - 0x17BDF - Stars + Same Colored Symbol & Black/White Squares & Colored Squares
+0x17DC6 (Second Purple Bridge 7) - 0x17D91 - Stars + Same Colored Symbol & Colored Squares
 
 Treehouse Left Orange Bridge (Treehouse) - Treehouse Laser Room Front Platform - 0x17DDB - Treehouse Laser Room Back Platform - 0x17DDB - Treehouse Burned House - 0x17DDB:
-158376 - 0x17DB3 (Left Orange Bridge 1) - True - Stars + Same Colored Symbol & Triangles
-158377 - 0x17DB5 (Left Orange Bridge 2) - 0x17DB3 - Stars + Same Colored Symbol & Triangles
-158378 - 0x17DB6 (Left Orange Bridge 3) - 0x17DB5 - Stars + Same Colored Symbol & Triangles
-158379 - 0x17DC0 (Left Orange Bridge 4) - 0x17DB6 - Stars + Same Colored Symbol & Triangles
-158380 - 0x17DD7 (Left Orange Bridge 5) - 0x17DC0 - Black/White Squares & Stars + Same Colored Symbol & Shapers
-158381 - 0x17DD9 (Left Orange Bridge 6) - 0x17DD7 - Black/White Squares & Stars + Same Colored Symbol & Shapers
-158382 - 0x17DB8 (Left Orange Bridge 7) - 0x17DD9 - Black/White Squares & Stars + Same Colored Symbol & Shapers
-158383 - 0x17DDC (Left Orange Bridge 8) - 0x17DB8 - Black/White Squares & Stars + Same Colored Symbol & Shapers
-158384 - 0x17DD1 (Left Orange Bridge 9 & Directional) - 0x17DDC - Black/White Squares & Stars + Same Colored Symbol
-158385 - 0x17DDE (Left Orange Bridge 10) - 0x17DD1 - Stars + Same Colored Symbol & Shapers
-158386 - 0x17DE3 (Left Orange Bridge 11) - 0x17DDE - Stars + Same Colored Symbol & Shapers
-158387 - 0x17DEC (Left Orange Bridge 12) - 0x17DE3 - Black/White Squares & Stars + Same Colored Symbol & Shapers
-158388 - 0x17DAE (Left Orange Bridge 13) - 0x17DEC - Stars + Same Colored Symbol & Shapers & Triangles
-158389 - 0x17DB0 (Left Orange Bridge 14) - 0x17DAE - Black/White Squares & Stars + Same Colored Symbol & Shapers
-158390 - 0x17DDB (Left Orange Bridge 15) - 0x17DB0 - Stars + Same Colored Symbol & Shapers & Triangles
+0x17DB3 (Left Orange Bridge 1) - True - Stars + Same Colored Symbol & Triangles
+0x17DB5 (Left Orange Bridge 2) - 0x17DB3 - Stars + Same Colored Symbol & Triangles
+0x17DB6 (Left Orange Bridge 3) - 0x17DB5 - Stars + Same Colored Symbol & Triangles
+0x17DC0 (Left Orange Bridge 4) - 0x17DB6 - Stars + Same Colored Symbol & Triangles
+0x17DD7 (Left Orange Bridge 5) - 0x17DC0 - Black/White Squares & Stars + Same Colored Symbol & Shapers
+0x17DD9 (Left Orange Bridge 6) - 0x17DD7 - Black/White Squares & Stars + Same Colored Symbol & Shapers
+0x17DB8 (Left Orange Bridge 7) - 0x17DD9 - Black/White Squares & Stars + Same Colored Symbol & Shapers
+0x17DDC (Left Orange Bridge 8) - 0x17DB8 - Black/White Squares & Stars + Same Colored Symbol & Shapers
+0x17DD1 (Left Orange Bridge 9 & Directional) - 0x17DDC - Black/White Squares & Stars + Same Colored Symbol
+0x17DDE (Left Orange Bridge 10) - 0x17DD1 - Stars + Same Colored Symbol & Shapers
+0x17DE3 (Left Orange Bridge 11) - 0x17DDE - Stars + Same Colored Symbol & Shapers
+0x17DEC (Left Orange Bridge 12) - 0x17DE3 - Black/White Squares & Stars + Same Colored Symbol & Shapers
+0x17DAE (Left Orange Bridge 13) - 0x17DEC - Stars + Same Colored Symbol & Shapers & Triangles
+0x17DB0 (Left Orange Bridge 14) - 0x17DAE - Black/White Squares & Stars + Same Colored Symbol & Shapers
+0x17DDB (Left Orange Bridge 15) - 0x17DB0 - Stars + Same Colored Symbol & Shapers & Triangles
 
 Treehouse Green Bridge (Treehouse) - Treehouse Green Bridge Front House - 0x17E61 - Treehouse Green Bridge Left House - 0x17E61:
-158369 - 0x17E3C (Green Bridge 1) - True - Shapers & Negative Shapers & Stars + Same Colored Symbol
-158370 - 0x17E4D (Green Bridge 2) - 0x17E3C - Shapers & Negative Shapers & Stars + Same Colored Symbol
-158371 - 0x17E4F (Green Bridge 3) - 0x17E4D - Shapers & Negative Shapers & Stars + Same Colored Symbol
-158372 - 0x17E52 (Green Bridge 4 & Directional) - 0x17E4F - Rotated Shapers & Negative Shapers & Stars + Same Colored Symbol
-158373 - 0x17E5B (Green Bridge 5) - 0x17E52 - Shapers & Negative Shapers & Stars + Same Colored Symbol
-158374 - 0x17E5F (Green Bridge 6) - 0x17E5B - Shapers & Negative Shapers & Stars + Same Colored Symbol
-158375 - 0x17E61 (Green Bridge 7) - 0x17E5F - Shapers & Negative Shapers & Stars + Same Colored Symbol
+0x17E3C (Green Bridge 1) - True - Shapers & Negative Shapers & Stars + Same Colored Symbol
+0x17E4D (Green Bridge 2) - 0x17E3C - Shapers & Negative Shapers & Stars + Same Colored Symbol
+0x17E4F (Green Bridge 3) - 0x17E4D - Shapers & Negative Shapers & Stars + Same Colored Symbol
+0x17E52 (Green Bridge 4 & Directional) - 0x17E4F - Rotated Shapers & Negative Shapers & Stars + Same Colored Symbol
+0x17E5B (Green Bridge 5) - 0x17E52 - Shapers & Negative Shapers & Stars + Same Colored Symbol
+0x17E5F (Green Bridge 6) - 0x17E5B - Shapers & Negative Shapers & Stars + Same Colored Symbol
+0x17E61 (Green Bridge 7) - 0x17E5F - Shapers & Negative Shapers & Stars + Same Colored Symbol
 
 Treehouse Green Bridge Front House (Treehouse):
-158610 - 0x17FA9 (Green Bridge Discard) - True - Arrows & Triangles
+0x17FA9 (Green Bridge Discard) - True - Arrows & Triangles
 
 Treehouse Green Bridge Left House (Treehouse):
-159211 - 0x220A7 (Right Orange Bridge EP) - 0x17DA2 - True
+0x220A7 (Right Orange Bridge EP) - 0x17DA2 - True
 
 Treehouse Laser Room Front Platform (Treehouse) - Treehouse Laser Room - 0x0C323:
 Door - 0x0C323 (Laser House Entry) - 0x17DA2 & 0x2700B & 0x17DDB | 0x17CBC
 
 Treehouse Laser Room Back Platform (Treehouse):
-158611 - 0x17FA0 (Laser Discard) - True - Arrows & Triangles
+0x17FA0 (Laser Discard) - True - Arrows & Triangles
 
 Treehouse Burned House (Treehouse):
-159202 - 0x00769 (Burned House Beach EP) - True - True
+0x00769 (Burned House Beach EP) - True - True
 
 Treehouse Laser Room (Treehouse):
-158712 - 0x03613 (Laser Panel) - True - True
-158403 - 0x17CBC (Laser House Door Timer Inside) - True - True
+0x03613 (Laser Panel) - True - True
+0x17CBC (Laser House Door Timer Inside) - True - True
 Laser - 0x028A4 (Laser) - 0x03613
 
 ==Mountain (Outside)==
 
 Mountainside Obelisk (Mountainside) - Entry - True:
-159730 - 0xFFE30 (Obelisk Side 1) - 0x001A3 & 0x335AE - True
-159731 - 0xFFE31 (Obelisk Side 2) - 0x000D3 & 0x035F5 & 0x09D5D & 0x09D5E & 0x09D63 - True
-159732 - 0xFFE32 (Obelisk Side 3) - 0x3370E & 0x035DE & 0x03601 & 0x03603 & 0x03D0D & 0x3369A & 0x336C8 & 0x33505 - True
-159733 - 0xFFE33 (Obelisk Side 4) - 0x03A9E & 0x016B2 & 0x3365F & 0x03731 & 0x036CE & 0x03C07 & 0x03A93 - True
-159734 - 0xFFE34 (Obelisk Side 5) - 0x03AA6 & 0x3397C & 0x0105D & 0x0A304 - True
-159735 - 0xFFE35 (Obelisk Side 6) - 0x035CB & 0x035CF - True
-159739 - 0x00367 (Obelisk) - True - True
+0xFFE30 (Obelisk Side 1) - 0x001A3 & 0x335AE - True
+0xFFE31 (Obelisk Side 2) - 0x000D3 & 0x035F5 & 0x09D5D & 0x09D5E & 0x09D63 - True
+0xFFE32 (Obelisk Side 3) - 0x3370E & 0x035DE & 0x03601 & 0x03603 & 0x03D0D & 0x3369A & 0x336C8 & 0x33505 - True
+0xFFE33 (Obelisk Side 4) - 0x03A9E & 0x016B2 & 0x3365F & 0x03731 & 0x036CE & 0x03C07 & 0x03A93 - True
+0xFFE34 (Obelisk Side 5) - 0x03AA6 & 0x3397C & 0x0105D & 0x0A304 - True
+0xFFE35 (Obelisk Side 6) - 0x035CB & 0x035CF - True
+0x00367 (Obelisk) - True - True
 
 Mountainside (Mountainside) - Main Island - True - Mountaintop - True - Mountainside Vault - 0x00085:
-159550 - 0x28B91 (Thundercloud EP) - 0xFFD03 - True
-158612 - 0x17C42 (Discard) - True - Arrows & Triangles
-158665 - 0x002A6 (Vault Panel) - True - Symmetry & Colored Dots & Triangles
+0x28B91 (Thundercloud EP) - 0xFFD03 - True
+0x17C42 (Discard) - True - Arrows & Triangles
+0x002A6 (Vault Panel) - True - Symmetry & Colored Dots & Triangles
 Door - 0x00085 (Vault Door) - 0x002A6
-159301 - 0x335AE (Cloud Cycle EP) - True - True
-159325 - 0x33505 (Bush EP) - True - True
-159335 - 0x03C07 (Apparent River EP) - True - True
+0x335AE (Cloud Cycle EP) - True - True
+0x33505 (Bush EP) - True - True
+0x03C07 (Apparent River EP) - True - True
 
 Mountainside Vault (Mountainside):
-158666 - 0x03542 (Vault Box) - True - True
+0x03542 (Vault Box) - True - True
 
 Mountaintop (Mountaintop) - Mountain Floor 1 - 0x17C34:
-158405 - 0x0042D (River Shape) - True - True
-158406 - 0x09F7F (Box Short) - 7 Lasers + Redirect - True
-158407 - 0x17C34 (Mountain Entry Panel) - 0x09F7F - Triangles
-158800 - 0xFFF00 (Box Long) - 11 Lasers + Redirect & 0x17C34 - True
-159300 - 0x001A3 (River Shape EP) - True - True
-159320 - 0x3370E (Arch Black EP) - True - True
-159324 - 0x336C8 (Arch White Right EP) - True - True
-159326 - 0x3369A (Arch White Left EP) - True - True
+0x0042D (River Shape) - True - True
+0x09F7F (Box Short) - 7 Lasers + Redirect - True
+0x17C34 (Mountain Entry Panel) - 0x09F7F - Triangles
+0xFFF00 (Box Long) - 11 Lasers + Redirect & 0x17C34 - True
+0x001A3 (River Shape EP) - True - True
+0x3370E (Arch Black EP) - True - True
+0x336C8 (Arch White Right EP) - True - True
+0x3369A (Arch White Left EP) - True - True
 
 ==Mountain (Inside)==
 
 Mountain Floor 1 (Mountain Floor 1) - Mountain Floor 1 Bridge - 0x09E39:
-158408 - 0x09E39 (Light Bridge Controller) - True - Black/White Squares & Colored Squares & Eraser
+0x09E39 (Light Bridge Controller) - True - Black/White Squares & Colored Squares & Eraser
 
 Mountain Floor 1 Bridge (Mountain Floor 1) - Mountain Floor 1 At Door - TrueOneWay - Mountain Floor 1 Trash Pillar - TrueOneWay - Mountain Floor 1 Back Section - TrueOneWay:
-158409 - 0x09E7A (Right Row 1) - True - Black/White Squares & Dots
-158410 - 0x09E71 (Right Row 2) - 0x09E7A - Black/White Squares & Dots & Stars + Same Colored Symbol
-158411 - 0x09E72 (Right Row 3) - 0x09E71 - Black/White Squares & Shapers & Stars + Same Colored Symbol
-158412 - 0x09E69 (Right Row 4) - 0x09E72 - Black/White Squares & Eraser & Stars + Same Colored Symbol
-158413 - 0x09E7B (Right Row 5) - 0x09E69 - Full Dots & Triangles
-158414 - 0x09E73 (Left Row 1) - True - Dots & Black/White Squares
-158415 - 0x09E75 (Left Row 2) - 0x09E73 - Arrows & Black/White Squares
-158416 - 0x09E78 (Left Row 3) - 0x09E75 - Arrows & Stars
-158417 - 0x09E79 (Left Row 4) - 0x09E78 - Arrows & Shapers & Rotated Shapers
-158418 - 0x09E6C (Left Row 5) - 0x09E79 - Arrows & Black/White Squares & Stars + Same Colored Symbol
-158419 - 0x09E6F (Left Row 6) - 0x09E6C - Arrows & Full Dots
-158420 - 0x09E6B (Left Row 7) - 0x09E6F - Arrows & Full Dots
-158424 - 0x09EAD (Trash Pillar 1) - True - Triangles & Arrows
-158425 - 0x09EAF (Trash Pillar 2) - 0x09EAD - Triangles & Arrows
+0x09E7A (Right Row 1) - True - Black/White Squares & Dots
+0x09E71 (Right Row 2) - 0x09E7A - Black/White Squares & Dots & Stars + Same Colored Symbol
+0x09E72 (Right Row 3) - 0x09E71 - Black/White Squares & Shapers & Stars + Same Colored Symbol
+0x09E69 (Right Row 4) - 0x09E72 - Black/White Squares & Eraser & Stars + Same Colored Symbol
+0x09E7B (Right Row 5) - 0x09E69 - Full Dots & Triangles
+0x09E73 (Left Row 1) - True - Dots & Black/White Squares
+0x09E75 (Left Row 2) - 0x09E73 - Arrows & Black/White Squares
+0x09E78 (Left Row 3) - 0x09E75 - Arrows & Stars
+0x09E79 (Left Row 4) - 0x09E78 - Arrows & Shapers & Rotated Shapers
+0x09E6C (Left Row 5) - 0x09E79 - Arrows & Black/White Squares & Stars + Same Colored Symbol
+0x09E6F (Left Row 6) - 0x09E6C - Arrows & Full Dots
+0x09E6B (Left Row 7) - 0x09E6F - Arrows & Full Dots
+0x09EAD (Trash Pillar 1) - True - Triangles & Arrows
+0x09EAF (Trash Pillar 2) - 0x09EAD - Triangles & Arrows
 
 Mountain Floor 1 Trash Pillar (Mountain Floor 1):
 
 Mountain Floor 1 Back Section (Mountain Floor 1):
-158421 - 0x33AF5 (Back Row 1) - True - Symmetry & Triangles
-158422 - 0x33AF7 (Back Row 2) - 0x33AF5 - Triangles
-158423 - 0x09F6E (Back Row 3) - 0x33AF7 - Symmetry & Triangles
+0x33AF5 (Back Row 1) - True - Symmetry & Triangles
+0x33AF7 (Back Row 2) - 0x33AF5 - Triangles
+0x09F6E (Back Row 3) - 0x33AF7 - Symmetry & Triangles
 
 Mountain Floor 1 At Door (Mountain Floor 1) - Mountain Floor 2 - 0x09E54:
 Door - 0x09E54 (Exit) - 0x09EAF & 0x09F6E & 0x09E6B & 0x09E7B
 
 Mountain Floor 2 (Mountain Floor 2) - Mountain Floor 2 Light Bridge Room Near - 0x09FFB - Mountain Floor 2 Beyond Bridge - 0x09E86 - Mountain Floor 2 Above The Abyss - True - Mountain Pink Bridge EP - TrueOneWay:
-158426 - 0x09FD3 (Near Row 1) - True - Stars + Same Colored Symbol & Colored Squares
-158427 - 0x09FD4 (Near Row 2) - 0x09FD3 - Stars + Same Colored Symbol & Triangles
-158428 - 0x09FD6 (Near Row 3) - 0x09FD4 - Stars + Same Colored Symbol & Colored Squares & Eraser
-158429 - 0x09FD7 (Near Row 4) - 0x09FD6 - Stars + Same Colored Symbol & Shapers & Eraser
-158430 - 0x09FD8 (Near Row 5) - 0x09FD7 - Symmetry & Triangles
+0x09FD3 (Near Row 1) - True - Stars + Same Colored Symbol & Colored Squares
+0x09FD4 (Near Row 2) - 0x09FD3 - Stars + Same Colored Symbol & Triangles
+0x09FD6 (Near Row 3) - 0x09FD4 - Stars + Same Colored Symbol & Colored Squares & Eraser
+0x09FD7 (Near Row 4) - 0x09FD6 - Stars + Same Colored Symbol & Shapers & Eraser
+0x09FD8 (Near Row 5) - 0x09FD7 - Symmetry & Triangles
 Door - 0x09FFB (Staircase Near) - 0x09FD8
 
 Mountain Floor 2 Above The Abyss (Mountain Floor 2) - Mountain Floor 2 Elevator Room - 0x09EDD & 0x09ED8 & 0x09E86:
 Door - 0x09EDD (Elevator Room Entry) - 0x09ED8 & 0x09E86
 
 Mountain Floor 2 Light Bridge Room Near (Mountain Floor 2):
-158431 - 0x09E86 (Light Bridge Controller Near) - True - Stars + Same Colored Symbol & Rotated Shapers & Eraser
+0x09E86 (Light Bridge Controller Near) - True - Stars + Same Colored Symbol & Rotated Shapers & Eraser
 
 Mountain Floor 2 Beyond Bridge (Mountain Floor 2) - Mountain Floor 2 Light Bridge Room Far - 0x09E07 - Mountain Pink Bridge EP - TrueOneWay - Mountain Floor 2 - 0x09ED8:
-158432 - 0x09FCC (Far Row 1) - True - Black/White Squares
-158433 - 0x09FCE (Far Row 2) - 0x09FCC - Triangles
-158434 - 0x09FCF (Far Row 3) - 0x09FCE - Stars
-158435 - 0x09FD0 (Far Row 4) - 0x09FCF - Stars + Same Colored Symbol & Colored Squares
-158436 - 0x09FD1 (Far Row 5) - 0x09FD0 - Dots
-158437 - 0x09FD2 (Far Row 6) - 0x09FD1 - Shapers
+0x09FCC (Far Row 1) - True - Black/White Squares
+0x09FCE (Far Row 2) - 0x09FCC - Triangles
+0x09FCF (Far Row 3) - 0x09FCE - Stars
+0x09FD0 (Far Row 4) - 0x09FCF - Stars + Same Colored Symbol & Colored Squares
+0x09FD1 (Far Row 5) - 0x09FD0 - Dots
+0x09FD2 (Far Row 6) - 0x09FD1 - Shapers
 Door - 0x09E07 (Staircase Far) - 0x09FD2
 
 Mountain Floor 2 Light Bridge Room Far (Mountain Floor 2):
-158438 - 0x09ED8 (Light Bridge Controller Far) - True - Stars + Same Colored Symbol & Rotated Shapers & Eraser
+0x09ED8 (Light Bridge Controller Far) - True - Stars + Same Colored Symbol & Rotated Shapers & Eraser
 
 Mountain Floor 2 Elevator Room (Mountain Floor 2) - Mountain Floor 2 Elevator - TrueOneWay:
-158613 - 0x17F93 (Elevator Discard) - True - Arrows & Triangles
+0x17F93 (Elevator Discard) - True - Arrows & Triangles
 
 Mountain Floor 2 Elevator (Mountain Floor 2) - Mountain Floor 2 Elevator Room - 0x09EEB - Mountain Floor 3 - 0x09EEB:
-158439 - 0x09EEB (Elevator Control Panel) - True - Dots
+0x09EEB (Elevator Control Panel) - True - Dots
 
 Mountain Floor 3 (Mountain Bottom Floor) - Mountain Floor 2 Elevator - TrueOneWay - Mountain Bottom Floor - 0x09F89 - Mountain Pink Bridge EP - TrueOneWay:
-158440 - 0x09FC1 (Giant Puzzle Bottom Left) - True - Shapers & Eraser
-158441 - 0x09F8E (Giant Puzzle Bottom Right) - True - Shapers & Eraser
-158442 - 0x09F01 (Giant Puzzle Top Right) - True - Shapers & Eraser
-158443 - 0x09EFF (Giant Puzzle Top Left) - True - Rotated Shapers
-158444 - 0x09FDA (Giant Puzzle) - 0x09FC1 & 0x09F8E & 0x09F01 & 0x09EFF - Shapers & Symmetry
-159313 - 0x09D5D (Yellow Bridge EP) - 0x09E86 & 0x09ED8 - True
-159314 - 0x09D5E (Blue Bridge EP) - 0x09E86 & 0x09ED8 - True
+0x09FC1 (Giant Puzzle Bottom Left) - True - Shapers & Eraser
+0x09F8E (Giant Puzzle Bottom Right) - True - Shapers & Eraser
+0x09F01 (Giant Puzzle Top Right) - True - Shapers & Eraser
+0x09EFF (Giant Puzzle Top Left) - True - Rotated Shapers
+0x09FDA (Giant Puzzle) - 0x09FC1 & 0x09F8E & 0x09F01 & 0x09EFF - Shapers & Symmetry
+0x09D5D (Yellow Bridge EP) - 0x09E86 & 0x09ED8 - True
+0x09D5E (Blue Bridge EP) - 0x09E86 & 0x09ED8 - True
 Door - 0x09F89 (Exit) - 0x09FDA
 
 Mountain Bottom Floor (Mountain Bottom Floor) - Mountain Path to Caves - 0x17F33 - Mountain Bottom Floor Pillars Room - 0x0C141:
-158614 - 0x17FA2 (Discard) - 0xFFF00 - Arrows & Triangles
-158445 - 0x01983 (Pillars Room Entry Left) - True - Shapers & Stars
-158446 - 0x01987 (Pillars Room Entry Right) - True - Colored Squares & Dots
+0x17FA2 (Discard) - 0xFFF00 - Arrows & Triangles
+0x01983 (Pillars Room Entry Left) - True - Shapers & Stars
+0x01987 (Pillars Room Entry Right) - True - Colored Squares & Dots
 Door - 0x0C141 (Pillars Room Entry) - 0x01983 & 0x01987
 Door - 0x17F33 (Rock Open) - 0x17FA2 | 0x334E1
 
 Mountain Bottom Floor Pillars Room (Mountain Bottom Floor) - Elevator - 0x339BB & 0x33961:
-158522 - 0x0383A (Right Pillar 1) - True - Stars
-158523 - 0x09E56 (Right Pillar 2) - 0x0383A - Stars & Dots
-158524 - 0x09E5A (Right Pillar 3) - 0x09E56 - Full Dots & Triangles
-158525 - 0x33961 (Right Pillar 4) - 0x09E5A - Dots & Symmetry & Triangles
-158526 - 0x0383D (Left Pillar 1) - True - Triangles
-158527 - 0x0383F (Left Pillar 2) - 0x0383D - Black/White Squares & Stars + Same Colored Symbol
-158528 - 0x03859 (Left Pillar 3) - 0x0383F - Shapers
-158529 - 0x339BB (Left Pillar 4) - 0x03859 - Triangles & Symmetry
+0x0383A (Right Pillar 1) - True - Stars
+0x09E56 (Right Pillar 2) - 0x0383A - Stars & Dots
+0x09E5A (Right Pillar 3) - 0x09E56 - Full Dots & Triangles
+0x33961 (Right Pillar 4) - 0x09E5A - Dots & Symmetry & Triangles
+0x0383D (Left Pillar 1) - True - Triangles
+0x0383F (Left Pillar 2) - 0x0383D - Black/White Squares & Stars + Same Colored Symbol
+0x03859 (Left Pillar 3) - 0x0383F - Shapers
+0x339BB (Left Pillar 4) - 0x03859 - Triangles & Symmetry
 
 Elevator (Mountain Bottom Floor):
-158530 - 0x3D9A6 (Elevator Door Close Left) - True - True
-158531 - 0x3D9A7 (Elevator Door Close Right) - True - True
-158532 - 0x3C113 (Elevator Entry Left) - 0x3D9A6 | 0x3D9A7 - True
-158533 - 0x3C114 (Elevator Entry Right) - 0x3D9A6 | 0x3D9A7 - True
-158534 - 0x3D9AA (Back Wall Left) - 0x3D9A6 | 0x3D9A7 - True
-158535 - 0x3D9A8 (Back Wall Right) - 0x3D9A6 | 0x3D9A7 - True
-158536 - 0x3D9A9 (Elevator Start) - 0x3D9AA & 7 Lasers | 0x3D9A8 & 7 Lasers - True
+0x3D9A6 (Elevator Door Close Left) - True - True
+0x3D9A7 (Elevator Door Close Right) - True - True
+0x3C113 (Elevator Entry Left) - 0x3D9A6 | 0x3D9A7 - True
+0x3C114 (Elevator Entry Right) - 0x3D9A6 | 0x3D9A7 - True
+0x3D9AA (Back Wall Left) - 0x3D9A6 | 0x3D9A7 - True
+0x3D9A8 (Back Wall Right) - 0x3D9A6 | 0x3D9A7 - True
+0x3D9A9 (Elevator Start) - 0x3D9AA & 7 Lasers | 0x3D9A8 & 7 Lasers - True
 
 Mountain Pink Bridge EP (Mountain Floor 2):
-159312 - 0x09D63 (Pink Bridge EP) - 0x09E39 - True
+0x09D63 (Pink Bridge EP) - 0x09E39 - True
 
 Mountain Path to Caves (Mountain Bottom Floor) - Caves - 0x2D77D - Caves Entry Door - TrueOneWay:
-158447 - 0x00FF8 (Caves Entry Panel) - True - Black/White Squares & Arrows & Triangles
+0x00FF8 (Caves Entry Panel) - True - Black/White Squares & Arrows & Triangles
 Door - 0x2D77D (Caves Entry) - 0x00FF8
-158448 - 0x334E1 (Rock Control) - True - True
+0x334E1 (Rock Control) - True - True
 
 ==Caves==
 
 Caves Entry Door (Caves):
 
 Caves (Caves) - Main Island - 0x2D73F | 0x2D859 - Caves Path to Challenge - 0x019A5 - Caves Entry Door - TrueOneWay:
-158451 - 0x335AB (Elevator Inside Control) - True - Dots & Black/White Squares
-158452 - 0x335AC (Elevator Upper Outside Control) - 0x335AB - Black/White Squares
-158453 - 0x3369D (Elevator Lower Outside Control) - 0x335AB - Black/White Squares & Dots
-158454 - 0x00190 (Blue Tunnel Right First 1) - True - Full Dots & Triangles & Arrows
-158455 - 0x00558 (Blue Tunnel Right First 2) - 0x00190 - Full Dots & Triangles & Arrows
-158456 - 0x00567 (Blue Tunnel Right First 3) - 0x00558 - Full Dots & Triangles & Arrows
-158457 - 0x006FE (Blue Tunnel Right First 4) - 0x00567 - Full Dots & Triangles & Arrows
-158458 - 0x01A0D (Blue Tunnel Left First 1) - True - Symmetry & Triangles & Arrows
-158459 - 0x008B8 (Blue Tunnel Left Second 1) - True - Triangles & Colored Squares & Arrows
-158460 - 0x00973 (Blue Tunnel Left Second 2) - 0x008B8 - Triangles & Colored Squares & Arrows
-158461 - 0x0097B (Blue Tunnel Left Second 3) - 0x00973 - Triangles & Colored Squares & Arrows & Stars + Same Colored Symbol
-158462 - 0x0097D (Blue Tunnel Left Second 4) - 0x0097B - Triangles & Colored Squares & Arrows & Stars + Same Colored Symbol
-158463 - 0x0097E (Blue Tunnel Left Second 5) - 0x0097D - Triangles & Colored Squares & Arrows & Stars + Same Colored Symbol
-158464 - 0x00994 (Blue Tunnel Right Second 1) - True - Rotated Shapers & Triangles
-158465 - 0x334D5 (Blue Tunnel Right Second 2) - 0x00994 - Rotated Shapers & Triangles
-158466 - 0x00995 (Blue Tunnel Right Second 3) - 0x334D5 - Rotated Shapers & Triangles
-158467 - 0x00996 (Blue Tunnel Right Second 4) - 0x00995 - Rotated Shapers & Triangles
-158468 - 0x00998 (Blue Tunnel Right Second 5) - 0x00996 - Shapers & Triangles
-158469 - 0x009A4 (Blue Tunnel Left Third 1) - True - Shapers & Triangles
-158470 - 0x018A0 (Blue Tunnel Right Third 1) - True - Shapers & Symmetry & Eraser
-158471 - 0x00A72 (Blue Tunnel Left Fourth 1) - True - Shapers & Negative Shapers & Triangles
-158472 - 0x32962 (First Floor Left) - True - Rotated Shapers & Dots
-158473 - 0x32966 (First Floor Grounded) - True - Black/White Squares & Stars + Same Colored Symbol & Shapers & Triangles
-158474 - 0x01A31 (First Floor Middle) - True - Colored Squares
-158475 - 0x00B71 (First Floor Right) - True - Colored Squares & Stars + Same Colored Symbol & Eraser & Shapers & Negative Shapers & Dots
-158478 - 0x288EA (First Wooden Beam) - True - Colored Squares & Black/White Squares & Eraser
-158479 - 0x288FC (Second Wooden Beam) - True - Black/White Squares & Stars + Same Colored Symbol & Eraser
-158480 - 0x289E7 (Third Wooden Beam) - True - Black/White Squares & Stars + Same Colored Symbol & Shapers & Rotated Shapers & Eraser
-158481 - 0x288AA (Fourth Wooden Beam) - True - Stars & Shapers & Eraser
-158482 - 0x17FB9 (Left Upstairs Single) - True - Stars & Full Dots
-158483 - 0x0A16B (Left Upstairs Left Row 1) - True - Full Dots & Black/White Squares
-158484 - 0x0A2CE (Left Upstairs Left Row 2) - 0x0A16B - Full Dots & Stars
-158485 - 0x0A2D7 (Left Upstairs Left Row 3) - 0x0A2CE - Full Dots & Shapers
-158486 - 0x0A2DD (Left Upstairs Left Row 4) - 0x0A2D7 - Full Dots & Triangles
-158487 - 0x0A2EA (Left Upstairs Left Row 5) - 0x0A2DD - Full Dots & Triangles & Eraser
-158488 - 0x0008F (Right Upstairs Left Row 1) - True - Dots
-158489 - 0x0006B (Right Upstairs Left Row 2) - 0x0008F - Black/White Squares & Colored Squares
-158490 - 0x0008B (Right Upstairs Left Row 3) - 0x0006B - Black/White Squares & Colored Squares & Stars + Same Colored Symbol
-158491 - 0x0008C (Right Upstairs Left Row 4) - 0x0008B - Black/White Squares & Colored Squares & Stars + Same Colored Symbol & Shapers
-158492 - 0x0008A (Right Upstairs Left Row 5) - 0x0008C - Black/White Squares & Colored Squares & Stars + Same Colored Symbol
-158493 - 0x00089 (Right Upstairs Left Row 6) - 0x0008A - Black/White Squares & Colored Squares & Stars + Same Colored Symbol & Rotated Shapers
-158494 - 0x0006A (Right Upstairs Left Row 7) - 0x00089 - Stars + Same Colored Symbol & Shapers & Negative Shapers
-158495 - 0x0006C (Right Upstairs Left Row 8) - 0x0006A - Dots & Shapers & Negative Shapers & Eraser
-158496 - 0x00027 (Right Upstairs Right Row 1) - True - Black/White Squares & Colored Squares & Eraser & Symmetry
-158497 - 0x00028 (Right Upstairs Right Row 2) - 0x00027 - Black/White Squares & Colored Squares & Eraser & Symmetry
-158498 - 0x00029 (Right Upstairs Right Row 3) - 0x00028 - Stars + Same Colored Symbol & Eraser & Symmetry
-158476 - 0x09DD5 (Lone Pillar) - True - Triangles & Dots
+0x335AB (Elevator Inside Control) - True - Dots & Black/White Squares
+0x335AC (Elevator Upper Outside Control) - 0x335AB - Black/White Squares
+0x3369D (Elevator Lower Outside Control) - 0x335AB - Black/White Squares & Dots
+0x00190 (Blue Tunnel Right First 1) - True - Full Dots & Triangles & Arrows
+0x00558 (Blue Tunnel Right First 2) - 0x00190 - Full Dots & Triangles & Arrows
+0x00567 (Blue Tunnel Right First 3) - 0x00558 - Full Dots & Triangles & Arrows
+0x006FE (Blue Tunnel Right First 4) - 0x00567 - Full Dots & Triangles & Arrows
+0x01A0D (Blue Tunnel Left First 1) - True - Symmetry & Triangles & Arrows
+0x008B8 (Blue Tunnel Left Second 1) - True - Triangles & Colored Squares & Arrows
+0x00973 (Blue Tunnel Left Second 2) - 0x008B8 - Triangles & Colored Squares & Arrows
+0x0097B (Blue Tunnel Left Second 3) - 0x00973 - Triangles & Colored Squares & Arrows & Stars + Same Colored Symbol
+0x0097D (Blue Tunnel Left Second 4) - 0x0097B - Triangles & Colored Squares & Arrows & Stars + Same Colored Symbol
+0x0097E (Blue Tunnel Left Second 5) - 0x0097D - Triangles & Colored Squares & Arrows & Stars + Same Colored Symbol
+0x00994 (Blue Tunnel Right Second 1) - True - Rotated Shapers & Triangles
+0x334D5 (Blue Tunnel Right Second 2) - 0x00994 - Rotated Shapers & Triangles
+0x00995 (Blue Tunnel Right Second 3) - 0x334D5 - Rotated Shapers & Triangles
+0x00996 (Blue Tunnel Right Second 4) - 0x00995 - Rotated Shapers & Triangles
+0x00998 (Blue Tunnel Right Second 5) - 0x00996 - Shapers & Triangles
+0x009A4 (Blue Tunnel Left Third 1) - True - Shapers & Triangles
+0x018A0 (Blue Tunnel Right Third 1) - True - Shapers & Symmetry & Eraser
+0x00A72 (Blue Tunnel Left Fourth 1) - True - Shapers & Negative Shapers & Triangles
+0x32962 (First Floor Left) - True - Rotated Shapers & Dots
+0x32966 (First Floor Grounded) - True - Black/White Squares & Stars + Same Colored Symbol & Shapers & Triangles
+0x01A31 (First Floor Middle) - True - Colored Squares
+0x00B71 (First Floor Right) - True - Colored Squares & Stars + Same Colored Symbol & Eraser & Shapers & Negative Shapers & Dots
+0x288EA (First Wooden Beam) - True - Colored Squares & Black/White Squares & Eraser
+0x288FC (Second Wooden Beam) - True - Black/White Squares & Stars + Same Colored Symbol & Eraser
+0x289E7 (Third Wooden Beam) - True - Black/White Squares & Stars + Same Colored Symbol & Shapers & Rotated Shapers & Eraser
+0x288AA (Fourth Wooden Beam) - True - Stars & Shapers & Eraser
+0x17FB9 (Left Upstairs Single) - True - Stars & Full Dots
+0x0A16B (Left Upstairs Left Row 1) - True - Full Dots & Black/White Squares
+0x0A2CE (Left Upstairs Left Row 2) - 0x0A16B - Full Dots & Stars
+0x0A2D7 (Left Upstairs Left Row 3) - 0x0A2CE - Full Dots & Shapers
+0x0A2DD (Left Upstairs Left Row 4) - 0x0A2D7 - Full Dots & Triangles
+0x0A2EA (Left Upstairs Left Row 5) - 0x0A2DD - Full Dots & Triangles & Eraser
+0x0008F (Right Upstairs Left Row 1) - True - Dots
+0x0006B (Right Upstairs Left Row 2) - 0x0008F - Black/White Squares & Colored Squares
+0x0008B (Right Upstairs Left Row 3) - 0x0006B - Black/White Squares & Colored Squares & Stars + Same Colored Symbol
+0x0008C (Right Upstairs Left Row 4) - 0x0008B - Black/White Squares & Colored Squares & Stars + Same Colored Symbol & Shapers
+0x0008A (Right Upstairs Left Row 5) - 0x0008C - Black/White Squares & Colored Squares & Stars + Same Colored Symbol
+0x00089 (Right Upstairs Left Row 6) - 0x0008A - Black/White Squares & Colored Squares & Stars + Same Colored Symbol & Rotated Shapers
+0x0006A (Right Upstairs Left Row 7) - 0x00089 - Stars + Same Colored Symbol & Shapers & Negative Shapers
+0x0006C (Right Upstairs Left Row 8) - 0x0006A - Dots & Shapers & Negative Shapers & Eraser
+0x00027 (Right Upstairs Right Row 1) - True - Black/White Squares & Colored Squares & Eraser & Symmetry
+0x00028 (Right Upstairs Right Row 2) - 0x00027 - Black/White Squares & Colored Squares & Eraser & Symmetry
+0x00029 (Right Upstairs Right Row 3) - 0x00028 - Stars + Same Colored Symbol & Eraser & Symmetry
+0x09DD5 (Lone Pillar) - True - Triangles & Dots
 Door - 0x019A5 (Pillar Door) - 0x09DD5
-158449 - 0x021D7 (Mountain Shortcut Panel) - True - Triangles
+0x021D7 (Mountain Shortcut Panel) - True - Triangles
 Door - 0x2D73F (Mountain Shortcut Door) - 0x021D7
-158450 - 0x17CF2 (Swamp Shortcut Panel) - True - Triangles
+0x17CF2 (Swamp Shortcut Panel) - True - Triangles
 Door - 0x2D859 (Swamp Shortcut Door) - 0x17CF2
-159341 - 0x3397C (Skylight EP) - True - True
+0x3397C (Skylight EP) - True - True
 
 Caves Path to Challenge (Caves) - Challenge - 0x0A19A:
-158477 - 0x0A16E (Challenge Entry Panel) - True - Shapers & Stars + Same Colored Symbol & Triangles
+0x0A16E (Challenge Entry Panel) - True - Shapers & Stars + Same Colored Symbol & Triangles
 Door - 0x0A19A (Challenge Entry) - 0x0A16E
 
 ==Challenge==
 
 Challenge (Challenge) - Tunnels - 0x0348A - Challenge Vault - 0x04D75:
-158499 - 0x0A332 (Start Timer) - 11 Lasers - True
-158500 - 0x0088E (Small Basic) - 0x0A332 - True
-158501 - 0x00BAF (Big Basic) - 0x0088E - True
-158502 - 0x00BF3 (Square) - 0x00BAF - Black/White Squares
-158503 - 0x00C09 (Maze Map) - 0x00BF3 - Dots
-158504 - 0x00CDB (Stars and Dots) - 0x00C09 - Stars & Dots
-158505 - 0x0051F (Symmetry) - 0x00CDB - Symmetry & Colored Dots & Dots
-158506 - 0x00524 (Stars and Shapers) - 0x0051F - Stars & Shapers
-158507 - 0x00CD4 (Big Basic 2) - 0x00524 - True
-158508 - 0x00CB9 (Choice Squares Right) - 0x00CD4 - Black/White Squares
-158509 - 0x00CA1 (Choice Squares Middle) - 0x00CD4 - Black/White Squares
-158510 - 0x00C80 (Choice Squares Left) - 0x00CD4 - Black/White Squares
-158511 - 0x00C68 (Choice Squares 2 Right) - 0x00CB9 | 0x00CA1 | 0x00C80 - Black/White Squares & Colored Squares
-158512 - 0x00C59 (Choice Squares 2 Middle) - 0x00CB9 | 0x00CA1 | 0x00C80 - Black/White Squares & Colored Squares
-158513 - 0x00C22 (Choice Squares 2 Left) - 0x00CB9 | 0x00CA1 | 0x00C80 - Black/White Squares & Colored Squares
-158514 - 0x034F4 (Maze Hidden 1) - 0x00C68 | 0x00C59 | 0x00C22 - Triangles
-158515 - 0x034EC (Maze Hidden 2) - 0x00C68 | 0x00C59 | 0x00C22 - Triangles
-158516 - 0x1C31A (Dots Pillar) - 0x034F4 & 0x034EC - Dots & Symmetry
-158517 - 0x1C319 (Squares Pillar) - 0x034F4 & 0x034EC - Black/White Squares & Symmetry
+0x0A332 (Start Timer) - 11 Lasers - True
+0x0088E (Small Basic) - 0x0A332 - True
+0x00BAF (Big Basic) - 0x0088E - True
+0x00BF3 (Square) - 0x00BAF - Black/White Squares
+0x00C09 (Maze Map) - 0x00BF3 - Dots
+0x00CDB (Stars and Dots) - 0x00C09 - Stars & Dots
+0x0051F (Symmetry) - 0x00CDB - Symmetry & Colored Dots & Dots
+0x00524 (Stars and Shapers) - 0x0051F - Stars & Shapers
+0x00CD4 (Big Basic 2) - 0x00524 - True
+0x00CB9 (Choice Squares Right) - 0x00CD4 - Black/White Squares
+0x00CA1 (Choice Squares Middle) - 0x00CD4 - Black/White Squares
+0x00C80 (Choice Squares Left) - 0x00CD4 - Black/White Squares
+0x00C68 (Choice Squares 2 Right) - 0x00CB9 | 0x00CA1 | 0x00C80 - Black/White Squares & Colored Squares
+0x00C59 (Choice Squares 2 Middle) - 0x00CB9 | 0x00CA1 | 0x00C80 - Black/White Squares & Colored Squares
+0x00C22 (Choice Squares 2 Left) - 0x00CB9 | 0x00CA1 | 0x00C80 - Black/White Squares & Colored Squares
+0x034F4 (Maze Hidden 1) - 0x00C68 | 0x00C59 | 0x00C22 - Triangles
+0x034EC (Maze Hidden 2) - 0x00C68 | 0x00C59 | 0x00C22 - Triangles
+0x1C31A (Dots Pillar) - 0x034F4 & 0x034EC - Dots & Symmetry
+0x1C319 (Squares Pillar) - 0x034F4 & 0x034EC - Black/White Squares & Symmetry
 Door - 0x04D75 (Vault Door) - 0x1C31A & 0x1C319
-158518 - 0x039B4 (Tunnels Entry Panel) - True - Triangles & Dots
+0x039B4 (Tunnels Entry Panel) - True - Triangles & Dots
 Door - 0x0348A (Tunnels Entry) - 0x039B4
-159530 - 0x28B30 (Water EP) - True - True
+0x28B30 (Water EP) - True - True
 
 Challenge Vault (Challenge):
-158667 - 0x0356B (Vault Box) - 0x1C31A & 0x1C319 - True
+0x0356B (Vault Box) - 0x1C31A & 0x1C319 - True
 
 ==Tunnels==
 
 Tunnels (Tunnels) - Windmill Interior - 0x27739 - Desert Behind Elevator - 0x27263 - Town - 0x09E87:
-158668 - 0x2FAF6 (Vault Box) - True - True
-158519 - 0x27732 (Theater Shortcut Panel) - True - True
+0x2FAF6 (Vault Box) - True - True
+0x27732 (Theater Shortcut Panel) - True - True
 Door - 0x27739 (Theater Shortcut) - 0x27732
-158520 - 0x2773D (Desert Shortcut Panel) - True - True
+0x2773D (Desert Shortcut Panel) - True - True
 Door - 0x27263 (Desert Shortcut) - 0x2773D
-158521 - 0x09E85 (Town Shortcut Panel) - True - Triangles & Dots
+0x09E85 (Town Shortcut Panel) - True - Triangles & Dots
 Door - 0x09E87 (Town Shortcut) - 0x09E85
-159557 - 0x33A20 (Theater Flowers EP) - 0x03553 & Theater to Tunnels - True
+0x33A20 (Theater Flowers EP) - 0x03553 & Theater to Tunnels - True
 
 ==Boat==
 
 The Ocean (Boat) - Main Island - TrueOneWay - Swamp Near Boat - TrueOneWay - Treehouse Entry Area - TrueOneWay - Quarry Boathouse Behind Staircase - TrueOneWay - Inside Glass Factory Behind Back Wall - TrueOneWay:
-159042 - 0x22106 (Desert EP) - True - True
-159223 - 0x03B25 (Shipwreck CCW Underside EP) - True - True
-159231 - 0x28B29 (Shipwreck Green EP) - True - True
-159232 - 0x28B2A (Shipwreck CW Underside EP) - True - True
-159323 - 0x03D0D (Bunker Yellow Line EP) - True - True
-159515 - 0x28A37 (Town Long Sewer EP) - True - True
-159520 - 0x33857 (Tutorial EP) - True - True
-159521 - 0x33879 (Tutorial Reflection EP) - True - True
-159522 - 0x03C19 (Tutorial Moss EP) - True - True
-159531 - 0x035C9 (Cargo Box EP) - 0x0A0C9 - True
+0x22106 (Desert EP) - True - True
+0x03B25 (Shipwreck CCW Underside EP) - True - True
+0x28B29 (Shipwreck Green EP) - True - True
+0x28B2A (Shipwreck CW Underside EP) - True - True
+0x03D0D (Bunker Yellow Line EP) - True - True
+0x28A37 (Town Long Sewer EP) - True - True
+0x33857 (Tutorial EP) - True - True
+0x33879 (Tutorial Reflection EP) - True - True
+0x03C19 (Tutorial Moss EP) - True - True
+0x035C9 (Cargo Box EP) - 0x0A0C9 - True
 
 ==Easter Eggs==
 

--- a/worlds/witness/data/definition_classes.py
+++ b/worlds/witness/data/definition_classes.py
@@ -25,7 +25,7 @@ class RegionDefinition:
 
 
 @dataclass
-class EntityDefinition(NamedTuple):
+class EntityDefinition:
     entity_name: str
     entity_id: int
     region: RegionDefinition | None

--- a/worlds/witness/data/definition_classes.py
+++ b/worlds/witness/data/definition_classes.py
@@ -20,8 +20,19 @@ class RegionDefinition:
     name: str
     short_name: str
     area: AreaDefinition
-    logical_entities: List[str] = field(default_factory=list)
-    physical_entities: List[str] = field(default_factory=list)
+    logical_entities: List[int] = field(default_factory=list)
+    physical_entities: List[int] = field(default_factory=list)
+
+
+@dataclass
+class EntityDefinition(NamedTuple):
+    entity_name: str
+    entity_id: int
+    region: RegionDefinition | None
+    entity_type: str
+    location_type: str | None
+    area: AreaDefinition
+    order: int = 0
 
 
 class ConnectionDefinition(NamedTuple):

--- a/worlds/witness/data/item_definition_classes.py
+++ b/worlds/witness/data/item_definition_classes.py
@@ -40,7 +40,7 @@ class ProgressiveItemDefinition(ItemDefinition):
 
 @dataclass(frozen=True)
 class DoorItemDefinition(ItemDefinition):
-    panel_id_hexes: List[str]
+    panel_entity_ids: List[int]
 
 
 @dataclass(frozen=True)

--- a/worlds/witness/data/static_items.py
+++ b/worlds/witness/data/static_items.py
@@ -4,7 +4,8 @@ from BaseClasses import ItemClassification
 
 from . import static_logic as static_witness_logic
 from .item_definition_classes import DoorItemDefinition, ItemCategory, ItemData
-from .static_locations import ID_START
+
+ID_START = 158000
 
 ITEM_DATA: Dict[str, ItemData] = {}
 ITEM_GROUPS: Dict[str, Set[str]] = {}
@@ -42,8 +43,8 @@ def populate_items() -> None:
         elif definition.category is ItemCategory.DOOR:
             classification = ItemClassification.progression
 
-            first_entity_hex = cast(DoorItemDefinition, definition).panel_id_hexes[0]
-            entity_type = static_witness_logic.ENTITIES_BY_HEX[first_entity_hex]["entityType"]
+            first_entity_id = cast(DoorItemDefinition, definition).panel_entity_ids[0]
+            entity_type = static_witness_logic.ENTITIES_BY_ID[first_entity_id].entity_type
 
             if entity_type == "Door":
                 ITEM_GROUPS.setdefault("Doors", set()).add(item_name)
@@ -77,7 +78,7 @@ def get_item_to_door_mappings() -> Dict[int, List[int]]:
     for item_name, item_data in ITEM_DATA.items():
         if not isinstance(item_data.definition, DoorItemDefinition) or item_data.ap_code is None:
             continue
-        output[item_data.ap_code] = [int(hex_string, 16) for hex_string in item_data.definition.panel_id_hexes]
+        output[item_data.ap_code] = item_data.definition.panel_entity_ids
     return output
 
 

--- a/worlds/witness/data/static_locations.py
+++ b/worlds/witness/data/static_locations.py
@@ -2,8 +2,6 @@ from typing import Dict, Set, cast
 
 from . import static_logic as static_witness_logic
 
-ID_START = 158000
-
 GENERAL_LOCATIONS = {
     "Tutorial Front Left",
     "Tutorial Back Left",
@@ -409,10 +407,6 @@ GENERAL_LOCATIONS = {
     "Mountain Bottom Floor Discard",
 }
 
-GENERAL_LOCATION_HEXES = {
-    static_witness_logic.ENTITIES_BY_NAME[entity_name]["entity_hex"] for entity_name in GENERAL_LOCATIONS
-}
-
 OBELISK_SIDES = {
     "Desert Obelisk Side 1",
     "Desert Obelisk Side 2",
@@ -450,42 +444,27 @@ OBELISK_SIDES = {
     "Town Obelisk Side 6",
 }
 
-ALL_LOCATIONS_TO_ID: Dict[str, int] = {}
-
 AREA_LOCATION_GROUPS: Dict[str, Set[str]] = {}
 
 
-def get_id(entity_hex: str) -> int:
-    """
-    Calculates the location ID for any given location
-    """
-
-    return cast(int, static_witness_logic.ENTITIES_BY_HEX[entity_hex]["id"])
-
-
-def get_event_name(entity_hex: str) -> str:
+def get_event_name(entity_id: int) -> str:
     """
     Returns the event name of any given panel.
     """
 
-    action = " Opened" if static_witness_logic.ENTITIES_BY_HEX[entity_hex]["entityType"] == "Door" else " Solved"
+    action = " Opened" if static_witness_logic.ENTITIES_BY_ID[entity_id].entity_type == "Door" else " Solved"
 
-    return cast(str, static_witness_logic.ENTITIES_BY_HEX[entity_hex]["checkName"]) + action
+    return cast(str, static_witness_logic.ENTITIES_BY_ID[entity_id].entity_name) + action
 
 
-ALL_LOCATIONS_TO_IDS = {
-    panel_obj["checkName"]: get_id(chex)
-    for chex, panel_obj in static_witness_logic.ENTITIES_BY_HEX.items()
-    if panel_obj["id"]
+ALL_LOCATIONS_TO_ID = {
+    panel_obj.entity_name: entity_id
+    for entity_id, panel_obj in static_witness_logic.ENTITIES_BY_ID.items()
+    if panel_obj.location_type is not None
 }
 
-ALL_LOCATIONS_TO_IDS = dict(
-    sorted(ALL_LOCATIONS_TO_IDS.items(), key=lambda loc: loc[1])
-)
+ALL_LOCATIONS_TO_ID = dict(sorted(ALL_LOCATIONS_TO_ID.items(), key=lambda item: item[1]))
 
-for key, item in ALL_LOCATIONS_TO_IDS.items():
-    ALL_LOCATIONS_TO_ID[key] = item
-
-for loc in ALL_LOCATIONS_TO_IDS:
-    area = static_witness_logic.ENTITIES_BY_NAME[loc]["area"].name
-    AREA_LOCATION_GROUPS.setdefault(area, set()).add(loc)
+for location_name in ALL_LOCATIONS_TO_ID:
+    area = static_witness_logic.ENTITIES_BY_NAME[location_name].area.name
+    AREA_LOCATION_GROUPS.setdefault(area, set()).add(location_name)

--- a/worlds/witness/data/static_logic.py
+++ b/worlds/witness/data/static_logic.py
@@ -1,5 +1,5 @@
 from collections import Counter, defaultdict
-from typing import Dict, FrozenSet, List, Optional, Set, Tuple
+from typing import Dict, FrozenSet, List, Optional, Set
 
 from Utils import cache_argsless
 
@@ -40,7 +40,7 @@ class StaticWitnessLogicObj:
         self.ENTITIES_BY_NAME: Dict[str, EntityDefinition] = {}
         self.STATIC_DEPENDENT_REQUIREMENTS_BY_ENTITY_ID: Dict[int, Dict[str, WitnessRule]] = {}
 
-        self.OBELISK_SIDE_ID_TO_EP_HEXES: Dict[int, Tuple[int]] = {}
+        self.OBELISK_SIDE_ID_TO_EP_IDS: Dict[int, List[int]] = {}
 
         self.EP_ID_TO_OBELISK_SIDE_ID: Dict[int, int] = {}
 
@@ -143,7 +143,7 @@ class StaticWitnessLogicObj:
 
             entity_name_full = line_split.pop(0)
 
-            entity_id = int(entity_name_full[0:7])
+            entity_id = int(entity_name_full[0:7], 16)
             entity_name = entity_name_full[9:-1]
 
             entity_requirement_string = line_split.pop(0)
@@ -201,7 +201,7 @@ class StaticWitnessLogicObj:
             elif "Pet the Dog" in entity_name:
                 entity_type = "Event"
                 location_type = "Good Boi"
-            elif entity_id & 0xFF000:
+            elif entity_id & 0xFF000 == 0xFF000:
                 entity_type = "Event"
                 location_type = None
             else:
@@ -222,9 +222,9 @@ class StaticWitnessLogicObj:
                 eps = set(next(iter(required_entities)))
                 eps -= {"Theater to Tunnels"}
 
-                eps_ints = (int(h, 16) for h in eps)
+                eps_ints = [int(h, 16) for h in eps]
 
-                self.OBELISK_SIDE_ID_TO_EP_HEXES[entity_id] = eps_ints
+                self.OBELISK_SIDE_ID_TO_EP_IDS[entity_id] = eps_ints
                 for ep_id in eps_ints:
                     self.EP_ID_TO_OBELISK_SIDE_ID[ep_id] = entity_id
 
@@ -310,7 +310,8 @@ def parse_items() -> None:
 
         if current_category in [ItemCategory.DOOR, ItemCategory.LASER]:
             # Map doors to IDs.
-            ALL_ITEMS[item_name] = DoorItemDefinition(item_code, current_category, arguments)
+            entity_ids = [int(entity_id_str, 16) for entity_id_str in arguments]
+            ALL_ITEMS[item_name] = DoorItemDefinition(item_code, current_category, entity_ids)
         elif current_category == ItemCategory.TRAP or current_category == ItemCategory.FILLER:
             # Read filler weights.
             weight = int(arguments[0]) if len(arguments) >= 1 else 1
@@ -350,6 +351,10 @@ def get_sigma_expert() -> StaticWitnessLogicObj:
 def get_umbra_variety() -> StaticWitnessLogicObj:
     return StaticWitnessLogicObj(get_umbra_variety_logic())
 
+vanilla: StaticWitnessLogicObj
+sigma_normal: StaticWitnessLogicObj
+sigma_expert: StaticWitnessLogicObj
+umbra_variety: StaticWitnessLogicObj
 
 def __getattr__(name: str) -> StaticWitnessLogicObj:
     if name == "vanilla":
@@ -369,10 +374,10 @@ ALL_REGIONS_BY_NAME = get_sigma_normal().ALL_REGIONS_BY_NAME
 ALL_AREAS_BY_NAME = get_sigma_normal().ALL_AREAS_BY_NAME
 STATIC_CONNECTIONS_BY_REGION_NAME = get_sigma_normal().STATIC_CONNECTIONS_BY_REGION_NAME
 
-ENTITIES_BY_HEX = get_sigma_normal().ENTITIES_BY_ID
+ENTITIES_BY_ID = get_sigma_normal().ENTITIES_BY_ID
 ENTITIES_BY_NAME = get_sigma_normal().ENTITIES_BY_NAME
-STATIC_DEPENDENT_REQUIREMENTS_BY_HEX = get_sigma_normal().STATIC_DEPENDENT_REQUIREMENTS_BY_ENTITY_ID
+STATIC_DEPENDENT_REQUIREMENTS_BY_ENTITY_ID = get_sigma_normal().STATIC_DEPENDENT_REQUIREMENTS_BY_ENTITY_ID
 
-OBELISK_SIDE_ID_TO_EP_HEXES = get_sigma_normal().OBELISK_SIDE_ID_TO_EP_HEXES
+OBELISK_SIDE_ID_TO_EP_IDS = get_sigma_normal().OBELISK_SIDE_ID_TO_EP_IDS
 
 EP_TO_OBELISK_SIDE = get_sigma_normal().EP_ID_TO_OBELISK_SIDE_ID

--- a/worlds/witness/data/static_logic.py
+++ b/worlds/witness/data/static_logic.py
@@ -1,9 +1,9 @@
 from collections import Counter, defaultdict
-from typing import Any, Dict, FrozenSet, List, Optional, Set
+from typing import Dict, FrozenSet, List, Optional, Set, Tuple
 
 from Utils import cache_argsless
 
-from .definition_classes import AreaDefinition, ConnectionDefinition, RegionDefinition, WitnessRule
+from .definition_classes import AreaDefinition, ConnectionDefinition, RegionDefinition, WitnessRule, EntityDefinition
 from .item_definition_classes import (
     CATEGORY_NAME_MAPPINGS,
     DoorItemDefinition,
@@ -36,19 +36,22 @@ class StaticWitnessLogicObj:
         self.CONNECTIONS_WITH_DUPLICATES: Dict[str, List[ConnectionDefinition]] = defaultdict(list)
         self.STATIC_CONNECTIONS_BY_REGION_NAME: Dict[str, List[ConnectionDefinition]] = {}
 
-        self.ENTITIES_BY_HEX: Dict[str, Dict[str, Any]] = {}
-        self.ENTITIES_BY_NAME: Dict[str, Dict[str, Any]] = {}
-        self.STATIC_DEPENDENT_REQUIREMENTS_BY_HEX: Dict[str, Dict[str, WitnessRule]] = {}
+        self.ENTITIES_BY_ID: Dict[int, EntityDefinition] = {}
+        self.ENTITIES_BY_NAME: Dict[str, EntityDefinition] = {}
+        self.STATIC_DEPENDENT_REQUIREMENTS_BY_ENTITY_ID: Dict[int, Dict[str, WitnessRule]] = {}
 
-        self.OBELISK_SIDE_ID_TO_EP_HEXES: Dict[int, Set[int]] = {}
+        self.OBELISK_SIDE_ID_TO_EP_HEXES: Dict[int, Tuple[int]] = {}
 
-        self.EP_TO_OBELISK_SIDE: Dict[str, str] = {}
-
-        self.ENTITY_ID_TO_NAME: Dict[str, str] = {}
+        self.EP_ID_TO_OBELISK_SIDE_ID: Dict[int, int] = {}
 
         self.read_logic_file(lines)
         self.reverse_connections()
         self.combine_connections()
+
+    def add_entity(self, entity: EntityDefinition) -> None:
+        entity.order = len(self.ENTITIES_BY_ID)
+        self.ENTITIES_BY_ID[entity.entity_id] = entity
+        self.ENTITIES_BY_NAME[entity.entity_name] = entity
 
     def add_easter_eggs(self) -> None:
         egg_counter = 0
@@ -58,61 +61,51 @@ class StaticWitnessLogicObj:
             correct_area = region_object.area
 
             for _ in range(entity_amount):
-                location_id = 160200 + egg_counter
-                entity_hex = hex(0xEE000 + egg_counter)
+                entity_id = 0xEE000 + egg_counter
                 egg_counter += 1
 
                 area_counts[correct_area.name] += 1
                 full_entity_name = f"{correct_area.name} Easter Egg {area_counts[correct_area.name]}"
 
-                self.ENTITIES_BY_HEX[entity_hex] = {
-                    "checkName": full_entity_name,
-                    "entity_hex": entity_hex,
-                    "region": region_object,
-                    "id": int(location_id),
-                    "entityType": "Easter Egg",
-                    "locationType": "Easter Egg",
-                    "area": correct_area,
-                    "order": len(self.ENTITIES_BY_HEX),
-                }
+                self.add_entity(EntityDefinition(
+                    full_entity_name,
+                    entity_id,
+                    region_object,
+                    "Easter Egg",
+                    "Easter Egg",
+                    correct_area,
+                ))
 
-                self.ENTITIES_BY_NAME[self.ENTITIES_BY_HEX[entity_hex]["checkName"]] = self.ENTITIES_BY_HEX[entity_hex]
-
-                self.STATIC_DEPENDENT_REQUIREMENTS_BY_HEX[entity_hex] = {
+                self.STATIC_DEPENDENT_REQUIREMENTS_BY_ENTITY_ID[entity_id] = {
                     "entities": frozenset({frozenset({})})
                 }
-                region_object.logical_entities.append(entity_hex)
-                region_object.physical_entities.append(entity_hex)
+                region_object.logical_entities.append(entity_id)
+                region_object.physical_entities.append(entity_id)
 
         easter_egg_region = self.ALL_REGIONS_BY_NAME["Easter Eggs"]
         easter_egg_area = easter_egg_region.area
         for i in range(sum(EASTER_EGGS.values())):
-            location_id = 160000 + i
-            entity_hex = hex(0xEE200 + i)
+            entity_id = 0xEE200 + i
 
             if i == 0:
                 continue
 
             full_entity_name = f"{i + 1} Easter Eggs Collected"
 
-            self.ENTITIES_BY_HEX[entity_hex] = {
-                "checkName": full_entity_name,
-                "entity_hex": entity_hex,
-                "region": easter_egg_region,
-                "id": int(location_id),
-                "entityType": "Easter Egg Total",
-                "locationType": "Easter Egg Total",
-                "area": easter_egg_area,
-                "order": len(self.ENTITIES_BY_HEX),
-            }
+            self.add_entity(EntityDefinition(
+                full_entity_name,
+                entity_id,
+                easter_egg_region,
+                "Easter Egg Total",
+                "Easter Egg Total",
+                easter_egg_area,
+            ))
 
-            self.ENTITIES_BY_NAME[self.ENTITIES_BY_HEX[entity_hex]["checkName"]] = self.ENTITIES_BY_HEX[entity_hex]
-
-            self.STATIC_DEPENDENT_REQUIREMENTS_BY_HEX[entity_hex] = {
+            self.STATIC_DEPENDENT_REQUIREMENTS_BY_ENTITY_ID[entity_id] = {
                 "entities": frozenset({frozenset({})})
             }
-            easter_egg_region.logical_entities.append(entity_hex)
-            easter_egg_region.physical_entities.append(entity_hex)
+            easter_egg_region.logical_entities.append(entity_id)
+            easter_egg_region.physical_entities.append(entity_id)
 
     def read_logic_file(self, lines: List[str]) -> None:
         """
@@ -144,41 +137,39 @@ class StaticWitnessLogicObj:
 
             line_split = line.split(" - ")
 
-            location_id = line_split.pop(0)
+            entity_type = "General"
+            if line_split[0] in ("Door", "Laser"):
+                entity_type = line_split.pop(0)
 
             entity_name_full = line_split.pop(0)
 
-            entity_hex = entity_name_full[0:7]
+            entity_id = int(entity_name_full[0:7])
             entity_name = entity_name_full[9:-1]
 
             entity_requirement_string = line_split.pop(0)
 
             full_entity_name = current_region.short_name + " " + entity_name
 
-            if location_id == "Door" or location_id == "Laser":
-                self.ENTITIES_BY_HEX[entity_hex] = {
-                    "checkName": full_entity_name,
-                    "entity_hex": entity_hex,
-                    "region": None,
-                    "id": None,
-                    "entityType": location_id,
-                    "locationType": None,
-                    "area": current_area,
-                    "order": len(self.ENTITIES_BY_HEX),
-                }
+            if entity_type in ("Door", "Laser"):
+                self.add_entity(EntityDefinition(
+                    full_entity_name,
+                    entity_id,
+                    None,
+                    entity_type,
+                    None,
+                    current_area,
+                ))
 
-                self.ENTITIES_BY_NAME[self.ENTITIES_BY_HEX[entity_hex]["checkName"]] = self.ENTITIES_BY_HEX[entity_hex]
-
-                self.STATIC_DEPENDENT_REQUIREMENTS_BY_HEX[entity_hex] = {
+                self.STATIC_DEPENDENT_REQUIREMENTS_BY_ENTITY_ID[entity_id] = {
                     "entities": parse_witness_rule(entity_requirement_string)
                 }
 
                 # Lasers and Doors exist in a region, but don't have a regional *requirement*
                 # If a laser is activated, you don't need to physically walk up to it for it to count
                 # As such, logically, they behave more as if they were part of the "Entry" region
-                self.ALL_REGIONS_BY_NAME["Entry"].logical_entities.append(entity_hex)
+                self.ALL_REGIONS_BY_NAME["Entry"].logical_entities.append(entity_id)
                 # However, it will also be important to keep track of their physical location for postgame purposes.
-                current_region.physical_entities.append(entity_hex)
+                current_region.physical_entities.append(entity_id)
                 continue
 
             item_requirement_string = line_split.pop(0)
@@ -210,7 +201,7 @@ class StaticWitnessLogicObj:
             elif "Pet the Dog" in entity_name:
                 entity_type = "Event"
                 location_type = "Good Boi"
-            elif entity_hex.startswith("0xFF"):
+            elif entity_id & 0xFF000:
                 entity_type = "Event"
                 location_type = None
             else:
@@ -231,30 +222,26 @@ class StaticWitnessLogicObj:
                 eps = set(next(iter(required_entities)))
                 eps -= {"Theater to Tunnels"}
 
-                eps_ints = {int(h, 16) for h in eps}
+                eps_ints = (int(h, 16) for h in eps)
 
-                self.OBELISK_SIDE_ID_TO_EP_HEXES[int(entity_hex, 16)] = eps_ints
-                for ep_hex in eps:
-                    self.EP_TO_OBELISK_SIDE[ep_hex] = entity_hex
+                self.OBELISK_SIDE_ID_TO_EP_HEXES[entity_id] = eps_ints
+                for ep_id in eps_ints:
+                    self.EP_ID_TO_OBELISK_SIDE_ID[ep_id] = entity_id
 
-            self.ENTITIES_BY_HEX[entity_hex] = {
-                "checkName": full_entity_name,
-                "entity_hex": entity_hex,
-                "region": current_region,
-                "id": int(location_id),
-                "entityType": entity_type,
-                "locationType": location_type,
-                "area": current_area,
-                "order": len(self.ENTITIES_BY_HEX),
-            }
+            self.add_entity(EntityDefinition(
+                full_entity_name,
+                entity_id,
+                current_region,
+                entity_type,
+                location_type,
+                current_area,
+            ))
 
-            self.ENTITY_ID_TO_NAME[entity_hex] = full_entity_name
+            self.ENTITIES_BY_NAME[self.ENTITIES_BY_ID[entity_id].entity_name] = self.ENTITIES_BY_ID[entity_id]
+            self.STATIC_DEPENDENT_REQUIREMENTS_BY_ENTITY_ID[entity_id] = requirement
 
-            self.ENTITIES_BY_NAME[self.ENTITIES_BY_HEX[entity_hex]["checkName"]] = self.ENTITIES_BY_HEX[entity_hex]
-            self.STATIC_DEPENDENT_REQUIREMENTS_BY_HEX[entity_hex] = requirement
-
-            current_region.logical_entities.append(entity_hex)
-            current_region.physical_entities.append(entity_hex)
+            current_region.logical_entities.append(entity_id)
+            current_region.physical_entities.append(entity_id)
 
         self.add_easter_eggs()
 
@@ -382,12 +369,10 @@ ALL_REGIONS_BY_NAME = get_sigma_normal().ALL_REGIONS_BY_NAME
 ALL_AREAS_BY_NAME = get_sigma_normal().ALL_AREAS_BY_NAME
 STATIC_CONNECTIONS_BY_REGION_NAME = get_sigma_normal().STATIC_CONNECTIONS_BY_REGION_NAME
 
-ENTITIES_BY_HEX = get_sigma_normal().ENTITIES_BY_HEX
+ENTITIES_BY_HEX = get_sigma_normal().ENTITIES_BY_ID
 ENTITIES_BY_NAME = get_sigma_normal().ENTITIES_BY_NAME
-STATIC_DEPENDENT_REQUIREMENTS_BY_HEX = get_sigma_normal().STATIC_DEPENDENT_REQUIREMENTS_BY_HEX
+STATIC_DEPENDENT_REQUIREMENTS_BY_HEX = get_sigma_normal().STATIC_DEPENDENT_REQUIREMENTS_BY_ENTITY_ID
 
 OBELISK_SIDE_ID_TO_EP_HEXES = get_sigma_normal().OBELISK_SIDE_ID_TO_EP_HEXES
 
-EP_TO_OBELISK_SIDE = get_sigma_normal().EP_TO_OBELISK_SIDE
-
-ENTITY_ID_TO_NAME = get_sigma_normal().ENTITY_ID_TO_NAME
+EP_TO_OBELISK_SIDE = get_sigma_normal().EP_ID_TO_OBELISK_SIDE_ID

--- a/worlds/witness/data/utils.py
+++ b/worlds/witness/data/utils.py
@@ -270,3 +270,7 @@ def is_easter_time() -> bool:
     last_easter_day = date(today.year, 4, 26)  # Latest possible is 4/25 + 1 day buffer for Easter Monday
 
     return earliest_easter_day <= today <= last_easter_day
+
+
+def entity_id_to_canonical_id_string(entity_id_int: int) -> str:
+    return f"0x{entity_id_int:0{5}X}"

--- a/worlds/witness/entity_hunt.py
+++ b/worlds/witness/entity_hunt.py
@@ -10,49 +10,49 @@ if TYPE_CHECKING:
     from .player_logic import WitnessPlayerLogic
 
 DISALLOWED_ENTITIES_FOR_PANEL_HUNT = {
-    "0x03629",  # Tutorial Gate Open, which is the panel that is locked by panel hunt
-    "0x03505",  # Tutorial Gate Close (same thing)
-    "0x3352F",  # Gate EP (same thing)
-    "0x09F7F",  # Mountaintop Box Short. This is reserved for panel_hunt_postgame.
-    "0x00CDB",  # Challenge Reallocating
-    "0x0051F",  # Challenge Reallocating
-    "0x00524",  # Challenge Reallocating
-    "0x00CD4",  # Challenge Reallocating
-    "0x00CB9",  # Challenge May Be Unsolvable
-    "0x00CA1",  # Challenge May Be Unsolvable
-    "0x00C80",  # Challenge May Be Unsolvable
-    "0x00C68",  # Challenge May Be Unsolvable
-    "0x00C59",  # Challenge May Be Unsolvable
-    "0x00C22",  # Challenge May Be Unsolvable
-    "0x0A3A8",  # Reset PP
-    "0x0A3B9",  # Reset PP
-    "0x0A3BB",  # Reset PP
-    "0x0A3AD",  # Reset PP
+    0x03629,  # Tutorial Gate Open, which is the panel that is locked by panel hunt
+    0x03505,  # Tutorial Gate Close (same thing)
+    0x3352F,  # Gate EP (same thing)
+    0x09F7F,  # Mountaintop Box Short. This is reserved for panel_hunt_postgame.
+    0x00CDB,  # Challenge Reallocating
+    0x0051F,  # Challenge Reallocating
+    0x00524,  # Challenge Reallocating
+    0x00CD4,  # Challenge Reallocating
+    0x00CB9,  # Challenge May Be Unsolvable
+    0x00CA1,  # Challenge May Be Unsolvable
+    0x00C80,  # Challenge May Be Unsolvable
+    0x00C68,  # Challenge May Be Unsolvable
+    0x00C59,  # Challenge May Be Unsolvable
+    0x00C22,  # Challenge May Be Unsolvable
+    0x0A3A8,  # Reset PP
+    0x0A3B9,  # Reset PP
+    0x0A3BB,  # Reset PP
+    0x0A3AD,  # Reset PP
 }
 
 ALL_HUNTABLE_PANELS = [
-    entity_hex
-    for entity_hex, entity_obj in static_witness_logic.ENTITIES_BY_HEX.items()
-    if entity_obj["entityType"] == "Panel" and entity_hex not in DISALLOWED_ENTITIES_FOR_PANEL_HUNT
+    entity_id
+    for entity_id, entity_obj in static_witness_logic.ENTITIES_BY_ID.items()
+    if entity_obj.entity_type == "Panel" and entity_id not in DISALLOWED_ENTITIES_FOR_PANEL_HUNT
 ]
 
 
 class EntityHuntPicker:
     def __init__(self, player_logic: "WitnessPlayerLogic", world: "WitnessWorld",
-                 pre_picked_entities: Set[str]) -> None:
+                 pre_picked_entities: Set[int]) -> None:
         self.player_logic = player_logic
         self.player_options = world.options
         self.player_name = world.player_name
         self.random = world.random
 
         self.PRE_PICKED_HUNT_ENTITIES = pre_picked_entities.copy()
-        self.HUNT_ENTITIES: Set[str] = set()
+        self.HUNT_ENTITIES: Set[int] = set()
 
         self._add_plandoed_hunt_panels_to_pre_picked()
 
         self.ALL_ELIGIBLE_ENTITIES, self.ELIGIBLE_ENTITIES_PER_AREA = self._get_eligible_panels()
 
-    def pick_panel_hunt_panels(self, total_amount: int) -> Set[str]:
+    def pick_panel_hunt_panels(self, total_amount: int) -> Set[int]:
         """
         The process of picking all hunt entities is:
 
@@ -71,13 +71,13 @@ class EntityHuntPicker:
 
         return self.HUNT_ENTITIES
 
-    def _entity_is_eligible(self, panel_hex: str, plando: bool = False) -> bool:
+    def _entity_is_eligible(self, panel_id: int, plando: bool = False) -> bool:
         """
         Determine whether an entity is eligible for entity hunt based on player options.
         """
-        panel_obj = static_witness_logic.ENTITIES_BY_HEX[panel_hex]
+        panel_obj = static_witness_logic.ENTITIES_BY_ID[panel_id]
 
-        if not self.player_logic.solvability_guaranteed(panel_hex) or panel_hex in self.player_logic.EXCLUDED_ENTITIES:
+        if not self.player_logic.solvability_guaranteed(panel_id) or panel_id in self.player_logic.EXCLUDED_ENTITIES:
             if plando:
                 warning(f"Panel {panel_obj['checkName']} is disabled / excluded and thus not eligible for panel hunt.")
             return False
@@ -101,12 +101,12 @@ class EntityHuntPicker:
         self.random.shuffle(panels_to_plando)
 
         for location_name in panels_to_plando:
-            entity_hex = static_witness_logic.ENTITIES_BY_NAME[location_name]["entity_hex"]
+            entity_id = static_witness_logic.ENTITIES_BY_NAME[location_name].entity_id
 
-            if entity_hex in self.PRE_PICKED_HUNT_ENTITIES:
+            if entity_id in self.PRE_PICKED_HUNT_ENTITIES:
                 continue
 
-            if self._entity_is_eligible(entity_hex, plando=True):
+            if self._entity_is_eligible(entity_id, plando=True):
                 if len(self.PRE_PICKED_HUNT_ENTITIES) == self.player_options.panel_hunt_total:
                     warning(
                         f"Panel {location_name} could not be plandoed as a hunt panel for {self.player_name}'s world, "
@@ -114,9 +114,9 @@ class EntityHuntPicker:
                     )
                     continue
 
-                self.PRE_PICKED_HUNT_ENTITIES.add(entity_hex)
+                self.PRE_PICKED_HUNT_ENTITIES.add(entity_id)
 
-    def _get_eligible_panels(self) -> Tuple[List[str], Dict[str, Set[str]]]:
+    def _get_eligible_panels(self) -> Tuple[List[int], Dict[str, Set[int]]]:
         """
         There are some entities that are not allowed for panel hunt for various technical of gameplay reasons.
         Make a list of all the ones that *are* eligible, plus a lookup of eligible panels per area.
@@ -129,7 +129,7 @@ class EntityHuntPicker:
 
         eligible_panels_by_area = defaultdict(set)
         for eligible_panel in all_eligible_panels:
-            associated_area = static_witness_logic.ENTITIES_BY_HEX[eligible_panel]["area"].name
+            associated_area = static_witness_logic.ENTITIES_BY_ID[eligible_panel]["area"].name
             eligible_panels_by_area[associated_area].add(eligible_panel)
 
         return all_eligible_panels, eligible_panels_by_area
@@ -145,7 +145,7 @@ class EntityHuntPicker:
 
         return contributing_percentage_per_area
 
-    def _get_next_random_batch(self, amount: int, same_area_discouragement: float) -> List[str]:
+    def _get_next_random_batch(self, amount: int, same_area_discouragement: float) -> List[int]:
         """
         Pick the next batch of hunt entities.
         Areas that already have a lot of hunt entities in them will be discouraged from getting more.
@@ -216,22 +216,22 @@ class EntityHuntPicker:
         """
 
         replacements = {
-            "0x18488": "0x00609",  # Replace Swamp Sliding Bridge Underwater -> Swamp Sliding Bridge Above Water
-            "0x03676": "0x03678",  # Replace Quarry Upper Ramp Control -> Lower Ramp Control
-            "0x03675": "0x03679",  # Replace Quarry Upper Lift Control -> Lower Lift Control
+            0x18488: 0x00609,  # Replace Swamp Sliding Bridge Underwater -> Swamp Sliding Bridge Above Water
+            0x03676: 0x03678,  # Replace Quarry Upper Ramp Control -> Lower Ramp Control
+            0x03675: 0x03679,  # Replace Quarry Upper Lift Control -> Lower Lift Control
 
-            "0x03702": "0x15ADD",  # Jungle Vault Box -> Jungle Vault Panel
-            "0x03542": "0x002A6",  # Mountainside Vault Box -> Mountainside Vault Panel
-            "0x03481": "0x033D4",  # Tutorial Vault Box -> Tutorial Vault Panel
-            "0x0339E": "0x0CC7B",  # Desert Vault Box -> Desert Vault Panel
-            "0x03535": "0x00AFB",  # Shipwreck Vault Box -> Shipwreck Vault Panel
+            0x03702: 0x15ADD,  # Jungle Vault Box -> Jungle Vault Panel
+            0x03542: 0x002A6,  # Mountainside Vault Box -> Mountainside Vault Panel
+            0x03481: 0x033D4,  # Tutorial Vault Box -> Tutorial Vault Panel
+            0x0339E: 0x0CC7B,  # Desert Vault Box -> Desert Vault Panel
+            0x03535: 0x00AFB,  # Shipwreck Vault Box -> Shipwreck Vault Panel
         }
 
         if self.player_options.shuffle_doors < 2:
             replacements.update(
                 {
-                    "0x334DC": "0x334DB",  # In door shuffle, the Shadows Timer Panels are disconnected
-                    "0x17CBC": "0x2700B",  # In door shuffle, the Laser Timer Panels are disconnected
+                    0x334DC: 0x334DB,  # In door shuffle, the Shadows Timer Panels are disconnected
+                    0x17CBC: 0x2700B,  # In door shuffle, the Laser Timer Panels are disconnected
                 }
             )
 

--- a/worlds/witness/entity_hunt.py
+++ b/worlds/witness/entity_hunt.py
@@ -87,7 +87,7 @@ class EntityHuntPicker:
             # However, I don't think they should be hunt panels in this case.
             self.player_options.disable_non_randomized_puzzles
             and not self.player_options.shuffle_discarded_panels
-            and panel_obj["locationType"] == "Discard"
+            and panel_obj.location_type == "Discard"
         )
 
     def _add_plandoed_hunt_panels_to_pre_picked(self) -> None:
@@ -129,7 +129,7 @@ class EntityHuntPicker:
 
         eligible_panels_by_area = defaultdict(set)
         for eligible_panel in all_eligible_panels:
-            associated_area = static_witness_logic.ENTITIES_BY_ID[eligible_panel]["area"].name
+            associated_area = static_witness_logic.ENTITIES_BY_ID[eligible_panel].area.name
             eligible_panels_by_area[associated_area].add(eligible_panel)
 
         return all_eligible_panels, eligible_panels_by_area

--- a/worlds/witness/generate_data_file.py
+++ b/worlds/witness/generate_data_file.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 
 from data import static_logic as static_witness_logic
+from data.utils import entity_id_to_canonical_id_string
 
 if __name__ == "__main__":
     with open("data/APWitnessData.h", "w") as datafile:
@@ -16,10 +17,10 @@ if __name__ == "__main__":
         area_to_entity_ids = defaultdict(list)
 
         for entity_id, entity_object in static_witness_logic.ENTITIES_BY_ID.items():
-            location_id = entity_object["id"]
+            location_id = entity_object.entity_id
 
             area = entity_object["area"].name
-            area_to_entity_ids[area].append(entity_id)
+            area_to_entity_ids[area].append(entity_id_to_canonical_id_string(entity_id))
 
             if location_id is None:
                 continue
@@ -47,8 +48,8 @@ if __name__ == "__main__":
         datafile.write("inline std::map<int, std::string> entityToName = {")
         datafile.write(
             "\n".join(
-                "\t{ " + entity_hex + ', "' + entity_object["checkName"] + '" },'
-                for entity_hex, entity_object in static_witness_logic.ENTITIES_BY_ID.items()
+                "\t{ " + entity_id_to_canonical_id_string(entity_id) + ', "' + entity_object.entity_name + '" },'
+                for entity_id, entity_object in static_witness_logic.ENTITIES_BY_ID.items()
             )
         )
         datafile.write("\n};\n\n")

--- a/worlds/witness/generate_data_file.py
+++ b/worlds/witness/generate_data_file.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
         for entity_id, entity_object in static_witness_logic.ENTITIES_BY_ID.items():
             location_id = entity_object.entity_id
 
-            area = entity_object["area"].name
+            area = entity_object.area.name
             area_to_entity_ids[area].append(entity_id_to_canonical_id_string(entity_id))
 
             if location_id is None:

--- a/worlds/witness/generate_data_file.py
+++ b/worlds/witness/generate_data_file.py
@@ -15,7 +15,7 @@ if __name__ == "__main__":
         area_to_location_ids = defaultdict(list)
         area_to_entity_ids = defaultdict(list)
 
-        for entity_id, entity_object in static_witness_logic.ENTITIES_BY_HEX.items():
+        for entity_id, entity_object in static_witness_logic.ENTITIES_BY_ID.items():
             location_id = entity_object["id"]
 
             area = entity_object["area"].name
@@ -48,7 +48,7 @@ if __name__ == "__main__":
         datafile.write(
             "\n".join(
                 "\t{ " + entity_hex + ', "' + entity_object["checkName"] + '" },'
-                for entity_hex, entity_object in static_witness_logic.ENTITIES_BY_HEX.items()
+                for entity_hex, entity_object in static_witness_logic.ENTITIES_BY_ID.items()
             )
         )
         datafile.write("\n};\n\n")

--- a/worlds/witness/generate_data_file.py
+++ b/worlds/witness/generate_data_file.py
@@ -22,20 +22,6 @@ if __name__ == "__main__":
             area = entity_object.area.name
             area_to_entity_ids[area].append(entity_id_to_canonical_id_string(entity_id))
 
-            if location_id is None:
-                continue
-
-            area_to_location_ids[area].append(str(location_id))
-
-        datafile.write("inline std::map<std::string, std::set<int64_t>> areaNameToLocationIDs = {\n")
-        datafile.write(
-            "\n".join(
-                '\t{"' + area + '", { ' + ", ".join(location_ids) + " }},"
-                for area, location_ids in area_to_location_ids.items()
-            )
-        )
-        datafile.write("\n};\n\n")
-
         datafile.write("inline std::map<std::string, std::set<int64_t>> areaNameToEntityIDs = {\n")
         datafile.write(
             "\n".join(

--- a/worlds/witness/hints.py
+++ b/worlds/witness/hints.py
@@ -77,13 +77,13 @@ def get_always_hint_locations(world: "WitnessWorld") -> List[str]:
     ]
 
     # Add Obelisk Sides that contain EPs that are meant to be hinted, if they are necessary to complete the Obelisk Side
-    if "0x339B6" not in world.player_logic.COMPLETELY_DISABLED_ENTITIES:
+    if 0x339B6 not in world.player_logic.COMPLETELY_DISABLED_ENTITIES:
         always.append("Town Obelisk Side 6")  # Eclipse EP
 
-    if "0x3388F" not in world.player_logic.COMPLETELY_DISABLED_ENTITIES:
+    if 0x3388F not in world.player_logic.COMPLETELY_DISABLED_ENTITIES:
         always.append("Treehouse Obelisk Side 4")  # Couch EP
 
-    if "0x335AE" not in world.player_logic.COMPLETELY_DISABLED_ENTITIES:
+    if 0x335AE not in world.player_logic.COMPLETELY_DISABLED_ENTITIES:
         always.append("Mountainside Obelisk Side 1")  # Cloud Cycle EP.
 
     return always
@@ -160,13 +160,13 @@ def get_priority_hint_locations(world: "WitnessWorld") -> List[str]:
     ]
 
     # Add Obelisk Sides that contain EPs that are meant to be hinted, if they are necessary to complete the Obelisk Side
-    if "0x33A20" not in world.player_logic.COMPLETELY_DISABLED_ENTITIES:
+    if 0x33A20 not in world.player_logic.COMPLETELY_DISABLED_ENTITIES:
         priority.append("Town Obelisk Side 6")  # Theater Flowers EP
 
-    if "0x28B29" not in world.player_logic.COMPLETELY_DISABLED_ENTITIES:
+    if 0x28B29 not in world.player_logic.COMPLETELY_DISABLED_ENTITIES:
         priority.append("Treehouse Obelisk Side 4")  # Shipwreck Green EP
 
-    if "0x33600" not in world.player_logic.COMPLETELY_DISABLED_ENTITIES:
+    if 0x33600 not in world.player_logic.COMPLETELY_DISABLED_ENTITIES:
         priority.append("Town Obelisk Side 2")  # Tutorial Patio Flowers EP.
 
     return priority

--- a/worlds/witness/hints.py
+++ b/worlds/witness/hints.py
@@ -516,7 +516,7 @@ def word_area_hint(world: "WitnessWorld", hinted_area: str, area_items: List[Ite
     hunt_panels = None
     if world.options.victory_condition == "panel_hunt" and hinted_area != "Easter Eggs":
         hunt_panels = sum(
-            static_witness_logic.ENTITIES_BY_ID[hunt_entity]["area"].name == hinted_area
+            static_witness_logic.ENTITIES_BY_ID[hunt_entity].area.name == hinted_area
             for hunt_entity in world.player_logic.HUNT_ENTITIES
         )
 

--- a/worlds/witness/hints.py
+++ b/worlds/witness/hints.py
@@ -516,7 +516,7 @@ def word_area_hint(world: "WitnessWorld", hinted_area: str, area_items: List[Ite
     hunt_panels = None
     if world.options.victory_condition == "panel_hunt" and hinted_area != "Easter Eggs":
         hunt_panels = sum(
-            static_witness_logic.ENTITIES_BY_HEX[hunt_entity]["area"].name == hinted_area
+            static_witness_logic.ENTITIES_BY_ID[hunt_entity]["area"].name == hinted_area
             for hunt_entity in world.player_logic.HUNT_ENTITIES
         )
 
@@ -620,7 +620,7 @@ def create_all_hints(world: "WitnessWorld", hint_amount: int, area_hints: int,
 
     already_hinted_locations |= {
         loc for loc in world.multiworld.get_reachable_locations(state, world.player)
-        if loc.address and static_witness_logic.ENTITIES_BY_NAME[loc.name]["area"].name == "Tutorial (Inside)"
+        if loc.address and static_witness_logic.ENTITIES_BY_NAME[loc.name].area.name == "Tutorial (Inside)"
     }
 
     intended_location_hints = hint_amount - area_hints

--- a/worlds/witness/options.py
+++ b/worlds/witness/options.py
@@ -335,7 +335,7 @@ class PanelHuntPlando(LocationSet):
 
     display_name = "Panel Hunt Plando"
 
-    valid_keys = [static_witness_logic.ENTITIES_BY_HEX[panel_hex]["checkName"] for panel_hex in ALL_HUNTABLE_PANELS]
+    valid_keys = [static_witness_logic.ENTITIES_BY_ID[entity_id].entity_name for entity_id in ALL_HUNTABLE_PANELS]
 
 
 class PuzzleRandomization(Choice):

--- a/worlds/witness/player_items.py
+++ b/worlds/witness/player_items.py
@@ -70,7 +70,10 @@ class WitnessPlayerItems:
             if not isinstance(item_data.definition, DoorItemDefinition):
                 continue
 
-            if all(not self._logic.solvability_guaranteed(e_hex) for e_hex in item_data.definition.panel_id_hexes):
+            if all(
+                not self._logic.solvability_guaranteed(entity_id)
+                for entity_id in item_data.definition.panel_entity_ids
+            ):
                 item_data.classification = ItemClassification.useful
 
             if item_data.definition.category == ItemCategory.LASER and self._world.options.shuffle_lasers == "local":

--- a/worlds/witness/player_logic.py
+++ b/worlds/witness/player_logic.py
@@ -293,7 +293,7 @@ class WitnessPlayerLogic:
 
     def get_entity_requirement(self, entity_id: int) -> WitnessRule:
         """
-        Get requirement of entity by its hex code.
+        Get requirement of entity by its id.
         These requirements are cached, with the actual function calculating them being reduce_req_within_region.
         """
         requirement = self.REQUIREMENTS_BY_ENTITY_ID.get(entity_id)

--- a/worlds/witness/player_logic.py
+++ b/worlds/witness/player_logic.py
@@ -1060,7 +1060,7 @@ class WitnessPlayerLogic:
             0x01BEA: difficulty == "none" and eps_shuffled,  # Keep PP2
             0x0A0C9: eps_shuffled or discards_shuffled or disable_non_randomized,  # Cargo Box Entry Door
             0x09EEB: discards_shuffled or mountain_upper_included,  # Mountain Floor 2 Elevator Control Panel
-            0x17CAB: symbols_shuffled or not disable_non_randomized or "0x17CAB" not in self.DOOR_ITEMS_BY_ID,
+            0x17CAB: symbols_shuffled or not disable_non_randomized or 0x17CAB not in self.DOOR_ITEMS_BY_ID,
             # Jungle Popup Wall Panel
         }
 

--- a/worlds/witness/player_logic.py
+++ b/worlds/witness/player_logic.py
@@ -104,7 +104,7 @@ class WitnessPlayerLogic:
             self.REFERENCE_LOGIC.STATIC_CONNECTIONS_BY_REGION_NAME
         )
         self.DEPENDENT_REQUIREMENTS_BY_HEX: Dict[str, Dict[str, WitnessRule]] = copy.deepcopy(
-            self.REFERENCE_LOGIC.STATIC_DEPENDENT_REQUIREMENTS_BY_HEX
+            self.REFERENCE_LOGIC.STATIC_DEPENDENT_REQUIREMENTS_BY_ENTITY_ID
         )
         self.REQUIREMENTS_BY_HEX: Dict[str, WitnessRule] = {}
 
@@ -176,7 +176,7 @@ class WitnessPlayerLogic:
         if self.is_disabled(entity_hex):
             return frozenset()
 
-        entity_obj = self.REFERENCE_LOGIC.ENTITIES_BY_HEX[entity_hex]
+        entity_obj = self.REFERENCE_LOGIC.ENTITIES_BY_ID[entity_hex]
 
         if entity_obj["region"] is not None and entity_obj["region"].name in self.UNREACHABLE_REGIONS:
             return frozenset()
@@ -240,7 +240,7 @@ class WitnessPlayerLogic:
 
             # For each entity in this option, resolve it to its actual requirement.
             for option_entity in option:
-                dep_obj = self.REFERENCE_LOGIC.ENTITIES_BY_HEX.get(option_entity, {})
+                dep_obj = self.REFERENCE_LOGIC.ENTITIES_BY_ID.get(option_entity, {})
 
                 if option_entity in {"7 Lasers", "11 Lasers", "7 Lasers + Redirect", "11 Lasers + Redirect",
                                      "PP2 Weirdness", "Theater to Tunnels", "Entity Hunt"}:
@@ -422,7 +422,7 @@ class WitnessPlayerLogic:
 
         if adj_type == "Added Locations":
             if "0x" in line:
-                line = self.REFERENCE_LOGIC.ENTITIES_BY_HEX[line]["checkName"]
+                line = self.REFERENCE_LOGIC.ENTITIES_BY_ID[line]["checkName"]
             self.ADDED_CHECKS.add(line)
 
     def handle_regular_postgame(self, world: "WitnessWorld") -> List[List[str]]:
@@ -731,13 +731,13 @@ class WitnessPlayerLogic:
             adjustment_linesets_in_order.append(get_obelisk_keys())
 
         if world.options.shuffle_EPs == "obelisk_sides":
-            ep_gen = ((ep_hex, ep_obj) for (ep_hex, ep_obj) in self.REFERENCE_LOGIC.ENTITIES_BY_HEX.items()
+            ep_gen = ((ep_hex, ep_obj) for (ep_hex, ep_obj) in self.REFERENCE_LOGIC.ENTITIES_BY_ID.items()
                       if ep_obj["entityType"] == "EP")
 
             for ep_hex, ep_obj in ep_gen:
-                obelisk = self.REFERENCE_LOGIC.ENTITIES_BY_HEX[self.REFERENCE_LOGIC.EP_TO_OBELISK_SIDE[ep_hex]]
+                obelisk = self.REFERENCE_LOGIC.ENTITIES_BY_ID[self.REFERENCE_LOGIC.EP_ID_TO_OBELISK_SIDE_ID[ep_hex]]
                 obelisk_name = obelisk["checkName"]
-                ep_name = self.REFERENCE_LOGIC.ENTITIES_BY_HEX[ep_hex]["checkName"]
+                ep_name = self.REFERENCE_LOGIC.ENTITIES_BY_ID[ep_hex]["checkName"]
                 self.ALWAYS_EVENT_NAMES_BY_HEX[ep_hex] = f"{obelisk_name} - {ep_name}"
         else:
             adjustment_linesets_in_order.append(["Disabled Locations:"] + get_ep_obelisks()[1:])
@@ -895,7 +895,7 @@ class WitnessPlayerLogic:
                 if not self.solvability_guaranteed(entity) or entity in self.DISABLE_EVERYTHING_BEHIND:
                     individual_entity_requirements.append(frozenset())
                 # If a connection requires acquiring an event, add that event to its requirements.
-                elif entity not in self.REFERENCE_LOGIC.ENTITIES_BY_HEX:
+                elif entity not in self.REFERENCE_LOGIC.ENTITIES_BY_ID:
                     individual_entity_requirements.append(frozenset({frozenset({entity})}))
                 elif entity in self.ALWAYS_EVENT_NAMES_BY_HEX:
                     individual_entity_requirements.append(
@@ -905,8 +905,8 @@ class WitnessPlayerLogic:
                 else:
                     entity_req = self.get_entity_requirement(entity)
 
-                    if self.REFERENCE_LOGIC.ENTITIES_BY_HEX[entity]["region"]:
-                        region_name = self.REFERENCE_LOGIC.ENTITIES_BY_HEX[entity]["region"].name
+                    if self.REFERENCE_LOGIC.ENTITIES_BY_ID[entity]["region"]:
+                        region_name = self.REFERENCE_LOGIC.ENTITIES_BY_ID[entity]["region"].name
                         entity_req = logical_and_witness_rules([entity_req, frozenset({frozenset({region_name})})])
 
                     individual_entity_requirements.append(entity_req)
@@ -1070,7 +1070,7 @@ class WitnessPlayerLogic:
         }
 
         for entity_hex, event_names in self.USED_EVENT_NAMES_BY_HEX.items():
-            entity_obj = self.REFERENCE_LOGIC.ENTITIES_BY_HEX[entity_hex]
+            entity_obj = self.REFERENCE_LOGIC.ENTITIES_BY_ID[entity_hex]
             entity_name = entity_obj["checkName"]
             entity_type = entity_obj["entityType"]
 
@@ -1089,7 +1089,7 @@ class WitnessPlayerLogic:
 
         # Make Panel Hunt Events
         for entity_hex in self.HUNT_ENTITIES:
-            entity_obj = self.REFERENCE_LOGIC.ENTITIES_BY_HEX[entity_hex]
+            entity_obj = self.REFERENCE_LOGIC.ENTITIES_BY_ID[entity_hex]
             entity_name = entity_obj["checkName"]
             self.EVENT_ITEM_PAIRS[entity_name + " (Panel Hunt)"] = ("+1 Panel Hunt", entity_hex)
 

--- a/worlds/witness/player_logic.py
+++ b/worlds/witness/player_logic.py
@@ -58,18 +58,16 @@ if TYPE_CHECKING:
 class WitnessPlayerLogic:
     """WITNESS LOGIC CLASS"""
 
-    VICTORY_LOCATION: str
-
     def __init__(self, world: "WitnessWorld", disabled_locations: Set[str], start_inv: Dict[str, int]) -> None:
         self.YAML_DISABLED_LOCATIONS: Set[str] = disabled_locations
         self.YAML_ADDED_ITEMS: Dict[str, int] = start_inv
 
-        self.EVENT_PANELS_FROM_PANELS: Set[str] = set()
-        self.EVENT_PANELS_FROM_REGIONS: Set[str] = set()
+        self.EVENT_PANELS_FROM_PANELS: Set[int] = set()
+        self.EVENT_PANELS_FROM_REGIONS: Set[int] = set()
 
-        self.IRRELEVANT_BUT_NOT_DISABLED_ENTITIES: Set[str] = set()
+        self.IRRELEVANT_BUT_NOT_DISABLED_ENTITIES: Set[int] = set()
 
-        self.ENTITIES_WITHOUT_ENSURED_SOLVABILITY: Set[str] = set()
+        self.ENTITIES_WITHOUT_ENSURED_SOLVABILITY: Set[int] = set()
 
         self.UNREACHABLE_REGIONS: Set[str] = set()
 
@@ -80,8 +78,8 @@ class WitnessPlayerLogic:
 
         self.PARENT_ITEM_COUNT_PER_BASE_ITEM: Dict[str, int] = defaultdict(lambda: 1)
         self.PROGRESSIVE_LISTS: Dict[str, List[str]] = {}
-        self.DOOR_ITEMS_BY_ID: Dict[str, List[str]] = {}
-        self.FORBIDDEN_DOORS: Set[str] = set()
+        self.DOOR_ITEMS_BY_ID: Dict[int, List[str]] = {}
+        self.FORBIDDEN_DOORS: Set[int] = set()
 
         self.STARTING_INVENTORY: Set[str] = set()
 
@@ -103,43 +101,43 @@ class WitnessPlayerLogic:
         self.CONNECTIONS_BY_REGION_NAME: Dict[str, List[ConnectionDefinition]] = copy.deepcopy(
             self.REFERENCE_LOGIC.STATIC_CONNECTIONS_BY_REGION_NAME
         )
-        self.DEPENDENT_REQUIREMENTS_BY_HEX: Dict[str, Dict[str, WitnessRule]] = copy.deepcopy(
+        self.DEPENDENT_REQUIREMENTS_BY_ENTITY_ID: Dict[int, Dict[str, WitnessRule]] = copy.deepcopy(
             self.REFERENCE_LOGIC.STATIC_DEPENDENT_REQUIREMENTS_BY_ENTITY_ID
         )
-        self.REQUIREMENTS_BY_HEX: Dict[str, WitnessRule] = {}
+        self.REQUIREMENTS_BY_ENTITY_ID: Dict[int, WitnessRule] = {}
 
-        self.EVENT_ITEM_PAIRS: Dict[str, Tuple[str, str]] = {}
-        self.COMPLETELY_DISABLED_ENTITIES: Set[str] = set()
-        self.DISABLE_EVERYTHING_BEHIND: Set[str] = set()
-        self.EXCLUDED_ENTITIES: Set[str] = set()
+        self.EVENT_ITEM_PAIRS: Dict[str, Tuple[str, int | str]] = {}
+        self.COMPLETELY_DISABLED_ENTITIES: Set[int] = set()
+        self.DISABLE_EVERYTHING_BEHIND: Set[int] = set()
+        self.EXCLUDED_ENTITIES: Set[int] = set()
         self.ADDED_CHECKS: Set[str] = set()
-        self.VICTORY_LOCATION = "0x0356B"
+        self.VICTORY_LOCATION: int = 0x0356B
 
-        self.PRE_PICKED_HUNT_ENTITIES: Set[str] = set()
-        self.HUNT_ENTITIES: Set[str] = set()
+        self.PRE_PICKED_HUNT_ENTITIES: Set[int] = set()
+        self.HUNT_ENTITIES: Set[int] = set()
 
-        self.AVAILABLE_EASTER_EGGS: Set[str] = set()
+        self.AVAILABLE_EASTER_EGGS: Set[int] = set()
         self.AVAILABLE_EASTER_EGGS_PER_REGION: Dict[str, int] = {}
-        self.ALWAYS_EVENT_NAMES_BY_HEX = {
-            "0x00509": "+1 Laser",
-            "0x012FB": "+1 Laser (Unredirected)",
-            "0x09F98": "Desert Laser Redirection",
-            "0xFFD03": "+1 Laser (Redirected)",
-            "0x01539": "+1 Laser",
-            "0x181B3": "+1 Laser",
-            "0x014BB": "+1 Laser",
-            "0x17C65": "+1 Laser",
-            "0x032F9": "+1 Laser",
-            "0x00274": "+1 Laser",
-            "0x0C2B2": "+1 Laser",
-            "0x00BF6": "+1 Laser",
-            "0x028A4": "+1 Laser",
-            "0x17C34": "Mountain Entry",
-            "0xFFF00": "Bottom Floor Discard Turns On",
+        self.ALWAYS_EVENT_NAMES_BY_ENTITY_ID = {
+            0x00509: "+1 Laser",
+            0x012FB: "+1 Laser (Unredirected)",
+            0x09F98: "Desert Laser Redirection",
+            0xFFD03: "+1 Laser (Redirected)",
+            0x01539: "+1 Laser",
+            0x181B3: "+1 Laser",
+            0x014BB: "+1 Laser",
+            0x17C65: "+1 Laser",
+            0x032F9: "+1 Laser",
+            0x00274: "+1 Laser",
+            0x0C2B2: "+1 Laser",
+            0x00BF6: "+1 Laser",
+            0x028A4: "+1 Laser",
+            0x17C34: "Mountain Entry",
+            0xFFF00: "Bottom Floor Discard Turns On",
         }
 
-        self.USED_EVENT_NAMES_BY_HEX: Dict[str, List[str]] = {}
-        self.CONDITIONAL_EVENTS: Dict[Tuple[str, str], str] = {}
+        self.USED_EVENT_NAMES_BY_ENTITY_ID: Dict[int, List[str]] = {}
+        self.CONDITIONAL_EVENTS: Dict[Tuple[int, int], str] = {}
 
         # The basic requirements to solve each entity come from StaticWitnessLogic.
         # However, for any given world, the options (e.g. which item shuffles are enabled) affect the requirements.
@@ -164,7 +162,7 @@ class WitnessPlayerLogic:
         # Create event-item pairs for specific panels in the game.
         self.make_event_panel_lists()
 
-    def reduce_req_within_region(self, entity_hex: str) -> WitnessRule:
+    def reduce_req_within_region(self, entity_id: int) -> WitnessRule:
         """
         Panels in this game often only turn on when other panels are solved.
         Those other panels may have different item requirements.
@@ -173,19 +171,19 @@ class WitnessPlayerLogic:
         Panels outside of the same region will still be checked manually.
         """
 
-        if self.is_disabled(entity_hex):
+        if self.is_disabled(entity_id):
             return frozenset()
 
-        entity_obj = self.REFERENCE_LOGIC.ENTITIES_BY_ID[entity_hex]
+        entity_obj = self.REFERENCE_LOGIC.ENTITIES_BY_ID[entity_id]
 
-        if entity_obj["region"] is not None and entity_obj["region"].name in self.UNREACHABLE_REGIONS:
+        if entity_obj.region is not None and entity_obj.region.name in self.UNREACHABLE_REGIONS:
             return frozenset()
 
         # For the requirement of an entity, we consider two things:
         # 1. Any items this entity needs (e.g. Symbols or Door Items)
-        these_items: WitnessRule = self.DEPENDENT_REQUIREMENTS_BY_HEX[entity_hex].get("items", frozenset({frozenset()}))
+        these_items: WitnessRule = self.DEPENDENT_REQUIREMENTS_BY_ENTITY_ID[entity_id].get("items", frozenset({frozenset()}))
         # 2. Any entities that this entity depends on (e.g. one panel powering on the next panel in a set)
-        these_panels: WitnessRule = self.DEPENDENT_REQUIREMENTS_BY_HEX[entity_hex]["entities"]
+        these_panels: WitnessRule = self.DEPENDENT_REQUIREMENTS_BY_ENTITY_ID[entity_id]["entities"]
 
         # Remove any items that don't actually exist in the settings (e.g. Symbol Shuffle turned off)
         these_items = frozenset({
@@ -199,9 +197,9 @@ class WitnessPlayerLogic:
 
         # If this entity is opened by a door item that exists in the itempool, add that item to its requirements.
         # Also, remove any original power requirements this entity might have had.
-        if entity_hex in self.DOOR_ITEMS_BY_ID and entity_hex not in self.FORBIDDEN_DOORS:
+        if entity_id in self.DOOR_ITEMS_BY_ID and entity_id not in self.FORBIDDEN_DOORS:
             # If this entity is opened by a door item that exists in the itempool, add that item to its requirements.
-            door_items = frozenset({frozenset([item]) for item in self.DOOR_ITEMS_BY_ID[entity_hex]})
+            door_items = frozenset({frozenset([item]) for item in self.DOOR_ITEMS_BY_ID[entity_id]})
 
             for dependent_item in door_items:
                 self.BASE_PROGESSION_ITEMS_ACTUALLY_IN_THE_GAME.update(dependent_item)
@@ -214,13 +212,13 @@ class WitnessPlayerLogic:
             # Those requirements need to be preserved even in door shuffle.
             entity_dependencies_need_to_be_preserved = (
                 # EPs keep all their entity dependencies
-                static_witness_logic.ENTITIES_BY_HEX[entity_hex]["entityType"] == "EP"
-                # 0x28A0D depends on another entity for *non-power* reasons -> This dependency needs to be preserved,
-                # except in Expert, where that dependency doesn't exist, but now there *is* a power dependency.
-                # In the future, it'd be wise to make a distinction between "power dependencies" and other dependencies.
-                or entity_hex == "0x28A0D" and not any("0x28998" in option for option in these_panels)
-                # Another dependency that is not power-based: The Symmetry Island Upper Panel latches
-                or entity_hex == "0x1C349"
+                    static_witness_logic.ENTITIES_BY_ID[entity_id].entity_type == "EP"
+                    # 0x28A0D depends on another entity for *non-power* reasons -> This dependency needs to be preserved,
+                    # except in Expert, where that dependency doesn't exist, but now there *is* a power dependency.
+                    # In the future, it'd be wise to make a distinction between "power dependencies" and other dependencies.
+                    or entity_id == 0x28A0D and not any(0x28998 in option for option in these_panels)
+                    # Another dependency that is not power-based: The Symmetry Island Upper Panel latches
+                    or entity_id == 0x1C349
             )
 
             # If this is not one of those special cases, solving this door entity only needs its own item requirement.
@@ -240,39 +238,50 @@ class WitnessPlayerLogic:
 
             # For each entity in this option, resolve it to its actual requirement.
             for option_entity in option:
-                dep_obj = self.REFERENCE_LOGIC.ENTITIES_BY_ID.get(option_entity, {})
-
+                # Special cases for non-entity string requirements
                 if option_entity in {"7 Lasers", "11 Lasers", "7 Lasers + Redirect", "11 Lasers + Redirect",
                                      "PP2 Weirdness", "Theater to Tunnels", "Entity Hunt"}:
                     new_items = frozenset({frozenset([option_entity])})
-                elif "Eggs" in option_entity:
-                    new_items = frozenset({frozenset([option_entity])})
-                elif option_entity in self.DISABLE_EVERYTHING_BEHIND:
-                    new_items = frozenset()
-                else:
-                    theoretical_new_items = self.get_entity_requirement(option_entity)
+                    dependent_items_for_option = logical_and_witness_rules([dependent_items_for_option, new_items])
+                    continue
 
-                    if not theoretical_new_items:
-                        # If the dependent entity is unsolvable & it is an EP, the current entity is an Obelisk Side.
-                        # In this case, we actually have to skip it because it will just become pre-solved instead.
-                        if dep_obj["entityType"] == "EP":
-                            continue
-                        # If the dependent entity is unsolvable and is NOT an EP, this requirement option is invalid.
-                        new_items = frozenset()
-                    elif option_entity in self.ALWAYS_EVENT_NAMES_BY_HEX:
-                        new_items = frozenset({frozenset([self.ALWAYS_EVENT_NAMES_BY_HEX[option_entity]])})
-                    elif (entity_hex, option_entity) in self.CONDITIONAL_EVENTS:
-                        new_items = frozenset({frozenset([self.CONDITIONAL_EVENTS[(entity_hex, option_entity)]])})
-                        self.USED_EVENT_NAMES_BY_HEX[option_entity].append(
-                            self.CONDITIONAL_EVENTS[(entity_hex, option_entity)]
+                if "Eggs" in option_entity:
+                    new_items = frozenset({frozenset([option_entity])})
+                    dependent_items_for_option = logical_and_witness_rules([dependent_items_for_option, new_items])
+                    continue
+
+                # Should be a hex string referencing an entity ID
+                option_entity_id = int(option_entity, 16)
+
+                if option_entity_id in self.DISABLE_EVERYTHING_BEHIND:
+                    new_items = frozenset()
+                    dependent_items_for_option = logical_and_witness_rules([dependent_items_for_option, new_items])
+                    continue
+
+                option_entity_obj = self.REFERENCE_LOGIC.ENTITIES_BY_ID[option_entity_id]
+                theoretical_new_items = self.get_entity_requirement(option_entity_id)
+
+                if not theoretical_new_items:
+                    # If the dependent entity is unsolvable & it is an EP, the current entity is an Obelisk Side.
+                    # In this case, we actually have to skip it because it will just become pre-solved instead.
+                    if option_entity_obj.entity_type == "EP":
+                        continue
+                    # If the dependent entity is unsolvable and is NOT an EP, this requirement option is invalid.
+                    new_items = frozenset()
+                elif option_entity in self.ALWAYS_EVENT_NAMES_BY_ENTITY_ID:
+                    new_items = frozenset({frozenset([self.ALWAYS_EVENT_NAMES_BY_ENTITY_ID[option_entity]])})
+                elif (entity_id, option_entity) in self.CONDITIONAL_EVENTS:
+                    new_items = frozenset({frozenset([self.CONDITIONAL_EVENTS[(entity_id, option_entity_id)]])})
+                    self.USED_EVENT_NAMES_BY_ENTITY_ID[option_entity_id].append(
+                        self.CONDITIONAL_EVENTS[(entity_id, option_entity_id)]
+                    )
+                else:
+                    new_items = theoretical_new_items
+                    if option_entity_obj.region and entity_obj.region != option_entity_obj.region:
+                        new_items = frozenset(
+                            frozenset(possibility | {option_entity_obj.region.name})
+                            for possibility in new_items
                         )
-                    else:
-                        new_items = theoretical_new_items
-                        if dep_obj["region"] and entity_obj["region"] != dep_obj["region"]:
-                            new_items = frozenset(
-                                frozenset(possibility | {dep_obj["region"].name})
-                                for possibility in new_items
-                            )
 
                 dependent_items_for_option = logical_and_witness_rules([dependent_items_for_option, new_items])
 
@@ -282,16 +291,16 @@ class WitnessPlayerLogic:
         # or-chain all separate dependent entity options.
         return logical_or_witness_rules(all_options)
 
-    def get_entity_requirement(self, entity_hex: str) -> WitnessRule:
+    def get_entity_requirement(self, entity_id: int) -> WitnessRule:
         """
         Get requirement of entity by its hex code.
         These requirements are cached, with the actual function calculating them being reduce_req_within_region.
         """
-        requirement = self.REQUIREMENTS_BY_HEX.get(entity_hex)
+        requirement = self.REQUIREMENTS_BY_ENTITY_ID.get(entity_id)
 
         if requirement is None:
-            requirement = self.reduce_req_within_region(entity_hex)
-            self.REQUIREMENTS_BY_HEX[entity_hex] = requirement
+            requirement = self.reduce_req_within_region(entity_id)
+            self.REQUIREMENTS_BY_ENTITY_ID[entity_id] = requirement
 
         return requirement
 
@@ -314,9 +323,9 @@ class WitnessPlayerLogic:
                 self.THEORETICAL_BASE_ITEMS.add(item_name)
 
             if static_witness_logic.ALL_ITEMS[item_name].category in [ItemCategory.DOOR, ItemCategory.LASER]:
-                entity_hexes = cast(DoorItemDefinition, static_witness_logic.ALL_ITEMS[item_name]).panel_id_hexes
-                for entity_hex in entity_hexes:
-                    self.DOOR_ITEMS_BY_ID.setdefault(entity_hex, []).append(item_name)
+                entity_ids = cast(DoorItemDefinition, static_witness_logic.ALL_ITEMS[item_name]).panel_entity_ids
+                for entity_ids in entity_ids:
+                    self.DOOR_ITEMS_BY_ID.setdefault(entity_ids, []).append(item_name)
 
             return
 
@@ -332,14 +341,14 @@ class WitnessPlayerLogic:
                 self.THEORETICAL_BASE_ITEMS.discard(item_name)
 
             if static_witness_logic.ALL_ITEMS[item_name].category in [ItemCategory.DOOR, ItemCategory.LASER]:
-                entity_hexes = cast(DoorItemDefinition, static_witness_logic.ALL_ITEMS[item_name]).panel_id_hexes
-                for entity_hex in entity_hexes:
-                    if entity_hex in self.DOOR_ITEMS_BY_ID and item_name in self.DOOR_ITEMS_BY_ID[entity_hex]:
-                        self.DOOR_ITEMS_BY_ID[entity_hex].remove(item_name)
+                entity_ids = cast(DoorItemDefinition, static_witness_logic.ALL_ITEMS[item_name]).panel_entity_ids
+                for entity_ids in entity_ids:
+                    if entity_ids in self.DOOR_ITEMS_BY_ID and item_name in self.DOOR_ITEMS_BY_ID[entity_ids]:
+                        self.DOOR_ITEMS_BY_ID[entity_ids].remove(item_name)
 
         if adj_type == "Forbidden Doors":
-            entity_hex = line[:7]
-            self.FORBIDDEN_DOORS.add(entity_hex)
+            entity_id = line[:7]
+            self.FORBIDDEN_DOORS.add(int(entity_id))
 
         if adj_type == "Starting Inventory":
             self.STARTING_INVENTORY.add(line)
@@ -347,16 +356,18 @@ class WitnessPlayerLogic:
         if adj_type == "Event Items":
             line_split = line.split(" - ")
             new_event_name = line_split[0]
-            entity_hex = line_split[1]
-            dependent_hex_set = line_split[2].split(",")
+            entity_id = int(line_split[1])
+            dependent_entity_ids = [int(id_string) for id_string in line_split[2].split(",")]
 
-            for dependent_hex in dependent_hex_set:
-                self.CONDITIONAL_EVENTS[(entity_hex, dependent_hex)] = new_event_name
+            for dependent_entity_id in dependent_entity_ids:
+                self.CONDITIONAL_EVENTS[(entity_id, dependent_entity_id)] = new_event_name
 
             return
 
         if adj_type == "Requirement Changes":
             line_split = line.split(" - ")
+
+            entity_id = int(line_split[0])
 
             requirement = {
                 "entities": parse_witness_rule(line_split[1]),
@@ -375,21 +386,21 @@ class WitnessPlayerLogic:
 
                 requirement["items"] = required_items
 
-            self.DEPENDENT_REQUIREMENTS_BY_HEX[line_split[0]] = requirement
+            self.DEPENDENT_REQUIREMENTS_BY_ENTITY_ID[entity_id] = requirement
 
             return
 
         if adj_type == "Disabled Locations":
-            entity_hex = line[:7]
+            entity_id = int(line[:7], 16)
 
-            self.COMPLETELY_DISABLED_ENTITIES.add(entity_hex)
+            self.COMPLETELY_DISABLED_ENTITIES.add(entity_id)
 
             return
 
         if adj_type == "Irrelevant Locations":
-            entity_hex = line[:7]
+            entity_id = int(line[:7], 16)
 
-            self.IRRELEVANT_BUT_NOT_DISABLED_ENTITIES.add(entity_hex)
+            self.IRRELEVANT_BUT_NOT_DISABLED_ENTITIES.add(entity_id)
 
             return
 
@@ -422,7 +433,8 @@ class WitnessPlayerLogic:
 
         if adj_type == "Added Locations":
             if "0x" in line:
-                line = self.REFERENCE_LOGIC.ENTITIES_BY_ID[line]["checkName"]
+                entity_id = int(line)
+                line = self.REFERENCE_LOGIC.ENTITIES_BY_ID[entity_id].entity_name
             self.ADDED_CHECKS.add(line)
 
     def handle_regular_postgame(self, world: "WitnessWorld") -> List[List[str]]:
@@ -519,9 +531,9 @@ class WitnessPlayerLogic:
         )
 
         if disable_mountain_lasers:
-            self.DISABLE_EVERYTHING_BEHIND.add("0x09F7F")  # Short box
-            self.PRE_PICKED_HUNT_ENTITIES.add("0x09F7F")
-            self.COMPLETELY_DISABLED_ENTITIES.add("0x3D9A9")  # Elevator Start
+            self.DISABLE_EVERYTHING_BEHIND.add(0x09F7F)  # Short box
+            self.PRE_PICKED_HUNT_ENTITIES.add(0x09F7F)
+            self.COMPLETELY_DISABLED_ENTITIES.add(0x3D9A9)  # Elevator Start
 
             # If mountain lasers are disabled, and challenge lasers > 7, the box will need to be rotated
             if chal_lasers > 7:
@@ -531,60 +543,60 @@ class WitnessPlayerLogic:
                 ])
 
         if disable_challenge_lasers:
-            self.DISABLE_EVERYTHING_BEHIND.add("0xFFF00")  # Long box
-            self.PRE_PICKED_HUNT_ENTITIES.add("0xFFF00")
-            self.COMPLETELY_DISABLED_ENTITIES.add("0x0A332")  # Challenge Timer
+            self.DISABLE_EVERYTHING_BEHIND.add(0xFFF00)  # Long box
+            self.PRE_PICKED_HUNT_ENTITIES.add(0xFFF00)
+            self.COMPLETELY_DISABLED_ENTITIES.add(0x0A332)  # Challenge Timer
 
         return postgame_adjustments
 
     def set_easter_egg_requirements(self, world: "WitnessWorld") -> None:
         eggs_per_check, logically_required_eggs_per_check = world.options.easter_egg_hunt.get_step_and_logical_step()
 
-        for entity_hex, entity_obj in static_witness_logic.ENTITIES_BY_HEX.items():
-            if entity_obj["entityType"] != "Easter Egg Total":
+        for entity_id, entity_obj in static_witness_logic.ENTITIES_BY_ID.items():
+            if entity_obj.entity_type != "Easter Egg Total":
                 continue
 
-            direct_egg_count = int(entity_obj["checkName"].split(" ")[0])
+            direct_egg_count = int(entity_obj.entity_name.split(" ")[0])
 
             if direct_egg_count % eggs_per_check:
-                self.COMPLETELY_DISABLED_ENTITIES.add(entity_hex)
+                self.COMPLETELY_DISABLED_ENTITIES.add(entity_id)
 
             requirement = direct_egg_count // eggs_per_check * logically_required_eggs_per_check
-            self.DEPENDENT_REQUIREMENTS_BY_HEX[entity_hex] = {
+            self.DEPENDENT_REQUIREMENTS_BY_ENTITY_ID[entity_id] = {
                 "entities": frozenset({frozenset({f"{requirement} Eggs"})})
             }
 
     def finalize_easter_eggs(self, world: "WitnessWorld") -> None:
         self.AVAILABLE_EASTER_EGGS = {
-            entity_hex for entity_hex, entity_obj in static_witness_logic.ENTITIES_BY_HEX.items()
-            if entity_obj["entityType"] == "Easter Egg" and self.solvability_guaranteed(entity_hex)
+            entity_id for entity_id, entity_obj in static_witness_logic.ENTITIES_BY_ID.items()
+            if entity_obj["entityType"] == "Easter Egg" and self.solvability_guaranteed(entity_id)
         }
         max_eggs = len(self.AVAILABLE_EASTER_EGGS)
 
         self.AVAILABLE_EASTER_EGGS_PER_REGION = defaultdict(int)
-        for entity_hex in self.AVAILABLE_EASTER_EGGS:
-            region_name = static_witness_logic.ENTITIES_BY_HEX[entity_hex]["region"].name
+        for entity_id in self.AVAILABLE_EASTER_EGGS:
+            region_name = static_witness_logic.ENTITIES_BY_ID[entity_id]["region"].name
             self.AVAILABLE_EASTER_EGGS_PER_REGION[region_name] += 1
 
         eggs_per_check, logically_required_eggs_per_check = world.options.easter_egg_hunt.get_step_and_logical_step()
 
-        for entity_hex, entity_obj in static_witness_logic.ENTITIES_BY_HEX.items():
+        for entity_id, entity_obj in static_witness_logic.ENTITIES_BY_ID.items():
             if entity_obj["entityType"] != "Easter Egg Total":
                 continue
-            if entity_hex in self.COMPLETELY_DISABLED_ENTITIES:
+            if entity_id in self.COMPLETELY_DISABLED_ENTITIES:
                 continue
 
-            direct_egg_count = int(entity_obj["checkName"].split(" ", 1)[0])
+            direct_egg_count = int(entity_obj.entity_name.split(" ", 1)[0])
             logically_required_egg_count = direct_egg_count // eggs_per_check * logically_required_eggs_per_check
             if direct_egg_count > max_eggs:
-                self.COMPLETELY_DISABLED_ENTITIES.add(entity_hex)
+                self.COMPLETELY_DISABLED_ENTITIES.add(entity_id)
                 continue
 
-            self.ADDED_CHECKS.add(entity_obj["checkName"])
+            self.ADDED_CHECKS.add(entity_obj.entity_name)
             if logically_required_egg_count > max_eggs:
                 # Exclude and set logic to require every egg
-                self.EXCLUDED_ENTITIES.add(entity_hex)
-                self.REQUIREMENTS_BY_HEX[entity_hex] = frozenset({frozenset({f"{max_eggs} Eggs"})})
+                self.EXCLUDED_ENTITIES.add(entity_id)
+                self.REQUIREMENTS_BY_ENTITY_ID[entity_id] = frozenset({frozenset({f"{max_eggs} Eggs"})})
 
     def make_options_adjustments(self, world: "WitnessWorld") -> None:
         """Makes logic adjustments based on options"""
@@ -600,16 +612,16 @@ class WitnessPlayerLogic:
 
         # Victory Condition
         if victory == "elevator":
-            self.VICTORY_LOCATION = "0x3D9A9"
+            self.VICTORY_LOCATION = 0x3D9A9
         elif victory == "challenge":
-            self.VICTORY_LOCATION = "0x0356B"
+            self.VICTORY_LOCATION = 0x0356B
         elif victory == "mountain_box_short":
-            self.VICTORY_LOCATION = "0x09F7F"
+            self.VICTORY_LOCATION = 0x09F7F
         elif victory == "mountain_box_long":
-            self.VICTORY_LOCATION = "0xFFF00"
+            self.VICTORY_LOCATION = 0xFFF00
         elif victory == "panel_hunt":
-            self.VICTORY_LOCATION = "0x03629"
-            self.COMPLETELY_DISABLED_ENTITIES.add("0x3352F")
+            self.VICTORY_LOCATION = 0x03629
+            self.COMPLETELY_DISABLED_ENTITIES.add(0x3352F)
 
         # Exclude panels from the post-game if shuffle_postgame is false.
         if not world.options.shuffle_postgame and victory != "panel_hunt":
@@ -714,8 +726,8 @@ class WitnessPlayerLogic:
             self.set_easter_egg_requirements(world)
         else:
             self.COMPLETELY_DISABLED_ENTITIES.update({
-                entity_hex for entity_hex, entity_obj in static_witness_logic.ENTITIES_BY_HEX.items()
-                if "Easter Egg" in entity_obj["entityType"]
+                entity_id for entity_id, entity_obj in static_witness_logic.ENTITIES_BY_ID.items()
+                if "Easter Egg" in entity_obj.entity_type
             })
 
         if world.options.victory_condition == "panel_hunt":
@@ -731,14 +743,18 @@ class WitnessPlayerLogic:
             adjustment_linesets_in_order.append(get_obelisk_keys())
 
         if world.options.shuffle_EPs == "obelisk_sides":
-            ep_gen = ((ep_hex, ep_obj) for (ep_hex, ep_obj) in self.REFERENCE_LOGIC.ENTITIES_BY_ID.items()
-                      if ep_obj["entityType"] == "EP")
+            ep_gen = (
+                (ep_entity_id, ep_obj)
+                for (ep_entity_id, ep_obj) in self.REFERENCE_LOGIC.ENTITIES_BY_ID.items()
+                if ep_obj.entity_type == "EP"
+            )
 
-            for ep_hex, ep_obj in ep_gen:
-                obelisk = self.REFERENCE_LOGIC.ENTITIES_BY_ID[self.REFERENCE_LOGIC.EP_ID_TO_OBELISK_SIDE_ID[ep_hex]]
-                obelisk_name = obelisk["checkName"]
-                ep_name = self.REFERENCE_LOGIC.ENTITIES_BY_ID[ep_hex]["checkName"]
-                self.ALWAYS_EVENT_NAMES_BY_HEX[ep_hex] = f"{obelisk_name} - {ep_name}"
+            for ep_entity_id, ep_obj in ep_gen:
+                obelisk_side_id = self.REFERENCE_LOGIC.EP_ID_TO_OBELISK_SIDE_ID[ep_entity_id]
+                obelisk_side = self.REFERENCE_LOGIC.ENTITIES_BY_ID[obelisk_side_id]
+                obelisk_side_name = obelisk_side.entity_name
+                ep_name = self.REFERENCE_LOGIC.ENTITIES_BY_ID[ep_entity_id].entity_name
+                self.ALWAYS_EVENT_NAMES_BY_ENTITY_ID[ep_entity_id] = f"{obelisk_side_name} - {ep_name}"
         else:
             adjustment_linesets_in_order.append(["Disabled Locations:"] + get_ep_obelisks()[1:])
 
@@ -749,16 +765,16 @@ class WitnessPlayerLogic:
             if yaml_disabled_location not in self.REFERENCE_LOGIC.ENTITIES_BY_NAME:
                 continue
 
-            loc_obj = self.REFERENCE_LOGIC.ENTITIES_BY_NAME[yaml_disabled_location]
+            corresponding_entity = self.REFERENCE_LOGIC.ENTITIES_BY_NAME[yaml_disabled_location]
 
-            if loc_obj["entityType"] == "EP":
-                self.COMPLETELY_DISABLED_ENTITIES.add(loc_obj["entity_hex"])
+            if corresponding_entity.entity_type == "EP":
+                self.COMPLETELY_DISABLED_ENTITIES.add(corresponding_entity.entity_id)
 
-            if loc_obj["entityType"] == "Easter Egg":
-                self.COMPLETELY_DISABLED_ENTITIES.add(loc_obj["entity_hex"])
+            if corresponding_entity.entity_type == "Easter Egg":
+                self.COMPLETELY_DISABLED_ENTITIES.add(corresponding_entity.entity_id)
 
-            elif loc_obj["entityType"] == "Panel":
-                self.EXCLUDED_ENTITIES.add(loc_obj["entity_hex"])
+            elif corresponding_entity.entity_type == "Panel":
+                self.EXCLUDED_ENTITIES.add(corresponding_entity.entity_id)
 
         for adjustment_lineset in adjustment_linesets_in_order:
             current_adjustment_type = None
@@ -855,13 +871,13 @@ class WitnessPlayerLogic:
                         continue
 
                     # Never disable a laser (They should still function even if you can't walk up to them).
-                    if static_witness_logic.ENTITIES_BY_HEX[entity]["entityType"] == "Laser":
+                    if static_witness_logic.ENTITIES_BY_ID[entity].entity_type == "Laser":
                         continue
 
                     newly_discovered_disabled_entities.add(entity)
 
             # Secondly, any entities that depend on disabled entities are unreachable as well.
-            for entity, req in self.REQUIREMENTS_BY_HEX.items():
+            for entity, req in self.REQUIREMENTS_BY_ENTITY_ID.items():
                 # If the requirement is empty (unsolvable) and it isn't disabled already, add it to "newly disabled"
                 if not req and not self.is_disabled(entity):
                     # Never disable the Victory Location.
@@ -869,8 +885,8 @@ class WitnessPlayerLogic:
                         continue
 
                     # If we are disabling a laser, something has gone wrong.
-                    if static_witness_logic.ENTITIES_BY_HEX[entity]["entityType"] == "Laser":
-                        laser_name = static_witness_logic.ENTITIES_BY_HEX[entity]["checkName"]
+                    if static_witness_logic.ENTITIES_BY_ID[entity].entity_type == "Laser":
+                        laser_name = static_witness_logic.ENTITIES_BY_ID[entity].entity_name
                         raise RuntimeError(f"Somehow, {laser_name} was disabled for player {world.player_name}."
                                            f" This is not allowed to happen, please report to Violet.")
 
@@ -890,23 +906,28 @@ class WitnessPlayerLogic:
         # Check each traversal option individually
         for option in connection.traversal_rule:
             individual_entity_requirements: List[WitnessRule] = []
-            for entity in option:
+            for single_requirement in option:
+                # Non-entity cases: Just pass it forward
+                if not single_requirement.startswith("0x"):
+                    individual_entity_requirements.append(frozenset({frozenset({single_requirement})}))
+                    continue
+
+                entity_id = int(single_requirement, 16)
+
                 # If a connection requires solving a disabled entity, it is not valid.
-                if not self.solvability_guaranteed(entity) or entity in self.DISABLE_EVERYTHING_BEHIND:
+                if not self.solvability_guaranteed(entity_id) or entity_id in self.DISABLE_EVERYTHING_BEHIND:
                     individual_entity_requirements.append(frozenset())
                 # If a connection requires acquiring an event, add that event to its requirements.
-                elif entity not in self.REFERENCE_LOGIC.ENTITIES_BY_ID:
-                    individual_entity_requirements.append(frozenset({frozenset({entity})}))
-                elif entity in self.ALWAYS_EVENT_NAMES_BY_HEX:
+                elif entity_id in self.ALWAYS_EVENT_NAMES_BY_ENTITY_ID:
                     individual_entity_requirements.append(
-                        frozenset({frozenset({self.ALWAYS_EVENT_NAMES_BY_HEX[entity]})})
+                        frozenset({frozenset({self.ALWAYS_EVENT_NAMES_BY_ENTITY_ID[entity_id]})})
                     )
                 # If a connection requires entities, use their newly calculated independent requirements.
                 else:
-                    entity_req = self.get_entity_requirement(entity)
+                    entity_req = self.get_entity_requirement(entity_id)
 
-                    if self.REFERENCE_LOGIC.ENTITIES_BY_ID[entity]["region"]:
-                        region_name = self.REFERENCE_LOGIC.ENTITIES_BY_ID[entity]["region"].name
+                    if self.REFERENCE_LOGIC.ENTITIES_BY_ID[entity_id].region:
+                        region_name = self.REFERENCE_LOGIC.ENTITIES_BY_ID[entity_id].region.name
                         entity_req = logical_and_witness_rules([entity_req, frozenset({frozenset({region_name})})])
 
                     individual_entity_requirements.append(entity_req)
@@ -931,19 +952,19 @@ class WitnessPlayerLogic:
 
         # Requirements are cached per entity. However, we might redo the whole reduction process multiple times.
         # So, we first clear this cache.
-        self.REQUIREMENTS_BY_HEX = {}
+        self.REQUIREMENTS_BY_ENTITY_ID = {}
 
         # We also clear any data structures that we might have filled in a previous dependency reduction
-        self.REQUIREMENTS_BY_HEX = {}
-        self.USED_EVENT_NAMES_BY_HEX = defaultdict(list)
+        self.REQUIREMENTS_BY_ENTITY_ID = {}
+        self.USED_EVENT_NAMES_BY_ENTITY_ID = defaultdict(list)
         self.CONNECTIONS_BY_REGION_NAME = {}
         self.BASE_PROGESSION_ITEMS_ACTUALLY_IN_THE_GAME = set()
 
         # Make independent requirements for entities
-        for entity_hex in self.DEPENDENT_REQUIREMENTS_BY_HEX.keys():
-            indep_requirement = self.get_entity_requirement(entity_hex)
+        for entity_id in self.DEPENDENT_REQUIREMENTS_BY_ENTITY_ID.keys():
+            indep_requirement = self.get_entity_requirement(entity_id)
 
-            self.REQUIREMENTS_BY_HEX[entity_hex] = indep_requirement
+            self.REQUIREMENTS_BY_ENTITY_ID[entity_id] = indep_requirement
 
         # Make independent region connection requirements based on the entities they require
         for region, connections in self.CONNECTIONS_BY_REGION_NAME_THEORETICAL.items():
@@ -975,17 +996,17 @@ class WitnessPlayerLogic:
             else:
                 self.PROGRESSION_ITEMS_ACTUALLY_IN_THE_GAME.add(item)
 
-    def solvability_guaranteed(self, entity_hex: str) -> bool:
+    def solvability_guaranteed(self, entity_id: int) -> bool:
         return not (
-            entity_hex in self.ENTITIES_WITHOUT_ENSURED_SOLVABILITY
-            or entity_hex in self.COMPLETELY_DISABLED_ENTITIES
-            or entity_hex in self.IRRELEVANT_BUT_NOT_DISABLED_ENTITIES
+            entity_id in self.ENTITIES_WITHOUT_ENSURED_SOLVABILITY
+            or entity_id in self.COMPLETELY_DISABLED_ENTITIES
+            or entity_id in self.IRRELEVANT_BUT_NOT_DISABLED_ENTITIES
         )
 
-    def is_disabled(self, entity_hex: str) -> bool:
+    def is_disabled(self, entity_id: int) -> bool:
         return (
-            entity_hex in self.COMPLETELY_DISABLED_ENTITIES
-            or entity_hex in self.IRRELEVANT_BUT_NOT_DISABLED_ENTITIES
+            entity_id in self.COMPLETELY_DISABLED_ENTITIES
+            or entity_id in self.IRRELEVANT_BUT_NOT_DISABLED_ENTITIES
         )
 
     def determine_unrequired_entities(self, world: "WitnessWorld") -> None:
@@ -1020,34 +1041,34 @@ class WitnessPlayerLogic:
         # It is easier to think about when these items *are* required, so we make that dict first
         # If the entity is disabled anyway, we don't need to consider that case
         is_item_required_dict = {
-            "0x03750": eps_shuffled or eggs_exist,  # Monastery Garden Entry Door
-            "0x275FA": eps_shuffled,  # Boathouse Hook Control
-            "0x17D02": eps_shuffled,  # Windmill Turn Control
-            "0x0368A": symbols_shuffled or door_panels,  # Quarry Stoneworks Stairs Door
-            "0x3865F": symbols_shuffled or door_panels or eps_shuffled,  # Quarry Boathouse 2nd Barrier
-            "0x17CC4": quarry_elevator_comes_to_you or eps_shuffled,  # Quarry Elevator Panel
-            "0x17E2B": swamp_bridge_comes_to_you and boat_shuffled or eps_shuffled,  # Swamp Long Bridge
-            "0x0CF2A": eggs_exist,  # Jungle Monastery Garden Shortcut
-            "0x0364E": False,  # Monastery Laser Shortcut Door
-            "0x03713": remote_doors,  # Monastery Laser Shortcut Panel
-            "0x03313": eggs_exist,  # Orchard Second Gate
-            "0x337FA": remote_doors,  # Jungle Bamboo Laser Shortcut Panel
-            "0x3873B": False,  # Jungle Bamboo Laser Shortcut Door
-            "0x335AB": False,  # Caves Elevator Controls
-            "0x335AC": False,  # Caves Elevator Controls
-            "0x3369D": False,  # Caves Elevator Controls
-            "0x01BEA": difficulty == "none" and eps_shuffled,  # Keep PP2
-            "0x0A0C9": eps_shuffled or discards_shuffled or disable_non_randomized,  # Cargo Box Entry Door
-            "0x09EEB": discards_shuffled or mountain_upper_included,  # Mountain Floor 2 Elevator Control Panel
-            "0x17CAB": symbols_shuffled or not disable_non_randomized or "0x17CAB" not in self.DOOR_ITEMS_BY_ID,
+            0x03750: eps_shuffled or eggs_exist,  # Monastery Garden Entry Door
+            0x275FA: eps_shuffled,  # Boathouse Hook Control
+            0x17D02: eps_shuffled,  # Windmill Turn Control
+            0x0368A: symbols_shuffled or door_panels,  # Quarry Stoneworks Stairs Door
+            0x3865F: symbols_shuffled or door_panels or eps_shuffled,  # Quarry Boathouse 2nd Barrier
+            0x17CC4: quarry_elevator_comes_to_you or eps_shuffled,  # Quarry Elevator Panel
+            0x17E2B: swamp_bridge_comes_to_you and boat_shuffled or eps_shuffled,  # Swamp Long Bridge
+            0x0CF2A: eggs_exist,  # Jungle Monastery Garden Shortcut
+            0x0364E: False,  # Monastery Laser Shortcut Door
+            0x03713: remote_doors,  # Monastery Laser Shortcut Panel
+            0x03313: eggs_exist,  # Orchard Second Gate
+            0x337FA: remote_doors,  # Jungle Bamboo Laser Shortcut Panel
+            0x3873B: False,  # Jungle Bamboo Laser Shortcut Door
+            0x335AB: False,  # Caves Elevator Controls
+            0x335AC: False,  # Caves Elevator Controls
+            0x3369D: False,  # Caves Elevator Controls
+            0x01BEA: difficulty == "none" and eps_shuffled,  # Keep PP2
+            0x0A0C9: eps_shuffled or discards_shuffled or disable_non_randomized,  # Cargo Box Entry Door
+            0x09EEB: discards_shuffled or mountain_upper_included,  # Mountain Floor 2 Elevator Control Panel
+            0x17CAB: symbols_shuffled or not disable_non_randomized or "0x17CAB" not in self.DOOR_ITEMS_BY_ID,
             # Jungle Popup Wall Panel
         }
 
         # In panel hunt, all panels are game, so all panels need to be reachable (unless disabled)
         if goal == "panel_hunt":
-            for entity_hex in is_item_required_dict:
-                if static_witness_logic.ENTITIES_BY_HEX[entity_hex]["entityType"] == "Panel":
-                    is_item_required_dict[entity_hex] = True
+            for entity_id in is_item_required_dict:
+                if static_witness_logic.ENTITIES_BY_ID[entity_id].entity_type == "Panel":
+                    is_item_required_dict[entity_id] = True
 
         # Now, return the keys of the dict entries where the result is False to get unrequired major items
         self.ENTITIES_WITHOUT_ENSURED_SOLVABILITY |= {
@@ -1059,20 +1080,20 @@ class WitnessPlayerLogic:
         Makes event-item pairs for entities with associated events, unless these entities are disabled.
         """
 
-        self.USED_EVENT_NAMES_BY_HEX[self.VICTORY_LOCATION].append("Victory")
+        self.USED_EVENT_NAMES_BY_ENTITY_ID[self.VICTORY_LOCATION].append("Victory")
 
-        for event_hex, event_name in self.ALWAYS_EVENT_NAMES_BY_HEX.items():
-            self.USED_EVENT_NAMES_BY_HEX[event_hex].append(event_name)
+        for entity_id, event_name in self.ALWAYS_EVENT_NAMES_BY_ENTITY_ID.items():
+            self.USED_EVENT_NAMES_BY_ENTITY_ID[entity_id].append(event_name)
 
-        self.USED_EVENT_NAMES_BY_HEX = {
-            event_hex: event_list for event_hex, event_list in self.USED_EVENT_NAMES_BY_HEX.items()
-            if self.solvability_guaranteed(event_hex)
+        self.USED_EVENT_NAMES_BY_ENTITY_ID = {
+            event_entity_id: event_list for event_entity_id, event_list in self.USED_EVENT_NAMES_BY_ENTITY_ID.items()
+            if self.solvability_guaranteed(event_entity_id)
         }
 
-        for entity_hex, event_names in self.USED_EVENT_NAMES_BY_HEX.items():
-            entity_obj = self.REFERENCE_LOGIC.ENTITIES_BY_ID[entity_hex]
-            entity_name = entity_obj["checkName"]
-            entity_type = entity_obj["entityType"]
+        for entity_id, event_names in self.USED_EVENT_NAMES_BY_ENTITY_ID.items():
+            entity_obj = self.REFERENCE_LOGIC.ENTITIES_BY_ID[entity_id]
+            entity_name = entity_obj.entity_name
+            entity_type = entity_obj.entity_type
 
             if entity_type == "Door":
                 action = " Opened"
@@ -1083,15 +1104,15 @@ class WitnessPlayerLogic:
 
             for i, event_name in enumerate(event_names):
                 if i == 0:
-                    self.EVENT_ITEM_PAIRS[entity_name + action] = (event_name, entity_hex)
+                    self.EVENT_ITEM_PAIRS[entity_name + action] = (event_name, entity_id)
                 else:
-                    self.EVENT_ITEM_PAIRS[entity_name + action + f" (Effect {i + 1})"] = (event_name, entity_hex)
+                    self.EVENT_ITEM_PAIRS[entity_name + action + f" (Effect {i + 1})"] = (event_name, entity_id)
 
         # Make Panel Hunt Events
-        for entity_hex in self.HUNT_ENTITIES:
-            entity_obj = self.REFERENCE_LOGIC.ENTITIES_BY_ID[entity_hex]
-            entity_name = entity_obj["checkName"]
-            self.EVENT_ITEM_PAIRS[entity_name + " (Panel Hunt)"] = ("+1 Panel Hunt", entity_hex)
+        for entity_id in self.HUNT_ENTITIES:
+            entity_obj = self.REFERENCE_LOGIC.ENTITIES_BY_ID[entity_id]
+            entity_name = entity_obj.entity_name
+            self.EVENT_ITEM_PAIRS[entity_name + " (Panel Hunt)"] = ("+1 Panel Hunt", entity_id)
 
         for region_name, easter_egg_count in self.AVAILABLE_EASTER_EGGS_PER_REGION.items():
             plural = "s" if easter_egg_count != 1 else ""

--- a/worlds/witness/regions.py
+++ b/worlds/witness/regions.py
@@ -128,12 +128,12 @@ class WitnessPlayerRegions:
                     region_name = "Entry"
                 else:
                     region_name = region.name
-                order = self.reference_logic.ENTITIES_BY_HEX[entity_or_region]["order"]
+                order = self.reference_logic.ENTITIES_BY_ID[entity_or_region]["order"]
             event_locations_per_region[region_name][event_location] = order
 
         for region_name, region in regions_to_create.items():
             location_entities_for_this_region = [
-                self.reference_logic.ENTITIES_BY_HEX[entity] for entity in region.logical_entities
+                self.reference_logic.ENTITIES_BY_ID[entity] for entity in region.logical_entities
             ]
             locations_for_this_region = {
                 entity["checkName"]: entity["order"] for entity in location_entities_for_this_region

--- a/worlds/witness/regions.py
+++ b/worlds/witness/regions.py
@@ -119,16 +119,16 @@ class WitnessPlayerRegions:
 
         for event_location, event_item_and_entity in player_logic.EVENT_ITEM_PAIRS.items():
             entity_or_region = event_item_and_entity[1]
-            if entity_or_region in static_witness_logic.ALL_REGIONS_BY_NAME:
+            if isinstance(entity_or_region, str):
                 region_name = entity_or_region
                 order = -1
             else:
-                region = static_witness_logic.ENTITIES_BY_HEX[event_item_and_entity[1]]["region"]
+                region = static_witness_logic.ENTITIES_BY_ID[entity_or_region].region
                 if region is None:
                     region_name = "Entry"
                 else:
                     region_name = region.name
-                order = self.reference_logic.ENTITIES_BY_ID[entity_or_region]["order"]
+                order = self.reference_logic.ENTITIES_BY_ID[entity_or_region].order
             event_locations_per_region[region_name][event_location] = order
 
         for region_name, region in regions_to_create.items():
@@ -136,8 +136,8 @@ class WitnessPlayerRegions:
                 self.reference_logic.ENTITIES_BY_ID[entity] for entity in region.logical_entities
             ]
             locations_for_this_region = {
-                entity["checkName"]: entity["order"] for entity in location_entities_for_this_region
-                if entity["checkName"] in self.player_locations.CHECK_LOCATION_TABLE
+                entity.entity_name: entity.order for entity in location_entities_for_this_region
+                if entity.entity_name in self.player_locations.CHECK_LOCATION_TABLE
             }
 
             events = event_locations_per_region[region_name]

--- a/worlds/witness/rules.py
+++ b/worlds/witness/rules.py
@@ -176,7 +176,7 @@ def _has_item(item: str, world: "WitnessWorld",
     in which case we return it as an item-count pair ("SimpleItemRepresentation"). This allows some optimisation later.
     """
 
-    assert item not in static_witness_logic.ENTITIES_BY_HEX, "Requirements can no longer contain entity hexes directly."
+    assert item not in static_witness_logic.ENTITIES_BY_ID, "Requirements can no longer contain entity hexes directly."
 
     if item in player_logic.REFERENCE_LOGIC.ALL_REGIONS_BY_NAME:
         region = world.get_region(item)
@@ -296,11 +296,11 @@ def _meets_item_requirements(requirements: WitnessRule, world: "WitnessWorld") -
     )
 
 
-def make_lambda(entity_hex: str, world: "WitnessWorld") -> Optional[CollectionRule]:
+def make_lambda(entity_id: int, world: "WitnessWorld") -> Optional[CollectionRule]:
     """
     Lambdas are created in a for loop so values need to be captured
     """
-    entity_req = world.player_logic.REQUIREMENTS_BY_HEX[entity_hex]
+    entity_req = world.player_logic.REQUIREMENTS_BY_ENTITY_ID[entity_id]
 
     return _meets_item_requirements(entity_req, world)
 
@@ -319,17 +319,18 @@ def set_rules(world: "WitnessWorld") -> None:
         real_location = location
 
         if location in world.player_locations.EVENT_LOCATION_TABLE:
-            entity_hex_or_region_name = world.player_logic.EVENT_ITEM_PAIRS[location][1]
-            if entity_hex_or_region_name in static_witness_logic.ALL_REGIONS_BY_NAME:
-                set_rule(world.get_location(location), make_region_lambda(entity_hex_or_region_name, world))
+            entity_id_or_region_name = world.player_logic.EVENT_ITEM_PAIRS[location][1]
+            if isinstance(entity_id_or_region_name, str):
+                set_rule(world.get_location(location), make_region_lambda(entity_id_or_region_name, world))
                 continue
 
-            real_location = static_witness_logic.ENTITIES_BY_HEX[entity_hex_or_region_name]["checkName"]
+            entity_id = entity_id_or_region_name
+            real_location = static_witness_logic.ENTITIES_BY_ID[entity_id].entity_name
 
         associated_entity = world.player_logic.REFERENCE_LOGIC.ENTITIES_BY_NAME[real_location]
-        entity_hex = associated_entity["entity_hex"]
+        entity_id = associated_entity.entity_id
 
-        rule = make_lambda(entity_hex, world)
+        rule = make_lambda(entity_id, world)
         if rule is None:
             continue
 

--- a/worlds/witness/rules.py
+++ b/worlds/witness/rules.py
@@ -176,7 +176,7 @@ def _has_item(item: str, world: "WitnessWorld",
     in which case we return it as an item-count pair ("SimpleItemRepresentation"). This allows some optimisation later.
     """
 
-    assert item not in static_witness_logic.ENTITIES_BY_ID, "Requirements can no longer contain entity hexes directly."
+    assert item not in static_witness_logic.ENTITIES_BY_ID, "Requirements can no longer contain entity ids directly."
 
     if item in player_logic.REFERENCE_LOGIC.ALL_REGIONS_BY_NAME:
         region = world.get_region(item)

--- a/worlds/witness/test/test_door_shuffle.py
+++ b/worlds/witness/test/test_door_shuffle.py
@@ -70,7 +70,7 @@ class TestForbiddenDoors(WitnessMultiworldTestBase):
 
             self.assertIn(
                 0x021D7,
-                slot_data["item_id_to_door_hexes"][WitnessWorld.item_name_to_id["Caves Panels"]],
+                slot_data["item_id_to_door_ids"][WitnessWorld.item_name_to_id["Caves Panels"]],
                 "Caves Panels should still contain Caves Mountain Shortcut Panel as a door they unlock.",
             )
 

--- a/worlds/witness/test/test_symbol_shuffle.py
+++ b/worlds/witness/test/test_symbol_shuffle.py
@@ -69,7 +69,7 @@ class TestSymbolRequirementsMultiworld(WitnessMultiworldTestBase):
             self.assertTrue(self.get_items_by_name("Arrows", 4))
 
         with self.subTest("Test that Discards ask for Triangles in normal, but Arrows in expert."):
-            desert_discard = "0x17CE7"
+            desert_discard = 0x17CE7
             triangles = frozenset({frozenset({"Triangles"})})
             arrows = frozenset({frozenset({"Arrows"})})
             both = frozenset({frozenset({"Triangles", "Arrows"})})

--- a/worlds/witness/test/test_symbol_shuffle.py
+++ b/worlds/witness/test/test_symbol_shuffle.py
@@ -74,7 +74,7 @@ class TestSymbolRequirementsMultiworld(WitnessMultiworldTestBase):
             arrows = frozenset({frozenset({"Arrows"})})
             both = frozenset({frozenset({"Triangles", "Arrows"})})
 
-            self.assertEqual(self.multiworld.worlds[1].player_logic.REQUIREMENTS_BY_HEX[desert_discard], triangles)
-            self.assertEqual(self.multiworld.worlds[2].player_logic.REQUIREMENTS_BY_HEX[desert_discard], arrows)
-            self.assertEqual(self.multiworld.worlds[3].player_logic.REQUIREMENTS_BY_HEX[desert_discard], triangles)
-            self.assertEqual(self.multiworld.worlds[4].player_logic.REQUIREMENTS_BY_HEX[desert_discard], both)
+            self.assertEqual(self.multiworld.worlds[1].player_logic.REQUIREMENTS_BY_ENTITY_ID[desert_discard], triangles)
+            self.assertEqual(self.multiworld.worlds[2].player_logic.REQUIREMENTS_BY_ENTITY_ID[desert_discard], arrows)
+            self.assertEqual(self.multiworld.worlds[3].player_logic.REQUIREMENTS_BY_ENTITY_ID[desert_discard], triangles)
+            self.assertEqual(self.multiworld.worlds[4].player_logic.REQUIREMENTS_BY_ENTITY_ID[desert_discard], both)


### PR DESCRIPTION
Nowadays that we have per-game IDs, making the distinction between entity IDs and location IDs no longer makes sense.

This greatly reduces the size of a Witness slot's slot_data by removing the conversion dict from one to the other.

Changes:
- Removed all location IDs from the WitnessLogic*.txt files
- Replaced every reference to a location ID with the entity ID
- Reference entity IDs as ints instead of strs whereever possible, rename everything called "_hex" to "_id"
- Change the untyped entity dict to an EntityDefinition dataclass

New client: https://github.com/NewSoupVi/The-Witness-Randomizer-for-Archipelago/releases/tag/9.0.0p1

Probably needs more testing (like seed comparisons and mypy checking)