### PR TITLE
APQuest: Fix ValueError on typing numbers/backspace

### DIFF
--- a/worlds/apquest/game/game.py
+++ b/worlds/apquest/game/game.py
@@ -158,11 +158,11 @@ class Game:
         if not self.gameboard.ready:
             return
 
-        if self.active_math_problem is not None:
-            if input_key in DIGIT_INPUTS_TO_DIGITS:
-                self.math_problem_input(DIGIT_INPUTS_TO_DIGITS[input_key])
-            if input_key == Input.BACKSPACE:
-                self.math_problem_delete()
+        if input_key in DIGIT_INPUTS_TO_DIGITS:
+            self.math_problem_input(DIGIT_INPUTS_TO_DIGITS[input_key])
+            return
+        if input_key == Input.BACKSPACE:
+            self.math_problem_delete()
             return
 
         if input_key == Input.LEFT:


### PR DESCRIPTION
## What is this fixing or adding?
Fixing this bug where typing a number key or backspace while not in a Math Trap gives an error. https://discord.com/channels/731205301247803413/1450979290379456522

## How was this tested?
Opening the game up and trying to mash numbers, also making sure that Math Traps still work properly.

## If this makes graphical changes, please attach screenshots.
🔢