### PR TITLE
Core: Make manifest error a messagebox and show which world

### DIFF
--- a/worlds/__init__.py
+++ b/worlds/__init__.py
@@ -144,7 +144,13 @@ if apworlds:
                     )
                     logging.error(e)
                 else:
-                    raise e
+                    if sys.stdout:
+                        e.add_note(f"Affected world source: {apworld_source.resolved_path}")
+                        raise e
+                    else:
+                        err_message = f"{e}\nAffected world source: {apworld_source.resolved_path}"
+                        messagebox("Couldn't load worlds", err_message, error=True)
+                        sys.exit(1)
             except BadZipFile as e:
                 err_message = (f"The world source {apworld_source.resolved_path} is not a valid zip. "
                                "It is likely either corrupted, or was packaged incorrectly.")


### PR DESCRIPTION
## What is this fixing or adding?
Currently, once an invalid manifest becomes an error in 0.7.0, opening the launcher (or most other things) on frozen will simply exit without any direct feedback, and even the log/console itself won't show which world actually failed to load. This would likely be quite bad™.

This adds the world source as a note to the exception raised from here, and changes this error to show a messagebox when there's no stdout similar to the BapZipFile error from #5871.

## How was this tested?
Changing `__version__` to 0.7.0, and then running with and without a manifestless custom world on both source and Windows frozen.

## If this makes graphical changes, please attach screenshots.
<img width="516" height="231" alt="image" src="https://github.com/user-attachments/assets/cd0070a3-a537-4b14-bee5-072dccfe2309" />
