### PR TITLE
Core: Add a generic mixin for progressive item handling

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1846,8 +1846,17 @@ class ClientMessageProcessor(CommonCommandProcessor):
                     self.output(f"Nothing found for recognized location name \"{hint_name}\". "
                                 f"Location appears to not exist in this multiworld.")
                 else:
-                    self.output(f"Nothing found for recognized item name \"{hint_name}\". "
-                                f"Item appears to not exist in this multiworld.")
+                    chain_name = None
+                    for chain_name, chain_items in self.ctx.slot_data[self.client.slot].get("progressive_chains", {}).items():
+                        if hint_name in chain_items:
+                            break
+
+                    if chain_name:
+                        self.output(f"Nothing found for recognized item name \"{hint_name}\". "
+                                    f"Item is part of the \"{chain_name}\" progressive chain, maybe try hinting for that instead.")
+                    else:
+                        self.output(f"Nothing found for recognized item name \"{hint_name}\". "
+                                    f"Item appears to not exist in this multiworld.")
             else:
                 self.output(f"You can't afford the hint. "
                             f"You have {points_available} points and need at least "

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -535,7 +535,6 @@ class World(metaclass=AutoWorldRegister):
 
         return group
 
-    # decent place to implement progressive items, in most cases can stay as-is
     def collect_item(self, state: "CollectionState", item: "Item", remove: bool = False) -> Optional[str]:
         """
         Collect an item name into state. For speed reasons items that aren't logically useful get skipped.
@@ -681,6 +680,27 @@ class World(metaclass=AutoWorldRegister):
         if self.explicit_indirect_conditions:
             for indirect_region in resolved_rule.region_dependencies().keys():
                 self.multiworld.register_indirect_condition(self.get_region(indirect_region), entrance)
+
+
+class ProgressiveItemsMixin:
+    progressive_items: dict[str, tuple[str]] = {}
+    """Progressive item rows that will be collected in order"""
+
+    def collect_item(self, state: "CollectionState", item: "Item", remove: bool = False) -> Optional[str]:
+        if item.advancement and item.name in self.progressive_items:
+            item_names = self.progressive_items[item.name]
+            if remove:
+                for item_name in reversed(item_names):
+                    if state.has(item_name, item.player):
+                        return item_name
+                return None
+            else:
+                for item_name in item_names:
+                    if not state.has(item_name, item.player):
+                        return item_name
+                return item_names[-1]
+
+        return super().collect_item(state, item, remove)
 
 
 # any methods attached to this can be used as part of CollectionState,

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -683,24 +683,32 @@ class World(metaclass=AutoWorldRegister):
 
 
 class ProgressiveItemsMixin:
-    progressive_items: dict[str, tuple[str]] = {}
-    """Progressive item rows that will be collected in order"""
+    progressive_chains: dict[str, tuple[str]] = {}
+    """Progressive item chains that will be collected in order"""
 
-    def collect_item(self, state: "CollectionState", item: "Item", remove: bool = False) -> Optional[str]:
-        if item.advancement and item.name in self.progressive_items:
-            item_names = self.progressive_items[item.name]
-            if remove:
-                for item_name in reversed(item_names):
-                    if state.has(item_name, item.player):
-                        return item_name
-                return None
-            else:
-                for item_name in item_names:
-                    if not state.has(item_name, item.player):
-                        return item_name
-                return item_names[-1]
+    def collect(self, state: "CollectionState", item: "Item") -> bool:
+        if super().collect(state, item):
+            if item.name in self.progressive_chains:
+                progressive_chain = self.progressive_chains[item.name]
+                collected_index = state.count(item.name, self.player) - 1
+                if collected_index < len(progressive_chain):
+                    state.add_item(progressive_chain[collected_index], self.player)
 
-        return super().collect_item(state, item, remove)
+            return True
+
+        return False
+
+    def remove(self, state: "CollectionState", item: "Item") -> bool:
+        if super().remove(state, item):
+            if item.name in self.progressive_chains:
+                progressive_chain = self.progressive_chains[item.name]
+                removed_index = state.count(item.name, self.player)
+                if removed_index < len(progressive_chain):
+                    state.remove_item(progressive_chain[removed_index], self.player)
+
+            return True
+
+        return False
 
 
 # any methods attached to this can be used as part of CollectionState,

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -715,6 +715,13 @@ class ProgressiveItemsMixin:
 
         return False
 
+    def fill_slot_data(self) -> Mapping[str, Any]:
+        slot_data = super().fill_slot_data()
+
+        slot_data["progressive_chains"] = self.progressive_chains;
+
+        return slot_data
+
 
 # any methods attached to this can be used as part of CollectionState,
 # please use a prefix as all of them get clobbered together

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -688,24 +688,32 @@ class World(metaclass=AutoWorldRegister):
 
 
 class ProgressiveItemsMixin:
-    progressive_items: dict[str, tuple[str]] = {}
-    """Progressive item rows that will be collected in order"""
+    progressive_chains: dict[str, tuple[str]] = {}
+    """Progressive item chains that will be collected in order"""
 
-    def collect_item(self, state: "CollectionState", item: "Item", remove: bool = False) -> Optional[str]:
-        if item.advancement and item.name in self.progressive_items:
-            item_names = self.progressive_items[item.name]
-            if remove:
-                for item_name in reversed(item_names):
-                    if state.has(item_name, item.player):
-                        return item_name
-                return None
-            else:
-                for item_name in item_names:
-                    if not state.has(item_name, item.player):
-                        return item_name
-                return item_names[-1]
+    def collect(self, state: "CollectionState", item: "Item") -> bool:
+        if super().collect(state, item):
+            if item.name in self.progressive_chains:
+                progressive_chain = self.progressive_chains[item.name]
+                collected_index = state.count(item.name, self.player) - 1
+                if collected_index < len(progressive_chain):
+                    state.add_item(progressive_chain[collected_index], self.player)
 
-        return super().collect_item(state, item, remove)
+            return True
+
+        return False
+
+    def remove(self, state: "CollectionState", item: "Item") -> bool:
+        if super().remove(state, item):
+            if item.name in self.progressive_chains:
+                progressive_chain = self.progressive_chains[item.name]
+                removed_index = state.count(item.name, self.player)
+                if removed_index < len(progressive_chain):
+                    state.remove_item(progressive_chain[removed_index], self.player)
+
+            return True
+
+        return False
 
 
 # any methods attached to this can be used as part of CollectionState,

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -540,7 +540,6 @@ class World(metaclass=AutoWorldRegister):
 
         return group
 
-    # decent place to implement progressive items, in most cases can stay as-is
     def collect_item(self, state: "CollectionState", item: "Item", remove: bool = False) -> Optional[str]:
         """
         Collect an item name into state. For speed reasons items that aren't logically useful get skipped.
@@ -686,6 +685,27 @@ class World(metaclass=AutoWorldRegister):
         if self.explicit_indirect_conditions:
             for indirect_region in resolved_rule.region_dependencies().keys():
                 self.multiworld.register_indirect_condition(self.get_region(indirect_region), entrance)
+
+
+class ProgressiveItemsMixin:
+    progressive_items: dict[str, tuple[str]] = {}
+    """Progressive item rows that will be collected in order"""
+
+    def collect_item(self, state: "CollectionState", item: "Item", remove: bool = False) -> Optional[str]:
+        if item.advancement and item.name in self.progressive_items:
+            item_names = self.progressive_items[item.name]
+            if remove:
+                for item_name in reversed(item_names):
+                    if state.has(item_name, item.player):
+                        return item_name
+                return None
+            else:
+                for item_name in item_names:
+                    if not state.has(item_name, item.player):
+                        return item_name
+                return item_names[-1]
+
+        return super().collect_item(state, item, remove)
 
 
 # any methods attached to this can be used as part of CollectionState,

--- a/worlds/factorio/__init__.py
+++ b/worlds/factorio/__init__.py
@@ -6,7 +6,7 @@ import typing
 
 import Utils
 from BaseClasses import Region, Location, Item, Tutorial, ItemClassification
-from worlds.AutoWorld import World, WebWorld
+from worlds.AutoWorld import ProgressiveItemsMixin, World, WebWorld
 from worlds.LauncherComponents import Component, components, Type, launch as launch_component
 from worlds.generic import Rules
 from .Locations import location_pools, location_table, craftsanity_locations
@@ -58,7 +58,7 @@ all_items["Atomic Cliff Remover Trap"] = factorio_base_id - 8
 all_items["Inventory Spill Trap"] = factorio_base_id - 9
 
 
-class Factorio(ProgressiveItemMixin, World):
+class Factorio(ProgressiveItemsMixin, World):
     """
     Factorio is a game about automation. You play as an engineer who has crash landed on the planet
     Nauvis, an inhospitable world filled with dangerous creatures called biters. Build a factory,
@@ -94,6 +94,7 @@ class Factorio(ProgressiveItemMixin, World):
     trap_names: tuple[str] = ("Evolution", "Attack", "Teleport", "Grenade", "Cluster Grenade", "Artillery",
                               "Atomic Rocket", "Atomic Cliff Remover", "Inventory Spill")
     want_progressives: dict[str, bool] = collections.defaultdict(lambda: False)
+    progressive_items = {name: technology.progressive for name, technology in progressive_technology_table.items()}
 
     def __init__(self, world, player: int):
         super(Factorio, self).__init__(world, player)
@@ -368,20 +369,6 @@ class Factorio(ProgressiveItemMixin, World):
             # make spoiler match mod info
             elif loc.revealed:
                 start_location_hints.add(loc.name)
-
-    def collect_item(self, state, item, remove=False):
-        if item.advancement and item.name in progressive_technology_table:
-            prog_table = progressive_technology_table[item.name].progressive
-            if remove:
-                for item_name in reversed(prog_table):
-                    if state.has(item_name, item.player):
-                        return item_name
-            else:
-                for item_name in prog_table:
-                    if not state.has(item_name, item.player):
-                        return item_name
-
-        return super(Factorio, self).collect_item(state, item, remove)
 
     @classmethod
     def stage_write_spoiler(cls, world, spoiler_handle):

--- a/worlds/factorio/__init__.py
+++ b/worlds/factorio/__init__.py
@@ -58,7 +58,7 @@ all_items["Atomic Cliff Remover Trap"] = factorio_base_id - 8
 all_items["Inventory Spill Trap"] = factorio_base_id - 9
 
 
-class Factorio(World):
+class Factorio(ProgressiveItemMixin, World):
     """
     Factorio is a game about automation. You play as an engineer who has crash landed on the planet
     Nauvis, an inhospitable world filled with dangerous creatures called biters. Build a factory,

--- a/worlds/factorio/__init__.py
+++ b/worlds/factorio/__init__.py
@@ -94,7 +94,7 @@ class Factorio(ProgressiveItemsMixin, World):
     trap_names: tuple[str] = ("Evolution", "Attack", "Teleport", "Grenade", "Cluster Grenade", "Artillery",
                               "Atomic Rocket", "Atomic Cliff Remover", "Inventory Spill")
     want_progressives: dict[str, bool] = collections.defaultdict(lambda: False)
-    progressive_items = {name: technology.progressive for name, technology in progressive_technology_table.items()}
+    progressive_chains = {name: technology.progressive for name, technology in progressive_technology_table.items()}
 
     def __init__(self, world, player: int):
         super(Factorio, self).__init__(world, player)


### PR DESCRIPTION
## What is this fixing or adding?

Add a generic progressive item system in the base world class. Since this is a common feature needed in multiple worlds it feels like it would make sense to have a generic system available in core for it.

I had to implement it as a mixin because groups expect to have the basic item collection behavior.

~~One additional benefit is that in a future PR we could propagate the information to the server/client to allow a better user experience when hinting progressive items (it seems common that people get the "Item appears to not exist in this multiworld" error because they hint for the individual item instead of the progressive one).~~

Edit: This is now implemented in the mixin and server code.

## How was this tested?

This was tester by modifying the Factorio world (the second commit in this PR) to use this system and do a few generations to test that it works properly.

## If this makes graphical changes, please attach screenshots.

No visible changes