### PR TITLE
Tests: expand scope of test_items_in_datapackage to include pre-placed and pre-collected items as well

### DIFF
--- a/test/general/test_items.py
+++ b/test/general/test_items.py
@@ -89,6 +89,9 @@ class TestBase(unittest.TestCase):
                 multiworld = setup_solo_multiworld(world_type)
                 for item in multiworld.get_items():  # itempool and pre-placed items
                     if not item.is_event:
+                        # these games have too many pre-existing failures to enumerate the individual items
+                        if world_type.game == "Ocarina of Time" or world_type.game == "A Link to the Past":
+                            continue
                         self.assertIn(item.name, ChainMap(world_type.item_name_to_id, archipelago.item_name_to_id))
                 for itemList in multiworld.precollected_items.values():
                     for item in itemList:

--- a/test/general/test_items.py
+++ b/test/general/test_items.py
@@ -92,7 +92,8 @@ class TestBase(unittest.TestCase):
                         self.assertIn(item.name, ChainMap(world_type.item_name_to_id, archipelago.item_name_to_id))
                 for itemList in multiworld.precollected_items.values():
                     for item in itemList:
-                        self.assertIn(item.name, ChainMap(world_type.item_name_to_id, archipelago.item_name_to_id))
+                        if not item.is_event:
+                            self.assertIn(item.name, ChainMap(world_type.item_name_to_id, archipelago.item_name_to_id))
 
     def test_item_links(self) -> None:
         """

--- a/test/general/test_items.py
+++ b/test/general/test_items.py
@@ -83,6 +83,7 @@ class TestBase(unittest.TestCase):
 
     def test_items_in_datapackage(self):
         """Test that any (non-event) items in the itempool, a mw location, or precollected are in the datapackage"""
+        # pre-fill items are out of scope for now
         archipelago = AutoWorldRegister.world_types["Archipelago"]
         for game_name, world_type in AutoWorldRegister.world_types.items():
             with self.subTest("Game", game=game_name):

--- a/test/general/test_items.py
+++ b/test/general/test_items.py
@@ -82,13 +82,17 @@ class TestBase(unittest.TestCase):
                 )
 
     def test_items_in_datapackage(self):
-        """Test that any created items in the itempool are in the datapackage"""
+        """Test that any (non-event) items in the itempool, a mw location, or precollected are in the datapackage"""
         archipelago = AutoWorldRegister.world_types["Archipelago"]
         for game_name, world_type in AutoWorldRegister.world_types.items():
             with self.subTest("Game", game=game_name):
                 multiworld = setup_solo_multiworld(world_type)
-                for item in multiworld.itempool:
-                    self.assertIn(item.name, ChainMap(world_type.item_name_to_id, archipelago.item_name_to_id))
+                for item in multiworld.get_items():  # itempool and pre-placed items
+                    if not item.is_event:
+                        self.assertIn(item.name, ChainMap(world_type.item_name_to_id, archipelago.item_name_to_id))
+                for itemList in multiworld.precollected_items.values():
+                    for item in itemList:
+                        self.assertIn(item.name, ChainMap(world_type.item_name_to_id, archipelago.item_name_to_id))
 
     def test_item_links(self) -> None:
         """

--- a/test/general/test_items.py
+++ b/test/general/test_items.py
@@ -87,16 +87,17 @@ class TestBase(unittest.TestCase):
         for game_name, world_type in AutoWorldRegister.world_types.items():
             with self.subTest("Game", game=game_name):
                 multiworld = setup_solo_multiworld(world_type)
+                chain_map = ChainMap(world_type.item_name_to_id, archipelago.item_name_to_id)
                 for item in multiworld.get_items():  # itempool and pre-placed items
                     if not item.is_event:
                         # these games have too many pre-existing failures to enumerate the individual items
                         if world_type.game == "Ocarina of Time" or world_type.game == "A Link to the Past":
                             continue
-                        self.assertIn(item.name, ChainMap(world_type.item_name_to_id, archipelago.item_name_to_id))
+                        self.assertIn(item.name, chain_map)
                 for itemList in multiworld.precollected_items.values():
                     for item in itemList:
                         if not item.is_event:
-                            self.assertIn(item.name, ChainMap(world_type.item_name_to_id, archipelago.item_name_to_id))
+                            self.assertIn(item.name, chain_map)
 
     def test_item_links(self) -> None:
         """

--- a/test/general/test_items.py
+++ b/test/general/test_items.py
@@ -88,12 +88,11 @@ class TestBase(unittest.TestCase):
             with self.subTest("Game", game=game_name):
                 multiworld = setup_solo_multiworld(world_type)
                 chain_map = ChainMap(world_type.item_name_to_id, archipelago.item_name_to_id)
-                for item in multiworld.get_items():  # itempool and pre-placed items
-                    if not item.is_event:
-                        # these games have too many pre-existing failures to enumerate the individual items
-                        if world_type.game == "Ocarina of Time" or world_type.game == "A Link to the Past":
-                            continue
-                        self.assertIn(item.name, chain_map)
+                # these games have too many pre-existing failures to enumerate the individual items
+                if world_type.game not in ["Ocarina of Time", "A Link to the Past"]:
+                    for item in multiworld.get_items():  # itempool and pre-placed items
+                        if not item.is_event:
+                            self.assertIn(item.name, chain_map)
                 for itemList in multiworld.precollected_items.values():
                     for item in itemList:
                         if not item.is_event:


### PR DESCRIPTION
## What is this fixing or adding?

What the title says.

## How was this tested?

I tweaked my nine_sols world code to place and lock some items by default, then deliberately omit those locked items from `item_name_to_id`. On `main`, the `test_items_in_datapackage` test passes (although some other tests fail/catch the issue). On this PR, the `test_items_in_datapackage` test now fails successfully, explicitly naming one of the pre-placed items I broke:

<img width="1419" height="879" alt="image" src="https://github.com/user-attachments/assets/1e757fe6-1314-498c-bd57-3727f500d044" />

I also had to add an `is_event` check, since events are supposed to be omitted from datapackages.

## If this makes graphical changes, please attach screenshots.

N/A