### PR TITLE
[FFMQ] Bugfix: Fix missing logic rule for Frozen Fields > Aquaria access

### DIFF
--- a/worlds/ffmq/Regions.py
+++ b/worlds/ffmq/Regions.py
@@ -155,6 +155,10 @@ def set_rules(self) -> None:
                             return True
             check_foresta(loc.parent_region)
 
+    if self.options.map_shuffle or self.options.crest_shuffle:
+        process_rules(self.multiworld.get_entrance("Subregion Frozen Fields to Subregion Aquaria", self.player),
+                      ["SummerAquaria"])
+
     if self.options.logic == "friendly":
         process_rules(self.multiworld.get_entrance("Overworld - Ice Pyramid", self.player),
                       ["MagicMirror"])


### PR DESCRIPTION
## What is this fixing or adding?
Fix a missing logic rule for access between two regions (Frozen Fields to Aquaria) when shuffling entrances.

## How was this tested?
Generated several seeds and read the spoiler file to make sure the new rule is applied.