### PR TITLE
Jak and Daxter: Second attempt at fixing trade tests.

### DIFF
--- a/worlds/jakanddaxter/test/test_trades.py
+++ b/worlds/jakanddaxter/test/test_trades.py
@@ -7,7 +7,9 @@ class TradesCostNothingTest(JakAndDaxterTestBase):
         "global_orbsanity_bundle_size": 10,
         "citizen_orb_trade_amount": 0,
         "oracle_orb_trade_amount": 0,
-        "start_inventory": {"Power Cell": 100},
+        "fire_canyon_cell_count": 0,
+        "mountain_pass_cell_count": 0,
+        "lava_tube_cell_count": 0,
     }
 
     def test_orb_items_are_filler(self):
@@ -26,7 +28,9 @@ class TradesCostEverythingTest(JakAndDaxterTestBase):
         "global_orbsanity_bundle_size": 10,
         "citizen_orb_trade_amount": 120,
         "oracle_orb_trade_amount": 150,
-        "start_inventory": {"Power Cell": 100},
+        "fire_canyon_cell_count": 0,
+        "mountain_pass_cell_count": 0,
+        "lava_tube_cell_count": 0,
     }
 
     def test_orb_items_are_progression(self):


### PR DESCRIPTION
## What is this fixing or adding?
#5587 showed another trade test failure for Jak, which makes me think that the unit tests do not respect the starting inventory we're providing in #5493. I guess that makes sense because the problem is a FillError, and starting inventory (TMK) has no impact on fill. 

So instead we're lowering the power cell requirements to zero for everything. Same principle as the previous PR: they are not dependent variables, we should make them constants and eliminate them as potential hazards.

## How was this tested?
Ran unit tests. Same warning as the previous PR applies.

## If this makes graphical changes, please attach screenshots.
N/A