### PR TITLE
Fix(undertale): prevent massive bounce msg spam for position updates

### DIFF
--- a/UndertaleClient.py
+++ b/UndertaleClient.py
@@ -391,9 +391,8 @@ async def process_undertale_cmd(ctx: UndertaleContext, cmd: str, args: dict):
                 f.close()
 
     elif cmd == "Bounced":
-        tags = args.get("tags", [])
-        if "Online" in tags:
-            data = args.get("data", {})
+        data = args.get("data", {})
+        if "x" in data and "room" in data:
             if data["player"] != ctx.slot and data["player"] is not None:
                 filename = f"FRISK" + str(data["player"]) + ".playerspot"
                 with open(os.path.join(ctx.save_game_folder, filename), "w") as f:
@@ -455,7 +454,7 @@ async def multi_watcher(ctx: UndertaleContext):
                         if ctx.other_undertale_status and not online_in_room:
                             continue
 
-                        message = [{"cmd": "Bounce", "games": ["Undertale"], "tags": ["Online"],
+                        message = [{"cmd": "Bounce", "games": ["Undertale"],
                                     "data": {"player": ctx.slot, "x": this_x, "y": this_y,
                                              "room": this_room, "spr": this_sprite,
                                              "frm": this_frame}}]


### PR DESCRIPTION
## What is this fixing or adding?
The Undertale client has a feature to report the position of the player inside the game (including room, coordinates etc) to the multiworld server, via the bounce functionality. Before, this was done every 100ms, unconditionally, to every online client. With increasing slot count, this made the amount of message being sent back and forth grow exponentially, straining the hoster.

To tackle this, the multi_watcher function was rewritten to cache position data and only trigger under specific circumstances, and a new dict with the key `undertale_room_status ` is written to datastorage. 
The dict contains a key for each Undertale slot in the multiworld, containing the last room id and a heartbeat time.
Every Undertale client  updates their slot object via the object method, every time the room id changes or every 30 seconds, whichever comes first.

All Undertale clients now subscribe to that undertale_room_status key, and get served the full dict every time it changes.

The multi_watcher function only triggers a bounce (and only to slots with games: ["Undertale"]) if:
  - the multiworld has more than one Undertale slot
  - position data has changed since the last interval
  - at least one of the other Undertale slots has sent a heartbeat in the past 60 seconds.
  - at least one active (so heart beat confirmed) other Undertale slot currently has the same room id.

To handle stale characters when they leave the room or time out (by heartbeat), the player file indicating their position is deleted when an update puts them in another room or shows them as inactive.

This should drastically reduce the amount of bounces, especially for bigger worlds, without any reduction in quality of the feature. With these new limiters, the polling interval should easily be able to stay identical. It will cause still up to 10 messages per client per second being sent out, especially at the start of a seed, but as players progress, that should decrease drastically. In addition, the amount of will only increase with the amount of Undertale worlds in a seed, not with the total amount of slots. In addition, idling will no longer push unnecessary bounces.


## How was this tested?
A Test session was run on the MWGG fork, featuring this exact code change. Position data was still submitted and other Undertale clients were still visible. in another room, they were not visible (so no coordintes overlap). When the other client left the room, they vanished. Same with timing out after 60 seconds.
Impact on server load was not tested, but seems self-evident.


## Note on Licensing
This change by myself is explicitly dual licensed (MiT & GPLv3) and I hereby allow usage of the new code under the MiT license.