### PR TITLE
ALTTP: Fix setting `Beat Agahnim 1` event twice

### DIFF
--- a/worlds/alttp/ItemPool.py
+++ b/worlds/alttp/ItemPool.py
@@ -263,7 +263,6 @@ def generate_itempool(world):
         ('Frog', 'Get Frog'),
         ('Missing Smith', 'Return Smith'),
         ('Floodgate', 'Open Floodgate'),
-        ('Agahnim 1', 'Beat Agahnim 1'),
         ('Flute Activation Spot', 'Activated Flute'),
         ('Capacity Upgrade Shop', 'Capacity Upgrade Shop')
     ]


### PR DESCRIPTION
## What is this fixing or adding?

alttp was setting the `Beat Agahnim 1` event onto the `Agahnim 1` location twice.

I was debugging a large multiworld generation issue with various custom worlds, where, for debugging purposes, I changed `multiworld.push_item` to make it crash like `location.place_locked_item` when the location was already filled, which also identified this minor issue in alttp.

## How was this tested?

Currently only in the large multiworld generation I am attempting to debug where I have `multiworld.push_item` modified to crash like `location.place_locked_item` when the location is already filled.