### PR TITLE
Docs: Explain building a single world with Build APWorlds component

### DIFF
--- a/docs/apworld specification.md
+++ b/docs/apworld specification.md
@@ -41,7 +41,7 @@ There are also the following optional fields:
 If the APWorld is packaged as an `.apworld` zip file, it also needs to have `version` and `compatible_version`,
 which refer to the version of the APContainer packaging scheme defined in [Files.py](../worlds/Files.py).  
 These get automatically added to the `archipelago.json` of an .apworld if it is packaged using the 
-["Build apworlds" launcher component](#build-apworlds-launcher-component),
+["Build APWorlds" launcher component](#build-apworlds-launcher-component),
 which is the correct way to package your `.apworld` as a world developer. Do not write these fields yourself.
 
 ### "Build APWorlds" Launcher Component
@@ -50,7 +50,9 @@ In the Archipelago Launcher, there is a "Build APWorlds" component that will pac
 and add `archipelago.json` manifest files to them.  
 These .apworld files will be output to `build/apworlds` (relative to the Archipelago root directory).  
 The `archipelago.json` file in each .apworld will automatically include the appropriate
-`version` and `compatible_version`.
+`version` and `compatible_version`.  
+The component can also be called from the command line to allow for specifying a certain list of worlds to build.
+For example, running `Launcher.py "Build APWorlds" -- "Game Name"` will build only the game called `Game Name`.
 
 If a world folder has an `archipelago.json` in its root, any fields it contains will be carried over.  
 So, a world folder with an `archipelago.json` that looks like this:


### PR DESCRIPTION
## What is this fixing or adding?
Adding an extra note to apworld docs about building a single world from command line. Also editing casing on a link.

## How was this tested?
👀