### PR TITLE
Landstalker: Add manifest file

### DIFF
--- a/worlds/landstalker/archipelago.json
+++ b/worlds/landstalker/archipelago.json
@@ -1,0 +1,6 @@
+{
+  "game": "Landstalker - The Treasures of King Nole",
+  "authors": ["Dinopony"],
+  "minimum_ap_version": "0.6.4",
+  "world_version": "1.8.7"
+}


### PR DESCRIPTION
## What is this fixing or adding?

This adds the `archipelago.json` manifest file for the Landstalker world.

## How was this tested?

A generation was performed, but it seems that the manifest isn't required for now.
