### PR TITLE
Docs: Don't serve non-static files in example_nginx.conf

### DIFF
--- a/deploy/example_nginx.conf
+++ b/deploy/example_nginx.conf
@@ -59,7 +59,7 @@ http {
     }
 
     location = /favicon.ico {
-      root /app/WebHostLib/;
+      alias /app/WebHostLib/static/static/favicon.ico;
       access_log off;
   }
 }


### PR DESCRIPTION
## What is this fixing or adding?

`try_files` will serve the file as long as it exists, which means without this change I can `GET /autolauncher.py` and be served the file.

## How was this tested?

Before this change I put `https://<domain>/autolauncher.py` in my browser and it downloaded that file. After this change this now 404s.

## If this makes graphical changes, please attach screenshots.
n/a