### PR TITLE
Change plando default from "force: silent" to "force: true"

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -1509,7 +1509,7 @@ class PlandoItem:
     locations: list[str]
     world: int | str | bool | None | typing.Iterable[str] | set[int] = False
     from_pool: bool = True
-    force: bool | typing.Literal["silent"] = "silent"
+    force: bool | typing.Literal["silent"] = True
     count: int | bool | dict[str, int] = False
     percentage: int = 100
 
@@ -1563,7 +1563,7 @@ class PlandoItems(Option[typing.List[PlandoItem]]):
                             raise OptionError(f"Plando `location` has to be string or list, not {type(locations)}")
                     world = item.get("world", False)
                     from_pool = item.get("from_pool", True)
-                    force = item.get("force", "silent")
+                    force = item.get("force", True)
                     if not isinstance(from_pool, bool):
                         raise OptionError(f"Plando 'from_pool' has to be true or false, not {from_pool!r}.")
                     if not (isinstance(force, bool) or force == "silent"):

--- a/worlds/generic/__init__.py
+++ b/worlds/generic/__init__.py
@@ -55,7 +55,7 @@ class PlandoItem(NamedTuple):
     location: str
     world: Union[bool, str] = False  # False -> own world, True -> not own world
     from_pool: bool = True  # if item should be removed from item pool
-    force: str = 'true'  # false -> warns if item not successfully placed. true -> errors out on failure to place item. silent -> does nothing on failure.
+    force: str = 'silent'  # false -> warns if item not successfully placed. true -> errors out on failure to place item.
 
     def warn(self, warning: str):
         if self.force in ['true', 'fail', 'failure', 'none', 'false', 'warn', 'warning']:


### PR DESCRIPTION
## What is this fixing or adding?
It changes the default for the "force:"-option in plando from silent to true.

https://discord.com/channels/731205301247803413/1425078461298638878
This was suggested here and highly upvoted. 

## How was this tested?
I generated this YAML and it failed:
```
game: ChecksFinder
ChecksFinder:
  plando_items:
    - items:
        Map Bombs: 1
      locations:
        - "Route 1 - Free Sample Man"
```
I generated this yaml also on 0.6.3 and it succeeded. The difference is that behind the scene the force-default was changed.

Thanks to Silvris for pointing me in the right direction.