### PR TITLE
WebHost: add missing docutils requirement and update

### DIFF
--- a/WebHostLib/requirements.txt
+++ b/WebHostLib/requirements.txt
@@ -11,3 +11,4 @@ bokeh>=3.6.3
 markupsafe>=3.0.2
 setproctitle>=1.3.5
 mistune>=3.1.3
+docutils>=0.22.2


### PR DESCRIPTION
## What is this fixing or adding?

This adds the missing requirement and bumps the version to latest, forcing an update.

## Why?

docutils is being used in WebHostLib.options directly.

A recent change bumped our actually required version:
#5544 fixed a deprecation warning.

The indirect requirement is too lax and allows a docutil that fails.

## How was this tested?

This version is already in use on the RC WebHost and on my local machine.

Also opened ~20 different option pages on WebHost with py3.11 just to be sure.