### PR TITLE
MultiServer: Fix breaking weakrefs for SetNotify

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -135,6 +135,7 @@ def get_saving_second(seed_name: str, interval: int = 60) -> int:
 
 class Client(Endpoint):
     __slots__ = (
+        "__weakref__",
         "version",
         "auth",
         "team",


### PR DESCRIPTION
## What is this fixing or adding?

https://discord.com/channels/731205301247803413/731214280439103580/1426949158278791168

This broke in #5527 

## How was this tested?

https://discord.com/channels/731205301247803413/731214280439103580/1426949158278791168

We really need a unit test for this in the future.
