### PR TITLE
Core: for #5700 introduce finalize_multiworld and pre_output stages: Added the methods to the unit tests

### DIFF
--- a/test/bases.py
+++ b/test/bases.py
@@ -248,6 +248,7 @@ class WorldTestBase(unittest.TestCase):
         with self.subTest("Game", game=self.game, seed=self.multiworld.seed):
             distribute_items_restrictive(self.multiworld)
             call_all(self.multiworld, "post_fill")
+            call_all(self.multiworld, "finalize_multiworld")
             self.assertTrue(fulfills_accessibility(), "Collected all locations, but can't beat the game.")
             placed_items = [loc.item for loc in self.multiworld.get_locations() if loc.item and loc.item.code]
             self.assertLessEqual(len(self.multiworld.itempool), len(placed_items),

--- a/test/general/test_ids.py
+++ b/test/general/test_ids.py
@@ -88,6 +88,7 @@ class TestIDs(unittest.TestCase):
                 multiworld = setup_solo_multiworld(world_type)
                 distribute_items_restrictive(multiworld)
                 call_all(multiworld, "post_fill")
+                call_all(multiworld, "finalize_multiworld")
                 datapackage = world_type.get_data_package_data()
                 for item_group, item_names in datapackage["item_name_groups"].items():
                     self.assertIsInstance(item_group, str,

--- a/test/general/test_implemented.py
+++ b/test/general/test_implemented.py
@@ -46,6 +46,8 @@ class TestImplemented(unittest.TestCase):
             with self.subTest(game=game_name, seed=multiworld.seed):
                 distribute_items_restrictive(multiworld)
                 call_all(multiworld, "post_fill")
+                call_all(multiworld, 'finalize_multiworld')
+                call_all(multiworld, 'pre_output')
                 for key, data in multiworld.worlds[1].fill_slot_data().items():
                     self.assertIsInstance(key, str, "keys in slot data must be a string")
                     convert_to_base_types(data)  # only put base data types into slot data
@@ -93,6 +95,7 @@ class TestImplemented(unittest.TestCase):
             with self.subTest(game=game_name, seed=multiworld.seed):
                 distribute_items_restrictive(multiworld)
                 call_all(multiworld, "post_fill")
+                call_all(multiworld, "finalize_multiworld")
 
                 # Note: `multiworld.get_spheres()` iterates a set of locations, so the order that locations are checked
                 # is nondeterministic and may vary between runs with the same seed.

--- a/test/general/test_items.py
+++ b/test/general/test_items.py
@@ -121,6 +121,7 @@ class TestBase(unittest.TestCase):
             call_all(multiworld, "pre_fill")
             distribute_items_restrictive(multiworld)
             call_all(multiworld, "post_fill")
+            call_all(multiworld, "finalize_multiworld")
             self.assertTrue(multiworld.can_beat_game(CollectionState(multiworld)), f"seed = {multiworld.seed}")
 
         for game_name, world_type in AutoWorldRegister.world_types.items():

--- a/test/multiworld/test_multiworlds.py
+++ b/test/multiworld/test_multiworlds.py
@@ -61,6 +61,7 @@ class TestAllGamesMultiworld(MultiworldTestBase):
         with self.subTest("filling multiworld", seed=self.multiworld.seed):
             distribute_items_restrictive(self.multiworld)
             call_all(self.multiworld, "post_fill")
+            call_all(self.multiworld, "finalize_multiworld")
             self.assertTrue(self.fulfills_accessibility(), "Collected all locations, but can't beat the game")
 
 
@@ -78,4 +79,5 @@ class TestTwoPlayerMulti(MultiworldTestBase):
         with self.subTest("filling multiworld", games=world_type.game, seed=self.multiworld.seed):
             distribute_items_restrictive(self.multiworld)
             call_all(self.multiworld, "post_fill")
+            call_all(self.multiworld, "finalize_multiworld")
             self.assertTrue(self.fulfills_accessibility(), "Collected all locations, but can't beat the game")


### PR DESCRIPTION
## What is this fixing or adding?
#5700 did not use the new world functions in its unit tests, which would likely fail if they were used

## How was this tested?
I added set a flag in APQuest, when pre_output was run, and asserted that flag was set in fill_slot_data and generate_output
I don't know how I could check if finalize_multiworld was ran every time it needed to because I'm not even sure when it should, I guessed it was each time after pre_fill since there is no prog balancing in the tests

## Additional notes
Ocarina of Time's special handling could have been removed by implementing pre_output in it, but that would slow down the PR, and I think it's a job for a different PR
