### PR TITLE
WebHost: add document for other games and tools, wiki etc.

### DIFF
--- a/worlds/generic/__init__.py
+++ b/worlds/generic/__init__.py
@@ -26,7 +26,10 @@ class GenericWeb(WebWorld):
                      'English', 'setup_en.md', 'setup/en', ['alwaysintreble'])
     triggers = Tutorial('Archipelago Triggers Guide', 'A guide to setting up and using triggers in your game settings.',
                         'English', 'triggers_en.md', 'triggers/en', ['alwaysintreble'])
-    tutorials = [setup, mac, commands, advanced_settings, triggers, plando]
+    other = Tutorial('Other Games and Tools',
+                     'A guide to additional games and tools that can be used with Archipelago.',
+                     'English', 'other_en.md', 'other/en', ['Berserker'])
+    tutorials = [setup, mac, commands, advanced_settings, triggers, plando, other]
 
 
 class GenericWorld(World):

--- a/worlds/generic/docs/other_en.md
+++ b/worlds/generic/docs/other_en.md
@@ -1,0 +1,24 @@
+# Other Games and Tools
+
+This guide provides information on additional community resources, tools, and games that function with Archipelago.
+
+## Community Resources
+
+The Archipelago community is active across several platforms where you can find support, new games, and tools.
+
+### Discord Servers
+Archipelago has two primary Discord servers for community interaction, game support, and hosting public games:
+- **[Archipelago Official Discord](https://discord.gg/8Z65BR2)**: The main hub for the community, including general discussion, support, and public multiworld hosting.
+- **[Archipelago After Dark Discord](https://discord.gg/fqvNCCRsu4)**: An adults-only server for 18+ and unrated content.
+
+Both servers feature an **#apworld-index** channel. These channels are repositories for "APWorlds" — additional game implementations that can be easily added to your Archipelago installation to support more games.
+
+### Documentation
+- **[Archipelago Wiki](https://archipelago.miraheze.org/)**: A community-maintained wiki.
+
+## Community Tools
+
+These community-developed tools are frequently used alongside Archipelago to improve the player experience.
+
+### PopTracker
+**[PopTracker](https://github.com/black-sliver/PopTracker)** is a universal multi-platform tracking application designed for randomizers. It supports many Archipelago games through tracker packs, providing both manual and automatic autotracking capabilities by connecting directly to an Archipelago server.


### PR DESCRIPTION
## What is this fixing or adding?
Splitoff from https://github.com/ArchipelagoMW/Archipelago/pull/6043, that just adds the document. 
Leaves Sudoku in the state of being the only hint game being listed explicitly.

## How was this tested?
## If this makes graphical changes, please attach screenshots.
<img width="1322" height="847" alt="image" src="https://github.com/user-attachments/assets/8330db66-3784-472a-ae38-1ca8b86aa958" />
