### PR TITLE
CommonClient: actually close the UI on /exit

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -65,6 +65,8 @@ class ClientCommandProcessor(CommandProcessor):
 
     def _cmd_exit(self) -> bool:
         """Close connections and client"""
+        if self.ctx.ui:
+            self.ctx.ui.stop()
         self.ctx.exit_event.set()
         return True
 


### PR DESCRIPTION
## What is this fixing or adding?
When I tried /exit the client just remained. This fixes that.

## How was this tested?
Locally and my client did indeed poof.
