### PR TITLE
Docs: Specify installation step for Celeste is in Everest

### DIFF
--- a/worlds/celeste_open_world/docs/guide_en.md
+++ b/worlds/celeste_open_world/docs/guide_en.md
@@ -10,7 +10,7 @@
 1. Install the latest version of Celeste (v1.4) on PC
 2. Install `Olympus` (mod manager/launcher) and `Everest` (mod loader) per its instructions: [Olympus Setup Instructions](https://everestapi.github.io/)
 3. Place the `Archipelago_Open_World.zip` from the GitHub release into the `mods` folder in your Celeste install
-4. (Recommended) From the main menu, enter `Mod Options` and set `Debug Mode` to `Everest` or `Always`. This will give you access to a rudimentary Text Client which can be toggled with the `~` key.
+4. (Recommended) From Everest's main menu, enter `Mod Options` and set `Debug Mode` to `Everest` or `Always`. This will give you access to a rudimentary Text Client which can be toggled with the `~` key.
 
 ## Joining a MultiWorld Game
 


### PR DESCRIPTION
Update documentation for Celeste installation to clarify step 4 is in the Everest menu, not Archipelago's menu.