### PR TITLE
Super Mario Land 2: Fix Space Zone 2 Logic

### DIFF
--- a/worlds/marioland2/logic.py
+++ b/worlds/marioland2/logic.py
@@ -478,7 +478,7 @@ def space_zone_2_boss(state, player):
 
 def space_zone_2_coins(state, player, coins):
     auto_scroll = is_auto_scroll(state, player, "Space Zone 2")
-    reachable_coins = 12
+    reachable_coins = 9
     if state.has_any(["Mushroom", "Fire Flower", "Carrot", "Space Physics"], player):
         reachable_coins += 15
         if state.has("Space Physics", player) or not auto_scroll:
@@ -487,7 +487,7 @@ def space_zone_2_coins(state, player, coins):
             state.has("Mushroom", player) and state.has_any(["Fire Flower", "Carrot"], player))):
         reachable_coins += 3
     if state.has("Space Physics", player):
-        reachable_coins += 79
+        reachable_coins += 82
         if not auto_scroll:
             reachable_coins += 21
     return coins <= reachable_coins


### PR DESCRIPTION
## What is this fixing or adding?
Corrects the number of reachable coins at the beginning of Space Zone 2

## How was this tested?
Ran Fuzzer