### PR TITLE
MultiServer: Fix hinting multi-copy items bleeding found status

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1158,7 +1158,7 @@ def collect_hints(ctx: Context, team: int, slot: int, item: typing.Union[int, st
             found = location_id in ctx.location_checks[team, finding_player]
             entrance = ctx.er_hint_data.get(finding_player, {}).get(location_id, "")
 
-            hint_status = status  # Copy because we're in a for loop
+            hint_status = status  # Assign again because we're in a for loop
             if found:
                 hint_status = HintStatus.HINT_FOUND
             elif hint_status is None:


### PR DESCRIPTION
In https://github.com/ArchipelagoMW/Archipelago/pull/4713, I made a mistake.

"status" is being passed as a param with default value None, but then I mutate it in the for loop.
This causes status to "bleed" from one copy of a multi-copy item to the others, specifically the "found" status.

I checked that there are no other instances of this. This code exists elsewhere, but not in a for loop, because this is the only case where we create multiple hints in the same call of one of the helpers.