### PR TITLE
Rewording python requirement for AP

### DIFF
--- a/docs/running from source.md
+++ b/docs/running from source.md
@@ -7,10 +7,9 @@ use that version. These steps are for developers or platforms without compiled r
 ## General
 
 What you'll need:
- * [Python 3.11.9 or newer](https://www.python.org/downloads/), not the Windows Store version
+ * [Python 3.11.9 or newer but less than 3.14](https://www.python.org/downloads/), not the Windows Store version
    * On Windows, please consider only using the latest supported version in production environments since security
      updates for older versions are not easily available.
-   * Python 3.13.x is currently the newest supported version
  * pip: included in downloads from python.org, separate in many Linux distributions
  * Matching C compiler
    * possibly optional, read operating system specific sections


### PR DESCRIPTION
Many many people have read this and then installed 3.14, so it clearly needs rewording.