### PR TITLE
Docs: explicitly document why get_filler_item_name may return non-IC.filler items, despite its name

### DIFF
--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -487,7 +487,7 @@ class World(metaclass=AutoWorldRegister):
         """
         Called when the item pool needs to be filled with additional items to match location count.
 
-        The returned item name must be for a "repeatable" item, i.e. one that it's okay to generate arbitrarily many of.
+        Any returned item name must be for a "repeatable" item, i.e. one that it's okay to generate arbitrarily many of.
         For most worlds this will be one or more of your filler items, but the classification of these items
         does not need to be ItemClassification.filler.
         The item name returned can be for a trap, useful, and/or progression item as long as it's repeatable.


### PR DESCRIPTION
## What is this fixing or adding?

Clearing up some longstanding confusion around `get_filler_item_name` not always returning (the name(s) of) `filler` item(s). I don't have a better idea for the method's name, and my understanding is that renaming methods is very difficult in this project anyway, but we can make the docstring more explicit about the method's real contract.

This proposed text reflects my understanding of this method based on past conversations such as https://discord.com/channels/731205301247803413/1214608557077700720/1365116330625204295 where veteran devs explicitly draw a distinction between "filler" the ItemClassification and "filler" that get_filler_item_name() is trying to generate.

I thought of doing this today because starting at https://discord.com/channels/731205301247803413/1214608557077700720/1450025033266233377 there was a semi-heated discussion of this same familiar confusion, which appeared to include a number of incorrect assertions that `get_filler_item_name` _does_ always return `filler` (though even its default implementation doesn't).

## How was this tested?

reading

## If this makes graphical changes, please attach screenshots.

N/A