### PR TITLE
Core: Throw OptionError for option type Toggle in certain scenarios

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -419,7 +419,7 @@ class Toggle(NumericOption):
             return cls(random.choice(list(cls.name_lookup)))
         elif text.lower() in {"off", "0", "false", "none", "null", "no", "disabled"}:
             return cls(0)
-        elif text.lower() in {"on", "1", "true", "yes","enabled"}:
+        elif text.lower() in {"on", "1", "true", "yes", "enabled"}:
             return cls(1)
         else:
             raise OptionError(f"Option {cls.__name__} does not support a value of {text}")


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?
In scenarios where someone uses a meta.yaml to assign weights to Toggles, if things are toggled off but not with the correct string, it previously did not return false and instead flipped to true. Doing this on larger scales (where meta.yamls are more beneficial) can lead to unfortunate outcomes where settings that were hoping to be avoided en masse are now enabled en masse. To fix this, Toggle was updated to have strings for **false** options but also for **true** ones, where if neither list was matched, it'd throw an OptionError in generation allowing for a yaml to be fixed.

## How was this tested?

Locally with APQuest by using the hard_mode option and setting it to "negative" and "disabled".

## If this makes graphical changes, please attach screenshots.
