### PR TITLE
Celeste OW: Fix incorrect closes_behind

### DIFF
--- a/worlds/celeste_open_world/data/CelesteLevelData.json
+++ b/worlds/celeste_open_world/data/CelesteLevelData.json
@@ -15046,7 +15046,7 @@
                             "name": "west",
                             "direction": "left",
                             "blocked": false,
-                            "closes_behind": true
+                            "closes_behind": false
                         },
                         {
                             "name": "east",


### PR DESCRIPTION
## What is this fixing or adding?

the west door of 4b room c-00 was mistakenly marked as closing behind the player

## How was this tested?

wasn't cuz i dunno how

## If this makes graphical changes, please attach screenshots.

N/A