### PR TITLE
Docs: update apsudoku docs / add links to web build

### DIFF
--- a/worlds/apsudoku/docs/en_Sudoku.md
+++ b/worlds/apsudoku/docs/en_Sudoku.md
@@ -11,3 +11,5 @@ Play Sudoku puzzles of varying difficulties, earning a hint for each puzzle corr
 ## Where is the options page?
 
 There is no options page; this game cannot be used in your .yamls. Instead, the client can connect to any slot in a multiworld.
+
+By using the connected room's Admin Password on the Admin Panel tab, you can configure some settings at any time to affect the entire room. This allows disabling hints entirely, as well as altering the hint odds for each difficulty.

--- a/worlds/apsudoku/docs/setup_en.md
+++ b/worlds/apsudoku/docs/setup_en.md
@@ -11,7 +11,11 @@ Does not need to be added at the start of a seed, as it does not create any slot
 
 ## Installation Procedures
 
-Go to the latest release from the [APSudoku Releases page](https://github.com/APSudoku/APSudoku/releases/latest). Download and extract the appropriate file for your platform.
+### Windows / Linux
+Go to the latest release from the [github APSudoku Releases page](https://github.com/APSudoku/APSudoku/releases/latest). Download and extract the appropriate file for your platform.
+
+### Web
+Go to the [github pages](apsudoku.github.io) or [itch.io](https://emilyv99.itch.io/apsudoku) site, and play in the browser.
 
 ## Joining a MultiWorld Game
 
@@ -35,6 +39,14 @@ Info:
 - You can also use the `Tracking` tab to view either a basic tracker or a valid [GodotAP tracker pack](https://github.com/EmilyV99/GodotAP/blob/main/tracker_packs/GET_PACKS.md)
 - While connected, the number of "unhinted" locations for your slot is shown in the upper-left of the the `Sudoku` tab. (If this reads 0, no further hints can be earned for this slot, as every locations is already hinted)
 - Click the various `?` buttons for information on controls/how to play
+
+## Admin Settings
+
+By using the connected room's Admin Password on the Admin Panel tab, you can configure some settings at any time to affect the entire room.
+
+- You can disable APSudoku for the entire room, preventing any hints from being granted.
+- You can customize the reward weights for each difficulty, making progression hints more or less likely, and/or adding a chance to get "no hint" after a solve.
+
 ## DeathLink Support
 
 If `DeathLink` is enabled when you click `Connect`:


### PR DESCRIPTION
## What is this fixing or adding?
- Mention the admin settings on the game page and setup guide
- Add links to the web version for online/mobile play

## How was this tested?
See screenshots below, taken in locally-run webhost.

## If this makes graphical changes, please attach screenshots.
Game Page:
<img width="1283" height="183" alt="image" src="https://github.com/user-attachments/assets/46cf8982-9b0b-408b-8efd-1e264ddffa98" />
Setup Guide:
<img width="1191" height="248" alt="image" src="https://github.com/user-attachments/assets/572193bd-f115-4550-922b-627c17de9821" />
<img width="1257" height="254" alt="image" src="https://github.com/user-attachments/assets/8787818f-e2ad-4779-907c-b85126ef93b8" />

