### PR TITLE
kvui: Fix audio being completely non-functional on Linux

### DIFF
--- a/kvui.py
+++ b/kvui.py
@@ -41,6 +41,8 @@ Config.set("graphics", "multisamples", "0")  # multisamples crash old intel driv
 # No longer necessary when we switch to kivy 3.0.0, which fixes this issue.
 from kivy.core.audio import SoundLoader
 for classobj in SoundLoader._classes:
+    # The least invasive way to force a SoundLoader class to load its audio engine seems to be calling
+    # .extensions(), which e.g. in audio_sdl2.pyx then calls a function called "mix_init()"
     classobj.extensions()
 
 from kivymd.uix.divider import MDDivider


### PR DESCRIPTION
APQuest currently is non-functional on Linux (specifically, Ubuntu 24.04 and Arch Linux) because there is a bug in the kivy library that infinitely hangs the application if you attempt to play any audio using kivy's SoundLoader.

The way to fix this is to initialize audio before the first import of kivy.core.window.
Note here that kivymd itself imports kivy.core.window, so it has to be before the first kivymd import as well.

Worlds don't have a workaround for this: The only realistic place this can be done is in kvui.py, since kvui.py has to be imported before any kivy imports are done.
So, I think we should try to get this through quickly for a core release so that kivy applications can use audio *at all*.

Related reading where we figured out what the issue was: https://github.com/kivymd/KivyMD/issues/1828

Tested:
Without this, APQuest doesn't work on Ubuntu 24.04
With this, APQuest does work on Ubuntu 24.04