### PR TITLE
Patch: Warn users of APWorld version mismatch before patching

### DIFF
--- a/worlds/Files.py
+++ b/worlds/Files.py
@@ -288,6 +288,22 @@ class APAutoPatchInterface(APPatch, abc.ABC, metaclass=AutoPatchRegister):
     def patch(self, target: str) -> None:
         """ create the output file with the file name `target` """
 
+    def verify_version(self) -> None:
+        """
+        Verify compatibility between a game's currently installed
+        world version and the version used for generation.
+        Warns the user or raises an IncompatiblePatchError if the versions are too different.
+        """
+        from Utils import messagebox
+        from .AutoWorld import AutoWorldRegister
+        game_version = AutoWorldRegister.world_types[self.game].world_version if self.game else None
+        if game_version and self.world_version and game_version != self.world_version:
+            info_msg = "This patch was generated with " \
+                       f"{self.game} version {self.world_version.as_simple_string()}, " \
+                       f"but its currently installed version is {game_version.as_simple_string()}. " \
+                       "You may encounter errors while patching or connecting."
+            messagebox("APWorld version mismatch", info_msg, False)
+
 
 class APProcedurePatch(APAutoPatchInterface):
     """


### PR DESCRIPTION
## What is this fixing or adding?
Adds an explicit warning for users if the game they're playing has a different APWorld than the one used for generation. I've noticed that the errors that follow in that situation can often leave users confused, especially when APWorlds change their patching procedures, so I'm hoping to mitigate that.

## How was this tested?
Generated a multiworld with Pokemon Crystal 5.3.5, patched, then downgraded to 5.3.0 and patched again

## If this makes graphical changes, please attach screenshots.
<img width="794" height="582" alt="image" src="https://github.com/user-attachments/assets/f31fdfdb-e95c-480b-82fc-05a8b2d1ab64" />
