### PR TITLE
Satisfactory: Fix typo in GoalSelection possible values description comment

### DIFF
--- a/worlds/satisfactory/Options.py
+++ b/worlds/satisfactory/Options.py
@@ -471,7 +471,7 @@ class GoalSelection(OptionSet):
     Configure them further with other options.
 
     Possible values are:
-    - **Space Elevator Tier**
+    - **Space Elevator Phase**
     - **AWESOME Sink Points (total)**
     - **AWESOME Sink Points (per minute)**
     - **Exploration Collectables**


### PR DESCRIPTION
## What is this fixing or adding?

The user-facing comment currently claims that `Space Elevator Tier` is a valid option value, but it is not.

Looks like it was caused by this code review 5c7435e63186340bd6bae2ec7d7e7ecbbfb461e5 and the value's rename 49e0f32c1e24d24029947374bf63ec3097b6444c happening separately or getting lost in a merge conflict or something.

This problem only affects the comment the user sees in sample YAMLs and in the web options portal; the value is already correct elsewhere in the code (excluding #5812).

## How was this tested?

Not tested, it's just a comment.
