### PR TITLE
CI: upgrade InnoSetup to 6.7.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           Invoke-WebRequest -Uri https://github.com/Ijwu/Enemizer/releases/download/${Env:ENEMIZER_VERSION}/win-x64.zip -OutFile enemizer.zip
           Expand-Archive -Path enemizer.zip -DestinationPath EnemizerCLI -Force
-          choco install innosetup --version=6.2.2 --allow-downgrade
+          choco install innosetup --version=6.7.0 --allow-downgrade
       - name: Build
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## What is this fixing or adding?

Upgrades InnoSetup to 6.7.0

## Why?

The old InnoSetup failed to download from chocolatey recently, but the need for the old version went away when we dropped Win7 support.

I have considered just removing/disabling the choco install, but I think it's better to use a known version than being at the mercy of whatever is packaged into the GH runner image.

### Why 6.7.0 and not 6.7.1 ?
According to choco, the 6.7.1 version was flagged by at least one antivirus and it's rather new, so it might still be.

## How was this tested?

Build is tested in CI.
I ran the CI output in Wine and it installed AP and launching the launcher launched.
Testing [the CI build](https://github.com/ArchipelagoMW/Archipelago/actions/runs/22412819934) on a real Windows before approving wouldn't hurt though.
