### PR TITLE
TWW: Encrypt APTWW patch file

### DIFF
--- a/worlds/tww/__init__.py
+++ b/worlds/tww/__init__.py
@@ -28,7 +28,7 @@ from .randomizers.ItemPool import generate_itempool
 from .randomizers.RequiredBosses import RequiredBossesRandomizer
 from .Rules import set_rules
 
-VERSION: tuple[int, int, int] = (3, 0, 0)
+VERSION: tuple[int, int, int] = (3, 1, 0)
 
 
 def run_client() -> None:
@@ -178,7 +178,7 @@ class TWWWorld(World):
 
     item_name_groups: ClassVar[dict[str, set[str]]] = item_name_groups
 
-    required_client_version: tuple[int, int, int] = (0, 5, 1)
+    required_client_version: tuple[int, int, int] = (0, 6, 0)
 
     web: ClassVar[TWWWeb] = TWWWeb()
 

--- a/worlds/tww/archipelago.json
+++ b/worlds/tww/archipelago.json
@@ -1,0 +1,6 @@
+{
+  "game": "The Wind Waker",
+  "minimum_ap_version": "0.6.0",
+  "world_version": "3.1.0",
+  "authors": ["tanjo3"]
+}

--- a/worlds/tww/requirements.txt
+++ b/worlds/tww/requirements.txt
@@ -1,1 +1,2 @@
 dolphin-memory-engine>=1.3.0
+cryptography>=45.0.7


### PR DESCRIPTION
## What is this fixing or adding?
This PR replaces the base64 encoding of APTWW patch files with hybrid encryption to prevent players from inspecting seed data during races. The previous base64 encoding offered no real protection, as anyone could trivially decode its contents. As the patch file is effectively a plandomizer, anyone could look up item placements or entrance connections in their world.

With this change, the public key embedded in the world code can only encrypt data. Decryption requires the private key, which is stored as a secret in the patcher repository. The encryption uses a [hybrid scheme](https://medium.com/@chandangupta86/hybrid-encryption-the-perfect-marriage-of-rsa-and-aes-for-secure-data-transmission-399cdb95924e) where a random AES key encrypts the payload, and the AES key is then encrypted with RSA. The output patch file contains the encrypted AES key, the nonce, and the encrypted payload. To perform the encryption, the `cryptography` library has been added to `requirements.txt` as a new dependency.

In addition to these security enhancements, this PR also replaces YAML serialization with JSON. YAML was originally used to make the patch file human-readable for debugging, but this is no longer relevant now that the contents are encrypted. JSON offers several advantages: it's built into Python's standard library, it's faster to serialize and parse, and it supports more complex types such as `StrEnum`.

Like with #5686 and #5819, this change requires a version update of the patcher program.
The updated code can be found here: https://github.com/tanjo3/wwrando/tree/ap-encrypt-patch-file

## How was this tested?
Generated a multiworld with TWW and used the patcher build created via GH Actions from [here](https://github.com/tanjo3/wwrando/actions/runs/21152254647). The ISO was successfully patched. Did a few checks and everything seemed to work as normal.

## If this makes graphical changes, please attach screenshots.
N/A