### PR TITLE
ModuleUpdate: Add explicit error when above max supported version

### DIFF
--- a/ModuleUpdate.py
+++ b/ModuleUpdate.py
@@ -5,7 +5,7 @@ import multiprocessing
 import warnings
 
 
-if sys.platform in ("win32", "darwin") and sys.version_info < (3, 11, 9):
+if sys.platform in ("win32", "darwin") and not (3, 11, 9) <= sys.version_info < (3, 14, 0):
     # Official micro version updates. This should match the number in docs/running from source.md.
     raise RuntimeError(f"Incompatible Python Version found: {sys.version_info}. "
                        "Official 3.11.9 through 3.13.x is supported.")


### PR DESCRIPTION
## What is this fixing or adding?
Also adds this info to the messages. Hopefully with #5822, this will prevent people from trying to use 3.14 so often.

## How was this tested?
Attempting to run on (too low patch) 3.11, 3.12, 3.13, and 3.14 to make sure they error on the 3.11 and 3.14 as expected, but are fine on the others.

## If this makes graphical changes, please attach screenshots.
🚫🥧