### PR TITLE
SM: Fix exception string

### DIFF
--- a/worlds/sm/variaRandomizer/randomizer.py
+++ b/worlds/sm/variaRandomizer/randomizer.py
@@ -460,8 +460,8 @@ class VariaRandomizer:
                     possibleStartAPs = sorted(list(set(possibleStartAPs).intersection(set(startLocationList))))
                     if len(possibleStartAPs) == 0:
                         #optErrMsgs += ["%s : %s" % (apName, cause) for apName, cause in reasons.items() if apName in startLocationList]
-                        raise Exception("Invalid start locations list with your settings." + 
-                                        "%s : %s" % (apName, cause) for apName, cause in reasons.items() if apName in startLocationList)
+                        raise Exception("Invalid start locations list with your settings. " +
+                                        ", ".join("%s : %s" % (apName, cause) for apName, cause in reasons.items() if apName in startLocationList))
                         #dumpErrorMsgs(args.output, optErrMsgs)
                 args.startLocation = random.choice(possibleStartAPs)
             elif args.startLocation not in possibleStartAPs:


### PR DESCRIPTION
## What is this fixing or adding?
Found that this was missing a space from #5564, but this message is also a generator expression instead of a string so it would look something like `Exception: <generator object <genexpr> at 0x000002100F9784F0>` if it actually got hit. I assume that something like this was the intention.
Also maybe this shouldn't just be a base `Exception` instance but that's separate.

## How was this tested?
Not
