### PR TITLE
Paint: v0.6.x updates

### DIFF
--- a/worlds/paint/__init__.py
+++ b/worlds/paint/__init__.py
@@ -118,9 +118,11 @@ class PaintWorld(World):
 
 def location_exists_with_options(world: PaintWorld, location: int):
     l = location % 198600
-    return l <= world.options.logic_percent * 4 and (l % 4 == 0 or
-                                                    (l > world.options.half_percent_checks * 4 and l % 2 == 0) or
-                                                    l > world.options.quarter_percent_checks * 4)
+    return l <= world.options.logic_percent.value * 4 and (
+            l % 4 == 0 or
+            (l > world.options.half_percent_checks.value * 4 and l % 2 == 0) or
+            l > world.options.quarter_percent_checks.value * 4
+    )
 
 
 class PaintState(LogicMixin):

--- a/worlds/paint/__init__.py
+++ b/worlds/paint/__init__.py
@@ -36,11 +36,15 @@ class PaintWorld(World):
     item_name_to_id = item_table
     origin_region_name = "Canvas"
 
+    per_pixel_logic_percent: float
+
     def generate_early(self) -> None:
         if self.options.canvas_size_increment < 50 and self.options.logic_percent <= 55:
             if self.multiworld.players == 1:
                 raise OptionError("Logic Percent must be greater than 55 when generating a single-player world with "
                                   "Canvas Size Increment below 50.")
+        # The full canvas size is 800*600, so 480000 pixels.
+        self.per_pixel_logic_percent = self.options.logic_percent.value / 480000
 
     def get_filler_item_name(self) -> str:
         if self.random.randint(0, 99) >= self.options.trap_count:

--- a/worlds/paint/__init__.py
+++ b/worlds/paint/__init__.py
@@ -46,13 +46,13 @@ class PaintWorld(World):
             self.options.logic_percent <= 55 and self.multiworld.players == 1:
             raise OptionError("Logic Percent must be greater than 55 when generating a single-player world with "
                                 "Canvas Size Increment below 50.")
-        if self.options.aspect_ratio == 2 or self.options.orientation == 0:
+        if self.options.aspect_ratio <= 2:
             self.final_width = 800
-        elif self.options.aspect_ratio == 1:
+        elif self.options.aspect_ratio == 4:
             self.final_width = 450
         else:
             self.final_width = 600
-        if self.options.aspect_ratio == 2 or self.options.orientation == 1:
+        if self.options.aspect_ratio >= 2:
             self.final_height = 800
         elif self.options.aspect_ratio == 1:
             self.final_height = 450

--- a/worlds/paint/__init__.py
+++ b/worlds/paint/__init__.py
@@ -1,4 +1,5 @@
 from typing import Dict, Any
+from math import ceil
 
 from BaseClasses import CollectionState, Item, MultiWorld, Tutorial, Region
 from Options import OptionError
@@ -36,15 +37,28 @@ class PaintWorld(World):
     item_name_to_id = item_table
     origin_region_name = "Canvas"
 
+    final_width: int
+    final_height: int
     per_pixel_logic_percent: float
 
     def generate_early(self) -> None:
-        if self.options.canvas_size_increment < 50 and self.options.logic_percent <= 55:
-            if self.multiworld.players == 1:
-                raise OptionError("Logic Percent must be greater than 55 when generating a single-player world with "
-                                  "Canvas Size Increment below 50.")
-        # The full canvas size is 800*600, so 480000 pixels.
-        self.per_pixel_logic_percent = self.options.logic_percent.value / 480000
+        if self.options.canvas_width_increment < 50 and self.options.canvas_height_increment < 50 and \
+            self.options.logic_percent <= 55 and self.multiworld.players == 1:
+            raise OptionError("Logic Percent must be greater than 55 when generating a single-player world with "
+                                "Canvas Size Increment below 50.")
+        if self.options.aspect_ratio == 2 or self.options.orientation == 0:
+            self.final_width = 800
+        elif self.options.aspect_ratio == 1:
+            self.final_width = 450
+        else:
+            self.final_width = 600
+        if self.options.aspect_ratio == 2 or self.options.orientation == 1:
+            self.final_height = 800
+        elif self.options.aspect_ratio == 1:
+            self.final_height = 450
+        else:
+            self.final_height = 600
+        self.per_pixel_logic_percent = self.options.logic_percent.value / (self.final_width * self.final_height)
 
     def get_filler_item_name(self) -> str:
         if self.random.randint(0, 99) >= self.options.trap_count:
