### PR TITLE
Kivy: update kivyMD to commit 365aa9b

### DIFF
--- a/data/launcher.kv
+++ b/data/launcher.kv
@@ -38,7 +38,7 @@
             pos_hint:{"center_x": 0.85, "center_y": 0.8}
             theme_text_color: "Custom"
             text_color: app.theme_cls.primaryColor
-            detect_visible: False
+            allow_hover: False
             on_release: app.set_favorite(self)
 
         MDIconButton:
@@ -48,7 +48,7 @@
             pos_hint:{"center_x": 0.95, "center_y": 0.8}
             theme_text_color: "Custom"
             text_color: app.theme_cls.primaryColor
-            detect_visible: False
+            allow_hover: False
 
         MDButton:
             pos_hint:{"center_x": 0.9, "center_y": 0.25}
@@ -56,7 +56,7 @@
             height: "25dp"
             component: main.component
             on_release: app.component_action(self)
-            detect_visible: False
+            allow_hover: False
             MDButtonText:
                 text: "Open"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ orjson==3.11.7
 typing_extensions==4.15.0
 pyshortcuts==1.9.7
 pathspec==1.0.4
-kivymd @ git+https://github.com/kivymd/KivyMD@5ff9d0d
+kivymd @ git+https://github.com/kivymd/KivyMD@365aa9b
 kivymd>=2.0.1.dev0
 
 # Legacy world dependencies that custom worlds rely on


### PR DESCRIPTION
## What is this fixing or adding?
Newer kivyMD emits a deprecation warning for detect_visible and suggests to switch to allow_hover which was added with 2.0.0.
So this switches to the new attr and updated kivyMD

## How was this tested?
locally, though the github runners seem to not like it at all.
