### PR TITLE
Core: Fix hint UI for items with markup characters in their names

### DIFF
--- a/kvui.py
+++ b/kvui.py
@@ -531,9 +531,7 @@ class AutocompleteHintInput(ResizableTextField):
             item_names = ctx.item_names._game_store[ctx.game].values()
 
             def on_press(text):
-                split_text = MarkupLabel(text=text).markup
-                self.set_text(self, "".join(text_frag for text_frag in split_text
-                                            if not text_frag.startswith("[")))
+                self.set_text(self, text)
                 self.dropdown.dismiss()
                 self.focus = True
 
@@ -544,11 +542,9 @@ class AutocompleteHintInput(ResizableTextField):
                 except ValueError:
                     pass  # substring not found
                 else:
-                    text = escape_markup(item_name)
-                    text = text[:index] + "[b]" + text[index:index+len(value)]+"[/b]"+text[index+len(value):]
                     self.dropdown.items.append({
-                        "text": text,
-                        "on_release": lambda txt=text: on_press(txt),
+                        "text": f"{escape_markup(item_name[:index])}[b]{escape_markup(item_name[index:index+len(lowered)])}[/b]{escape_markup(item_name[index+len(lowered):])}",
+                        "on_release": lambda txt=item_name: on_press(txt),
                         "markup": True
                     })
             if not self.dropdown.parent:


### PR DESCRIPTION
## What is this fixing or adding?

Fixes wonky hint autocomplete for items with `&`, `[`, `]`, or in their name.

## How was this tested?

Manually.

## If this makes graphical changes, please attach screenshots.

Before:
<img width="439" height="356" alt="image" src="https://github.com/user-attachments/assets/40e2a45a-fb70-4f08-9373-afd615e3dcdd" />
<img width="439" height="36" alt="image" src="https://github.com/user-attachments/assets/d8793ba9-d8e1-4e47-a544-18fe63bd9429" />

After:
<img width="439" height="356" alt="image" src="https://github.com/user-attachments/assets/21833c45-4867-4f3d-989c-944089188054" />
<img width="439" height="36" alt="image" src="https://github.com/user-attachments/assets/ad53fe85-d335-43e5-b55c-ef092742834d" />
