### PR TITLE
MultiServer: new `_multiple` hinting commands; `!hint` with hint_cost 0 and `/hint` now only grant 1 hint

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1791,7 +1791,7 @@ class ClientMessageProcessor(CommonCommandProcessor):
                 elif not cost or points_available // cost > 0:
                     self.output(
                         f"There may be more hintables, you can rerun the command"
-                        f"{"" if hint_count > 0 else "with a non-zero count "} to find more.")
+                        f"{'' if hint_count > 0 else 'with a non-zero count '} to find more.")
                 else:
                     self.output(
                         f"There may be more hintables, however, you cannot afford to pay for any more. "
@@ -1805,7 +1805,7 @@ class ClientMessageProcessor(CommonCommandProcessor):
                         f"There may be more hintables, however, you cannot afford to pay for any more. "
                         f" You have {points_available} and need at least {cost}.")
                 elif hint_count > 0:  # only give the information that there are no more hints if the user COULD have paid the cost
-                    self.output(f"No new hint(s) found.{" No points deducted." if cost else ""}")
+                    self.output(f"No new hint(s) found.{' No points deducted.' if cost else ''}")
                 else:
                     self.output(
                         "There may be more hintables, you can rerun the command with a non-zero amount to find more.")
@@ -1819,8 +1819,7 @@ class ClientMessageProcessor(CommonCommandProcessor):
                                 f"Item appears to not exist in this multiworld.")
             else:
                 self.output(f"You can't afford the hint. "
-                            f"You have {points_available} points and need at least "
-                            f"{self.ctx.get_hint_cost(self.client.slot)}.")
+                            f"You have {points_available} points and need at least {cost}.")
             return False
 
     @mark_raw

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1782,26 +1782,33 @@ class ClientMessageProcessor(CommonCommandProcessor):
                     self.ctx.hints_used[self.client.team, self.client.slot] += 1
 
                 self.ctx.notify_hints(self.client.team, hints)
