### PR TITLE
KH2: Add SuperBosses, Cups, AtlanticaToggle and SummonLevelLocationToggle to slot data

### DIFF
--- a/worlds/kh2/__init__.py
+++ b/worlds/kh2/__init__.py
@@ -117,6 +117,7 @@ class KH2World(World):
                 "SuperBosses",
                 "Cups",
                 "AtlanticaToggle",
+                "SummonLevelLocationToggle",
         )
         slot_data.update({
             "hitlist":                [],  # remove this after next update


### PR DESCRIPTION
## What is this fixing or adding?
This adds SuperBosses, Cups, AtlanticaToggle and SummonLevelLocationToggle to slot data so that trackers may use them

## How was this tested?
I generated, it didn't crash

## If this makes graphical changes, please attach screenshots.
N/A