### PR TITLE
Dark Souls 3: Mark Eygon's set locations as Missable and require Catacombs for Yuria's Ring of Sacrifice

### DIFF
--- a/worlds/dark_souls_3/Locations.py
+++ b/worlds/dark_souls_3/Locations.py
@@ -2086,13 +2086,13 @@ location_tables: Dict[str, List[DS3LocationData]] = {
 
         # Shrine Handmaid after killing Dragonslayer Armour (or Eygon of Carim)
         DS3LocationData("FS: Morne's Helm - shop after killing Eygon or LC boss", "Morne's Helm",
-                        boss=True, shop=True),
+                        boss=True, shop=True, missable=True),
         DS3LocationData("FS: Morne's Armor - shop after killing Eygon or LC boss", "Morne's Armor",
-                        boss=True, shop=True),
+                        boss=True, shop=True, missable=True),
         DS3LocationData("FS: Morne's Gauntlets - shop after killing Eygon or LC boss",
-                        "Morne's Gauntlets", boss=True, shop=True),
+                        "Morne's Gauntlets", boss=True, shop=True, missable=True),
         DS3LocationData("FS: Morne's Leggings - shop after killing Eygon or LC boss",
-                        "Morne's Leggings", boss=True, shop=True),
+                        "Morne's Leggings", boss=True, shop=True, missable=True),
     ],
     "Consumed King's Garden": [
         DS3LocationData("CKG: Soul of Consumed Oceiros", "Soul of Consumed Oceiros",

--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -690,6 +690,13 @@ class DarkSouls3World(World):
             self._can_get(state, "FK: Soul of the Blood of the Wolf")
         ))
 
+        #Yoel dies spawning the Hollow's Ashes after entering the Catacombs, so require Abyss Watchers
+        self._add_location_rule([
+            "FS: Ring of Sacrifice - Yuria shop"
+        ], lambda state: (
+            self._can_get(state, "FK: Soul of the Blood of the Wolf")
+        ))
+        
         self._add_location_rule([
             "CKG: Drakeblood Helm - tomb, after killing AP mausoleum NPC",
             "CKG: Drakeblood Armor - tomb, after killing AP mausoleum NPC",


### PR DESCRIPTION
## What is this fixing or adding?

1. The maintainer requested that Eygon's set be marked as missable until event hacking has been made working because of issues with it not appearing in the shop properly for players.

2. Yuria's Ring of Sacrifice check requires Yoel to die, and Yoel dies once you enter the Catacombs, so require Catacombs access for this check.

## How was this tested?
Running Archipelago off of a fork, editing the changes, then building AP and generating DS3 with the new logic fixes.