### PR TITLE
OptionsCreator:  Respect World.hidden flag

### DIFF
--- a/OptionsCreator.py
+++ b/OptionsCreator.py
@@ -632,8 +632,6 @@ class OptionsCreator(ThemedApp):
             self.create_options_panel(world_btn)
 
         for world, cls in sorted(AutoWorldRegister.world_types.items(), key=lambda x: x[0]):
-            if world == "Archipelago":
-                continue
             if cls.hidden:
                 continue
             world_text = MDButtonText(text=world, size_hint_y=None, width=dp(150),


### PR DESCRIPTION
## What is this fixing or adding?

Upon trying to use the Options Creator in my main install, I noticed that things like Universal Tracker and Discord Rich Presence were appearing in the yaml creator list.

These are all normally hidden by the `world.hidden` flag.  This PR makes the local yaml creator respect that flag.

## How was this tested?

Launched it, checked for Universal Tracker.

## If this makes graphical changes, please attach screenshots.
