### PR TITLE
Pokémon R/B: Specify encounter types for Dexsanity hint data

### DIFF
--- a/worlds/pokemon_rb/__init__.py
+++ b/worlds/pokemon_rb/__init__.py
@@ -653,17 +653,10 @@ class PokemonRedBlueWorld(World):
     def extend_hint_information(self, hint_data):
         if self.options.dexsanity or self.options.door_shuffle:
             hint_data[self.player] = {}
-        randomized_encounter_types = []
-        if self.options.randomize_wild_pokemon:
-            randomized_encounter_types.append("Wild Encounter")
-        if self.options.randomize_static_pokemon:
-            randomized_encounter_types.append("Static Pokemon")
-        if self.options.randomize_legendary_pokemon:
-            randomized_encounter_types.append("Legendary Pokemon")
-        if self.options.dexsanity and randomized_encounter_types:
+        if self.options.dexsanity:
             mon_locations = {mon: set() for mon in poke_data.pokemon_data.keys()}
             for loc in location_data:
-                if loc.type in randomized_encounter_types:
+                if loc.type in ["Wild Encounter", "Static Pokemon", "Legendary Pokemon"]:
                     mon = self.multiworld.get_location(loc.name, self.player).item.name
                     if mon.startswith("Static "):
                         mon = " ".join(mon.split(" ")[1:])


### PR DESCRIPTION
## What is this fixing or adding?
Changes `PokemonRedBlueWorld.extend_hint_information` to add more details to Pokemon encounters:
- To distinguish from land encounters, Surf and Static/Legendary Pokemon have an extra label
  - Fishing encounters and Game Corner Prizes are exceptions, since the former are their own "region" and the latter is obvious enough
- ~~Only the randomized encounter types get written to hint data~~ (walked that change back for consistency with other Pokémon implementations)
- Removed Missable Pokemon from it, since they are not in logic and only one of the 3 is catchable in a normal plathrough

## How was this tested?
Generated 2 games (All random Pokemon and only wilds randomized) and compared with the spoiler log to check that the hint data had the expected results

## If this makes graphical changes, please attach screenshots.
<img width="1584" height="533" alt="image" src="https://github.com/user-attachments/assets/284f4e9d-4821-42d7-bd96-bba70d643529" />
