### PR TITLE
Docs: update macOS setup instructions for more specificity on Python version.

### DIFF
--- a/worlds/generic/docs/mac_en.md
+++ b/worlds/generic/docs/mac_en.md
@@ -2,7 +2,7 @@
 Archipelago does not have a compiled release on macOS. However, it is possible to run from source code on macOS. This guide expects you to have some experience with running software from the terminal.
 ## Prerequisite Software
 Here is a list of software to install and source code to download.
-1. Python 3.11 "universal2" or newer from the [macOS Python downloads page](https://www.python.org/downloads/macos/).
+1. Python 3.11.9 "universal2" or newer from the [macOS Python downloads page](https://www.python.org/downloads/macos/).
    **Python 3.14 is not supported yet.**
 2. Xcode from the [macOS App Store](https://apps.apple.com/us/app/xcode/id497799835).
 3. The source code from the [Archipelago releases page](https://github.com/ArchipelagoMW/Archipelago/releases).


### PR DESCRIPTION
## What is this fixing or adding?
Changes minimum required Python version on mac documentation page from 3.11 to 3.11.9, allowing a more explicit and easy to follow setup process for non-technical users.

## How was this tested?
Local website instance with edit made. Error correction via macOS Archipelago setup led to discovery of documentation improvement to begin with.

## If this makes graphical changes, please attach screenshots.
<img width="1559" height="414" alt="image" src="https://github.com/user-attachments/assets/ea7266db-b856-45d2-8388-c07393c90ce4" />
