### PR TITLE
Aquaria - Fixing bug where Urchin Costume is not a progression damaging item

### DIFF
--- a/worlds/aquaria/Items.py
+++ b/worlds/aquaria/Items.py
@@ -271,7 +271,7 @@ item_table = {
     ItemNames.TRIDENT: ItemData(698031, 1, ItemType.JUNK, ItemGroup.COLLECTIBLE),  # collectible_trident_head
     ItemNames.TURTLE_EGG: ItemData(698032, 1, ItemType.JUNK, ItemGroup.COLLECTIBLE),  # collectible_turtle_egg
     ItemNames.JELLY_EGG: ItemData(698033, 1, ItemType.JUNK, ItemGroup.COLLECTIBLE),  # collectible_upsidedown_seed
-    ItemNames.URCHIN_COSTUME: ItemData(698034, 1, ItemType.JUNK, ItemGroup.COLLECTIBLE),  # collectible_urchin_costume
+    ItemNames.URCHIN_COSTUME: ItemData(698034, 1, ItemType.PROGRESSION, ItemGroup.COLLECTIBLE),  # collectible_urchin_costume
     ItemNames.BABY_WALKER: ItemData(698035, 1, ItemType.JUNK, ItemGroup.COLLECTIBLE),  # collectible_walker
     ItemNames.VEDHA_S_CURE_ALL: ItemData(698036, 1, ItemType.NORMAL, ItemGroup.RECIPE),  # ingredient_Vedha'sCure-All
     ItemNames.ZUUNA_S_PEROGI: ItemData(698037, 1, ItemType.NORMAL, ItemGroup.RECIPE),  # ingredient_Zuuna'sperogi
@@ -384,8 +384,8 @@ four_gods_excludes = [ItemNames.ANEMONE, ItemNames.ARNASSI_STATUE, ItemNames.BIG
                       ItemNames.MITHALAS_BANNER, ItemNames.MITHALAS_POT, ItemNames.MUTANT_COSTUME, ItemNames.SEED_BAG,
                       ItemNames.KING_S_SKULL, ItemNames.SONG_PLANT_SPORE, ItemNames.STONE_HEAD, ItemNames.SUN_KEY,
                       ItemNames.GIRL_COSTUME, ItemNames.ODD_CONTAINER, ItemNames.TRIDENT, ItemNames.TURTLE_EGG,
-                      ItemNames.JELLY_EGG, ItemNames.URCHIN_COSTUME, ItemNames.BABY_WALKER,
-                      ItemNames.RAINBOW_MUSHROOM, ItemNames.RAINBOW_MUSHROOM, ItemNames.RAINBOW_MUSHROOM,
+                      ItemNames.JELLY_EGG, ItemNames.BABY_WALKER, ItemNames.RAINBOW_MUSHROOM,
+                      ItemNames.RAINBOW_MUSHROOM, ItemNames.RAINBOW_MUSHROOM, ItemNames.FISH_OIL,
                       ItemNames.LEAF_POULTICE, ItemNames.LEAF_POULTICE, ItemNames.LEAF_POULTICE,
                       ItemNames.LEECHING_POULTICE, ItemNames.LEECHING_POULTICE, ItemNames.ARCANE_POULTICE,
                       ItemNames.ROTTEN_MEAT, ItemNames.ROTTEN_MEAT, ItemNames.ROTTEN_MEAT, ItemNames.ROTTEN_MEAT,

--- a/worlds/aquaria/Regions.py
+++ b/worlds/aquaria/Regions.py
@@ -37,7 +37,7 @@ def _has_li(state: CollectionState, player: int) -> bool:
 DAMAGING_ITEMS:Iterable[str] = [
     ItemNames.ENERGY_FORM, ItemNames.NATURE_FORM, ItemNames.BEAST_FORM,
     ItemNames.LI_AND_LI_SONG, ItemNames.BABY_NAUTILUS, ItemNames.BABY_PIRANHA,
-    ItemNames.BABY_BLASTER
+    ItemNames.BABY_BLASTER, ItemNames.URCHIN_COSTUME
 ]
 
 def _has_damaging_item(state: CollectionState, player: int, damaging_items:Iterable[str] = DAMAGING_ITEMS) -> bool:

--- a/worlds/aquaria/__init__.py
+++ b/worlds/aquaria/__init__.py
@@ -76,7 +76,7 @@ class AquariaWorld(World):
     item_name_groups = {
         "Damage": {ItemNames.ENERGY_FORM, ItemNames.NATURE_FORM, ItemNames.BEAST_FORM,
                    ItemNames.LI_AND_LI_SONG, ItemNames.BABY_NAUTILUS, ItemNames.BABY_PIRANHA,
-                   ItemNames.BABY_BLASTER},
+                   ItemNames.BABY_BLASTER, ItemNames.URCHIN_COSTUME},
         "Light": {ItemNames.SUN_FORM, ItemNames.BABY_DUMBO}
     }
     """Grouping item make it easier to find them"""


### PR DESCRIPTION
## What is this fixing or adding?

The item Urchin costume is a damaging item. It should be classified as so in the logic and being updated as a progression item also.

## How was this tested?

* I run every unit tests,
* I generated 100 completely random game,
* I tried the game with the Urchin Costume to tried to break urn to be sure the costume qualified as a damaging item.