### PR TITLE
Fix faulty process instantiation in Launcher.py causing SNIClient to hang

### DIFF
--- a/Launcher.py
+++ b/Launcher.py
@@ -456,7 +456,7 @@ def run_component(component: Component, *args):
         if refresh_components:
             refresh_components()
     elif component.script_name:
-        subprocess.run([*get_exe(component.script_name), *args])
+        subprocess.Popen([*get_exe(component.script_name), *args])
     else:
         logging.warning(f"Component {component} does not appear to be executable.")
 


### PR DESCRIPTION
## What is this fixing or adding?
The `run_component()` function in the Archipelago launcher incorrectly used the subprocess.py module, causing infinite hang during the long running SNIClient process caused when dragging and dropping an ap file into the launcher directly. Fixes #6109

## How was this tested?
Tested issue on Linux via OP contribution, and Windows in my local environment. Solved after altering module function call.