### PR TITLE
WebHost: make the all games charts bigger

### DIFF
--- a/WebHostLib/static/styles/stats.css
+++ b/WebHostLib/static/styles/stats.css
@@ -13,3 +13,7 @@
     margin-bottom: 30px;
 }
 
+.full-width {
+    width: 100%;
+}
+

--- a/WebHostLib/stats.py
+++ b/WebHostLib/stats.py
@@ -78,7 +78,7 @@ def stats():
     from worlds import network_data_package
     known_games = set(network_data_package["games"])
     plot = figure(title="Games Played Per Day", x_axis_type='datetime', x_axis_label="Date",
-                  y_axis_label="Games Played", sizing_mode="scale_both", width=PLOT_WIDTH, height=500)
+                  y_axis_label="Games Played", sizing_mode="scale_both", width=PLOT_WIDTH * 2, height=1000)
 
     total_games, games_played = get_db_data(known_games)
     days = sorted(games_played)
@@ -96,7 +96,7 @@ def stats():
     total = sum(total_games.values())
     pie = figure(title=f"Games Played in the Last 30 Days (Total: {total})", toolbar_location=None,
                  tools="hover", tooltips=[("Game:", "@games"), ("Played:", "@count")],
-                 sizing_mode="scale_both", width=PLOT_WIDTH, height=500, x_range=(-0.5, 1.2))
+                 sizing_mode="scale_both", width=PLOT_WIDTH * 2, height=1000, x_range=(-0.5, 1.2))
     pie.axis.visible = False
     pie.xgrid.visible = False
     pie.ygrid.visible = False

--- a/WebHostLib/templates/stats.html
+++ b/WebHostLib/templates/stats.html
@@ -19,7 +19,7 @@
 
         <div id="charts-wrapper">
         {% for chart in charts %}
-            <div class="chart-container">
+            <div class="chart-container{% if loop.index0 < 2 %} full-width{% endif %}">
                 {{ chart|indent(16)|safe }}
             </div>
         {% endfor %}


### PR DESCRIPTION
## What is this fixing or adding?
Makes the first two charts, which are all games history and all games pie chart 4 times the size.

## How was this tested?
locally, would like to see what this looks like on today.

## If this makes graphical changes, please attach screenshots.
<img width="2497" height="1323" alt="image" src="https://github.com/user-attachments/assets/2a2506bf-5318-4d2c-af74-9add22f35bb6" />
