### PR TITLE
Undertale: Use `check_locations` helper to avoid redundant sends

### DIFF
--- a/UndertaleClient.py
+++ b/UndertaleClient.py
@@ -300,11 +300,8 @@ async def process_undertale_cmd(ctx: UndertaleContext, cmd: str, args: dict):
         if start_index == 0:
             ctx.items_received = []
         elif start_index != len(ctx.items_received):
-            sync_msg = [{"cmd": "Sync"}]
-            if ctx.locations_checked:
-                sync_msg.append({"cmd": "LocationChecks",
-                                 "locations": list(ctx.locations_checked)})
-            await ctx.send_msgs(sync_msg)
+            await ctx.check_locations(ctx.locations_checked)
+            await ctx.send_msgs([{"cmd": "Sync"}])
         if start_index == len(ctx.items_received):
             counter = -1
             placedWeapon = 0
@@ -473,10 +470,9 @@ async def game_watcher(ctx: UndertaleContext):
                 for file in files:
                     if ".item" in file:
                         os.remove(os.path.join(root, file))
-            sync_msg = [{"cmd": "Sync"}]
-            if ctx.locations_checked:
-                sync_msg.append({"cmd": "LocationChecks", "locations": list(ctx.locations_checked)})
-            await ctx.send_msgs(sync_msg)
+            await ctx.check_locations(ctx.locations_checked)
+            await ctx.send_msgs([{"cmd": "Sync"}])
+
             ctx.syncing = False
         if ctx.got_deathlink:
             ctx.got_deathlink = False
@@ -511,7 +507,7 @@ async def game_watcher(ctx: UndertaleContext):
                         for l in lines:
                             sending = sending+[(int(l.rstrip('\n')))+12000]
                     finally:
-                        await ctx.send_msgs([{"cmd": "LocationChecks", "locations": sending}])
+                        await ctx.check_locations(sending)
                 if "victory" in file and str(ctx.route) in file:
                     victory = True
                 if ".playerspot" in file and "Online" not in ctx.tags:


### PR DESCRIPTION
## What is this fixing or adding?
I guess since #5990 already got merged, this can be added separately. Currently whenever the `check.spot` file exists, a `LocationChecks` of all `checked_locations` will be sent 10 times a second, even though this almost always is redundant. It might be better to clean up the logic for sending checks separately, but at least replacing this with the helper will make it so sends only contain things in `missing_locations`, and are only sent at all if there's at least one check to send.

## How was this tested?
I did a quick test using this before with `--log_network`, and I also tested it on the current main with #5990. As a side note, even though I only had one Undertale slot connected while testing this, I was still getting bounce packets sent out contrary to the description there.