### PR TITLE
Setup: Add rule_builder.cached_world to included list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -657,7 +657,7 @@ cx_Freeze.setup(
     options={
         "build_exe": {
             "packages": ["worlds", "kivy", "cymem", "websockets", "kivymd"],
-            "includes": [],
+            "includes": ["rule_builder.cached_world"],
             "excludes": ["numpy", "Cython", "PySide2", "PIL",
                          "pandas"],
             "zip_includes": [],


### PR DESCRIPTION
## What is this fixing or adding?

`rule_builder.cached_world` isn't being imported anywhere so it's not being included in the build. Adding it to the includes list will force it to be included in the build.

I haven't touched a setup.py file in like 10 years so I hope this is right

## How was this tested?

Ran `setup.py build_exe`, checked `library.zip`, saw `rule_builder/cached_world.pyc`

## If this makes graphical changes, please attach screenshots.

no