### PR TITLE
AHiT: Fix likely unintended concatenation

### DIFF
--- a/worlds/ahit/Regions.py
+++ b/worlds/ahit/Regions.py
@@ -243,7 +243,7 @@ guaranteed_first_acts = [
     "Time Rift - Mafia of Cooks",
     "Time Rift - Dead Bird Studio",
     "Time Rift - Sleepy Subcon",
-    "Time Rift - Alpine Skyline"
+    "Time Rift - Alpine Skyline",
     "Time Rift - Tour",
     "Time Rift - Rumbi Factory",
 ]


### PR DESCRIPTION
## What is this fixing or adding?
I noticed a few instances of missing commas while looking for instances of #5564, and these are likely bugs affecting actual behavior, so I'm posting them separately.

## How was this tested?
Trying to act plando `Welcome to Mafia Town: Time Rift - Alpine Skyline` and having it work (with insanity ActRandomizer).