### PR TITLE
Ducks Can Drive: New Game Support

### DIFF
--- a/worlds/duckscandrive/__init__.py
+++ b/worlds/duckscandrive/__init__.py
@@ -67,6 +67,16 @@ class DucksWorld(World):
     def _banana_included(self) -> bool:
         return bool(self.options.include_banana.value)
 
+    def _pars_included(self) -> bool:
+        return bool(self.options.include_par_times.value)
+
+    def _location_active(self, data) -> bool:
+        if data.track.display == BANANA_DISPLAY and not self._banana_included():
+            return False
+        if data.is_par and not self._pars_included():
+            return False
+        return True
+
     def create_item(self, name: str) -> DucksItem:
         data = item_table[name]
         classification = ItemClassification.progression if data.progression else ItemClassification.filler
@@ -84,7 +94,7 @@ class DucksWorld(World):
             city.locations.append(DucksLocation(self.player, name, loc_id, city))
 
         for name, data in time_trial_location_table.items():
-            if data.track.display == BANANA_DISPLAY and not self._banana_included():
+            if not self._location_active(data):
                 continue
             time_trials.locations.append(DucksLocation(self.player, name, data.id, time_trials))
 
@@ -97,14 +107,21 @@ class DucksWorld(World):
         self.multiworld.regions += [menu, city, time_trials]
 
     def create_items(self) -> None:
+        # Pool invariant: item count == non-victory location count.
+        # Dropping Banana subtracts exactly one location and one item, so no
+        # duck rebalance needed for that option. Dropping par times removes
+        # 6 locations with no matching items, so Rubber Duck count drops by
+        # 6 to keep the pool balanced.
+        banana_on = self._banana_included()
+        pars_on = self._pars_included()
+        duck_override = 8 + (6 if pars_on else 0)  # BOOK_COUNT + par locations
+
         banana_unlock = f"{BANANA_DISPLAY} Unlock"
         for name, data in item_table.items():
-            if name == banana_unlock and not self._banana_included():
-                # Dropping Banana drops exactly one location and one item,
-                # so the 25 progressives + rubber-duck pool stays balanced
-                # with no further adjustment.
+            if name == banana_unlock and not banana_on:
                 continue
-            for _ in range(data.count):
+            count = duck_override if name == "Rubber Duck" else data.count
+            for _ in range(count):
                 self.multiworld.itempool.append(self.create_item(name))
 
     def set_rules(self) -> None:
@@ -121,7 +138,7 @@ class DucksWorld(World):
         # Time-trial locations require the matching per-track unlock. The
         # client mod disables the menu button until the unlock arrives.
         for name, data in time_trial_location_table.items():
-            if data.track.display == BANANA_DISPLAY and not self._banana_included():
+            if not self._location_active(data):
                 continue
             unlock = f"{data.track.display} Unlock"
             location = self.multiworld.get_location(name, self.player)
@@ -138,4 +155,5 @@ class DucksWorld(World):
         return {
             "starting_money": self.options.starting_money.value,
             "include_banana": self._banana_included(),
+            "include_par_times": self._pars_included(),
         }

--- a/worlds/duckscandrive/__init__.py
+++ b/worlds/duckscandrive/__init__.py
@@ -15,7 +15,12 @@ from BaseClasses import Item, ItemClassification, Location, Region, Tutorial
 from worlds.AutoWorld import WebWorld, World
 
 from .items import TIERS_PER_STAT, UPGRADE_STATS, item_name_groups, item_name_to_id, item_table
-from .locations import book_location_table, location_name_to_id, upgrade_location_table
+from .locations import (
+    book_location_table,
+    location_name_to_id,
+    time_trial_location_table,
+    upgrade_location_table,
+)
 from .options import DucksOptions
 
 
@@ -64,6 +69,7 @@ class DucksWorld(World):
     def create_regions(self) -> None:
         menu = Region("Menu", self.player, self.multiworld)
         city = Region("City", self.player, self.multiworld)
+        time_trials = Region("Time Trials", self.player, self.multiworld)
 
         for name, data in upgrade_location_table.items():
             city.locations.append(DucksLocation(self.player, name, data.id, city))
@@ -71,12 +77,16 @@ class DucksWorld(World):
         for name, loc_id in book_location_table.items():
             city.locations.append(DucksLocation(self.player, name, loc_id, city))
 
+        for name, loc_id in time_trial_location_table.items():
+            time_trials.locations.append(DucksLocation(self.player, name, loc_id, time_trials))
+
         victory = DucksLocation(self.player, "Fully Upgraded Car", None, city)
         victory.place_locked_item(DucksItem("Victory", ItemClassification.progression, None, self.player))
         city.locations.append(victory)
 
         menu.connect(city)
-        self.multiworld.regions += [menu, city]
+        menu.connect(time_trials)
+        self.multiworld.regions += [menu, city, time_trials]
 
     def create_items(self) -> None:
         for name, data in item_table.items():

--- a/worlds/duckscandrive/__init__.py
+++ b/worlds/duckscandrive/__init__.py
@@ -77,8 +77,8 @@ class DucksWorld(World):
         for name, loc_id in book_location_table.items():
             city.locations.append(DucksLocation(self.player, name, loc_id, city))
 
-        for name, loc_id in time_trial_location_table.items():
-            time_trials.locations.append(DucksLocation(self.player, name, loc_id, time_trials))
+        for name, data in time_trial_location_table.items():
+            time_trials.locations.append(DucksLocation(self.player, name, data.id, time_trials))
 
         victory = DucksLocation(self.player, "Fully Upgraded Car", None, city)
         victory.place_locked_item(DucksItem("Victory", ItemClassification.progression, None, self.player))
@@ -95,15 +95,21 @@ class DucksWorld(World):
 
     def set_rules(self) -> None:
         # Strict rule: Upgrade tier N requires N Progressive <Stat> items.
-        # That makes the number of progressives received equal to the number
-        # of tiers the player can buy in-game (1-to-1). Sphere-1 is populated
-        # by the 21 free book + time-trial locations, so Fill can seed the
-        # upgrade ladders from there — no circular dependency.
+        # Sphere-1 comes from the 8 book locations plus whatever track
+        # unlocks Fill decides to place there, which is enough capacity to
+        # seed both the upgrade ladders and the TT locations themselves.
         for name, data in upgrade_location_table.items():
             progressive = f"Progressive {data.stat}"
             required = data.tier
             location = self.multiworld.get_location(name, self.player)
             location.access_rule = lambda state, item=progressive, count=required: state.has(item, self.player, count)
+
+        # Time-trial locations require the matching per-track unlock. The
+        # client mod disables the menu button until the unlock arrives.
+        for name, data in time_trial_location_table.items():
+            unlock = f"{data.track.display} Unlock"
+            location = self.multiworld.get_location(name, self.player)
+            location.access_rule = lambda state, item=unlock: state.has(item, self.player)
 
         self.multiworld.completion_condition[self.player] = lambda state: state.has_all_counts(
             {f"Progressive {stat}": TIERS_PER_STAT for stat in UPGRADE_STATS},

--- a/worlds/duckscandrive/__init__.py
+++ b/worlds/duckscandrive/__init__.py
@@ -46,6 +46,9 @@ class DucksWeb(WebWorld):
     ]
 
 
+BANANA_DISPLAY = "Banana"
+
+
 class DucksWorld(World):
     """Ducks Can Drive is a chaotic small-scale driving game by Joseph Cook (2023)."""
 
@@ -60,6 +63,9 @@ class DucksWorld(World):
     item_name_groups = item_name_groups
 
     required_client_version = (0, 5, 0)
+
+    def _banana_included(self) -> bool:
+        return bool(self.options.include_banana.value)
 
     def create_item(self, name: str) -> DucksItem:
         data = item_table[name]
@@ -78,6 +84,8 @@ class DucksWorld(World):
             city.locations.append(DucksLocation(self.player, name, loc_id, city))
 
         for name, data in time_trial_location_table.items():
+            if data.track.display == BANANA_DISPLAY and not self._banana_included():
+                continue
             time_trials.locations.append(DucksLocation(self.player, name, data.id, time_trials))
 
         victory = DucksLocation(self.player, "Fully Upgraded Car", None, city)
@@ -89,7 +97,13 @@ class DucksWorld(World):
         self.multiworld.regions += [menu, city, time_trials]
 
     def create_items(self) -> None:
+        banana_unlock = f"{BANANA_DISPLAY} Unlock"
         for name, data in item_table.items():
+            if name == banana_unlock and not self._banana_included():
+                # Dropping Banana drops exactly one location and one item,
+                # so the 25 progressives + rubber-duck pool stays balanced
+                # with no further adjustment.
+                continue
             for _ in range(data.count):
                 self.multiworld.itempool.append(self.create_item(name))
 
@@ -107,6 +121,8 @@ class DucksWorld(World):
         # Time-trial locations require the matching per-track unlock. The
         # client mod disables the menu button until the unlock arrives.
         for name, data in time_trial_location_table.items():
+            if data.track.display == BANANA_DISPLAY and not self._banana_included():
+                continue
             unlock = f"{data.track.display} Unlock"
             location = self.multiworld.get_location(name, self.player)
             location.access_rule = lambda state, item=unlock: state.has(item, self.player)
@@ -121,4 +137,5 @@ class DucksWorld(World):
         # configure behaviour that has to live client-side (money top-up, etc).
         return {
             "starting_money": self.options.starting_money.value,
+            "include_banana": self._banana_included(),
         }

