### PR TITLE
Docs: Replace the 'true filler' weasel words in adding games.md's mention of get_filler_item_name()

### DIFF
--- a/docs/adding games.md
+++ b/docs/adding games.md
@@ -140,7 +140,8 @@ if possible.
 
 * An implementation of
   [get_filler_item_name](https://github.com/ArchipelagoMW/Archipelago/blob/main/worlds/AutoWorld.py#L473)
-  * By default, this function chooses any item name from `item_name_to_id`, which may include items you consider "non-repeatable".
+  * By default, this function chooses any item name from `item_name_to_id`, which may include items you consider
+  "non-repeatable".
 * An `options_dataclass` defining the options players have available to them
   * This should be accompanied by a type hint for `options` with the same class name
 * A [bug report page](https://github.com/ArchipelagoMW/Archipelago/blob/main/worlds/AutoWorld.py#L220)


### PR DESCRIPTION
## What is this fixing or adding?

"repeatable" is defined explicitly by get_filler_item_name's docstring, so it's probably the best we can do here. Short of deleting the sentence entirely and leaving it to gfin()'s docstring to explain why gfin() exists.

Related to https://github.com/ArchipelagoMW/Archipelago/pull/5956. During the 2nd Discord conversation linked in that PR, the new world dev explicitly cited this "true filler item" wording as part of their confusion: https://discord.com/channels/731205301247803413/1214608557077700720/1464321595353858312

## How was this tested?

reading

## If this makes graphical changes, please attach screenshots.

N/A