### PR TITLE
Core, Webhost: update and pin dependency versions

### DIFF
--- a/WebHostLib/requirements.txt
+++ b/WebHostLib/requirements.txt
@@ -1,14 +1,14 @@
-flask>=3.1.1
-werkzeug>=3.1.3
-pony>=0.7.19; python_version <= '3.12'
+flask==3.1.3
+werkzeug==3.1.6
+pony==0.7.19; python_version <= '3.12'
 pony @ git+https://github.com/black-sliver/pony@7feb1221953b7fa4a6735466bf21a8b4d35e33ba#0.7.19; python_version >= '3.13'
-waitress>=3.0.2
-Flask-Caching>=2.3.0
+waitress==3.0.2
+Flask-Caching==2.3.1
 Flask-Compress==1.18  # pkg_resources can't resolve the "backports.zstd" dependency of >1.18, breaking ModuleUpdate.py
-Flask-Limiter>=3.12
-Flask-Cors>=6.0.2
-bokeh>=3.6.3
-markupsafe>=3.0.2
-setproctitle>=1.3.5
-mistune>=3.1.3
-docutils>=0.22.2
+Flask-Limiter==4.1.1
+Flask-Cors==6.0.2
+bokeh==3.8.2
+markupsafe==3.0.3
+setproctitle==1.3.7
+mistune==3.2.0
+docutils==0.22.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,21 +1,21 @@
-colorama>=0.4.6
-websockets>=13.0.1,<14
-PyYAML>=6.0.3
-jellyfish>=1.2.1
-jinja2>=3.1.6
-schema>=0.7.8
-kivy>=2.3.1
-bsdiff4>=1.2.6
-platformdirs>=4.5.0
-certifi>=2025.11.12
-cython>=3.2.1
-cymem>=2.0.13
-orjson>=3.11.4
-typing_extensions>=4.15.0
-pyshortcuts>=1.9.6
-pathspec>=0.12.1
+colorama==0.4.6
+websockets==13.1  # ,<14
+PyYAML==6.0.3
+jellyfish==1.2.1
+jinja2==3.1.6
+schema==0.7.8
+kivy==2.3.1
+bsdiff4==1.2.6
+platformdirs==4.9.4
+certifi==2026.2.25
+cython==3.2.4
+cymem==2.0.13
+orjson==3.11.7
+typing_extensions==4.15.0
+pyshortcuts==1.9.7
+pathspec==1.0.4
 kivymd @ git+https://github.com/kivymd/KivyMD@5ff9d0d
 kivymd>=2.0.1.dev0
 
 # Legacy world dependencies that custom worlds rely on
-Pymem>=1.13.0
+Pymem==1.14.0

--- a/worlds/alttp/requirements.txt
+++ b/worlds/alttp/requirements.txt
@@ -1,2 +1,2 @@
-maseya-z3pr>=1.0.0rc1
-xxtea>=3.0.0
+maseya-z3pr==1.0.0rc1
+xxtea==3.7.0

--- a/worlds/factorio/requirements.txt
+++ b/worlds/factorio/requirements.txt
@@ -1,1 +1,1 @@
-factorio-rcon-py>=2.1.2
+factorio-rcon-py==2.1.3


### PR DESCRIPTION
## What is this fixing or adding?

Updates and pins dependencies in core, webhost, alttp and factorio.

(We should probably go through all worlds in a separate PR.)

### NOT pinned

* KivyMD: this needs a solution in ModuleUpdate.py, so I didn't want to touch it.

### NOT updated to latest

* websockets: 14.x breaks for us. Updated to 13.1 instead
* werkzeug: the release is kinda big and only up to 3.1.6 lists security updates
* Flask-Compress: we had an issue with >1.18 and I did not test if it was fixed. The Changelog does not mention our problem. 
* bokeh: read below

## Why?

* `>=` requirements are prone to supply chain attacks.
* Problems may not be fully reproducible and we have no idea what is actually running.

Downside: switching branches may lead to up-/downgrading libs, so we should still try to batch updates and/or add a toggle to disable ModuleUpdate for developers.

## How was this tested?

See notes in details below, but also CI should catch most of it.

## Update Details

`xxtea==3.7.0`: already used, changes look fine

`factorio-rcon-py==2.1.3`: already used, changes look fine

`websockets==13.1`: already used, changelog looks safe
`platformdirs==4.9.4`: changelog looks fine, but the code changes are too big to review. We definitely have tested 4.9.2 and the changes since then are mostly build/CI and small other changes that look fine.
`cython==3.2.4`: Have been using this. Changelog looks fine, code changes are too much to review
`orjson==3.11.7`: Have been using this. Changelog looks fine, 3.11.6 fixed a crash. It's too big of a change to review. :/ .6 -> .7 looks fine on github.
`pyshortcuts==1.9.7`: no idea what this is doing on macos, but the rest looks sane.
`pathspec==1.0.4`: when we merged it was 1.0.3, changes to 1.0.4 look fine
`Pymem==1.14.0`: we actually have been using that a long time now, but I have no idea what's going on in their repo and they also don't use trusted publishing.

`flask==3.1.3`: fixes a security issue that doesn't matter to us, remaining changes are typing, CI and doc updates
`werkzeug==3.1.6`: fixes a security issue that may or may not matter. there is also 3.1.7, but it's too much to look at
`Flask-Limiter==4.1.1`: The one we list was yanked. I have been using 4.1.1 for a while, but I have not fully reviewed the code changes.
`bokeh==3.8.2`: We've been testing that one on archipelago.today. Did not look at 3.9.0 yet.
`mistune==3.2.0`: I believe we've been using that on archipelago.today.
`docutils==0.22.4`: I believe we've been using that on archipelago.today.