### PR TITLE
CommonClient: Add explicit message for connection timeout

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -869,7 +869,7 @@ async def server_loop(ctx: CommonContext, address: typing.Optional[str] = None) 
     logger.info(f'Connecting to Archipelago server at {address}')
     try:
         port = server_url.port or 38281  # raises ValueError if invalid
-        socket = await websockets.connect(address, port=port, open_timeout=20, ping_timeout=None, ping_interval=None,
+        socket = await websockets.connect(address, port=port, ping_timeout=None, ping_interval=None,
                                           ssl=get_ssl_context() if address.startswith("wss://") else None,
                                           max_size=ctx.max_size)
         if ctx.ui is not None:


### PR DESCRIPTION
## What is this fixing or adding?
I ~~also~~ added a message box specifically for a timeout to to make the cause more clear (and I edited the message box function to not add two extra spaces for a blank text, not sure if that'll affect any current cases).

## How was this tested?
Trying to connect to a local MultiServer with delay artificially added to the start of the `WebSocketServerProtocol.handler` function to try to simulate slowdown.

## If this makes graphical changes, please attach screenshots.
<img width="512" height="143" alt="image" src="https://github.com/user-attachments/assets/50afad6c-dbe7-4872-8854-fa99f190504f" />
