### PR TITLE
CommonClient: Make hint cost (shown in server label) update

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -1069,13 +1069,17 @@ async def process_server_cmd(ctx: CommonContext, args: dict):
         if "players" in args:
             ctx.consume_players_package(args["players"])
         if "hint_points" in args:
-            ctx.hint_points = args['hint_points']
+            ctx.hint_points = args["hint_points"]
         if "checked_locations" in args:
             checked = set(args["checked_locations"])
             ctx.checked_locations |= checked
             ctx.missing_locations -= checked
         if "permissions" in args:
             ctx.update_permissions(args["permissions"])
+
+        # Update hint info for local display
+        if "hint_cost" in args:
+            ctx.hint_cost = int(args["hint_cost"])
 
     elif cmd == 'Print':
         ctx.on_print(args)

--- a/kvui.py
+++ b/kvui.py
@@ -363,15 +363,16 @@ class ServerLabel(HoverBehavior, MDTooltip, MDBoxLayout):
                     text += "\nPermissions:"
                     for permission_name, permission_data in ctx.permissions.items():
                         text += f"\n    {permission_name}: {permission_data}"
-                if ctx.hint_cost == 0:
-                    text += "\n!hint is free to use."
-                elif ctx.hint_cost is not None and ctx.total_locations:
-                    min_cost = int(ctx.server_version >= (0, 3, 9))
-                    text += f"\nA new !hint <itemname> costs {ctx.hint_cost}% of checks made. " \
-                            f"For you this means every " \
-                            f"{max(min_cost, int(ctx.hint_cost * 0.01 * ctx.total_locations))} " \
-                            "location checks." \
-                            f"\nYou currently have {ctx.hint_points} points."
+                if ctx.total_locations and ctx.hint_cost is not None:
+                    if ctx.hint_cost == 0:
+                        text += "\n!hint is free to use."
+                    else:
+                        min_cost = int(ctx.server_version >= (0, 3, 9))
+                        text += f"\nA new !hint <itemname> costs {ctx.hint_cost}% of checks made. " \
+                                f"For you this means every " \
+                                f"{max(min_cost, int(ctx.hint_cost * 0.01 * ctx.total_locations))} " \
+                                "location checks." \
+                                f"\nYou currently have {ctx.hint_points} points."
                 if ctx.stored_data and "_read_race_mode" in ctx.stored_data:
                     text += "\nRace mode is enabled." \
                         if ctx.stored_data["_read_race_mode"] else "\nRace mode is disabled."

--- a/kvui.py
+++ b/kvui.py
@@ -363,15 +363,15 @@ class ServerLabel(HoverBehavior, MDTooltip, MDBoxLayout):
                     text += "\nPermissions:"
                     for permission_name, permission_data in ctx.permissions.items():
                         text += f"\n    {permission_name}: {permission_data}"
-                if ctx.hint_cost is not None and ctx.total_locations:
+                if ctx.hint_cost == 0:
+                    text += "\n!hint is free to use."
+                elif ctx.hint_cost is not None and ctx.total_locations:
                     min_cost = int(ctx.server_version >= (0, 3, 9))
                     text += f"\nA new !hint <itemname> costs {ctx.hint_cost}% of checks made. " \
                             f"For you this means every " \
                             f"{max(min_cost, int(ctx.hint_cost * 0.01 * ctx.total_locations))} " \
                             "location checks." \
                             f"\nYou currently have {ctx.hint_points} points."
-                elif ctx.hint_cost == 0:
-                    text += "\n!hint is free to use."
                 if ctx.stored_data and "_read_race_mode" in ctx.stored_data:
                     text += "\nRace mode is enabled." \
                         if ctx.stored_data["_read_race_mode"] else "\nRace mode is disabled."


### PR DESCRIPTION
## What is this fixing or adding?
Currently if you change the `hint_cost` option, the popup you get when hovering over the sever label will remain unchanged until reconnecting. This text in fact is already re-generated each time, but it's the `ctx.hint_cost` itself that does not update on a `RoomUpdate`. It looks like this isn't used anywhere else, so this shouldn't hit something unexpectedly even if it's a fix. It might make sense to update other things as well here (currently `location_check_points` gets set to `check_points` without being defined on `CommonContext` and isn't used anywhere?).

Also currently I think it's impossible for the message saying hints are free to show up based on how it's ordered. I don't think there's a situation where the current message would need to be shown instead even though `hint_cost` is 0.

## How was this tested?
Connecting to a local server and changing hint cost.

## If this makes graphical changes, please attach screenshots.
<img width="344" height="235" alt="image" src="https://github.com/user-attachments/assets/98650059-f557-442b-af20-2c19282b1d27" />