### PR TITLE
Muse Dash: Fix nondeterministic generation with include_songs

### DIFF
--- a/worlds/musedash/__init__.py
+++ b/worlds/musedash/__init__.py
@@ -124,7 +124,8 @@ class MuseDashWorld(World):
 
         self.starting_songs = [s for s in start_items if s in song_items]
         self.starting_songs = self.md_collection.filter_songs_to_dlc(self.starting_songs, dlc_songs)
-        self.included_songs = [s for s in include_songs if s in song_items and s not in self.starting_songs]
+        # Sort first for deterministic iteration order.
+        self.included_songs = [s for s in sorted(include_songs) if s in song_items and s not in self.starting_songs]
         self.included_songs = self.md_collection.filter_songs_to_dlc(self.included_songs, dlc_songs)
 
         # Making sure songs chosen for goal are allowed by DLC and remove the chosen from being added to the pool.


### PR DESCRIPTION
## What is this fixing or adding?
The include_songs option is an OptionSet, whose value is a set, but was being iterated to produce self.included_songs. Sets are unordered and may have a different iteration order each time a python process is run. This meant that the order of the elements in self.included_songs could differ even when generating with a fixed seed.

This caused nondeterministic generation with the same seed because create_song_pool() deterministically randomly picks songs from self.included_songs, which could be in a different order each time, so different songs could be picked.

## How was this tested?

I ran generations, that use include_songs, before and after with a fixed seed, observing different output each time before this PR, and constant output each time after this PR, and ran the [fuzzer](https://github.com/Eijebong/Archipelago-fuzzer/) with its [determinism hook](https://github.com/Eijebong/Archipelago-fuzzer/blob/main/hooks/determinism.py), which failed almost every generation before this PR and succeeded at every generation (that did not raise some other error during generation, e.g. OptionError/FillError) after this PR.