### PR TITLE
Factorio: Fix client creating savefile in current directory

### DIFF
--- a/worlds/factorio/Client.py
+++ b/worlds/factorio/Client.py
@@ -19,7 +19,7 @@ import factorio_rcon
 from CommonClient import ClientCommandProcessor, CommonContext, logger, server_loop, gui_enabled, get_base_parser
 from MultiServer import mark_raw
 from NetUtils import ClientStatus, NetworkItem, JSONtoTextParser, JSONMessagePart
-from Utils import async_start, get_file_safe_name, is_windows, Version, format_SI_prefix, get_text_between
+from Utils import async_start, get_file_safe_name, is_windows, Version, format_SI_prefix, get_text_between, user_path
 from .settings import FactorioSettings
 from settings import get_settings
 
@@ -456,7 +456,7 @@ async def get_info(ctx: FactorioContext, rcon_client: factorio_rcon.RCONClient):
 
 
 async def factorio_spinup_server(ctx: FactorioContext) -> bool:
-    savegame_name = os.path.abspath("Archipelago.zip")
+    savegame_name = user_path("factorio", "saves", "Archipelago.zip")
     if not os.path.exists(savegame_name):
         logger.info(f"Creating savegame {savegame_name}")
         subprocess.run((


### PR DESCRIPTION
## What is this fixing or adding?

The first save the Factorio client creates to extract the mod information is created in the current directory which can cause problems if it is not readable or clutter an unreleated directory if it is readable (even if it is the Archipelago directory, it creates an Archipelago.zip file which is not clear that it is related to the Factorio client).

This fix the problem by always creating the file in `{user_path}/factorio/saves/`

This will fix https://github.com/ArchipelagoMW/Archipelago/issues/5641

## How was this tested?

I launched the client and verified that the file was created in the right place.