### PR TITLE
LADX: switch to asyncio.get_running_loop()

### DIFF
--- a/worlds/ladx/LinksAwakeningClient.py
+++ b/worlds/ladx/LinksAwakeningClient.py
@@ -136,7 +136,7 @@ class RAGameboy():
         return response
 
     async def async_recv(self, timeout=1.0):
-        response = await asyncio.wait_for(asyncio.get_event_loop().sock_recv(self.socket, 4096), timeout)
+        response = await asyncio.wait_for(asyncio.get_running_loop().sock_recv(self.socket, 4096), timeout)
         return response
 
     async def check_safe_gameplay(self, throw=True):


### PR DESCRIPTION
## What is this fixing or adding?
In the beta branch after pulling main I had an issue where get_event_loop still worked on source but stopped working when packed into an apworld. Switching to get_running_loop fixes it and apparently its recommended anyhow (https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_event_loop) so I figured it should be switched here too.

I don't know what changed to make this matter.

## How was this tested?
Connected to a game