### PR TITLE
Satisfactory: Fix nondeterministic creation of trap filler items

### DIFF
--- a/worlds/satisfactory/Items.py
+++ b/worlds/satisfactory/Items.py
@@ -904,7 +904,7 @@ class Items:
         self.options = options
 
         self.trap_chance = self.options.trap_chance.value
-        self.enabled_traps = tuple(self.options.trap_selection_override.value)
+        self.enabled_traps = tuple(sorted(self.options.trap_selection_override.value))
 
     @classmethod
     def create_item_uninitialized(cls, name: str, player: int) -> Item:


### PR DESCRIPTION
## What is this fixing or adding?

The `trap_selection_override` option is an `OptionSet` subclass, so its `.value` is a `set`.

Sets have nondeterministic iteration order (the iteration order depends on the hashes of the objects within the set, which can change depending on the random hashseed of the Python process).

This `.enabled_traps` is used in `Items.get_filler_item_name()` with `random.choice(self.enabled_traps)`, which is called as part of creating the item pool in `Items.build_item_pool()` (for clarity, this `random` is the world's `Random` instance passed as an argument, so no problems there). So, with `self.enabled_traps` being in a nondeterministic order, the picked trap to add to the item pool through `random.choice(self.enabled_traps)` would be nondeterministic.

Sorting the `trap_selection_override.value` before converting to a `tuple` ensures that the names in `.enabled_traps` are always in a deterministic order.

This issue was identified by merging the main branch into the PR branch for https://github.com/ArchipelagoMW/Archipelago/pull/4410 and seeing Satisfactory fail the tests for hash-determinism. With this fix applied, the tests in that PR pass.

## How was this tested?

Running the tests in https://github.com/ArchipelagoMW/Archipelago/pull/4410
