### PR TITLE
SNI Client: fix that it isnt using host.yaml settings

### DIFF
--- a/SNIClient.py
+++ b/SNIClient.py
@@ -18,7 +18,7 @@ from json import loads, dumps
 from CommonClient import CommonContext, server_loop, ClientCommandProcessor, gui_enabled, get_base_parser
 
 import Utils
-from settings import Settings
+import settings
 from Utils import async_start
 from MultiServer import mark_raw
 if typing.TYPE_CHECKING:
@@ -286,7 +286,7 @@ class SNESState(enum.IntEnum):
 
 
 def launch_sni() -> None:
-    sni_path = Settings.sni_options.sni_path
+    sni_path = settings.get_settings().sni_options.sni_path
 
     if not os.path.isdir(sni_path):
         sni_path = Utils.local_path(sni_path)
@@ -669,7 +669,7 @@ async def game_watcher(ctx: SNIContext) -> None:
 
 
 async def run_game(romfile: str) -> None:
-    auto_start = Settings.sni_options.snes_rom_start
+    auto_start = settings.get_settings().sni_options.snes_rom_start
     if auto_start is True:
         import webbrowser
         webbrowser.open(romfile)


### PR DESCRIPTION
## What is this fixing or adding?
The SNI client isn't using the settings in host.yaml, its just using defaults.
Reported here: https://discord.com/channels/731205301247803413/1408222871578345624
And I also observed this myself

The previous change was here https://github.com/ArchipelagoMW/Archipelago/pull/5239/files

## How was this tested?
Modifying host.yaml and relaunching