### PR TITLE
factorio: Add no-enemies mode to worldgen schema

### DIFF
--- a/worlds/factorio/Options.py
+++ b/worlds/factorio/Options.py
@@ -345,6 +345,7 @@ class FactorioWorldGen(OptionDict):
         "seed": None,
         "starting_area": 1,
         "peaceful_mode": False,
+        "no_enemies_mode": False,
         "cliff_settings": {
             "name": "cliff",
             "cliff_elevation_0": 10,
@@ -394,6 +395,7 @@ class FactorioWorldGen(OptionDict):
             Optional("height"): And(int, lambda n: n >= 0),
             Optional("starting_area"): FloatRange(0.166, 6),
             Optional("peaceful_mode"): LuaBool,
+            Optional("no_enemies_mode"): LuaBool,
             Optional("cliff_settings"): {
                 "name": str, "cliff_elevation_0": FloatRange(0, 99),
                 "cliff_elevation_interval": FloatRange(0.066, 241),  # 40/frequency


### PR DESCRIPTION
## What is this fixing or adding?
2.0 added a new "No Enemies" toggle to the worldgen settings (in addition to the original Pacifist Mode).  This adds it to the schema, so players can use it in their yamls

## How was this tested?
Genned a couple of Factorios

## If this makes graphical changes, please attach screenshots.
