### PR TITLE
Docs: Semantics of the Connect packet's uuid

### DIFF
--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -301,6 +301,12 @@ Sent by the client to initiate a connection to an Archipelago game session.
 | tags           | list\[str\]                       | Denotes special features or capabilities that the sender is capable of. [Tags](#Tags)        |
 | slot_data      | bool                              | If true, the Connect answer will contain slot_data                                           |
 
+The `uuid` is meant to identify a player, or more accurately a device that a player uses to play AP games.
+The idea is that some multiworlds (e.g. "races") would only ever allow "one player" to connect to each slot,
+and that requires knowing when one connection is "the same player" as a previous connection.
+Typically this means you want to generate a uuid on first launch, write it to some sort of cache file, then reload the
+cached uuid on all subsequent connections.
+
 #### items_handling flags
 | Value | Meaning |
 | ----- | ------- |


### PR DESCRIPTION
## What is this fixing or adding?

"Everyone knows" at this point that `uuid` is poorly understood. Core devs complain that they can't use it because no one implements it correctly, world devs complain that core never documented it properly, and the cycle goes on.

I'm in no position to decide what `uuid` should/does mean. But nobody who is ever documented it, and there are some useful Discord messages I can find from people who are, so here's my best guess at how it should be documented to get the conversation started.

FTR, the most useful Discord messages I found and consulted for this draft are:

> Black Sliver — 8/6/25, 23:02
> re what the UUID is for:
> it allows replacing the current connection. that is only relevant in e.g. race settings where only a single connection to a slot in a room is allowed, however that feature is currently not implemented (anymore in favor of allowing cooperative gameplay on a single seed)
> if you want to replace an existing connection, the "token" needs to be sufficiently random to avoid another person kicking you from your slot 
> so og. AP used UUIDs for that
> 
> TriMay — 8/6/25, 23:03
> this I understood, it's the implementation details I do not
> 
> Black Sliver — 8/6/25, 23:03
> current core AP implementation generates a single UUID for all of its baked-in clients and keeps that until you delete your C:/Program Data/Archipelago
> which technically allows tracking, but ap.gg does not store the client UUID in non-volatile memory
> so once the connection is dead, the UUID is not accessible by AP anymore
> being able to replace the connection is necessary in such a (race) setting (that is not implemented currently) if your PC crashes or your ISP rotates IP addresses and you reconnect to the slot without a proper closing handshake happening for the old (dead) connection 
> or you switch from mobile to wifi, i guess
> 
> TriMay — 8/6/25, 23:08
> So it's a session token
> Sorta
> A long lasting session token
> 
> Black Sliver — 8/6/25, 23:10
> sorta, but the user generates the token themselves, and it could be per-room and could rotate if the room shuts down

and

> Emily (ping if you need me) — 12/17/25, 20:46
> notable update to GodotAP for anyone using it; the uuid field should now work "Properly", generating a UUIDv4 on first launch which is saved alongside the configs.
> This isn't used for anything now, but would matter if ⁠Per-World Passwords gets implemented.
> (Previously, UUIDs were generated as simple random integers, new for each connection- this is apparently wrong, although many clients do this wrong as the actual AP docs on the topic are exceedingly lacking) 

## How was this tested?

reading

## If this makes graphical changes, please attach screenshots.

N/A