### PR TITLE
Docs: Remove `/apstart` from Terraria docs

### DIFF
--- a/worlds/terraria/docs/setup_en.md
+++ b/worlds/terraria/docs/setup_en.md
@@ -57,7 +57,6 @@ on the Archipelago website to generate a YAML using a graphical interface.
 significantly more difficult with this mod, so it is recommended to choose a lower difficulty than you normally would
 play on.
 4. Open the world in single player or multiplayer.
-5. When you're ready, open chat, and enter `/apstart` to start the game.
    
 ## Commands
 


### PR DESCRIPTION
## What is this fixing or adding?

Remove reference to `/apstart` in Terraria docs. The `/apstart` command was removed in https://github.com/Seldom-SE/archipelago_terraria_client/commit/b65cca3ae0c28090f9dacfc923b5fecb20c4d178. Now, the Archipelago session starts automatically.

## How was this tested?

Manual inspection of webhost

## If this makes graphical changes, please attach screenshots.

<img width="2791" height="1547" alt="Screenshot From 2025-10-11 10-25-18" src="https://github.com/user-attachments/assets/90249fc3-5840-421c-9bf0-55ff1516b0e5" />
