### PR TITLE
Docs: Mention APQuest as a reference in `docs/adding games.md`

### DIFF
--- a/docs/adding games.md
+++ b/docs/adding games.md
@@ -91,8 +91,9 @@ repository and creating a new world package in `/worlds/`.
 
 The base World class can be found in [AutoWorld](/worlds/AutoWorld.py). Methods available for your world to call 
 during generation can be found in [BaseClasses](/BaseClasses.py) and [Fill](/Fill.py). Some examples and documentation 
-regarding the API can be found in the [world api doc](/docs/world%20api.md). Before publishing, make sure to also 
-check out [world maintainer.md](/docs/world%20maintainer.md).
+regarding the API can be found in the [world api doc](/docs/world%20api.md), and the [APQuest](/worlds/apquest/) world
+is a complete world implementation that functions as an introduction to world development. Before publishing, make sure
+to also check out [world maintainer.md](/docs/world%20maintainer.md).
 
 ### Hard Requirements
 


### PR DESCRIPTION
## What is this fixing or adding?

Currently, [docs/adding games.md](https://github.com/ArchipelagoMW/Archipelago/blob/a3e8f69909b3e77344033be88b2f87b7b54b939a/docs/adding%20games.md) (link leads to the document as it stood when opening this PR) makes absolutely no mention of the APQuest world, even though it's useful for new APWorld developers. This PR adds a brief mention of its existence so that it can be more easily discovered.

## How was this tested?

n/a (This is a documentation update only.)