### PR TITLE
Options: Remove the "" from the start inventory examples

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -1477,7 +1477,7 @@ class StartInventory(ItemDict):
 
 
 class StartInventoryPool(StartInventory):
-    """Start with the specified amount of these items and don't place them in the world. Example: Bomb: 1
+    """Start with the specified amount of these items and don't place them in the world. Example: {Bomb: 1, Arrow: 3}
 
     The game decides what the replacement items will be.
     """

--- a/Options.py
+++ b/Options.py
@@ -1469,7 +1469,7 @@ class NonLocalItems(ItemSet):
 
 
 class StartInventory(ItemDict):
-    """Start with the specified amount of these items. Example: "Bomb: 1" """
+    """Start with the specified amount of these items. Example: Bomb: 1 """
     verify_item_name = True
     display_name = "Start Inventory"
     rich_text_doc = True
@@ -1477,7 +1477,7 @@ class StartInventory(ItemDict):
 
 
 class StartInventoryPool(StartInventory):
-    """Start with the specified amount of these items and don't place them in the world. Example: "Bomb: 1"
+    """Start with the specified amount of these items and don't place them in the world. Example: Bomb: 1
 
     The game decides what the replacement items will be.
     """

--- a/Options.py
+++ b/Options.py
@@ -1469,7 +1469,7 @@ class NonLocalItems(ItemSet):
 
 
 class StartInventory(ItemDict):
-    """Start with the specified amount of these items. Example: Bomb: 1 """
+    """Start with the specified amount of these items. Example: {Bomb: 1, Arrow: 3} """
     verify_item_name = True
     display_name = "Start Inventory"
     rich_text_doc = True


### PR DESCRIPTION
## What is this fixing or adding?
Someone saw the start inventory example in the comment for the option, and thought that meant you needed to wrap the key value pair in quotes. I think their interpretation is reasonable, so I think we should change the comment.

## How was this tested?
yeah