### PR TITLE
SM64: Remove outdated FAQ item from Setup Guide

### DIFF
--- a/worlds/sm64ex/docs/setup_en.md
+++ b/worlds/sm64ex/docs/setup_en.md
@@ -161,12 +161,6 @@ with its name.
 When using a US Rom, the In-Game messages are missing some letters: `J Q V X Z` and `?`.
 The Japanese Version should have no problem displaying these.
 
-### Toad does not have an item for me.
-
-This happens on older builds when you load an existing file that had already received an item from that toad.
-To resolve this, exit and start from a `NEW` file. The server will automatically restore your progress.
-Alternatively, updating your build will prevent this issue in the future.
-
 ### What happens if I lose connection?
 
 SM64EX tries to reconnect a few times, so be patient.


### PR DESCRIPTION
Follow up of #3879

Removes the FAQ item concerning Toad not giving the relevant Power Star. It is no longer possible to connect to a multiworld game on the website with a version of the client with this bug, as all versions with this bug report AP v0.3.5 or less. Therefore, the FAQ item is no longer relevant.