### PR TITLE
Core: Add mixin for `start_inventory_from_pool`

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -1724,6 +1724,11 @@ class PerGameCommonOptions(CommonOptions):
 
 
 @dataclass
+class StartInventoryPoolMixin:
+    start_inventory_from_pool: StartInventoryPool
+
+
+@dataclass
 class DeathLinkMixin:
     death_link: DeathLink
 


### PR DESCRIPTION
## What is this fixing or adding?
The `StartInventoryPool` option apparently requires the option name be exactly `start_inventory_from_pool` to work- but this relies on the dev naming it properly, which is a needless source of error.

This adds a `StartInventoryPoolMixin`, similar to the existing `DeathLinkMixin`, to alleviate this problem by handling the option name for you.

## How was this tested?
It wasn't.

## If this makes graphical changes, please attach screenshots.
N/A