### PR TITLE
Core: Add Pymem to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,6 @@ pyshortcuts>=1.9.6
 pathspec>=0.12.1
 kivymd @ git+https://github.com/kivymd/KivyMD@5ff9d0d
 kivymd>=2.0.1.dev0
+
+# Legacy world dependencies that custom worlds rely on
+Pymem>=1.13.0


### PR DESCRIPTION
As to not break custom worlds when Jak & Daxter moves from PyMem to PyMemoryEditor

Tested: No