### PR TITLE
CelesteOpenWorld: Fix farewell goal logic

### DIFF
--- a/worlds/celeste_open_world/Locations.py
+++ b/worlds/celeste_open_world/Locations.py
@@ -202,8 +202,10 @@ def create_regions_and_locations(world: CelesteOpenWorld):
                 region.add_exits([room_region.name])
 
             if room.checkpoint != None:
+                goal_and_level_farewell = (level.name.startswith("10") and world.goal_area.startswith("10"))
+                is_locked_goal = world.options.lock_goal_area and (level.name == world.goal_area or goal_and_level_farewell)
                 if room.checkpoint == "Start":
-                    if world.options.lock_goal_area and (level.name == world.goal_area or (level.name[:2] == world.goal_area[:2] and world.goal_area[:2] == "10")):
+                    if is_locked_goal:
                         world.goal_start_region: str = room.checkpoint_region
                     elif level.name == "8a":
                         world.epilogue_start_region: str = room.checkpoint_region
@@ -217,7 +219,7 @@ def create_regions_and_locations(world: CelesteOpenWorld):
                         checkpoint_location_name: world.location_name_to_id[checkpoint_location_name]
                     }, CelesteLocation)
 
-                    if world.options.lock_goal_area and (level.name == world.goal_area or (level.name[:2] == world.goal_area[:2] and world.goal_area[:2] == "10")):
+                    if is_locked_goal:
                         world.goal_checkpoint_names[room.checkpoint_region] = checkpoint_location_name
                     else:
                         menu_region.add_exits([room.checkpoint_region], {room.checkpoint_region: checkpoint_rule})


### PR DESCRIPTION
## What is this fixing or adding?
This fixes some logic related to setting farewell as the goal area, and also locking this goal area behind strawberries.

I can confirm on the current version this can generate assuming that you can reach Farewell - Singular without the required strawberries (happened in my game)

~The reason this check doesn't work is because a == b == c in Python doesn't work as might be expected - The a == b statement is evaluated first, and the result of this is compared with c, so `level.name[:2] == world.goal_area[:2] == "10"` will always evaluate to `False == "10"` or `True == "10"` (May be wrong on precedence, I forget if it does the LHS or RHS first).~

Please ignore, thanks liam for correcting!


## How was this tested?
Not tested apologies, new to the repo and unsure how to best test this rule in isolation.

## If this makes graphical changes, please attach screenshots.
N/A