### PR TITLE
SC2: Fix custom mission order if used in weights.yaml

### DIFF
--- a/worlds/sc2/mission_order/options.py
+++ b/worlds/sc2/mission_order/options.py
@@ -176,8 +176,7 @@ class CustomMissionOrder(OptionDict):
         # This function constructs self.value by parts,
         # so the parent constructor isn't called
         self.value: Dict[str, Dict[str, Any]] = {}
-        if yaml_value == self.default: # If this option is default, it shouldn't mess with its own values
-            yaml_value = copy.deepcopy(self.default)
+        yaml_value = copy.deepcopy(yaml_value) # Ensure that all the mutations are local to the world
 
         for campaign in yaml_value:
             self.value[campaign] = {}


### PR DESCRIPTION
## What is this fixing or adding?
Fixes generator crashing if weights.yaml is using custom mission order from attempting to use already mutated dict

## How was this tested?
Generating a multiworld with weights yaml and --multi=10 parameter. Forced all the worlds to use the custom mission order by a trigger. See the attached file
[weights.yaml.zip](https://github.com/user-attachments/files/23402558/weights.yaml.zip)

## If this makes graphical changes, please attach screenshots.
No
