### PR TITLE
CommonClient: Improve HintLog sorting to sort by multiple keys / be more generic

### DIFF
--- a/kvui.py
+++ b/kvui.py
@@ -638,13 +638,15 @@ class HintLabel(RecycleDataViewBehavior, MDBoxLayout):
                 status_label = self.ids["status"]
                 if status_label.collide_point(*touch.pos):
                     if self.hint["status"] == HintStatus.HINT_FOUND:
-                        return
+                        return True
                     ctx = MDApp.get_running_app().ctx
                     if ctx.slot_concerns_self(self.hint["receiving_player"]):  # If this player owns this hint
                         # open a dropdown
                         self.dropdown.open()
+                        return True
                 elif self.selected:
                     self.parent.clear_selection()
+                    return True
                 else:
                     text = "".join((self.receiving_text, "\'s ", self.item_text, " is at ", self.location_text, " in ",
                                     self.finding_text, "\'s World", (" at " + self.entrance_text)
@@ -661,20 +663,11 @@ class HintLabel(RecycleDataViewBehavior, MDBoxLayout):
             # find correct column
             for child in self.children:
                 if child.collide_point(*touch.pos):
-                    key = child.sort_key
-                    if key == "status":
-                        parent.hint_sorter = lambda element: status_sort_weights[element["status"]["hint"]["status"]]
-                    else:
-                        parent.hint_sorter = lambda element: (
-                            remove_between_brackets.sub("", element[key]["text"]).lower()
-                        )
-                    if key == parent.sort_key:
-                        # second click reverses order
-                        parent.reversed = not parent.reversed
-                    else:
-                        parent.sort_key = key
-                        parent.reversed = False
-                    MDApp.get_running_app().update_hints()
+                    if parent.sort_by_key(child.sort_key):
+                        MDApp.get_running_app().update_hints()
+                        return True
+                    return False
+        return False
 
     def apply_selection(self, rv, index, is_selected):
         """ Respond to the selection of items in the view. """
@@ -1215,7 +1208,48 @@ status_sort_weights: dict[HintStatus, int] = {
     HintStatus.HINT_PRIORITY: 4,
 }
 
-class HintLog(MDRecycleView):
+
+class ColumnSorter:
+    key: str
+    sort_func: typing.Callable[[dict], typing.Any]
+    reverse: bool
+
+    def __init__(self, key: str, sort_func: typing.Callable[[dict], typing.Any], reverse: bool = False):
+        self.key = key
+        self.sort_func = sort_func
+        self.reverse = reverse
+
+    def sort(self, data: list[typing.Any]):
+        data.sort(key=self.sort_func, reverse=self.reverse)
+
+
+class ColumnSortMixin:
+    column_sorters: list[ColumnSorter]
+
+    def __init__(self):
+        self.column_sorters = []
+
+    def sort_by_key(self, key: str) -> bool:
+        found_sorter: ColumnSorter | None = None
+        for sorter in self.column_sorters:
+            if sorter.key == key:
+                found_sorter = sorter
+                break
+        if found_sorter:
+            idx = self.column_sorters.index(found_sorter)
+            if idx == len(self.column_sorters) - 1:  # reverse the order if already primarily sorted by this key
+                found_sorter.reverse = not found_sorter.reverse
+            else:
+                self.column_sorters.append(self.column_sorters.pop(idx))  # move this sorter to the end
+            return True
+        return False
+
+    def sort_columns(self, data):
+        for sorter in self.column_sorters:
+            sorter.sort(data)
+
+
+class HintLog(MDRecycleView, ColumnSortMixin):
     header = {
         "receiving": {"text": "[u]Receiving Player[/u]"},
         "item": {"text": "[u]Item[/u]"},
@@ -1227,13 +1261,24 @@ class HintLog(MDRecycleView):
         "striped": True,
     }
     data: list[typing.Any]
-    sort_key: str = ""
-    reversed: bool = True
 
     def __init__(self, parser):
         super(HintLog, self).__init__()
         self.data = [self.header]
         self.parser = parser
+        # Setup default sorters for each key in a sensible default order
+        # The last in the list will end up being the 'primary' sort, as each sorter is applied in-order.
+        # Custom clients should be able to modify these and add additional sorters
+        for key in ["entrance", "receiving", "finding", "item", "location"]:
+            self.column_sorters.append(ColumnSorter(
+                key,
+                lambda element, k=key: remove_between_brackets.sub("", element[k]["text"]).lower(),
+            ))
+        self.column_sorters.append(ColumnSorter(
+            "status",
+            lambda element: status_sort_weights[element["status"]["hint"]["status"]],
+            True
+        ))
 
     def refresh_hints(self, hints):
         if not hints:  # Fix the scrolling looking visually wrong in some edge cases
@@ -1271,15 +1316,12 @@ class HintLog(MDRecycleView):
                 },
             })
 
