### PR TITLE
WebHost: Fix flask-compress to 1.18 for Python 3.11 (to get CI to pass again)

### DIFF
--- a/WebHostLib/requirements.txt
+++ b/WebHostLib/requirements.txt
@@ -4,7 +4,8 @@ pony>=0.7.19; python_version <= '3.12'
 pony @ git+https://github.com/black-sliver/pony@7feb1221953b7fa4a6735466bf21a8b4d35e33ba#0.7.19; python_version >= '3.13'
 waitress>=3.0.2
 Flask-Caching>=2.3.0
-Flask-Compress>=1.17
+Flask-Compress>=1.17; python_version >= '3.12'
+Flask-Compress==1.18; python_version <= '3.11'  # 3.11's pkg_resources can't resolve the new "backports.zstd" dependency
 Flask-Limiter>=3.12
 bokeh>=3.6.3
 markupsafe>=3.0.2


### PR DESCRIPTION
From Discord:

Well, flask-compress updated and now our 3.11 CI is failing

Why? They switched to a lib called backports.zstd
And 3.11 pkg_resources can't handle that.

pip finds it. But in our ModuleUpdate.py, we first pkg_resources.require packages, and this fails. I can't reproduce this locally yet, but in CI, it seems like even though backports.zstd is installed, it still fails on it and prompts installing it over and over in every unit test Now what do we do :KEKW:
Black Sliver suggested pinning flask-compress for 3.11 But I would just like to point out that this means we can't unpin it until we drop 3.11 the real thing is we probably need to move away from pkg_resources? lol  since it's been deprecated literally since the oldest version we support