### PR TITLE
MM3: Bump world version

### DIFF
--- a/worlds/mm3/archipelago.json
+++ b/worlds/mm3/archipelago.json
@@ -1,6 +1,6 @@
 {
   "game": "Mega Man 3",
   "authors": ["Silvris"],
-  "world_version": "0.1.7",
+  "world_version": "0.1.8",
   "minimum_ap_version": "0.6.4"
 }


### PR DESCRIPTION
## What is this fixing or adding?
Bumps MM3 world version. MM3 was actually merged with an additional bug fix compared to the previously listed version, so the number needs bumped so old custom worlds are no longer loaded following release.

## How was this tested?
It's a number.