### PR TITLE
Pokemon Emerald: Assume all species can be placed if Dexsanity is enabled

### DIFF
--- a/worlds/pokemon_emerald/pokemon.py
+++ b/worlds/pokemon_emerald/pokemon.py
@@ -279,7 +279,9 @@ def randomize_wild_encounters(world: "PokemonEmeraldWorld") -> None:
     }
 
     already_placed = set()
-    num_placeable_species = NUM_REAL_SPECIES - len(world.blacklisted_wilds)
+    num_placeable_species = NUM_REAL_SPECIES
+    if not world.options.dexsanity:
+        num_placeable_species -= len(world.blacklisted_wilds)
 
     priority_species = [data.constants["SPECIES_WAILORD"], data.constants["SPECIES_RELICANTH"]]
 


### PR DESCRIPTION
## What is this fixing or adding?
This ensures that all species will be placed at least once if Dexsanity is enabled. Previously it was possible for species to not be placed which works fine on frozen but would leave some locations effectively excluded due to them being unreachable.

## How was this tested?
Fuzz results (when running from source) before: 
<img width="155" height="114" alt="before" src="https://github.com/user-attachments/assets/db7b713a-0bab-44bd-bb3d-a98a12b6e022" />

Fuzz results (when running from source) after:
<img width="155" height="114" alt="after" src="https://github.com/user-attachments/assets/82e2741c-3319-4dcf-8933-8510af41aac1" />

No instances of errors such as `Fill.FillError: Could not access required locations for accessibility check. Missing: [Pokedex - Rayquaza]` remain after the change.


## If this makes graphical changes, please attach screenshots.
N/A

@Zunawe 