### PR TITLE
Satisfactory: Update Universal Tracker Method for FinalElevatorPhase Option

### DIFF
--- a/worlds/satisfactory/__init__.py
+++ b/worlds/satisfactory/__init__.py
@@ -183,8 +183,7 @@ class SatisfactoryWorld(World):
 
         self.options.goal_selection.value = slot_data["Data"]["Options"]["GoalSelection"]
         self.options.goal_requirement.value = slot_data["Data"]["Options"]["GoalRequirement"]
-        # TODO rename slot data FinalElevatorTier to FinalElevatorPhase in the mod, then here
-        self.options.final_elevator_phase.value = slot_data["Data"]["Options"]["FinalElevatorTier"]
+        self.options.final_elevator_phase.value = slot_data["Data"]["Options"]["FinalElevatorPhase"]
         self.options.goal_awesome_sink_points_total.value = slot_data["Data"]["Options"]["FinalResourceSinkPointsTotal"]
         self.options.goal_awesome_sink_points_per_minute.value = \
             slot_data["Data"]["Options"]["FinalResourceSinkPointsPerMinute"]


### PR DESCRIPTION
## What is this fixing or adding?
Currently Universal Tracker fails to load the Satisfactory slot due to this one line not being updated from "FinalElevatorTier" to "FinalElevatorPhase".


## How was this tested?
Edited the Satisfactory APWorld archive locally. Verified Universal Tracker now works with the modified apworld file.
