### PR TITLE
WebHost: Pin Flask-Compress to 1.18 for all versions of Python

### DIFF
--- a/WebHostLib/requirements.txt
+++ b/WebHostLib/requirements.txt
@@ -4,7 +4,7 @@ pony>=0.7.19; python_version <= '3.12'
 pony @ git+https://github.com/black-sliver/pony@7feb1221953b7fa4a6735466bf21a8b4d35e33ba#0.7.19; python_version >= '3.13'
 waitress>=3.0.2
 Flask-Caching>=2.3.0
-Flask-Compress==1.18;  # pkg_resources can't resolve the "backports.zstd" dependency of >1.18, breaking ModuleUpdate.py
+Flask-Compress==1.18  # pkg_resources can't resolve the "backports.zstd" dependency of >1.18, breaking ModuleUpdate.py
 Flask-Limiter>=3.12
 bokeh>=3.6.3
 markupsafe>=3.0.2


### PR DESCRIPTION
Turns out that the pkgutil freakout happens on 3.12 and 3.13 too, it just doesn't in CI for... some reason. But yes, two people reproduced this on Windows Python 3.12 and Windows Python 3.13 respectively.