### PR TITLE
CommonClient: Fix manually connecting to a url when the username or password has a space in it

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -856,7 +856,7 @@ async def server_loop(ctx: CommonContext, address: typing.Optional[str] = None) 
 
     server_url = urllib.parse.urlparse(address)
     if server_url.username:
-        ctx.auth = urllib.parse.unquote(server_url.username)
+        ctx.username = urllib.parse.unquote(server_url.username)
     if server_url.password:
         ctx.password = urllib.parse.unquote(server_url.password)
 


### PR DESCRIPTION
`handle_url_arg` does this correctly, which is why this works correctly when e.g. clicking a link on the room page: https://github.com/ArchipelagoMW/Archipelago/blob/main/CommonClient.py#L1166-L1169

But it doesn't work when manually connecting to an archipelago url.