### PR TITLE
weights: Fixing negatives and zeroes disappearing from option dicts updated by triggers

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -347,7 +347,9 @@ def update_weights(weights: dict, new_weights: dict, update_type: str, name: str
             elif isinstance(new_value, list):
                 cleaned_value.extend(new_value)
             elif isinstance(new_value, dict):
-                cleaned_value = dict(Counter(cleaned_value) + Counter(new_value))
+                counter_value = Counter(cleaned_value)
+                counter_value.update(new_value)
+                cleaned_value = dict(counter_value)
             else:
                 raise Exception(f"Cannot apply merge to non-dict, set, or list type {option_name},"
                                 f" received {type(new_value).__name__}.")
@@ -361,7 +363,9 @@ def update_weights(weights: dict, new_weights: dict, update_type: str, name: str
                 for element in new_value:
                     cleaned_value.remove(element)
             elif isinstance(new_value, dict):
-                cleaned_value = dict(Counter(cleaned_value) - Counter(new_value))
+                counter_value = Counter(cleaned_value)
+                counter_value.subtract(new_value)
+                cleaned_value = dict(counter_value)
             else:
                 raise Exception(f"Cannot apply remove to non-dict, set, or list type {option_name},"
                                 f" received {type(new_value).__name__}.")

--- a/test/general/test_player_options.py
+++ b/test/general/test_player_options.py
@@ -37,3 +37,23 @@ class TestPlayerOptions(unittest.TestCase):
         self.assertEqual(new_weights["dict_2"]["option_g"], 50)
         self.assertEqual(len(new_weights["set_1"]), 2)
         self.assertIn("option_d", new_weights["set_1"])
+
+    def test_update_dict_supports_negatives_and_zeroes(self):
+        original_options = {
+            "dict_1": {"a": 1, "b": -1},
+            "dict_2": {"a": 1, "b": -1},
+        }
+        new_weights = Generate.update_weights(
+            original_options,
+            {
+                "+dict_1": {"a": -2, "b": 2},
+                "-dict_2": {"a": 1, "b": 2},
+            },
+            "Tested",
+            "",
+        )
+        self.assertEqual(new_weights["dict_1"]["a"], -1)
+        self.assertEqual(new_weights["dict_1"]["b"], 1)
+        self.assertEqual(new_weights["dict_2"]["a"], 0)
+        self.assertEqual(new_weights["dict_2"]["b"], -3)
+        self.assertIn("a", new_weights["dict_2"])


### PR DESCRIPTION
## What is this fixing or adding?
See the bug thread on discord: https://discord.com/channels/731205301247803413/1439121267469975734

sc2 uses an OptionDict where a key being present with value of 0 is significant. It's a known issue that it doesn't show up on the webhost and will have to be updated to work there, but changing the behaviour so that -1 is the special value won't work either because triggers just erase zeros and negatives from any dict modified by addition or subtraction.

Sraw was the first one to bump into this, his sc2 exclusions were getting erased under triggers. Silvris provided some references to code, and MysteryEm was the one to explain that the counter `-` and `+` functions had this behaviour.

Edit: As mysterem brought it up, I'll note that this behaviour is strictly counter to what the docs say should happen. From triggers_en.md:
> For dicts, + will add the value(s) to the given key(s) inside the dict if it exists, or add it otherwise. - is the inverse operation of addition (and negative values are allowed).

## How was this tested?
Added a unit test.

Tested with my provided yaml snippet on the bug, and determined that the modified keys now properly showed up in the spoiler.

```yaml
Starcraft 2:
  excluded_items: {}
  trig_test: always
  triggers:
  - option_name: trig_test
    option_category: Starcraft 2
    option_result: always
    options:
      Starcraft 2:
        +excluded_items:
          Marine: 0
          Marauder: 0
          Reaper: 0
          Medivac: 0
          Factory Units: 0
```
Note that "Factory Units" is a unit group that gets expanded by the sc2 option into about a dozen items. Expected behaviour is that all of those items will be separate keys with values all 0.

In the spoiler:
```
Excluded Items:                  Marine: 0, Marauder: 0, Reaper: 0, Medivac: 0, Goliath: 0, Vulture: 0, Thor: 0, Blackhammer: 0, Siege Tank: 0, Warhound: 0, Cyclone: 0, Widow Mine: 0, Hellion: 0, Predator: 0, Diamondback: 0, Shock Division: 0, Bulwark Company: 0
```
(Without this change, this option showed up as blank in the spoiler)

## If this makes graphical changes, please attach screenshots.
None