### PR TITLE
OptionCreator: 0.6.6 reported issues

### DIFF
--- a/OptionsCreator.py
+++ b/OptionsCreator.py
@@ -29,7 +29,7 @@ import webbrowser
 import re
 from urllib.parse import urlparse
 from worlds.AutoWorld import AutoWorldRegister, World
-from Options import (Option, Toggle, TextChoice, Choice, FreeText, NamedRange, Range, OptionSet, OptionList, Removed,
+from Options import (Option, Toggle, TextChoice, Choice, FreeText, NamedRange, Range, OptionSet, OptionList,
                      OptionCounter, Visibility)
 
 
@@ -318,26 +318,28 @@ class OptionsCreator(ThemedApp):
         else:
             self.show_result_snack("Name cannot be longer than 16 characters.")
 
-    def create_range(self, option: typing.Type[Range], name: str):
+    def create_range(self, option: typing.Type[Range], name: str, bind=True):
         def update_text(range_box: VisualRange):
             self.options[name] = int(range_box.slider.value)
             range_box.tag.text = str(int(range_box.slider.value))
             return
 
         box = VisualRange(option=option, name=name)
-        box.slider.bind(on_touch_move=lambda _, _1: update_text(box))
+        if bind:
+            box.slider.bind(value=lambda _, _1: update_text(box))
         self.options[name] = option.default
         return box
 
     def create_named_range(self, option: typing.Type[NamedRange], name: str):
         def set_to_custom(range_box: VisualNamedRange):
-            if (not self.options[name] == range_box.range.slider.value) \
-                    and (not self.options[name] in option.special_range_names or
-                         range_box.range.slider.value != option.special_range_names[self.options[name]]):
-                # we should validate the touch here,
-                # but this is much cheaper
+            range_box.range.tag.text = str(int(range_box.range.slider.value))
+            if range_box.range.slider.value in option.special_range_names.values():
+                value = next(key for key, val in option.special_range_names.items()
+                             if val == range_box.range.slider.value)
+                self.options[name] = value
+                set_button_text(box.choice, value.title())
+            else:
                 self.options[name] = int(range_box.range.slider.value)
-                range_box.range.tag.text = str(int(range_box.range.slider.value))
                 set_button_text(range_box.choice, "Custom")
 
         def set_button_text(button: MDButton, text: str):
@@ -346,7 +348,7 @@ class OptionsCreator(ThemedApp):
         def set_value(text: str, range_box: VisualNamedRange):
             range_box.range.slider.value = min(max(option.special_range_names[text.lower()], option.range_start),
                                                option.range_end)
-            range_box.range.tag.text = str(int(range_box.range.slider.value))
+            range_box.range.tag.text = str(option.special_range_names[text.lower()])
             set_button_text(range_box.choice, text)
             self.options[name] = text.lower()
             range_box.range.slider.dropdown.dismiss()
@@ -355,13 +357,18 @@ class OptionsCreator(ThemedApp):
             # for some reason this fixes an issue causing some to not open
             box.range.slider.dropdown.open()
 
-        box = VisualNamedRange(option=option, name=name, range_widget=self.create_range(option, name))
-        if option.default in option.special_range_names:
+        box = VisualNamedRange(option=option, name=name, range_widget=self.create_range(option, name, bind=False))
+        default: int | str = option.default
+        if default in option.special_range_names:
             # value can get mismatched in this case
-            box.range.slider.value = min(max(option.special_range_names[option.default], option.range_start),
+            box.range.slider.value = min(max(option.special_range_names[default], option.range_start),
                                                option.range_end)
             box.range.tag.text = str(int(box.range.slider.value))
-        box.range.slider.bind(on_touch_move=lambda _, _2: set_to_custom(box))
+        elif default in option.special_range_names.values():
+            # better visual
+            default = next(key for key, val in option.special_range_names.items() if val == option.default)
+            set_button_text(box.choice, default.title())
+        box.range.slider.bind(value=lambda _, _2: set_to_custom(box))
         items = [
             {
                 "text": choice.title(),
@@ -371,7 +378,7 @@ class OptionsCreator(ThemedApp):
         ]
         box.range.slider.dropdown = MDDropdownMenu(caller=box.choice, items=items)
         box.choice.bind(on_release=open_dropdown)
-        self.options[name] = option.default
+        self.options[name] = default
         return box
 
     def create_free_text(self, option: typing.Type[FreeText] | typing.Type[TextChoice], name: str):


### PR DESCRIPTION
## What is this fixing or adding?
* Item and Location Groups were being excluded from OptionList/Set/Counter valid keys
* OptionList/Set/Counter options would not be exported to the final yaml if the button to edit them was never pressed.
* Ranges were setting their value every time *any* range would be set, now reduced to just when their value changes.
* NamedRanges would fight with their nested Range to set their output value, with the nested Range always winning.
* NamedRanges now displays the name of the slider value if one exists. 


# How was this tested?
Manually, by exporting Pokemon Emerald yamls.
