### PR TITLE
Docs: fix name of "Build APWorlds" component

### DIFF
--- a/docs/apworld specification.md
+++ b/docs/apworld specification.md
@@ -44,9 +44,9 @@ These get automatically added to the `archipelago.json` of an .apworld if it is 
 ["Build apworlds" launcher component](#build-apworlds-launcher-component),
 which is the correct way to package your `.apworld` as a world developer. Do not write these fields yourself.
 
-### "Build apworlds" Launcher Component
+### "Build APWorlds" Launcher Component
 
-In the Archipelago Launcher, there is a "Build apworlds" component that will package all world folders to `.apworld`,
+In the Archipelago Launcher, there is a "Build APWorlds" component that will package all world folders to `.apworld`,
 and add `archipelago.json` manifest files to them.  
 These .apworld files will be output to `build/apworlds` (relative to the Archipelago root directory).  
 The `archipelago.json` file in each .apworld will automatically include the appropriate

--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -318,5 +318,5 @@ if not is_frozen():
         open_folder(apworlds_folder)
 
 
-    components.append(Component('Build APWorlds', func=_build_apworlds, cli=True,
+    components.append(Component("Build APWorlds", func=_build_apworlds, cli=True,
                                 description="Build APWorlds from loose-file world folders."))


### PR DESCRIPTION
## What is this fixing or adding?

The name in the documentation didn't match the real name.
(and style guide says strings should be double-quoted)

## How was this tested?

nah