### PR TITLE
CommonClient: only send single GetDataPackage

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -673,7 +673,7 @@ class CommonContext:
                     else:
                         self.update_game(cached_game, game)
         if needed_updates:
-            await self.send_msgs([{"cmd": "GetDataPackage", "games": [game_name]} for game_name in needed_updates])
+            await self.send_msgs([{"cmd": "GetDataPackage", "games": [game_name for game_name in needed_updates]}])
 
     def update_game(self, game_package: dict, game: str):
         self.item_names.update_game(game, game_package["item_name_to_id"])


### PR DESCRIPTION
## What is this fixing or adding?

The client has been sending individual `GetDataPackage` request for every game that needs it.
The client is extremely slow to process the resulting flood of packages, probably due to UI updates (it causes the UI to glitch while processing, see screenshot).

This change makes the client send out a single `GetDataPackage` with all the necessary games included.

## How was this tested?
Ran client against server to verify that datapackages are still received.

<img width="1292" height="909" alt="image" src="https://github.com/user-attachments/assets/26969337-05ac-471d-bb4d-98e3387ef94f" />
