### PR TITLE
Satisfactory: Fix broken links on the Setup guide

### DIFF
--- a/worlds/satisfactory/docs/en_Satisfactory.md
+++ b/worlds/satisfactory/docs/en_Satisfactory.md
@@ -2,9 +2,9 @@
 
 <!-- Spellchecker config - cspell:ignore FICSIT Nobelisk Zoop -->
 
-## Where is the settings page?
+## Where is the options page?
 
-The [player settings page for this game](../player-options)
+The [player options page for this game](../player-options)
 contains all the options you need to configure and export a config file.
 
 ## What does randomization do to this game?
@@ -18,7 +18,7 @@ The materials required for constructing Assemblers and Foundries is altered to i
 
 ## What is the goal of Satisfactory?
 
-The player can choose from a number of goals using their YAML settings:
+The player can choose from a number of goals using their YAML options:
 
 - Complete the selected number of **[Space Elevator](https://satisfactory.wiki.gg/wiki/Space_Elevator) Phases**.
   - The goal completes upon submitting your selected Space Elevator Phase. Any other progression you may have access to (HUB, MAM, AWESOME Shop) is not required for goal completion.
@@ -62,7 +62,7 @@ In Satisfactory multiplayer, each Satisfactory player gets a copy of the sample.
 Certain recipes and items, like Somersloops, are always excluded from samples.
 
 You can separately configure how many samples to receive for buildings, equipment, and crafting components
-in your player settings.
+in your player options.
 
 ## What is a Resource Bundle?
 
@@ -78,7 +78,7 @@ unless they can't fit, in which case they can be collected by building an Archip
 
 Traps are items intended to disrupt the player that replace non-progression filler items.
 Satisfactory's traps currently include spawning disruptive creatures or sending inconvenient items to your Archipelago Portal.
-The player settings page gives full control over which traps are enabled,
+The player options page gives full control over which traps are enabled,
 how many traps replace filler items,
 as well as some pre-selected groups of themed traps.
 
@@ -108,7 +108,7 @@ Bundles will instantly be added to the Archipelago Portal network and can be col
 ## What is EnergyLink?
 
 EnergyLink is an energy storage supported by certain games that is shared across all worlds in a multiworld.
-In Satisfactory, if enabled in the player settings, all base-game Power Storage buildings will act as Energy Link interfaces.
+In Satisfactory, if enabled in the player options, all base-game Power Storage buildings will act as Energy Link interfaces.
 They will deposit surplus produced energy and draw energy from the shared storage when needed.
 
 Just like the base game, there is no limit to the discharge/draw rate of one building,
@@ -198,10 +198,10 @@ It is possible to use other Satisfactory mods in tandem with the Archipelago Sat
 However, no guarantee is made that they will work correctly,
 especially if they affect game progression, recipes, or add unlocks to base-game technologies.
 
-Content added by unaffiliated mods may end up inaccessible based on your chosen slot settings,
+Content added by unaffiliated mods may end up inaccessible based on your chosen slot options,
 for example, its milestones could be in a tier that is after your goal.
 You may be able to write patches using [ContentLib](https://ficsit.app/mod/ContentLib)
-to adjust other mods to work with your slot settings,
+to adjust other mods to work with your slot options,
 but doing so is out of the scope of this guide.
 
 [The Satisfactory Archipelago mod GitHub](https://github.com/Jarno458/SatisfactoryArchipelagoMod/blob/main/Docs/AdditionalMods.md)

--- a/worlds/satisfactory/docs/setup_en.md
+++ b/worlds/satisfactory/docs/setup_en.md
@@ -121,7 +121,7 @@ and different players in the same multiworld can all have different options.
 
 The Player Settings page on the website
 allows you to configure your personal settings and export a config file from them.
-Satisfactory player settings page: [Satisfactory Settings Page](/games/Satisfactory/player-settings)
+Satisfactory player settings page: [Satisfactory Settings Page](/games/Satisfactory/player-options)
 
 #### Verifying Your Config File
 
@@ -144,8 +144,8 @@ to spawn the items you desire.
 #### Advanced Configuration
 
 Advanced users can utilize the
-[Weighted Options Page](/weighted-options)
-and [Plando](/tutorial/Archipelago/plando)
+[Weighted Options Page](/games/Satisfactory/weighted-options)
+and [Plando](/tutorial/Archipelago/plando_en)
 to futher customize their experience.
 
 ### Generating and Hosting the Multiworld

--- a/worlds/satisfactory/docs/setup_en.md
+++ b/worlds/satisfactory/docs/setup_en.md
@@ -119,9 +119,9 @@ and different players in the same multiworld can all have different options.
 
 #### Where do I get a config file?
 
-The Player Settings page on the website
-allows you to configure your personal settings and export a config file from them.
-Satisfactory player settings page: [Satisfactory Settings Page](/games/Satisfactory/player-options)
+The Player Options page on the website
+allows you to configure your personal options and export a config file from them.
+Satisfactory player options page: [Satisfactory Options Page](/games/Satisfactory/player-options)
 
 #### Verifying Your Config File
 
@@ -131,7 +131,7 @@ YAML Validator page: [Yaml Validation Page](/mysterycheck)
 
 #### Starting Inventory
 
-The Player Settings page provides a few options for controlling what materials you start with
+The Player Options page provides a few options for controlling what materials you start with
 and when certain key technologies are unlocked.
 Any Resource Bundle type items added to your starting inventory will be delivered to your player inventory when you initally spawn,
 unless they can't fit, in which case they can be collected by building an Archipelago Portal.

--- a/worlds/satisfactory/docs/setup_en.md
+++ b/worlds/satisfactory/docs/setup_en.md
@@ -138,7 +138,7 @@ unless they can't fit, in which case they can be collected by building an Archip
 
 Advanced users can use Plando, Weighted Options, and manual yaml editing to further configure the starting inventory.
 If you don't wish to use these techniques, consider using Satisfactory's
-[Advanced Game Settings (Satisfactory Wiki)](https://satisfactory.wiki.gg/wiki/Advanced_Game_Settings)
+[Creative Mode (Satisfactory Wiki)](https://satisfactory.wiki.gg/wiki/Creative_Mode)
 to spawn the items you desire.
 
 #### Advanced Configuration


### PR DESCRIPTION
## What is this fixing or adding?

The Setup guide (https://archipelago.gg/tutorial/Satisfactory/setup_en) has some broken links.

A user reported them on the Archipelago Discord: https://discord.com/channels/731205301247803413/1454822629423841442/1490311386017042512

## How was this tested?

I edited the URLs for the pages via Inspect Element to swap them to the same values I set when editing the file, then followed them to test. I didn't build a new web host to test them since I am away from my normal development machine.

