### PR TITLE
Webhost: Exclude hidden games from tutorials list

### DIFF
--- a/WebHostLib/misc.py
+++ b/WebHostLib/misc.py
@@ -121,6 +121,8 @@ def tutorial_landing():
     tutorials = {}
     worlds = AutoWorldRegister.world_types
     for world_name, world_type in worlds.items():
+        if world_type.hidden and world_name != "Archipelago":
+            continue
         current_world = tutorials[world_name] = {}
         for tutorial in world_type.web.tutorials:
             current_tutorial = current_world.setdefault(tutorial.tutorial_name, {

--- a/WebHostLib/misc.py
+++ b/WebHostLib/misc.py
@@ -119,11 +119,12 @@ def tutorial_redirect(game: str, file: str, lang: str):
 @cache.cached()
 def tutorial_landing():
     tutorials = {}
-    worlds = AutoWorldRegister.world_types
-    for world_name, world_type in worlds.items():
+    worlds = {}
+    for world_name, world_type in AutoWorldRegister.world_types.items():
         if world_type.hidden and world_name != "Archipelago":
             continue
         current_world = tutorials[world_name] = {}
+        worlds[world_name] = world_type
         for tutorial in world_type.web.tutorials:
             current_tutorial = current_world.setdefault(tutorial.tutorial_name, {
                 "description": tutorial.description, "files": {}})


### PR DESCRIPTION
## What is this fixing or adding?

Exclude Worlds marked with `hidden = True` from the tutorials list, except for `Archipelago`

## How was this tested?

locally, made sure the default tutorials still show

<img width="1338" height="654" alt="image" src="https://github.com/user-attachments/assets/216fd576-9724-4f23-b549-890e94d5a228" />

## If this makes graphical changes, please attach screenshots.

no, they're hidden, that's the point