### PR TITLE
LttP Agahnim 1 Swordless KDS Key Logic Fix

### DIFF
--- a/worlds/alttp/Rules.py
+++ b/worlds/alttp/Rules.py
@@ -1055,7 +1055,7 @@ def open_rules(world, player):
 
 
 def swordless_rules(world, player):
-    set_rule(world.get_entrance('Agahnim 1', player), lambda state: (state.has('Hammer', player) or state.has('Fire Rod', player) or can_shoot_arrows(state, player) or state.has('Cane of Somaria', player)) and state._lttp_has_key('Small Key (Agahnims Tower)', player, 2))
+    set_rule(world.get_entrance('Agahnim 1', player), lambda state: (state.has('Hammer', player) or state.has('Fire Rod', player) or can_shoot_arrows(state, player) or state.has('Cane of Somaria', player)) and state._lttp_has_key('Small Key (Agahnims Tower)', player, 4))
     set_rule(world.get_entrance('Skull Woods Torch Room', player), lambda state: state._lttp_has_key('Small Key (Skull Woods)', player, 3) and state.has('Fire Rod', player))  # no curtain
 
     set_rule(world.get_location('Ice Palace - Jelly Key Drop', player), lambda state: state.has('Fire Rod', player) or state.has('Bombos', player))


### PR DESCRIPTION
## What is this fixing or adding?
Correcting Agahnim Tower 1 for Swordless logic to account for Key Drop Shuffle, which hadn't been caught/corrected yet. Current logic allows for small key to be placed on Lumberjack Tree in a No Glitches All Bosses Swordless seed with Key Drop Shuffle enabled

## How was this tested?
Tested using plando to try and force an Agahnim Tower Small Key onto Lumberjack Tree in a No Glitches, All Bosses, Swordless seed with Key Drop Shuffle enabled. Yaml was successful in plando prior to the change. Tested with 10 generations after the change all showing plando failed to place the key on Lumberjack Tree.
I have attached the yaml used to test this as well as a spoiler log each from before the change where the plando succeeded and one from after where the plando failed and placed a different item onto the Lumberjack Tree.
[Swordless test (1).yaml](https://github.com/user-attachments/files/24010473/Swordless.test.1.yaml)
[Swordless KDS Spoiler Before Changes.txt](https://github.com/user-attachments/files/24010474/Swordless.KDS.Spoiler.Before.Changes.txt)
[Swordless KDS Spoiler After Change.txt](https://github.com/user-attachments/files/24010475/Swordless.KDS.Spoiler.After.Change.txt)

## If this makes graphical changes, please attach screenshots.
None