### PR TITLE
TWW: Fix client sending duplicate items

### DIFF
--- a/worlds/tww/TWWClient.py
+++ b/worlds/tww/TWWClient.py
@@ -209,6 +209,13 @@ class TWWContext(CommonContext):
             # Request the connected slot's dictionary (used as a set) of visited stages.
             visited_stages_key = AP_VISITED_STAGE_NAMES_KEY_FORMAT % self.slot
             Utils.async_start(self.send_msgs([{"cmd": "Get", "keys": [visited_stages_key]}]))
+        elif cmd == "ReceivedItems":
+            # Loop through all received items and check for the index of the first progressive magic meter.
+            magic_meter_id = ITEM_TABLE["Progressive Magic Meter"].code
+            for idx, item in enumerate(self.items_received):
+                if item.item == magic_meter_id:
+                    self.received_magic_idx = idx
+                    break
         elif cmd == "Retrieved":
             requested_keys_dict = args["keys"]
             # Read the connected slot's dictionary (used as a set) of visited stages.

--- a/worlds/tww/TWWClient.py
+++ b/worlds/tww/TWWClient.py
@@ -174,6 +174,7 @@ class TWWContext(CommonContext):
 
         """
         self.auth = None
+        self.received_magic_idx = -1
         self.salvage_locations_map = {}
         self.current_stage_name = ""
         self.visited_stage_names = None

--- a/worlds/tww/TWWClient.py
+++ b/worlds/tww/TWWClient.py
@@ -211,9 +211,8 @@ class TWWContext(CommonContext):
             Utils.async_start(self.send_msgs([{"cmd": "Get", "keys": [visited_stages_key]}]))
         elif cmd == "ReceivedItems":
             # Loop through all received items and check for the index of the first progressive magic meter.
-            magic_meter_id = ITEM_TABLE["Progressive Magic Meter"].code
             for idx, item in enumerate(self.items_received):
-                if item.item == magic_meter_id:
+                if LOOKUP_ID_TO_NAME.get(item.item) == "Progressive Magic Meter":
                     self.received_magic_idx = idx
                     break
         elif cmd == "Retrieved":

--- a/worlds/tww/TWWClient.py
+++ b/worlds/tww/TWWClient.py
@@ -382,6 +382,9 @@ async def give_items(ctx: TWWContext) -> None:
 
         if item_id is None:
             logger.warning(f'Item "{item_name}" does not have an associated item ID!')
+
+            # Skip ahead to the next item since we cannot give this one.
+            write_short(EXPECTED_INDEX_ADDR, expected_idx + 1)
         else:
             # Special case: Use a different item ID for the second progressive magic meter.
             if item_name == "Progressive Magic Meter":

--- a/worlds/tww/__init__.py
+++ b/worlds/tww/__init__.py
@@ -26,7 +26,7 @@ from .randomizers.ItemPool import generate_itempool
 from .randomizers.RequiredBosses import RequiredBossesRandomizer
 from .Rules import set_rules
 
-VERSION: tuple[int, int, int] = (3, 0, 0)
+VERSION: tuple[int, int, int] = (3, 1, 0)
 
 
 def run_client() -> None:
@@ -130,7 +130,7 @@ class TWWWorld(World):
 
     item_name_groups: ClassVar[dict[str, set[str]]] = item_name_groups
 
-    required_client_version: tuple[int, int, int] = (0, 5, 1)
+    required_client_version: tuple[int, int, int] = (0, 6, 0)
 
     web: ClassVar[TWWWeb] = TWWWeb()
 

--- a/worlds/tww/archipelago.json
+++ b/worlds/tww/archipelago.json
@@ -1,0 +1,6 @@
+{
+  "game": "The Wind Waker",
+  "minimum_ap_version": "0.6.0",
+  "world_version": "3.1.0",
+  "authors": ["tanjo3"]
+}


### PR DESCRIPTION
## What is this fixing or adding?
#5664 was the right idea, but the execution was wrong, in an attempt to fix the issue raised in #5662 (I blame being sick). It referenced the wrong index when checking for the magic meter's index. This PR updates the index to actually be the received-item index rather than the index within the item-get array in the game's memory.

However, this PR also tackles a larger issue. I've received occasional reports of players getting extra copies of progressive items. For example, a player with two bottles might occasionally find a third in their inventory. I do not know how to replicate this behaviour consistently, and I've only run into it once in my time playing TWW on AP.

This PR includes two additional changes intended to hopefully resolve these issues. The first is using `CommonContext`'s `check_locations` helper method for sending `'LocationChecks'` packages. I saw this fix a minor issue that I encountered when the server was reset during playthrough. The second is to send only one item per call to `give_items`, rather than sending all outstanding items in a loop. If I had to guess where the item duplication issue stems from, it'd be a bug in the previous implementation, particularly if the player resets the game or disconnects during the item-get loop.

This PR resolves #5688.

## How was this tested?
Played through most of a seed with most options on. I soft-reset (reset the game without saving) aggressively, as that seems to be when most item duplication issues arise. Did not run into any duplicated items. Everything worked fine. Receiving items is now slower, not as instant as it used to be. But it's still very fast and not noticeable unless you receive multiple items at once.

This change requires a version update of the patcher program.
The updated code can be found here: https://github.com/tanjo3/wwrando/tree/archipelago

## If this makes graphical changes, please attach screenshots.
N/A