### PR TITLE
Saving Princess: Fix each slot sharing the same `music_table`

### DIFF
--- a/worlds/saving_princess/__init__.py
+++ b/worlds/saving_princess/__init__.py
@@ -97,11 +97,12 @@ class SavingPrincessWorld(World):
     settings: ClassVar[SavingPrincessSettings]
 
     is_pool_expanded: bool = False
-    music_table: List[int] = list(range(16))
+    music_table: List[int]
 
     def generate_early(self) -> None:
         if not self.player_name.isascii():
             raise OptionError(f"{self.player_name}'s name must be only ASCII.")
+        self.music_table = list(range(16))
         self.is_pool_expanded = self.options.expanded_pool > 0
         if self.options.music_shuffle:
             self.random.shuffle(self.music_table)


### PR DESCRIPTION
## What is this fixing or adding?

`music_table` was initialized on the `SavingPrincessWorld` *class*, so was being shared by each Saving Princess slot in the multiworld.

This has been fixed by initializing the `music_table` attribute on each `SavingPrincessWorld` *instance* in `generate_early()` instead.

All Saving Princess slots in a multiworld would end up with the same music shuffle, even if a slot chose not to shuffle their music, but at least one slot did choose to shuffle their music.

Multiworlds generated on WebHost could also inherit the already shuffled `music_table` from a previously generated multiworld, resulting in shuffled music even when every Saving Princess slot in the multiworld did not shuffle music.

Going by the MusicShuffle option's description, this seems like a very minor, and purely cosmetic issue in generate worlds.

## How was this tested?

I ran generations of Saving Princess with `fill_slot_data()` modified to log the result of `self.music_table`, and could observer that before this PR, every slot would see the same result, and that after this PR, each slot would have its own result, with slots that did not have music_shuffle enabled in their yaml not having their music shuffled.

I also ran generations before and after this PR with the [fuzzer](https://github.com/Eijebong/Archipelago-fuzzer) with an experimental hook (no public release yet) to try to detect cases where worlds are modifying state shared by multiple slots.

`music_table` could alternatively be initialized in `__init__()` instead of `generate_early()`, I just chose `generate_early()` because the world currently does not override `__init__()`.

It initially appears as if this issue could result in nondeterministic generation, besides the result of the music shuffle, if multiple multiworlds are generated on the same Python process (generally only WebHost does this in a real environment), because each generation would start with the `music_table`  in the state that the previous generation left it, however, the RNG progression of Python's `Random.shuffle()` does not appear to be affected by the `music_table` being in a different initial order, so the RNG progression remains the same and the seeds remain deterministic (besides the result of the music shuffle).