### PR TITLE
TWW: Add save file validation

### DIFF
--- a/worlds/tww/TWWClient.py
+++ b/worlds/tww/TWWClient.py
@@ -688,11 +688,12 @@ async def dolphin_sync_task(ctx: TWWContext) -> None:
                 # If Dolphin is not hooked, attempt to connect to Dolphin.
                 await _attempt_dolphin_connection(ctx)
             else:
+                # If the player is not in-game (e.g., on file select), clear the give item array
+                # This prevents title-screen Link from being given any items.
                 if not check_ingame():
-                    # If the player is not in-game (e.g., on file select), clear the give item array
-                    # This prevents title-screen Link from being given any items.
                     dolphin_memory_engine.write_bytes(GIVE_ITEM_ARRAY_ADDR, bytes([0xFF] * ctx.len_give_item_array))
-                elif ctx.slot is None:
+
+                if ctx.slot is None:
                     # If the player has not authenticated their slot name, attempt to do so.
                     if not ctx.auth:
                         ctx.auth = read_string(SLOT_NAME_ADDR, 0x40)

--- a/worlds/tww/__init__.py
+++ b/worlds/tww/__init__.py
@@ -26,7 +26,7 @@ from .randomizers.ItemPool import generate_itempool
 from .randomizers.RequiredBosses import RequiredBossesRandomizer
 from .Rules import set_rules
 
-VERSION: tuple[int, int, int] = (3, 0, 0)
+VERSION: tuple[int, int, int] = (3, 1, 0)
 
 
 def run_client() -> None:
@@ -130,7 +130,7 @@ class TWWWorld(World):
 
     item_name_groups: ClassVar[dict[str, set[str]]] = item_name_groups
 
-    required_client_version: tuple[int, int, int] = (0, 5, 1)
+    required_client_version: tuple[int, int, int] = (0, 6, 0)
 
     web: ClassVar[TWWWeb] = TWWWeb()
 

--- a/worlds/tww/archipelago.json
+++ b/worlds/tww/archipelago.json
@@ -1,0 +1,6 @@
+{
+  "game": "The Wind Waker",
+  "minimum_ap_version": "0.6.0",
+  "world_version": "3.1.0",
+  "authors": ["tanjo3"]
+}


### PR DESCRIPTION
## What is this fixing or adding?
All seeds for TWW use the same game ID. What this means is that when a player loads a new seed with a newly randomized ISO, their old save file will still be there. Assigning each seed a unique game ID, or even just allowing a few more game IDs (see #5186), can help with this, but there is the issue of juggling these extra game save files, as each game ID creates a new .gci file in Dolphin.

This PR **does not** address this issue. Instead, it's addressing another issue that is related to player experience when playing with multiple TWW seeds. There is currently no save file validation when connecting to the server. Since TWW checks for set flags (in simple terms) to check locations, if a player connects to a save file for a different seed, all the locations checked in that save file will automatically be checked for the current slot, even though the player never checked those locations in that save file. In a worst-case scenario, a player might accidentally open a save file with every location checked and instantly "release" their current slot.

To resolve this, the patcher generates a hash from the seed and slot name, yielding a unique identifier. This identifier is added to the randomized ISO. Upon creating a new save file, the identifier is copied from the ISO to the save file. Thus, whenever a save file is opened, the client can check that the save file and ISO identifiers match. If they do not, the client will automatically disconnect the player from the server, preventing any locations from accidentally being sent.

This change, however, doesn't prevent loading the save state of a different save file from sending locations, as save states will modify the identifier in both the save file and the ISO.

As a bonus, since there is this additional validation, the slot name authentication has been moved up in the task loop, meaning that a player can now connect to the server while on the title screen or file select screen. If they do connect to an invalid save file, the changes in this PR will disconnect them immediately.

Like with #5686, this change requires a version update of the patcher program.
The updated code can be found here: https://github.com/tanjo3/wwrando/tree/ap-add-seed-identifier

## How was this tested?
Ran the game, attempted to connect to a valid save file, and an invalid save file. The client properly disconnected me when I tried to connect to the invalid save file. I was able to properly connect and play when I loaded the valid save file.

## If this makes graphical changes, please attach screenshots.
N/A