### PR TITLE
Docs (DS3): Fix the documentation for the Simple Early Bosses option 

### DIFF
--- a/worlds/dark_souls_3/Options.py
+++ b/worlds/dark_souls_3/Options.py
@@ -220,7 +220,7 @@ class RandomizeEnemiesOption(DefaultOnToggle):
 class SimpleEarlyBossesOption(DefaultOnToggle):
     """Avoid replacing Iudex Gundyr and Vordt with difficult bosses.
 
-    This limits these boss fights to bosses that are known to scale gracefully to low-level fights.
+    This limits these fights to bosses that are known to scale gracefully for low-level fights.
     This doesn't necessarily mean that those bosses will be from the early game, just that they're
     not too difficult when scaled down.
 


### PR DESCRIPTION

## What is this fixing or adding?

This fixes the documentation for the `simple_early_bosses` option for DS3.

## How was this tested?

N/A, docs only
