### PR TITLE
LADX: Protect Lua connector from spam

### DIFF
--- a/data/lua/connector_ladx_bizhawk.lua
+++ b/data/lua/connector_ladx_bizhawk.lua
@@ -49,7 +49,7 @@ require('common')
 
 print("Listening for connections on port 55355")
 print("")
-print("Please connect with the LADX Archipelago client. LADX does NOT use the BizHawk client")
+print("Please connect with the Link's Awakening DX client, NOT the BizHawk client")
 print("")
 print("This script makes BizHawk pretend to be RetroArch for the purposes of connecting to the client, it's normal for the client to say that it's connecting to RetroArch")
 print("")

--- a/data/lua/connector_ladx_bizhawk.lua
+++ b/data/lua/connector_ladx_bizhawk.lua
@@ -51,7 +51,7 @@ print("Listening for connections on port 55355")
 print("")
 print("Please connect with the LADX Archipelago client. LADX does NOT use the BizHawk client")
 print("")
-print("This script makes BizHawk pretend to be RetroArch for the purposes of connecting to the client, it's normal for the client to say that it's connecting to RetorArch")
+print("This script makes BizHawk pretend to be RetroArch for the purposes of connecting to the client, it's normal for the client to say that it's connecting to RetroArch")
 print("")
 
 udp:setsockname('127.0.0.1', 55355)


### PR DESCRIPTION
## What is this fixing or adding?
This adds bounds checking to RAM reads and writes for the BizHawk Lua connector. Before this, the LttP client would spam the connector with a flurry of invalid reads, to the point of slowing gameplay for some users. Not sending a response at all seems to result in only a single read attempt from the LttP client. When an invalid read or write is detected, it also asks the user to close SNI to prevent slowdowns.

I also added some boilerplate FAQ content that gets printed out on load, based on what we often see asked in the LADX Discord channel.

## How was this tested?
I started the LADX and LttP clients and ran a patched LADX ROM in BizHawk with the connector Lua loaded. After my update, the LttP client only tries to read once every few seconds.

My machine doesn't slow down even without my change, so I can't verify that the slowdown goes away. Worst case, the user at least gets a useful message with clear instructions.