### PR TITLE
OptionsCreator: Add search for worlds

### DIFF
--- a/data/optionscreator.kv
+++ b/data/optionscreator.kv
@@ -117,10 +117,22 @@ ContainerLayout:
         padding: 3, 5, 0, 3
         spacing: "2dp"
 
-        ScrollBox:
-            id: scrollbox
+        MDBoxLayout:
+            orientation: "vertical"
             size_hint_x: None
             width: "150dp"
+            spacing: "5dp"
+
+            ResizableTextField:
+                id: world_search
+                multiline: False
+                size_hint_y: None
+
+                MDTextFieldHintText:
+                    text: "Search Games"
+
+            ScrollBox:
+                id: scrollbox
 
         MDDivider:
             orientation: "vertical"


### PR DESCRIPTION
## What is this fixing or adding?
Search for options creator. It just filters the buttons based on the text input. Very straightforward. 

## How was this tested?
<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/7a4af56f-6cd7-4f00-b1d9-e748200c9da4" />
<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/1cfd1808-6d3f-42a6-b0af-602274260b75" />
<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/8ee1de27-c005-4325-bfbd-2e47b8c0627c" />
<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/dd520a62-13c9-4c58-ab06-b4854c1ed481" />