--- a/worlds/duckscandrive/__init__.py
+++ b/worlds/duckscandrive/__init__.py
@@ -1,0 +1,98 @@
+"""Archipelago world definition for *Ducks Can Drive* (Steam app 2472840).
+
+First-pass content surface: the five `Garage.Upgrade*` tracks, each with five
+tiers, giving 25 locations and 25 matching `Progressive <Stat>` items.
+Goal: fully upgrade the car (all 25 progressives collected).
+
+Books, time-trial finishes, and time-trial par-times will be added as later
+passes; this file keeps the scope tight to validate the client's Connect
+handshake and LocationChecks flow end to end.
+"""
+from __future__ import annotations
+
+from BaseClasses import Item, ItemClassification, Location, Region, Tutorial
+
+from worlds.AutoWorld import WebWorld, World
+
+from .items import TIERS_PER_STAT, UPGRADE_STATS, item_name_groups, item_name_to_id, item_table
+from .locations import location_name_to_id, location_table
+from .options import DucksOptions
+
+
+class DucksItem(Item):
+    game = "Ducks Can Drive"
+
+
+class DucksLocation(Location):
+    game = "Ducks Can Drive"
+
+
+class DucksWeb(WebWorld):
+    theme = "ocean"
+    tutorials = [
+        Tutorial(
+            "Multiworld Setup Guide",
+            "A guide to setting up Ducks Can Drive for Archipelago.",
+            "English",
+            "setup_en.md",
+            "setup/en",
+            ["sebdevar"],
+        ),
+    ]
+
+
+class DucksWorld(World):
+    """Ducks Can Drive is a chaotic small-scale driving game by Joseph Cook (2023)."""
+
+    game = "Ducks Can Drive"
+    web = DucksWeb()
+
+    options_dataclass = DucksOptions
+    options: DucksOptions
+
+    item_name_to_id = item_name_to_id
+    location_name_to_id = location_name_to_id
+    item_name_groups = item_name_groups
+
+    required_client_version = (0, 5, 0)
+
+    def create_item(self, name: str) -> DucksItem:
+        data = item_table[name]
+        classification = ItemClassification.progression if data.progression else ItemClassification.filler
+        return DucksItem(name, classification, data.id, self.player)
+
+    def create_regions(self) -> None:
+        menu = Region("Menu", self.player, self.multiworld)
+        garage = Region("Garage", self.player, self.multiworld)
+
+        for name, data in location_table.items():
+            location = DucksLocation(self.player, name, data.id, garage)
+            garage.locations.append(location)
+
+        victory = DucksLocation(self.player, "Fully Upgraded Car", None, garage)
+        victory.place_locked_item(DucksItem("Victory", ItemClassification.progression, None, self.player))
+        garage.locations.append(victory)
+
+        menu.connect(garage)
+        self.multiworld.regions += [menu, garage]
+
+    def create_items(self) -> None:
+        for name, data in item_table.items():
+            for _ in range(data.count):
+                self.multiworld.itempool.append(self.create_item(name))
+
+    def set_rules(self) -> None:
+        # Tier N requires N-1 progressives of its stat, so every Tier 1 location
+        # is a free sphere-1 check (the player's starting money buys the first
+        # upgrade without AP input). A circular rule — tier N requires N — would
+        # leave sphere-1 empty and the seed unfillable.
+        for name, data in location_table.items():
+            progressive = f"Progressive {data.stat}"
+            required = data.tier - 1
+            location = self.multiworld.get_location(name, self.player)
+            location.access_rule = lambda state, item=progressive, count=required: state.has(item, self.player, count)
+
+        self.multiworld.completion_condition[self.player] = lambda state: state.has_all_counts(
+            {f"Progressive {stat}": TIERS_PER_STAT for stat in UPGRADE_STATS},
+            self.player,
+        )

--- a/worlds/duckscandrive/__init__.py
+++ b/worlds/duckscandrive/__init__.py
@@ -15,7 +15,7 @@ from BaseClasses import Item, ItemClassification, Location, Region, Tutorial
 from worlds.AutoWorld import WebWorld, World
 
 from .items import TIERS_PER_STAT, UPGRADE_STATS, item_name_groups, item_name_to_id, item_table
-from .locations import location_name_to_id, location_table
+from .locations import book_location_table, location_name_to_id, upgrade_location_table
 from .options import DucksOptions
 
 
@@ -63,18 +63,20 @@ class DucksWorld(World):
 
     def create_regions(self) -> None:
         menu = Region("Menu", self.player, self.multiworld)
-        garage = Region("Garage", self.player, self.multiworld)
+        city = Region("City", self.player, self.multiworld)
 
-        for name, data in location_table.items():
-            location = DucksLocation(self.player, name, data.id, garage)
-            garage.locations.append(location)
+        for name, data in upgrade_location_table.items():
+            city.locations.append(DucksLocation(self.player, name, data.id, city))
 
-        victory = DucksLocation(self.player, "Fully Upgraded Car", None, garage)
+        for name, loc_id in book_location_table.items():
+            city.locations.append(DucksLocation(self.player, name, loc_id, city))
+
+        victory = DucksLocation(self.player, "Fully Upgraded Car", None, city)
         victory.place_locked_item(DucksItem("Victory", ItemClassification.progression, None, self.player))
-        garage.locations.append(victory)
+        city.locations.append(victory)
 
-        menu.connect(garage)
-        self.multiworld.regions += [menu, garage]
+        menu.connect(city)
+        self.multiworld.regions += [menu, city]
 
     def create_items(self) -> None:
         for name, data in item_table.items():
@@ -85,8 +87,9 @@ class DucksWorld(World):
         # Tier N requires N-1 progressives of its stat, so every Tier 1 location
         # is a free sphere-1 check (the player's starting money buys the first
         # upgrade without AP input). A circular rule — tier N requires N — would
-        # leave sphere-1 empty and the seed unfillable.
-        for name, data in location_table.items():
+        # leave sphere-1 empty and the seed unfillable. Book locations are free
+        # pickups and get no access rule.
+        for name, data in upgrade_location_table.items():
             progressive = f"Progressive {data.stat}"
             required = data.tier - 1
             location = self.multiworld.get_location(name, self.player)

--- a/worlds/duckscandrive/__init__.py
+++ b/worlds/duckscandrive/__init__.py
@@ -94,14 +94,14 @@ class DucksWorld(World):
                 self.multiworld.itempool.append(self.create_item(name))
 
     def set_rules(self) -> None:
-        # Tier N requires N-1 progressives of its stat, so every Tier 1 location
-        # is a free sphere-1 check (the player's starting money buys the first
-        # upgrade without AP input). A circular rule — tier N requires N — would
-        # leave sphere-1 empty and the seed unfillable. Book locations are free
-        # pickups and get no access rule.
+        # Strict rule: Upgrade tier N requires N Progressive <Stat> items.
+        # That makes the number of progressives received equal to the number
+        # of tiers the player can buy in-game (1-to-1). Sphere-1 is populated
+        # by the 21 free book + time-trial locations, so Fill can seed the
+        # upgrade ladders from there — no circular dependency.
         for name, data in upgrade_location_table.items():
             progressive = f"Progressive {data.stat}"
-            required = data.tier - 1
+            required = data.tier
             location = self.multiworld.get_location(name, self.player)
             location.access_rule = lambda state, item=progressive, count=required: state.has(item, self.player, count)
 

--- a/worlds/duckscandrive/__init__.py
+++ b/worlds/duckscandrive/__init__.py
@@ -109,3 +109,10 @@ class DucksWorld(World):
             {f"Progressive {stat}": TIERS_PER_STAT for stat in UPGRADE_STATS},
             self.player,
         )
+
+    def fill_slot_data(self) -> dict[str, object]:
+        # Sent to the client in the Connected packet; read by the mod to
+        # configure behaviour that has to live client-side (money top-up, etc).
+        return {
+            "starting_money": self.options.starting_money.value,
+        }

--- a/worlds/duckscandrive/archipelago.json
+++ b/worlds/duckscandrive/archipelago.json
@@ -1,4 +1,4 @@
 {
     "game": "Ducks Can Drive",
-    "world_version": "0.0.3"
+    "world_version": "0.0.4"
 }

--- a/worlds/duckscandrive/archipelago.json
+++ b/worlds/duckscandrive/archipelago.json
@@ -1,4 +1,4 @@
 {
     "game": "Ducks Can Drive",
-    "world_version": "0.0.6"
+    "world_version": "0.0.7"
 }

--- a/worlds/duckscandrive/archipelago.json
+++ b/worlds/duckscandrive/archipelago.json
@@ -1,4 +1,4 @@
 {
     "game": "Ducks Can Drive",
-    "world_version": "0.0.4"
+    "world_version": "0.0.5"
 }

--- a/worlds/duckscandrive/archipelago.json
+++ b/worlds/duckscandrive/archipelago.json
@@ -1,4 +1,4 @@
 {
     "game": "Ducks Can Drive",
-    "world_version": "0.0.7"
+    "world_version": "0.0.8"
 }

--- a/worlds/duckscandrive/archipelago.json
+++ b/worlds/duckscandrive/archipelago.json
@@ -1,0 +1,4 @@
+{
+    "game": "Ducks Can Drive",
+    "world_version": "0.0.1"
+}

--- a/worlds/duckscandrive/archipelago.json
+++ b/worlds/duckscandrive/archipelago.json
@@ -1,4 +1,4 @@
 {
     "game": "Ducks Can Drive",
-    "world_version": "0.0.1"
+    "world_version": "0.0.2"
 }

--- a/worlds/duckscandrive/archipelago.json
+++ b/worlds/duckscandrive/archipelago.json
@@ -1,4 +1,4 @@
 {
     "game": "Ducks Can Drive",
-    "world_version": "0.0.5"
+    "world_version": "0.0.6"
 }

--- a/worlds/duckscandrive/archipelago.json
+++ b/worlds/duckscandrive/archipelago.json
@@ -1,4 +1,4 @@
 {
     "game": "Ducks Can Drive",
-    "world_version": "0.0.2"
+    "world_version": "0.0.3"
 }

