### PR TITLE
Stardew Valley: morel doesn't spawn in fall secret woods

### DIFF
--- a/worlds/stardew_valley/content/vanilla/pelican_town.py
+++ b/worlds/stardew_valley/content/vanilla/pelican_town.py
@@ -144,7 +144,7 @@ pelican_town = ContentPack(
         ),
         Mushroom.morel: (
             Tag(ItemTag.FORAGE),
-            ForagingSource(seasons=(Season.spring, Season.fall), regions=(Region.secret_woods,)),
+            ForagingSource(seasons=(Season.spring,), regions=(Region.secret_woods,)),
         ),
         Mushroom.red: (
             Tag(ItemTag.FORAGE),


### PR DESCRIPTION
Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?

The logic of the morel mushroom in Stardew Valley was a bit too lenient

## How was this tested?

The secret woods was entered many times during fall, and no morel spawned.
The change removes fall from the logic sources
