### PR TITLE
CommonClient: Make hint sorting customizable by subclasses (for UT)

### DIFF
--- a/kvui.py
+++ b/kvui.py
@@ -629,6 +629,14 @@ class HintLabel(RecycleDataViewBehavior, MDBoxLayout):
         self.hint = data["status"]["hint"]
         return super(HintLabel, self).refresh_view_attrs(rv, index, data)
 
+    def get_hint_sorter(self, key: str):
+        """Return a callable for sorting hints for the specified sort_key.
+        This is split out to a function to allow custom sorting by subclasses in custom clients."""
+        if key == "status":
+            return lambda element: status_sort_weights[element["status"]["hint"]["status"]]
+        else:
+            return lambda element: remove_between_brackets.sub("", element[key]["text"]).lower()
+
     def on_touch_down(self, touch):
         """ Add selection on touch down """
         if super(HintLabel, self).on_touch_down(touch):
@@ -662,12 +670,7 @@ class HintLabel(RecycleDataViewBehavior, MDBoxLayout):
             for child in self.children:
                 if child.collide_point(*touch.pos):
                     key = child.sort_key
-                    if key == "status":
-                        parent.hint_sorter = lambda element: status_sort_weights[element["status"]["hint"]["status"]]
-                    else:
-                        parent.hint_sorter = lambda element: (
-                            remove_between_brackets.sub("", element[key]["text"]).lower()
-                        )
+                    parent.hint_sorter = self.get_hint_sorter(key)
                     if key == parent.sort_key:
                         # second click reverses order
                         parent.reversed = not parent.reversed


### PR DESCRIPTION
## What is this fixing or adding?
Make the hint sorter when clicking on a header of the HintLog tab be fetched via a separate function. This allows subclasses of HintLabel to define custom sorting behavior- this is required by Universal Tracker to allow sorting by the `In Logic` column to function.

## How was this tested?
In [this branch](https://github.com/EmilyV99/Archipelago/tree/universal_tracker) I implemented this change alongside matching changes to UT code to allow sorting UT by the `In Logic` tab. I tested this on an active room I am playing which had a number of things hinted that are in logic, not in logic, and already found- the 3 separate values that UT uses in the `In Logic` column. The custom sorting behavior implemented there seems to work fine- but can't be added to UT until these changes are added to core.

## If this makes graphical changes, please attach screenshots.
<img width="1363" height="576" alt="image" src="https://github.com/user-attachments/assets/4cf9f107-ac93-4a42-8c81-4074ff8f4c26" />
(Sorting by the `In Logic` tab puts the in-logic locations at the top)