### PR TITLE
Noita: Fix filling Shop Item locations without updating item.location

### DIFF
--- a/worlds/noita/items.py
+++ b/worlds/noita/items.py
@@ -79,7 +79,7 @@ def create_all_items(world: NoitaWorld) -> None:
         if world.multiworld.players == 1:
             for location in world.multiworld.get_unfilled_locations(player):
                 if "Shop Item" in location.name:
-                    location.item = create_item(player, itempool.pop())
+                    world.multiworld.push_item(location, create_item(player, itempool.pop()), False)
             locations_to_fill = len(world.multiworld.get_unfilled_locations(player))
 
     itempool += create_random_items(world, filler_weights, locations_to_fill - len(itempool))


### PR DESCRIPTION
## What is this fixing or adding?

In single-player multiworlds with small item pools, Noita was manually placing some items into Shop Item locations, but was only setting location.item, and not also setting item.location so that the item and location refer to one another.

This has been fixed by using the MultiWorld.push_item() helper method to place the items instead of manually placing the items.

## How was this tested?

I ran generations with the archipelago [fuzzer tool](https://github.com/Eijebong/Archipelago-fuzzer), and a [fuzzer hook](https://github.com/Mysteryem/Archipelago-fuzzer/blob/mysteryem_hooks/hooks/check_placement_item_location_references.py) that checks an equivalent of `all(loc.item.location is loc for loc in multiworld.get_filled_locations())` after each generation step.

Before the changes in this PR, Noita would often fail after the `create_items` generation step because there would be cases where `loc.item.location` was `None`, when it should have been `loc`.