### PR TITLE
CVCotM: Fix determinism with Halve DSS Cards Placed.

### DIFF
--- a/worlds/cvcotm/items.py
+++ b/worlds/cvcotm/items.py
@@ -110,7 +110,7 @@ def get_item_counts(world: "CVCotMWorld") -> Dict[ItemClassification, Dict[str, 
 
     # If Halve DSS Cards Placed is on, determine which cards we will exclude here.
     if world.options.halve_dss_cards_placed:
-        excluded_cards = list(ACTION_CARDS.union(ATTRIBUTE_CARDS))
+        excluded_cards = sorted(ACTION_CARDS.union(ATTRIBUTE_CARDS))
 
         has_freeze_action = False
         has_freeze_attr = False


### PR DESCRIPTION
## What is this fixing or adding?
Fixes seeds generated with the Halve DSS Cards Placed option on being non-deterministic. This was being caused due to the initial list of cards to randomly remove being copied to a plain `list` from a `set` object, when the list should have been `sorted` due to how `set` orders work. This fixes that.

## How was this tested?
Generated the same seed a couple times with Half DSS Cards Placed on and verified the spoiler logs showed the exact same item placements.