### PR TITLE
KH1: Fix mutating VANILLA_ABILITY_AP_COSTS in output

### DIFF
--- a/worlds/kh1/__init__.py
+++ b/worlds/kh1/__init__.py
@@ -580,7 +580,7 @@ class KH1World(World):
     
     def get_ap_costs(self):
         if self.ap_costs is None:
-            ap_costs = VANILLA_ABILITY_AP_COSTS.copy()
+            ap_costs = [ap_cost.copy() for ap_cost in VANILLA_ABILITY_AP_COSTS]
             if self.options.randomize_ap_costs.current_key == "shuffle":
                 possible_costs = []
                 for ap_cost in VANILLA_ABILITY_AP_COSTS:


### PR DESCRIPTION
## What is this fixing or adding?

The created `ap_costs` `list[dict]` was only a shallow copy of the `VANILLA_ABILITY_AP_COSTS` `list[dict]`, but the `ap_cost` `dict` elements within `ap_costs` were being mutated, which were the same `dict` instances still within `VANILLA_ABILITY_AP_COSTS`.

Each `ap_cost` `dict` is now also copied, to avoid modifying the `dict`s within `VANILLA_ABILITY_AP_COSTS`.

`KH1World.get_ap_costs()` is called by `GenerateJSON.generate_json()` which is called by `KH1World.generate_output()`, so maybe this could have resulted in incorrect AP costs when generating with multiple KH1 slots.

## How was this tested?

I was experimenting with some ideas for a fuzzer hook to try to detect some cases of shared, global state being mutated by worlds and one of the ideas detected this issue in KH1.

Example of mutation of the elements within `VANILLA_ABILITY_AP_COSTS` when `ap_costs` is only a shallow copy:
https://github.com/ArchipelagoMW/Archipelago/blob/27a7e538df37f9a2f2a4c1584cc63704f165ee11/worlds/kh1/__init__.py#L593-L596

With this PR, KH1 now passes the experimental fuzzer hook I was working on.

I have run KH1 generations with this PR, but don't own KH1 to test further, and I have not gone out of my way to confirm any cases of AP costs being messed up due to this issue.