### PR TITLE
Core: Bump version from 0.6.6 to 0.6.7

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -49,7 +49,7 @@ class Version(typing.NamedTuple):
         return ".".join(str(item) for item in self)
 
 
-__version__ = "0.6.6"
+__version__ = "0.6.7"
 version_tuple = tuplize_version(__version__)
 
 is_linux = sys.platform.startswith("linux")


### PR DESCRIPTION
## What is this fixing or adding?

Changes the AP version to 0.6.7, which will be the next

## Why

0.6.6 is out, so make dev servers report 0.6.7

## How was this tested?

Trivial change