### PR TITLE
SMW: Prevent receiving your own traps while aliased

### DIFF
--- a/worlds/smw/Client.py
+++ b/worlds/smw/Client.py
@@ -132,7 +132,7 @@ class SMWSNIClient(SNIClient):
             self.instance_id = time.time()
 
         source_name = args["data"]["source"]
-        if "TrapLink" in ctx.tags and "TrapLink" in args["tags"] and source_name != ctx.slot_info[ctx.slot].name:
+        if "TrapLink" in ctx.tags and "TrapLink" in args["tags"] and source_name != ctx.player_names[ctx.slot]:
             trap_name: str = args["data"]["trap_name"]
             if trap_name not in trap_name_to_value:
                 # We don't know how to handle this trap, ignore it


### PR DESCRIPTION
## What is this fixing or adding?
This fixes receiving your own traps via TrapLink while aliased, because `ctx.slot_info` is not updated with the aliased name, while `ctx.player_names` is.

## How was this tested?
The same fix was applied to the Pokemon Crystal client and tested there, I don't own SMW to be able to end-to-end test the SMW client.

## If this makes graphical changes, please attach screenshots.
N/A
