### PR TITLE
Core: add export_datapackage tool

### DIFF
--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -5,7 +5,7 @@ import weakref
 from enum import Enum, auto
 from typing import Optional, Callable, List, Iterable, Tuple
 
-from Utils import local_path, open_filename, is_frozen, is_kivy_running
+from Utils import local_path, open_filename, is_frozen, is_kivy_running, open_file, user_path
 
 
 class Type(Enum):
@@ -204,6 +204,18 @@ def install_apworld(apworld_path: str = "") -> None:
         Utils.messagebox("Install complete.", f"Installed APWorld from {source}.")
 
 
+def export_datapackage() -> None:
+    import json
+
+    from worlds import network_data_package
+
+    path = user_path("datapackage_export.json")
+    with open(path, "w") as f:
+        json.dump(network_data_package, f, indent=4)
+
+    open_file(path)
+
+
 components: List[Component] = [
     # Launcher
     Component('Launcher', 'Launcher', component_type=Type.HIDDEN),
@@ -231,7 +243,9 @@ components: List[Component] = [
               file_identifier=SuffixIdentifier('.apzl')),
 
     #MegaMan Battle Network 3
-    Component('MMBN3 Client', 'MMBN3Client', file_identifier=SuffixIdentifier('.apbn3'))
+    Component('MMBN3 Client', 'MMBN3Client', file_identifier=SuffixIdentifier('.apbn3')),
+
+    Component("Export Datapackage", func=export_datapackage, component_type=Type.TOOL),
 ]
 
 


### PR DESCRIPTION
## What is this fixing or adding?
Adds a button to the launcher to export the datapackage of all worlds, as it is a common request to list all locations, items or groups thereof.

## How was this tested?
As an apworld at https://discord.com/channels/731205301247803413/731205301818359821/1436567977607692399 and I also ran it in this form.
