### PR TITLE
Rule builder: Add macro rule

### DIFF
--- a/rule_builder/rules.py
+++ b/rule_builder/rules.py
@@ -715,7 +715,7 @@ class Macro(WrapperRule[TWorld], game="Archipelago"):
 
     @override
     @classmethod
-    def from_dict(cls, data: Mapping[str, Any], world_cls: type[World]) -> Self:
+    def from_dict(cls, data: Mapping[str, Any], world_cls: "type[World]") -> Self:
         child = data.get("child")
         if child is None:
             raise ValueError("Child rule cannot be None")

--- a/rule_builder/rules.py
+++ b/rule_builder/rules.py
@@ -70,8 +70,8 @@ class CustomRuleRegister(type):
         if rule_hash in cls.resolved_rules:
             return cls.resolved_rules[rule_hash]
         cls.resolved_rules[rule_hash] = rule
-        if isinstance(rule, Macro):
-            cls.rule_macros[rule.player][rule.name] = rule
+        if isinstance(rule, Macro.Resolved):
+            cls.rule_macros.setdefault(rule.player, {})[rule.name] = rule
         return rule
 
     @classmethod


### PR DESCRIPTION
## What is this fixing or adding?

Adds a simple "Macro" rule builder rule to define common reused rules in a more user-friendly way.

The only real use case of this right now is for user facing explanations, which is nice, but I'm not sure it's actually good enough as-is to be something people would use. Is this still useful? Do people need a way to provide arguments or something?

## How was this tested?

Implemented this in Astalon for all the common reused rules. Also added a custom /explain UT implementation that gives the user details. The goal is to reduce the amount of repeated rules when explaining paths.

https://github.com/drtchops/Archipelago/blob/f356df4c6ca214aa44fa1b7e8443c6eebdb709d5/worlds/astalon/logic/main_campaign.py#L86-L116

Before this change:

<img width="805" height="415" alt="image" src="https://github.com/user-attachments/assets/1a9d9a1a-9843-4b13-b0da-2bb9da97eea2" />

After, with the separate explain call also shown:

<img width="794" height="534" alt="image" src="https://github.com/user-attachments/assets/b3318b41-52e9-4bab-a4bf-fa6b3e7be4db" />

## If this makes graphical changes, please attach screenshots.

not really