### PR TITLE
Core/WebHost: Allow WebWorlds without associated Worlds for HintGames / Tools, add associated WebHost pages

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -1716,7 +1716,7 @@ def get_option_groups(world: typing.Type[World], visibility_level: Visibility = 
     """Generates and returns a dictionary for the option groups of a specified world."""
     option_to_name = {option: option_name for option_name, option in world.options_dataclass.type_hints.items()}
 
-    ordered_groups = {group.name: group.options for group in world.web.option_groups}
+    ordered_groups = {group.name: group.options for group in world.option_groups}
 
     # add a default option group for uncategorized options to get thrown into
     if "Game Options" not in ordered_groups:

--- a/Options.py
+++ b/Options.py
@@ -144,7 +144,7 @@ class Option(typing.Generic[T], metaclass=AssembleOptions):
     If this is False, the docstring is instead interpreted as plain text, and
     displayed as-is on the WebHost with whitespace preserved.
 
-    If this is None, it inherits the value of `WebWorld.rich_text_options_doc`. For
+    If this is None, it inherits the value of `World.rich_text_options_doc`. For
     backwards compatibility, this defaults to False, but worlds are encouraged to
     set it to True and use reStructuredText for their Option documentation.
 

--- a/OptionsCreator.py
+++ b/OptionsCreator.py
@@ -554,21 +554,23 @@ class OptionsCreator(ThemedApp):
         self.option_layout.clear_widgets()
         self.options.clear()
         cls: typing.Type[World] = world_button.world_cls
+        from worlds.AutoWorld import WebWorldRegister
+        web_world = WebWorldRegister.web_worlds.get(cls.game, None)
 
         self.current_game = cls.game
-        if not cls.web.options_page:
+        if not web_world.options_page:
             self.current_game = "None"
             return
-        elif isinstance(cls.web.options_page, str):
+        elif isinstance(web_world.options_page, str):
             self.current_game = "None"
-            if validate_url(cls.web.options_page):
-                webbrowser.open(cls.web.options_page)
+            if validate_url(web_world.options_page):
+                webbrowser.open(web_world.options_page)
                 MDSnackbar(MDSnackbarText(text="Launching in default browser..."), y=dp(24), pos_hint={"center_x": 0.5},
                            size_hint_x=0.5).open()
                 world_button.state = "normal"
             else:
                 # attach onto archipelago.gg and see if we pass
-                new_url = "https://archipelago.gg/" + cls.web.options_page
+                new_url = "https://archipelago.gg/" + web_world.options_page
                 if validate_url(new_url):
                     webbrowser.open(new_url)
                     MDSnackbar(MDSnackbarText(text="Launching in default browser..."), y=dp(24),
@@ -586,10 +588,10 @@ class OptionsCreator(ThemedApp):
             expansion_box.layout.spacing = dp(3)
             expansion_box.scroll_type = ["bars"]
             expansion_box.do_scroll_x = False
-            group_names = ["Game Options", *(group.name for group in cls.web.option_groups)]
+            group_names = ["Game Options", *(group.name for group in cls.option_groups)]
             groups = {name: [] for name in group_names}
             for name, option in cls.options_dataclass.type_hints.items():
-                group = next((group.name for group in cls.web.option_groups if option in group.options), "Game Options")
+                group = next((group.name for group in cls.option_groups if option in group.options), "Game Options")
                 groups[group].append((name, option))
 
             for group, options in groups.items():

--- a/WebHostLib/misc.py
+++ b/WebHostLib/misc.py
@@ -86,6 +86,20 @@ def games():
     return render_template("supportedGames.html", worlds=get_visible_worlds(WorldType.GAME))
 
 
+@app.route('/hintgames')
+@cache.cached()
+def hint_games():
+    """List of supported hint games"""
+    return render_template("hintGames.html", worlds=get_visible_worlds(WorldType.HINT_GAME))
+
+
+@app.route('/tools')
+@cache.cached()
+def tools():
+    """List of supported tools"""
+    return render_template("tools.html", worlds=get_visible_worlds(WorldType.TOOL))
+
+
 @app.route('/tutorial/<string:game>/<string:file>')
 @cache.cached()
 def tutorial(game: str, file: str):

--- a/WebHostLib/misc.py
+++ b/WebHostLib/misc.py
@@ -9,7 +9,7 @@ from flask import request, redirect, url_for, render_template, Response, session
 from pony.orm import count, commit, db_session
 from werkzeug.utils import secure_filename
 
-from worlds.AutoWorld import AutoWorldRegister, World
+from worlds.AutoWorld import WebWorldRegister, WebWorld, WorldType
 from . import app, cache
 from .markdown import render_markdown
 from .models import Seed, Room, Command, UUID, uuid4
@@ -26,9 +26,9 @@ class WebWorldTheme(StrEnum):
     STONE = "stone"
 
 def get_world_theme(game_name: str) -> str:
-    if game_name not in AutoWorldRegister.world_types:
+    if game_name not in WebWorldRegister.web_worlds:
         return "grass"
-    chosen_theme = AutoWorldRegister.world_types[game_name].web.theme
+    chosen_theme = WebWorldRegister.web_worlds[game_name].theme
     available_themes = [theme.value for theme in WebWorldTheme]
     if chosen_theme not in available_themes:
         warnings.warn(f"Theme '{chosen_theme}' for {game_name} not valid, switching to default 'grass' theme.")
@@ -36,12 +36,13 @@ def get_world_theme(game_name: str) -> str:
     return chosen_theme
 
 
-def get_visible_worlds() -> dict[str, type(World)]:
-    worlds = {}
-    for game, world in AutoWorldRegister.world_types.items():
-        if not world.hidden:
-            worlds[game] = world
-    return worlds
+def get_visible_worlds(world_type: WorldType | None = None) -> dict[str, type(WebWorld)]:
+    web_worlds = {}
+    for game, web_world in WebWorldRegister.web_worlds.items():
+        if not web_world.hidden:
+            if world_type is None or web_world.world_type == world_type:
+                web_worlds[game] = web_world
+    return web_worlds
 
 
 @app.errorhandler(404)
@@ -82,7 +83,7 @@ def game_info(game, lang):
 @cache.cached()
 def games():
     """List of supported games"""
-    return render_template("supportedGames.html", worlds=get_visible_worlds())
+    return render_template("supportedGames.html", worlds=get_visible_worlds(WorldType.GAME))
 
 
 @app.route('/tutorial/<string:game>/<string:file>')
@@ -118,10 +119,10 @@ def tutorial_redirect(game: str, file: str, lang: str):
 @cache.cached()
 def tutorial_landing():
     tutorials = {}
-    worlds = AutoWorldRegister.world_types
-    for world_name, world_type in worlds.items():
+    worlds = WebWorldRegister.web_worlds
+    for world_name, web_world in worlds.items():
         current_world = tutorials[world_name] = {}
-        for tutorial in world_type.web.tutorials:
+        for tutorial in web_world.tutorials:
             current_tutorial = current_world.setdefault(tutorial.tutorial_name, {
                 "description": tutorial.description, "files": {}})
             current_tutorial["files"][secure_filename(tutorial.file_name).rsplit(".", 1)[0]] = {
@@ -293,8 +294,8 @@ def get_datapackage():
 @cache.cached()
 def get_sitemap():
     available_games: List[Dict[str, Union[str, bool]]] = []
-    for game, world in AutoWorldRegister.world_types.items():
-        if not world.hidden:
-            has_settings: bool = isinstance(world.web.options_page, bool) and world.web.options_page
+    for game, web_world in WebWorldRegister.web_worlds.items():
+        if not web_world.hidden:
+            has_settings: bool = isinstance(web_world.options_page, bool) and web_world.options_page
             available_games.append({ 'title': game, 'has_settings': has_settings })
     return render_template("siteMap.html", games=available_games)

--- a/WebHostLib/misc.py
+++ b/WebHostLib/misc.py
@@ -86,7 +86,7 @@ def games():
     return render_template("supportedGames.html", worlds=get_visible_worlds(WorldType.GAME))
 
 
-@app.route('/hintgames')
+@app.route('/hint_games')
 @cache.cached()
 def hint_games():
     """List of supported hint games"""

--- a/WebHostLib/options.py
+++ b/WebHostLib/options.py
@@ -10,7 +10,7 @@ from flask import redirect, render_template, request, Response, abort
 
 import Options
 from Utils import local_path
-from worlds.AutoWorld import AutoWorldRegister
+from worlds.AutoWorld import AutoWorldRegister, WebWorldRegister
 from . import app, cache
 from .generate import get_meta
 from .misc import get_world_theme
@@ -25,18 +25,20 @@ def create() -> None:
 
 def render_options_page(template: str, world_name: str, is_complex: bool = False) -> Union[Response, str]:
     world = AutoWorldRegister.world_types[world_name]
-    if world.hidden or world.web.options_page is False:
+    web_world = WebWorldRegister.web_worlds[world_name]
+    if web_world.hidden or web_world.options_page is False:
         return redirect("games")
     visibility_flag = Options.Visibility.complex_ui if is_complex else Options.Visibility.simple_ui
 
     start_collapsed = {"Game Options": False}
-    for group in world.web.option_groups:
+    for group in world.option_groups:
         start_collapsed[group.name] = group.start_collapsed
 
     return render_template(
         template,
         world_name=world_name,
         world=world,
+        web_world=web_world,
         option_groups=Options.get_option_groups(world, visibility_level=visibility_flag),
         start_collapsed=start_collapsed,
         issubclass=issubclass,
@@ -89,7 +91,7 @@ def option_presets(game: str) -> Response:
     world = AutoWorldRegister.world_types[game]
 
     presets = {}
-    for preset_name, preset in world.web.options_presets.items():
+    for preset_name, preset in world.options_presets.items():
         presets[preset_name] = {}
         for preset_option_name, preset_option in preset.items():
             if preset_option == "random":

--- a/WebHostLib/options.py
+++ b/WebHostLib/options.py
@@ -38,7 +38,6 @@ def render_options_page(template: str, world_name: str, is_complex: bool = False
         template,
         world_name=world_name,
         world=world,
-        web_world=web_world,
         option_groups=Options.get_option_groups(world, visibility_level=visibility_flag),
         start_collapsed=start_collapsed,
         issubclass=issubclass,

--- a/WebHostLib/templates/header/baseHeader.html
+++ b/WebHostLib/templates/header/baseHeader.html
@@ -17,7 +17,7 @@
             </div>
             <div id="base-header-popover-menu">
                 <a href="/games">supported games</a>
-                <a href="/hintgames">hint games</a>
+                <a href="/hint_games">hint games</a>
                 <a href="/tools">tools</a>
                 <a href="/tutorial">setup guides</a>
                 <a href="/generate">generate game</a>

--- a/WebHostLib/templates/header/baseHeader.html
+++ b/WebHostLib/templates/header/baseHeader.html
@@ -17,6 +17,8 @@
             </div>
             <div id="base-header-popover-menu">
                 <a href="/games">supported games</a>
+                <a href="/hintgames">hint games</a>
+                <a href="/tools">tools</a>
                 <a href="/tutorial">setup guides</a>
                 <a href="/generate">generate game</a>
                 <a href="/uploads">host game</a>

--- a/WebHostLib/templates/hintGames.html
+++ b/WebHostLib/templates/hintGames.html
@@ -1,0 +1,71 @@
+{% extends 'pageWrapper.html' %}
+
+{% block head %}
+    <title>Hint Games</title>
+    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename="styles/markdown.css") }}" />
+    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename="styles/supportedGames.css") }}" />
+    <script type="application/ecmascript" src="{{ url_for('static', filename="assets/supportedGames.js") }}"></script>
+    <noscript>
+    <style>
+        /* always un-collapse all and hide arrow and search bar */
+        .js-only{
+          display: none;
+        }
+
+        #games p.collapsed{
+          display: block;
+        }
+
+        #games h2 .collapse-arrow{
+          display: none;
+        }
+
+        #games .collapse-toggle{
+          cursor: unset;
+        }
+    </style>
+    </noscript>
+{% endblock %}
+
+{% block body %}
+    {% include 'header/oceanHeader.html' %}
+    <div id="games" class="markdown">
+        <h1>Hint Games</h1>
+        <p>A 'Hint Game' is a special type of Archipelago game. Unlike normal games, Hint Games are not included
+        as part of the randomization at generation time; you can add a hint game at any time in the middle of a run.
+        Hint Games do not send randomized items to other games, instead sending random <em>hints</em>.</p>
+        <p>A hint game is played by connecting the game's Client to an open Archipelago room, connecting
+        to whichever existing Slot you want to earn random hints for. (This should be a slot that you yourself are playing,
+        unless you explicitly have permission from the person whose slot it is!)</p>
+        <p>Currently, Hint Games are mostly limited to unlocking hints for <em>which item is at a random location in your world</em>.
+        Hints for <em>where a random item of yours is, in any world</em> are not supported by Archipelago's API at this time.</p>
+        <div class="js-only">
+            <label for="game-search">Search for your game below!</label><br />
+            <div class="page-controls">
+                <input id="game-search" placeholder="Search by title..." autofocus />
+                <button id="expand-all">Expand All</button>
+                <button id="collapse-all">Collapse All</button>
+            </div>
+        </div>
+        {% for game_name in worlds | title_sorted %}
+        {% set world = worlds[game_name] %}
+        <details data-game="{{ game_name }}">
+            <summary class="h2">{{ game_name }}</summary>
+            {{ world.__doc__ | default("No description provided.", true) }}<br />
+            <a href="{{ url_for("game_info", game=game_name, lang="en") }}">Game Page</a>
+            {% if world.tutorials %}
+            <span class="link-spacer">|</span>
+            <a href="{{ url_for("tutorial_landing", _anchor = game_name | urlencode) }}">Setup Guides</a>
+            {% endif %}
+            {% if world.options_page is string %}
+            <span class="link-spacer">|</span>
+            <a href="{{ world.options_page }}">Options Page (External Link)</a>
+            {% endif %}
+            {% if world.bug_report_page %}
+            <span class="link-spacer">|</span>
+            <a href="{{ world.bug_report_page }}">Report a Bug</a>
+            {% endif %}
+        </details>
+        {% endfor %}
+    </div>
+{% endblock %}

