### PR TITLE
HK: Fix cached filler item names persisting between generations

### DIFF
--- a/worlds/hk/__init__.py
+++ b/worlds/hk/__init__.py
@@ -189,7 +189,7 @@ class HKWorld(World):
 
     ranges: typing.Dict[str, typing.Tuple[int, int]]
     charm_costs: typing.List[int]
-    cached_filler_items = {}
+    cached_filler_items: typing.List[str]
     grub_count: int
     grub_player_count: typing.Dict[int, int]
 
@@ -201,6 +201,7 @@ class HKWorld(World):
         self.ranges = {}
         self.created_shop_items = 0
         self.vanilla_shop_costs = deepcopy(vanilla_shop_costs)
+        self.cached_filler_items = []
 
     def generate_early(self):
         options = self.options
@@ -699,7 +700,7 @@ class HKWorld(World):
         return f"{base}_{i}"
 
     def get_filler_item_name(self) -> str:
-        if self.player not in self.cached_filler_items:
+        if not self.cached_filler_items:
             fillers = ["One_Geo", "Soul_Refill"]
             exclusions = self.white_palace_exclusions()
             for group in (
@@ -709,8 +710,8 @@ class HKWorld(World):
                 if getattr(self.options, group):
                     fillers.extend(item for item in hollow_knight_randomize_options[group].items if item not in
                                    exclusions)
-            self.cached_filler_items[self.player] = fillers
-        return self.random.choice(self.cached_filler_items[self.player])
+            self.cached_filler_items = fillers
+        return self.random.choice(self.cached_filler_items)
 
 
 def create_region(multiworld: MultiWorld, player: int, name: str, location_names=None) -> Region:


### PR DESCRIPTION
## What is this fixing or adding?

HK's `get_filler_item_name` was writing lists into a `ClassVar[dict[int, str]]` on the `HKWorld` class. This dict would not be cleaned out between generations on the same process, leaving behind cached data from previous generations.

I confirmed the issue when running single-slot generations on a local webhost, where `self.cached_filler_items` could be already populated during `HKWorld.__init__()`.

This has been fixed by putting an individual cache list on each HKWorld instance, instead of a shared cached, keyed by slot number, on the class.

## How was this tested?

By running a local webhost, with extra logging in `HKWorld`, and making the webhost repeatedly generate a multiworld with the attached yaml (I used the fuzzer to get a yaml that would actually call `get_filler_item_name()` during generation, by deliberately forcing a generation failure whenever HK's `get_filler_item_name()` would be called).
[Players.zip](https://github.com/user-attachments/files/25401498/Players.zip)
