### PR TITLE
Core: add random range and additional random descriptions to template yaml

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -1726,15 +1726,15 @@ def generate_yaml_templates(target_folder: typing.Union[str, "pathlib.Path"], ge
 
     def dictify_range(option: Range):
         data = {option.default: 50}
-        for sub_option in ["random", "random-low", "random-high"]:
+        for sub_option in ["random", "random-low", "random-high",
+                           f"random-range-{option.range_start}-{option.range_end}"]:
             if sub_option != option.default:
                 data[sub_option] = 0
-        random_range_key = f"random-range-{option.range_start}-{option.range_end}"
-        data[random_range_key] = 0
         notes = {
-            "random-low": "random weighted towards lower values",
-            "random-high": "random weighted towards higher values",
-            random_range_key: f"random value between {option.range_start} and {option.range_end}"
+            "random-low": "random value weighted towards lower values",
+            "random-high": "random value weighted towards higher values",
+            f"random-range-{option.range_start}-{option.range_end}": f"random value between "
+                                                                     f"{option.range_start} and {option.range_end}"
         }
         for name, number in getattr(option, "special_range_names", {}).items():
             notes[name] = f"equivalent to {number}"


### PR DESCRIPTION
## What is this fixing or adding?
Less drastic fix for #5582, since I think if you remove `random-low` and `random-high` from the yaml, complaints will come in from the opposite direction.

This adds a default random range to the template yaml with the min/max being set to the option's min and max, and adds descriptions stating that low/high are weighted towards their specific values, while range actually sets the specific range.

## How was this tested?
Ran unittests, since that tests template yamls being able to generate already.
Generated template yamls in the launcher, and checked the output

Example:
```yaml
  triforce_pieces_percentage:
    # Set to how many triforce pieces according to a percentage of the required ones, are available to collect in the world.
    #
    # You can define additional values between the minimum and maximum values.
    # Minimum value is 100
    # Maximum value is 1000
    150: 50
    random: 0
    random-low: 0 # random weighted towards lower values
    random-high: 0 # random weighted towards higher values
    random-range-100-1000: 0 # random value between 100 and 1000
```