### PR TITLE
Core: Make manifest accessible as a world attribute

### DIFF
--- a/docs/apworld specification.md
+++ b/docs/apworld specification.md
@@ -35,8 +35,8 @@ There are also the following optional fields:
 * `world_version` - an arbitrary version for that world in order to only load the newest valid world.
   An APWorld without a world_version is always treated as older than one with a version
   (**Must** use exactly the format `"major.minor.build"`, e.g. `1.0.0`)
-* `authors` - a list of authors, to eventually be displayed in various user-facing places such as WebHost and
-  package managers. Should always be a list of strings.
+* `authors` - a list of authors of the world. Displayed in user-facing places like the Supported Games page
+  on WebHost. Should always be a list of strings.
 
 If the APWorld is packaged as an `.apworld` zip file, it also needs to have `version` and `compatible_version`,
 which refer to the version of the APContainer packaging scheme defined in [Files.py](../worlds/Files.py).  

--- a/docs/apworld specification.md
+++ b/docs/apworld specification.md
@@ -35,8 +35,8 @@ There are also the following optional fields:
 * `world_version` - an arbitrary version for that world in order to only load the newest valid world.
   An APWorld without a world_version is always treated as older than one with a version
   (**Must** use exactly the format `"major.minor.build"`, e.g. `1.0.0`)
-* `authors` - a list of authors of the world. Displayed in user-facing places like the Supported Games page
-  on WebHost. Should always be a list of strings.
+* `authors` - a list of authors, to eventually be displayed in various user-facing places such as WebHost and
+  package managers. Should always be a list of strings.
 
 If the APWorld is packaged as an `.apworld` zip file, it also needs to have `version` and `compatible_version`,
 which refer to the version of the APContainer packaging scheme defined in [Files.py](../worlds/Files.py).  

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -353,6 +353,8 @@ class World(metaclass=AutoWorldRegister):
     """path it was loaded from"""
     world_version: ClassVar[Version] = Version(0, 0, 0)
     """Optional world version loaded from archipelago.json"""
+    manifest: ClassVar[dict[str, Any]]
+    """Mapping of the world's archipelago.json manifest. Use game and world_version attrs instead for those values."""
 
     def __init__(self, multiworld: "MultiWorld", player: int):
         assert multiworld is not None

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -353,7 +353,7 @@ class World(metaclass=AutoWorldRegister):
     """path it was loaded from"""
     world_version: ClassVar[Version] = Version(0, 0, 0)
     """Optional world version loaded from archipelago.json"""
-    manifest: ClassVar[dict[str, Any]]
+    manifest: ClassVar[dict[str, Any]] = {}
     """Mapping of the world's archipelago.json manifest. Use game and world_version attrs instead for those values."""
 
     def __init__(self, multiworld: "MultiWorld", player: int):

--- a/worlds/__init__.py
+++ b/worlds/__init__.py
@@ -11,7 +11,7 @@ import json
 from pathlib import Path
 from types import ModuleType
 from typing import List, Sequence
-from zipfile import BadZipFile
+from zipfile import ZipFile, BadZipFile
 
 from NetUtils import DataPackage
 from Utils import local_path, user_path, Version, version_tuple, tuplize_version, messagebox
@@ -200,6 +200,15 @@ if apworlds:
                     # world could fail to load at this point
                     if apworld.world_version:
                         AutoWorldRegister.world_types[apworld.game].world_version = apworld.world_version
+
+                    assert apworld.path
+                    with ZipFile(apworld.path, "r") as zf:
+                        manifest = apworld.read_contents(zf)
+                    # version/compatible_version shouldn't be needed by world, makes it consistent with folder world
+                    manifest.pop("version", None)
+                    manifest.pop("compatible_version", None)
+                    AutoWorldRegister.world_types[apworld.game].manifest = manifest
+
     load_apworlds()
     del load_apworlds
 

--- a/worlds/__init__.py
+++ b/worlds/__init__.py
@@ -118,6 +118,7 @@ for world_source in world_sources:
         game = manifest.get("game")
         if game in AutoWorldRegister.world_types:
             AutoWorldRegister.world_types[game].world_version = tuplize_version(manifest.get("world_version", "0.0.0"))
+            AutoWorldRegister.world_types[game].manifest = manifest
 
 if apworlds:
     # encapsulation for namespace / gc purposes


### PR DESCRIPTION
## What is this fixing or adding?
Allows worlds or core component to more easily read extra fields from the manifest by adding the whole parsed dict beyond just the world_version field. Having the attribute like this is what was mentioned before as being the preferred way of exposing things like authors.

## How was this tested?
Loading worlds and attempting to access manifest field on games with or without it.

## If this makes graphical changes, please attach screenshots.
👨ℹ️🎄