### PR TITLE
Jak1: use Utils.user_path for consistant user data

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -68,6 +68,7 @@ Output Logs/
 /setup.ini
 /installdelete.iss
 /data/user.kv
+/data/jak1/
 /datapackage
 /custom_worlds
 

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ Output Logs/
 /setup.ini
 /installdelete.iss
 /data/user.kv
+/data/jak1/
 /datapackage
 /datapackage_export.json
 /custom_worlds

--- a/worlds/jakanddaxter/agents/memory_reader.py
+++ b/worlds/jakanddaxter/agents/memory_reader.py
@@ -8,6 +8,7 @@ from PyMemoryEditor import OpenProcess, ProcessNotFoundError, ProcessIDNotExists
 from dataclasses import dataclass
 
 import Utils
+from .utils import user_data_path
 from ..game_id import jak1_gk
 from ..locs import (orb_locations as orbs,
                     cell_locations as cells,
@@ -482,7 +483,7 @@ class JakAndDaxterMemoryReader:
             signed=False)
 
     def save_data(self):
-        with open("jakanddaxter_location_outbox.json", "w+") as f:
+        with open(user_data_path("jakanddaxter_location_outbox.json"), "w+") as f:
             dump = {
                 "outbox_index": self.outbox_index,
                 "location_outbox": self.location_outbox
@@ -491,7 +492,7 @@ class JakAndDaxterMemoryReader:
 
     def load_data(self):
         try:
-            with open("jakanddaxter_location_outbox.json", "r") as f:
+            with open(user_data_path("jakanddaxter_location_outbox.json"), "r") as f:
                 load = json.load(f)
                 self.outbox_index = load["outbox_index"]
                 self.location_outbox = load["location_outbox"]

--- a/worlds/jakanddaxter/agents/repl_client.py
+++ b/worlds/jakanddaxter/agents/repl_client.py
@@ -14,6 +14,7 @@ import asyncio
 from asyncio import StreamReader, StreamWriter, Lock
 
 from NetUtils import NetworkItem
+from .utils import user_data_path
 from ..game_id import jak1_id, jak1_max, jak1_gk, jak1_goalc
 from ..items import item_table, trap_item_table
 from ..locs import (
@@ -502,7 +503,7 @@ class JakAndDaxterReplClient:
         return ok
 
     async def save_data(self):
-        with open("jakanddaxter_item_inbox.json", "w+") as f:
+        with open(user_data_path("jakanddaxter_item_inbox.json"), "w+") as f:
             dump = {
                 "inbox_index": self.inbox_index,
                 "item_inbox": [{
@@ -517,7 +518,7 @@ class JakAndDaxterReplClient:
 
     def load_data(self):
         try:
-            with open("jakanddaxter_item_inbox.json", "r") as f:
+            with open(user_data_path("jakanddaxter_item_inbox.json"), "r") as f:
                 load = json.load(f)
                 self.inbox_index = load["inbox_index"]
                 self.item_inbox = {k: NetworkItem(

--- a/worlds/jakanddaxter/agents/utils.py
+++ b/worlds/jakanddaxter/agents/utils.py
@@ -1,0 +1,18 @@
+import os
+from functools import cache
+
+from Utils import user_path
+
+
+@cache
+def user_data_path(filename: str) -> str:
+    """
+    Wrapper for Utils.user_path for jak1 related user data.
+
+    This avoids permission issues when Archipelago is installed in
+    system-owned locations (e.g. /opt).
+    """
+    _user_path = user_path()  # Uses Utils user path for consistency across worlds
+    data_path = os.path.join(_user_path, "data", "jak1")  # Custom folder structure for jak1
+    os.makedirs(data_path, exist_ok=True)  # Makes sure it exists
+    return os.path.join(data_path, filename)


### PR DESCRIPTION
Utils.user_path has their own logic of assigning a path to user data. To make our world data consistent across the root project we will use this to create a crossplatform compatible directory for our save data.

## What is this fixing or adding?

Previously the save data of Jak1 was created at the endpoint location of Archipelago. However, when the endpoint is inside a system owned directory the save data couldn't be created due to writing permissions. This happens for example with the AUR package that installs Archipelago in /opt/ on Linux.

To be consistent with other worlds we will be using the `Utils.user_path()` function which returns a writable path for user data. I make sure that the data and jak1 folder  are created if they do not exist. Caching it as saving happens often.

Added the folder in the gitignore so it doesn't end up in the repo when running from source.

## How was this tested?
Tested it on Arch linux. Running from source, appimage and from /opt/ folder.

Still needs testing on windows and other platforms.
