### PR TITLE
Pokemon RB: Fix returning None in get_pre_fill_items with key_items_only

### DIFF
--- a/worlds/pokemon_rb/__init__.py
+++ b/worlds/pokemon_rb/__init__.py
@@ -518,7 +518,8 @@ class PokemonRedBlueWorld(World):
 
     def get_pre_fill_items(self) -> typing.List["Item"]:
         pool = [self.create_item(mon) for mon in poke_data.pokemon_data]
-        pool.append(self.pc_item)
+        if self.pc_item is not None:
+            pool.append(self.pc_item)
         return pool
 
     @classmethod


### PR DESCRIPTION
## What is this fixing or adding?

With `key_items_only: true` in a yaml, `self.pc_item` does not get set, so `get_pre_fill_items()`, which includes `self.pc_item`, would return a list of items that also contains `None`.

This would cause `MultiWorld.get_all_state(collect_pre_fill_items=True)` to crash when it tries to collect `None` into the state.

`get_pre_fill_items()` has been changed to check that `self.pc_item` is non-None before appending it to the returned list.

With `key_items_only: false`, `self.pc_item` gets set in the `create_regions` step. The `test_all_state_is_available` core test only checks for being able to create an 'all state' after `create_regions` is run, so maybe it is safe to assume that `get_pre_fill_items()` won't be called until after `create_regions`. In-case it is not actually safe to assume this, the change to check `self.pc_item` for being non-None will avoid issues in this case too.

Please format your title with what portion of the project this pull request is
targeting and what it's changing.

## How was this tested?

I have been running the fuzzer with a hook that runs the contents of the `test.test_implemented.TestImplemented.test_prefill_items` test (Test that every world can reach every location from allstate before pre_fill), which was crashing when constructing the 'all-state' with `key_items_only: true` before this PR, and is no longer crashing with this PR applied.
