### PR TITLE
Celeste open world: Deprioritizing strawberries

### DIFF
--- a/worlds/celeste_open_world/Items.py
+++ b/worlds/celeste_open_world/Items.py
@@ -93,7 +93,7 @@ class CelesteItemData(NamedTuple):
 
 
 collectable_item_data_table: dict[str, CelesteItemData] = {
-    ItemName.strawberry: CelesteItemData(celeste_base_id + 0x0, ItemClassification.progression_skip_balancing),
+    ItemName.strawberry: CelesteItemData(celeste_base_id + 0x0, ItemClassification.progression_deprioritized_skip_balancing),
     ItemName.raspberry:  CelesteItemData(celeste_base_id + 0x1, ItemClassification.filler),
 }
 


### PR DESCRIPTION
## What is this fixing or adding?
The "deprioritized" flag is described at its [definition](https://github.com/ArchipelagoMW/Archipelago/blob/fb45a2f87e392a7ea69daa33905b8aee3e83e19d/BaseClasses.py#L1569) in `BaseClasses.py` as being suitable for "items that would feel bad for the player to find on a priority location. Usually, these are items that are plentiful or insignificant." Although strawberries are clearly progression items when used to gate the goal area and/or epilogue, they don't have as much impact as a reward for, say, defeating a boss, when compared to interactables or key items, given that there may be hundreds of strawberries in the item pool. For this reason, it seems to me that they're a fitting use case for this flag. 

## How was this tested?
I've played several archipelagos, with and without this change. I find that the experience is improved both in solo archipelagos and with friends. 