### PR TITLE
The Messenger: Add missing indirect conditions

### DIFF
--- a/worlds/messenger/rules.py
+++ b/worlds/messenger/rules.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from BaseClasses import CollectionState, CollectionRule
+from BaseClasses import CollectionState, CollectionRule, Region
 from worlds.generic.Rules import add_rule, allow_self_locking_items
 from .constants import NOTES, PHOBEKINS
 from .options import MessengerAccessibility
@@ -13,6 +13,7 @@ class MessengerRules:
     player: int
     world: "MessengerWorld"
     connection_rules: dict[str, CollectionRule]
+    indirect_conditions: dict[str, list[Region]]
     region_rules: dict[str, CollectionRule]
     location_rules: dict[str, CollectionRule]
     maximum_price: int
@@ -219,6 +220,16 @@ class MessengerRules:
                 lambda state: self.can_dboost(state) or self.has_dart(state),
         }
 
+        # dict of connection names and the regions checked in the requirements to traverse the exit
+        self.indirect_conditions = {
+            "Howling Grotto - Breezy Crushers Checkpoint -> Howling Grotto - Crushing Pits Shop": [
+                self.world.get_region("Howling Grotto - Emerald Golem Shop")
+            ],
+            "Glacial Peak - Left -> Elemental Skylands - Air Shmup": [
+                self.world.get_location("Quillshroom Marsh - Queen of Quills").parent_region
+            ],
+        }
+
         self.location_rules = {
             # hq
             "Money Wrench": self.can_shop,
@@ -364,6 +375,8 @@ class MessengerRules:
         for entrance_name, rule in self.connection_rules.items():
             entrance = multiworld.get_entrance(entrance_name, self.player)
             entrance.access_rule = rule
+            for region in self.indirect_conditions.get(entrance_name, ()):
+                multiworld.register_indirect_condition(region, entrance)
         for loc in multiworld.get_locations(self.player):
             if loc.name in self.location_rules:
                 loc.access_rule = self.location_rules[loc.name]


### PR DESCRIPTION
## What is this fixing or adding?
Adds 2 missing indirect conditions to The Messenger

The missing indirect conditions potentially could have caused nondeterministic generation with the same seed because they were found to cause `multiworld.get_spheres()` iteration to vary, but nondeterministic generation has not been observed in solo seeds (fuzzing with a hook to test for nondeterministic generation passed with 500 solo The Messenger seeds).

## How was this tested?
The missing indirect conditions were found by running [Eije's fuzzer](https://github.com/Eijebong/Archipelago-fuzzer), with its [indirect conditions hook](https://github.com/Eijebong/Archipelago-fuzzer/blob/main/hooks/indirect_conditions.py) that basically just runs the `test_explicit_indirect_conditions_spheres` core test against fuzzer generations, and then pinpointed to the rules responsible using my [hook to get tracebacks to the rules](https://github.com/Mysteryem/Archipelago-fuzzer/blob/mysteryem_hooks/hooks/check_missing_indirect_conditions.py). These fuzzer hooks no longer fail with the PR applied.