### PR TITLE
Rule Builder: Implement inverting of OptionFilters

### DIFF
--- a/rule_builder/options.py
+++ b/rule_builder/options.py
@@ -33,6 +33,18 @@ OPERATOR_STRINGS: Final[dict[Operator, str]] = {
     "ge": ">=",
     "le": "<=",
 }
+OPERATOR_INVERSES: Final[dict[Operator, Operator]] = {
+    "eq": "ne",
+    "ne": "eq",
+    "gt": "le",
+    "le": "gt",
+    "lt": "ge",
+    "ge": "lt",
+    "contains": "does not contain",
+    "does not contain": "contains",
+    "in": "not in",
+    "not in": "in",
+}
 REVERSE_OPERATORS: Final[tuple[Operator, ...]] = ("in", "not in")
 
 
@@ -89,6 +101,10 @@ class OptionFilter:
     def multiple_from_dict(cls, data: Iterable[dict[str, Any]]) -> tuple[Self, ...]:
         """Returns a tuple of OptionFilters instances from an iterable of dict representations"""
         return tuple(cls.from_dict(o) for o in data)
+
+    def __invert__(self) -> "OptionFilter":
+        """Returns a new OptionFilter instance that is a negation of the original"""
+        return OptionFilter(self.option, self.value, OPERATOR_INVERSES[self.operator])
 
     @override
     def __str__(self) -> str:

--- a/rule_builder/options.py
+++ b/rule_builder/options.py
@@ -8,7 +8,10 @@ from typing_extensions import override
 
 from Options import CommonOptions, Option
 
-Operator = Literal["eq", "ne", "gt", "lt", "ge", "le", "contains", "in"]
+Operator = Literal["eq", "ne", "gt", "lt", "ge", "le", "contains", "in", "does not contain", "not in"]
+
+def _does_not_contain(a: Any, b: Any, /) -> bool:
+    return b not in a
 
 OPERATORS: Final[dict[Operator, Callable[..., bool]]] = {
     "eq": operator.eq,
@@ -19,6 +22,8 @@ OPERATORS: Final[dict[Operator, Callable[..., bool]]] = {
     "le": operator.le,
     "contains": operator.contains,
     "in": operator.contains,
+    "does not contain": _does_not_contain,
+    "not in": _does_not_contain,
 }
 OPERATOR_STRINGS: Final[dict[Operator, str]] = {
     "eq": "==",
@@ -28,7 +33,7 @@ OPERATOR_STRINGS: Final[dict[Operator, str]] = {
     "ge": ">=",
     "le": "<=",
 }
-REVERSE_OPERATORS: Final[tuple[Operator, ...]] = ("in",)
+REVERSE_OPERATORS: Final[tuple[Operator, ...]] = ("in", "not in")
 
 
 @dataclasses.dataclass(frozen=True)

--- a/test/general/test_rule_builder.py
+++ b/test/general/test_rule_builder.py
@@ -9,7 +9,7 @@ from NetUtils import JSONMessagePart
 from Options import Choice, FreeText, Option, OptionSet, PerGameCommonOptions, Range, Toggle
 from rule_builder.cached_world import CachedRuleBuilderWorld
 from rule_builder.field_resolvers import FieldResolver, FromOption, FromWorldAttr, resolve_field
-from rule_builder.options import Operator, OptionFilter
+from rule_builder.options import Operator, OptionFilter, OPERATORS, OPERATOR_INVERSES
 from rule_builder.rules import (
     And,
     CanReachEntrance,
@@ -155,6 +155,13 @@ class CachedRuleBuilderTestCase(RuleBuilderTestCase):
 
         self.world_cls = RuleBuilderWorld
 
+class TestOperatorInverses(unittest.TestCase):
+    def test_all_operators_have_inverses(self) -> None:
+        self.assertEqual(set(OPERATORS), set(OPERATOR_INVERSES))
+
+    def test_operator_inverses_are_involutions(self) -> None:
+        for operator, inverse in OPERATOR_INVERSES.items():
+            self.assertEqual(operator, OPERATOR_INVERSES[inverse])
 
 @classvar_matrix(
     rules=(
@@ -276,10 +283,14 @@ class TestSimplify(RuleBuilderTestCase):
         (ChoiceOption, 1, "ge", "second", True),
         (ChoiceOption, 1, "in", (0, 1), True),
         (ChoiceOption, 1, "in", ("first", "second"), True),
+        (ChoiceOption, 1, "not in", (0, 1), False),
+        (ChoiceOption, 1, "not in", ("first", "second"), False),
         (FreeTextOption, "no", "eq", "yes", False),
         (FreeTextOption, "yes", "eq", "yes", True),
         (SetOption, ("one", "two"), "contains", "three", False),
         (SetOption, ("one", "two"), "contains", "two", True),
+        (SetOption, ("one", "two"), "does not contain", "three", True),
+        (SetOption, ("one", "two"), "does not contain", "two", False),
     )
 )
 class TestOptions(RuleBuilderTestCase):


### PR DESCRIPTION
## What is this fixing or adding?

Support for inverting `OptionFilter`s via the `~` unary operator.

As the supported operators for OptionFilter do not include inverses of “in” and “contains”, these were added first. They are called “not in” (to match python syntax) and “does not contain” (most logical name I could think of). As they do not have an equivalent function in the `operator` module, a custom function had to be defined, local to [rule_builder/options.py](https://github.com/StellatedCUBE/Archipelago/blob/e039deb87b2ca12e493617563bcf1bdac1167991/rule_builder/options.py#L13).

Once the set of valid operators was closed on inversion, support for the `__invert__` unary operator was added to `OptionFilter`. This operator creates a new `OptionFilter` instance with the same option and value, and the inverse operator.

## How was this tested?

Tests were added to [test/general/test_rule_builder.py](https://github.com/StellatedCUBE/Archipelago/blob/OptionFilter-invert/test/general/test_rule_builder.py)