### PR TITLE
Super Mario Land 2: Fix Goal Logic

### DIFF
--- a/worlds/marioland2/logic.py
+++ b/worlds/marioland2/logic.py
@@ -604,8 +604,8 @@ def macro_zone_4_coins(state, player, coins):
 
 
 def marios_castle_wario(state, player):
-    return ((has_pipe_right(state, player) and has_pipe_left(state, player))
-            or (has_pipe_right(state, player) and state.has("Mario's Castle Midway Bell", player))
+    return (has_pipe_right(state, player) and 
+           (has_pipe_left(state, player) or state.has("Mario's Castle Midway Bell", player)))
 
 
 def marios_castle_midway_bell(state, player):


### PR DESCRIPTION
## What is this fixing or adding?
Super Mario Land 2's final level has a midway bell that can be added right before the final boss. The player is still required to enter a right-sided pipe to enter the arena however, and this isn't reflected in the logic.
