### PR TITLE
weights: Fixing negatives and zeroes disappearing from option dicts updated by triggers

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -347,7 +347,9 @@ def update_weights(weights: dict, new_weights: dict, update_type: str, name: str
             elif isinstance(new_value, list):
                 cleaned_value.extend(new_value)
             elif isinstance(new_value, dict):
-                cleaned_value = dict(Counter(cleaned_value) + Counter(new_value))
+                counter_value = Counter(cleaned_value)
+                counter_value.update(new_value)
+                cleaned_value = dict(counter_value)
             else:
                 raise Exception(f"Cannot apply merge to non-dict, set, or list type {option_name},"
                                 f" received {type(new_value).__name__}.")
@@ -361,7 +363,9 @@ def update_weights(weights: dict, new_weights: dict, update_type: str, name: str
                 for element in new_value:
                     cleaned_value.remove(element)
             elif isinstance(new_value, dict):
-                cleaned_value = dict(Counter(cleaned_value) - Counter(new_value))
+                counter_value = Counter(cleaned_value)
+                counter_value.subtract(new_value)
+                cleaned_value = dict(counter_value)
             else:
                 raise Exception(f"Cannot apply remove to non-dict, set, or list type {option_name},"
                                 f" received {type(new_value).__name__}.")

--- a/test/general/test_player_options.py
+++ b/test/general/test_player_options.py
@@ -37,3 +37,23 @@ class TestPlayerOptions(unittest.TestCase):
         self.assertEqual(new_weights["dict_2"]["option_g"], 50)
         self.assertEqual(len(new_weights["set_1"]), 2)
         self.assertIn("option_d", new_weights["set_1"])
+
+    def test_update_dict_supports_negatives_and_zeroes(self):
+        original_options = {
+            "dict_1": {"a": 1, "b": -1},
+            "dict_2": {"a": 1, "b": -1},
+        }
+        new_weights = Generate.update_weights(
+            original_options,
+            {
+                "+dict_1": {"a": -2, "b": 2},
+                "-dict_2": {"a": 1, "b": 2},
+            },
+            "Tested",
+            "",
+        )
+        self.assertEqual(new_weights["dict_1"]["a"], -1)
+        self.assertEqual(new_weights["dict_1"]["b"], 1)
+        self.assertEqual(new_weights["dict_2"]["a"], 0)
+        self.assertEqual(new_weights["dict_2"]["b"], -3)
+        self.assertIn("a", new_weights["dict_2"])


### PR DESCRIPTION
## What is this fixing or adding?
Reopening #5640 as that seems to have been erroneously closed. It has the same contents so I'm going to assume that the approvals effectively carry over. There were 3 approvals.

## How was this tested?
See #5640.

## If this makes graphical changes, please attach screenshots.
None