### PR TITLE
sc2: Item group fixes and new item groups

### DIFF
--- a/worlds/sc2/item/item_groups.py
+++ b/worlds/sc2/item/item_groups.py
@@ -934,7 +934,6 @@ item_name_groups[ItemGroupNames.PROTOSS_LADDER_UNITS] = [
     item_names.HIGH_TEMPLAR,
     item_names.DARK_TEMPLAR,
     item_names.DARK_TEMPLAR_ARCHON_MERGE,
-    # No shuttle
     item_names.OBSERVER,
     item_names.WARP_PRISM,
     item_names.IMMORTAL,


### PR DESCRIPTION
## What is this fixing or adding?
* Fixing missing buildings in Terran buildings group
* Adding sc1 and melee unit groups

The missing terran buildings issue was reported a few weeks back, I've forgotten by whom.

I've included comment annotations on units that I expect will have more melee-like units available in future. There's a few judgement calls here for sure, as melee vipers aren't morphs, melee swarm hosts, queens, and motherships are nothing like the campaign versions, I could go either way on the zerg mercs/sc1 zerg heroes, and whether archon merge items should be in the lists may depend on how people want to use them. I figure this should provide a decent component for people wanting to exclude sc1 units or do sc1-only / melee-only runs.

## How was this tested?
Inspection; looked at Liquipedia tech trees for each group but may have missed some.
Eagle-eyed reviewers welcome.

## If this makes graphical changes, please attach screenshots.
None