### PR TITLE
Stardew Valley: Add archipelago.json

### DIFF
--- a/worlds/stardew_valley/archipelago.json
+++ b/worlds/stardew_valley/archipelago.json
@@ -1,5 +1,6 @@
 {
   "game": "Stardew Valley",
   "authors": ["KaitoKid", "Jouramie", "Witchybun (Mod Support)", "Exempt-Medic (Proofreading)"],
-  "minimum_ap_version": "0.6.3"
+  "minimum_ap_version": "0.6.4",
+  "world_version": "6.0.0"
 }


### PR DESCRIPTION
## What is this fixing or adding?
Add `archipelago.json`.
- I added the same authors currently in `StardewWebWorld`.
- Starting world version at 6.0.0 because I don't want to try figuring out which version we're at. 

## How was this tested?
Packaged with the launcher

## If this makes graphical changes, please attach screenshots.
N/A