### PR TITLE
Tests: fix race in test hosting shutdown

### DIFF
--- a/test/hosting/webhost.py
+++ b/test/hosting/webhost.py
@@ -188,6 +188,7 @@ def stop_room(app_client: "FlaskClient",
             if address:
                 room.timeout = original_timeout
                 room.last_activity = new_last_activity
+                room.commands.clear()  # make sure there is no leftover /exit
                 print("timeout restored")
 
 


### PR DESCRIPTION
## What is this fixing or adding?

Since we set the room timeout, there is a race between `/exit` and the timed shutdown.

By removing any unhandled `/exit` after shutdown, the winner of the race does not matter.

## How was this tested?

Seeing another PR fail and figuring out that this fixes it.