### PR TITLE
Core: Update .gitignore to include an exe setup.py downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ EnemizerCLI/
 /SNI/
 /sni-*/
 /appimagetool*
+/VC_redist.x64.exe
 /host.yaml
 /options.yaml
 /config.yaml


### PR DESCRIPTION
## What is this fixing or adding?
add automatically downloaded VC_redist exe to gitignore
https://github.com/ArchipelagoMW/Archipelago/blob/main/setup.py#L368

## How was this tested?
`git status`

## If this makes graphical changes, please attach screenshots.
