### PR TITLE
[FFMQ] Update link to upstream rando

### DIFF
--- a/worlds/ffmq/docs/setup_en.md
+++ b/worlds/ffmq/docs/setup_en.md
@@ -60,7 +60,7 @@ validator page: [YAML Validation page](/mysterycheck)
 2. You will be presented with a "Seed Info" page.
 3. Click the "Create New Room" link.
 4. You will be presented with a server page, from which you can download your `.apmq` patch file.
-5. Go to the [FFMQR website](https://ffmqrando.net/Archipelago) and select your Final Fantasy Mystic Quest ROM
+5. Go to the [FFMQR website](https://ap.ffmqrando.net/Archipelago) and select your Final Fantasy Mystic Quest ROM
 and the .apmq file you received, choose optional preferences, and click `Generate` to get your patched ROM.
 7. Since this is a single-player game, you will no longer need the client, so feel free to close it.
 
@@ -72,7 +72,7 @@ When you join a multiworld game, you will be asked to provide your config file t
 the host will provide you with either a link to download your patch file, or with a zip file containing
 everyone's patch files. Your patch file should have a `.apmq` extension.
 
-Go to the [FFMQR website](https://ffmqrando.net/Archipelago) and select your Final Fantasy Mystic Quest ROM
+Go to the [FFMQR website](https://ap.ffmqrando.net/Archipelago) and select your Final Fantasy Mystic Quest ROM
 and the .apmq file you received, choose optional preferences, and click `Generate` to get your patched ROM.
 
 Manually launch the SNI Client, and run the patched ROM in your chosen software or hardware.

--- a/worlds/ffmq/docs/setup_fr.md
+++ b/worlds/ffmq/docs/setup_fr.md
@@ -64,7 +64,7 @@ Si vous voulez valider votre fichier de configuration pour être sûr qu'il fonc
 2. Il vous sera alors présenté une page d'informations sur la seed
 3. Cliquez sur le lien "Create New Room".
 4. Vous verrez s'afficher la page du server, de laquelle vous pourrez télécharger votre fichier patch `.apmq`.
-5. Rendez-vous sur le [site FFMQR](https://ffmqrando.net/Archipelago).
+5. Rendez-vous sur le [site FFMQR](https://ap.ffmqrando.net/Archipelago).
 Sur cette page, sélectionnez votre ROM Final Fantasy Mystic Quest original dans le boîte "ROM", puis votre ficher patch `.apmq` dans la boîte "Load Archipelago Config File".
 Cliquez sur "Generate". Un téléchargement avec votre ROM aléatoire devrait s'amorcer.
 6. Puisque cette partie est à un seul joueur, vous n'avez plus besoin du client Archipelago ni du serveur, sentez-vous libre de les fermer.
@@ -77,7 +77,7 @@ Quand vous rejoignez un multiworld, il vous sera demandé de fournir votre fichi
 s'occupe de la génération. Une fois cela fait, l'hôte vous fournira soit un lien pour télécharger votre patch, soit un
 fichier `.zip` contenant les patchs de tous les joueurs. Votre patch devrait avoir l'extension `.apmq`.
 
-Allez au [site FFMQR](https://ffmqrando.net/Archipelago) et sélectionnez votre ROM Final Fantasy Mystic Quest original dans le boîte "ROM", puis votre ficher patch `.apmq` dans la boîte "Load Archipelago Config File".
+Allez au [site FFMQR](https://ap.ffmqrando.net/Archipelago) et sélectionnez votre ROM Final Fantasy Mystic Quest original dans le boîte "ROM", puis votre ficher patch `.apmq` dans la boîte "Load Archipelago Config File".
 Cliquez sur "Generate". Un téléchargement avec votre ROM aléatoire devrait s'amorcer.
 
 Ouvrez le client SNI (sur Windows ArchipelagoSNIClient.exe, sur Linux ouvrez le `.appImage` puis cliquez sur SNI Client), puis ouvrez le ROM téléchargé avec votre émulateur choisi.


### PR DESCRIPTION
## What is this fixing or adding?
The 1.7 version of the upstream rando will lose backward compatibility with versions 1.5 and 1.6, this update the links in the guides to direct AP website players to a 1.5/1.6 compatible version.

## How was this tested?
n/a

## If this makes graphical changes, please attach screenshots.
n/a