### PR TITLE
Core: add launcher run config

### DIFF
--- a/.run/_Launcher.run.xml
+++ b/.run/_Launcher.run.xml
@@ -1,0 +1,27 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="_Launcher" type="PythonConfigurationType" factoryName="Python">
+    <module name="Archipelago" />
+    <option name="ENV_FILES" value="" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="SDK_NAME" value="Python 3.12" />
+    <option name="WORKING_DIRECTORY" value="" />
+    <option name="IS_MODULE_SDK" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <option name="DEBUG_JUST_MY_CODE" value="false" />
+    <option name="RUN_TOOL" value="" />
+    <option name="SCRIPT_NAME" value="$PROJECT_DIR$/Launcher.py" />
+    <option name="PARAMETERS" value="" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/_Launcher.run.xml
+++ b/.run/_Launcher.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="_Launcher" type="PythonConfigurationType" factoryName="Python">
+  <configuration default="false" name="Launcher" type="PythonConfigurationType" factoryName="Python">
     <module name="Archipelago" />
     <option name="ENV_FILES" value="" />
     <option name="INTERPRETER_OPTIONS" value="" />

--- a/.run/_Launcher.run.xml
+++ b/.run/_Launcher.run.xml
@@ -8,9 +8,8 @@
       <env name="PYTHONUNBUFFERED" value="1" />
     </envs>
     <option name="SDK_HOME" value="" />
-    <option name="SDK_NAME" value="Python 3.12" />
-    <option name="WORKING_DIRECTORY" value="" />
-    <option name="IS_MODULE_SDK" value="false" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/" />
+    <option name="IS_MODULE_SDK" value="true" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <option name="DEBUG_JUST_MY_CODE" value="false" />


### PR DESCRIPTION
## What is this fixing or adding?
Ever since Build APWorlds run config was added it has been extremely inconvenient / annoying / buggy trying to just run the launcher normally. Explicitly adding a launcher run config fixes this.

## How was this tested?
Run config created via pycharm. Running it runs the launcher successfully.
Cloned a fresh repo clone and opened with pycharm for the first time on this branch. Run configs loaded properly and in the correct order (the launcher run config is named `_Launcher` to place it alphabetically before `Build APWorlds` to influence the load order, which is necessary because only the first run config loaded for a file appears in it's right-click menu).

## If this makes graphical changes, please attach screenshots.
<img width="296" height="113" alt="image" src="https://github.com/user-attachments/assets/46cf6553-40ef-4ff9-bcd1-83a7d947502a" />
<img width="432" height="388" alt="image" src="https://github.com/user-attachments/assets/a9e71371-80e0-466b-86a7-490099194cdf" />