### PR TITLE
APWorld Builder: Add option to skip opening output folder

### DIFF
--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -269,8 +269,9 @@ if not is_frozen():
         from Launcher import open_folder
 
         import argparse
-        parser = argparse.ArgumentParser("Build script for APWorlds")
-        parser.add_argument("worlds", type=str, default=(), nargs="*", help="Names of APWorlds to build.")
+        parser = argparse.ArgumentParser(prog="Build APWorlds", description="Build script for APWorlds")
+        parser.add_argument("worlds", type=str, default=(), nargs="*", help="names of APWorlds to build")
+        parser.add_argument("--skip_open_folder", action="store_true", help="don't open the output build folder")
         args = parser.parse_args(launch_args)
 
         if args.worlds:
@@ -320,7 +321,9 @@ if not is_frozen():
                     zf.write(pathlib.Path(world_directory, file), pathlib.Path(file_name, file))
 
                 zf.writestr(apworld.manifest_path, json.dumps(manifest))
-        open_folder(apworlds_folder)
+
+        if not args.skip_open_folder:
+            open_folder(apworlds_folder)
 
     components.append(Component("Build APWorlds", func=_build_apworlds, cli=True,
                                 description="Build APWorlds from loose-file world folders."))


### PR DESCRIPTION
## What is this fixing or adding?
Adding one part from #5499 to match the generate template's option for the same thing. The way that argparse is setup here is also probably better and maybe should be added to there as well.

## How was this tested?
Running the component with and without the arg, and also looking at the help/error messages.

## If this makes graphical changes, please attach screenshots.
🚫📂