### PR TITLE
KH2: Fix nondeterministic generation when CasualBounties is enabled

### DIFF
--- a/worlds/kh2/Locations.py
+++ b/worlds/kh2/Locations.py
@@ -1281,7 +1281,7 @@ exclusion_table = {
         LocationName.HadesCupTrophyParadoxCups,
         LocationName.MusicalOrichalcumPlus,
     ],
-    "HitlistCasual":          {
+    "HitlistCasual":          [
         LocationName.FuturePete,
         LocationName.BetwixtandBetweenBondofFlame,
         LocationName.GrimReaper2,
@@ -1299,7 +1299,7 @@ exclusion_table = {
         LocationName.MCP,
         LocationName.Lvl50,
         LocationName.Lvl99
-    },
+    ],
     "Cups":          {
         LocationName.ProtectBeltPainandPanicCup,
         LocationName.SerenityGemPainandPanicCup,


### PR DESCRIPTION
## What is this fixing or adding?

When CasualBounties was enabled, the location names in `exclusion_table["HitlistCasual"]` would be iterated into `self.random_super_boss_list` in `generate_early`, but `exclusion_table["HitlistCasual"]` was a `set`, so its iteration order would vary on each generation, even with same seed.

Random location names would be picked from `self.random_super_boss_list` to place Bounty items at, so different locations could be picked on each generation with the same seed.

`exclusion_table["Hitlist"]` is similar and was already a `list`, avoiding the issue of nondeterministic iteration order, so `exclusion_table["HitlistCasual"]` has been changed to a `list` to match.

## How was this tested?

I ran generations, with `--seed 1`, `Goal: hitlist` and `CasualBounties: 'true'`, before and after this PR. Before, the output would be different each time, and after, the output would be the same each time.

The part of `generate_early` that iterates `exclusion_table["HitlistCasual"]` into `self.random_super_boss_list`:
https://github.com/ArchipelagoMW/Archipelago/blob/d83da1b8180cf0992042d3457efb5aacaacfc74c/worlds/kh2/__init__.py#L253-L273