### PR TITLE
Core: Add platform checks for Android and iOS

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -55,9 +55,12 @@ class Version(typing.NamedTuple):
 __version__ = "0.6.7"
 version_tuple = tuplize_version(__version__)
 
-is_linux = sys.platform.startswith("linux")
+is_android = sys.platform == "android" or "P4A_BOOTSTRAP" in os.environ or "ANDROID_ARGUMENT" in os.environ
+is_linux = sys.platform.startswith("linux") and not is_android
 is_macos = sys.platform == "darwin"
 is_windows = sys.platform in ("win32", "cygwin", "msys")
+is_ios = sys.platform == "ios"
+is_mobile = is_android or is_ios
 
 
 def int16_as_bytes(value: int) -> typing.List[int]:


### PR DESCRIPTION
## What is this fixing or adding?
"fixes" android being detected as linux, which I am not 100% sure is the best solution, as it technically is also a linux just a very special one. Adds is_android and is_ios; is_ios is untested.

## How was this tested?
On windows and android.
