### PR TITLE
CI: update appimage runtime to fix problems with sleep

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,10 @@ env:
   # NOTE: since appimage/appimagetool and appimage/type2-runtime does not have tags anymore,
   #       we check the sha256 and require manual intervention if it was updated.
   APPIMAGE_FORK: 'PopTracker'
-  APPIMAGETOOL_VERSION: 'r-2025-10-19'
-  APPIMAGETOOL_X86_64_HASH: '9493a6b253a01f84acb9c624c38810ecfa11d99daa829b952b0bff43113080f9'
-  APPIMAGE_RUNTIME_VERSION: 'r-2025-08-11'
-  APPIMAGE_RUNTIME_X86_64_HASH: 'e70ffa9b69b211574d0917adc482dd66f25a0083427b5945783965d55b0b0a8b'
+  APPIMAGETOOL_VERSION: 'r-2025-11-18'
+  APPIMAGETOOL_X86_64_HASH: '4577a452b30af2337123fbb383aea154b618e51ad5448c3b62085cbbbfbfd9a2'
+  APPIMAGE_RUNTIME_VERSION: 'r-2025-11-07'
+  APPIMAGE_RUNTIME_X86_64_HASH: '27ddd3f78e483fc5f7856e413d7c17092917f8c35bfe3318a0d378aa9435ad17'
 
 permissions:  # permissions required for attestation
   id-token: 'write'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ env:
   # NOTE: since appimage/appimagetool and appimage/type2-runtime does not have tags anymore,
   #       we check the sha256 and require manual intervention if it was updated.
   APPIMAGE_FORK: 'PopTracker'
-  APPIMAGETOOL_VERSION: 'r-2025-10-19'
-  APPIMAGETOOL_X86_64_HASH: '9493a6b253a01f84acb9c624c38810ecfa11d99daa829b952b0bff43113080f9'
-  APPIMAGE_RUNTIME_VERSION: 'r-2025-08-11'
-  APPIMAGE_RUNTIME_X86_64_HASH: 'e70ffa9b69b211574d0917adc482dd66f25a0083427b5945783965d55b0b0a8b'
+  APPIMAGETOOL_VERSION: 'r-2025-11-18'
+  APPIMAGETOOL_X86_64_HASH: '4577a452b30af2337123fbb383aea154b618e51ad5448c3b62085cbbbfbfd9a2'
+  APPIMAGE_RUNTIME_VERSION: 'r-2025-11-07'
+  APPIMAGE_RUNTIME_X86_64_HASH: '27ddd3f78e483fc5f7856e413d7c17092917f8c35bfe3318a0d378aa9435ad17'
 
 permissions:  # permissions required for attestation
   id-token: 'write'


### PR DESCRIPTION
## What is this fixing or adding?

Update Appimage runtime and appmagetool to latest.

## Why

https://discord.com/channels/731205301247803413/1444794588245262588 should be fixed by this commit: https://github.com/PopTracker/type2-runtime/commit/0253327f4e36819ff4cad8518b9ce03ff10041c4
Old appimagetool should be compatible to new runtime, but there are 2 bug fixes in it as well, so updating doesn't hurt.

## How was this tested?

* both components are tested upstream
* CI change is tested in CI
* launcher built in CI still launches on my PC