--- a/WebHostLib/templates/playerOptions/macros.html
+++ b/WebHostLib/templates/playerOptions/macros.html
@@ -209,7 +209,7 @@
 {% macro OptionTitle(option_name, option) %}
     <label for="{{ option_name }}">
         {{ option.display_name|default(option_name) }}:
-        {% set rich_text = option.rich_text_doc or (option.rich_text_doc is none and web_world.rich_text_options_doc) %}
+        {% set rich_text = option.rich_text_doc or (option.rich_text_doc is none and world.rich_text_options_doc) %}
         <span
             class="interactive tooltip-container"
             {% if not rich_text %}

--- a/WebHostLib/templates/playerOptions/macros.html
+++ b/WebHostLib/templates/playerOptions/macros.html
@@ -209,7 +209,7 @@
 {% macro OptionTitle(option_name, option) %}
     <label for="{{ option_name }}">
         {{ option.display_name|default(option_name) }}:
-        {% set rich_text = option.rich_text_doc or (option.rich_text_doc is none and world.web.rich_text_options_doc) %}
+        {% set rich_text = option.rich_text_doc or (option.rich_text_doc is none and web_world.rich_text_options_doc) %}
         <span
             class="interactive tooltip-container"
             {% if not rich_text %}

--- a/WebHostLib/templates/playerOptions/playerOptions.html
+++ b/WebHostLib/templates/playerOptions/playerOptions.html
@@ -59,7 +59,7 @@
                     </label>
                     <select id="game-options-preset" name="game-options-preset" disabled>
                         <option value="default">Default</option>
