### PR TITLE
TUNIC: Make UT care about hex goal amount

### DIFF
--- a/worlds/tunic/ut_stuff.py
+++ b/worlds/tunic/ut_stuff.py
@@ -23,6 +23,7 @@ def setup_options_from_slot_data(world: "TunicWorld") -> None:
             world.options.maskless.value = world.passthrough["maskless"]
             world.options.hexagon_quest.value = world.passthrough["hexagon_quest"]
             world.options.hexagon_quest_ability_type.value = world.passthrough.get("hexagon_quest_ability_type", 0)
+            world.options.hexagon_goal.value = world.passthrough["Hexagon Quest Goal"]
             world.options.entrance_rando.value = world.passthrough["entrance_rando"]
             world.options.shuffle_ladders.value = world.passthrough["shuffle_ladders"]
             world.options.shuffle_fuses.value = world.passthrough.get("shuffle_fuses", 0)


### PR DESCRIPTION
## What is this fixing or adding?
UT showing when goal is accessible is fairly recent, so now it makes sense to actually set that value here.

## How was this tested?
Using UT