### PR TITLE
Docs: Reword 'could be generated from json' to avoid encouraging slow world loads

### DIFF
--- a/docs/world api.md
+++ b/docs/world api.md
@@ -491,9 +491,10 @@ class MyGameWorld(World):
     base_id = 1234
     # instead of dynamic numbering, IDs could be part of data
 
-    # The following two dicts are required for the generation to know which
-    # items exist. They could be generated from json or something else. They can
-    # include events, but don't have to since events will be placed manually.
+    # The following two dicts are required for the generation to know which items exist.
+    # They can be generated with arbitrary code during world load, but keep in mind that
+    # anything expensive (e.g. parsing non-python data files) will delay world loading.
+    # They can include events, but don't have to since events will be placed manually.
     item_name_to_id = {name: id for
                        id, name in enumerate(mygame_items, base_id)}
     location_name_to_id = {name: id for


### PR DESCRIPTION
## What is this fixing or adding?

As the title says.

This is another tweak inspired by a Discord conversation: https://discord.com/channels/731205301247803413/1214608557077700720/1470851004068003963

> Soana — 2/10/26, 18:36
> Can I load items and locations from a separate file (e.g., ⁨items.json⁩ and ⁨locations.json⁩)? A lot of games seem to do that and the documentation mentions it as an option, but the last announcement in ⁠ap-dev-announcements seems to imply that it shouldn't be done? (Also, if the answer is "yes", is there a generally agreed list of acceptable formats?)
> 
> Faris — 2/10/26, 18:39
> You can, but you should be converting them to python files if they are static files
> 
> [several similar answers]
> 
> Soana — 2/10/26, 18:46
> Also, it would be nice if the docs and/or APQuest mentioned something about this (unless I missed it of course), reading a side note in an otherwise unrelated Discord announcement that says "like mentioned before you shouldn't do this thing [that the docs explicitly mention as an option]" isn't the best and most discoverable way to find out :/ 
> 
> Ixrec — 2/10/26, 18:47
> "the docs explicitly mention"?
> 
> [...]
> 
> Soana — 2/10/26, 18:48
> ⁨world api.md⁩ mentions ⁨item_name_to_id⁩ and ⁨location_name_to_id⁩ "could be generated from json or something else"

## How was this tested?

reading

## If this makes graphical changes, please attach screenshots.

N/A