### PR TITLE
DS3: Fix item smoothing placing single items onto multiple locations 

### DIFF
--- a/worlds/dark_souls_3/__init__.py
+++ b/worlds/dark_souls_3/__init__.py
@@ -1524,12 +1524,20 @@ class DarkSouls3World(World):
         items: List[DarkSouls3Item]
     ) -> DarkSouls3Item:
         """Returns the next item in items that can be assigned to location."""
+        best_unsuitable = -1
         for i, item in enumerate(items):
             if location.can_fill(self.multiworld.state, item, False):
-                return items.pop(i)
+                if item.location.can_fill(self.multiworld.state, location.item, False):
+                    # Both locations accept their new items.
+                    return items.pop(i)
+                else:
+                    if best_unsuitable == -1:
+                        # Only the first location accepts the new item, but this is a better choice than neither
+                        # location accepting their new item.
+                        best_unsuitable = i
 
         # If we can't find a suitable item, give up and assign an unsuitable one.
-        return items.pop(0)
+        return items.pop(best_unsuitable if best_unsuitable != -1 else 0)
 
     def _get_our_locations(self) -> List[DarkSouls3Location]:
         return cast(List[DarkSouls3Location], self.multiworld.get_locations(self.player))


### PR DESCRIPTION
## What is this fixing or adding?
Item smoothing would change what items are placed at locations, but was not adjusting the original locations the items were placed at, leading to some cases where the original location and the new location would both think they have the same item placed at them.

This has been fixed by making item smooth swap the locations of items instead of replacing the placed item at only one of the locations involved.

The original DS3 code would only have worked correctly when all the items present in `converted_item_order` are all the placed items on locations in `all_matching_locations`, in which case every location would receive a new item, so there would not be any locations left to still reference an old item that was supposed to be moved elsewhere.

The `_pop_item()` function has been updated to check that *both* locations accept the new items, instead of only checking one of the locations.

## How was this tested?

I have a [fuzzer](https://github.com/Eijebong/Archipelago-fuzzer) [hook](https://github.com/Mysteryem/Archipelago-fuzzer/blob/mysteryem_hooks/hooks/check_placement_item_location_references.py) that checks that all items and locations agree on what items are placed where. Each item can only reference a single location it is placed at, and each location can only reference a single item that is placed at it, so if an item is placed at multiple locations, there will always be a disagreement between the items and locations as to what items are placed where.

The changes in this PR eliminate the failures when running the fuzzer with this hook.

I am not fully sure if swapping the placement of both items results in the desired effect of the item smoothing, but it eliminates the issue of single items being placed at multiple locations.