-                if not_found_hints and hint_count > 0:
-                    points_available = get_client_points(self.ctx, self.client)
-                    if hints and cost and int((points_available // cost) <= 0):
-                        self.output(
-                            f"There may be more hintables, however, you cannot afford to pay for any more. "
-                            f" You have {points_available} and need at least "
-                            f"{self.ctx.get_hint_cost(self.client.slot)}.")
-                    elif hints:
-                        self.output(
-                            "There may be more hintables, you can rerun the command to find more.")
-                    else:
-                        self.output(f"You can't afford the hint. "
-                                    f"You have {points_available} points and need at least "
-                                    f"{self.ctx.get_hint_cost(self.client.slot)}.")
+                points_available = get_client_points(self.ctx, self.client)
+                if hint_count <= 0 and not hints:
+                    self.output("No matching hints already exist.")
+                elif not hints:
+                    self.output(f"You can't afford the hint. "
+                                f"You have {points_available} points and need at least {cost}.")
+                elif not cost or points_available // cost > 0:
+                    self.output(
+                        f"There may be more hintables, you can rerun the command"
+                        f"{"" if hint_count > 0 else "with a non-zero count "} to find more.")
+                else:
+                    self.output(
+                        f"There may be more hintables, however, you cannot afford to pay for any more. "
+                        f" You have {points_available} and need at least {cost}.")
                 self.ctx.save()
                 return True
             elif old_hints:
                 self.ctx.notify_hints(self.client.team, old_hints)
-                if hint_count > 0:
-                    self.output("Hint was previously used, no points deducted.")
+                if cost and points_available // cost <= 0:
+                    self.output(
+                        f"There may be more hintables, however, you cannot afford to pay for any more. "
+                        f" You have {points_available} and need at least {cost}.")
+                elif hint_count > 0:  # only give the information that there are no more hints if the user COULD have paid the cost
+                    self.output(f"No new hint(s) found.{" No points deducted." if cost else ""}")
+                else:
+                    self.output(
+                        "There may be more hintables, you can rerun the command with a non-zero amount to find more.")
         else:
             if points_available >= cost:
                 if for_location:

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1817,34 +1817,27 @@ class ClientMessageProcessor(CommonCommandProcessor):
 
     @mark_raw
     def _cmd_hint(self, item_name: str = "") -> bool:
-        """Use !hint {item_name},
-        for example !hint Lamp to get a spoiler peek for that item.
-        Only gives one result per command; use !hint_all {item_name}
-        to hint as many as possible instead."""
+        """For example, '!hint Lamp' to get a spoiler peek for that item.
+        Only gives one result per command; see !hint_all for multiple at once."""
         return self.get_hints(item_name, False, False)
 
     @mark_raw
-    def _cmd_hint_location(self, location: str = "") -> bool:
-        """Use !hint_location {location_name},
-        for example !hint_location atomic-bomb to get a spoiler peek for that location.
-        Only gives 1 result when hinting a location group; use !hint_location_all {location_name}
-        to hint as many as possible instead."""
-        return self.get_hints(location, True, False)
+    def _cmd_hint_location(self, location_name: str = "") -> bool:
+        """For example, '!hint_location atomic-bomb' to get a spoiler peek for that location.
+        Only gives 1 result per command; use !hint_location_all for multiple at once."""
+        return self.get_hints(location_name, True, False)
+
     @mark_raw
     def _cmd_hint_all(self, item_name: str = "") -> bool:
-        """Use !hint_all {item_name},
-        for example !hint Lamp to get a spoiler peek for that item.
-        Will return as many results as possible, possibly spending multiple
-        hints worth of hint points in the process."""
+        """For example, '!hint Power Star' to get a spoiler peek for that item.
+        Will return as many results as possible, possibly spending multiple hints worth of hint points in the process."""
         return self.get_hints(item_name, False, True)
 
     @mark_raw
-    def _cmd_hint_location_all(self, location: str = "") -> bool:
-        """Use !hint_location_all {location_name},
-        for example !hint_location atomic-bomb to get a spoiler peek for that location.
-        Will return as many results as possible (relevant when using a location group name),
-        possibly spending multiple hints worth of hint points in the process."""
-        return self.get_hints(location, True, True)
+    def _cmd_hint_location_all(self, location_name: str = "") -> bool:
+        """For example, '!hint_location_all Everywhere' to get a spoiler peek for matching locations.
+        Will return as many results as possible, possibly spending multiple hints worth of hint points in the process."""
+        return self.get_hints(location_name, True, True)
 
 
 def get_checked_checks(ctx: Context, team: int, slot: int) -> typing.List[int]:

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1688,7 +1688,7 @@ class ClientMessageProcessor(CommonCommandProcessor):
             self.output("Cheating is disabled.")
             return False
 
-    def get_hints(self, input_text: str, for_location: bool = False) -> bool:
+    def get_hints(self, input_text: str, for_location: bool = False, hint_all: bool = False) -> bool:
         points_available = get_client_points(self.ctx, self.client)
         cost = self.ctx.get_hint_cost(self.client.slot)
         if not input_text:
@@ -1758,18 +1758,15 @@ class ClientMessageProcessor(CommonCommandProcessor):
         if hints:
             new_hints = set(hints) - self.ctx.hints[self.client.team, self.client.slot]
             old_hints = list(set(hints) - new_hints)
-            if old_hints and not new_hints:
-                self.ctx.notify_hints(self.client.team, old_hints)
-                self.output("Hint was previously used, no points deducted.")
             if new_hints:
                 found_hints = [hint for hint in new_hints if hint.found]
                 not_found_hints = [hint for hint in new_hints if not hint.found]
-                if not not_found_hints:  # everything's been found, no need to pay
-                    can_pay = 1000
-                elif cost:
-                    can_pay = int((points_available // cost) > 0)  # limit to 1 new hint per call
+                if not cost:
+                    can_pay = 1000 if hint_all else 1
+                elif hint_all:
+                    can_pay = min(points_available // cost, 1000)  # Limit to 1000 max
                 else:
-                    can_pay = 1000
+                    can_pay = int((points_available // cost) > 0)  # limit to 1 new hint per call
 
                 self.ctx.random.shuffle(not_found_hints)
                 # By popular vote, make hints prefer non-local placements
@@ -1779,18 +1776,15 @@ class ClientMessageProcessor(CommonCommandProcessor):
                                      reverse=True)
 
                 hints = found_hints + old_hints
-                while can_pay > 0:
-                    if not not_found_hints:
-                        break
-                    hint = not_found_hints.pop()
-                    hints.append(hint)
+                while can_pay > 0 and not_found_hints:
+                    hints.append(not_found_hints.pop())
                     can_pay -= 1
                     self.ctx.hints_used[self.client.team, self.client.slot] += 1
 
                 self.ctx.notify_hints(self.client.team, hints)
                 if not_found_hints:
                     points_available = get_client_points(self.ctx, self.client)
-                    if hints and cost and int((points_available // cost) == 0):
+                    if hints and cost and int((points_available // cost) <= 0):
                         self.output(
                             f"There may be more hintables, however, you cannot afford to pay for any more. "
                             f" You have {points_available} and need at least "
@@ -1804,7 +1798,9 @@ class ClientMessageProcessor(CommonCommandProcessor):
                                     f"{self.ctx.get_hint_cost(self.client.slot)}.")
                 self.ctx.save()
                 return True
-
+            elif old_hints:
+                self.ctx.notify_hints(self.client.team, old_hints)
+                self.output("Hint was previously used, no points deducted.")
         else:
             if points_available >= cost:
                 if for_location:
@@ -1823,15 +1819,32 @@ class ClientMessageProcessor(CommonCommandProcessor):
     def _cmd_hint(self, item_name: str = "") -> bool:
         """Use !hint {item_name},
         for example !hint Lamp to get a spoiler peek for that item.
-        If hint costs are on, this will only give you one new result,
-        you can rerun the command to get more in that case."""
-        return self.get_hints(item_name)
+        Only gives one result per command; use !hint_all {item_name}
+        to hint as many as possible instead."""
+        return self.get_hints(item_name, False, False)
 
     @mark_raw
     def _cmd_hint_location(self, location: str = "") -> bool:
         """Use !hint_location {location_name},
-        for example !hint_location atomic-bomb to get a spoiler peek for that location."""
-        return self.get_hints(location, True)
+        for example !hint_location atomic-bomb to get a spoiler peek for that location.
+        Only gives 1 result when hinting a location group; use !hint_location_all {location_name}
+        to hint as many as possible instead."""
+        return self.get_hints(location, True, False)
+    @mark_raw
+    def _cmd_hint_all(self, item_name: str = "") -> bool:
+        """Use !hint_all {item_name},
+        for example !hint Lamp to get a spoiler peek for that item.
+        Will return as many results as possible, possibly spending multiple
+        hints worth of hint points in the process."""
+        return self.get_hints(item_name, False, True)
+
+    @mark_raw
+    def _cmd_hint_location_all(self, location: str = "") -> bool:
+        """Use !hint_location_all {location_name},
+        for example !hint_location atomic-bomb to get a spoiler peek for that location.
+        Will return as many results as possible (relevant when using a location group name),
+        possibly spending multiple hints worth of hint points in the process."""
+        return self.get_hints(location, True, True)
 
 
 def get_checked_checks(ctx: Context, team: int, slot: int) -> typing.List[int]:

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1688,9 +1688,11 @@ class ClientMessageProcessor(CommonCommandProcessor):
             self.output("Cheating is disabled.")
             return False
 
-    def get_hints(self, input_text: str, for_location: bool = False, hint_all: bool = False) -> bool:
+    def get_hints(self, input_text: str, for_location: bool = False, hint_count: int = 1) -> bool:
         points_available = get_client_points(self.ctx, self.client)
         cost = self.ctx.get_hint_cost(self.client.slot)
+        if hint_count > 1000 or hint_count < 0:
+            hint_count = 1000
         if not input_text:
             hints = {hint.re_check(self.ctx, self.client.team) for hint in
                      self.ctx.hints[self.client.team, self.client.slot]}
@@ -1762,11 +1764,9 @@ class ClientMessageProcessor(CommonCommandProcessor):
                 found_hints = [hint for hint in new_hints if hint.found]
                 not_found_hints = [hint for hint in new_hints if not hint.found]
                 if not cost:
-                    can_pay = 1000 if hint_all else 1
-                elif hint_all:
-                    can_pay = min(points_available // cost, 1000)  # Limit to 1000 max
+                    can_pay = hint_count
                 else:
-                    can_pay = int((points_available // cost) > 0)  # limit to 1 new hint per call
+                    can_pay = min(points_available // cost, hint_count)
 
                 self.ctx.random.shuffle(not_found_hints)
                 # By popular vote, make hints prefer non-local placements
@@ -1818,26 +1818,24 @@ class ClientMessageProcessor(CommonCommandProcessor):
     @mark_raw
     def _cmd_hint(self, item_name: str = "") -> bool:
         """For example, '!hint Lamp' to get a spoiler peek for that item.
-        Only gives one result per command; see !hint_all for multiple at once."""
-        return self.get_hints(item_name, False, False)
+        Only gives one result per command; see !hint_multiple for multiple at once."""
+        return self.get_hints(item_name, False, 1)
 
     @mark_raw
     def _cmd_hint_location(self, location_name: str = "") -> bool:
         """For example, '!hint_location atomic-bomb' to get a spoiler peek for that location.
-        Only gives 1 result per command; use !hint_location_all for multiple at once."""
-        return self.get_hints(location_name, True, False)
+        Only gives 1 result per command; use !hint_location_multiple for multiple at once."""
+        return self.get_hints(location_name, True, 1)
 
-    @mark_raw
-    def _cmd_hint_all(self, item_name: str = "") -> bool:
-        """For example, '!hint_all Power Star' to get a spoiler peek for that item.
-        Will return as many results as possible, possibly spending multiple hints worth of hint points in the process."""
-        return self.get_hints(item_name, False, True)
+    def _cmd_hint_multiple(self, amount: int | str, *item_name: str) -> bool:
+        """For example, '!hint_multiple 5 Power Star' to get a spoiler peek for that item.
+        Will return as many results as possible up to the specified amount, possibly spending multiple hints worth of hint points in the process."""
+        return self.get_hints(" ".join(item_name), False, int(amount))
 
-    @mark_raw
-    def _cmd_hint_location_all(self, location_name: str = "") -> bool:
-        """For example, '!hint_location_all Everywhere' to get a spoiler peek for matching locations.
-        Will return as many results as possible, possibly spending multiple hints worth of hint points in the process."""
-        return self.get_hints(location_name, True, True)
+    def _cmd_hint_location_multiple(self, amount: int | str, *location_name: str) -> bool:
+        """For example, '!hint_location_multiple 5 Everywhere' to get a spoiler peek for matching locations.
+        Will return as many results as possible up to the specified amount, possibly spending multiple hints worth of hint points in the process."""
+        return self.get_hints(" ".join(location_name), True, int(amount))
 
 
 def get_checked_checks(ctx: Context, team: int, slot: int) -> typing.List[int]:
@@ -2438,8 +2436,10 @@ class ServerCommandProcessor(CommonCommandProcessor):
             self.output(response)
             return False
 
-    def get_hints(self, player_name: str, input_text: str, for_location: bool = False, hint_all: bool = False) -> bool:
+    def get_hints(self, player_name: str, input_text: str, for_location: bool = False, hint_count: int = 1) -> bool:
         seeked_player, usable, response = get_intended_text(player_name, self.ctx.player_names.values())
+        if hint_count > 1000 or hint_count < 0:
+            hint_count = 1000
         if not usable:
             self.output(response)
             return False
@@ -2482,8 +2482,6 @@ class ServerCommandProcessor(CommonCommandProcessor):
                 hints = collect_hints(self.ctx, team, slot, target_id)
         if not hints:
             self.output("No hints found.")
-        elif hint_all:
-            self.ctx.notify_hints(team, hints)
         else:
             new_hints = set(hints) - self.ctx.hints[team, slot]
             old_hints = list(set(hints) - new_hints)
@@ -2499,8 +2497,9 @@ class ServerCommandProcessor(CommonCommandProcessor):
                                      reverse=True)
 
                 hints = found_hints + old_hints
-                if not_found_hints:
+                while not_found_hints and hint_count > 0:
                     hints.append(not_found_hints.pop())
+                    hint_count -= 1
 
                 self.ctx.notify_hints(team, hints)
                 self.ctx.save()
@@ -2510,19 +2509,19 @@ class ServerCommandProcessor(CommonCommandProcessor):
 
     def _cmd_hint(self, player_name: str, *item_name: str) -> bool:
         """Send out a single new hint for a player's item or item group to their team"""
-        return self.get_hints(player_name, " ".join(item_name), False, False)
+        return self.get_hints(player_name, " ".join(item_name), False, 1)
 
     def _cmd_hint_location(self, player_name: str, *location_name: str) -> bool:
         """Send out a single new hint for a player's location or location group to their team"""
-        return self.get_hints(player_name, " ".join(location_name), True, False)
+        return self.get_hints(player_name, " ".join(location_name), True, 1)
 
-    def _cmd_hint_all(self, player_name: str, *item_name: str) -> bool:
-        """Send out all matching hints for a player's item or item group to their team"""
-        return self.get_hints(player_name, " ".join(item_name), False, True)
+    def _cmd_hint_multiple(self, amount: int | str, player_name: str, *item_name: str) -> bool:
+        """Send out multiple matching hints for a player's item or item group to their team"""
+        return self.get_hints(player_name, " ".join(item_name), False, int(amount))
 
-    def _cmd_hint_location_all(self, player_name: str, *location_name: str) -> bool:
-        """Send out all matching hints for a player's location or location group to their team"""
-        return self.get_hints(player_name, " ".join(location_name), True, True)
+    def _cmd_hint_location_multiple(self, amount: int | str, player_name: str, *location_name: str) -> bool:
+        """Send out multiple matching hints for a player's location or location group to their team"""
+        return self.get_hints(player_name, " ".join(location_name), True, int(amount))
 
     def _cmd_option(self, option_name: str, option_value: str):
         """Set an option for the server."""

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1829,7 +1829,7 @@ class ClientMessageProcessor(CommonCommandProcessor):
 
     @mark_raw
     def _cmd_hint_all(self, item_name: str = "") -> bool:
-        """For example, '!hint Power Star' to get a spoiler peek for that item.
+        """For example, '!hint_all Power Star' to get a spoiler peek for that item.
         Will return as many results as possible, possibly spending multiple hints worth of hint points in the process."""
         return self.get_hints(item_name, False, True)
 

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1782,7 +1782,7 @@ class ClientMessageProcessor(CommonCommandProcessor):
                     self.ctx.hints_used[self.client.team, self.client.slot] += 1
 
                 self.ctx.notify_hints(self.client.team, hints)
-                if not_found_hints:
+                if not_found_hints and hint_count > 0:
                     points_available = get_client_points(self.ctx, self.client)
                     if hints and cost and int((points_available // cost) <= 0):
                         self.output(
@@ -1800,7 +1800,8 @@ class ClientMessageProcessor(CommonCommandProcessor):
                 return True
             elif old_hints:
                 self.ctx.notify_hints(self.client.team, old_hints)
-                self.output("Hint was previously used, no points deducted.")
+                if hint_count > 0:
+                    self.output("Hint was previously used, no points deducted.")
         else:
             if points_available >= cost:
                 if for_location:

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2445,83 +2445,91 @@ class ServerCommandProcessor(CommonCommandProcessor):
             self.output(response)
             return False
 
-    def _cmd_hint(self, player_name: str, *item_name: str) -> bool:
-        """Send out a hint for a player's item to their team"""
+    def get_hints(self, player_name: str, input_text: str, for_location: bool = False, hint_all: bool = False) -> bool:
         seeked_player, usable, response = get_intended_text(player_name, self.ctx.player_names.values())
-        if usable:
-            team, slot = self.ctx.player_name_lookup[seeked_player]
-            game = self.ctx.games[slot]
-            full_name = " ".join(item_name)
-
-            if full_name.isnumeric():
-                item, usable, response = int(full_name), True, None
-            elif game in self.ctx.all_item_and_group_names:
-                item, usable, response = get_intended_text(full_name, self.ctx.all_item_and_group_names[game])
-            else:
-                self.output("Can't look up item for unknown game. Hint for ID instead.")
-                return False
-
-            if usable:
-                if game in self.ctx.item_name_groups and item in self.ctx.item_name_groups[game]:
-                    hints = []
-                    for item_name_from_group in self.ctx.item_name_groups[game][item]:
-                        if item_name_from_group in self.ctx.item_names_for_game(game):  # ensure item has an ID
-                            hints.extend(collect_hints(self.ctx, team, slot, item_name_from_group))
-                else:  # item name or id
-                    hints = collect_hints(self.ctx, team, slot, item)
-
-                if hints:
-                    self.ctx.notify_hints(team, hints)
-
-                else:
-                    self.output("No hints found.")
-                return True
-            else:
-                self.output(response)
-                return False
-
-        else:
+        if not usable:
             self.output(response)
             return False
-
-    def _cmd_hint_location(self, player_name: str, *location_name: str) -> bool:
-        """Send out a hint for a player's location to their team"""
-        seeked_player, usable, response = get_intended_text(player_name, self.ctx.player_names.values())
-        if usable:
-            team, slot = self.ctx.player_name_lookup[seeked_player]
-            game = self.ctx.games[slot]
-            full_name = " ".join(location_name)
-
-            if full_name.isnumeric():
-                location, usable, response = int(full_name), True, None
-            elif game in self.ctx.all_location_and_group_names:
-                location, usable, response = get_intended_text(full_name, self.ctx.all_location_and_group_names[game])
+        team, slot = self.ctx.player_name_lookup[seeked_player]
+        game = self.ctx.games[slot]
+        if input_text.isnumeric():
+            target_id, usable, response = int(input_text), True, None
+        elif for_location:
+            if game in self.ctx.all_location_and_group_names:
+                target_id, usable, response = get_intended_text(input_text, self.ctx.all_location_and_group_names[game])
             else:
                 self.output("Can't look up location for unknown game. Hint for ID instead.")
                 return False
-
-            if usable:
-                if isinstance(location, int):
-                    hints = collect_hint_location_id(self.ctx, team, slot, location)
-                elif game in self.ctx.location_name_groups and location in self.ctx.location_name_groups[game]:
-                    hints = []
-                    for loc_name_from_group in self.ctx.location_name_groups[game][location]:
-                        if loc_name_from_group in self.ctx.location_names_for_game(game):
-                            hints.extend(collect_hint_location_name(self.ctx, team, slot, loc_name_from_group))
-                else:
-                    hints = collect_hint_location_name(self.ctx, team, slot, location)
-                if hints:
-                    self.ctx.notify_hints(team, hints)
-                else:
-                    self.output("No hints found.")
-                return True
-            else:
-                self.output(response)
-                return False
-
         else:
+            if game in self.ctx.all_item_and_group_names:
+                target_id, usable, response = get_intended_text(input_text, self.ctx.all_item_and_group_names[game])
+            else:
+                self.output("Can't look up item for unknown game. Hint for ID instead.")
+                return False
+        if not usable:
             self.output(response)
             return False
+        if for_location:
+            if isinstance(target_id, int):
+                hints = collect_hint_location_id(self.ctx, team, slot, target_id)
+            elif game in self.ctx.location_name_groups and target_id in self.ctx.location_name_groups[game]:
+                hints = []
+                for loc_name_from_group in self.ctx.location_name_groups[game][target_id]:
+                    if loc_name_from_group in self.ctx.location_names_for_game(game):
+                        hints.extend(collect_hint_location_name(self.ctx, team, slot, loc_name_from_group))
+            else:
+                hints = collect_hint_location_name(self.ctx, team, slot, target_id)
+        else:
+            if game in self.ctx.item_name_groups and target_id in self.ctx.item_name_groups[game]:
+                hints = []
+                for item_name_from_group in self.ctx.item_name_groups[game][target_id]:
+                    if item_name_from_group in self.ctx.item_names_for_game(game):  # ensure item has an ID
+                        hints.extend(collect_hints(self.ctx, team, slot, item_name_from_group))
+            else:  # item name or id
+                hints = collect_hints(self.ctx, team, slot, target_id)
+        if not hints:
+            self.output("No hints found.")
+        elif hint_all:
+            self.ctx.notify_hints(team, hints)
+        else:
+            new_hints = set(hints) - self.ctx.hints[team, slot]
+            old_hints = list(set(hints) - new_hints)
+            if new_hints:
+                found_hints = [hint for hint in new_hints if hint.found]
+                not_found_hints = [hint for hint in new_hints if not hint.found]
+
+                self.ctx.random.shuffle(not_found_hints)
+                # By popular vote, make hints prefer non-local placements
+                not_found_hints.sort(key=lambda hint: int(hint.receiving_player != hint.finding_player))
+                # By another popular vote, prefer early sphere
+                not_found_hints.sort(key=lambda hint: self.ctx.get_sphere(hint.finding_player, hint.location),
+                                     reverse=True)
+
+                hints = found_hints + old_hints
+                if not_found_hints:
+                    hints.append(not_found_hints.pop())
+
+                self.ctx.notify_hints(team, hints)
+                self.ctx.save()
+            elif old_hints:
+                self.ctx.notify_hints(team, old_hints)
+        return True
+
+    def _cmd_hint(self, player_name: str, *item_name: str) -> bool:
+        """Send out a single new hint for a player's item or item group to their team"""
+        return self.get_hints(player_name, " ".join(item_name), False, False)
+
+    def _cmd_hint_location(self, player_name: str, *location_name: str) -> bool:
+        """Send out a single new hint for a player's location or location group to their team"""
+        return self.get_hints(player_name, " ".join(location_name), True, False)
+
+    def _cmd_hint_all(self, player_name: str, *item_name: str) -> bool:
+        """Send out all matching hints for a player's item or item group to their team"""
+        return self.get_hints(player_name, " ".join(item_name), False, True)
+
+    def _cmd_hint_location_all(self, player_name: str, *location_name: str) -> bool:
+        """Send out all matching hints for a player's location or location group to their team"""
+        return self.get_hints(player_name, " ".join(location_name), True, True)
 
     def _cmd_option(self, option_name: str, option_value: str):
         """Set an option for the server."""

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1798,7 +1798,7 @@ class ClientMessageProcessor(CommonCommandProcessor):
                         f" You have {points_available} and need at least {cost}.")
                 self.ctx.save()
                 return True
-            elif old_hints:
+            else:
                 self.ctx.notify_hints(self.client.team, old_hints)
                 if cost and points_available // cost <= 0:
                     self.output(
@@ -1809,6 +1809,7 @@ class ClientMessageProcessor(CommonCommandProcessor):
                 else:
                     self.output(
                         "There may be more hintables, you can rerun the command with a non-zero amount to find more.")
+                return False
         else:
             if points_available >= cost:
                 if for_location:


### PR DESCRIPTION
## What is this fixing or adding?
`!hint` and `!hint_location` with `hint_cost == 0`, as well as `/hint` and `/hint_location`, previously granted every single matching hint in a single command run. This is sometimes desired, but often is undesired, granting the user (either themselves, or as the host) more hints than intended; as described in #6118.

This PR changes this behavior, making these commands all now grant only a single new hint per command run.
Due to hinting everything SOMETIMES being the actual desire, new commands `!hint_all`, `!hint_location_all`, `/hint_all`, and `/hint_location_all` have been added, which have the previous behavior of hinting everything.
Additionally, `!hint_all` and `!hint_location_all` can be used ***even when `hint_cost > 0`*** - these will act similarly to running `!hint` or `!hint_location` repeatedly, charging the appropriate amount of hint points, and stopping either when there are no more matching hints to grant, or not enough hint points to hint more. This in itself could be useful in some circumstances, such as having everything needed for go mode but more mcguffins, and being able to `!hint_all mcguffin` to hint as many more of them as you can.

EDIT: `_all` has been changed to `_multiple`, taking a maximum count.

EDIT: Also fixed `!hint` leaking information it should not have leaked, which was a separate issue already present on main before my changes, though fixing this and the other changes here are all intertwined / would have major conflicts with each other as separate PRs, so I figure it's simplest to just push this fix to the same PR.

## How was this tested?
Server commands:
Ran a local stardew slot; used `/hint Tester Progressive Pickaxe` 4 times, each time granted one additional hint. Ran it a 5th time, it correctly displayed the 4 matching hints (there are only 4 of that item). Ran `/hint_all Tester Progressive Axe`, granted all 4 hints at once. Running it again correctly re-displayed the 4 hints.
Ran `/help`, correctly displays the new commands and updated command help text.

Client commands:
I `/send_location`'d a bunch of locations to get hint points, then tested client commands.
`!hint` and `!hint_all` with no arguements behave identically, as expected.
`!help` correctly shows the new commands and updated command help text.
`!hint_all Progressive Hoe` correctly spent 3 hints finding said item; the 4th was omitted, as there were only enough hint points for 3 hints.
`!hint_all Progressive Watering Can` correctly spent 4 hints finding all 4 items, while I had enough points for 5 hints.
Setting hint cost to 0 then, `!hint Fishing Level`, correctly displays 2 already-found Fishing Levels and creates ONE new hint.
Running `!hint Fishing Level` again correctly adds 1 more new hint.
Then running `!hint_all Fishing Level` correctly hints every Fishing Level.

EDIT: `_all` was then changed to `_multiple`, I've retested the help commands showing the proper descriptions, and retested `!hint_multiple` several times on `Mining Level`, explicitly testing the `amount = 0` case (lists all matching hints without buying any new hints)

## If this makes graphical changes, please attach screenshots.
<img width="1060" height="325" alt="image" src="https://github.com/user-attachments/assets/5b8ced88-a523-4613-8513-9c7db99385e3" />
<img width="761" height="135" alt="image" src="https://github.com/user-attachments/assets/11ea3623-9c7c-41dd-8520-f732372c8d86" />
<img width="1057" height="356" alt="image" src="https://github.com/user-attachments/assets/34c6bc86-63b7-4181-8802-12bdf1145f87" />
<img width="997" height="199" alt="image" src="https://github.com/user-attachments/assets/2a068ff2-5173-4e6c-a2df-3b66d347312e" />
<img width="901" height="232" alt="image" src="https://github.com/user-attachments/assets/746e95d5-d9c5-4157-92de-1a64b1ecb3cf" />
<img width="760" height="224" alt="image" src="https://github.com/user-attachments/assets/c7d944c5-4580-4d51-9589-388dd114a185" />
<img width="807" height="257" alt="image" src="https://github.com/user-attachments/assets/5d5e4364-7a22-499e-b9c4-b8cbb23128fe" />
<img width="804" height="395" alt="image" src="https://github.com/user-attachments/assets/7532a652-0c11-4de6-94bb-f4ceab3432af" />

## EDIT: changed `_all` to `_multiple`

<img width="1250" height="365" alt="image" src="https://github.com/user-attachments/assets/3e3d70b0-dbeb-4b20-97cb-2b3410de915a" />
<img width="788" height="135" alt="image" src="https://github.com/user-attachments/assets/d97fb8af-411f-46cc-bac6-08f590ac91ed" />
<img width="757" height="130" alt="image" src="https://github.com/user-attachments/assets/f96bbd05-067d-4504-8cd8-5786c0276ca8" />
<img width="806" height="299" alt="image" src="https://github.com/user-attachments/assets/ba8bbe54-969a-40b1-b576-8c22d62da9bd" />
<img width="806" height="299" alt="image" src="https://github.com/user-attachments/assets/6848ee20-86f7-471b-b74b-62100273a66b" />
<img width="800" height="386" alt="image" src="https://github.com/user-attachments/assets/9e57e607-b6b2-468e-9b99-a09b20af6f42" />

## EDIT: Tweaked output of commands to not leak information that should not be leaked
<img width="1022" height="363" alt="image" src="https://github.com/user-attachments/assets/944f9bbf-1259-4de7-9886-3efc0c7ed2f4" />
<img width="1026" height="368" alt="image" src="https://github.com/user-attachments/assets/3b359fa4-e815-403e-9bbf-a56d683a2690" />
(with insufficient points for another hint, messages for something that is fully hinted and non-fully-hinted are now identical)
<img width="876" height="358" alt="image" src="https://github.com/user-attachments/assets/347f1d23-b174-4d8a-b346-b64ef530dfd2" />
(even with sufficient points for a hint, `!hint_multiple 0 [name]` will not give away whether there are actually more hints or not, as the command would not risk spending the points, so should not give information)
<img width="1020" height="390" alt="image" src="https://github.com/user-attachments/assets/16f64982-8c20-4afb-b87d-2de6431ea9ea" />
(in this last image, the hint cost was 0 for the first command, then changed back to 1 for the second command)

(`No new hints found.` has replaced `Hint was previously used, no points deducted.` when `hint_cost == 0`)

(`No new hints found. No points deducted.` has replaced `Hint was previously used, no points deducted.` when `hint_cost > 0`)