### PR TITLE
customserver: don't set last_activity that will be overwritten later

### DIFF
--- a/WebHostLib/customserver.py
+++ b/WebHostLib/customserver.py
@@ -325,7 +325,7 @@ def run_server_process(name: str, ponyconfig: dict, static_server_data: dict,
 
             except (KeyboardInterrupt, SystemExit):
                 if ctx.saving:
-                    ctx._save()
+                    ctx._save(True)
                     setattr(asyncio.current_task(), "save", None)
             except Exception as e:
                 with db_session:
@@ -336,7 +336,7 @@ def run_server_process(name: str, ponyconfig: dict, static_server_data: dict,
                 raise
             else:
                 if ctx.saving:
-                    ctx._save()
+                    ctx._save(True)
                     setattr(asyncio.current_task(), "save", None)
             finally:
                 try:


### PR DESCRIPTION
## What is this fixing or adding?

Changes the saving during shutdown to not update the last_activity column twice.

This **may or may not** be related to the "spinup after 1 minute" we see on webhost:
* in some logs we saw that there was no "shutting down room" message, which means that  `last_activity` was likely not updated

Note that getting an error there might still leak the saving thread if exit_event is never set, so a follow-up PR to rework that, or log the error, would be good.

## Why

In the regular shutdown flow, last_activity will be overwritten a few lines down.

Should the update to last_activity fail, setting it in the changed lines would be problematic.

But even if the update does not fail, updating the column would be useless work since it'll be overwritten anyway.

## How was this tested?

Only in CI. test_hosting should cover the change.