### PR TITLE
WebHost: turn Room.timeout from a database column into a flask app config field

### DIFF
--- a/WebHostLib/__init__.py
+++ b/WebHostLib/__init__.py
@@ -26,6 +26,7 @@ app.jinja_env.filters['get_file_safe_name'] = get_file_safe_name
 app.config["SELFHOST"] = True  # application process is in charge of running the websites
 app.config["GENERATORS"] = 8  # maximum concurrent world gens
 app.config["HOSTERS"] = 8  # maximum concurrent room hosters
+app.config["ROOM_IDLE_TIMEOUT"] = 2 * 60 * 60  # seconds of idle before a Room spins down
 app.config["SELFLAUNCH"] = True  # application process is in charge of launching Rooms.
 app.config["SELFLAUNCHCERT"] = None  # can point to a SSL Certificate to encrypt Room websocket connections
 app.config["SELFLAUNCHKEY"] = None  # can point to a SSL Certificate Key to encrypt Room websocket connections

--- a/WebHostLib/api/room.py
+++ b/WebHostLib/api/room.py
@@ -38,6 +38,5 @@ def room_info(room_id: UUID) -> Dict[str, Any]:
         "players": get_players(room.seed),
         "last_port": room.last_port,
         "last_activity": room.last_activity,
-        "timeout": room.timeout,
         "downloads": downloads,
     }

--- a/WebHostLib/api/user.py
+++ b/WebHostLib/api/user.py
@@ -16,7 +16,6 @@ def get_rooms():
             "creation_time": room.creation_time,
             "last_activity": room.last_activity,
             "last_port": room.last_port,
-            "timeout": room.timeout,
             "tracker": to_url(room.tracker),
         })
     return jsonify(response)

--- a/WebHostLib/customserver.py
+++ b/WebHostLib/customserver.py
@@ -231,7 +231,8 @@ def set_up_logging(room_id) -> logging.Logger:
 
 def run_server_process(name: str, ponyconfig: dict, static_server_data: dict,
                        cert_file: typing.Optional[str], cert_key_file: typing.Optional[str],
-                       host: str, rooms_to_run: multiprocessing.Queue, rooms_shutting_down: multiprocessing.Queue):
+                       host: str, rooms_to_run: multiprocessing.Queue, rooms_shutting_down: multiprocessing.Queue,
+                       room_idle_timeout: int):
     from setproctitle import setproctitle
 
     setproctitle(name)
@@ -316,7 +317,7 @@ def run_server_process(name: str, ponyconfig: dict, static_server_data: dict,
                 else:
                     ctx.logger.exception("Could not determine port. Likely hosting failure.")
                 with db_session:
-                    ctx.auto_shutdown = Room.get(id=room_id).timeout
+                    ctx.auto_shutdown = room_idle_timeout
                 if ctx.saving:
                     setattr(asyncio.current_task(), "save", lambda: ctx._save(True))
                 assert ctx.shutdown_task is None
@@ -347,7 +348,7 @@ def run_server_process(name: str, ponyconfig: dict, static_server_data: dict,
                         # ensure the Room does not spin up again on its own, minute of safety buffer
                         room = Room.get(id=room_id)
                         room.last_activity = datetime.datetime.utcnow() - \
-                                             datetime.timedelta(minutes=1, seconds=room.timeout)
+                                             datetime.timedelta(minutes=1, seconds=room_idle_timeout)
                     del room
                     logging.info(f"Shutting down room {room_id} on {name}.")
                 finally:

--- a/WebHostLib/misc.py
+++ b/WebHostLib/misc.py
@@ -231,7 +231,7 @@ def host_room(room: UUID):
     now = datetime.datetime.utcnow()
     # indicate that the page should reload to get the assigned port
     should_refresh = ((not room.last_port and now - room.creation_time < datetime.timedelta(seconds=3))
-                      or room.last_activity < now - datetime.timedelta(seconds=room.timeout))
+                      or room.last_activity < now - datetime.timedelta(seconds=app.config["ROOM_IDLE_TIMEOUT"]))
 
     if now - room.last_activity > datetime.timedelta(minutes=1):
         # we only set last_activity if needed, otherwise parallel access on /room will cause an internal server error

--- a/WebHostLib/models.py
+++ b/WebHostLib/models.py
@@ -27,7 +27,6 @@ class Room(db.Entity):
     seed = Required('Seed', index=True)
     multisave = Optional(buffer, lazy=True)
     show_spoiler = Required(int, default=0)  # 0 -> never, 1 -> after completion, -> 2 always
-    timeout = Required(int, default=lambda: 2 * 60 * 60)  # seconds since last activity to shutdown
     tracker = Optional(UUID, index=True)
     # Port special value -1 means the server errored out. Another attempt can be made with a page refresh
     last_port = Optional(int, default=lambda: 0)

--- a/WebHostLib/templates/hostRoom.html
+++ b/WebHostLib/templates/hostRoom.html
@@ -29,7 +29,7 @@
                 and a <a href="{{ url_for("get_multiworld_sphere_tracker", tracker=room.tracker) }}">Sphere Tracker</a> enabled.
                 <br />
             {% endif %}
-            The server for this room will be paused after {{ room.timeout//60//60 }} hours of inactivity.
+            The server for this room will be paused after {{ config["ROOM_IDLE_TIMEOUT"]//60//60 }} hours of inactivity.
             Should you wish to continue later,
             anyone can simply refresh this page and the server will resume.<br>
             {% if room.last_port == -1 %}


### PR DESCRIPTION
## What is this fixing or adding?
removes a per room property we haven't used in over 2 years, also optimizes autolauncher since ponyorm can now fully compile the timeout ahead of time

## How was this tested?
locally with a mariadb instance. The column still existing does no harm and can be removed later seperately.
