### PR TITLE
TWW: Fix client sending duplicate magic meter

### DIFF
--- a/worlds/tww/TWWClient.py
+++ b/worlds/tww/TWWClient.py
@@ -146,8 +146,8 @@ class TWWContext(CommonContext):
         self.curr_stage_switches_bitfield: int
         self.curr_stage_pickups_bitfield: int
 
-        # Keep track of whether the player has yet received their first progressive magic meter.
-        self.received_magic: bool = False
+        # Keep track of when the player received their first progressive magic meter.
+        self.received_magic_idx: int = -1
 
         # A dictionary that maps salvage locations to their sunken treasure bit.
         self.salvage_locations_map: dict[str, int] = {}
@@ -349,10 +349,10 @@ def _give_item(ctx: TWWContext, item_name: str) -> bool:
         if slot == 0xFF:
             # Special case: Use a different item ID for the second progressive magic meter.
             if item_name == "Progressive Magic Meter":
-                if ctx.received_magic:
+                if ctx.received_magic_idx == -1:
+                    ctx.received_magic_idx = idx
+                elif idx > ctx.received_magic_idx:
                     item_id = 0xB2
-                else:
-                    ctx.received_magic = True
             dolphin_memory_engine.write_byte(GIVE_ITEM_ARRAY_ADDR + idx, item_id)
             return True
 


### PR DESCRIPTION
## What is this fixing or adding?
Fixes #5662. When the player receives a progressive magic meter and then resets without saving, they'll receive a duplicate second progressive magic meter when they load back into the save file due to a client logic bug. This PR fixes the logic by instead recording the received-item index of the first magic meter rather than a simple True/False indicating whether they received it. The second magic meter is sent only if its received-item index is greater than the first.

## How was this tested?
Repeated the steps to reproduce the bug and did not receive an extra magic meter.

## If this makes graphical changes, please attach screenshots.
N/A