### PR TITLE
Game Docs: Fix main setup guide links

### DIFF
--- a/worlds/cv64/docs/setup_en.md
+++ b/worlds/cv64/docs/setup_en.md
@@ -30,7 +30,7 @@ the White Jewels.
 
 1. Create your options file (YAML). You can make one on the
 [Castlevania 64 options page](../../../games/Castlevania%2064/player-options).
-2. Follow the general Archipelago instructions for [generating a game](../../Archipelago/setup/en#generating-a-game).
+2. Follow the general Archipelago instructions for [generating a game](/tutorial/Archipelago/setup_en#generating-a-game).
 This will generate an output file for you. Your patch file will have the `.apcv64` file extension.
 3. Open `ArchipelagoLauncher.exe`
 4. Select "Open Patch" on the left side and select your patch file.

--- a/worlds/cvcotm/docs/setup_en.md
+++ b/worlds/cvcotm/docs/setup_en.md
@@ -28,7 +28,7 @@ clear it.
 ## Generating and Patching a Game
 
 1. Create your settings file (YAML). You can make one on the [Castlevania: Circle of the Moon options page](../../../games/Castlevania%20-%20Circle%20of%20the%20Moon/player-options).
-2. Follow the general Archipelago instructions for [generating a game](../../Archipelago/setup/en#generating-a-game).
+2. Follow the general Archipelago instructions for [generating a game](/tutorial/Archipelago/setup_en#generating-a-game).
 This will generate an output file for you. Your patch file will have the `.apcvcotm` file extension.
 3. Open `ArchipelagoLauncher.exe`.
 4. Select "Open Patch" on the left side and select your patch file.

--- a/worlds/marioland2/docs/setup_en.md
+++ b/worlds/marioland2/docs/setup_en.md
@@ -44,7 +44,7 @@ You can generate a yaml or download a template by visiting the [Super Mario Land
 ### Generating and Patching a Game
 
 1. Create your options file (YAML).
-2. Follow the general Archipelago instructions for [generating a game](../../Archipelago/setup/en#generating-a-game).
+2. Follow the general Archipelago instructions for [generating a game](/tutorial/Archipelago/setup_en#generating-a-game).
 This will generate an output file for you. Your patch file will have a `.apsml2` file extension.
 3. Open `ArchipelagoLauncher.exe`
 4. Select "Open Patch" on the left side and select your patch file.

--- a/worlds/mm2/docs/setup_en.md
+++ b/worlds/mm2/docs/setup_en.md
@@ -23,7 +23,7 @@ clear it.
 
 1. Create your options file (YAML). You can make one on the
 [Mega Man 2 options page](../../../games/Mega%20Man%202/player-options).
-2. Follow the general Archipelago instructions for [generating a game](../../Archipelago/setup/en#generating-a-game).
+2. Follow the general Archipelago instructions for [generating a game](/tutorial/Archipelago/setup_en#generating-a-game).
 This will generate an output file for you. Your patch file will have the `.apmm2` file extension.
 3. Open `ArchipelagoLauncher.exe`
 4. Select "Open Patch" on the left side and select your patch file.

--- a/worlds/pokemon_emerald/docs/setup_en.md
+++ b/worlds/pokemon_emerald/docs/setup_en.md
@@ -28,7 +28,7 @@ clear it.
 
 1. Create your options file (YAML). You can make one on the
 [Pokémon Emerald options page](../../../games/Pokemon%20Emerald/player-options).
-2. Follow the general Archipelago instructions for [generating a game](../../Archipelago/setup/en#generating-a-game).
+2. Follow the general Archipelago instructions for [generating a game](/tutorial/Archipelago/setup_en#generating-a-game).
 This will generate an output file for you. Your patch file will have the `.apemerald` file extension.
 3. Open `ArchipelagoLauncher.exe`
 4. Select "Open Patch" on the left side and select your patch file.

--- a/worlds/pokemon_emerald/docs/setup_es.md
+++ b/worlds/pokemon_emerald/docs/setup_es.md
@@ -29,7 +29,7 @@ con [PopTracker](https://github.com/black-sliver/PopTracker/releases)
 1. Crea tu archivo de configuración (YAML). Puedes hacerlo en
 [Página de Opciones de Pokémon Emerald](../../../games/Pokemon%20Emerald/player-options).
 2. Sigue las instrucciones generales de Archipelago para
-[Generar un juego](../../Archipelago/setup/en#generating-a-game). Esto generará un archivo de salida (output file) para
+[Generar un juego](/tutorial/Archipelago/setup_en#generating-a-game). Esto generará un archivo de salida (output file) para
 ti. Tu archivo de parche tendrá la extensión de archivo `.apemerald`.
 3. Abre `ArchipelagoLauncher.exe`
 4. Selecciona "Open Patch" en el lado derecho y elige tu archivo de parcheo.

--- a/worlds/pokemon_emerald/docs/setup_sv.md
+++ b/worlds/pokemon_emerald/docs/setup_sv.md
@@ -30,7 +30,7 @@ används tillsammans med
 1. Skapa din konfigurationsfil (YAML). Du kan göra en via att använda
 [Pokémon Emerald options hemsida](../../../games/Pokemon%20Emerald/player-options).
 2. Följ de allmänna Archipelago instruktionerna för att
-[Generera ett spel](../../Archipelago/setup/en#generating-a-game).
+[Generera ett spel](/tutorial/Archipelago/setup_en#generating-a-game).
 Detta kommer generera en fil för dig. Din patchfil kommer ha `.apemerald` som sitt filnamnstillägg.
 3. Öppna `ArchipelagoLauncher.exe`
 4. Välj "Open Patch" på vänstra sidan, och välj din patchfil.

--- a/worlds/pokemon_rb/docs/setup_en.md
+++ b/worlds/pokemon_rb/docs/setup_en.md
@@ -73,7 +73,7 @@ And the following special characters (these each count as one character):
 ### Generating and Patching a Game
 
 1. Create your options file (YAML).
-2. Follow the general Archipelago instructions for [generating a game](../../Archipelago/setup/en#generating-a-game).
+2. Follow the general Archipelago instructions for [generating a game](/tutorial/Archipelago/setup_en#generating-a-game).
 This will generate an output file for you. Your patch file will have a `.apred` or `.apblue` file extension.
 3. Open `ArchipelagoLauncher.exe`
 4. Select "Open Patch" on the left side and select your patch file.

--- a/worlds/pokemon_rb/docs/setup_es.md
+++ b/worlds/pokemon_rb/docs/setup_es.md
@@ -77,7 +77,7 @@ Y los siguientes caracteres especiales (cada uno ocupa un carácter):
 ### Generar y parchar un juego
 
 1. Crea tu archivo de opciones (YAML).
-2. Sigue las instrucciones generales de Archipelago para [generar un juego](../../Archipelago/setup/en#generating-a-game).
+2. Sigue las instrucciones generales de Archipelago para [generar un juego](/tutorial/Archipelago/setup_en#generating-a-game).
 Haciendo esto se generará un archivo de salida. Tu parche tendrá la extensión de archivo `.apred` o `.apblue`.
 3. Abre `ArchipelagoLauncher.exe`
 4. Selecciona "Open Patch" en el lado izquierdo y selecciona tu parche.


### PR DESCRIPTION
## What is this fixing or adding?
I thought there might have already something open about this before, but currently there's a few different game pages which have broken links to the main setup page due to using relative paths and the change from `setup/lang` to `setup_lang` meaning there's now one fewer level. I tried checking for links to any of the main setup guides, but the only broken one I found was actually this same link to the generating a game section across a few different game setup guides.

I've just fixed these links here, but I also noticed there are a few games which link directly to the main website (i.e. `https://archipelago.gg/tutorial/Archipelago/...`) while I think it'd be preferred to stay on the current webhost instance.

## How was this tested?
Checking that all the links now work on local webhost.

## If this makes graphical changes, please attach screenshots.
🚫4️⃣0️⃣4️⃣