### PR TITLE
The Messenger: Add missing rules for Key of Strength

### DIFF
--- a/worlds/messenger/connections.py
+++ b/worlds/messenger/connections.py
@@ -316,7 +316,7 @@ CONNECTIONS: dict[str, dict[str, list[str]]] = {
         "Searing Mega Shard Shop": [
             "Searing Crags - Falling Rocks Shop",
             "Searing Crags - Before Final Climb Shop",
-            "Searing Crags - Key of Strength Shop",
+            "Searing Crags - Key of Strength Room",
         ],
         "Before Final Climb Shop": [
             "Searing Crags - Raining Rocks Checkpoint",
@@ -330,6 +330,9 @@ CONNECTIONS: dict[str, dict[str, list[str]]] = {
             "Searing Crags - Top",
         ],
         "Key of Strength Shop": [
+            "Searing Crags - Key of Strength Room",
+        ],
+        "Key of Strength Room": [
             "Searing Crags - Searing Mega Shard Shop",
         ],
         "Triple Ball Spinner Checkpoint": [

--- a/worlds/messenger/regions.py
+++ b/worlds/messenger/regions.py
@@ -96,7 +96,7 @@ LOCATIONS: dict[str, list[str]] = {
         "Searing Crags - Power Thistle",
         "Searing Crags - Astral Tea Leaves",
     ],
-    "Searing Crags - Key of Strength Shop": [
+    "Searing Crags - Key of Strength Room": [
         "Searing Crags - Key of Strength",
     ],
     "Searing Crags - Portal": [

--- a/worlds/messenger/rules.py
+++ b/worlds/messenger/rules.py
@@ -108,17 +108,18 @@ class MessengerRules:
             "Searing Crags - Right -> Searing Crags - Portal":
                 lambda state: self.has_tabi(state) and self.has_wingsuit(state),
             "Searing Crags - Colossuses Shop -> Searing Crags - Key of Strength Shop":
-                lambda state: state.has("Power Thistle", self.player)
-                              and (self.has_dart(state)
-                                   or (self.has_wingsuit(state)
-                                       and self.can_destroy_projectiles(state))),
+                lambda state: state.has("Power Thistle", self.player),
+            "Searing Crags - Key of Strength Shop -> Searing Crags - Key of Strength Room":
+                lambda state: self.has_dart(state)
+                              or (self.has_wingsuit(state)
+                                  and self.can_destroy_projectiles(state)),
             "Searing Crags - Falling Rocks Shop -> Searing Crags - Searing Mega Shard Shop":
                 self.has_dart,
             "Searing Crags - Searing Mega Shard Shop -> Searing Crags - Before Final Climb Shop":
                 lambda state: self.has_dart(state) or self.can_destroy_projectiles(state),
             "Searing Crags - Searing Mega Shard Shop -> Searing Crags - Falling Rocks Shop":
                 self.has_dart,
-            "Searing Crags - Searing Mega Shard Shop -> Searing Crags - Key of Strength Shop":
+            "Searing Crags - Searing Mega Shard Shop -> Searing Crags - Key of Strength Room":
                 self.false,
             "Searing Crags - Before Final Climb Shop -> Searing Crags - Colossuses Shop":
                 self.has_dart,
@@ -406,7 +407,7 @@ class MessengerHardRules(MessengerRules):
                     lambda state: self.has_dart(state) or
                                   (self.can_destroy_projectiles(state) and
                                    (self.has_wingsuit(state) or self.can_dboost(state))),
-                "Searing Crags - Searing Mega Shard Shop -> Searing Crags - Key of Strength Shop":
+                "Searing Crags - Searing Mega Shard Shop -> Searing Crags - Key of Strength Room":
                     lambda state: self.can_leash(state) or self.has_windmill(state),
                 "Searing Crags - Before Final Climb Shop -> Searing Crags - Colossuses Shop":
                     self.true,
@@ -512,7 +513,6 @@ class MessengerOOBRules(MessengerRules):
 
         self.location_rules = {
             "Bamboo Creek - Claustro": self.has_wingsuit,
-            "Searing Crags - Key of Strength": self.has_wingsuit,
             "Sunken Shrine - Key of Love": lambda state: state.has_all({"Sun Crest", "Moon Crest"}, self.player),
             "Searing Crags - Pyro": self.has_tabi,
             "Underworld - Key of Chaos": self.has_tabi,


### PR DESCRIPTION
## What is this fixing or adding?

This adds the missing rules for the Key of Strength. Currently, if you hit a portal rando on the Key of Strength Shop, the Key of Strength is considered in logic. It should not, it requires at least the rope dart or the windmill shuriken. 

I did not have a choice but to create another room specifically for the location. The issue come from the fact that hard logic allow to get the key from below, by entering the room from the Mega Shard Shop. Adding a rule to the location would have made the location out of logic even tho the room can be entered in hard logic.

## How was this tested?
I plandoed a portal to Key of Strength Shop and tested with the UT + Pop Tracker integration from https://github.com/ArchipelagoMW/Archipelago/pull/6030. Before the changes, the Key of Strength and the Mega Shard are considered in logic.

<img width="902" height="718" alt="image" src="https://github.com/user-attachments/assets/55161dba-3b6a-496b-af07-accb58637195" />

After this change, none of them are.

<img width="947" height="745" alt="image" src="https://github.com/user-attachments/assets/996b33b1-707a-4e00-bf1d-368f91a9ff67" />

## If this makes graphical changes, please attach screenshots.
Yes