### PR TITLE
Docs: Replace broken line links with either code formatting or file links

### DIFF
--- a/docs/adding games.md
+++ b/docs/adding games.md
@@ -109,52 +109,46 @@ A bare minimum world implementation must satisfy the following requirements:
 
 Within the `World` subclass you should also have:
 
-* A [unique game name](https://github.com/ArchipelagoMW/Archipelago/blob/main/worlds/AutoWorld.py#L260)
-* An [instance](https://github.com/ArchipelagoMW/Archipelago/blob/main/worlds/AutoWorld.py#L295) of a `WebWorld` 
-subclass for webhost documentation and behaviors
+* A unique game name (`World.game`)
+* An instance of a `WebWorld` subclass on `World.web` for webhost documentation and behaviors
   * In your `WebWorld`, if you wrote a game_info doc in more than one language, override the list of 
-    [game info languages](https://github.com/ArchipelagoMW/Archipelago/blob/main/worlds/AutoWorld.py#L210) with the 
-    ones you include.
-  * In your `WebWorld`, override the list of 
-    [tutorials](https://github.com/ArchipelagoMW/Archipelago/blob/main/worlds/AutoWorld.py#L213) with each tutorial
-    or setup doc you included in the game folder.
+    `game info languages` with the ones you include.
+  * In your `WebWorld`, override the list of `tutorials` with each tutorial or setup doc you included in the game folder.
 * A mapping for items and locations defining their names and ids for clients to be able to identify them. These are 
   `item_name_to_id` and `location_name_to_id`, respectively.
 * An implementation of `create_item` that can create an item when called by either your code or by another process 
   within Archipelago
 * At least one `Region` for your player to start from (i.e. the Origin Region)
-  * The default name of this region is "Menu" but you may configure a different name with 
-    [origin_region_name](https://github.com/ArchipelagoMW/Archipelago/blob/main/worlds/AutoWorld.py#L298-L299)
+  * The default name of this region is "Menu" but you may configure a different name with `origin_region_name`
 * A non-zero number of locations, added to your regions
 * A non-zero number of items **equal** to the number of locations, added to the multiworld itempool
   * In rare cases, there may be 0-location-0-item games, but this is extremely atypical.
-* A set 
-  [completion condition](https://github.com/ArchipelagoMW/Archipelago/blob/main/BaseClasses.py#L77) (aka "goal") for
-  the player.
+* A set `completion_condition` (aka "goal") for the player.
   * Use your player as the index (`multiworld.completion_condition[player]`) for your world's completion goal.
+
+Consult the relevant docstrings in [AutoWorld.py](https://github.com/ArchipelagoMW/Archipelago/blob/main/worlds/AutoWorld.py)
+and [BaseClasses.py](https://github.com/ArchipelagoMW/Archipelago/blob/main/worlds/BaseClasses.py)
+for more details on these APIs.
 
 ### Encouraged Features
 
 These are "nice to have" features for a world, but they are not strictly required. It is encouraged to add them 
 if possible.
 
-* An implementation of
-  [get_filler_item_name](https://github.com/ArchipelagoMW/Archipelago/blob/main/worlds/AutoWorld.py#L473)
+* An implementation of `get_filler_item_name()`
   * By default, this function chooses any item name from `item_name_to_id`, so you want to limit it to only the true
     filler items.
 * An `options_dataclass` defining the options players have available to them
   * This should be accompanied by a type hint for `options` with the same class name
-* A [bug report page](https://github.com/ArchipelagoMW/Archipelago/blob/main/worlds/AutoWorld.py#L220)
-* A list of [option groups](https://github.com/ArchipelagoMW/Archipelago/blob/main/worlds/AutoWorld.py#L226) 
-  for better organization on the webhost
-* A dictionary of [options presets](https://github.com/ArchipelagoMW/Archipelago/blob/main/worlds/AutoWorld.py#L223)
-  for player convenience
-* A dictionary of [item name groups](https://github.com/ArchipelagoMW/Archipelago/blob/main/worlds/AutoWorld.py#L273)
-  for player convenience
-* A dictionary of 
-  [location name groups](https://github.com/ArchipelagoMW/Archipelago/blob/main/worlds/AutoWorld.py#L276)
-  for player convenience
+* A `bug_report_page`
+* A list of `option_groups` for better organization on the webhost
+* A dictionary of `options_presets` for player convenience
+* A dictionary of `item_name_groups` for player convenience
+* A dictionary of `location_name_groups` for player convenience
   * Other games may also benefit from your name group dictionaries for hints, features, etc.
+
+Again, consult the relevant docstrings in [AutoWorld.py](https://github.com/ArchipelagoMW/Archipelago/blob/main/worlds/AutoWorld.py)
+for more details on these APIs.
 
 ### Discouraged or Prohibited Behavior
 

--- a/docs/world api.md
+++ b/docs/world api.md
@@ -277,8 +277,9 @@ like entrance randomization in logic.
 
 Regions have a list called `exits`, containing `Entrance` objects representing transitions to other regions.
 
-There must be one special region (Called "Menu" by default, but configurable using [origin_region_name](https://github.com/ArchipelagoMW/Archipelago/blob/main/worlds/AutoWorld.py#L310-L311)),
-from which the logic unfolds. AP assumes that a player will always be able to return to this starting region by resetting the game ("Save and quit").
+There must be one special region (Called "Menu" by default, but configurable using `origin_region_name`, from which the
+logic unfolds. AP assumes that a player will always be able to return to this starting region by resetting the game
+("Save and quit").
 
 ### Entrances
 
@@ -292,7 +293,7 @@ generation (entrance randomization).
 An access rule is a function that returns `True` or `False` for a `Location` or `Entrance` based on the current `state`
 (items that have been collected).
 
-The two possible ways to make a [CollectionRule](https://github.com/ArchipelagoMW/Archipelago/blob/main/worlds/generic/Rules.py#L10) are:
+The two possible ways to make a `CollectionRule` are:
 - `def rule(state: CollectionState) -> bool:`
 - `lambda state: ... boolean expression ...`
 
@@ -317,8 +318,8 @@ Even doing `state.can_reach_location` or `state.can_reach_entrance` is problemat
 You can use `multiworld.register_indirect_condition(region, entrance)` to explicitly tell the generator that, when a given region becomes accessible, it is necessary to re-check a specific entrance.
 You **must** use `multiworld.register_indirect_condition` if you perform this kind of `can_reach` from an entrance access rule, unless you have a **very** good technical understanding of the relevant code and can reason why it will never lead to problems in your case.
 
-Alternatively, you can set [world.explicit_indirect_conditions = False](https://github.com/ArchipelagoMW/Archipelago/blob/main/worlds/AutoWorld.py#L301-L304),
-avoiding the need for indirect conditions at the expense of performance.
+Alternatively, you can set `world.explicit_indirect_conditions = False`, avoiding the need for indirect conditions at
+the expense of performance.
 
 ### Item Rules
 
@@ -696,8 +697,7 @@ def set_rules(self) -> None:
 ### Custom Logic Rules
 
 Custom methods can be defined for your logic rules. The access rule that ultimately gets assigned to the Location or
-Entrance should be
-a [`CollectionRule`](https://github.com/ArchipelagoMW/Archipelago/blob/main/worlds/generic/Rules.py#L10).
+Entrance should be a `CollectionRule`.
 Typically, this is done by defining a lambda expression on demand at the relevant bit, typically calling other
 functions, but this can also be achieved by defining a method with the appropriate format and assigning it directly.
 For an example, see [The Messenger](/worlds/messenger/rules.py).


### PR DESCRIPTION
## What is this fixing or adding?

When I say "line link", I mean github links to a specific line of Archipelago code. The kind of links that end in `#L123`. On a permalink tied to a specific git commit, this is fine, but on "normal" links, these are guaranteed to break someday. In fact, it seems like every single line link in /docs/ today is already broken. So hopefully that lends some weight to the argument that we should _never use non-perma line links_.

It's easy to see why these line links were used. It _would_ be nice if we had a stable way of linking directly to the source code of a specific method, and especially that method's docstring. But the reality is that we don't, so when we're documenting a specific method we're forced to choose between:
1. a line link that's guaranteed to break in the future if anything else in the file ever changes
2. a permalink that's likely to become outdated if the docstring ever changes
3. linking to an external documentation site that does provide stable up-to-date method links
4. linking only to the _file_ (which is less likely to become outdated), and relying on additional text/formatting to indicate what the user has to search for to find what they care about in that file
5. not linking to anything at all, and relying entirely on text/formatting instead

My opinion/experience is that 1 is a non-starter in projects of this scale (after all, these links have already broken), and that 2 is only viable for "point-in-time docs" (e.g. announcements, proposals, RFCs, etc that are not maintained indefinitely) which I believe AP currently has none of. 3 would be ideal, but no such (stable, up-to-date, actively maintained) site exists today for AP. Thus, this PR implements a mix of 4 and 5.

## How was this tested?

reading and clicking on links

## If this makes graphical changes, please attach screenshots.

N/A