### PR TITLE
remove duplicate kivymd entry

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ typing_extensions>=4.15.0
 pyshortcuts>=1.9.6
 pathspec>=0.12.1
 kivymd @ git+https://github.com/kivymd/KivyMD@5ff9d0d
-kivymd>=2.0.1.dev0
 
 # Legacy world dependencies that custom worlds rely on
 Pymem>=1.13.0


### PR DESCRIPTION
## What is this fixing or adding?

fixes source generation with flatpak-pip-generator

- removes the second occurence of kivymd (because it's not published to pypi, flatpak-pip-generator)

see https://docs.flatpak.org/en/latest/python.html for more information

## How was this tested?

https://git.slonk.ing/slonkhub/gg.archipelago.Archipelago