### PR TITLE
Tests: Move world dependencies in tests to APQuest

### DIFF
--- a/test/general/test_options.py
+++ b/test/general/test_options.py
@@ -44,19 +44,19 @@ class TestOptions(unittest.TestCase):
             }],
             [{
                 "name": "ItemLinkGroup",
-                "item_pool": ["Hammer", "Bow"],
+                "item_pool": ["Hammer", "Sword"],
                 "link_replacement": False,
                 "replacement_item": None,
             }]
         ]
         # we really need some sort of test world but generic doesn't have enough items for this
-        world = AutoWorldRegister.world_types["A Link to the Past"]
+        world = AutoWorldRegister.world_types["APQuest"]
         plando_options = PlandoOptions.from_option_string("bosses")
         item_links = [ItemLinks.from_any(item_link_groups[0]), ItemLinks.from_any(item_link_groups[1])]
         for link in item_links:
             link.verify(world, "tester", plando_options)
             self.assertIn("Hammer", link.value[0]["item_pool"])
-            self.assertIn("Bow", link.value[0]["item_pool"])
+            self.assertIn("Sword", link.value[0]["item_pool"])
         
         # TODO test that the group created using these options has the items
 

--- a/test/programs/data/one_player/test.yaml
+++ b/test/programs/data/one_player/test.yaml
@@ -2,8 +2,8 @@ description: Almost blank test yaml
 name: Player{NUMBER}
 
 game:
-  Timespinner: 1  # what else
+  APQuest: 1  # what else
 requires:
   version: 0.2.6
-Timespinner: {}
+APQuest: {}
 


### PR DESCRIPTION
## What is this fixing or adding?
move test worlds to apquest, consolidating the worlds the test framework is dependent on so only it is required

Note: `test/hosting/__main__.py` still mentions v6, but it doesn't get run by test discovery (and would need some tweaking to work with apquest)

## How was this tested?
ran pytest and unittest discover with all folders in worlds deleted besides generic and apquest

## If this makes graphical changes, please attach screenshots.
