### PR TITLE
Core: Allow configuring logfile retention

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -595,10 +595,17 @@ def init_logging(name: str, loglevel: typing.Union[str, int] = logging.INFO,
         sys.excepthook = handle_exception
 
     def _cleanup():
+        log_retention_days = get_settings().general_options.log_retention_days
+        if log_retention_days <= 0:
+            logging.debug("Automatic logfile cleanup has been disabled")
+            return
+        else:
+            logging.debug(f"Old logfiles will be deleted after: {log_retention_days} days")
+
         for file in os.scandir(log_folder):
             if file.name.endswith(".txt"):
                 last_change = datetime.datetime.fromtimestamp(file.stat().st_mtime)
-                if datetime.datetime.now() - last_change > datetime.timedelta(days=7):
+                if datetime.datetime.now() - last_change > datetime.timedelta(days=log_retention_days):
                     try:
                         os.unlink(file.path)
                     except Exception as e:

--- a/settings.py
+++ b/settings.py
@@ -517,7 +517,14 @@ class GeneralOptions(Group):
         """
         # created on demand, so marked as optional
 
+    class LogRetentionDays(int):
+        """
+        The number of days to retain logs before deleting old log files
+        0 -> Log files will not be automatically deleted
+        """
+
     output_path: OutputPath = OutputPath("output")
+    log_retention_days: LogRetentionDays = 7
 
 
 class ServerOptions(Group):


### PR DESCRIPTION
## What is this fixing or adding?
Adds the ability to configure how many days Archipelago logfiles are retained before automatic cleanup. Also allows disabling automatic cleanup by setting the `log_retention_days` value to 0.

## How was this tested?
Ran pytest in general and utils test folders.
Generated local host.yaml and verified debug log messages with different values for `log_retention_days`.
