### PR TITLE
Docs: Add recommendation to fork the repository

### DIFF
--- a/docs/running from source.md
+++ b/docs/running from source.md
@@ -14,8 +14,8 @@ What you'll need:
  * Matching C compiler
    * possibly optional, read operating system specific sections
 
-If you intend to make your own APWorld, it is highly recommended to fork the repository and make your own branch for it for 
-easier updates from the main repository. For more information on how to use Git see [Git](#optional-git).
+If you intend to make your own APWorld, it is highly recommended to fork the repository and make your own branch for 
+easier updates from the main repository. For more information on how to use Git see [Optional: Git](#optional-git).
 
 Then run any of the starting point scripts, like Generate.py, and the included ModuleUpdater should prompt to install or update the
 required modules and after pressing enter proceed to install everything automatically.

--- a/docs/running from source.md
+++ b/docs/running from source.md
@@ -14,6 +14,9 @@ What you'll need:
  * Matching C compiler
    * possibly optional, read operating system specific sections
 
+If you intend to make your own APWorld, it is highly recommended to fork the repository and make your own branch for it for 
+easier updates from the main repository. For more information on how to use Git see [Git](#optional-git).
+
 Then run any of the starting point scripts, like Generate.py, and the included ModuleUpdater should prompt to install or update the
 required modules and after pressing enter proceed to install everything automatically.
 After this, you should be able to run the programs.


### PR DESCRIPTION
## What is this fixing or adding?
Adds a note recommending forking the main repository as most contributing workflows will require this at some stage.
Alternatively this could be changed to just cloning the repository as technically APWorlds can be developed without a fork, but merging an APWorld would most be easiest through a fork as well, however creating a fork requires a GitHub account while simply cloning the repository doesn't. 
Additionally as this is documentation for developers it seems weird that git is optional (especially as the ModuleUpdate.py seems to rely on it anyways at least on Windows), however this change should most likely be made in a separate PR, but can be added here if desired.

## How was this tested?
It wasn't, internal docs change only

## If this makes graphical changes, please attach screenshots.
<img width="1030" height="752" alt="image" src="https://github.com/user-attachments/assets/9bb46255-4f20-4fde-8533-6c7ee921547a" />
