### PR TITLE
CommonClient: add tab for filtering to server messages relevant to current slot

### DIFF
--- a/kvui.py
+++ b/kvui.py
@@ -1090,7 +1090,7 @@ class GameManager(ThemedApp):
         self.log_panels["All"].on_message_markup(text)
         concerns_self = any(("player" in part and self.ctx.slot_concerns_self(part["player"])) for part in data) or \
                         all("player" not in part for part in data)
-        #only print if there's a player that is us, or there is not a player at all
+        # only print if there's a player that is us, or there is not a player at all
         if concerns_self:
             self.log_panels["Self"].on_message_markup(text)
 

--- a/kvui.py
+++ b/kvui.py
@@ -926,6 +926,9 @@ class GameManager(ThemedApp):
             if len(self.logging_pairs) > 1:
                 self.add_client_tab(display_name, self.log_panels[display_name])
 
+        self.log_panels["Self"] = UILog(logging.getLogger("Client"))
+        self.add_client_tab("Self", self.log_panels["Self"])
+
         self.hint_log = HintLog(self.json_to_kivy_parser)
         hint_panel = self.add_client_tab("Hints", HintLayout(self.hint_log))
         self.log_panels["Hints"] = hint_panel.content
@@ -1085,6 +1088,11 @@ class GameManager(ThemedApp):
         text = self.json_to_kivy_parser(data)
         self.log_panels["Archipelago"].on_message_markup(text)
         self.log_panels["All"].on_message_markup(text)
+        concerns_self = any(("player" in part and self.ctx.slot_concerns_self(part["player"])) for part in data) or \
+                        all("player" not in part for part in data)
+        #only print if there's a player that is us, or there is not a player at all
+        if concerns_self:
+            self.log_panels["Self"].on_message_markup(text)
 
     def focus_textinput(self):
         if hasattr(self, "textinput"):


### PR DESCRIPTION
## What is this fixing or adding?
Adds a new client tab that receives all messages from the server (same as the `Archipelago` tab) that either do not include a player argument (such as player chat or server messages) or those that have a player argument that references the current slot. This allows players to see only items incoming to/from their slot.

## How was this tested?
Generated a game with three players and sent out a location from each. Confirmed that when the player was not being referenced (ie. P2 sent item to P3), the message was not copied over into the Self tab.

## If this makes graphical changes, please attach screenshots.
<img width="800" height="83" alt="image" src="https://github.com/user-attachments/assets/c8a07bb3-6f72-456b-ad14-47a3b444e21e" />
