### PR TITLE
Clients: remove datapackage from persistent_storage

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -345,6 +345,9 @@ def persistent_load() -> Dict[str, Dict[str, Any]]:
         try:
             with open(path, "r") as f:
                 storage = unsafe_parse_yaml(f.read())
+            if "datapackage" in storage:
+                del storage["datapackage"]
+                logging.debug("Removed old datapackage from persistent storage")
         except Exception as e:
             logging.debug(f"Could not read store: {e}")
     if storage is None:
@@ -368,11 +371,6 @@ def load_data_package_for_checksum(game: str, checksum: typing.Optional[str]) ->
                     return json.load(f)
             except Exception as e:
                 logging.debug(f"Could not load data package: {e}")
-
-    # fall back to old cache
-    cache = persistent_load().get("datapackage", {}).get("games", {}).get(game, {})
-    if cache.get("checksum") == checksum:
-        return cache
 
     # cache does not match
     return {}


### PR DESCRIPTION
## What is this fixing or adding?

Remove datapackage from persistent_storage next time it gets written to.
The per-checksum data package cache has been in use for a while now, so we probably don't save any network traffic anymore by keeping it around, and removing it means faster load and save times for persistent_storage.

(Imo, there is no point in flushing right away, because we are very likely to write at some point anyway, and it's kind of unlikely that the loading is slow enough to be a problem that would be solved by flushing).

## Why

Simplifies datapackage code.
Speeds up loading/saving of _persistent_storage.yaml for users that still have datapackages in it.
Potentially skips loading of _persistent_storage.yaml for `load_data_package_for_checksum` if nothing else is needed from it (this is not true for Text Client since the last server is read from the same file).

## How was this tested?

Putting datapackage into _persistent_storage.yaml and seeing it disappear when making Text Client connect to different rooms (to force a _persistent_storage.yaml write).