### PR TITLE
Noita: Fix names when you only select 1 chest or pedestal

### DIFF
--- a/worlds/noita/locations.py
+++ b/worlds/noita/locations.py
@@ -208,7 +208,7 @@ location_region_mapping: dict[str, dict[str, LocationData]] = {
 
 
 def make_location_range(location_name: str, base_id: int, amt: int) -> dict[str, int]:
-    if amt == 1:
+    if amt == 1 and "Chest" not in location_name and "Pedestal" not in location_name:
         return {location_name: base_id}
     return {f"{location_name} {i+1}": base_id + i for i in range(amt)}
 


### PR DESCRIPTION
## What is this fixing or adding?
Fixes a bug where the location name for a biome's chest or pedestal generates without its number if you only choose to have 1 of that check spawn per biome. I have no idea why AP does not crash because of this.

## How was this tested?
Test generation after fixing.