### PR TITLE
Launcher: Add support for konsole as a launch shell

### DIFF
--- a/Launcher.py
+++ b/Launcher.py
@@ -209,7 +209,7 @@ def launch(exe, in_terminal=False):
             subprocess.Popen(["start", "Running Archipelago", *exe], shell=True)
             return
         elif is_linux:
-            terminal = which('x-terminal-emulator') or which('gnome-terminal') or which('xterm')
+            terminal = which('x-terminal-emulator') or which('gnome-terminal') or which('xterm') or which('konsole')
             if terminal:
                 subprocess.Popen([terminal, '-e', shlex.join(exe)])
                 return


### PR DESCRIPTION
Fixes #6051, at least in the short term.

Long-term, it would be better to have these names in an array and print the list when none are found, so end users know what's going on - as an example:

```
Failed to find a terminal to launch the subprocess - if your terminal is not in this list, please file a ticket:
    x-terminal-emulator
    gnome-terminal
    xterm
    konsole
```