-                        {% for preset_name in world.web.options_presets %}
+                        {% for preset_name in world.options_presets %}
                             <option value="{{ preset_name }}">{{ preset_name }}</option>
                         {% endfor %}
                         <option value="custom" hidden>Custom</option>

--- a/WebHostLib/templates/siteMap.html
+++ b/WebHostLib/templates/siteMap.html
@@ -22,6 +22,8 @@
             <li><a href="{{ url_for('get_sitemap') }}">Site Map</a></li>
             <li><a href="{{ url_for('start_playing') }}">Start Playing</a></li>
             <li><a href="{{ url_for('games') }}">Supported Games Page</a></li>
+            <li><a href="{{ url_for('hintgames') }}">Hint Games Page</a></li>
+            <li><a href="{{ url_for('tools') }}">Tools Page</a></li>
             <li><a href="{{ url_for('tutorial_landing') }}">Tutorials Page</a></li>
             <li><a href="{{ url_for('user_content') }}">User Content</a></li>
             <li><a href="{{ url_for('stats') }}">Game Statistics</a></li>

--- a/WebHostLib/templates/siteMap.html
+++ b/WebHostLib/templates/siteMap.html
@@ -22,7 +22,7 @@
             <li><a href="{{ url_for('get_sitemap') }}">Site Map</a></li>
             <li><a href="{{ url_for('start_playing') }}">Start Playing</a></li>
             <li><a href="{{ url_for('games') }}">Supported Games Page</a></li>
-            <li><a href="{{ url_for('hintgames') }}">Hint Games Page</a></li>
+            <li><a href="{{ url_for('hint_games') }}">Hint Games Page</a></li>
             <li><a href="{{ url_for('tools') }}">Tools Page</a></li>
             <li><a href="{{ url_for('tutorial_landing') }}">Tutorials Page</a></li>
             <li><a href="{{ url_for('user_content') }}">User Content</a></li>

--- a/WebHostLib/templates/supportedGames.html
+++ b/WebHostLib/templates/supportedGames.html
@@ -48,22 +48,22 @@
             <summary class="h2">{{ game_name }}</summary>
             {{ world.__doc__ | default("No description provided.", true) }}<br />
             <a href="{{ url_for("game_info", game=game_name, lang="en") }}">Game Page</a>
-            {% if world.web.tutorials %}
+            {% if world.tutorials %}
             <span class="link-spacer">|</span>
             <a href="{{ url_for("tutorial_landing", _anchor = game_name | urlencode) }}">Setup Guides</a>
             {% endif %}
-            {% if world.web.options_page is string %}
+            {% if world.options_page is string %}
             <span class="link-spacer">|</span>
-            <a href="{{ world.web.options_page }}">Options Page (External Link)</a>
-            {% elif world.web.options_page %}
+            <a href="{{ world.options_page }}">Options Page (External Link)</a>
+            {% elif world.options_page %}
             <span class="link-spacer">|</span>
             <a href="{{ url_for("player_options", game=game_name) }}">Options Page</a>
             <span class="link-spacer">|</span>
             <a href="{{ url_for("weighted_options", game=game_name) }}">Advanced Options</a>
             {% endif %}
-            {% if world.web.bug_report_page %}
+            {% if world.bug_report_page %}
             <span class="link-spacer">|</span>
-            <a href="{{ world.web.bug_report_page }}">Report a Bug</a>
+            <a href="{{ world.bug_report_page }}">Report a Bug</a>
             {% endif %}
         </details>
         {% endfor %}

--- a/WebHostLib/templates/tools.html
+++ b/WebHostLib/templates/tools.html
@@ -33,9 +33,9 @@
         <h1>Tools</h1>
         <p>This is a list of tools that may be useful when using Archipelago.</p>
         <div class="js-only">
-            <label for="game-search">Search for your game below!</label><br />
+            <label for="game-search">Search for your tool below!</label><br />
             <div class="page-controls">
-                <input id="game-search" placeholder="Search by title..." autofocus />
+                <input id="game-search" placeholder="Search by name..." autofocus />
                 <button id="expand-all">Expand All</button>
                 <button id="collapse-all">Collapse All</button>
             </div>
@@ -45,7 +45,7 @@
         <details data-game="{{ game_name }}">
             <summary class="h2">{{ game_name }}</summary>
             {{ world.__doc__ | default("No description provided.", true) }}<br />
-            <a href="{{ url_for("game_info", game=game_name, lang="en") }}">Game Page</a>
+            <a href="{{ url_for("game_info", game=game_name, lang="en") }}">Tool Page</a>
             {% if world.tutorials %}
             <span class="link-spacer">|</span>
             <a href="{{ url_for("tutorial_landing", _anchor = game_name | urlencode) }}">Setup Guides</a>

--- a/WebHostLib/templates/tools.html
+++ b/WebHostLib/templates/tools.html
@@ -1,0 +1,64 @@
+{% extends 'pageWrapper.html' %}
+
+{% block head %}
+    <title>Tools</title>
+    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename="styles/markdown.css") }}" />
+    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename="styles/supportedGames.css") }}" />
+    <script type="application/ecmascript" src="{{ url_for('static', filename="assets/supportedGames.js") }}"></script>
+    <noscript>
+    <style>
+        /* always un-collapse all and hide arrow and search bar */
+        .js-only{
+          display: none;
+        }
+
+        #games p.collapsed{
+          display: block;
+        }
+
+        #games h2 .collapse-arrow{
+          display: none;
+        }
+
+        #games .collapse-toggle{
+          cursor: unset;
+        }
+    </style>
+    </noscript>
+{% endblock %}
+
+{% block body %}
+    {% include 'header/oceanHeader.html' %}
+    <div id="games" class="markdown">
+        <h1>Tools</h1>
+        <p>This is a list of tools that may be useful when using Archipelago.</p>
+        <div class="js-only">
+            <label for="game-search">Search for your game below!</label><br />
+            <div class="page-controls">
+                <input id="game-search" placeholder="Search by title..." autofocus />
+                <button id="expand-all">Expand All</button>
+                <button id="collapse-all">Collapse All</button>
+            </div>
+        </div>
+        {% for game_name in worlds | title_sorted %}
+        {% set world = worlds[game_name] %}
+        <details data-game="{{ game_name }}">
+            <summary class="h2">{{ game_name }}</summary>
+            {{ world.__doc__ | default("No description provided.", true) }}<br />
+            <a href="{{ url_for("game_info", game=game_name, lang="en") }}">Game Page</a>
+            {% if world.tutorials %}
+            <span class="link-spacer">|</span>
+            <a href="{{ url_for("tutorial_landing", _anchor = game_name | urlencode) }}">Setup Guides</a>
+            {% endif %}
+            {% if world.options_page is string %}
+            <span class="link-spacer">|</span>
+            <a href="{{ world.options_page }}">Options Page (External Link)</a>
+            {% endif %}
+            {% if world.bug_report_page %}
+            <span class="link-spacer">|</span>
+            <a href="{{ world.bug_report_page }}">Report a Bug</a>
+            {% endif %}
+        </details>
+        {% endfor %}
+    </div>
+{% endblock %}

