### PR TITLE
MultiServer: Add SetUnnotify handler

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2202,10 +2202,10 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
             for key in args["keys"]:
                 ctx.stored_data_notification_clients[key].add(client)
 
-        elif cmd == "UnsetNotify":
+        elif cmd == "SetUnnotify":
             if "keys" not in args or type(args["keys"]) != list:
                 await ctx.send_msgs(client, [{'cmd': 'InvalidPacket', "type": "arguments",
-                                              "text": 'UnsetNotify', "original_cmd": cmd}])
+                                              "text": 'SetUnnotify', "original_cmd": cmd}])
                 return
             for key in args["keys"]:
                 ctx.stored_data_notification_clients[key].discard(client)

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -285,7 +285,7 @@ These packets are sent purely from client to server. They are not accepted by cl
 * [Get](#Get)
 * [Set](#Set)
 * [SetNotify](#SetNotify)
-* [UnsetNotify](#UnsetNotify)
+* [SetUnnotify](#SetUnnotify)
 
 ### Connect
 Sent by the client to initiate a connection to an Archipelago game session.
@@ -497,12 +497,12 @@ Used to register your current session for receiving all [SetReply](#SetReply) pa
 | ------ | ----- | ------ |
 | keys | list\[str\] | Keys to receive all [SetReply](#SetReply) packages for. |
 
-### UnsetNotify
-Used to unregister your current session from receiving any [SetReply](#SetReply) packages of certain keys.
+### SetUnnotify
+Used to unregister your current session from receiving automatic [SetReply](#SetReply) packages of certain keys.
 #### Arguments
 | Name | Type | Notes |
 | ------ | ----- | ------ |
-| keys | list\[str\] | Keys to no longer receive any [SetReply](#SetReply) packages for. |
+| keys | list\[str\] | Keys to no longer receive automatic [SetReply](#SetReply) packages for. |
 
 ## Appendix
 


### PR DESCRIPTION
## What is this fixing or adding?
Adds the `UnsetNotify` Client -> Server network packet, to allow clients to no longer receive `SetReply` packets for supplied keys. This will help reduce network traffic for certain client features.

## How was this tested?
Has not yet been.


## If this makes graphical changes, please attach screenshots.
