### PR TITLE
Improve the documentation for priority locations to mention de-prioritized

### DIFF
--- a/docs/options api.md
+++ b/docs/options api.md
@@ -269,7 +269,7 @@ placed on them.
 
 ### PriorityLocations
 Marks locations given here as `LocationProgressType.Priority` forcing progression items on them if any are available in
-the pool. Progression items without a deprioritized flag will be used first when filling priority_locations.  Progression items with
+the pool. Progression items without a deprioritized flag will be used first when filling priority_locations. Progression items with
 a deprioritized flag will be used next.
 
 ### ItemLinks


### PR DESCRIPTION
## What is this fixing or adding?
I'm updating the documentation for priority locations to mention the de-prioritized flag.

## How was this tested?


## If this makes graphical changes, please attach screenshots.
No visual changes