### PR TITLE
Docs: Make image in contributing doc show on main GitHub page

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -20,7 +20,7 @@ game contributions:
   It is recommended that automated github actions are turned on in your fork to have github run unit tests after
   pushing.
   You can turn them on here:  
-  ![Github actions example](./img/github-actions-example.png)
+  ![Github actions example](/docs/img/github-actions-example.png)
 
 * **When reviewing PRs, please leave a message about what was done.**
   We don't have full test coverage, so manual testing can help.


### PR DESCRIPTION
## What is this fixing or adding?
Seemingly in the past couple months, GitHub added a "Contributing" tab that makes it so `contributing.md` can be selected to view from the main repo page. However, the image inside of it fails to load since it uses a relative path, and apparently this makes it try to search from the root when viewed there. This just changes it to an absolute path to fix that.

## How was this tested?
👀, also checking the doc page from the normal place as well.

## If this makes graphical changes, please attach screenshots.
<img width="500" alt="image" src="https://github.com/user-attachments/assets/6ae9e70a-def3-49d3-a91a-4b5cb2b324a1" />

VVV
<img width="600" alt="image" src="https://github.com/user-attachments/assets/bda4fd50-816d-48d1-a449-be38028bb2c1" />