-        data.sort(key=self.hint_sorter, reverse=self.reversed)
+        self.sort_columns(data)
+
         for i in range(0, len(data), 2):
             data[i]["striped"] = True
         data.insert(0, self.header)
         self.data = data
-
-    @staticmethod
-    def hint_sorter(element: dict) -> str:
-        return element["status"]["hint"]["status"]  # By status by default
 
     def fix_heights(self):
         """Workaround fix for divergent texture and layout heights"""


### PR DESCRIPTION
## What is this fixing or adding?
Revamps how the `HintLog` sorting works, using stable sorting to tiebreak the main sort column via other columns.
- Adds a `ColumnSorter` class which stores a key, sorting lambda, and reverse bool
- Adds a `ColumnSortMixin` handling logic for a list of `ColumnSorter`s. This is implemented like this instead of directly on the `HintLog` class, so that other clients can use it for their own custom non-hint tabs as well.
- instead of the `HintLog` having a single key, sort function, and reverse bool, it now implements the `ColumnSortMixin`.
- the `HintLabel` code no longer has to directly modify sorting lambdas. Instead, it just tells the hint log which key string it wants to sort by, and the `ColumnSortMixin`'s `sort_by_key` function handles the rest.
- When sorting by a key, the `ColumnSorter` for that key is moved to the end of the list- this means that all sorters will be applied, so if you were to sort by `Item` and then by `Status`, you would see that `Priority` status hints are all at the top- but within the priority hints, they are sub-sorted by `Item` name.
  - If the key is already at the end of the list, the `reverse` bool of the sorter is toggled instead, to swap ascending/descending of that key's sort.
- Due to how this works more generically, this should allow any client that wants to add it's own columns / sorting (ex. Universal Tracker for it's `In Logic` column) should be able to simply add their own sorters to the `column_sorters` list to accomplish this.
  - As such, this PR would *replace* #6135 that I had recently opened (which implemented a much simpler, although honestly less clean, change to allow UT to add a custom sorter here)

## How was this tested?
Connected to a large ongoing Stardew seed I'm playing with CommonClient, which has many hints of various statuses. Sorted by various columns and ensured that the sorting behavior looks right in each instance.
Implemented UT support for this in a UT branch, and tested that it works with UT's `In Logic` column having it's own sorter.

## If this makes graphical changes, please attach screenshots.
<img width="1366" height="568" alt="image" src="https://github.com/user-attachments/assets/bab7c62c-6d64-40ed-8ef4-ac96b709dd21" />
(Primarily sorted by Status, secondarily sorted by Location)
<img width="1362" height="556" alt="image" src="https://github.com/user-attachments/assets/f36c9777-5de3-495a-bc4b-8643d02092c3" />
(Primarily sorted by Status, secondarily sorted by Item)
<img width="1365" height="587" alt="image" src="https://github.com/user-attachments/assets/753b20d9-9fdd-48b8-84d6-168758ffffee" />
(UT: Sorted by In Logic / Status / Location)
<img width="1359" height="592" alt="image" src="https://github.com/user-attachments/assets/927a9909-3764-482f-810d-3902e66edd8e" />
(UT: Sorted by In Logic / Status / Item)