### PR TITLE
WebHost: add stats show cli command

### DIFF
--- a/WebHostLib/__init__.py
+++ b/WebHostLib/__init__.py
@@ -11,6 +11,7 @@ from pony.flask import Pony
 from werkzeug.routing import BaseConverter
 
 from Utils import title_sorted, get_file_safe_name
+from .cli import CLI
 
 UPLOAD_FOLDER = os.path.relpath('uploads')
 LOGS_FOLDER = os.path.relpath('logs')
@@ -64,6 +65,7 @@ app.config["ASSET_RIGHTS"] = False
 
 cache = Cache()
 Compress(app)
+CLI(app)
 
 
 def to_python(value: str) -> uuid.UUID:

--- a/WebHostLib/cli/__init__.py
+++ b/WebHostLib/cli/__init__.py
@@ -1,0 +1,8 @@
+from flask import Flask
+
+
+class CLI:
+    def __init__(self, app: Flask) -> None:
+        from .stats import stats_cli
+
+        app.cli.add_command(stats_cli)

--- a/WebHostLib/cli/stats.py
+++ b/WebHostLib/cli/stats.py
@@ -1,0 +1,36 @@
+import click
+from flask.cli import AppGroup
+from pony.orm import raw_sql
+
+from Utils import format_SI_prefix
+
+stats_cli = AppGroup("stats")
+
+
+@stats_cli.command("show")
+def show() -> None:
+    from pony.orm import db_session, select
+
+    from WebHostLib.models import GameDataPackage
+
+    total_games_package_count: int = 0
+    total_games_package_size: int
+    top_10_package_sizes: list[tuple[int, str]] = []
+
+    with db_session:
+        data_length = raw_sql("LENGTH(data)")
+        data_length_desc = raw_sql("LENGTH(data) DESC")
+        data_length_sum = raw_sql("SUM(LENGTH(data))")
+        total_games_package_count = GameDataPackage.select().count()
+        total_games_package_size = select(data_length_sum for _ in GameDataPackage).first()  # type: ignore
+        top_10_package_sizes = list(
+            select((data_length, dp.checksum) for dp in GameDataPackage)  # type: ignore
+            .order_by(lambda _, _2: data_length_desc)
+            .limit(10)
+        )
+
+    click.echo(f"Total number of games packages: {total_games_package_count}")
+    click.echo(f"Total size of games packages:   {format_SI_prefix(total_games_package_size, power=1024)}B")
+    click.echo(f"Top {len(top_10_package_sizes)} biggest games packages:")
+    for size, checksum in top_10_package_sizes:
+        click.echo(f"    {checksum}: {size:>8d}")


### PR DESCRIPTION
## What is this fixing or adding?

Adds a cli command to print some stats on command line.
Currently only shows sum and top10 biggest games packages.

Usage: `flask -A "WebHost:get_app()" stats show`


The specific use of raw_sql and select(... X) instead of X.select() is to work around limitations in pony:
* sum() is only allowed if pony knows it's used on a number
* len(bytes) is not a thing in pony

## Why?

Currently we have no way to inspect anything from command line directly, this is a start.

## How was this tested?

Running the command line above locally against sqlite. LENGTH and SUM also exist in mariadb, so the rawsql should be fine.

I have not tried to run this against a massive database to see if there are any performance issues, but I don't have access to such a big DB.

## Example output
```sh
$ flask -A "WebHost:get_app()" stats show
Total number of games packages: 3
Total size of games packages:   3.61 kB
Top 3 biggest games packages:
    bdc36b1d3246c2051770a26d71a4d962d081cc18:     2931
    854499b00d82a68764ce591dd80218ad75e83e2b:      509
    ac9141e9ad0318df2fa27da5f20c50a842afeecb:      254
```