### PR TITLE
The Messenger: Fix lambda capture issue in add_closed_portal_reqs

### DIFF
--- a/worlds/messenger/portals.py
+++ b/worlds/messenger/portals.py
@@ -306,4 +306,4 @@ def add_closed_portal_reqs(world: "MessengerWorld") -> None:
     closed_portals = [entrance for entrance in PORTALS if f"{entrance} Portal" not in world.starting_portals]
     for portal in closed_portals:
         tower_exit = world.multiworld.get_entrance(f"ToTHQ {portal} Portal", world.player)
-        tower_exit.access_rule = lambda state: state.has(portal, world.player)
+        tower_exit.access_rule = lambda state, portal_item=portal: state.has(portal_item, world.player)


### PR DESCRIPTION
## What is this fixing or adding?

I wrote a [fuzzer hook](https://github.com/Mysteryem/Archipelago-fuzzer/blob/mysteryem_hooks/hooks/detect_rule_variable_capture_issues.py) for detecting lambda capture issues and it identified this case in `add_closed_portal_reqs` where each rule would end up using the last value of `portal` in the loop.

## How was this tested?

All I've done is run some generations with the fuzzer. I don't know enough about The Messenger to test it properly, or to know what impact this issue would have had on generation.