### PR TITLE
Core: Make Generate.main only init logging on __main__

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -87,7 +87,8 @@ def main(args=None) -> tuple[argparse.Namespace, int]:
 
     seed = get_seed(args.seed)
 
-    Utils.init_logging(f"Generate_{seed}", loglevel=args.log_level, add_timestamp=args.log_time)
+    if __name__ == "__main__":
+        Utils.init_logging(f"Generate_{seed}", loglevel=args.log_level, add_timestamp=args.log_time)
     random.seed(seed)
     seed_name = get_seed_name(random)
 


### PR DESCRIPTION
## What is this fixing or adding?
make Generate.main only init logging on __main__

## How was this tested?
used UT, its logs are no longer called "Generate"
used Generate.py, its logs were still called "Generate"

## If this makes graphical changes, please attach screenshots.