--- a/WebHostLib/templates/tools.html
+++ b/WebHostLib/templates/tools.html
@@ -32,6 +32,10 @@
     <div id="games" class="markdown">
         <h1>Tools</h1>
         <p>This is a list of tools that may be useful when using Archipelago.</p>
+        {% if not worlds %}
+
+        <p>There are currently no tools to list on this page.</p>
+        {% else %}
         <div class="js-only">
             <label for="game-search">Search for your tool below!</label><br />
             <div class="page-controls">
@@ -60,5 +64,6 @@
             {% endif %}
         </details>
         {% endfor %}
+        {% endif %}
     </div>
 {% endblock %}

--- a/docs/options api.md
+++ b/docs/options api.md
@@ -147,7 +147,7 @@ class HiddenChoiceOption(Choice):
 ```
 
 ### Option Groups
-Options may be categorized into groups for display on the WebHost. Option groups are displayed in the order specified
+Options may be categorized into groups for display. Option groups are displayed in the order specified
 by your world on the player-options and weighted-options pages. In the generated template files, there will be a comment
 with the group name at the beginning of each group of options. The `start_collapsed` Boolean only affects how the groups
 appear on the WebHost, with the grouping being collapsed when this is `True`.
@@ -163,11 +163,11 @@ Location Options" group can also be moved to a different position in the group o
 be first, regardless of where it is in your list.
 
 ```python
-from worlds.AutoWorld import WebWorld
+from worlds.AutoWorld import World
 from Options import OptionGroup
 from . import Options
 
