### PR TITLE
Core: Allow String Comparisons for NamedRange Class

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -808,6 +808,15 @@ class NamedRange(Range):
             return cls(cls.special_range_names[text])
         return super().from_text(text)
 
+    def __eq__(self, other):
+        if isinstance(other, str):
+            other = other.lower()
+            assert other in self.special_range_names, (
+                f"compared against an unknown string. {self} == {other}"
+            )
+            return self.value == self.special_range_names[other]
+        return super().__eq__(other)
+
 
 class FreezeValidKeys(AssembleOptions):
     def __new__(mcs, name, bases, attrs):


### PR DESCRIPTION
## What is this fixing or adding?
Allows string comparisons for NamedRange classes.

Example, if special_range_names is `{"vanilla": 1}`, value for current option is -1, and you test:

`self.options.named_range_class == "vanilla"`

It will return true.

## How was this tested?
Confirmed that a bug in SML2 as a result of this feature not existing is fixed by it.