### PR TITLE
Pokemon Emerald: Fix rare fuzzer errors

### DIFF
--- a/worlds/pokemon_emerald/opponents.py
+++ b/worlds/pokemon_emerald/opponents.py
@@ -63,7 +63,7 @@ def randomize_opponent_parties(world: "PokemonEmeraldWorld") -> None:
                 if len(merged_blacklist) < NUM_REAL_SPECIES:
                     break
             else:
-                raise RuntimeError("This should never happen")
+                merged_blacklist: Set[int] = set()
 
             candidates = [
                 species

--- a/worlds/pokemon_emerald/pokemon.py
+++ b/worlds/pokemon_emerald/pokemon.py
@@ -245,7 +245,7 @@ def _rename_wild_events(world: "PokemonEmeraldWorld", map_data: MapData, new_slo
             for r, sc in _encounter_subcategory_ranges[encounter_type].items()
             if i in r
         )
-        subcategory_species = []
+        subcategory_species: list[int] = []
         for k in subcategory_range:
             if new_slots[k] not in subcategory_species:
                 subcategory_species.append(new_slots[k])
@@ -278,7 +278,7 @@ def randomize_wild_encounters(world: "PokemonEmeraldWorld") -> None:
         RandomizeWildPokemon.option_match_base_stats_and_type,
     }
 
-    already_placed = set()
+    already_placed: set[int] = set()
     num_placeable_species = NUM_REAL_SPECIES - len(world.blacklisted_wilds)
 
     priority_species = [data.constants["SPECIES_WAILORD"], data.constants["SPECIES_RELICANTH"]]
@@ -349,7 +349,7 @@ def randomize_wild_encounters(world: "PokemonEmeraldWorld") -> None:
                             if len(merged_blacklist) < NUM_REAL_SPECIES:
                                 break
                         else:
-                            raise RuntimeError("This should never happen")
+                            merged_blacklist = set()
 
                         candidates = [
                             species
@@ -365,7 +365,7 @@ def randomize_wild_encounters(world: "PokemonEmeraldWorld") -> None:
                     species_old_to_new_map[species_id] = new_species_id
 
                     if world.options.dexsanity and encounter_type != EncounterType.ROCK_SMASH \
-                            and map_name not in OUT_OF_LOGIC_MAPS:
+                            and map_name not in OUT_OF_LOGIC_MAPS and new_species_id not in world.blacklisted_wilds:
                         already_placed.add(new_species_id)
 
             # Actually create the new list of slots and encounter table


### PR DESCRIPTION
## What is this fixing or adding?

If the goal is legendary hunt, then Wailord and Relicanth are placed as "priority species" so that they're absolutely guaranteed to exist in order to open the Regi caves. And then dexsanity species are placed by progressively adding all placed species to a blacklist, limiting the options until every species has been placed once before opening up the possible species for the rest of the maps.

The bug is that Relicanth and Wailord were being added to the "placed species" blacklist even if they're excluded from dexsanity, resulting in the size of the blacklist being slightly too big for the comparison that checks whether we're done with dexsanity placements. So one or two species aren't guaranteed to be placed.

There are a number of reasons players don't encounter this, but it's by far the most common fuzzer error.

One other rare error was hitting "This should never happen" I believe because I didn't think a `for/else` would enter the `else` if there were zero iterations of the loop. But the correct result should be an empty blacklist, so it's an easy fix.

## How was this tested?

Ran 1000 2-game fuzzer games.

```
Success: 768
Failures: 1
Timeouts: 0
Ignored: 231
```

The one failure here is a badge shuffle placement failing twice in a row, which is less than one in a thousand and derivative of fill's restrictive starts issue.
