### PR TITLE
CI: update pytest to 9.0.1

### DIFF
--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -1,3 +1,2 @@
-pytest>=8.4.2,<9  # pytest 9.0.0 is broken for our CI
+pytest>=9.0.1,<10  # this includes subtests support
 pytest-xdist>=3.8.0
-pytest-subtests>=0.15.0  # will not be required anymore once we upgrade to pytest 9.x


### PR DESCRIPTION
## What is this fixing or adding?

Updates pytest to 9.0.1

## Why

When someone types `pip install pytest` they are likely to get that version, so we want to use it in CI as well.

## How was this tested?

CI
