### PR TITLE
WebHost: Fix weighted options initial text of ranges and value of checkboxes

### DIFF
--- a/WebHostLib/static/assets/weightedOptions.js
+++ b/WebHostLib/static/assets/weightedOptions.js
@@ -8,19 +8,7 @@ window.addEventListener('load', () => {
   document.addEventListener('change', (evt) => {
     // Handle updates to range inputs
     if (evt.target.type === 'range') {
-      // Update span containing range value. All ranges have a corresponding `{rangeId}-value` span
-      document.getElementById(`${evt.target.id}-value`).innerText = evt.target.value;
-
-      // If the changed option was the name of a game, determine whether to show or hide that game's div
-      if (evt.target.id.startsWith('game||')) {
-        const gameName = evt.target.id.split('||')[1];
-        const gameDiv = document.getElementById(`${gameName}-container`);
-        if (evt.target.value > 0) {
-          gameDiv.classList.remove('hidden');
-        } else {
-          gameDiv.classList.add('hidden');
-        }
-      }
+      updateRangeText(evt.target.id, evt.target.value);
     }
   });
 
@@ -110,6 +98,7 @@ window.addEventListener('load', () => {
             break;
           case 'range':
             input.value = parseInt(previousSettings[option][value], 10);
+            updateRangeText(input.id, previousSettings[option][value]);
             break;
           case 'number':
             input.value = previousSettings[option][value].toString();
@@ -221,3 +210,25 @@ const unsetDeletedOption = (optionName, value) => {
     delete deletedOptions[optionName];
   }
 };
+
+/**
+ * Updates a range's associated text to given value.
+ * 
+ * @param {string} optionName - The name of the option.
+ * @param {string} value - The value that the range was set to.
+ */
+const updateRangeText = (optionName, value) => {
+  // Update span containing range value. All ranges have a corresponding `{rangeId}-value` span
+  document.getElementById(`${optionName}-value`).innerText = value;
+
+  // If the changed option was the name of a game, determine whether to show or hide that game's div
+  if (optionName.startsWith('game||')) {
+    const gameName = evt.target.id.split('||')[1];
+    const gameDiv = document.getElementById(`${gameName}-container`);
+    if (value > 0) {
+      gameDiv.classList.remove('hidden');
+    } else {
+      gameDiv.classList.add('hidden');
+    }
+  }
+}

--- a/WebHostLib/static/assets/weightedOptions.js
+++ b/WebHostLib/static/assets/weightedOptions.js
@@ -48,6 +48,9 @@ window.addEventListener('load', () => {
     // Save data to localStorage
     const weightedOptions = {};
     document.querySelectorAll('input[name]').forEach((input) => {
+      // Ignore hidden input meant to ensure an empty value is submitted in form
+      if (input.type == 'hidden') return;
+
       const keys = input.getAttribute('name').split('||');
 
       // Determine keys
@@ -216,6 +219,7 @@ const unsetDeletedOption = (optionName, value) => {
  * 
  * @param {string} optionName - The name of the option.
  * @param {string} value - The value that the range was set to.
+ * @returns {void}
  */
 const updateRangeText = (optionName, value) => {
   // Update span containing range value. All ranges have a corresponding `{rangeId}-value` span
@@ -231,4 +235,4 @@ const updateRangeText = (optionName, value) => {
       gameDiv.classList.add('hidden');
     }
   }
-}
+};

--- a/WebHostLib/templates/playerOptions/macros.html
+++ b/WebHostLib/templates/playerOptions/macros.html
@@ -140,7 +140,7 @@
 
 {% macro OptionList(option_name, option) %}
     {{ OptionTitle(option_name, option) }}
-    <input type="hidden" id="{{ option_name }}-{{ key }}-hidden" name="{{ option_name }}" value="_ensure-empty-list"/>
+    <input type="hidden" id="_{{ option_name }}-hidden" name="{{ option_name }}" value="_ensure-empty-list"/>
     <div class="option-container">
         {% for key in (option.valid_keys if option.valid_keys is ordered else option.valid_keys|sort) %}
             <div class="option-entry">
@@ -153,7 +153,7 @@
 
 {% macro LocationSet(option_name, option) %}
     {{ OptionTitle(option_name, option) }}
-    <input type="hidden" id="{{ option_name }}-{{ key }}-hidden" name="{{ option_name }}" value="_ensure-empty-list"/>
+    <input type="hidden" id="_{{ option_name }}-hidden" name="{{ option_name }}" value="_ensure-empty-list"/>
     <div class="option-container">
         {% for group_name in world.location_name_groups.keys()|sort %}
             {% if group_name != "Everywhere" %}
@@ -177,7 +177,7 @@
 
 {% macro ItemSet(option_name, option) %}
     {{ OptionTitle(option_name, option) }}
-    <input type="hidden" id="{{ option_name }}-{{ key }}-hidden" name="{{ option_name }}" value="_ensure-empty-list"/>
+    <input type="hidden" id="_{{ option_name }}-hidden" name="{{ option_name }}" value="_ensure-empty-list"/>
     <div class="option-container">
         {% for group_name in world.item_name_groups.keys()|sort %}
             {% if group_name != "Everything" %}
@@ -201,7 +201,7 @@
 
 {% macro OptionSet(option_name, option) %}
     {{ OptionTitle(option_name, option) }}
-    <input type="hidden" id="{{ option_name }}-{{ key }}-hidden" name="{{ option_name }}" value="_ensure-empty-list"/>
+    <input type="hidden" id="_{{ option_name }}-hidden" name="{{ option_name }}" value="_ensure-empty-list"/>
     <div class="option-container">
         {% for key in (option.valid_keys if option.valid_keys is ordered else option.valid_keys|sort) %}
             <div class="option-entry">

--- a/WebHostLib/templates/weightedOptions/macros.html
+++ b/WebHostLib/templates/weightedOptions/macros.html
@@ -139,7 +139,7 @@
 {% endmacro %}
 
 {% macro OptionList(option_name, option) %}
-    <input type="hidden" id="{{ option_name }}-{{ key }}-hidden" name="{{ option_name }}" value="_ensure-empty-list"/>
+    <input type="hidden" id="_{{ option_name }}-hidden" name="{{ option_name }}" value="_ensure-empty-list"/>
     <div class="list-container">
         {% for key in (option.valid_keys if option.valid_keys is ordered else option.valid_keys|sort) %}
             <div class="list-entry">
@@ -159,7 +159,7 @@
 {% endmacro %}
 
 {% macro LocationSet(option_name, option, world) %}
-    <input type="hidden" id="{{ option_name }}-{{ key }}-hidden" name="{{ option_name }}" value="_ensure-empty-list"/>
+    <input type="hidden" id="_{{ option_name }}-hidden" name="{{ option_name }}" value="_ensure-empty-list"/>
     <div class="set-container">
         {% for group_name in world.location_name_groups.keys()|sort %}
             {% if group_name != "Everywhere" %}
@@ -182,7 +182,7 @@
 {% endmacro %}
 
 {% macro ItemSet(option_name, option, world) %}
-    <input type="hidden" id="{{ option_name }}-{{ key }}-hidden" name="{{ option_name }}" value="_ensure-empty-list"/>
+    <input type="hidden" id="_{{ option_name }}-hidden" name="{{ option_name }}" value="_ensure-empty-list"/>
     <div class="set-container">
         {% for group_name in world.item_name_groups.keys()|sort %}
             {% if group_name != "Everything" %}
@@ -205,7 +205,7 @@
 {% endmacro %}
 
 {% macro OptionSet(option_name, option) %}
-    <input type="hidden" id="{{ option_name }}-{{ key }}-hidden" name="{{ option_name }}" value="_ensure-empty-list"/>
+    <input type="hidden" id="_{{ option_name }}-hidden" name="{{ option_name }}" value="_ensure-empty-list"/>
     <div class="set-container">
         {% for key in (option.valid_keys if option.valid_keys is ordered else option.valid_keys|sort) %}
             <div class="set-entry">


### PR DESCRIPTION
## What is this fixing or adding?
Fixes #5891 where when loading non-default weight ranges from localStorage, the text would still display the default until updated.
Also apparently #5240 broke the saving of checkboxes for OptionList/OptionSet options since they would get set to `"_ensure-empty-list"` by it initially and the remaining values would fail to actually be set. (Also they had an undefined `{ key }` in id in their template, so I decided to change that.)

The style guide for js has changed since this file was added, so I'm not sure if it'd also be desired to reformat this file while it's being touched.

## How was this tested?
Making sure that the initially loaded options on a local WebHost work as expected now. Also checking that the ensure empty list behavior didn't break in the exported yaml.

## If this makes graphical changes, please attach screenshots.
🔢+✅