### PR TITLE
Core: Log execution time of fill_slot_data during the generation

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -272,7 +272,7 @@ def main(args, seed=None, baked_server_options: dict[str, object] | None = None)
                 }
 
                 for slot in multiworld.player_ids:
-                    slot_data[slot] = multiworld.worlds[slot].fill_slot_data()
+                    slot_data[slot] = AutoWorld.call_single(multiworld, "fill_slot_data", slot)
 
                 def precollect_hint(location: Location, auto_status: HintStatus):
                     entrance = er_hint_data.get(location.player, {}).get(location.address, "")


### PR DESCRIPTION
The execution time for the fill_slot_data step of the generation is currently not being logged. However, I feel like there's games where fill_slot_data is long enough to justify logging it.

## What is this fixing or adding?
Whenever an autoworld takes more than a second to execute fill_slot_data, print the execution time of fill_slot_data.
This was done by calling fill_slot_data with call_single, instead of calling fill_slot_data directly.

## How was this tested?
With a game that has a long execution time of fill_slot_data (Banjo-Tooie), a game that has a short execution time (Super Mario World), and a game that doesn't override fill_slot_data (Bumper Stickers).

## If this makes graphical changes, please attach screenshots.
<img width="626" height="155" alt="image" src="https://github.com/user-attachments/assets/25781b8a-32e4-442e-affb-99d6e865a41f" />

