### PR TITLE
TUNIC: Fix fuse rule in lower zig

### DIFF
--- a/worlds/tunic/er_rules.py
+++ b/worlds/tunic/er_rules.py
@@ -1047,7 +1047,7 @@ def set_er_region_rules(world: "TunicWorld", regions: dict[str, Region], portal_
         connecting_region=regions["Rooted Ziggurat Portal Room"])
     regions["Rooted Ziggurat Portal Room"].connect(
         connecting_region=regions["Rooted Ziggurat Portal"],
-        rule=lambda state: has_fuses("Activate Ziggurat Fuse", state, world) and has_ability(prayer, state, world))
+        rule=lambda state: has_ability(prayer, state, world))
 
     regions["Rooted Ziggurat Portal Room"].connect(
         connecting_region=regions["Rooted Ziggurat Portal Room Exit"],


### PR DESCRIPTION
## What is this fixing or adding?
While doing the other PR for entrance hint stuff, I ran into this bug, which requires a pretty specific entrance layout to reach. I think it's only really reachable if:
- Zig lower to tower leads to a dead end (or to the falling entrance if fewer shops is on)
- Zig lower to portal room entrance leads to the portal in the portal room

And the bug is just a fuse rule added to that portal where that portal doesn't require the fuse to be activated, so ER thinks you can do it but state doesn't.

## How was this tested?
Test gens, it's a bug fix.