### PR TITLE
WebHost: Hopefully stop rooms from reopening

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -635,7 +635,7 @@ class Context:
                         time.sleep(max(1.0, next_wakeup))
                         if self.save_dirty:
                             self.logger.debug("Saving via thread.")
-                            self._save()
+                            self._save(bool(self.exit_event.is_set()))
                     except OperationalError as e:
                         self.logger.exception(e)
                         self.logger.info(f"Saving failed. Retry in {self.auto_save_interval} seconds.")


### PR DESCRIPTION
## What is this fixing or adding?
use exit_event as a hint for if the _save call should expect the room to be closing

as noted in my [report in discord,](https://discord.com/channels/731205301247803413/731214280439103580/1461900126904778785) i'm not confident that exit_event *should* be used like this, but it seems to function so i'll leave confirmation of that as an exercise of further reviewers

## How was this tested?
dropped timeout time to 60 seconds and was able to relatively consistently see the issue of restarting rooms and watched their last active time update with only a connected text client
retried with this fix and did not see the last active time jump forward nor the room reopen

## If this makes graphical changes, please attach screenshots.
