### PR TITLE
Test: check fields in world source manifest

### DIFF
--- a/test/general/test_world_manifest.py
+++ b/test/general/test_world_manifest.py
@@ -69,6 +69,7 @@ class TestWorldManifest(unittest.TestCase):
         )
 
     def test_world_version(self) -> None:
+        """Test that world_version matches the requirements in apworld specification.md""" 
         if "world_version" in self.manifest:
             world_version: str = self.manifest["world_version"]
             self.assertIsInstance(
@@ -92,10 +93,10 @@ class TestWorldManifest(unittest.TestCase):
         self.assertNotIn(
             "version",
             self.manifest,
-            f"archipelago.json for '{self.game}' may not define 'version', see apworld specification.md.",
+            f"archipelago.json for '{self.game}' must not define 'version', see apworld specification.md.",
         )
         self.assertNotIn(
             "compatible_version",
             self.manifest,
-            f"archipelago.json for '{self.game}' may not define 'compatible_version', see apworld specification.md.",
+            f"archipelago.json for '{self.game}' must not define 'compatible_version', see apworld specification.md.",
         )


### PR DESCRIPTION
## What is this fixing or adding?

If manifest is defined in world source, check that
* game is correctly defined
* version is in the required format (unless missing)
* container version is not defined.

## How was this tested?

CI, mypy