### PR TITLE
Multiserver: Remove dead code

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -917,12 +917,6 @@ async def server(websocket: "ServerConnection", path: str = "/", ctx: Context = 
 
 
 async def on_client_connected(ctx: Context, client: Client):
-    players = []
-    for team, clients in ctx.clients.items():
-        for slot, connected_clients in clients.items():
-            if connected_clients:
-                name = ctx.player_names[team, slot]
-                players.append(NetworkPlayer(team, slot, ctx.name_aliases.get((team, slot), name), name))
     games = {ctx.games[x] for x in range(1, len(ctx.games) + 1)}
     games.add("Archipelago")
     await ctx.send_msgs(client, [{


### PR DESCRIPTION
## What is this fixing or adding?
Removes a dead list construction from `Multiserver.on_client_connected()`

## How was this tested?
Ran Multiserver locally, connected a text client, didn't crash

## If this makes graphical changes, please attach screenshots.
N/A