### PR TITLE
Docs: Fix missing } in example_nginx.conf

### DIFF
--- a/deploy/example_nginx.conf
+++ b/deploy/example_nginx.conf
@@ -61,5 +61,6 @@ http {
     location = /favicon.ico {
       alias /app/WebHostLib/static/static/favicon.ico;
       access_log off;
+    }
   }
 }


### PR DESCRIPTION
## What is this fixing or adding?

Fixed a missing '}' I missed in #5971.

Fixes #6026.

## How was this tested?
Ran `docker compose up -d` in `deploy/` on main. Observed the error reported in #6026. Added the missing `}`. Re-ran `docker compose up -d`. Observed that the nginx container now runs properly. Navigated to the container's host IP on port 8080 and saw the webhost homepage.
