### PR TITLE
Core: make plando_items not create items

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -990,7 +990,10 @@ def parse_planned_blocks(multiworld: MultiWorld) -> dict[int, list[PlandoItemBlo
                 item_list: list[str] = []
                 for key, value in items.items():
                     if value is True:
-                        value = multiworld.itempool.count(multiworld.worlds[player].create_item(key))
+                        value = 0
+                        for item in multiworld.itempool:
+                            if item.name == key and item.player == player:
+                                value += 1
                     item_list += [key] * value
                 items = item_list
             new_block.items = items


### PR DESCRIPTION
## What is this fixing or adding?
Plando creates items just to test the item name and player with __eq__. However, if __eq__ did more, then plando would have unexpected behavior for the user. 
Creating items might also have effect on the world, which might not expect that item to not exist shortly after. 
Finally, duckboycool has shown that using count with an item is slower that just doing a loop. 
So, I just replaced that with a loop to remove all these issues

## How was this tested?
Generated an apquest seed


## If this makes graphical changes, please attach screenshots.
