### PR TITLE
Saving Princess: add manifest

### DIFF
--- a/worlds/saving_princess/archipelago.json
+++ b/worlds/saving_princess/archipelago.json
@@ -1,0 +1,6 @@
+{
+    "game": "Saving Princess",
+    "authors": [ "LeonarthCG" ],
+    "minimum_ap_version": "0.6.6",
+    "world_version": "1.0.0"
+}


### PR DESCRIPTION
## What is this fixing or adding?
Add manifest, as per https://github.com/ArchipelagoMW/Archipelago/pull/5477.
Minimum version is set to 0.6.6, as that's what I last tested Saving Princess on.

## How was this tested?
Through the Build APWorlds component, I first built the apworld with a world_version of 1.0.0 and moved it to custom_worlds. Then, I built another world that is nearly identical (except for the file and client name), but with a world_version of 1.1.0.
Finally, I deleted the folder world.
The launcher successfully picked the higher world_version apworld.

I also tried loading the world with a minimum_ap_version of 0.6.9, which successfully kept it from being loaded (although the error was kinda verbose?).
