### PR TITLE
Docs: explicitly document why 2^53-1 is the max size, not ^31 or ^63

### DIFF
--- a/docs/world api.md
+++ b/docs/world api.md
@@ -225,9 +225,10 @@ and has a classification. The name needs to be unique within each game and must 
 letter or symbol). The ID needs to be unique across all locations within the game. 
 Locations and items can share IDs, and locations can share IDs with other games' locations.
 
-World-specific IDs **must** be in the range 1 to 2<sup>53</sup>-1 (the largest integer that a 64-bit float can hold,
-and thus all popular programming languages can handle). IDs ≤ 0 are global and reserved. It's **recommended** to keep
-your IDs in the range 1 to 2<sup>31</sup>-1, so only 32-bit integers are needed to hold your IDs.
+World-specific IDs **must** be in the range 1 to 2<sup>53</sup>-1 (the largest integer that is "[safe](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER#description)"
+to store in a 64-bit float, and thus all popular programming languages can handle). IDs ≤ 0 are global and reserved.
+It's **recommended** to keep your IDs in the range 1 to 2<sup>31</sup>-1,
+so only 32-bit integers are needed to hold your IDs.
 
 Classification is one of `LocationProgressType.DEFAULT`, `PRIORITY` or `EXCLUDED`.
 The Fill algorithm will force progression items to be placed at priority locations, giving a higher chance of them being


### PR DESCRIPTION
## What is this fixing or adding?

Not everyone is familiar with the technical problem of passing large integers in 64-bit floats, so the number 2^53-1 looks pretty arbitrary.

This number is mentioned once in world api.md and multiple times in network protocol.md. I chose to put this explanation in world api.md because having only one mention makes it easier to fit in, and because world api.md already does a lot more explaining rationale and introducing concepts than the other doc.

The other reason I thought to do this is that [Berserker recently said](https://discord.com/channels/731205301247803413/1214608557077700720/1440028303351349349):
> Now that we have per game ID's I'd like to reduce it to signed 32 bit integers, as that allows a smaller server on the C side.
> So if you want to be safe in regards to that potential future change, pick ids in that range

I'm not sure if the core team as a whole wants to commit to recommending this in written docs, but IMO this is worth either documenting explicitly, or "formally" deciding it's unlikely enough we don't want to document it. I've kept this recommendation as a second commit in case we decide against it.

## How was this tested?

reading

## If this makes graphical changes, please attach screenshots.

N/A