### PR TITLE
Core: Fix #5605 - Trigger values being shared by weights.yaml slots

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -367,7 +367,10 @@ def update_weights(weights: dict, new_weights: dict, update_type: str, name: str
                                 f" received {type(new_value).__name__}.")
             cleaned_weights[option_name] = cleaned_value
         else:
-            cleaned_weights[option_name] = new_weights[option]
+            # Options starting with + and - may modify values in-place, and new_weights may be shared by multiple slots
+            # using the same .yaml, so ensure that the new value is a copy.
+            cleaned_value = copy.deepcopy(new_weights[option])
+            cleaned_weights[option_name] = cleaned_value
     new_options = set(cleaned_weights) - set(weights)
     weights.update(cleaned_weights)
     if new_options:


### PR DESCRIPTION
## What is this fixing or adding?

The "+" and "-" trigger operations modify sets/lists in-place, but triggers could set a value to the same set/list for multiple slots using weights.yaml.

This fix deep-copies all values set from new (trigger) weights to ensure that the values do not get shared across multiple slots.

## How was this tested?

I ran generations with the following `weights.yaml` before and after this PR, with `players: 2` in my `host.yaml`.

Before this PR, generation would always fail with a `ValueError: Your trigger number 2 is invalid. Please fix your triggers.` caused by `ValueError: list.remove(x): x not in list` because both players would share the same priority locations list set by the first trigger, and both players would also attempt to remove `Act Completion (Time Rift - Gallery)` from this list, which would succeed for the first player, but fail for the second player due to the list now being empty.
```yaml
name: Player{number}
game: A Hat in Time
A Hat in Time:
  trigger_activation: 1
  triggers:
    - option_category: A Hat in Time
      option_name: trigger_activation
      option_result: 1
      options:
        A Hat in Time:
          priority_locations:
            - Act Completion (Time Rift - Gallery)
    - option_category: A Hat in Time
      option_name: trigger_activation
      option_result: 1
      options:
        A Hat in Time:
          -priority_locations: [Act Completion (Time Rift - Gallery)]
```
