### PR TITLE
APQuest: Improve the auto-generated .gitignore for data/sounds

### DIFF
--- a/worlds/apquest/client/utils.py
+++ b/worlds/apquest/client/utils.py
@@ -16,10 +16,6 @@ def make_data_directory(dir_name: str) -> Path:
     gitignore = specific_data_directory / ".gitignore"
 
     with open(gitignore, "w") as f:
-        f.write(
-            """*
-!.gitignore
-"""
-        )
+        f.write("*\n")
 
     return specific_data_directory


### PR DESCRIPTION
I didn't quite think this through: In this specific case, you want the gitignore to also ignore itself, since it itself is an auto-generated file that you don't want to show up in your git status / etc. Labeling this as a bug because I think it'll be quite annoying to some specific people & it was unintentional & it's just bad