### PR TITLE
CV64: Fix not having Clocktower Key3 when placed in a start_inventory.

### DIFF
--- a/worlds/cv64/data/patches.py
+++ b/worlds/cv64/data/patches.py
@@ -2034,7 +2034,7 @@ new_game_extras = [
     0x24090000,  # ADDIU T1, R0, 0x0000  <- Starting Ice Traps
     0xA1099BE2,  # SB    T1, 0x9BE2 (T0)
     0x240C0000,  # ADDIU T4, R0, 0x0000
-    0x240D0022,  # ADDIU T5, R0, 0x0022
+    0x240D0023,  # ADDIU T5, R0, 0x0023
     0x11AC0007,  # BEQ   T5, T4, [forward 0x07]
     0x3C0A8040,  # LUI   T2, 0x8040
     0x014C5021,  # ADDU  T2, T2, T4


### PR DESCRIPTION
## What is this fixing or adding?
Literal ONE byte difference (or two bytes, if we count the comment as well, haha). 

The custom routine that copies the player's array of counts of inventory items placed in `start_inventory` and `start_inventory_from_pool` into their actual in-game inventory upon starting a new game was one byte short of copying the whole thing, so the item for the count at the end of it (Clocktower Key3) was not actually being given properly. This PR fixes that.

## How was this tested?
Placed some and then all keys in `start_inventory` (including all Clocktower Keys in both cases) and verified I had everything in-game.