### PR TITLE
MultiServer: Add commands to list item and location groups on server

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2536,8 +2536,8 @@ class ServerCommandProcessor(CommonCommandProcessor):
     def _cmd_location_groups(self, player_name: str, *key: str) -> bool:
         """
         List all location group names for the specified player.
-        :param key: Which location group to filter to. Will log all groups if empty.
 
+        :param key: Which location group to filter to. Will log all groups if empty.
         """
         seeked_player, usable, response = get_intended_text(player_name, self.ctx.player_names.values())
         if usable:

--- a/worlds/generic/docs/commands_en.md
+++ b/worlds/generic/docs/commands_en.md
@@ -67,7 +67,8 @@ including the exclamation point.
 - `/option <option name> <option value>` Set a server option. For a list of options, use the `/options` command.
 - `/alias <player name> <alias name>` Assign a player an alias, allowing you to reference the player by the alias in commands.
   `!alias <player name>` on its own will reset the alias to the player's original name.
-
+- `/item_groups <player name>` Lists all the item group names for the specified player's game.
+- `/location_groups <player name>` Lists all the location group names for the specified player's game.
 
 ### Collect/Release
 - `/collect <player name>` Send out any items remaining in the multiworld belonging to the given player.


### PR DESCRIPTION
## What is this fixing or adding?
Adds additional commands:
```
def _cmd_item_groups(self, player_name: str, *key: str) -> bool:
```
and
```
def _cmd_location_groups(self, player_name: str, *key: str) -> bool:
```
To MultiServer.py.
Primarily for testing newly added item groups without needing to spin up a client but also keeps the commands consistent with the already existing commands on the client side.

## How was this tested?
- Run up a generation of any game with item and location groups
- `/item_groups Player1` item groups are listed.
- `/location_groups Player1` location groups are listed.
- `/item_groups Player1 <ItemGroupName>` items are listed for the named group.
- `/location_groups Player1 <LocationGroupName>` locations are listed for the named group.
Also tested
- Invalid name, prints the response suggesting a valid player name
- Invalid group, defaults to printing all groups

