### PR TITLE
Core: Make .apworlds importable using importlib (without force-importing them first)

### DIFF
--- a/worlds/__init__.py
+++ b/worlds/__init__.py
@@ -179,7 +179,7 @@ if apworlds:
                            f"as its game {apworld.game} is already loaded.",
                            add_as_failed_to_load=False)
             else:
-                importer = zipimport.zipimporter(apworld.resolved_path)
+                importer = zipimport.zipimporter(apworld_source.resolved_path)
                 world_name = Path(apworld.path).stem
 
                 spec = importer.find_spec(f"worlds.{world_name}")


### PR DESCRIPTION
This makes it so that `import worlds.apquest` works without any of the module manipulation, which simplifies & unifies the `WorldSource.load_world()` codepath, and crucially will bring us one step closer to lazy loading.

I'm not sure it's okay that I'm just ignoring `path` and `target`. I will have to look into it more.

Tested:
Removed worlds/apquest/, added worlds/apquest.apworld, launched APQuest client successfully.