--- a/worlds/duckscandrive/docs/en_Ducks Can Drive.md
+++ b/worlds/duckscandrive/docs/en_Ducks Can Drive.md
@@ -1,0 +1,28 @@
+# Ducks Can Drive
+
+*Ducks Can Drive* is a chaotic small-scale driving game by Joseph Cook (2023). Players drive a duck in a car, making deliveries, finding collectibles, and beating time trials.
+
+## Goal
+
+The goal is to fully upgrade your car. There are 5 upgrade tracks (Speed, Acceleration, Offroad, Boost, Handling), each with 5 tiers. Collecting all 25 `Progressive <Stat>` items and purchasing the upgrades in the garage completes the game.
+
+## Locations
+
+The following locations are randomized:
+- **Upgrade Tiers (25):** Each of the 5 tiers across 5 stats in the Garage.
+- **Duck Books (8):** Collectible books hidden throughout the City.
+- **Time Trial Finishes (7):** Completing each of the 7 tracks.
+- **Time Trial Pars (6):** Beating the par time for each track (except Banana).
+
+## Items
+
+The item pool contains:
+- **Progressive Upgrades (25):** Unlocks the ability to purchase higher tiers in the Garage.
+- **Track Unlocks (7):** Unlocks access to the offline Time Trial tracks.
+- **Rubber Ducks (Filler):** Acts as filler items.
+
+## Slot Options
+
+- **Starting Money:** Starting money budget granted for this seed.
+- **Include Banana Track:** Adds the secret Banana track to the pool.
+- **Include Par-Time Locations:** Toggles whether speedrunning goals are part of the seed.