-class MyWorldWeb(WebWorld):
+class MyWorld(World):
     option_groups = [
         OptionGroup("Color Options", [
             Options.ColorblindMode,

--- a/docs/options api.md
+++ b/docs/options api.md
@@ -95,15 +95,15 @@ user hovers over the yellow "(?)" icon, and included in the YAML templates gener
 The WebHost can display Option documentation either as plain text with all whitespace preserved (other than the base
 indentation), or as HTML generated from the standard Python [reStructuredText] format. Although plain text is the
 default for backwards compatibility, world authors are encouraged to write their Option documentation as
-reStructuredText and enable rich text rendering by setting `WebWorld.rich_text_options_doc = True`.
+reStructuredText and enable rich text rendering by setting `World.rich_text_options_doc = True`.
 
 [reStructuredText]: https://docutils.sourceforge.io/rst.html
 
 ```python
-from worlds.AutoWorld import WebWorld
+from worlds.AutoWorld import World
 
 
-class ExampleWebWorld(WebWorld):
+class ExampleWorld(World):
     # Render all this world's options as rich text.
     rich_text_options_doc = True
 ```

--- a/docs/world api.md
+++ b/docs/world api.md
@@ -61,12 +61,6 @@ to create webhost pages for Hint Games or Tools, which do not necessarily requir
 
 * `options_page` can be changed to a link instead of an AP-generated options page.
 
-* `rich_text_options_doc` controls whether [Option documentation] uses plain text (`False`) or rich text (`True`). It
-  defaults to `False`, but world authors are encouraged to set it to `True` for nicer-looking documentation that looks
-  good on both the WebHost and the YAML template.
-
-  [Option documentation]: /docs/options%20api.md#option-documentation
-
 * `theme` to be used for your game-specific AP pages. Available themes:
 
   | dirt                                       | grass (default)                             | grassFlowers                                       | ice                                       | jungle                                       | ocean                                       | partyTime                                       | stone                                       |
@@ -420,6 +414,14 @@ class RLWorld(World):
     # ...
 ```
 
+### Option Documentation
+
+* `rich_text_options_doc` controls whether [Option documentation] uses plain text (`False`) or rich text (`True`). It
+  defaults to `False`, but world authors are encouraged to set it to `True` for nicer-looking documentation that looks
+  good on both the WebHost and the YAML template.
+
+  [Option documentation]: /docs/options%20api.md#option-documentation
+
 ### A World Class Skeleton
 
 ```python
@@ -467,9 +469,6 @@ class MyGameWeb(WebWorld):
     # You can choose between dirt, grass, grassFlowers, ice, jungle, ocean, partyTime, and stone.
     theme = "grassFlowers"
     
-    # If True, your game's option doc comments will be rendered as rich text.
-    rich_text_options_doc = False
-    
     # A WebWorld can have any number of tutorials, but should always have at least an English setup guide.
     # Many WebWorlds just have one setup guide, but some have multiple, e.g. for different languages.
     # We need to create a Tutorial object for every setup guide.
@@ -495,9 +494,13 @@ class MyGameWorld(World):
     # This is how we associate the options defined in our options.py with our world.
     options_dataclass = MyGameOptions  # options the player can set
     options: MyGameOptions  # typing hints for option results
+    
     # If we have option groups and/or option presets, we need to specify these here as well.
     options_presets = mygame_option_presets
     option_groups = mygame_option_groups
+    
+    # If True, your game's option doc comments will be rendered as rich text.
+    rich_text_options_doc = False
     
     settings: typing.ClassVar[MyGameSettings]  # will be automatically assigned from type hint
     topology_present = True  # show path to required location checks in spoiler

--- a/docs/world api.md
+++ b/docs/world api.md
@@ -31,10 +31,10 @@ follow [reST style](https://peps.python.org/pep-0287/).
 Example:
 
 ```python
-from worlds.AutoWorld import World
+from worlds.AutoWorld import WebWorld
 
 
-class MyGameWorld(World):
+class MyGameWeb(WebWorld):
     """This is the description of My Game that will be displayed on the AP website."""
 ```
 
@@ -53,6 +53,11 @@ for each player of the game for any given generated multiworld.
 
 A `WebWorld` class contains specific attributes and methods that can be modified for your world specifically on the
 webhost:
+
+* `game` must match your game's name.
+
+* `world_type` should be `WorldType.GAME` for a standard game. Alternately, `WorldType.HINT_GAME` and `WorldType.TOOL` are available
+to create webhost pages for Hint Games or Tools, which do not necessarily require a `World` class. 
 
 * `options_page` can be changed to a link instead of an AP-generated options page.
 
@@ -75,104 +80,6 @@ webhost:
 
 * `game_info_languages` (optional) list of strings for defining the existing game info pages your game supports. The
   documents must be prefixed with the same string as defined here. Default already has 'en'.
-
-* `options_presets` (optional) `dict[str, dict[str, Any]]` where the keys are the names of the presets and the values
-  are the options to be set for that preset. The options are defined as a `dict[str, Any]` where the keys are the names
-  of the options and the values are the values to be set for that option. These presets will be available for users to
-  select from on the game's options page.
-
-Note: The values must be a non-aliased value for the option type and can only include the following option types:
-
-* If you have a `Range`/`NamedRange` option, the value should be an `int` between the `range_start` and `range_end`
-  values.
-    * If you have a `NamedRange` option, the value can alternatively be a `str` that is one of the
-      `special_range_names` keys.
-* If you have a `Choice` option, the value should be a `str` that is one of the `option_<name>` values.
-* If you have a `Toggle`/`DefaultOnToggle` option, the value should be a `bool`.
-* `random` is also a valid value for any of these option types.
-
-`OptionDict`, `OptionList`, `OptionSet`, `FreeText`, or custom `Option`-derived classes are not supported for presets on
-the webhost at this time.
-
-Here is an example of a defined preset:
-
-```python
-# presets.py
-options_presets = {
-    "Limited Potential": {
-        "progression_balancing":    0,
-        "fairy_chests_per_zone":    2,
-        "starting_class":           "random",
-        "chests_per_zone":          30,
-        "vendors":                  "normal",
-        "architect":                "disabled",
-        "gold_gain_multiplier":     "half",
-        "number_of_children":       2,
-        "free_diary_on_generation": False,
-        "health_pool":              10,
-        "mana_pool":                10,
-        "attack_pool":              10,
-        "magic_damage_pool":        10,
-        "armor_pool":               5,
-        "equip_pool":               10,
-        "crit_chance_pool":         5,
-        "crit_damage_pool":         5,
-    }
-}
-
-
-# __init__.py
-class RLWeb(WebWorld):
-    options_presets = options_presets
-    # ...
-```
-
-* `location_descriptions` (optional) WebWorlds can provide a map that contains human-friendly descriptions of locations 
-or location groups.
-
-  ```python
-  # locations.py
-  location_descriptions = {
-      "Red Potion #6": "In a secret destructible block under the second stairway",
-      "L2 Spaceship": """
-        The group of all items in the spaceship in Level 2.
-  
-        This doesn't include the item on the spaceship door, since it can be
-        accessed without the Spaceship Key.
-      """
-  }
-  
-  # __init__.py
-  from worlds.AutoWorld import WebWorld
-  from .locations import location_descriptions
-  
-  
-  class MyGameWeb(WebWorld):
-      location_descriptions = location_descriptions
-  ```
-
-* `item_descriptions` (optional) WebWorlds can provide a map that contains human-friendly descriptions of items or item 
-groups.
-
-  ```python
-  # items.py
-  item_descriptions = {
-      "Red Potion": "A standard health potion",
-      "Spaceship Key": """
-        The key to the spaceship in Level 2.
-  
-        This is necessary to get to the Star Realm.
-      """,
-  }
-  
-  # __init__.py
-  from worlds.AutoWorld import WebWorld
-  from .items import item_descriptions
-  
-  
-  class MyGameWeb(WebWorld):
-      item_descriptions = item_descriptions
-  ```
 
 ### MultiWorld Object
 
@@ -394,6 +301,14 @@ World classes must inherit from the `World` class in `/worlds/AutoWorld.py`, whi
 
 AP will pick up your world automatically due to the `AutoWorld` implementation.
 
+A WebWorld should also be included, which must inherit from the `WebWorld` class in `/worlds/AutoWorld.py`.
+This will also automatically be registered by AP, and must have a 'game' field matching your `World` class's 'game' field.
+
+### Hint Games and Tools
+
+For "Hint Games" or "Tools", a `WebWorld` can be supplied without a corresponding `World` to create pages on the WebHost.
+Such a `WebWorld` should have its `world_type` set to `WorldType.HINT_GAME` or `WorldType.TOOL` to indicate this.
+
 ### Requirements
 
 If your world needs specific python packages, they can be listed in `worlds/<world_name>/requirements.txt`.
@@ -449,6 +364,62 @@ class MyGameLocation(Location):
 
 in your `__init__.py` or your `locations.py`.
 
+### Option Presets
+Option presets can be supplied on your World class as follows:
+
+* `options_presets` (optional) `dict[str, dict[str, Any]]` where the keys are the names of the presets and the values
+  are the options to be set for that preset. The options are defined as a `dict[str, Any]` where the keys are the names
+  of the options and the values are the values to be set for that option. These presets will be available for users to
+  select from on the game's options page.
+
+Note: The values must be a non-aliased value for the option type and can only include the following option types:
+
+* If you have a `Range`/`NamedRange` option, the value should be an `int` between the `range_start` and `range_end`
+  values.
+    * If you have a `NamedRange` option, the value can alternatively be a `str` that is one of the
+      `special_range_names` keys.
+* If you have a `Choice` option, the value should be a `str` that is one of the `option_<name>` values.
+* If you have a `Toggle`/`DefaultOnToggle` option, the value should be a `bool`.
+* `random` is also a valid value for any of these option types.
+
+`OptionDict`, `OptionList`, `OptionSet`, `FreeText`, or custom `Option`-derived classes are not supported for presets on
+the webhost at this time.
+
+Here is an example of a defined preset:
+
+```python
+# presets.py
+options_presets = {
+    "Limited Potential": {
+        "progression_balancing":    0,
+        "fairy_chests_per_zone":    2,
+        "starting_class":           "random",
+        "chests_per_zone":          30,
+        "vendors":                  "normal",
+        "architect":                "disabled",
+        "gold_gain_multiplier":     "half",
+        "number_of_children":       2,
+        "free_diary_on_generation": False,
+        "health_pool":              10,
+        "mana_pool":                10,
+        "attack_pool":              10,
+        "magic_damage_pool":        10,
+        "armor_pool":               5,
+        "equip_pool":               10,
+        "crit_chance_pool":         5,
+        "crit_damage_pool":         5,
+    }
+}
+
+
+# __init__.py
+from worlds.AutoWorld import World
+from .options import options_presets
+class RLWorld(World):
+    options_presets = options_presets
+    # ...
+```
+
 ### A World Class Skeleton
 
 ```python
@@ -456,11 +427,11 @@ in your `__init__.py` or your `locations.py`.
 
 import settings
 import typing
-from .options import MyGameOptions  # the options we defined earlier
+from .options import MyGameOptions, mygame_option_groups, mygame_option_presets  # the options we defined earlier, as well as groups/presets
 from .items import mygame_items  # data used below to add items to the World
-from .locations import mygame_locations  # same as above
-from worlds.AutoWorld import World
-from BaseClasses import Region, Location, Entrance, Item, RegionType, ItemClassification
+from .locations import mygame_locations, mygame_location_groups, mygame_location_descriptions  # same as above
+from worlds.AutoWorld import World, WebWorld, WorldType
+from BaseClasses import Region, Location, Entrance, Item, RegionType, ItemClassification, Tutorial
 
 
 class MyGameItem(Item):  # or from Items import MyGameItem
@@ -477,33 +448,85 @@ class MyGameSettings(settings.Group):
 
     rom_file: RomFile = RomFile("MyGame.sfc")
 
+    
+class MyGameWeb(WebWorld):
+    """
+    My Game is a game about doing stuff.
+    """
+    # The docstring should contain a description of the game, to be displayed on the WebHost.
+    
+    # We need to override the "game" field of the WebWorld superclass.
+    # This must be the same string as the regular World class.
+    game = "My Game"
+    
+    # The type of world. Set this to WorldType.GAME if you're making a standard world,
+    # or use WorldType.HINT_GAME or WorldType.TOOL types if making a WebWorld for a Hint Game / Tool
+    world_type = WorldType.GAME
+
+    # Your game pages will have a visual theme (affecting e.g. the background image).
+    # You can choose between dirt, grass, grassFlowers, ice, jungle, ocean, partyTime, and stone.
+    theme = "grassFlowers"
+    
+    # If True, your game's option doc comments will be rendered as rich text.
+    rich_text_options_doc = False
+    
+    # A WebWorld can have any number of tutorials, but should always have at least an English setup guide.
+    # Many WebWorlds just have one setup guide, but some have multiple, e.g. for different languages.
+    # We need to create a Tutorial object for every setup guide.
+    # In order, we need to provide a title, a description, a language, a filepath, a link, and authors.
+    # The filepath is relative to a "/docs/" directory in the root folder of your apworld.
+    # The "link" parameter is unused, but we still need to provide it.
+    setup_en = Tutorial(
+        tutorial_name='Setup Guide',
+        description='A guide to playing My Game',
+        language='English',
+        file_name='setup_en.md',
+        link='setup/en',
+        authors=['Your Name']
+    )
+    # We add these tutorials to our WebWorld by overriding the "tutorials" field.
+    tutorials = [setup_en]
+    
 
 class MyGameWorld(World):
-    """Insert description of the world/game here."""
-    game = "My Game"  # name of the game/world
+    # You must override the "game" field to say the name of the game.
+    game = "My Game"
+    
+    # This is how we associate the options defined in our options.py with our world.
     options_dataclass = MyGameOptions  # options the player can set
     options: MyGameOptions  # typing hints for option results
+    # If we have option groups and/or option presets, we need to specify these here as well.
+    options_presets = mygame_option_presets
+    option_groups = mygame_option_groups
+    
     settings: typing.ClassVar[MyGameSettings]  # will be automatically assigned from type hint
     topology_present = True  # show path to required location checks in spoiler
 
-    # ID of first item and location, could be hard-coded but code may be easier
-    # to read with this as a property.
-    base_id = 1234
-    # instead of dynamic numbering, IDs could be part of data
+    # There is always one region that the generator starts from & assumes you can always go back to.
+    # This defaults to "Menu", but you can change it by overriding origin_region_name.
+    origin_region_name = "Menu"
 
     # The following two dicts are required for the generation to know which
     # items exist. They could be generated from json or something else. They can
     # include events, but don't have to since events will be placed manually.
-    item_name_to_id = {name: id for
-                       id, name in enumerate(mygame_items, base_id)}
-    location_name_to_id = {name: id for
-                           id, name in enumerate(mygame_locations, base_id)}
+    item_name_to_id = {name: id for id, name in enumerate(mygame_items, 1)}
+    location_name_to_id = {name: id for id, name in enumerate(mygame_locations, 1)}
 
     # Items can be grouped using their names to allow easy checking if any item
     # from that group has been collected. Group names can also be used for !hint
     item_name_groups = {
         "weapons": {"sword", "lance"},
     }
+    
+    # The same can be done for locations
+    location_name_groups = mygame_location_groups
+
+    # Human-readable descriptions can also be provided for items and locations
+    item_descriptions = {
+        "sword": "A weapon to slash at enemies!",
+        "lance": "A weapon to stab at enemies from a distance!",
+    }
+    location_descriptions = mygame_location_descriptions
 ```
 
 ### Generation

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,6 @@ non_apworlds: set[str] = {
     "Ocarina of Time",
     "Overcooked! 2",
     "Raft",
-    "Sudoku",
     "Super Mario 64",
     "VVVVVV",
     "Wargroove",

--- a/test/hosting/world.py
+++ b/test/hosting/world.py
@@ -20,7 +20,7 @@ def copy(src: str, dst: str) -> None:
     src_cls = AutoWorldRegister.world_types[src]
     src_folder = Path(src_cls.__file__).parent
     worlds_folder = src_folder.parent
-    if (not src_cls.__file__.endswith(("__init__.py", "world.py")) or not src_folder.is_dir()
+    if (not src_cls.__file__.endswith(("__init__.py", "world.py", "web_world.py")) or not src_folder.is_dir()
             or not (worlds_folder / "generic").is_dir()):
         raise ValueError(f"Unsupported layout for copy_world from {src}")
     dst_folder = worlds_folder / dst_folder_name
@@ -29,12 +29,12 @@ def copy(src: str, dst: str) -> None:
     shutil.copytree(src_folder, dst_folder)
     _new_worlds[dst] = str(dst_folder)
 
-    for potential_world_class_file in ("__init__.py", "world.py"):
+    for potential_world_class_file in ("__init__.py", "world.py", "web_world.py"):
         with open(dst_folder / potential_world_class_file, "r", encoding="utf-8-sig") as f:
             contents = f.read()
         r_src = re.escape(src)
         contents = re.sub(r'game\s*(:\s*[a-zA-Z\[\]]+)?\s*=\s*[\'"]' + r_src + r'[\'"]', f'game = "{dst}"', contents)
-        with open(dst_folder / "__init__.py", "w", encoding="utf-8") as f:
+        with open(dst_folder / potential_world_class_file, "w", encoding="utf-8") as f:
             f.write(contents)
 
 

--- a/test/webhost/test_descriptions.py
+++ b/test/webhost/test_descriptions.py
@@ -8,7 +8,7 @@ class TestWebDescriptions(unittest.TestCase):
         """Ensure all item descriptions match an item name or item group name"""
         for game_name, world_type in AutoWorldRegister.world_types.items():
             valid_names = world_type.item_names.union(world_type.item_name_groups)
-            for name in world_type.web.item_descriptions:
+            for name in world_type.item_descriptions:
                 with self.subTest("Name should be valid", game=game_name, item=name):
                     self.assertIn(name, valid_names,
                                   "All item descriptions must match defined item names")
@@ -17,7 +17,7 @@ class TestWebDescriptions(unittest.TestCase):
         """Ensure all location descriptions match a location name or location group name"""
         for game_name, world_type in AutoWorldRegister.world_types.items():
             valid_names = world_type.location_names.union(world_type.location_name_groups)
-            for name in world_type.web.location_descriptions:
+            for name in world_type.location_descriptions:
                 with self.subTest("Name should be valid", game=game_name, location=name):
                     self.assertIn(name, valid_names,
                                   "All location descriptions must match defined location names")

--- a/test/webhost/test_docs.py
+++ b/test/webhost/test_docs.py
@@ -5,7 +5,7 @@ import os
 from werkzeug.utils import secure_filename
 
 import WebHost
-from worlds.AutoWorld import AutoWorldRegister
+from worlds.AutoWorld import AutoWorldRegister, WebWorldRegister
 
 
 class TestDocs(unittest.TestCase):
@@ -13,11 +13,17 @@ class TestDocs(unittest.TestCase):
     def setUpClass(cls) -> None:
         WebHost.copy_tutorials_files_to_static()
 
-    def test_has_tutorial(self):
+    def test_has_webworld(self):
         for game_name, world_type in AutoWorldRegister.world_types.items():
             if not world_type.hidden:
                 with self.subTest(game_name):
-                    tutorials = world_type.web.tutorials
+                    self.assertIn(game_name, WebWorldRegister.web_worlds, msg=f"{game_name} has no associated WebWorld.")
+
+    def test_has_tutorial(self):
+        for game_name, web_world in WebWorldRegister.web_worlds.items():
+            if not web_world.hidden:
+                with self.subTest(game_name):
+                    tutorials = web_world.tutorials
                     self.assertGreater(len(tutorials), 0, msg=f"{game_name} has no setup tutorial.")
 
                     safe_name = secure_filename(game_name)
@@ -29,11 +35,11 @@ class TestDocs(unittest.TestCase):
                         )
 
     def test_has_game_info(self):
-        for game_name, world_type in AutoWorldRegister.world_types.items():
-            if not world_type.hidden:
+        for game_name, web_world in WebWorldRegister.web_worlds.items():
+            if not web_world.hidden:
                 safe_name = secure_filename(game_name)
                 target_path = Utils.local_path("WebHostLib", "static", "generated", "docs", safe_name)
-                for game_info_lang in world_type.web.game_info_languages:
+                for game_info_lang in web_world.game_info_languages:
                     with self.subTest(game_name):
                         self.assertTrue(
                             os.path.isfile(Utils.local_path(target_path, f'{game_info_lang}_{safe_name}.md')),

--- a/test/webhost/test_option_presets.py
+++ b/test/webhost/test_option_presets.py
@@ -9,7 +9,7 @@ class TestOptionPresets(unittest.TestCase):
     def test_option_presets_have_valid_options(self):
         """Test that all predefined option presets are valid options."""
         for game_name, world_type in AutoWorldRegister.world_types.items():
-            presets = world_type.web.options_presets
+            presets = world_type.options_presets
             for preset_name, preset in presets.items():
                 for option_name, option_value in preset.items():
                     with self.subTest(game=game_name, preset=preset_name, option=option_name):
@@ -39,7 +39,7 @@ class TestOptionPresets(unittest.TestCase):
         value.
         """
         for game_name, world_type in AutoWorldRegister.world_types.items():
-            presets = world_type.web.options_presets
+            presets = world_type.options_presets
             for preset_name, preset in presets.items():
                 for option_name, option_value in preset.items():
                     with self.subTest(game=game_name, preset=preset_name, option=option_name):

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -68,7 +68,7 @@ class AutoWorldRegister(type):
                 else:
                     raise RuntimeError(f"World {name} should no longer have attribute 'web'!")
         if outdated_web:  # move some values from WebWorld to World
-            for key in ["option_groups", "option_presets", "location_descriptions", "item_descriptions"]:
+            for key in ["option_groups", "option_presets", "rich_text_options_doc", "location_descriptions", "item_descriptions"]:
                 if key not in dct:
                     if hasattr(outdated_web, key):
                         dct[key] = getattr(outdated_web, key)
@@ -304,6 +304,21 @@ class WebWorld(metaclass=WebWorldRegister):
     bug_report_page: Optional[str]
     """display a link to a bug report page, most likely a link to a GitHub issue page."""
 
+
+class World(metaclass=AutoWorldRegister):
+    """A World object encompasses a game's Items, Locations, Rules and additional data or functionality required.
+    A Game should have its own subclass of World in which it defines the required data structures."""
+
+    options_dataclass: ClassVar[Type[PerGameCommonOptions]] = PerGameCommonOptions
+    """link your Options mapping"""
+    options: PerGameCommonOptions
+    """resulting options for the player of this world"""
+
+    options_presets: Dict[str, Dict[str, Any]] = {}
+    """A dictionary containing a collection of developer-defined game option presets."""
+    option_groups: ClassVar[List[OptionGroup]] = []
+    """Ordered list of option groupings. Any options not set in a group will be placed in a pre-built "Game Options"."""
+
     rich_text_options_doc = False
     """Whether the WebHost should render Options' docstrings as rich text.
 
@@ -318,20 +333,6 @@ class WebWorld(metaclass=WebWorldRegister):
 
     .. _reStructuredText: https://docutils.sourceforge.io/rst.html
     """
-
-
-class World(metaclass=AutoWorldRegister):
-    """A World object encompasses a game's Items, Locations, Rules and additional data or functionality required.
-    A Game should have its own subclass of World in which it defines the required data structures."""
-
-    options_dataclass: ClassVar[Type[PerGameCommonOptions]] = PerGameCommonOptions
-    """link your Options mapping"""
-    options: PerGameCommonOptions
-    """resulting options for the player of this world"""
-    options_presets: Dict[str, Dict[str, Any]] = {}
-    """A dictionary containing a collection of developer-defined game option presets."""
-    option_groups: ClassVar[List[OptionGroup]] = []
-    """Ordered list of option groupings. Any options not set in a group will be placed in a pre-built "Game Options"."""
 
     game: ClassVar[str]
     """name the game"""

--- a/worlds/apquest/__init__.py
+++ b/worlds/apquest/__init__.py
@@ -10,3 +10,4 @@ from . import components as components
 # The main thing we do in our __init__.py is importing our world class from our world.py to initialize it.
 # Obviously, this world class needs to exist first. For this, read world.py.
 from .world import APQuestWorld as APQuestWorld
+from .web_world import APQuestWebWorld as APQuestWebWorld

--- a/worlds/apquest/__init__.py
+++ b/worlds/apquest/__init__.py
@@ -7,7 +7,8 @@
 # You can ignore this for now. If you are specifically interested in components, you can read components.py.
 from . import components as components
 
-# The main thing we do in our __init__.py is importing our world class from our world.py to initialize it.
-# Obviously, this world class needs to exist first. For this, read world.py.
+# The main thing we do in our __init__.py is importing our World and WebWorld classes
+# from our world.py and web_world.py to initialize them.
+# Obviously,these classes needs to exist first. For this, read world.py and web_world.py.
 from .world import APQuestWorld as APQuestWorld
 from .web_world import APQuestWebWorld as APQuestWebWorld

--- a/worlds/apquest/web_world.py
+++ b/worlds/apquest/web_world.py
@@ -1,14 +1,22 @@
 from BaseClasses import Tutorial
-from worlds.AutoWorld import WebWorld
-
-from .options import option_groups, option_presets
+from worlds.AutoWorld import WebWorld, WorldType
 
 
 # For our game to display correctly on the website, we need to define a WebWorld subclass.
 class APQuestWebWorld(WebWorld):
+    """
+    APQuest is a minimal 8bit-era inspired adventure game with grid-like movement.
+    Good games don't need more than six checks.
+    """
+    # The docstring should contain a description of the game, to be displayed on the WebHost.
+
     # We need to override the "game" field of the WebWorld superclass.
     # This must be the same string as the regular World class.
     game = "APQuest"
+
+    # We need to tell WebHost what type of world we are. For normal games, this is WorldType.GAME
+    # Other types are used to create webhost pages not related to a World class.
+    world_type = WorldType.GAME
 
     # Your game pages will have a visual theme (affecting e.g. the background image).
     # You can choose between dirt, grass, grassFlowers, ice, jungle, ocean, partyTime, and stone.
@@ -43,7 +51,3 @@ class APQuestWebWorld(WebWorld):
 
     # We add these tutorials to our WebWorld by overriding the "tutorials" field.
     tutorials = [setup_en, setup_de]
-
-    # If we have option groups and/or option presets, we need to specify these here as well.
-    option_groups = option_groups
-    options_presets = option_presets

--- a/worlds/apquest/world.py
+++ b/worlds/apquest/world.py
@@ -30,6 +30,7 @@ class APQuestWorld(World):
     # (Note: options.py has been imported as "apquest_options" at the top of this file to avoid a name conflict)
     options_dataclass = apquest_options.APQuestOptions
     options: apquest_options.APQuestOptions  # Common mistake: This has to be a colon (:), not an equals sign (=).
+
     # If we have option groups and/or option presets, we need to specify these here as well.
     option_groups = apquest_options.option_groups
     options_presets = apquest_options.option_presets

--- a/worlds/apquest/world.py
+++ b/worlds/apquest/world.py
@@ -5,7 +5,7 @@ from typing import Any
 from worlds.AutoWorld import World
 
 # Imports of your world's files must be relative.
-from . import items, locations, regions, rules, web_world
+from . import items, locations, regions, rules
 from . import options as apquest_options  # rename due to a name conflict with World.options
 
 # APQuest will go through all the parts of the world api one step at a time,
@@ -23,23 +23,16 @@ from . import options as apquest_options  # rename due to a name conflict with W
 # regions.py, locations.py, rules.py, items.py, options.py and web_world.py.
 # It is recommended that you read these in that specific order, then come back to the world class.
 class APQuestWorld(World):
-    """
-    APQuest is a minimal 8bit-era inspired adventure game with grid-like movement.
-    Good games don't need more than six checks.
-    """
-
-    # The docstring should contain a description of the game, to be displayed on the WebHost.
-
     # You must override the "game" field to say the name of the game.
     game = "APQuest"
-
-    # The WebWorld is a definition class that governs how this world will be displayed on the website.
-    web = web_world.APQuestWebWorld()
 
     # This is how we associate the options defined in our options.py with our world.
     # (Note: options.py has been imported as "apquest_options" at the top of this file to avoid a name conflict)
     options_dataclass = apquest_options.APQuestOptions
     options: apquest_options.APQuestOptions  # Common mistake: This has to be a colon (:), not an equals sign (=).
+    # If we have option groups and/or option presets, we need to specify these here as well.
+    option_groups = apquest_options.option_groups
+    options_presets = apquest_options.option_presets
 
     # Our world class must have a static location_name_to_id and item_name_to_id defined.
     # We define these in regions.py and items.py respectively, so we just set them here.

--- a/worlds/apsudoku/__init__.py
+++ b/worlds/apsudoku/__init__.py
@@ -8,18 +8,18 @@ class AP_SudokuWebWorld(WebWorld):
     """
     Play a little Sudoku while you're in BK mode to maybe get some useful hints
     """
-    game = 'Sudoku'
+    game = "Sudoku"
     world_type = WorldType.HINT_GAME
     options_page = False
-    theme = 'partyTime'
+    theme = "partyTime"
 
     setup_en = Tutorial(
-        tutorial_name='Setup Guide',
-        description='A guide to playing APSudoku',
-        language='English',
-        file_name='setup_en.md',
-        link='setup/en',
-        authors=['EmilyV']
+        tutorial_name="Setup Guide",
+        description="A guide to playing APSudoku",
+        language="English",
+        file_name="setup_en.md",
+        link="setup/en",
+        authors=["EmilyV"]
     )
     
     tutorials = [setup_en]

--- a/worlds/apsudoku/__init__.py
+++ b/worlds/apsudoku/__init__.py
@@ -1,9 +1,15 @@
 from typing import Dict
 
 from BaseClasses import Tutorial
-from ..AutoWorld import WebWorld, World
+from worlds.AutoWorld import WebWorld, WorldType
+
 
 class AP_SudokuWebWorld(WebWorld):
+    """
+    Play a little Sudoku while you're in BK mode to maybe get some useful hints
+    """
+    game = 'Sudoku'
+    world_type = WorldType.HINT_GAME
     options_page = False
     theme = 'partyTime'
 
@@ -17,18 +23,3 @@ class AP_SudokuWebWorld(WebWorld):
     )
     
     tutorials = [setup_en]
-
-class AP_SudokuWorld(World):
-    """
-    Play a little Sudoku while you're in BK mode to maybe get some useful hints
-    """
-    game = "Sudoku"
-    web = AP_SudokuWebWorld()
-
-    item_name_to_id: Dict[str, int] = {}
-    location_name_to_id: Dict[str, int] = {}
-
-    @classmethod
-    def stage_assert_generate(cls, multiworld):
-        raise Exception("APSudoku cannot be used for generating worlds, the client can instead connect to any slot from any world")
-

--- a/worlds/apsudoku/archipelago.json
+++ b/worlds/apsudoku/archipelago.json
@@ -1,0 +1,4 @@
+{
+	"game": "Sudoku",
+	"authors": ["EmilyV99"]
+}


### PR DESCRIPTION
## What is this fixing or adding?
HintGames/Tools currently must have a `World` class just to display on WebHost- and they display alongside supported games in doing so. This PR adds new pages on WebHost for `HintGames` and `Tools` explicitly, and allows standalone `WebWorld` classes without associated `World` classes for these types.

### Notable changes:
#### Core:
- `option_groups`, `option_presets`, `rich_text_options_doc`, `location_descriptions`, and `item_descriptions` have been moved to `World` from `WebWorld`
- `game`, `__file__`, `hidden`, and `zip_path` have been duplicated to `WebWorld`.
  - Web-related checks for `hidden` now only check `WebWorld.hidden`, rather than `World.hidden`. These values can differ from each other, if the world author desires.
- "web" has been removed from World. WebWorlds now specify "world_type", and are registered in their own registry.
  - Added test `test_has_webworld` to `TestDocs`, which checks that a matching `WebWorld` exists for every World (replacing the previous `assert` of `World.web` existing, which has been removed).
- The "world description" shown on WebHost now uses the docstring of the `WebWorld`, rather than the `World`
#### Docs:
- Updated `world api.md` / `options api.md` to reflect the core changes.
#### Webhost:
- 2 new pages, `Hint Games` and `Tools`, listed under `Supported Games` in the `Get Started` dropdown.
#### Tests:
- `test/hosting/world.py` was iterating multiple files to read, but then writing them all back out as `__init__.py`... this worked before technically, but fixed it (it wouldn't work now because `web_world.py` had to be added to the test's list to cover updating APQuest to the new format)
#### Worlds:
- Updated `APSudoku` to the new WebWorld format, removing `APSudoku`'s World class entirely. It now appears on the `Hint Games` page instead of the `Supported Games` page.
- Updated `APQuest` to the new WebWorld format, including commenting, to keep the example world up-to-date. @NewSoupVi 

## How was this tested?
Updated APSudoku's world files to use a standalone `WebWorld` with no `World`. Ran WebHost locally. All entries appear to be correct, both old worlds (which are going through compat code on loading in AutoWorldRegister), and the APSudoku WebWorld (which is skipping that as it has a valid `world_type` set).

APQuest also shows the proper description/guides/options/etc after I updated it.

Ran both the Launcher and Local Yaml Creator, saw no issues.

## If this makes graphical changes, please attach screenshots.
Hint games page:
<img width="1320" height="649" alt="image" src="https://github.com/user-attachments/assets/333ff6b6-32fb-4ccd-af42-f3252560ae5b" />
Navigation dropdown:
<img width="452" height="518" alt="image" src="https://github.com/user-attachments/assets/01a8d8b0-2397-479b-a1eb-8b5d13bcf893" />
Tools page:
<img width="1306" height="643" alt="image" src="https://github.com/user-attachments/assets/872b6509-c314-417d-8c1c-65d9d0451285" />
Supported games, descriptions and links still working:
<img width="1295" height="644" alt="image" src="https://github.com/user-attachments/assets/8f2807e4-3f8f-48c0-b2e4-e41aaeda1175" />
