### PR TITLE
Launcher: fix shortcuts on the AppImage

### DIFF
--- a/Launcher.py
+++ b/Launcher.py
@@ -228,7 +228,7 @@ def create_shortcut(button: Any, component: Component) -> None:
 
     script = f"{script} \"{component.display_name}\""
     make_shortcut(script, name=f"Archipelago {component.display_name}", icon=local_path("data", "icon.ico"),
-                  startmenu=False, terminal=False, working_dir=wkdir)
+                  startmenu=False, terminal=False, working_dir=wkdir, noexe=Utils.is_frozen())
     button.menu.dismiss()
 
 


### PR DESCRIPTION
## What is this fixing or adding?
https://discord.com/channels/731205301247803413/1446583931347538112
As AppImages mount themselves to a temp directory when ran, the launcher shortcuts would reference the current temp directory rather than the specific AppImage used.

## How was this tested?
Had the individual in question test creating shortcuts using built appimages.
Tested that shortcuts still work on a local frozen build on Windows.
