### PR TITLE
Core/Webhost: Default `release_mode` and `collect_mode` to `goal` instead of `auto`

### DIFF
--- a/WebHostLib/templates/generate.html
+++ b/WebHostLib/templates/generate.html
@@ -49,7 +49,7 @@
                                     <td>
                                         <select name="release_mode" id="release_mode">
                                             <option value="auto">Automatic on goal completion</option>
-                                            <option value="goal">Allow !release after goal completion</option>
+                                            <option value="goal" selected>Allow !release after goal completion</option>
                                             <option value="auto-enabled">
                                                 Automatic on goal completion and manual !release
                                             </option>
@@ -70,7 +70,7 @@
                                     <td>
                                         <select name="collect_mode" id="collect_mode">
                                             <option value="auto">Automatic on goal completion</option>
-                                            <option value="goal">Allow !collect after goal completion</option>
+                                            <option value="goal" selected>Allow !collect after goal completion</option>
                                             <option value="auto-enabled">
                                                 Automatic on goal completion and manual !collect
                                             </option>

--- a/settings.py
+++ b/settings.py
@@ -621,8 +621,8 @@ class ServerOptions(Group):
     disable_item_cheat: DisableItemCheat | bool = False
     location_check_points: LocationCheckPoints = LocationCheckPoints(1)
     hint_cost: HintCost = HintCost(10)
-    release_mode: ReleaseMode = ReleaseMode("auto")
-    collect_mode: CollectMode = CollectMode("auto")
+    release_mode: ReleaseMode = ReleaseMode("goal")
+    collect_mode: CollectMode = CollectMode("goal")
     remaining_mode: RemainingMode = RemainingMode("goal")
     countdown_mode: CountdownMode = CountdownMode("auto")
     auto_shutdown: AutoShutdown = AutoShutdown(0)


### PR DESCRIPTION
## What is this fixing or adding?
Changes the default `release_mode` and `collect_mode` for both local gens and webhost to `goal` (`Allow !command after goal completion`) rather than `auto` (`Automatic on goal completion`).

Much discussion was had in [this discord suggestion thread](https://discord.com/channels/731205301247803413/1497687625463759010), which while there were many varying opinions on possible future changes to how `!collect` works fundamentally, mostly everyone seemed to agree that the current default of `auto` was simply worse as a default than `goal`- notably, releasing and collecting automatically is a much more destructive action, which can cause unnecessary harm in situations such as "Oops I selected the wrong goal in my yaml!" or "This world has a world bug and goaled me early!" (both of which have occurred with examples cited in that thread).

By changing the default to `goal`, more control is given to the player, and bugs / mistakes such as those mentioned above would cause much less harm (giving you the goal message early, but you can still just play until the goal you meant to select- rather than suddenly having your entire game empty itself out, and empty out locations from others).

## How was this tested?
Deleted `host.yaml` and recreated it with `Launcher.py --update_settings`; verified the new defaults were correct.
Locally ran WebHost, and verified the dropdowns default to the new defaults.

## If this makes graphical changes, please attach screenshots.
<img width="455" height="67" alt="image" src="https://github.com/user-attachments/assets/dc655483-d075-411f-919f-c2a114fbd322" />
<img width="323" height="182" alt="image" src="https://github.com/user-attachments/assets/a2f716b0-77be-4012-be27-62468f6abc73" />
