### PR TITLE
Core: Pre Output Steps Log

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -207,6 +207,8 @@ def main(args, seed=None, baked_server_options: dict[str, object] | None = None)
     else:
         logger.info("Progression balancing skipped.")
 
+    logger.info("Running Pre Output Steps")
+
     AutoWorld.call_all(multiworld, "finalize_multiworld")
     AutoWorld.call_all(multiworld, "pre_output")
 

--- a/Main.py
+++ b/Main.py
@@ -207,7 +207,7 @@ def main(args, seed=None, baked_server_options: dict[str, object] | None = None)
     else:
         logger.info("Progression balancing skipped.")
 
-    logger.info("Running Pre Output Steps")
+    logger.info("Running pre-output steps.")
 
     AutoWorld.call_all(multiworld, "finalize_multiworld")
     AutoWorld.call_all(multiworld, "pre_output")


### PR DESCRIPTION
With the addition of finalise_multiworld and pre_output, there is no longer a clear indicator for the moment at which the progression balancing step is finished. Previously, the log that signified that the output phase started was enough, since it directly followed the progression balancing step, but now that there is something between the progression balancing and the output step, adding a log before the 2 new steps feels necessary..

## What is this fixing or adding?
A log saying that the pre-output steps are starting. I know that it may lead to confusion with the fact that there is a step that's called pre_output, so feedback to have a better text for that log would be appreciated.

## How was this tested?
Looking at logs during generation, and in the log files.

## If this makes graphical changes, please attach screenshots.
<img width="686" height="182" alt="image" src="https://github.com/user-attachments/assets/3c6acf61-21e1-403f-9493-b0bd7f32c48f" />
