### PR TITLE
MultiServer: graceful shutdown for ctrl+c and sigterm

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -21,6 +21,7 @@ import time
 import typing
 import weakref
 import zlib
+from signal import SIGINT, SIGTERM
 
 import ModuleUpdate
 
@@ -2563,6 +2564,8 @@ async def console(ctx: Context):
             input_text = await queue.get()
             queue.task_done()
             ctx.commandprocessor(input_text)
+        except asyncio.exceptions.CancelledError:
+            ctx.logger.info("ConsoleTask cancelled")
         except:
             import traceback
             traceback.print_exc()
@@ -2729,6 +2732,15 @@ async def main(args: argparse.Namespace):
     console_task = asyncio.create_task(console(ctx))
     if ctx.auto_shutdown:
         ctx.shutdown_task = asyncio.create_task(auto_shutdown(ctx, [console_task]))
+
+    def stop():
+        for remove_signal in [SIGINT, SIGTERM]:
+            asyncio.get_event_loop().remove_signal_handler(remove_signal)
+        ctx.commandprocessor._cmd_exit()
+
+    for signal in [SIGINT, SIGTERM]:
+        asyncio.get_event_loop().add_signal_handler(signal, stop)
+
     await ctx.exit_event.wait()
     console_task.cancel()
     if ctx.shutdown_task:


### PR DESCRIPTION
## What is this fixing or adding?

Properly shuts down MultiServer when pressing Ctrl+C or sending a "kill" by running the `/exit` handler.

The problem with the current way Ctrl+C is handled is that it only stops *one* task. If that happens to be ConsoleTask, all this does is disabling console input. By installing a signal handler, we instead decide what happens explicitly.

The first time `stop()` is ran, the handlers are removed so you can still force a stop should the MultiServer somehow hang in the newly added code.

## Why?

Because currently you have to press Ctrl+C twice on Linux to shutdown, and the socket is closed in the destructor rather than through regular program flow.
Also the old handling shows a somewhat meaningless Traceback for each Ctrl+C.

## How was this tested?

By starting MultiServer, pressing Ctrl+C and looking at console output.
By starting MultiServer, sending a kill and looking at console output.

I only tested on Linux. Someone double-checking on Windows would be good.