### PR TITLE
lufia2ac: update CollectionRule import

### DIFF
--- a/worlds/lufia2ac/__init__.py
+++ b/worlds/lufia2ac/__init__.py
@@ -5,11 +5,11 @@ from enum import IntFlag
 from typing import Any, ClassVar, Dict, Iterator, List, Set, Tuple, Type
 
 import settings
-from BaseClasses import Item, ItemClassification, Location, MultiWorld, Region, Tutorial
+from BaseClasses import CollectionRule, Item, ItemClassification, Location, MultiWorld, Region, Tutorial
 from Options import PerGameCommonOptions
 from Utils import __version__
 from worlds.AutoWorld import WebWorld, World
-from worlds.generic.Rules import add_rule, CollectionRule, set_rule
+from worlds.generic.Rules import add_rule, set_rule
 from .Client import L2ACSNIClient  # noqa: F401
 from .Items import ItemData, ItemType, l2ac_item_name_to_id, l2ac_item_table, L2ACItem, start_id as items_start_id
 from .Locations import l2ac_location_name_to_id, L2ACLocation


### PR DESCRIPTION
## What is this fixing or adding?

Changes the import of `CollectionRule` from `worlds.generic.Rules` to `BaseClasses`, as requested by https://discord.com/channels/731205301247803413/1467222232626495582/1472675797121765639.

## How was this tested?

Existing unittests.