### PR TITLE
OOT: UTC deprecation warning fix

### DIFF
--- a/worlds/oot/Patches.py
+++ b/worlds/oot/Patches.py
@@ -272,7 +272,7 @@ def patch_rom(world, rom):
         world_str = ""
     rom.write_bytes(rom.sym('WORLD_STRING_TXT'), makebytes(world_str, 12))
 
-    time_str = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M") + " UTC"
+    time_str = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M") + " UTC"
     rom.write_bytes(rom.sym('TIME_STRING_TXT'), makebytes(time_str, 25))
 
     rom.write_byte(rom.sym('CFG_SHOW_SETTING_INFO'), 0x01)


### PR DESCRIPTION
## What is this fixing or adding?
Offshoot of #4906 that is OOT specific since it does not use the new function from that PR.
Fixes deprecation warning by removing usage of `utcnow()`.

## How was this tested?
```
~ ❯ python
Python 3.13.7 [...]
Type "help", "copyright", "credits" or "license" for more information.
>>> import datetime
>>> datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M") + " UTC"
<python-input-1>:1: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
'2026-02-27 13:02 UTC'
>>> datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M") + " UTC"
'2026-02-27 13:02 UTC'
```

## If this makes graphical changes, please attach screenshots.
See above.