### PR TITLE
Blasphemous: Randomizer 3.2 (minor update)

### DIFF
--- a/worlds/blasphemous/Options.py
+++ b/worlds/blasphemous/Options.py
@@ -23,13 +23,6 @@ class ChoiceIsRandom(Choice):
             f'known options are {", ".join(f"{option}" for option in cls.name_lookup.values())}')
 
 
-class PrieDieuWarp(DefaultOnToggle):
-    """
-    Automatically unlocks the ability to warp between Prie Dieu shrines.
-    """
-    display_name = "Unlock Fast Travel"
-
-
 class SkipCutscenes(DefaultOnToggle):
     """
     Automatically skips most cutscenes.
@@ -213,7 +206,6 @@ class BlasphemousDeathLink(DeathLink):
 @dataclass
 class BlasphemousOptions(PerGameCommonOptions):
     start_inventory_from_pool: StartInventoryPool
-    prie_dieu_warp: PrieDieuWarp
     skip_cutscenes: SkipCutscenes
     corpse_hints: CorpseHints
     difficulty: Difficulty
@@ -237,7 +229,6 @@ class BlasphemousOptions(PerGameCommonOptions):
 
 blas_option_groups = [
     OptionGroup("Quality of Life",  [
-        PrieDieuWarp,
         SkipCutscenes,
         CorpseHints,
         SkipLongQuests,

--- a/worlds/blasphemous/Rules.py
+++ b/worlds/blasphemous/Rules.py
@@ -645,7 +645,7 @@ class BlasRules:
     def aubade(self, state: CollectionState) -> bool:
         return (
             state.has("Aubade of the Nameless Guardian", self.player)
-            and self.total_fervour(state) >= 90
+            and self.total_fervour(state) >= 100
         )
     
     def tirana(self, state: CollectionState) -> bool:

--- a/worlds/blasphemous/__init__.py
+++ b/worlds/blasphemous/__init__.py
@@ -287,7 +287,7 @@ class BlasphemousWorld(World):
             "StartingLocation": self.options.starting_location.value,
             "VersionCreated": "AP",
             
-            "UnlockTeleportation": bool(self.options.prie_dieu_warp.value),
+            "UnlockTeleportation": True,
             "AllowHints": bool(self.options.corpse_hints.value),
             "AllowPenitence": bool(self.options.penitence.value),
             

--- a/worlds/blasphemous/__init__.py
+++ b/worlds/blasphemous/__init__.py
@@ -297,7 +297,7 @@ class BlasphemousWorld(World):
             "ShuffleDash": bool(self.options.dash_shuffle.value),
             "ShuffleWallClimb": bool(self.options.wall_climb_shuffle.value),
             
-            "ShuffleSwordSkills": bool(self.options.wall_climb_shuffle.value),
+            "ShuffleSwordSkills": bool(self.options.skill_randomizer.value),
             "ShuffleThorns": thorns,
             "JunkLongQuests": bool(self.options.skip_long_quests.value),
             "StartWithWheel": bool(self.options.start_wheel.value),

--- a/worlds/blasphemous/archipelago.json
+++ b/worlds/blasphemous/archipelago.json
@@ -1,0 +1,5 @@
+{
+    "game": "Blasphemous",
+    "world_version": "3.2.2",
+    "authors": ["TRPG", "Damocles"]
+}

--- a/worlds/blasphemous/docs/en_Blasphemous.md
+++ b/worlds/blasphemous/docs/en_Blasphemous.md
@@ -11,7 +11,7 @@ All items that appear on the ground are randomized, and there are options to ran
 In addition, there are other changes to the game that make it better optimized for a randomizer:
 
 - Some items and enemies are never randomized.
-- Teleportation between Prie Dieus can be unlocked from the beginning.
+- Teleportation between Prie Dieus is always unlocked.
 - New save files are created in True Torment mode (NG+), but enemies and bosses will use their regular attack & defense values. A penitence can be chosen if the option is enabled.
 - Save files can not be ascended - the randomizer is meant to be completed in a single playthrough.
 - The Ossuary will give a reward for every four bones collected.


### PR DESCRIPTION
- Fixed incorrect fervour cost for Aubade of the Nameless Guardian
- Removed "Unlock Fast Travel" option (teleporting is now always unlocked)
- Added apworld manifest file