### PR TITLE
MultiServer: Send `InvalidPacket` for `UpdateHint` when hint does not exist

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2098,7 +2098,11 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
                 return
             hint = ctx.get_hint(client.team, player, location)
             if not hint:
-                return  # Ignored safely
+                await ctx.send_msgs(client,
+                                    [{'cmd': 'InvalidPacket', "type": "arguments",
+                                      "text": f"UpdateHint: Hint for location {location} in player {player}'s world not found",
+                                      "original_cmd": cmd}])
+                return
             if client.slot not in ctx.slot_set(hint.receiving_player):
                 await ctx.send_msgs(client,
                                     [{'cmd': 'InvalidPacket', "type": "arguments", "text": 'UpdateHint: No Permission',

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2086,26 +2086,26 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
             ctx.notify_hints(client.team, hints, only_new=True, persist_even_if_found=True)
             ctx.save()
         
-        elif cmd == 'UpdateHint':
+        elif cmd == "UpdateHint":
             location = args["location"]
             player = args["player"]
             status = args["status"]
             if not isinstance(player, int) or not isinstance(location, int) \
                     or (status is not None and not isinstance(status, int)):
                 await ctx.send_msgs(client,
-                                    [{'cmd': 'InvalidPacket', "type": "arguments", "text": 'UpdateHint',
+                                    [{"cmd": "InvalidPacket", "type": "arguments", "text": "UpdateHint",
                                       "original_cmd": cmd}])
                 return
             hint = ctx.get_hint(client.team, player, location)
             if not hint:
                 await ctx.send_msgs(client,
-                                    [{'cmd': 'InvalidPacket', "type": "arguments",
+                                    [{"cmd": "InvalidPacket", "type": "arguments",
                                       "text": f"UpdateHint: Hint for location {location} in player {player}'s world not found",
                                       "original_cmd": cmd}])
                 return
             if client.slot not in ctx.slot_set(hint.receiving_player):
                 await ctx.send_msgs(client,
-                                    [{'cmd': 'InvalidPacket', "type": "arguments", "text": 'UpdateHint: No Permission',
+                                    [{"cmd": "InvalidPacket", "type": "arguments", "text": "UpdateHint: No Permission",
                                       "original_cmd": cmd}])
                 return
             new_hint = hint
@@ -2115,13 +2115,13 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
                 status = HintStatus(status)
             except ValueError:
                 await ctx.send_msgs(client,
-                                    [{'cmd': 'InvalidPacket', "type": "arguments",
-                                      "text": 'UpdateHint: Invalid Status', "original_cmd": cmd}])
+                                    [{"cmd": "InvalidPacket", "type": "arguments",
+                                      "text": "UpdateHint: Invalid Status", "original_cmd": cmd}])
                 return
             if status == HintStatus.HINT_FOUND:
                 await ctx.send_msgs(client,
-                                    [{'cmd': 'InvalidPacket', "type": "arguments",
-                                      "text": 'UpdateHint: Cannot manually update status to "HINT_FOUND"', "original_cmd": cmd}])
+                                    [{"cmd": "InvalidPacket", "type": "arguments",
+                                      "text": "UpdateHint: Cannot manually update status to \"HINT_FOUND\"", "original_cmd": cmd}])
                 return
             new_hint = new_hint.re_prioritize(ctx, status)
             if hint == new_hint:


### PR DESCRIPTION
## What is this fixing or adding?
`UpdateHint` previously ignored packets in this case. [Someone misread the documentation today](https://discord.com/channels/731205301247803413/1214608557077700720/1491100031359385681) and was using the wrong player number, and as such got no feedback that the command was invalid- this adds a clear error message `InvalidPacket` response to [help make the error clearer](https://discord.com/channels/731205301247803413/1214608557077700720/1491106060667457606).

## How was this tested?
Temporarily modified TextClient to use the wrong player number, and attempted to modify hint priorities.

## If this makes graphical changes, please attach screenshots.
<img width="798" height="342" alt="image" src="https://github.com/user-attachments/assets/f6d80e01-7051-4768-8682-972dc7f2cdc8" />