### PR TITLE
WebHost: make autolauncher max room timeout configurable

### DIFF
--- a/WebHostLib/__init__.py
+++ b/WebHostLib/__init__.py
@@ -46,6 +46,8 @@ app.config["SELFGEN"] = True  # application process is in charge of scheduling G
 app.config["JOB_THRESHOLD"] = 1
 # after what time in seconds should generation be aborted, freeing the queue slot. Can be set to None to disable.
 app.config["JOB_TIME"] = 600
+# maximum time in seconds since last activity for a room to be hosted
+app.config["MAX_ROOM_TIMEOUT"] = 259200
 # memory limit for generator processes in bytes
 app.config["GENERATOR_MEMORY_LIMIT"] = 4294967296
 

--- a/WebHostLib/autolauncher.py
+++ b/WebHostLib/autolauncher.py
@@ -129,7 +129,7 @@ def autohost(config: dict):
                     with db_session:
                         rooms = select(
                             room for room in Room if
-                            room.last_activity >= utcnow() - timedelta(days=3))
+                            room.last_activity >= utcnow() - timedelta(seconds=config["MAX_ROOM_TIMEOUT"]))
                         for room in rooms:
                             # we have to filter twice, as the per-room timeout can't currently be PonyORM transpiled.
                             if room.last_activity >= utcnow() - timedelta(seconds=room.timeout + 5):


### PR DESCRIPTION
## What is this fixing or adding?
Compromise version of https://github.com/ArchipelagoMW/Archipelago/pull/5709, which does not give the memory benefit of clearing the database column, but does free some CPU computation while still allowing site forks to have per room timeouts.

## How was this tested?
Nope
