### PR TITLE
CI: update softprops/action-gh-release to v3.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV  # tag x.y.z will become "Archipelago x.y.z"
       - name: Create Release
-        uses: softprops/action-gh-release@975c1b265e11dd76618af1c374e7981f9a6ff44a
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           draft: true  # don't publish right away, especially since windows build is added by hand
           prerelease: false
@@ -97,13 +97,15 @@ jobs:
             build/exe.*/ArchipelagoServer.exe
             setups/*
       - name: Add to Release
-        uses: softprops/action-gh-release@975c1b265e11dd76618af1c374e7981f9a6ff44a
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           draft: true  # see above
           prerelease: false
           name: Archipelago ${{ env.RELEASE_VERSION }}
           files: |
             setups/*
+          fail_on_unmatched_files: true
+          overwrite_files: false  # Windows release is usually built by hand
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -165,12 +167,14 @@ jobs:
             build/exe.*/ArchipelagoServer
             dist/*
       - name: Add to Release
-        uses: softprops/action-gh-release@975c1b265e11dd76618af1c374e7981f9a6ff44a
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           draft: true  # see above
           prerelease: false
           name: Archipelago ${{ env.RELEASE_VERSION }}
           files: |
             dist/*
+          fail_on_unmatched_files: true
+          overwrite_files: false  # should never happen; avoids accidentally changing a release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What is this fixing or adding?

Updates the action we use during release to latest v3.0.0 (and pins it by hash).

Also enables new options that the action now supports.

## Why?

It looks like the update will be required once GH drops support for Node 20 in fall, however Node 20 will already be EOL end of April, so we should update by then.

## How was this tested?

Updated this [in PopTracker](https://github.com/black-sliver/PopTracker/pull/496) and pushed a test tag to see that everything still works [in the workflow](https://github.com/black-sliver/PopTracker/actions/runs/24804696075).

I reviewed the changelog and briefly reviewed the repo.