### PR TITLE
Docs: Rewrite get_filler_item_name's docstring to avoid implying it's for filling all unfilled locations

### DIFF
--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -495,7 +495,9 @@ class World(metaclass=AutoWorldRegister):
 
     def get_filler_item_name(self) -> str:
         """
-        Called when the item pool needs to be filled with additional items to match location count.
+        If core AP removes an item from your item pool, this method is called to choose a replacement item
+        so item count and location count remain equal.
+        For example: plando, item_links and start_inventory_from_pool are features that may cause this.
 
         Any returned item name must be for a "repeatable" item, i.e. one that it's okay to generate arbitrarily many of.
         For most worlds this will be one or more of your filler items, but the classification of these items


### PR DESCRIPTION
## What is this fixing or adding?

In https://github.com/ArchipelagoMW/Archipelago/pull/5747 we resolved the "it can only return filler" misconception about get_filler_item_name.

This PR is targeting a different misconception: that you can create N locations, M items, with M < N, and then somehow rely on get_filler_item_name to be used to fill in the remaining locations for you. I claim that this is a real problem on the basis of these two Discord conversations:

https://discord.com/channels/731205301247803413/1214608557077700720/1383579483860111401 in which Jarno, Exempt-Medic and qwint all agree the current phrasing is bad

> Jarno — 6/14/25, 23:50
> so i just noticed this
>    [get_filler_item_name docstring]
> To me this looks like it implies i dont have to fill my itempool with fillers anymore as the generator will just do that for me?
> 
> Exempt-Medic — 6/14/25, 23:51
> It won't
> That docstring is... wow
> 
> Jarno — 6/14/25, 23:51
> thats how i remember 👍 but that description
> 
> qwint (trans wrongs!) — 6/14/25, 23:57
> huh, yea that's wrong lmao
> it's used when additional items need to be added to replace items core has removed from the itempool
> but it won't try to explicitly match location count, that's on you as a world author

https://discord.com/channels/731205301247803413/1214608557077700720/1464319896774119534 in which a new world dev makes this exact mistake, but asks it as a question so we were able to correct them

> bunnie — 1/23/26, 18:03
> is get_filler_item_name used for anything other than for filling the item pool to match the location amount? i was just wondering if i can just not completly fill the pool during create_items and rely on whatever function that calls get_filler_item_name to fill it.
> 
> [...]
> 
> duckboycool— 1/23/26, 18:04
> You should match the number of items and locations yourself.
> But it is used automatically for things like item links and plando.
> 
> [...]
> 
> bunnie — 1/23/26, 18:04
> ok thank you
> ok make sense, i am not very aware of that side of things, ty

FWIW, if we ever do get rename this method: I think qwint was on the right track with "replace", i.e. `get_replacement_item_name()` would be a clear improvement.

## How was this tested?

reading

## If this makes graphical changes, please attach screenshots.

N/A