### PR TITLE
Core: Clean up .apworld world module import workarounds

### DIFF
--- a/worlds/__init__.py
+++ b/worlds/__init__.py
@@ -54,17 +54,12 @@ class WorldSource:
             start = time.perf_counter()
             if self.is_zip:
                 importer = zipimport.zipimporter(self.resolved_path)
-                spec = importer.find_spec(os.path.basename(self.path).rsplit(".", 1)[0])
+                world_name = os.path.basename(self.path).rsplit(".", 1)[0]
+                spec = importer.find_spec(f"worlds.{world_name}")
                 assert spec, f"{self.path} is not a loadable module"
                 mod = importlib.util.module_from_spec(spec)
-
-                mod.__package__ = f"worlds.{mod.__package__}"
-
-                mod.__name__ = f"worlds.{mod.__name__}"
                 sys.modules[mod.__name__] = mod
-                with warnings.catch_warnings():
-                    warnings.filterwarnings("ignore", message="__package__ != __spec__.parent")
-                    importer.exec_module(mod)
+                importer.exec_module(mod)
             else:
                 importlib.import_module(f".{self.path}", "worlds")
             self.time_taken = time.perf_counter()-start


### PR DESCRIPTION
## What is this fixing or adding?

`zipimporter.find_spec` only cares about the last part of the path in `worlds.world_name`, `world_name`, so the full name, including the `worlds.` prefix, can be passed to `find_spec`.

This removes the workarounds of manually setting the module's `__name__` and `__package__`, and eliminates warnings about the spec and module having different `__package__` attributes, because the `__name__` and `__package__` are already correct due to the full name being used in `find_spec` to start with.

## How was this tested?
I stepped through with a debugger to confirm that the imported module's `.__name__` and `.__package__` were the same as before this PR, and that the module's `.__spec__.parent` now matches the module's `.__package__`.

I ran a successful local generation of an apworld in my custom_worlds directory.
