### PR TITLE
CI: use rehosted appimage runtime and appimagetool

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,10 @@ env:
   ENEMIZER_VERSION: 7.1
   # NOTE: since appimage/appimagetool and appimage/type2-runtime does not have tags anymore,
   #       we check the sha256 and require manual intervention if it was updated.
-  APPIMAGETOOL_VERSION: continuous
+  APPIMAGE_FORK: 'PopTracker'
+  APPIMAGETOOL_VERSION: 'r-2025-10-19'
   APPIMAGETOOL_X86_64_HASH: '9493a6b253a01f84acb9c624c38810ecfa11d99daa829b952b0bff43113080f9'
-  APPIMAGE_RUNTIME_VERSION: continuous
+  APPIMAGE_RUNTIME_VERSION: 'r-2025-08-11'
   APPIMAGE_RUNTIME_X86_64_HASH: 'e70ffa9b69b211574d0917adc482dd66f25a0083427b5945783965d55b0b0a8b'
 
 permissions:  # permissions required for attestation
@@ -141,9 +142,9 @@ jobs:
       - name: Install build-time dependencies
         run: |
           echo "PYTHON=python3.12" >> $GITHUB_ENV
-          wget -nv https://github.com/AppImage/appimagetool/releases/download/$APPIMAGETOOL_VERSION/appimagetool-x86_64.AppImage
+          wget -nv https://github.com/$APPIMAGE_FORK/appimagetool/releases/download/$APPIMAGETOOL_VERSION/appimagetool-x86_64.AppImage
           echo "$APPIMAGETOOL_X86_64_HASH appimagetool-x86_64.AppImage" | sha256sum -c
-          wget -nv https://github.com/AppImage/type2-runtime/releases/download/$APPIMAGE_RUNTIME_VERSION/runtime-x86_64
+          wget -nv https://github.com/$APPIMAGE_FORK/type2-runtime/releases/download/$APPIMAGE_RUNTIME_VERSION/runtime-x86_64
           echo "$APPIMAGE_RUNTIME_X86_64_HASH runtime-x86_64" | sha256sum -c
           chmod a+rx appimagetool-x86_64.AppImage
           ./appimagetool-x86_64.AppImage --appimage-extract

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,10 @@ env:
   ENEMIZER_VERSION: 7.1
   # NOTE: since appimage/appimagetool and appimage/type2-runtime does not have tags anymore,
   #       we check the sha256 and require manual intervention if it was updated.
-  APPIMAGETOOL_VERSION: continuous
+  APPIMAGE_FORK: 'PopTracker'
+  APPIMAGETOOL_VERSION: 'r-2025-10-19'
   APPIMAGETOOL_X86_64_HASH: '9493a6b253a01f84acb9c624c38810ecfa11d99daa829b952b0bff43113080f9'
-  APPIMAGE_RUNTIME_VERSION: continuous
+  APPIMAGE_RUNTIME_VERSION: 'r-2025-08-11'
   APPIMAGE_RUNTIME_X86_64_HASH: 'e70ffa9b69b211574d0917adc482dd66f25a0083427b5945783965d55b0b0a8b'
 
 permissions:  # permissions required for attestation
@@ -127,9 +128,9 @@ jobs:
       - name: Install build-time dependencies
         run: |
           echo "PYTHON=python3.12" >> $GITHUB_ENV
-          wget -nv https://github.com/AppImage/appimagetool/releases/download/$APPIMAGETOOL_VERSION/appimagetool-x86_64.AppImage
+          wget -nv https://github.com/$APPIMAGE_FORK/appimagetool/releases/download/$APPIMAGETOOL_VERSION/appimagetool-x86_64.AppImage
           echo "$APPIMAGETOOL_X86_64_HASH appimagetool-x86_64.AppImage" | sha256sum -c
-          wget -nv https://github.com/AppImage/type2-runtime/releases/download/$APPIMAGE_RUNTIME_VERSION/runtime-x86_64
+          wget -nv https://github.com/$APPIMAGE_FORK/type2-runtime/releases/download/$APPIMAGE_RUNTIME_VERSION/runtime-x86_64
           echo "$APPIMAGE_RUNTIME_X86_64_HASH runtime-x86_64" | sha256sum -c
           chmod a+rx appimagetool-x86_64.AppImage
           ./appimagetool-x86_64.AppImage --appimage-extract


### PR DESCRIPTION
## What is this fixing or adding?

Switches appimagetool and AppImage type2-runtime to a fork that re-hosts upstream continuous releases as tagged, immutable releases.

This fixes the problem of CI randomly breaking when upstream pushes updates and allows better reproducibility of builds.

## Why?

Unsigned releases with no version info are kind of risky for both CI and users, so we have been pinning them via hash.
Whenever upstream released an update, our CI workflow would break because they reuse the same tag with a different file.

There is also a bit more info in the READMEs of the forks [here](https://github.com/PopTracker/appimagetool?tab=readme-ov-file#readme) and [here](https://github.com/PopTracker/type2-runtime?tab=readme-ov-file#readme).

## How was this tested?

CI. The change only affects the download *source*. The file contents (and hashes) are unchanged.