@@ -65,8 +79,10 @@ class PaintWorld(World):
         self.push_precollected(self.create_item(starting_tools.pop(self.options.starting_tool)))
         items_to_create = ["Free-Form Select", "Select", "Fill With Color", "Pick Color", "Text", "Curve", "Polygon"]
         items_to_create += starting_tools
-        items_to_create += ["Progressive Canvas Width"] * (400 // self.options.canvas_size_increment)
-        items_to_create += ["Progressive Canvas Height"] * (300 // self.options.canvas_size_increment)
+        items_to_create += ["Progressive Canvas Width"] * ceil(self.final_width /\
+                                                               (self.options.canvas_width_increment * 2))
+        items_to_create += ["Progressive Canvas Height"] * ceil(self.final_height /\
+                                                                (self.options.canvas_height_increment * 2))
         depth_items = ["Progressive Color Depth (Red)", "Progressive Color Depth (Green)",
                        "Progressive Color Depth (Blue)"]
         for item in depth_items:
@@ -100,8 +116,10 @@ class PaintWorld(World):
         set_completion_rules(self, self.player)
 
     def fill_slot_data(self) -> Dict[str, Any]:
-        return dict(self.options.as_dict("logic_percent", "goal_percent", "goal_image", "death_link",
-                                         "canvas_size_increment"), version="0.5.2")
+        return dict(self.options.as_dict("logic_percent", "goal_percent", "death_link", "canvas_width_increment",
+                                         "canvas_height_increment"),
+                    final_width=self.final_width, final_height=self.final_height,
+                    version=self.world_version.as_simple_string())
 
     def collect(self, state: CollectionState, item: Item) -> bool:
         change = super().collect(state, item)

--- a/worlds/paint/archipelago.json
+++ b/worlds/paint/archipelago.json
@@ -1,5 +1,5 @@
 {
     "game": "Paint",
     "authors": ["MarioManTAW"],
-    "world_version": "0.6.0"
+    "world_version": "0.6.1"
 }

--- a/worlds/paint/archipelago.json
+++ b/worlds/paint/archipelago.json
@@ -1,5 +1,5 @@
 {
     "game": "Paint",
     "authors": ["MarioManTAW"],
-    "world_version": "0.5.2"
+    "world_version": "0.6.0"
 }

--- a/worlds/paint/archipelago.json
+++ b/worlds/paint/archipelago.json
@@ -1,5 +1,5 @@
 {
     "game": "Paint",
     "authors": ["MarioManTAW"],
-    "world_version": "0.6.1"
+    "world_version": "0.6.2"
 }

--- a/worlds/paint/items.py
+++ b/worlds/paint/items.py
@@ -41,8 +41,14 @@ item_data_table: Dict[str, PaintItemData] = {
     "Invert Colors Trap":               PaintItemData(198526, ItemClassification.trap),
     "Flip Horizontal Trap":             PaintItemData(198527, ItemClassification.trap),
     "Flip Vertical Trap":               PaintItemData(198528, ItemClassification.trap),
+    "Help Trap":                        PaintItemData(198529, ItemClassification.trap),
+    "Zoom In Trap":                     PaintItemData(198530, ItemClassification.trap),
+    "Zoom Out Trap":                    PaintItemData(198531, ItemClassification.trap),
+    "Tool Swap Trap":                   PaintItemData(198532, ItemClassification.trap),
 }
 
 item_table = {name: data.code for name, data in item_data_table.items()}
-traps = ["Undo Trap", "Clear Image Trap", "Invert Colors Trap", "Flip Horizontal Trap", "Flip Vertical Trap"]
-deathlink_traps = ["Invert Colors Trap", "Flip Horizontal Trap", "Flip Vertical Trap"]
+traps = [
+    "Undo Trap", "Clear Image Trap", "Invert Colors Trap", "Flip Horizontal Trap", "Flip Vertical Trap", "Help Trap",
+    "Zoom In Trap", "Zoom Out Trap", "Tool Swap Trap"
+]

--- a/worlds/paint/locations.py
+++ b/worlds/paint/locations.py
@@ -1,14 +1,22 @@
-from typing import NamedTuple, Dict
+from typing import NamedTuple, Dict, Optional
 
-from BaseClasses import CollectionState, Location
+from BaseClasses import CollectionState, Location, Region
 
 
 class PaintLocation(Location):
     game = "Paint"
+
+    required_percent: float
+
+    def __init__(self, player: int, name: str = '', address: Optional[int] = None, parent: Optional[Region] = None):
+        super().__init__(player, name, address, parent)
+        assert self.address is not None
+        self.required_percent = (self.address % 198600) / 4
+
     def access_rule(self, state: CollectionState):
         from .rules import paint_percent_available
         return paint_percent_available(state, state.multiworld.worlds[self.player], self.player) >=\
-               (self.address % 198600) / 4
+               self.required_percent
 
 
 class PaintLocationData(NamedTuple):

--- a/worlds/paint/locations.py
+++ b/worlds/paint/locations.py
@@ -2,6 +2,8 @@ from typing import NamedTuple, Dict, Optional
 
 from BaseClasses import CollectionState, Location, Region
 
+from .rules import paint_percent_available
+
 
 class PaintLocation(Location):
     game = "Paint"
@@ -14,7 +16,6 @@ class PaintLocation(Location):
         self.required_percent = (self.address % 198600) / 4
 
     def access_rule(self, state: CollectionState):
-        from .rules import paint_percent_available
         return paint_percent_available(state, state.multiworld.worlds[self.player], self.player) >=\
                self.required_percent
 

--- a/worlds/paint/options.py
+++ b/worlds/paint/options.py
@@ -80,19 +80,14 @@ class CanvasHeightIncrement(Choice):
 
 class AspectRatio(Choice):
     """Sets the aspect ratio of your final image. Useful when using a custom goal image, also affects game length.
-    Possible options are fullscreen (800x600), widescreen (800x450), or square (800x800)."""
+    Possible options are fullscreen (800x600), widescreen (800x450), square (800x800), fullscreen vertical (600x800),
+    and widescreen vertical (450x800)."""
     display_name = "Aspect Ratio"
     option_fullscreen = 0
     option_widescreen = 1
     option_square = 2
-    default = 0
-
-
-class Orientation(Choice):
-    """Sets the orientation of your final image. Useful when using a custom goal image.
-    Does nothing if aspect ratio is square."""
-    option_horizontal = 0
-    option_vertical = 1
+    option_fullscreen_vertical = 3
+    option_widescreen_vertical = 4
     default = 0
 
 
@@ -146,7 +141,6 @@ class PaintOptions(PerGameCommonOptions):
     canvas_width_increment: CanvasWidthIncrement
     canvas_height_increment: CanvasHeightIncrement
     aspect_ratio: AspectRatio
-    orientation: Orientation
     goal_image: GoalImage
     starting_tool: StartingTool
     trap_count: TrapCount

--- a/worlds/paint/options.py
+++ b/worlds/paint/options.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from Options import Range, PerGameCommonOptions, StartInventoryPool, Toggle, Choice, Visibility
+from Options import OptionSet, Range, PerGameCommonOptions, StartInventoryPool, Toggle, Choice, Visibility
 
 
 class LogicPercent(Range):
@@ -125,10 +125,26 @@ class TrapCount(Range):
     default = 0
 
 
+class TrapBlacklist(OptionSet):
+    """These types of traps will not be generated into the item pool nor received from Trap Link.
+    Possible traps are "Undo Trap", "Clear Image Trap", "Invert Colors Trap", "Flip Horizontal Trap",
+    "Flip Vertical Trap", "Help Trap", "Zoom In Trap", "Zoom Out Trap", "Tool Swap Trap"."""
+    display_name = "Trap Blacklist"
+    valid_keys = [
+        "Undo Trap", "Clear Image Trap", "Invert Colors Trap", "Flip Horizontal Trap", "Flip Vertical Trap",
+        "Help Trap", "Zoom In Trap", "Zoom Out Trap", "Tool Swap Trap"
+    ]
+
+
+class TrapLink(Toggle):
+    """Received traps will be simultaneously sent to other players with trap link on. This also works in reverse."""
+    display_name = "Trap Link"
+
+
 class DeathLink(Toggle):
     """If on, using the Undo or Clear Image functions will send a death to all other players with death link on.
     Receiving a death will clear the image and reset the history.
-    This option also prevents Undo and Clear Image traps from being generated in the item pool."""
+    This option also adds Undo and Clear Image traps to the trap blacklist."""
     display_name = "Death Link"
 
 
@@ -145,5 +161,7 @@ class PaintOptions(PerGameCommonOptions):
     goal_image: GoalImage
     starting_tool: StartingTool
     trap_count: TrapCount
+    trap_blacklist: TrapBlacklist
+    trap_link: TrapLink
     death_link: DeathLink
     start_inventory_from_pool: StartInventoryPool

--- a/worlds/paint/options.py
+++ b/worlds/paint/options.py
@@ -105,6 +105,7 @@ class GoalImage(Range):
 
 class StartingTool(Choice):
     """Sets which tool (other than Magnifier) you will be able to use from the start."""
+    display_name = "Starting Tool"
     option_brush = 0
     option_pencil = 1
     option_eraser = 2

--- a/worlds/paint/options.py
+++ b/worlds/paint/options.py
@@ -51,6 +51,49 @@ class CanvasSizeIncrement(Choice):
     option_50 = 50
     option_100 = 100
     default = 100
+    visibility = Visibility.none
+
+
+class CanvasWidthIncrement(Choice):
+    """Sets the number of pixels the canvas will expand for each width item received.
+    Ensure an adequate number of locations are generated if setting this below 50."""
+    display_name = "Canvas Width Increment"
+    # option_10 = 10
+    # option_20 = 20
+    option_25 = 25
+    option_50 = 50
+    option_100 = 100
+    default = 100
+
+
+class CanvasHeightIncrement(Choice):
+    """Sets the number of pixels the canvas will expand for each height item received.
+    Ensure an adequate number of locations are generated if setting this below 50."""
+    display_name = "Canvas Height Increment"
+    # option_10 = 10
+    # option_20 = 20
+    option_25 = 25
+    option_50 = 50
+    option_100 = 100
+    default = 100
+
+
+class AspectRatio(Choice):
+    """Sets the aspect ratio of your final image. Useful when using a custom goal image, also affects game length.
+    Possible options are fullscreen (800x600), widescreen (800x450), or square (800x800)."""
+    display_name = "Aspect Ratio"
+    option_fullscreen = 0
+    option_widescreen = 1
+    option_square = 2
+    default = 0
+
+
+class Orientation(Choice):
+    """Sets the orientation of your final image. Useful when using a custom goal image.
+    Does nothing if aspect ratio is square."""
+    option_horizontal = 0
+    option_vertical = 1
+    default = 0
 
 
 class GoalImage(Range):
@@ -100,6 +143,10 @@ class PaintOptions(PerGameCommonOptions):
     half_percent_checks: HalfPercentChecks
     quarter_percent_checks: QuarterPercentChecks
     canvas_size_increment: CanvasSizeIncrement
+    canvas_width_increment: CanvasWidthIncrement
+    canvas_height_increment: CanvasHeightIncrement
+    aspect_ratio: AspectRatio
+    orientation: Orientation
     goal_image: GoalImage
     starting_tool: StartingTool
     trap_count: TrapCount

--- a/worlds/paint/rules.py
+++ b/worlds/paint/rules.py
@@ -50,12 +50,9 @@ def calculate_paint_percent_available(state: CollectionState, world: "PaintWorld
         b = min(b, 7)
     w = state.count("Progressive Canvas Width", player)
     h = state.count("Progressive Canvas Height", player)
-    # This code looks a little messy but it's a mathematical formula derived from the similarity calculations in the
-    # client. The first line calculates the maximum score achievable for a single pixel with the current items in the
-    # worst possible case. This per-pixel score is then multiplied by the number of pixels currently available (the
-    # starting canvas is 400x300) over the total number of pixels with everything unlocked (800x600) to get the
-    # total score achievable assuming the worst possible target image. Finally, this is multiplied by the logic percent
-    # option which restricts the logic so as to not require pixel perfection.
+    # This code calculates the total similarity in logic using the formula:
+    # (expected score per pixel) * (pixels currently available) * (logic percent from options) / (total pixel count)
+    # The expected score and logic percent per pixel are calculated elsewhere for efficiency.
     return (SINGLE_PIXEL_SCORE_LOOKUP[r, g, b] *
             min(400 + w * world.options.canvas_size_increment.value, 800) *
             min(300 + h * world.options.canvas_size_increment.value, 600) *

--- a/worlds/paint/rules.py
+++ b/worlds/paint/rules.py
@@ -1,8 +1,11 @@
 from itertools import product
 from math import sqrt
+from typing import TYPE_CHECKING
 
 from BaseClasses import CollectionState
-from . import PaintWorld
+
+if TYPE_CHECKING:
+    from . import PaintWorld
 
 
 # There are only 512 (8**3) possible sets of arguments when each of r, g and b can be from 0 inclusive to 7 inclusive,
@@ -23,14 +26,14 @@ def _make_single_pixel_score_lookup():
 SINGLE_PIXEL_SCORE_LOOKUP = _make_single_pixel_score_lookup()
 
 
-def paint_percent_available(state: CollectionState, world: PaintWorld, player: int) -> bool:
+def paint_percent_available(state: CollectionState, world: "PaintWorld", player: int) -> bool:
     if state.paint_percent_stale[player]:
         state.paint_percent_available[player] = calculate_paint_percent_available(state, world, player)
         state.paint_percent_stale[player] = False
     return state.paint_percent_available[player]
 
 
-def calculate_paint_percent_available(state: CollectionState, world: PaintWorld, player: int) -> float:
+def calculate_paint_percent_available(state: CollectionState, world: "PaintWorld", player: int) -> float:
     p = state.has("Pick Color", player)
     r = state.count("Progressive Color Depth (Red)", player)
     g = state.count("Progressive Color Depth (Green)", player)
@@ -57,7 +60,7 @@ def calculate_paint_percent_available(state: CollectionState, world: PaintWorld,
             world.options.logic_percent / 480000)
 
 
-def set_completion_rules(world: PaintWorld, player: int) -> None:
+def set_completion_rules(world: "PaintWorld", player: int) -> None:
     world.multiworld.completion_condition[player] = \
         lambda state: (paint_percent_available(state, world, player) >=
                        min(world.options.logic_percent, world.options.goal_percent))

--- a/worlds/paint/rules.py
+++ b/worlds/paint/rules.py
@@ -32,13 +32,17 @@ def paint_percent_available(state: CollectionState, world: PaintWorld, player: i
 
 def calculate_paint_percent_available(state: CollectionState, world: PaintWorld, player: int) -> float:
     p = state.has("Pick Color", player)
-    r = min(state.count("Progressive Color Depth (Red)", player), 7)
-    g = min(state.count("Progressive Color Depth (Green)", player), 7)
-    b = min(state.count("Progressive Color Depth (Blue)", player), 7)
+    r = state.count("Progressive Color Depth (Red)", player)
+    g = state.count("Progressive Color Depth (Green)", player)
+    b = state.count("Progressive Color Depth (Blue)", player)
     if not p:
         r = min(r, 2)
         g = min(g, 2)
         b = min(b, 2)
+    else:
+        r = min(r, 7)
+        g = min(g, 7)
+        b = min(b, 7)
     w = state.count("Progressive Canvas Width", player)
     h = state.count("Progressive Canvas Height", player)
     # This code looks a little messy but it's a mathematical formula derived from the similarity calculations in the

--- a/worlds/paint/rules.py
+++ b/worlds/paint/rules.py
@@ -55,12 +55,12 @@ def calculate_paint_percent_available(state: CollectionState, world: "PaintWorld
     # total score achievable assuming the worst possible target image. Finally, this is multiplied by the logic percent
     # option which restricts the logic so as to not require pixel perfection.
     return (SINGLE_PIXEL_SCORE_LOOKUP[r, g, b] *
-            min(400 + w * world.options.canvas_size_increment, 800) *
-            min(300 + h * world.options.canvas_size_increment, 600) *
-            world.options.logic_percent / 480000)
+            min(400 + w * world.options.canvas_size_increment.value, 800) *
+            min(300 + h * world.options.canvas_size_increment.value, 600) *
+            world.options.logic_percent.value / 480000)
 
 
 def set_completion_rules(world: "PaintWorld", player: int) -> None:
     world.multiworld.completion_condition[player] = \
         lambda state: (paint_percent_available(state, world, player) >=
-                       min(world.options.logic_percent, world.options.goal_percent))
+                       min(world.options.logic_percent.value, world.options.goal_percent.value))

--- a/worlds/paint/rules.py
+++ b/worlds/paint/rules.py
@@ -12,14 +12,16 @@ if TYPE_CHECKING:
 # so pre-calculate them.
 def _make_single_pixel_score_lookup():
     """
-    Create a lookup for the maximum possible score for a pixel in the worst case, for r, g and b from 0-7 inclusive.
+    Create a lookup for the maximum possible score for a pixel in the worst case, for r, g and b color depth from 0-7
+    inclusive.
     """
-    rgb = [(2 ** (7 - i) - 1) ** 2 for i in range(8)]
+    # The color depth calculation is the same for r, g and b, so can be calculated once for each possible input value.
+    color_depth = {i: (2 ** (7 - i) - 1) ** 2 for i in range(8)}
     return {
-        t: 1 - sqrt(
-            (rgb[t[0]] + rgb[t[1]] + rgb[t[2]]) * 12
+        (r, g, b): 1 - sqrt(
+            (color_depth[r] + color_depth[g] + color_depth[b]) * 12
         ) / 765
-        for t in product(range(8), repeat=3)
+        for r, g, b in product(range(8), repeat=3)
     }
 
 

--- a/worlds/paint/rules.py
+++ b/worlds/paint/rules.py
@@ -61,6 +61,6 @@ def calculate_paint_percent_available(state: CollectionState, world: "PaintWorld
 
 
 def set_completion_rules(world: "PaintWorld", player: int) -> None:
+    goal_percent = min(world.options.logic_percent.value, world.options.goal_percent.value)
     world.multiworld.completion_condition[player] = \
-        lambda state: (paint_percent_available(state, world, player) >=
-                       min(world.options.logic_percent.value, world.options.goal_percent.value))
+        lambda state: paint_percent_available(state, world, player) >= goal_percent

--- a/worlds/paint/rules.py
+++ b/worlds/paint/rules.py
@@ -57,7 +57,7 @@ def calculate_paint_percent_available(state: CollectionState, world: "PaintWorld
     return (SINGLE_PIXEL_SCORE_LOOKUP[r, g, b] *
             min(400 + w * world.options.canvas_size_increment.value, 800) *
             min(300 + h * world.options.canvas_size_increment.value, 600) *
-            world.options.logic_percent.value / 480000)
+            world.per_pixel_logic_percent)
 
 
 def set_completion_rules(world: "PaintWorld", player: int) -> None:

--- a/worlds/paint/rules.py
+++ b/worlds/paint/rules.py
@@ -54,8 +54,8 @@ def calculate_paint_percent_available(state: CollectionState, world: "PaintWorld
     # (expected score per pixel) * (pixels currently available) * (logic percent from options) / (total pixel count)
     # The expected score and logic percent per pixel are calculated elsewhere for efficiency.
     return (SINGLE_PIXEL_SCORE_LOOKUP[r, g, b] *
-            min(400 + w * world.options.canvas_size_increment.value, 800) *
-            min(300 + h * world.options.canvas_size_increment.value, 600) *
+            min(world.final_width // 2 + w * world.options.canvas_width_increment.value, world.final_width) *
+            min(world.final_height // 2 + h * world.options.canvas_height_increment.value, world.final_height) *
             world.per_pixel_logic_percent)
 
 

--- a/worlds/paint/rules.py
+++ b/worlds/paint/rules.py
@@ -53,10 +53,10 @@ def calculate_paint_percent_available(state: CollectionState, world: "PaintWorld
     # This code calculates the total similarity in logic using the formula:
     # (expected score per pixel) * (pixels currently available) * (logic percent from options) / (total pixel count)
     # The expected score and logic percent per pixel are calculated elsewhere for efficiency.
-    return (SINGLE_PIXEL_SCORE_LOOKUP[r, g, b] *
+    return round(SINGLE_PIXEL_SCORE_LOOKUP[r, g, b] *
             min(world.final_width // 2 + w * world.options.canvas_width_increment.value, world.final_width) *
             min(world.final_height // 2 + h * world.options.canvas_height_increment.value, world.final_height) *
-            world.per_pixel_logic_percent)
+            world.per_pixel_logic_percent, ndigits=3)
 
 
 def set_completion_rules(world: "PaintWorld", player: int) -> None:


### PR DESCRIPTION
## What is this fixing or adding?
### v0.6.0
- New options for Paint allow more flexibility for players when choosing goal images.
- Pulled performance upgrades from #5252
- Added missing display name for `starting_tool` so it looks more consistent on webhost.
### v0.6.1
- New options for traps, including a trap blacklist and implementation of the Trap Link protocol.
### v0.6.2
- Fixed a floating-point precision error that could cause generation issues with certain logic percent values.

## How was this tested?
- Did a couple local gens, everything seemed fine
