### PR TITLE
[Webhost API] Update static_tracker to include slot names

### DIFF
--- a/WebHostLib/api/tracker.py
+++ b/WebHostLib/api/tracker.py
@@ -233,7 +233,7 @@ def static_tracker_data(tracker: UUID) -> dict[str, Any]:
         "groups": groups,
         "datapackage": tracker_data._multidata["datapackage"],
         "player_locations_total": player_locations_total,
-        "players": players_info,
+        "player_game": players_info,
     }
 
 

--- a/docs/webhost api.md
+++ b/docs/webhost api.md
@@ -385,8 +385,8 @@ Will provide a dict of static tracker data with the following keys:
   - This hash can then be sent to the datapackage API to receive the appropriate datapackage as necessary
 - The number of checks found vs. total checks available per player (`player_locations_total`)
   - Same logic as the multitracker template: found = len(player_checks_done.locations) / total = player_locations_total.total_locations (all available checks).
-- The game each player is playing (`player_game`)
-  - Provided as a list of objects with `team`, `player`, and `game`.
+- The static slot info for each player (`player_game`)
+  - Provided as a list of objects with `team`, `player` (slot number), `player_name` (slot name), and `game`.
 
 Example:
 ```json
@@ -433,11 +433,13 @@ Example:
     {
       "team": 0,
       "player": 1,
+      "player_name": "PlayerX",
       "game": "Archipelago"
     },
     {
       "team": 0,
       "player": 2,
+      "player_name": "PlayerY",
       "game": "The Messenger"
     }
   ]


### PR DESCRIPTION
Since there are cases where you know the tracker ID, but not the room ID, there is no way to get the non-alias (raw) player name when querying the tracker api.

## What is this fixing or adding?
Modified PlayerGame to PlayerInfo, then added "player_name" to the returned dict to give non-alias'd names to the tracker API. Aliased names can be found from /tracker.

## How was this tested?
Locally

## If this makes graphical changes, please attach screenshots.
N/A
```
...
"player_game": [
        {
            "game": "ChecksFinder",
            "player": 1,
            "player_name": "Game1",
            "team": 0
        },
        {
            "game": "ChecksFinder",
            "player": 2,
            "player_name": "Game2",
            "team": 0
        },
        {
            "game": "ChecksFinder",
            "player": 3,
            "player_name": "Game3",
            "team": 0
        },
...
```
(Bad example with GameX, but that really is their slot name lol)
