### PR TITLE
Docs: Add references to running from source

### DIFF
--- a/docs/adding games.md
+++ b/docs/adding games.md
@@ -87,7 +87,8 @@ The world is your game integration for the Archipelago generator, webhost, and m
 information necessary for creating the items and locations to be randomized, the logic for item placement, the 
 datapackage information so other game clients can recognize your game data, and documentation. Your world must be
 written as a Python package to be loaded by Archipelago. This is currently done by creating a fork of the Archipelago
-repository and creating a new world package in `/worlds/`. 
+repository and creating a new world package in `/worlds/` (see [running from source](/docs/running%20from%20source.md)
+for setup).
 
 The base World class can be found in [AutoWorld](/worlds/AutoWorld.py). Methods available for your world to call 
 during generation can be found in [BaseClasses](/BaseClasses.py) and [Fill](/Fill.py). Some examples and documentation 

--- a/docs/apworld specification.md
+++ b/docs/apworld specification.md
@@ -46,8 +46,8 @@ which is the correct way to package your `.apworld` as a world developer. Do not
 
 ### "Build APWorlds" Launcher Component
 
-In the Archipelago Launcher, there is a "Build APWorlds" component that will package all world folders to `.apworld`,
-and add `archipelago.json` manifest files to them.  
+In the Archipelago Launcher (on [source only](/docs/running%20from%20source.md)), there is a "Build APWorlds"
+component that will package all world folders to `.apworld`, and add `archipelago.json` manifest files to them.  
 These .apworld files will be output to `build/apworlds` (relative to the Archipelago root directory).  
 The `archipelago.json` file in each .apworld will automatically include the appropriate
 `version` and `compatible_version`.  


### PR DESCRIPTION
## What is this fixing or adding?
People often don't realize they should be running from source, and this confusion about the build component not showing up in the launcher in particular has come up a few times. Hopefully it'll help for it to be explicitly referenced in these couple of spots.

## How was this tested?
👀
