### PR TITLE
Docs: Add a warning to world api.md#events that you want StatusUpdate, not events, for actually sending the goal

### DIFF
--- a/docs/world api.md
+++ b/docs/world api.md
@@ -327,6 +327,11 @@ reject the placement of an item there.
 
 ### Events (or "generation-only items/locations")
 
+> **Warning:** If you're trying to tell the Archipelago server that the player has achieved their goal, you want to send
+a [StatusUpdate packet](network%20protocol.md#statusupdate), or however [your client library](network%20protocol.md)
+wraps it. Despite the popularity of "victory events" during generation, events have nothing to do with how goals are
+triggered during gameplay.
+
 An event item or location is one that only exists during multiworld generation; the server is never made aware of them.
 Event locations can never be checked by the player, and event items cannot be received during play.
 


### PR DESCRIPTION
## What is this fixing or adding?

What the title says. Despite [the recent rewrite of the Events section](https://github.com/ArchipelagoMW/Archipelago/pull/5012), the misconception that victory events do something useful after generation persists among new world devs. Assuming that breaking API changes to make the whole system fundamentally more intuitive are off the table, the only mitigation I can think of is adding a warning like this.

## How was this tested?

reading

## If this makes graphical changes, please attach screenshots.

N/A