### PR TITLE
MultiServer: don't keep multidata alive for race_mode

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -496,7 +496,8 @@ class Context:
 
         self.read_data = {}
         # there might be a better place to put this.
-        self.read_data["race_mode"] = lambda: decoded_obj.get("race_mode", 0)
+        race_mode = decoded_obj.get("race_mode", 0)
+        self.read_data["race_mode"] = lambda: race_mode
         mdata_ver = decoded_obj["minimum_versions"]["server"]
         if mdata_ver > version_tuple:
             raise RuntimeError(f"Supplied Multidata (.archipelago) requires a server of at least version {mdata_ver}, "


### PR DESCRIPTION
## What is this fixing or adding?

The `self.read_data["race_mode"]` had `decoded_obj` in its capture, which means it would keep that object from being garbage collected, but we only need a single integer from it.
Removing the capture should save some memory.
Multidata should never change while the server is running, so it should be safe to just capture the value.

## How was this tested?

Applied the change, started Multiserver and connected to it. No other testing has been done.