### PR TITLE
Rule Builder: Fix count resolution when Oring HasAnyCount

### DIFF
--- a/rule_builder/rules.py
+++ b/rule_builder/rules.py
@@ -527,7 +527,7 @@ class Or(NestedRule[TWorld], game="Archipelago"):
                     items[item] = 1
             elif isinstance(child, HasAnyCount.Resolved):
                 for item, count in child.item_counts:
-                    if item not in items or items[item] < count:
+                    if item not in items or count < items[item]:
                         items[item] = count
             else:
                 clauses.append(child)

--- a/test/general/test_rule_builder.py
+++ b/test/general/test_rule_builder.py
@@ -233,6 +233,14 @@ class CachedRuleBuilderTestCase(RuleBuilderTestCase):
             Or(Has("A"), HasAny("B", "C"), HasAnyCount({"D": 1, "E": 1})),
             HasAny.Resolved(("A", "B", "C", "D", "E"), player=1),
         ),
+        (
+            And(HasAllCounts({"A": 1, "B": 2}), HasAllCounts({"A": 2, "B": 2})),
+            HasAllCounts.Resolved((("A", 2), ("B", 2)), player=1),
+        ),
+        (
+            Or(HasAnyCount({"A": 1, "B": 2}), HasAnyCount({"A": 2, "B": 2})),
+            HasAnyCount.Resolved((("A", 1), ("B", 2)), player=1),
+        ),
     )
 )
 class TestSimplify(RuleBuilderTestCase):


### PR DESCRIPTION
## What is this fixing or adding?

Fixes item count resolution when `Or`ing `HasAnyCount` rules so they work the same as `Has`. ie, you only need the lowest count for an item.

## How was this tested?

unit tests

## If this makes graphical changes, please attach screenshots.

no