### PR TITLE
Docs: Better document state.locations_checked

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -727,6 +727,7 @@ class CollectionState():
     advancements: Set[Location]
     path: Dict[Union[Region, Entrance], PathValue]
     locations_checked: Set[Location]
+    """Internal cache for Advancement Locations already checked by this CollectionState. Not for use in logic."""
     stale: Dict[int, bool]
     allow_partial_entrances: bool
     additional_init_functions: List[Callable[[CollectionState, MultiWorld], None]] = []


### PR DESCRIPTION
## What is this fixing or adding?
Add docstring to state.locations_checked to dissuade world authors from attempting to use it in logic.

this seems to come up often enough that it's worth the docstring in the code

## How was this tested?
:eyes:

## If this makes graphical changes, please attach screenshots.
