### PR TITLE
Options: add schema to OptionCounter

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -929,7 +929,7 @@ class OptionDict(Option[typing.Dict[str, typing.Any]], VerifyKeys, typing.Mappin
 class OptionCounter(OptionDict):
     min: int | None = None
     max: int | None = None
-    schema = Schema({str: int})
+    schema = Schema({Optional(str): int})
 
     def __init__(self, value: dict[str, int]) -> None:
         super(OptionCounter, self).__init__(collections.Counter(value))

--- a/Options.py
+++ b/Options.py
@@ -929,6 +929,7 @@ class OptionDict(Option[typing.Dict[str, typing.Any]], VerifyKeys, typing.Mappin
 class OptionCounter(OptionDict):
     min: int | None = None
     max: int | None = None
+    schema = Schema({str: int})
 
     def __init__(self, value: dict[str, int]) -> None:
         super(OptionCounter, self).__init__(collections.Counter(value))


### PR DESCRIPTION
## What is this fixing or adding?
adds a str: int schema to optioncounter so it doesn't fail in comparing to max

## How was this tested?
```yaml
name: test
game: Hollow Knight
Hollow Knight:
  start_inventory:
    # Start with these items.
    {Gathering_Swarm}
```
<img width="407" height="57" alt="image" src="https://github.com/user-attachments/assets/0c49a765-0d1a-4208-a016-9a3c85884bb0" />


## If this makes graphical changes, please attach screenshots.
