### PR TITLE
#4444: use `inspect` to handle `get_filler_item_name()` compat

### DIFF
--- a/test/general/test_rule_builder.py
+++ b/test/general/test_rule_builder.py
@@ -32,7 +32,7 @@ from rule_builder.rules import (
 )
 from test.general import setup_solo_multiworld
 from test.param import classvar_matrix
-from worlds.AutoWorld import AutoWorldRegister, World
+from worlds.AutoWorld import AutoWorldRegister, World, FillerReason
 
 
 class CachedCollectionState(CollectionState):
@@ -122,7 +122,7 @@ class RuleBuilderTestCase(unittest.TestCase):
                 return RuleBuilderItem(name, classification, self.item_name_to_id[name], self.player)
 
             @override
-            def get_filler_item_name(self) -> str:
+            def get_filler_item_name(self, reason: FillerReason = FillerReason.undefined) -> str:
                 return "Filler"
 
         self.world_cls = RuleBuilderWorld
@@ -150,7 +150,7 @@ class CachedRuleBuilderTestCase(RuleBuilderTestCase):
                 return RuleBuilderItem(name, classification, self.item_name_to_id[name], self.player)
 
             @override
-            def get_filler_item_name(self) -> str:
+            def get_filler_item_name(self, reason: FillerReason = FillerReason.undefined) -> str:
                 return "Filler"
 
         self.world_cls = RuleBuilderWorld

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -520,7 +520,7 @@ class World(metaclass=AutoWorldRegister):
         """
         raise NotImplementedError
 
-    def get_filler_item_name(self) -> str:
+    def get_filler_item_name(self, reason: FillerReason = FillerReason.undefined) -> str:
         """
         Called when the item pool needs to be filled with additional items to match location count.
 
@@ -588,7 +588,11 @@ class World(metaclass=AutoWorldRegister):
 
     # following methods should not need to be overridden.
     def create_filler(self, reason: FillerReason = FillerReason.undefined) -> "Item":
-        return self.create_item(self.get_filler_item_name())
+        import inspect
+        if len(inspect.signature(self.get_filler_item_name).parameters) == 0:
+            return self.create_item(self.get_filler_item_name())
+        else:
+            return self.create_item(self.get_filler_item_name(reason))
 
     # convenience methods
     def get_location(self, location_name: str) -> "Location":

--- a/worlds/yugioh06/__init__.py
+++ b/worlds/yugioh06/__init__.py
@@ -336,9 +336,6 @@ class Yugioh06World(World):
             classification = ItemClassification.useful
         return Item(name, classification, self.item_name_to_id[name], self.player)
 
-    def create_filler(self) -> Item:
-        return self.create_item("5000DP")
-
     def get_filler_item_name(self) -> str:
         return "5000DP"
 


### PR DESCRIPTION
### NOTE: this is not targetting `main`, this is targetting #4444 
## What is this fixing or adding?
Handles adding the FillerReason param to `get_filler_item_name()`

## How was this tested?
Ran a generation of `Paint` using multiple items in `start_inventory_from_pool`, with various code changes:
- Just adding the param to `get_filler_item_name()`, this errors out due to calling with 2 params when the Paint code expects 1 param.
- Adding the `inspect` code in `create_filler()` then fixed this error, ensuring that it calls the Paint code without the reason parameter.
- Then modifying the Paint `get_filler_item_name()` function to take the second FillerReason parameter, I confirmed that it is being given both parameters correctly.

(I also modified yugioh06, as it was modifying `create_filler` which would already be failing I expect? and it also had no reason to modify `create_filler` anyway because it had modified it to do exactly what the core `create_filler` was already doing. I did not explicitly test THAT part of the change)