--- a/worlds/duckscandrive/docs/setup_en.md
+++ b/worlds/duckscandrive/docs/setup_en.md
@@ -1,0 +1,96 @@
+# Ducks Can Drive — Archipelago Setup Guide
+
+*Ducks Can Drive* is a small free driving game by Joseph Cook. This guide
+walks you through installing the client mod, configuring your connection,
+and joining an Archipelago multiworld.
+
+## Required software
+
+- **Ducks Can Drive** — free on [Steam](https://store.steampowered.com/app/2472840/Ducks_Can_Drive/).
+- **MelonLoader 0.7.x** — mod loader for Unity Mono games. Download from [MelonLoader on GitHub](https://github.com/LavaGang/MelonLoader/releases) (pick the latest `MelonLoader.x64.zip`).
+- **DucksAP mod** — the client. Get the latest `DucksAP.dll` from the [DucksAP releases page](https://github.com/sebdevar/ducks-archipelago/releases) (or build it yourself — see the project README).
+
+## Install MelonLoader into the game
+
+1. Find the game's install folder. Default on Windows: `C:\Program Files (x86)\Steam\steamapps\common\Ducks Can Drive\`. You can also right-click the game in Steam → *Manage* → *Browse local files*.
+2. Extract the contents of `MelonLoader.x64.zip` directly into that folder so that a `MelonLoader\` directory sits next to `Ducks Can Drive.exe`.
+3. Launch the game once. MelonLoader bootstraps itself and creates `Mods\`, `Plugins\`, and `UserData\` subfolders. Close the game.
+
+## Install DucksAP
+
+1. Drop `DucksAP.dll` into the game's `Mods\` folder (created in the previous step).
+2. Launch the game once more so MelonLoader generates `UserData\DucksAP.cfg` with default values. Close the game.
+
+## Configure the connection
+
+Open `UserData\DucksAP.cfg` in a text editor. It looks like this:
+
+```toml
+[DucksAP]
+# Archipelago server URL, e.g. ws://localhost:38281
+server = ""
+# Slot name configured in the multiworld yaml
+slot = ""
+# Optional server password
+password = ""
+```
+
+Fill in the three fields to match the multiworld you're joining, then save.
+- For a hosted game, `server` typically looks like `ws://archipelago.gg:38281` (replace the port with the one your tracker shows).
+- For a local test, use `ws://localhost:<port>` where `<port>` is whatever `MultiServer.py` is running on.
+- `slot` must match the `name:` field in your player YAML.
+- Leave `password` empty if the server isn't password-protected.
+
+## Per-slot options
+
+Options you can set in your player YAML (see `StartingMoney` in `options.py`):
+
+- **`starting_money`** — lifetime money budget the mod grants across all city entries for this seed. Default `12500` covers every tier in one sitting; lower values (e.g. `3000`) force you to budget across sessions. Once spent, the pool is empty — you can still earn money from in-session deliveries but it won't carry over.
+
+## Joining a multiworld
+
+1. Launch Ducks Can Drive. The MelonLoader console window pops up alongside the game.
+2. Watch the console (or the on-screen message overlay in the top-left) for `Connected to Archipelago`. If connection fails, see **Troubleshooting** below.
+3. Play the game normally — see **How the AP integration works** below.
+
+## How the AP integration works
+
+Ducks Can Drive has three in-game systems, all of which feed into Archipelago:
+
+### Upgrades (25 locations)
+
+The garage in the city lets you buy five upgrade tiers for five stats (Speed, Acceleration, Offroad, Boost, Handling). Each tier is one AP location. You'll see the upgrade ladder gated on receiving `Progressive <Stat>` items:
+
+- Having N `Progressive <Stat>` items permits you to buy exactly N tiers of that stat.
+- The UI squares for already-earned tiers are painted green on city entry.
+- Buying a tier sends the corresponding `Upgrade <Stat> Tier N` check.
+
+Money is a lifetime pool sized by `starting_money`. The mod overwrites the stock game's per-entry $500 with your remaining budget on every city entry.
+
+### Books (8 locations)
+
+The 8 collectible duckbooks (`Book1`..`Book8`) scattered in the city are free-pickup AP locations. No gating — drive into the trigger, get the check.
+
+### Time trials (13 locations)
+
+Each of the 7 offline time-trial tracks has a "Finish `<track>`" AP location, and 6 of them have an additional "Beat par on `<track>`" location (Banana has no par). Tracks are locked until Archipelago delivers the matching `<Track> Unlock` item — locked buttons are greyed out in the Track Select menu.
+
+### Goal
+
+Collecting all 25 `Progressive <Stat>` items is the goal. The mod sends a `CLIENT_GOAL` status update to the server automatically when your inventory fills up.
+
+## On-screen overlay
+
+The top-left of the screen shows recent Archipelago events — connects, item receives, and goal — for about 8 seconds each. It's the quickest way to tell if a check or item went through without alt-tabbing to the MelonLoader console.
+
+## Troubleshooting
+
+- **`[ap] no server URL configured; skipping connect.`** — You haven't edited `UserData\DucksAP.cfg`, or the `server` line is still empty quotes. Add a URL, save, and relaunch.
+- **`[ap] <- ConnectionRefused`** — Slot name mismatch, wrong password, or your APWorld version doesn't match what the server expects. Check the tracker page for the correct slot name; re-generate the multiworld if you've bumped the APWorld version.
+- **Money feels stuck at $0 despite unspent deliveries.** — The AP money pool is separate from in-session delivery earnings, and in-session earnings don't persist across city entries. If `starting_money` is spent, further city entries start you at $0 from the AP side; you have to grind deliveries each session.
+- **Buttons in the Track Select menu are greyed out.** — That's intended — you haven't received the matching `<Track> Unlock` item yet. Keep playing; checks in the city will eventually deliver them.
+- **Garage tier squares don't turn green until I buy.** — Leaving and re-entering the city should re-paint them from your AP inventory. If it still doesn't, the squares will at least fill in as you buy each tier.
+
+## Reporting issues
+
+Please include your `MelonLoader\Latest.log` (or the most recent log under `MelonLoader\Logs\`) when filing an issue, plus the contents of `UserData\DucksAP.cfg`. Don't share server passwords.

--- a/worlds/duckscandrive/docs/setup_en.md
+++ b/worlds/duckscandrive/docs/setup_en.md
@@ -46,6 +46,7 @@ Fill in the three fields to match the multiworld you're joining, then save.
 Options you can set in your player YAML (see `StartingMoney` in `options.py`):
 
 - **`starting_money`** — lifetime money budget the mod grants across all city entries for this seed. Default `12500` covers every tier in one sitting; lower values (e.g. `3000`) force you to budget across sessions. Once spent, the pool is empty — you can still earn money from in-session deliveries but it won't carry over.
+- **`include_banana`** — off by default. When on, adds the secret Banana Offline track to the seed as a location (and its unlock to the item pool). Banana has no Track Select menu button — the only way into it is to let a time-trial's timer run past 10 minutes without finishing. Leave off unless you specifically want a scavenger-hunt objective in your seed.
 
 ## Joining a multiworld
 

--- a/worlds/duckscandrive/docs/setup_en.md
+++ b/worlds/duckscandrive/docs/setup_en.md
@@ -47,6 +47,7 @@ Options you can set in your player YAML (see `StartingMoney` in `options.py`):
 
 - **`starting_money`** — lifetime money budget the mod grants across all city entries for this seed. Default `12500` covers every tier in one sitting; lower values (e.g. `3000`) force you to budget across sessions. Once spent, the pool is empty — you can still earn money from in-session deliveries but it won't carry over.
 - **`include_banana`** — off by default. When on, adds the secret Banana Offline track to the seed as a location (and its unlock to the item pool). Banana has no Track Select menu button — the only way into it is to let a time-trial's timer run past 10 minutes without finishing. Leave off unless you specifically want a scavenger-hunt objective in your seed.
+- **`include_par_times`** — on by default. The six par-time locations (Duck Circuit under 35s, Lake Loop under 40s, etc.) reward skillful driving. Turn off if you'd rather a gentler seed that only rewards finishing the tracks, not speedrunning them; Rubber Duck filler count scales down automatically to keep the pool balanced.
 
 ## Joining a multiworld
 

--- a/worlds/duckscandrive/docs/setup_en.md
+++ b/worlds/duckscandrive/docs/setup_en.md
@@ -89,7 +89,7 @@ The top-left of the screen shows recent Archipelago events — connects, item re
 
 - **`[ap] no server URL configured; skipping connect.`** — You haven't edited `UserData\DucksAP.cfg`, or the `server` line is still empty quotes. Add a URL, save, and relaunch.
 - **`[ap] <- ConnectionRefused`** — Slot name mismatch, wrong password, or your APWorld version doesn't match what the server expects. Check the tracker page for the correct slot name; re-generate the multiworld if you've bumped the APWorld version.
-- **Money feels stuck at $0 despite unspent deliveries.** — The AP money pool is separate from in-session delivery earnings, and in-session earnings don't persist across city entries. If `starting_money` is spent, further city entries start you at $0 from the AP side; you have to grind deliveries each session.
+- **Money feels stuck at \$0 despite unspent deliveries.** — The AP money pool is separate from in-session delivery earnings, and in-session earnings don't persist across city entries. If `starting_money` is spent, further city entries start you at $0 from the AP side; you have to grind deliveries each session.
 - **Buttons in the Track Select menu are greyed out.** — That's intended — you haven't received the matching `<Track> Unlock` item yet. Keep playing; checks in the city will eventually deliver them.
 - **Garage tier squares don't turn green until I buy.** — Leaving and re-entering the city should re-paint them from your AP inventory. If it still doesn't, the squares will at least fill in as you buy each tier.
 

--- a/worlds/duckscandrive/items.py
+++ b/worlds/duckscandrive/items.py
@@ -1,0 +1,33 @@
+"""Item definitions for Ducks Can Drive.
+
+A progressive item per upgrade stat, five of each. The client mod translates
+one received `Progressive <Stat>` item into permission to buy the next tier of
+that stat in-game.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+DUCKS_BASE_ID = 0xDCD000  # 14,471,168 — distinctive local-dev range.
+
+UPGRADE_STATS: tuple[str, ...] = ("Speed", "Acceleration", "Offroad", "Boost", "Handling")
+TIERS_PER_STAT: int = 5
+
+
+@dataclass(frozen=True)
+class ItemData:
+    id: int
+    count: int
+    progression: bool
+
+
+item_table: dict[str, ItemData] = {
+    f"Progressive {stat}": ItemData(id=DUCKS_BASE_ID + i, count=TIERS_PER_STAT, progression=True)
+    for i, stat in enumerate(UPGRADE_STATS)
+}
+
+item_name_to_id: dict[str, int] = {name: data.id for name, data in item_table.items()}
+
+item_name_groups: dict[str, set[str]] = {
+    "Upgrades": {f"Progressive {stat}" for stat in UPGRADE_STATS},
+}

--- a/worlds/duckscandrive/items.py
+++ b/worlds/duckscandrive/items.py
@@ -1,14 +1,16 @@
 """Item definitions for Ducks Can Drive.
 
-A progressive item per upgrade stat (five of each) plus a filler "Rubber Duck"
-that lands at the eight book locations. The mod maps received `Progressive
-<Stat>` items to permission to buy the next tier of that stat in-game; Rubber
-Ducks are pool padding with no gameplay effect.
+Three item families:
+* Progressive upgrade items (one per stat, 5 copies each) — permit buying the
+  next tier of that stat in-game.
+* Track-unlock items (one per time-trial, 1 copy each) — gate access to the
+  corresponding offline time-trial scene.
+* Rubber Duck filler — pure pool padding, no gameplay effect.
 
 ID ranges on the shared base `DUCKS_BASE_ID = 0xDCD000`:
-* `+0x00..0x04` — Progressive upgrade items
-* `+0x10`      — Rubber Duck filler (single item id; count tracks the
-                  non-upgrade location pool)
+* `+0x00..0x04` — Progressive upgrade items (5)
+* `+0x10`      — Rubber Duck filler (single id, count = non-upgrade locations minus unlocks)
+* `+0x20..0x26` — Track-unlock items (7)
 * `+0x100..0x1FF` — Upgrade locations (see `locations.py`)
 * `+0x200..0x2FF` — Book locations
 * `+0x300..0x3FF` — Time-trial finish locations
@@ -17,6 +19,7 @@ ID ranges on the shared base `DUCKS_BASE_ID = 0xDCD000`:
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Optional
 
 DUCKS_BASE_ID = 0xDCD000  # 14,471,168 — distinctive local-dev range.
 
@@ -24,9 +27,12 @@ UPGRADE_STATS: tuple[str, ...] = ("Speed", "Acceleration", "Offroad", "Boost", "
 TIERS_PER_STAT: int = 5
 
 FILLER_OFFSET: int = 0x10
+TRACK_UNLOCK_OFFSET: int = 0x20
+
 BOOK_COUNT: int = 8
 TIME_TRIAL_LOCATION_COUNT: int = 13  # 7 finishes + 6 pars (Banana has no par)
-RUBBER_DUCK_COUNT: int = BOOK_COUNT + TIME_TRIAL_LOCATION_COUNT
+TRACK_UNLOCK_COUNT: int = 7
+RUBBER_DUCK_COUNT: int = BOOK_COUNT + TIME_TRIAL_LOCATION_COUNT - TRACK_UNLOCK_COUNT  # 14
 
 
 @dataclass(frozen=True)
@@ -36,17 +42,42 @@ class ItemData:
     progression: bool
 
 
+@dataclass(frozen=True)
+class TimeTrialTrack:
+    scene_name: str
+    display: str
+    par_seconds: Optional[float]
+
+
+TIME_TRIAL_TRACKS: tuple[TimeTrialTrack, ...] = (
+    TimeTrialTrack("Duck Circuit Offline",   "Duck Circuit",   35.0),
+    TimeTrialTrack("Lake Loop Offline",      "Lake Loop",      40.0),
+    TimeTrialTrack("Quack Crossing Offline", "Quack Crossing", 45.0),
+    TimeTrialTrack("Wing Circuit Offline",   "Wing Circuit",   54.0),
+    TimeTrialTrack("Blackbill Ship Offline", "Blackbill Ship", 95.0),
+    TimeTrialTrack("Bill Beach Offline",     "Bill Beach",     90.0),
+    TimeTrialTrack("Banana Offline",         "Banana",         None),
+)
+
+
 item_table: dict[str, ItemData] = {
     **{
         f"Progressive {stat}": ItemData(id=DUCKS_BASE_ID + i, count=TIERS_PER_STAT, progression=True)
         for i, stat in enumerate(UPGRADE_STATS)
     },
     "Rubber Duck": ItemData(id=DUCKS_BASE_ID + FILLER_OFFSET, count=RUBBER_DUCK_COUNT, progression=False),
+    **{
+        f"{track.display} Unlock": ItemData(
+            id=DUCKS_BASE_ID + TRACK_UNLOCK_OFFSET + i, count=1, progression=True,
+        )
+        for i, track in enumerate(TIME_TRIAL_TRACKS)
+    },
 }
 
 item_name_to_id: dict[str, int] = {name: data.id for name, data in item_table.items()}
 
 item_name_groups: dict[str, set[str]] = {
     "Upgrades": {f"Progressive {stat}" for stat in UPGRADE_STATS},
+    "Track Unlocks": {f"{track.display} Unlock" for track in TIME_TRIAL_TRACKS},
     "Filler": {"Rubber Duck"},
 }

--- a/worlds/duckscandrive/items.py
+++ b/worlds/duckscandrive/items.py
@@ -1,8 +1,15 @@
 """Item definitions for Ducks Can Drive.
 
-A progressive item per upgrade stat, five of each. The client mod translates
-one received `Progressive <Stat>` item into permission to buy the next tier of
-that stat in-game.
+A progressive item per upgrade stat (five of each) plus a filler "Rubber Duck"
+that lands at the eight book locations. The mod maps received `Progressive
+<Stat>` items to permission to buy the next tier of that stat in-game; Rubber
+Ducks are pool padding with no gameplay effect.
+
+ID ranges on the shared base `DUCKS_BASE_ID = 0xDCD000`:
+* `+0x00..0x04` — Progressive upgrade items
+* `+0x10`      — Rubber Duck (single item id, count = 8)
+* `+0x100..0x1FF` — Upgrade locations (see `locations.py`)
+* `+0x200..0x2FF` — Book locations (see `locations.py`)
 """
 from __future__ import annotations
 
@@ -13,6 +20,9 @@ DUCKS_BASE_ID = 0xDCD000  # 14,471,168 — distinctive local-dev range.
 UPGRADE_STATS: tuple[str, ...] = ("Speed", "Acceleration", "Offroad", "Boost", "Handling")
 TIERS_PER_STAT: int = 5
 
+FILLER_OFFSET: int = 0x10
+BOOK_COUNT: int = 8
+
 
 @dataclass(frozen=True)
 class ItemData:
@@ -22,12 +32,16 @@ class ItemData:
 
 
 item_table: dict[str, ItemData] = {
-    f"Progressive {stat}": ItemData(id=DUCKS_BASE_ID + i, count=TIERS_PER_STAT, progression=True)
-    for i, stat in enumerate(UPGRADE_STATS)
+    **{
+        f"Progressive {stat}": ItemData(id=DUCKS_BASE_ID + i, count=TIERS_PER_STAT, progression=True)
+        for i, stat in enumerate(UPGRADE_STATS)
+    },
+    "Rubber Duck": ItemData(id=DUCKS_BASE_ID + FILLER_OFFSET, count=BOOK_COUNT, progression=False),
 }
 
 item_name_to_id: dict[str, int] = {name: data.id for name, data in item_table.items()}
 
 item_name_groups: dict[str, set[str]] = {
     "Upgrades": {f"Progressive {stat}" for stat in UPGRADE_STATS},
+    "Filler": {"Rubber Duck"},
 }

--- a/worlds/duckscandrive/items.py
+++ b/worlds/duckscandrive/items.py
@@ -7,9 +7,12 @@ Ducks are pool padding with no gameplay effect.
 
 ID ranges on the shared base `DUCKS_BASE_ID = 0xDCD000`:
 * `+0x00..0x04` — Progressive upgrade items
-* `+0x10`      — Rubber Duck (single item id, count = 8)
+* `+0x10`      — Rubber Duck filler (single item id; count tracks the
+                  non-upgrade location pool)
 * `+0x100..0x1FF` — Upgrade locations (see `locations.py`)
-* `+0x200..0x2FF` — Book locations (see `locations.py`)
+* `+0x200..0x2FF` — Book locations
+* `+0x300..0x3FF` — Time-trial finish locations
+* `+0x400..0x4FF` — Time-trial par-time locations
 """
 from __future__ import annotations
 
@@ -22,6 +25,8 @@ TIERS_PER_STAT: int = 5
 
 FILLER_OFFSET: int = 0x10
 BOOK_COUNT: int = 8
+TIME_TRIAL_LOCATION_COUNT: int = 13  # 7 finishes + 6 pars (Banana has no par)
+RUBBER_DUCK_COUNT: int = BOOK_COUNT + TIME_TRIAL_LOCATION_COUNT
 
 
 @dataclass(frozen=True)
@@ -36,7 +41,7 @@ item_table: dict[str, ItemData] = {
         f"Progressive {stat}": ItemData(id=DUCKS_BASE_ID + i, count=TIERS_PER_STAT, progression=True)
         for i, stat in enumerate(UPGRADE_STATS)
     },
-    "Rubber Duck": ItemData(id=DUCKS_BASE_ID + FILLER_OFFSET, count=BOOK_COUNT, progression=False),
+    "Rubber Duck": ItemData(id=DUCKS_BASE_ID + FILLER_OFFSET, count=RUBBER_DUCK_COUNT, progression=False),
 }
 
 item_name_to_id: dict[str, int] = {name: data.id for name, data in item_table.items()}

--- a/worlds/duckscandrive/locations.py
+++ b/worlds/duckscandrive/locations.py
@@ -2,21 +2,28 @@
 
 Three families:
 
-* **Upgrade locations** — 5 tiers × 5 stats (`Garage.Upgrade*`). Gated
-  in logic so tier N ≥ 2 requires N-1 progressives of that stat.
+* **Upgrade locations** — 5 tiers × 5 stats (`Garage.Upgrade*`). Gated in
+  logic so tier N requires N progressives of that stat.
 * **Book locations** — 8 collectibles (`Book1`..`Book8`). Free pickups
   scattered around the City scene.
 * **Time-trial locations** — for each of the 7 offline tracks, a
-  "Finish <track>" location, and for the 6 tracks that have a par
-  time, a "Beat par on <track>" location. All free sphere-1 (tracks
-  are accessible from the main menu without any AP prerequisite).
+  "Finish &lt;track&gt;" location, and for the 6 tracks that have a par
+  time, a "Beat par on &lt;track&gt;" location. Both gated on the
+  matching "&lt;track&gt; Unlock" item; until the player receives it
+  the TT menu button is a no-op in-game.
 """
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
 
-from .items import BOOK_COUNT, DUCKS_BASE_ID, TIERS_PER_STAT, UPGRADE_STATS
+from .items import (
+    BOOK_COUNT,
+    DUCKS_BASE_ID,
+    TIERS_PER_STAT,
+    TIME_TRIAL_TRACKS,
+    TimeTrialTrack,
+    UPGRADE_STATS,
+)
 
 UPGRADES_OFFSET = 0x100
 BOOKS_OFFSET = 0x200
@@ -32,21 +39,10 @@ class UpgradeLocationData:
 
 
 @dataclass(frozen=True)
-class TimeTrialTrack:
-    scene_name: str   # the Unity scene name, used by the client mod
-    display: str      # shown in AP tracker / yaml
-    par_seconds: Optional[float]
-
-
-TIME_TRIAL_TRACKS: tuple[TimeTrialTrack, ...] = (
-    TimeTrialTrack("Duck Circuit Offline",   "Duck Circuit",   35.0),
-    TimeTrialTrack("Lake Loop Offline",      "Lake Loop",      40.0),
-    TimeTrialTrack("Quack Crossing Offline", "Quack Crossing", 45.0),
-    TimeTrialTrack("Wing Circuit Offline",   "Wing Circuit",   54.0),
-    TimeTrialTrack("Blackbill Ship Offline", "Blackbill Ship", 95.0),
-    TimeTrialTrack("Bill Beach Offline",     "Bill Beach",     90.0),
-    TimeTrialTrack("Banana Offline",         "Banana",         None),
-)
+class TimeTrialLocationData:
+    id: int
+    track: TimeTrialTrack
+    is_par: bool
 
 
 def _build_upgrade_table() -> dict[str, UpgradeLocationData]:
@@ -65,21 +61,25 @@ def _build_book_table() -> dict[str, int]:
     }
 
 
-def _build_time_trial_table() -> dict[str, int]:
-    table: dict[str, int] = {}
+def _build_time_trial_table() -> dict[str, TimeTrialLocationData]:
+    table: dict[str, TimeTrialLocationData] = {}
     for index, track in enumerate(TIME_TRIAL_TRACKS):
-        table[f"Finish {track.display}"] = DUCKS_BASE_ID + TT_FINISH_OFFSET + index
+        table[f"Finish {track.display}"] = TimeTrialLocationData(
+            id=DUCKS_BASE_ID + TT_FINISH_OFFSET + index, track=track, is_par=False,
+        )
         if track.par_seconds is not None:
-            table[f"Beat par on {track.display}"] = DUCKS_BASE_ID + TT_PAR_OFFSET + index
+            table[f"Beat par on {track.display}"] = TimeTrialLocationData(
+                id=DUCKS_BASE_ID + TT_PAR_OFFSET + index, track=track, is_par=True,
+            )
     return table
 
 
 upgrade_location_table: dict[str, UpgradeLocationData] = _build_upgrade_table()
 book_location_table: dict[str, int] = _build_book_table()
-time_trial_location_table: dict[str, int] = _build_time_trial_table()
+time_trial_location_table: dict[str, TimeTrialLocationData] = _build_time_trial_table()
 
 location_name_to_id: dict[str, int] = {
     **{name: data.id for name, data in upgrade_location_table.items()},
     **book_location_table,
-    **time_trial_location_table,
+    **{name: data.id for name, data in time_trial_location_table.items()},
 }

--- a/worlds/duckscandrive/locations.py
+++ b/worlds/duckscandrive/locations.py
@@ -1,0 +1,33 @@
+"""Location definitions for Ducks Can Drive.
+
+Five tiers per stat gives 25 upgrade locations. Tier N is reached when the
+player buys the N-th upgrade of that stat at the garage; the client mod sends
+a `LocationChecks` packet at that moment.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .items import DUCKS_BASE_ID, TIERS_PER_STAT, UPGRADE_STATS
+
+LOCATIONS_OFFSET = 0x100  # keep location IDs clearly separated from item IDs
+
+
+@dataclass(frozen=True)
+class LocationData:
+    id: int
+    stat: str
+    tier: int
+
+
+def _build_table() -> dict[str, LocationData]:
+    table: dict[str, LocationData] = {}
+    for stat_index, stat in enumerate(UPGRADE_STATS):
+        for tier in range(1, TIERS_PER_STAT + 1):
+            loc_id = DUCKS_BASE_ID + LOCATIONS_OFFSET + stat_index * 0x10 + tier
+            table[f"Upgrade {stat} Tier {tier}"] = LocationData(id=loc_id, stat=stat, tier=tier)
+    return table
+
+
+location_table: dict[str, LocationData] = _build_table()
+location_name_to_id: dict[str, int] = {name: data.id for name, data in location_table.items()}

--- a/worlds/duckscandrive/locations.py
+++ b/worlds/duckscandrive/locations.py
@@ -1,20 +1,27 @@
 """Location definitions for Ducks Can Drive.
 
-Two families, both in the City scene:
+Three families:
 
 * **Upgrade locations** — 5 tiers × 5 stats (`Garage.Upgrade*`). Gated
   in logic so tier N ≥ 2 requires N-1 progressives of that stat.
-* **Book locations** — 8 collectibles (`Book1`..`Book8`). Free sphere-1
-  — any player who can reach the city can pick them up.
+* **Book locations** — 8 collectibles (`Book1`..`Book8`). Free pickups
+  scattered around the City scene.
+* **Time-trial locations** — for each of the 7 offline tracks, a
+  "Finish <track>" location, and for the 6 tracks that have a par
+  time, a "Beat par on <track>" location. All free sphere-1 (tracks
+  are accessible from the main menu without any AP prerequisite).
 """
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Optional
 
 from .items import BOOK_COUNT, DUCKS_BASE_ID, TIERS_PER_STAT, UPGRADE_STATS
 
 UPGRADES_OFFSET = 0x100
 BOOKS_OFFSET = 0x200
+TT_FINISH_OFFSET = 0x300
+TT_PAR_OFFSET = 0x400
 
 
 @dataclass(frozen=True)
@@ -22,6 +29,24 @@ class UpgradeLocationData:
     id: int
     stat: str
     tier: int
+
+
+@dataclass(frozen=True)
+class TimeTrialTrack:
+    scene_name: str   # the Unity scene name, used by the client mod
+    display: str      # shown in AP tracker / yaml
+    par_seconds: Optional[float]
+
+
+TIME_TRIAL_TRACKS: tuple[TimeTrialTrack, ...] = (
+    TimeTrialTrack("Duck Circuit Offline",   "Duck Circuit",   35.0),
+    TimeTrialTrack("Lake Loop Offline",      "Lake Loop",      40.0),
+    TimeTrialTrack("Quack Crossing Offline", "Quack Crossing", 45.0),
+    TimeTrialTrack("Wing Circuit Offline",   "Wing Circuit",   54.0),
+    TimeTrialTrack("Blackbill Ship Offline", "Blackbill Ship", 95.0),
+    TimeTrialTrack("Bill Beach Offline",     "Bill Beach",     90.0),
+    TimeTrialTrack("Banana Offline",         "Banana",         None),
+)
 
 
 def _build_upgrade_table() -> dict[str, UpgradeLocationData]:
@@ -40,10 +65,21 @@ def _build_book_table() -> dict[str, int]:
     }
 
 
+def _build_time_trial_table() -> dict[str, int]:
+    table: dict[str, int] = {}
+    for index, track in enumerate(TIME_TRIAL_TRACKS):
+        table[f"Finish {track.display}"] = DUCKS_BASE_ID + TT_FINISH_OFFSET + index
+        if track.par_seconds is not None:
+            table[f"Beat par on {track.display}"] = DUCKS_BASE_ID + TT_PAR_OFFSET + index
+    return table
+
+
 upgrade_location_table: dict[str, UpgradeLocationData] = _build_upgrade_table()
 book_location_table: dict[str, int] = _build_book_table()
+time_trial_location_table: dict[str, int] = _build_time_trial_table()
 
 location_name_to_id: dict[str, int] = {
     **{name: data.id for name, data in upgrade_location_table.items()},
     **book_location_table,
+    **time_trial_location_table,
 }

--- a/worlds/duckscandrive/locations.py
+++ b/worlds/duckscandrive/locations.py
@@ -1,33 +1,49 @@
 """Location definitions for Ducks Can Drive.
 
-Five tiers per stat gives 25 upgrade locations. Tier N is reached when the
-player buys the N-th upgrade of that stat at the garage; the client mod sends
-a `LocationChecks` packet at that moment.
+Two families, both in the City scene:
+
+* **Upgrade locations** — 5 tiers × 5 stats (`Garage.Upgrade*`). Gated
+  in logic so tier N ≥ 2 requires N-1 progressives of that stat.
+* **Book locations** — 8 collectibles (`Book1`..`Book8`). Free sphere-1
+  — any player who can reach the city can pick them up.
 """
 from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .items import DUCKS_BASE_ID, TIERS_PER_STAT, UPGRADE_STATS
+from .items import BOOK_COUNT, DUCKS_BASE_ID, TIERS_PER_STAT, UPGRADE_STATS
 
-LOCATIONS_OFFSET = 0x100  # keep location IDs clearly separated from item IDs
+UPGRADES_OFFSET = 0x100
+BOOKS_OFFSET = 0x200
 
 
 @dataclass(frozen=True)
-class LocationData:
+class UpgradeLocationData:
     id: int
     stat: str
     tier: int
 
 
-def _build_table() -> dict[str, LocationData]:
-    table: dict[str, LocationData] = {}
+def _build_upgrade_table() -> dict[str, UpgradeLocationData]:
+    table: dict[str, UpgradeLocationData] = {}
     for stat_index, stat in enumerate(UPGRADE_STATS):
         for tier in range(1, TIERS_PER_STAT + 1):
-            loc_id = DUCKS_BASE_ID + LOCATIONS_OFFSET + stat_index * 0x10 + tier
-            table[f"Upgrade {stat} Tier {tier}"] = LocationData(id=loc_id, stat=stat, tier=tier)
+            loc_id = DUCKS_BASE_ID + UPGRADES_OFFSET + stat_index * 0x10 + tier
+            table[f"Upgrade {stat} Tier {tier}"] = UpgradeLocationData(id=loc_id, stat=stat, tier=tier)
     return table
 
 
-location_table: dict[str, LocationData] = _build_table()
-location_name_to_id: dict[str, int] = {name: data.id for name, data in location_table.items()}
+def _build_book_table() -> dict[str, int]:
+    return {
+        f"Book {n}": DUCKS_BASE_ID + BOOKS_OFFSET + n
+        for n in range(1, BOOK_COUNT + 1)
+    }
+
+
+upgrade_location_table: dict[str, UpgradeLocationData] = _build_upgrade_table()
+book_location_table: dict[str, int] = _build_book_table()
+
+location_name_to_id: dict[str, int] = {
+    **{name: data.id for name, data in upgrade_location_table.items()},
+    **book_location_table,
+}

--- a/worlds/duckscandrive/options.py
+++ b/worlds/duckscandrive/options.py
@@ -38,7 +38,21 @@ class IncludeBanana(Toggle):
     display_name = "Include Banana Track"
 
 
+class IncludeParTimes(Toggle):
+    """Include the per-track par-time locations in the seed.
+
+    Six of the seven tracks (all except Banana) have a par time the player
+    has to beat to fire the "Beat par on <track>" location check. Pars are
+    reachable — they just require skillful driving — so this defaults on.
+    Turn off if you'd rather a seed that only rewards finishing tracks, not
+    speedrunning them.
+    """
+    display_name = "Include Par-Time Locations"
+    default = 1  # on
+
+
 @dataclass
 class DucksOptions(PerGameCommonOptions):
     starting_money: StartingMoney
     include_banana: IncludeBanana
+    include_par_times: IncludeParTimes

--- a/worlds/duckscandrive/options.py
+++ b/worlds/duckscandrive/options.py
@@ -7,13 +7,16 @@ from Options import PerGameCommonOptions, Range
 
 
 class StartingMoney(Range):
-    """Money the car spawns with every time the player enters the City scene.
+    """Lifetime money budget the client mod grants for this seed.
 
-    The stock game hard-codes $100 and `Car.Start` resets stats every time, so
-    without a top-up sphere-1 requires grinding the Photon delivery loop before
-    any AP check can fire. The default of 12,500 covers all 25 upgrade tiers in
-    one session; lower values make money matter again and can be used for
-    slower-paced seeds. Range covers everything from 'pure grind' to 'pure AP'.
+    The stock game resets Car.money to $500 on every City entry, so "starting
+    money" as a per-entry top-up was trivially farmable by re-entering the
+    city. Under the current policy the mod overwrites the stock prefab money
+    with (starting_money - lifetime_spent) on every City entry and tracks each
+    Garage purchase in PlayerPrefs, so the option is a true one-shot pool
+    shared across all city entries. Deliveries still earn money in-session
+    (stock PayDay) but those earnings don't carry across scene loads.
+    12,500 covers every tier in the seed; lower values force budget choices.
     """
     display_name = "Starting Money"
     range_start = 100

--- a/worlds/duckscandrive/options.py
+++ b/worlds/duckscandrive/options.py
@@ -1,0 +1,16 @@
+"""Per-slot options for Ducks Can Drive.
+
+Intentionally minimal for the first working APWorld — only the common options
+every game gets. Ducks-specific options (book shuffle, TT par-time gating,
+starting stats, etc.) will be added as the content surface grows.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from Options import PerGameCommonOptions
+
+
+@dataclass
+class DucksOptions(PerGameCommonOptions):
+    pass

--- a/worlds/duckscandrive/options.py
+++ b/worlds/duckscandrive/options.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from Options import PerGameCommonOptions, Range
+from Options import PerGameCommonOptions, Range, Toggle
 
 
 class StartingMoney(Range):
@@ -24,6 +24,21 @@ class StartingMoney(Range):
     default = 12_500
 
 
+class IncludeBanana(Toggle):
+    """Include the secret Banana track in the seed.
+
+    Banana Offline has no Track Select menu button — in the stock game it
+    only loads when a time-trial timer runs past 10 minutes without the
+    player finishing. Enabling this adds one finish location and one
+    track-unlock item to the pool, but the player has to know the secret
+    timeout path to actually reach Banana. Off by default so most seeds
+    don't contain a location that's practically unreachable without
+    meta-knowledge.
+    """
+    display_name = "Include Banana Track"
+
+
 @dataclass
 class DucksOptions(PerGameCommonOptions):
     starting_money: StartingMoney
+    include_banana: IncludeBanana

--- a/worlds/duckscandrive/options.py
+++ b/worlds/duckscandrive/options.py
@@ -1,16 +1,26 @@
-"""Per-slot options for Ducks Can Drive.
-
-Intentionally minimal for the first working APWorld — only the common options
-every game gets. Ducks-specific options (book shuffle, TT par-time gating,
-starting stats, etc.) will be added as the content surface grows.
-"""
+"""Per-slot options for Ducks Can Drive."""
 from __future__ import annotations
 
 from dataclasses import dataclass
 
-from Options import PerGameCommonOptions
+from Options import PerGameCommonOptions, Range
+
+
+class StartingMoney(Range):
+    """Money the car spawns with every time the player enters the City scene.
+
+    The stock game hard-codes $100 and `Car.Start` resets stats every time, so
+    without a top-up sphere-1 requires grinding the Photon delivery loop before
+    any AP check can fire. The default of 12,500 covers all 25 upgrade tiers in
+    one session; lower values make money matter again and can be used for
+    slower-paced seeds. Range covers everything from 'pure grind' to 'pure AP'.
+    """
+    display_name = "Starting Money"
+    range_start = 100
+    range_end = 100_000
+    default = 12_500
 
 
 @dataclass
 class DucksOptions(PerGameCommonOptions):
-    pass
+    starting_money: StartingMoney

--- a/worlds/duckscandrive/test/test_generate.py
+++ b/worlds/duckscandrive/test/test_generate.py
@@ -1,0 +1,51 @@
+"""Sanity tests for the Ducks Can Drive world.
+
+WorldTestBase.setUp builds a single-player MultiWorld and runs the generation
+pipeline through `pre_fill`. Items are still in the pool (Fill has not been
+called), so beatability checks must collect items manually.
+
+The inherited `test_all_state_can_reach_everything` already verifies every
+location is reachable when every item has been collected; these tests cover
+the narrower shape guarantees of this specific world.
+"""
+from test.bases import WorldTestBase
+
+
+class TestDucksGenerate(WorldTestBase):
+    game = "Ducks Can Drive"
+
+    def test_empty_state_is_not_beatable(self) -> None:
+        self.assertBeatable(False)
+
+    def test_collecting_all_progressives_beats_the_game(self) -> None:
+        self.collect_by_name([
+            "Progressive Speed",
+            "Progressive Acceleration",
+            "Progressive Offroad",
+            "Progressive Boost",
+            "Progressive Handling",
+        ])
+        self.assertBeatable(True)
+
+    def test_location_and_item_counts(self) -> None:
+        assert len(self.multiworld.get_locations(self.player)) == 26  # 25 upgrades + victory event
+        assert len(self.multiworld.itempool) == 25
+
+    def test_victory_location_holds_victory_event(self) -> None:
+        victory = self.multiworld.get_location("Fully Upgraded Car", self.player)
+        assert victory.item is not None
+        assert victory.item.name == "Victory"
+
+    def test_tier_one_locations_are_always_reachable(self) -> None:
+        for stat in ("Speed", "Acceleration", "Offroad", "Boost", "Handling"):
+            location = self.multiworld.get_location(f"Upgrade {stat} Tier 1", self.player)
+            assert location.can_reach(self.multiworld.state), f"Tier 1 {stat} must be sphere-1"
+
+    def test_tier_five_requires_four_progressives_of_that_stat(self) -> None:
+        location = self.multiworld.get_location("Upgrade Speed Tier 5", self.player)
+        assert not location.can_reach(self.multiworld.state)
+        state = self.multiworld.state.copy()
+        progressives = self.get_items_by_name("Progressive Speed")[:4]
+        for item in progressives:
+            state.collect(item)
+        assert location.can_reach(state)

--- a/worlds/duckscandrive/test/test_generate.py
+++ b/worlds/duckscandrive/test/test_generate.py
@@ -28,10 +28,10 @@ class TestDucksGenerate(WorldTestBase):
         self.assertBeatable(True)
 
     def test_location_and_item_counts(self) -> None:
-        # 25 upgrades + 8 books + 13 time-trial + 1 victory event
-        assert len(self.multiworld.get_locations(self.player)) == 47
-        # 25 progressives + 21 rubber ducks; victory is placed, not pooled
-        assert len(self.multiworld.itempool) == 46
+        # Default (banana off): 25 upgrades + 8 books + 12 TT (no Finish Banana) + 1 victory
+        assert len(self.multiworld.get_locations(self.player)) == 46
+        # 25 progressives + 6 track unlocks (no Banana Unlock) + 14 rubber ducks
+        assert len(self.multiworld.itempool) == 45
 
     def test_victory_location_holds_victory_event(self) -> None:
         victory = self.multiworld.get_location("Fully Upgraded Car", self.player)
@@ -59,15 +59,18 @@ class TestDucksGenerate(WorldTestBase):
         rubber_ducks = [item for item in self.multiworld.itempool if item.name == "Rubber Duck"]
         assert len(rubber_ducks) == 14
 
-    def test_seven_track_unlock_items_exist_once_each(self) -> None:
+    def test_six_track_unlock_items_exist_once_each_by_default(self) -> None:
+        # Banana Unlock is excluded when include_banana is off.
         for display in ("Duck Circuit", "Lake Loop", "Quack Crossing", "Wing Circuit",
-                        "Blackbill Ship", "Bill Beach", "Banana"):
+                        "Blackbill Ship", "Bill Beach"):
             matches = [item for item in self.multiworld.itempool if item.name == f"{display} Unlock"]
             assert len(matches) == 1, f"expected exactly one '{display} Unlock', got {len(matches)}"
+        banana = [item for item in self.multiworld.itempool if item.name == "Banana Unlock"]
+        assert len(banana) == 0, "Banana Unlock must not be in the pool with include_banana off"
 
     def test_time_trial_finishes_require_matching_unlock(self) -> None:
         for display in ("Duck Circuit", "Lake Loop", "Quack Crossing", "Wing Circuit",
-                        "Blackbill Ship", "Bill Beach", "Banana"):
+                        "Blackbill Ship", "Bill Beach"):
             location = self.multiworld.get_location(f"Finish {display}", self.player)
             assert not location.can_reach(self.multiworld.state), f"Finish {display} must require unlock"
 
@@ -75,8 +78,10 @@ class TestDucksGenerate(WorldTestBase):
             state.collect(self.get_item_by_name(f"{display} Unlock"))
             assert location.can_reach(state), f"Finish {display} must unlock after its item"
 
-    def test_banana_has_no_par_location(self) -> None:
+    def test_banana_locations_absent_by_default(self) -> None:
         import pytest
+        with pytest.raises(KeyError):
+            self.multiworld.get_location("Finish Banana", self.player)
         with pytest.raises(KeyError):
             self.multiworld.get_location("Beat par on Banana", self.player)
 
@@ -93,6 +98,27 @@ class TestDucksGenerate(WorldTestBase):
     def test_fill_slot_data_emits_starting_money(self) -> None:
         data = self.world.fill_slot_data()
         assert data["starting_money"] == 12_500  # matches StartingMoney.default
+
+    def test_fill_slot_data_emits_include_banana_false_by_default(self) -> None:
+        assert self.world.fill_slot_data()["include_banana"] is False
+
+
+class TestDucksGenerateWithBanana(WorldTestBase):
+    game = "Ducks Can Drive"
+    options = {"include_banana": True}
+
+    def test_banana_locations_and_unlock_present(self) -> None:
+        assert self.multiworld.get_location("Finish Banana", self.player) is not None
+        bananas = [item for item in self.multiworld.itempool if item.name == "Banana Unlock"]
+        assert len(bananas) == 1
+
+    def test_location_and_item_counts_with_banana(self) -> None:
+        # 25 upgrades + 8 books + 13 TT + 1 victory = 47 locations
+        assert len(self.multiworld.get_locations(self.player)) == 47
+        assert len(self.multiworld.itempool) == 46
+
+    def test_fill_slot_data_flags_include_banana(self) -> None:
+        assert self.world.fill_slot_data()["include_banana"] is True
 
     def test_tier_five_requires_five_progressives_of_that_stat(self) -> None:
         location = self.multiworld.get_location("Upgrade Speed Tier 5", self.player)

--- a/worlds/duckscandrive/test/test_generate.py
+++ b/worlds/duckscandrive/test/test_generate.py
@@ -99,8 +99,10 @@ class TestDucksGenerate(WorldTestBase):
         data = self.world.fill_slot_data()
         assert data["starting_money"] == 12_500  # matches StartingMoney.default
 
-    def test_fill_slot_data_emits_include_banana_false_by_default(self) -> None:
-        assert self.world.fill_slot_data()["include_banana"] is False
+    def test_fill_slot_data_defaults(self) -> None:
+        data = self.world.fill_slot_data()
+        assert data["include_banana"] is False
+        assert data["include_par_times"] is True
 
 
 class TestDucksGenerateWithBanana(WorldTestBase):
@@ -119,6 +121,34 @@ class TestDucksGenerateWithBanana(WorldTestBase):
 
     def test_fill_slot_data_flags_include_banana(self) -> None:
         assert self.world.fill_slot_data()["include_banana"] is True
+
+
+class TestDucksGenerateNoPars(WorldTestBase):
+    game = "Ducks Can Drive"
+    options = {"include_par_times": False}
+
+    def test_par_locations_absent(self) -> None:
+        import pytest
+        for display in ("Duck Circuit", "Lake Loop", "Quack Crossing", "Wing Circuit",
+                        "Blackbill Ship", "Bill Beach"):
+            with pytest.raises(KeyError):
+                self.multiworld.get_location(f"Beat par on {display}", self.player)
+
+    def test_finishes_still_present(self) -> None:
+        for display in ("Duck Circuit", "Lake Loop", "Quack Crossing", "Wing Circuit",
+                        "Blackbill Ship", "Bill Beach"):
+            assert self.multiworld.get_location(f"Finish {display}", self.player) is not None
+
+    def test_location_and_item_counts_no_pars(self) -> None:
+        # 25 upgrades + 8 books + 6 finishes (no pars, no banana) + 1 victory = 40
+        assert len(self.multiworld.get_locations(self.player)) == 40
+        # 25 progressives + 6 unlocks + 8 rubber ducks = 39
+        assert len(self.multiworld.itempool) == 39
+        ducks = [item for item in self.multiworld.itempool if item.name == "Rubber Duck"]
+        assert len(ducks) == 8
+
+    def test_fill_slot_data_flags_pars_off(self) -> None:
+        assert self.world.fill_slot_data()["include_par_times"] is False
 
     def test_tier_five_requires_five_progressives_of_that_stat(self) -> None:
         location = self.multiworld.get_location("Upgrade Speed Tier 5", self.player)

--- a/worlds/duckscandrive/test/test_generate.py
+++ b/worlds/duckscandrive/test/test_generate.py
@@ -28,8 +28,10 @@ class TestDucksGenerate(WorldTestBase):
         self.assertBeatable(True)
 
     def test_location_and_item_counts(self) -> None:
-        assert len(self.multiworld.get_locations(self.player)) == 26  # 25 upgrades + victory event
-        assert len(self.multiworld.itempool) == 25
+        # 25 upgrades + 8 books + 1 victory event
+        assert len(self.multiworld.get_locations(self.player)) == 34
+        # 25 progressives + 8 rubber ducks; victory is placed, not pooled
+        assert len(self.multiworld.itempool) == 33
 
     def test_victory_location_holds_victory_event(self) -> None:
         victory = self.multiworld.get_location("Fully Upgraded Car", self.player)
@@ -40,6 +42,15 @@ class TestDucksGenerate(WorldTestBase):
         for stat in ("Speed", "Acceleration", "Offroad", "Boost", "Handling"):
             location = self.multiworld.get_location(f"Upgrade {stat} Tier 1", self.player)
             assert location.can_reach(self.multiworld.state), f"Tier 1 {stat} must be sphere-1"
+
+    def test_all_eight_books_exist_and_are_free_sphere_one(self) -> None:
+        for n in range(1, 9):
+            location = self.multiworld.get_location(f"Book {n}", self.player)
+            assert location.can_reach(self.multiworld.state), f"Book {n} must be sphere-1"
+
+    def test_rubber_duck_item_is_pooled_eight_times(self) -> None:
+        rubber_ducks = [item for item in self.multiworld.itempool if item.name == "Rubber Duck"]
+        assert len(rubber_ducks) == 8
 
     def test_tier_five_requires_four_progressives_of_that_stat(self) -> None:
         location = self.multiworld.get_location("Upgrade Speed Tier 5", self.player)

--- a/worlds/duckscandrive/test/test_generate.py
+++ b/worlds/duckscandrive/test/test_generate.py
@@ -70,6 +70,10 @@ class TestDucksGenerate(WorldTestBase):
             location = self.multiworld.get_location(f"Beat par on {display}", self.player)
             assert location.can_reach(self.multiworld.state)
 
+    def test_fill_slot_data_emits_starting_money(self) -> None:
+        data = self.world.fill_slot_data()
+        assert data["starting_money"] == 12_500  # matches StartingMoney.default
+
     def test_tier_five_requires_four_progressives_of_that_stat(self) -> None:
         location = self.multiworld.get_location("Upgrade Speed Tier 5", self.player)
         assert not location.can_reach(self.multiworld.state)

--- a/worlds/duckscandrive/test/test_generate.py
+++ b/worlds/duckscandrive/test/test_generate.py
@@ -28,10 +28,10 @@ class TestDucksGenerate(WorldTestBase):
         self.assertBeatable(True)
 
     def test_location_and_item_counts(self) -> None:
-        # 25 upgrades + 8 books + 1 victory event
-        assert len(self.multiworld.get_locations(self.player)) == 34
-        # 25 progressives + 8 rubber ducks; victory is placed, not pooled
-        assert len(self.multiworld.itempool) == 33
+        # 25 upgrades + 8 books + 13 time-trial + 1 victory event
+        assert len(self.multiworld.get_locations(self.player)) == 47
+        # 25 progressives + 21 rubber ducks; victory is placed, not pooled
+        assert len(self.multiworld.itempool) == 46
 
     def test_victory_location_holds_victory_event(self) -> None:
         victory = self.multiworld.get_location("Fully Upgraded Car", self.player)
@@ -48,9 +48,27 @@ class TestDucksGenerate(WorldTestBase):
             location = self.multiworld.get_location(f"Book {n}", self.player)
             assert location.can_reach(self.multiworld.state), f"Book {n} must be sphere-1"
 
-    def test_rubber_duck_item_is_pooled_eight_times(self) -> None:
+    def test_rubber_duck_count_matches_non_upgrade_locations(self) -> None:
+        # 8 books + 13 TT locations = 21 rubber ducks
         rubber_ducks = [item for item in self.multiworld.itempool if item.name == "Rubber Duck"]
-        assert len(rubber_ducks) == 8
+        assert len(rubber_ducks) == 21
+
+    def test_all_seven_time_trial_finishes_exist_and_are_free(self) -> None:
+        for display in ("Duck Circuit", "Lake Loop", "Quack Crossing", "Wing Circuit",
+                        "Blackbill Ship", "Bill Beach", "Banana"):
+            location = self.multiworld.get_location(f"Finish {display}", self.player)
+            assert location.can_reach(self.multiworld.state), f"Finish {display} must be sphere-1"
+
+    def test_banana_has_no_par_location(self) -> None:
+        import pytest
+        with pytest.raises(KeyError):
+            self.multiworld.get_location("Beat par on Banana", self.player)
+
+    def test_six_par_locations_exist(self) -> None:
+        for display in ("Duck Circuit", "Lake Loop", "Quack Crossing", "Wing Circuit",
+                        "Blackbill Ship", "Bill Beach"):
+            location = self.multiworld.get_location(f"Beat par on {display}", self.player)
+            assert location.can_reach(self.multiworld.state)
 
     def test_tier_five_requires_four_progressives_of_that_stat(self) -> None:
         location = self.multiworld.get_location("Upgrade Speed Tier 5", self.player)

--- a/worlds/duckscandrive/test/test_generate.py
+++ b/worlds/duckscandrive/test/test_generate.py
@@ -38,10 +38,16 @@ class TestDucksGenerate(WorldTestBase):
         assert victory.item is not None
         assert victory.item.name == "Victory"
 
-    def test_tier_one_locations_are_always_reachable(self) -> None:
+    def test_upgrade_tier_one_requires_one_progressive(self) -> None:
+        # Strict rule: not sphere-1 from empty state; becomes reachable once a
+        # matching progressive is collected.
         for stat in ("Speed", "Acceleration", "Offroad", "Boost", "Handling"):
             location = self.multiworld.get_location(f"Upgrade {stat} Tier 1", self.player)
-            assert location.can_reach(self.multiworld.state), f"Tier 1 {stat} must be sphere-1"
+            assert not location.can_reach(self.multiworld.state), f"Tier 1 {stat} must require a progressive"
+
+            state = self.multiworld.state.copy()
+            state.collect(self.get_item_by_name(f"Progressive {stat}"))
+            assert location.can_reach(state), f"Tier 1 {stat} must be reachable after one Progressive {stat}"
 
     def test_all_eight_books_exist_and_are_free_sphere_one(self) -> None:
         for n in range(1, 9):
@@ -74,11 +80,13 @@ class TestDucksGenerate(WorldTestBase):
         data = self.world.fill_slot_data()
         assert data["starting_money"] == 12_500  # matches StartingMoney.default
 
-    def test_tier_five_requires_four_progressives_of_that_stat(self) -> None:
+    def test_tier_five_requires_five_progressives_of_that_stat(self) -> None:
         location = self.multiworld.get_location("Upgrade Speed Tier 5", self.player)
         assert not location.can_reach(self.multiworld.state)
         state = self.multiworld.state.copy()
         progressives = self.get_items_by_name("Progressive Speed")[:4]
         for item in progressives:
             state.collect(item)
+        assert not location.can_reach(state), "four progressives must not yet unlock tier 5"
+        state.collect(self.get_items_by_name("Progressive Speed")[4])
         assert location.can_reach(state)

--- a/worlds/duckscandrive/test/test_generate.py
+++ b/worlds/duckscandrive/test/test_generate.py
@@ -55,26 +55,40 @@ class TestDucksGenerate(WorldTestBase):
             assert location.can_reach(self.multiworld.state), f"Book {n} must be sphere-1"
 
     def test_rubber_duck_count_matches_non_upgrade_locations(self) -> None:
-        # 8 books + 13 TT locations = 21 rubber ducks
+        # 8 books + 13 TT locations - 7 track-unlock items = 14 rubber ducks
         rubber_ducks = [item for item in self.multiworld.itempool if item.name == "Rubber Duck"]
-        assert len(rubber_ducks) == 21
+        assert len(rubber_ducks) == 14
 
-    def test_all_seven_time_trial_finishes_exist_and_are_free(self) -> None:
+    def test_seven_track_unlock_items_exist_once_each(self) -> None:
+        for display in ("Duck Circuit", "Lake Loop", "Quack Crossing", "Wing Circuit",
+                        "Blackbill Ship", "Bill Beach", "Banana"):
+            matches = [item for item in self.multiworld.itempool if item.name == f"{display} Unlock"]
+            assert len(matches) == 1, f"expected exactly one '{display} Unlock', got {len(matches)}"
+
+    def test_time_trial_finishes_require_matching_unlock(self) -> None:
         for display in ("Duck Circuit", "Lake Loop", "Quack Crossing", "Wing Circuit",
                         "Blackbill Ship", "Bill Beach", "Banana"):
             location = self.multiworld.get_location(f"Finish {display}", self.player)
-            assert location.can_reach(self.multiworld.state), f"Finish {display} must be sphere-1"
+            assert not location.can_reach(self.multiworld.state), f"Finish {display} must require unlock"
+
+            state = self.multiworld.state.copy()
+            state.collect(self.get_item_by_name(f"{display} Unlock"))
+            assert location.can_reach(state), f"Finish {display} must unlock after its item"
 
     def test_banana_has_no_par_location(self) -> None:
         import pytest
         with pytest.raises(KeyError):
             self.multiworld.get_location("Beat par on Banana", self.player)
 
-    def test_six_par_locations_exist(self) -> None:
+    def test_par_locations_require_matching_unlock(self) -> None:
         for display in ("Duck Circuit", "Lake Loop", "Quack Crossing", "Wing Circuit",
                         "Blackbill Ship", "Bill Beach"):
             location = self.multiworld.get_location(f"Beat par on {display}", self.player)
-            assert location.can_reach(self.multiworld.state)
+            assert not location.can_reach(self.multiworld.state)
+
+            state = self.multiworld.state.copy()
+            state.collect(self.get_item_by_name(f"{display} Unlock"))
+            assert location.can_reach(state)
 
     def test_fill_slot_data_emits_starting_money(self) -> None:
         data = self.world.fill_slot_data()


### PR DESCRIPTION
## Description
This PR adds support for **Ducks Can Drive**, a chaotic small-scale driving game.

The implementation covers the core progression of the game, including car upgrades, collectible books, and time-trial challenges.

The Client can be found here: https://github.com/Sebdevar/ducksCanDrive-archipelago

### Key Features:
*   **Car Upgrades:** 5 stats (Speed, Acceleration, Handling, etc.) each with 5 tiers, gated by "Progressive <Stat>" items.
*   **Collectible Books:** 8 locations providing filler/utility items.
*   **Time Trials:** 13 locations across various tracks, requiring per-track "Unlock" items.
*   **Options:** 
    *   `starting_money`: Configure starting in-game currency.
    *   `include_banana`: Toggle for the special Banana track.
    *   `include_par_times`: Toggle for additional locations based on beating track par times.
*   **Documentation:** Includes English setup guide and game info page.
*   **Tests:** Full generation tests covering various option combinations.

### Verification:
*   Ran `pytest worlds/duckscandrive/test/test_generate.py` - **33 passed**.
*   Verified logic for progressive items and track unlocks.
*   Confirmed `archipelago.json` metadata is present and correct.

## Checklist
- [x] Follows [style guidelines](https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/style.md).
- [x] Logic is covered by unit tests.
- [x] `setup_en.md` and `en_GameName.md` are provided in the `docs` folder.
- [x] `world_version` in `archipelago.json` is set.