### PR TITLE
CI: downgrade pytest to 8.4.2

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest pytest-subtests pytest-xdist
+        pip install -r ci-requirements.txt
         python ModuleUpdate.py --yes --force --append "WebHostLib/requirements.txt"
         python Launcher.py --update_settings  # make sure host.yaml exists for tests
     - name: Unittests

--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -1,0 +1,3 @@
+pytest>=8.4.2,<9  # pytest 9.0.0 is broken for our CI
+pytest-xdist>=3.8.0
+pytest-subtests>=0.15.0  # will not be required anymore once we upgrade to pytest 9.x


### PR DESCRIPTION
## What is this fixing or adding?

* downgrade pytest to 8.4.2 in CI
* move CI requirements to separate file for easier upgrading in the future

## Why?

pytest 9.0.0 does not support unittest.skipTest, so our CI is failing.
See https://github.com/pytest-dev/pytest/issues/13895

## How was this tested?

CI