### PR TITLE
MM2: Fix /request command help

### DIFF
--- a/worlds/mm2/client.py
+++ b/worlds/mm2/client.py
@@ -140,8 +140,8 @@ def cmd_pool(self: "BizHawkClientCommandProcessor") -> None:
 
 
 def cmd_request(self: "BizHawkClientCommandProcessor", amount: str, target: str) -> None:
-    from worlds._bizhawk.context import BizHawkClientContext
     """Request a refill from EnergyLink."""
+    from worlds._bizhawk.context import BizHawkClientContext
     if self.ctx.game != "Mega Man 2":
         logger.warning("This command can only be used when playing Mega Man 2.")
         return


### PR DESCRIPTION
## What is this fixing or adding?

Hi! This is just a tiny one-line fix. The `import` instruction made it so the docstring below it was not found by `inspect.getdoc` in [MultiServer.py:1373](https://github.com/ArchipelagoMW/Archipelago/blob/5a88641228c6237abef9e075a03ab80112f5d089/MultiServer.py#L1373) - resulting in the `/help` command in the text client not showing any information if EnergyLink is enabled, only an exception from trying to call `split` on `None`.

(Tagging @Silvris as world maintainer)

## How was this tested?

I ran into this problem on both the v0.6.5 release and latest `main`, using Python 3.13.11 on Debian. After this change, `/help` and the mouseover information when hovering over "Command" works as expected.