### PR TITLE
LADX: fix a gap in item name sanitization

### DIFF
--- a/worlds/ladx/__init__.py
+++ b/worlds/ladx/__init__.py
@@ -493,7 +493,7 @@ class LinksAwakeningWorld(World):
                             loc.ladxr_item.item = 'PIECE_OF_POWER'
                         else:
                             loc.ladxr_item.item = 'GUARDIAN_ACORN'
-                        loc.ladxr_item.custom_item_name = loc.item.name
+                        loc.ladxr_item.setCustomItemName(loc.item.name)
 
                     if loc.item:
                         loc.ladxr_item.item_owner = loc.item.player


### PR DESCRIPTION
## What is this fixing or adding?
setCustomItemName sanitizes item names before setting them, I had missed this spot. Without sanitizing, an item with `"` in it will cause patching to fail.

## How was this tested?
generating with another world, with `foreign_item_icons: indicate_progression` to hit the code path