### PR TITLE
CC: Match ServerLabel's team to other UIs

### DIFF
--- a/kvui.py
+++ b/kvui.py
@@ -349,7 +349,7 @@ class ServerLabel(HoverBehavior, MDTooltip, MDBoxLayout):
             ctx = self.ctx
             text = f"Connected to: {ctx.server_address}."
             if ctx.slot is not None:
-                text += f"\nYou are Slot Number {ctx.slot} in Team Number {ctx.team}, " \
+                text += f"\nYou are Slot Number {ctx.slot} in Team Number {ctx.team + 1}, " \
                         f"named {ctx.player_names[ctx.slot]}."
                 if ctx.items_received:
                     text += f"\nYou have received {len(ctx.items_received)} items. " \


### PR DESCRIPTION
## What is this fixing or adding?
add one to team number when shown to user

## How was this tested?
got the screenshot below

## If this makes graphical changes, please attach screenshots.
<img width="499" height="503" alt="image" src="https://github.com/user-attachments/assets/c169bee1-b05e-4e85-a05d-cfad9d945d39" />
