### PR TITLE
Terraria: fix failing to generate with Calamity enabled and full accessibility on Mechanical Bosses goal

### DIFF
--- a/worlds/terraria/Rules.dsv
+++ b/worlds/terraria/Rules.dsv
@@ -382,6 +382,9 @@ Hardmode Forge;                     ;                                           
 Adamantite Bar;                     ;                                           (Hardmode Forge & Adamantite Ore) | Wall of Flesh;
 Adamantite Pickaxe;                 Pickaxe(180);                               Hardmode Anvil & Adamantite Bar;
 Forbidden Armor;                    Armor Minions(2);                           Hardmode Anvil & Adamantite Bar & Forbidden Fragment;
+Infernal Suevite;                   Calamity;                                   @pickaxe(150) | Brimstone Elemental;
+Unholy Core;                        Calamity;                                   (Infernal Suevite & Hellstone) | Brimstone Elemental;
+Ruin Medallion;                     Calamity;                                   (Hardmode Anvil & Coin of Deceit & Unholy Core & Essence of Havoc) | Dark Matter Sheath;
 Aquatic Scourge;                    Calamity | Location | Item;
 Cragmaw Mire;                       Calamity | Location | Item;                 #Acid Rain Tier 2;
 Nuclear Fuel Rod;                   Calamity | Minions(1);                      #Cragmaw Mire | Star-Tainted Generator;
@@ -411,9 +414,6 @@ Topped Off;                         Achievement;                                
 Old One's Army Tier 2;              Location | Item;                            #Old One's Army Tier 1 & ((Wall of Flesh & @mech_boss(1)) | #Old One's Army Tier 3);
 
 // Brimstone Elemental
-Infernal Suevite;                   Calamity;                                   @pickaxe(150) | Brimstone Elemental;
-Unholy Core;                        Calamity;                                   (Infernal Suevite & Hellstone) | Brimstone Elemental;
-Ruin Medallion;                     Calamity;                                   (Hardmode Anvil & Coin of Deceit & Unholy Core & Essence of Havoc) | Dark Matter Sheath;
 
 // The Destroyer
 Soul of Might;                      ;                                           #The Destroyer | Avenger Emblem | Light Disc | (@calamity & (Mechanical Glove | Celestial Emblem));


### PR DESCRIPTION
## What is this fixing or adding?

If you generate a Terraria game with:
- Calamity: true
- Accessibility: Full
- Goal: Mechanical Bosses

it would fail to generate. This is because I had put the items required to craft the summoning item for Brimstone Elemental (a boss accessible at the same time as mech bosses) in progression after the mech bosses, so they were excluded for that goal.

## How was this tested?
Generated test worlds
