### PR TITLE
MultiServer: update help doc on auto_shutdown

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2622,8 +2622,8 @@ def parse_args() -> argparse.Namespace:
                              goal:     !remaining can be used after goal completion
                              ''')
     parser.add_argument('--auto_shutdown', default=defaults["auto_shutdown"], type=int,
-                        help="automatically shut down the server after this many minutes without new location checks. "
-                             "0 to keep running. Not yet implemented.")
+                        help="automatically shut down the server after this many seconds without new location checks. "
+                             "0 to keep running.")
     parser.add_argument('--use_embedded_options', action="store_true",
                         help='retrieve release, remaining and hint options from the multidata file,'
                              ' instead of host.yaml')


### PR DESCRIPTION
## What is this fixing or adding?
TIL this arg existed, but unlike how it is documented it is implemented and also works on seconds

## How was this tested?
running a server on `--auto_shutdown 10` and speedrunning an apquest solo seed before the game could kick me (and making sure it did kick me when i wasn't checking things)

## If this makes graphical changes, please attach screenshots.
