### PR TITLE
Core: replace the eval in OptionsCreator.py

### DIFF
--- a/OptionsCreator.py
+++ b/OptionsCreator.py
@@ -509,8 +509,10 @@ class OptionsCreator(ThemedApp):
                     self.options[name] = "random-" + str(self.options[name])
                 else:
                     self.options[name] = self.options[name].replace("random-", "")
-                    if self.options[name].isnumeric() or self.options[name] in ("True", "False"):
-                        self.options[name] = eval(self.options[name])
+                    if self.options[name].isnumeric():
+                        self.options[name] = int(self.options[name])
+                    elif self.options[name] in ("True", "False"):
+                        self.options[name] = self.options[name] == "True"
 
                 base_object = instance.parent.parent
                 label_object = instance.parent


### PR DESCRIPTION
## What is this fixing or adding?

Replaces the `eval` in OptionsCreator.py with converting strings to `int`/`bool` directly.

`eval`, while probably safe here, can be a security concern, which could have complicated maintenance and/or refactors.

## How was this tested?

I clicked the "Random?" button on numeric, boolean and other options, with extra logging to log the new value of `self.options[name]` each time, and which conditional branch was being hit.