### PR TITLE
Messenger: Require Wingsuit to traverse Dark Cave

### DIFF
--- a/worlds/messenger/rules.py
+++ b/worlds/messenger/rules.py
@@ -192,7 +192,7 @@ class MessengerRules:
                               or (self.has_dart(state) and self.has_wingsuit(state)),
             # Dark Cave
             "Dark Cave - Right -> Dark Cave - Left":
-                lambda state: state.has("Candle", self.player) and self.has_dart(state),
+                lambda state: state.has("Candle", self.player) and self.has_dart(state) and self.has_wingsuit(state),
             # Riviere Turquoise
             "Riviere Turquoise - Waterfall Shop -> Riviere Turquoise - Flower Flight Checkpoint":
                 lambda state: self.has_dart(state) or (


### PR DESCRIPTION
## What is this fixing or adding?
Dark Cave has a section that cannot be traversed without using Wingsuit to ride the air current. It is the only way to get on the platform to then reach the lanterns, as there are no clingable walls, and no strikable objects can be reached with Rope Dart from underneath the platform. (For those unfamiliar with the game, this area is traversed from right to left.)

![Dark_Cave_Overworld_Map](https://github.com/user-attachments/assets/dde7223b-c6ec-4b2f-b149-a247123e5784)

This PR adds `has_wingsuit(state)` to the requirements for this connection.

## How was this tested?
Ensured unit tests passed, performed some test generations with a portal-shuffle yaml.