### PR TITLE
Paint: Add manifest

### DIFF
--- a/worlds/paint/archipelago.json
+++ b/worlds/paint/archipelago.json
@@ -1,0 +1,5 @@
+{
+    "game": "Paint",
+    "authors": ["MarioManTAW"],
+    "world_version": "0.5.2"
+}


### PR DESCRIPTION
## What is this fixing or adding?
All games will need to include an apworld manifest beginning in 0.7.0 so this updates Paint to the new spec.
