### PR TITLE
WebHost: Fix world sorting in /tutorial/

### DIFF
--- a/WebHostLib/misc.py
+++ b/WebHostLib/misc.py
@@ -128,8 +128,13 @@ def tutorial_landing():
                 "authors": tutorial.authors,
                 "language": tutorial.language
             }
-    tutorials = {world_name: tutorials for world_name, tutorials in title_sorted(
-        tutorials.items(), key=lambda element: "\x00" if element[0] == "Archipelago" else worlds[element[0]].game)}
+
+    worlds = dict(
+        title_sorted(
+            worlds.items(), key=lambda element: "\x00" if element[0] == "Archipelago" else worlds[element[0]].game
+        )
+    )
+
     return render_template("tutorialLanding.html", worlds=worlds, tutorials=tutorials)
 
 


### PR DESCRIPTION
## What is this fixing or adding?
While there is an attempt to `title_sorted` the worlds, it's done on the wrong dict. `tutorials` is never iterated; it's only accessed by index (via `tutorials[world_name].items()`) thus its order does not matter. The dict that needs to be sorted is `worlds`, as that's what's iterated (via `% for world_name, world_type in worlds.items() %}`)

As a result, on main the worlds on the tutorial page are not title_sorted like they are in the Supported Games list (notice how on https://archipelago.gg/tutorial/ "A Hat in Time" and "A Link to the Past" are both sorted with the As rather than with the Hs and Ls respectively).

In addition, `worlds/__init__.py` loads all world sources first, then all apworlds. `AutoWorldRegister.world_types` is a dict which as of Python 3.7 maintains insertion order. If a custom WebHost is adding additional worlds via custom_worlds, those will all be after any worlds from the worlds/ folder. Since `worlds` is never sorted, when rendering `/tutorial/` on the WebHost, all custom worlds end up coming after all worlds in worlds/:

<img width="600" alt="image" src="https://github.com/user-attachments/assets/65bd37b1-8af8-4a8a-af82-73496eea7e81" />


## How was this tested?

Confirmed locally that "Archipelago" is still first:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/f04952ff-4589-4479-9aa6-1f6fcc9827fa" />

And that "A Hat in Time" is now sorted with the Hs:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/595ed05c-e67f-4e71-b864-14c2b5ec910f" />

Put `pokemon_frlg.apworld` in `custom_worlds`. Loaded the webhost before the change, see screenshot above. Loaded after the change:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/1e1a4f4e-b535-4445-a591-ebc65f181b30" />