### PR TITLE
WebHost: Fix hosting with invalid worlds installed

### DIFF
--- a/WebHost.py
+++ b/WebHost.py
@@ -109,13 +109,14 @@ if __name__ == "__main__":
         logging.exception(e)
         logging.warning("Could not update LttP sprites.")
     app = get_app()
-    from worlds import AutoWorldRegister
+    from worlds import AutoWorldRegister, network_data_package
     # Update to only valid WebHost worlds
     invalid_worlds = {name for name, world in AutoWorldRegister.world_types.items()
                       if not hasattr(world.web, "tutorials")}
     if invalid_worlds:
         logging.error(f"Following worlds not loaded as they are invalid for WebHost: {invalid_worlds}")
     AutoWorldRegister.world_types = {k: v for k, v in AutoWorldRegister.world_types.items() if k not in invalid_worlds}
+    network_data_package["games"] = {k: v for k, v in network_data_package["games"].items() if k not in invalid_worlds}
     create_options_files()
     copy_tutorials_files_to_static()
     if app.config["SELFLAUNCH"]:


### PR DESCRIPTION
## What is this fixing or adding?
#5433 ignored worlds without docs as they broke parts of webhost, however just removing the worlds from `AutoWorldRegister` led to an error in `Context._init_game_data` since these games were still in `gamespackage`. Removing from there as well seems to fix it, although I'm not positive if there might be other places with issues, so I echo what was said in 5433 that there should probably be a more proper system made for this.

## How was this tested?
Trying to host with an invalid world installed, and connecting with text client.
