### PR TITLE
Core: Add SDL_MOUSE_FOCUS_CLICKTHROUGH=1 environment variable to kvui

### DIFF
--- a/kvui.py
+++ b/kvui.py
@@ -19,6 +19,7 @@ os.environ["KIVY_NO_CONSOLELOG"] = "1"
 os.environ["KIVY_NO_FILELOG"] = "1"
 os.environ["KIVY_NO_ARGS"] = "1"
 os.environ["KIVY_LOG_ENABLE"] = "0"
+os.environ["SDL_MOUSE_FOCUS_CLICKTHROUGH"] = "1"
 
 import Utils
 


### PR DESCRIPTION
## What is this fixing or adding?
This fixes the "double click" required when pressing buttons on the Kivy UI when the window is unfocused.

## How was this tested?
Tested by trying various buttons on the Launcher while the window is focused and unfocused. Tested on Windows 10, untested on other operating systems.
https://github.com/user-attachments/assets/6006db8a-b612-493b-956c-0f1b56827de5
