### PR TITLE
Core: Remove `worlds.generic.PlandoItem`

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -455,13 +455,10 @@ safe_builtins = frozenset((
 
 
 class RestrictedUnpickler(pickle.Unpickler):
-    generic_properties_module: Optional[object]
-
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super(RestrictedUnpickler, self).__init__(*args, **kwargs)
         self.options_module = importlib.import_module("Options")
         self.net_utils_module = importlib.import_module("NetUtils")
-        self.generic_properties_module = None
 
     def find_class(self, module: str, name: str) -> type:
         if module == "builtins" and name in safe_builtins:
@@ -475,10 +472,6 @@ class RestrictedUnpickler(pickle.Unpickler):
                                              "SlotType", "NetworkSlot", "HintStatus"}:
             return getattr(self.net_utils_module, name)
         # Options and Plando are unpickled by WebHost -> Generate
-        if module == "worlds.generic" and name == "PlandoItem":
-            if not self.generic_properties_module:
-                self.generic_properties_module = importlib.import_module("worlds.generic")
-            return getattr(self.generic_properties_module, name)
         # pep 8 specifies that modules should have "all-lowercase names" (options, not Options)
         if module.lower().endswith("options"):
             if module == "Options":

--- a/worlds/generic/__init__.py
+++ b/worlds/generic/__init__.py
@@ -49,24 +49,3 @@ class GenericWorld(World):
         if name == "Nothing":
             return Item(name, ItemClassification.filler, -1, self.player)
         raise InvalidItemError(name)
-
-@deprecated("worlds.generic.PlandoItem is deprecated and will be removed in the next version. "
-            "Use Options.PlandoItem(s) instead.")
-class PlandoItem(NamedTuple):
-    item: str
-    location: str
-    world: Union[bool, str] = False  # False -> own world, True -> not own world
-    from_pool: bool = True  # if item should be removed from item pool
-    force: str = 'silent'  # false -> warns if item not successfully placed. true -> errors out on failure to place item.
-
-    def warn(self, warning: str):
-        if self.force in ['true', 'fail', 'failure', 'none', 'false', 'warn', 'warning']:
-            logging.warning(f'{warning}')
-        else:
-            logging.debug(f'{warning}')
-
-    def failed(self, warning: str, exception=Exception):
-        if self.force in ['true', 'fail', 'failure']:
-            raise exception(warning)
-        else:
-            self.warn(warning)


### PR DESCRIPTION
## What is this fixing or adding?
Resolves #5560 by removing the class and the code handling it in `RestrictedUnpickler`, which was deprecated in #5335. I think this is appropriate to do by 0.7.0 since there's been the notice for decent while now, and as best as I'm aware, no custom worlds actually used it prior to then anyway.

## How was this tested?
It didn't break unittests last time.
