### PR TITLE
WebHost: Custom file name for patches

### DIFF
--- a/WebHostLib/downloads.py
+++ b/WebHostLib/downloads.py
@@ -33,12 +33,15 @@ def download_patch(room_id, patch_id):
                             new_zip.writestr("archipelago.json", json.dumps(manifest))
                         else:
                             new_zip.writestr(file.filename, zf.read(file), file.compress_type, 9)
-            if "patch_file_ending" in manifest:
-                patch_file_ending = manifest["patch_file_ending"]
+            if "force_file_name" in manifest and manifest["force_file_name"]:
+                fname = manifest["force_file_name"]
             else:
-                patch_file_ending = AutoPatchRegister.patch_types[patch.game].patch_file_ending
-            fname = f"P{patch.player_id}_{patch.player_name}_{app.jinja_env.filters['suuid'](room_id)}" \
-                    f"{patch_file_ending}"
+                if "patch_file_ending" in manifest:
+                    patch_file_ending = manifest["patch_file_ending"]
+                else:
+                    patch_file_ending = AutoPatchRegister.patch_types[patch.game].patch_file_ending
+                fname = f"P{patch.player_id}_{patch.player_name}_{app.jinja_env.filters['suuid'](room_id)}" \
+                        f"{patch_file_ending}"
             new_file.seek(0)
             return send_file(new_file, as_attachment=True, download_name=fname)
         else:

--- a/worlds/Files.py
+++ b/worlds/Files.py
@@ -233,6 +233,7 @@ class APPlayerContainer(APContainer):
         self.player = player
         self.player_name = player_name
         self.server = server
+        self.force_file_name: str = ""
 
     def read_contents(self, opened_zipfile: zipfile.ZipFile) -> Dict[str, Any]:
         manifest = super().read_contents(opened_zipfile)
@@ -249,6 +250,7 @@ class APPlayerContainer(APContainer):
             "player_name": self.player_name,
             "game": self.game,
             "patch_file_ending": self.patch_file_ending,
+            "force_file_name": self.force_file_name,
         })
         return manifest
 

--- a/worlds/Files.py
+++ b/worlds/Files.py
@@ -250,7 +250,7 @@ class APPlayerContainer(APContainer):
             "player_name": self.player_name,
             "game": self.game,
             "patch_file_ending": self.patch_file_ending,
-            "force_file_name": self.force_file_name,
+            "force_file_name": self.force_file_name,  # if set, forces the file to be this name when downloaded ignoring patch_file_ending
         })
         return manifest
 


### PR DESCRIPTION
## What is this fixing or adding?
Currently custom worlds don't have any ablility to set file names when downloading from the website. This is currently an issue for the factorio forks as factorio mods require specific named files

This PR adds a optional field to the patches manifest called `force_file_name` that the webhost will use to set the patches file name
This ignores the `patch_file_ending` field

It also adds a variable to `APPlayerContainer` to more easily set `force_file_name`

## How was this tested?
Running WebHost localy uploaded a Multiworld with 3 factorio bob's slots and patch files
patch file with no `force_file_name` in the manifest when downloaded had current file name
patch file with empty `force_file_name` in the manifest when downloaded had current file name
patch file with `force_file_name` set in the manifest when downloaded had the exact name as was in the manifest

## If this makes graphical changes, please attach screenshots.
N/A