### PR TITLE
Core: allow async def functions as commands

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1301,6 +1301,13 @@ class CommandMeta(type):
             commands.update(base.commands)
         commands.update({command_name[5:]: method for command_name, method in attrs.items() if
                          command_name.startswith("_cmd_")})
+        for command_name, method in commands.items():
+            # wrap async def functions so they run on default asyncio loop
+            if inspect.iscoroutinefunction(method):
+                def _wrapper(self, *args, _method=method, **kwargs):
+                    return async_start(_method(self, *args, **kwargs))
+                functools.update_wrapper(_wrapper, method)
+                commands[command_name] = _wrapper
         return super(CommandMeta, cls).__new__(cls, name, bases, attrs)
 
 


### PR DESCRIPTION
## What is this fixing or adding?
Twice this week we had world devs confused why their async def methods don't fire. There is also no warning emitted.
My first draft was an assert, but then I realized I can just make a wrapper.

## How was this tested?
I switched some of the existing commands over to async to test this. During this testing I noticed that if you just open a text client and then run /exit it just stays open. But that turned out to be an existing bug unrelated to this change.
