### PR TITLE
Timespinner: Exclude Removed Location from Web Tracker

### DIFF
--- a/WebHostLib/tracker.py
+++ b/WebHostLib/tracker.py
@@ -959,7 +959,7 @@ if "Timespinner" in network_data_package["games"]:
 
         timespinner_location_ids = {
             "Present": list(range(1337000, 1337085)),
-            "Past": list(range(1337086, 1337175)),
+            "Past": list(range(1337086, 1337157)) + list(range(1337159, 1337175)),
             "Ancient Pyramid": [
                 1337236,
                 1337246, 1337247, 1337248, 1337249]


### PR DESCRIPTION
## What is this fixing or adding?

This removes an invalid location that was showing in the web tracker.

This was a _display-only_ issue, the location was not in the Archipelago fill logic, nor was it an actual location in the randomizer.

As seen in the below locations, this location was intentionally left blank even before the initial Timespinner implementation was merged to main years ago, it was just unintentionally included in the web tracker list.
- https://github.com/TriumphantBass/TsRandomizer/commit/7a5965cebbd898fb5ad98563a1c6bdb972759af5#diff-ba74e9cb22d6641c1955548d3da0fa8c4e03ea285b28e7f6acf6a7af00111734R201
- https://github.com/TriumphantBass/Archipelago/blob/main/worlds/timespinner/Locations.py#L211

## If this makes graphical changes, please attach screenshots.
Before screenshot, with the unknown location listed.
<img width="364" height="162" alt="image" src="https://github.com/user-attachments/assets/5677998f-f8df-4735-8b10-7a3def34a683" />
