### PR TITLE
Stardew Valley: Bypass CollectionState overhead by just calling prog_items

### DIFF
--- a/worlds/stardew_valley/stardew_rule/state.py
+++ b/worlds/stardew_valley/stardew_rule/state.py
@@ -27,7 +27,7 @@ class TotalReceived(BaseStardewRule):
     def __call__(self, state: CollectionState) -> bool:
         c = 0
         for item in self.items:
-            c += state.count(item, self.player)
+            c += state.prog_items[self.player][item]
             if c >= self.count:
                 return True
         return False
@@ -56,7 +56,7 @@ class Received(CombinableStardewRule):
         return self.count
 
     def __call__(self, state: CollectionState) -> bool:
-        return state.has(self.item, self.player, self.count)
+        return state.prog_items[self.player][self.item] >= self.count
 
     def evaluate_while_simplifying(self, state: CollectionState) -> Tuple[StardewRule, bool]:
         return self, self(state)

--- a/worlds/stardew_valley/test/TestStardewRule.py
+++ b/worlds/stardew_valley/test/TestStardewRule.py
@@ -1,4 +1,5 @@
 import unittest
+from collections import Counter
 from typing import cast
 from unittest.mock import MagicMock, Mock
 
@@ -103,7 +104,7 @@ class TestEvaluateWhileSimplifying(unittest.TestCase):
 
     def test_short_circuit_when_combinable_rules_is_false(self):
         collection_state = MagicMock()
-        collection_state.has = Mock(return_value=False)
+        collection_state.prog_items = {1: Counter()}
         other_rule = MagicMock()
         rule = And(Received("Potato", 1, 10), cast(StardewRule, other_rule))
 
@@ -113,6 +114,7 @@ class TestEvaluateWhileSimplifying(unittest.TestCase):
 
     def test_identity_is_removed_from_other_rules(self):
         collection_state = MagicMock()
+        collection_state.prog_items = {1: Counter()}
         rule = Or(false_, Received("Potato", 1, 10))
 
         rule.evaluate_while_simplifying(collection_state)
@@ -122,6 +124,7 @@ class TestEvaluateWhileSimplifying(unittest.TestCase):
 
     def test_complement_replaces_combinable_rules(self):
         collection_state = MagicMock()
+        collection_state.prog_items = {1: Counter()}
         rule = Or(Received("Potato", 1, 10), true_)
 
         rule.evaluate_while_simplifying(collection_state)
@@ -132,6 +135,7 @@ class TestEvaluateWhileSimplifying(unittest.TestCase):
         expected_simplified = true_
         expected_result = True
         collection_state = MagicMock()
+        collection_state.prog_items = {1: Counter()}
         rule = Or(Or(expected_simplified), Received("Potato", 1, 10))
 
         actual_simplified, actual_result = rule.evaluate_while_simplifying(collection_state)
@@ -142,6 +146,7 @@ class TestEvaluateWhileSimplifying(unittest.TestCase):
 
     def test_already_simplified_rules_are_not_simplified_again(self):
         collection_state = MagicMock()
+        collection_state.prog_items = {1: Counter()}
         other_rule = MagicMock()
         other_rule.evaluate_while_simplifying = Mock(return_value=(other_rule, False))
         rule = Or(cast(StardewRule, other_rule), Received("Potato", 1, 10))


### PR DESCRIPTION
## What is this fixing or adding?
I read somewhere that rule builder bypasses the collection state methods to directly fetch the item count in the prog_items. I tried that in stardew as well, there's a ~3% performance gain. Not much, but clearly worth the 2 lines change.

## How was this tested?
Just run the tests. I copied and pasted from collection state so what could go wrong anyway?

## If this makes graphical changes, please attach screenshots.
N/A