### PR TITLE
Rule Builder: Fix rule hash collisions

### DIFF
--- a/rule_builder/rules.py
+++ b/rule_builder/rules.py
@@ -36,7 +36,7 @@ def _create_hash_fn(resolved_rule_cls: "CustomRuleRegister") -> Callable[..., in
 class CustomRuleRegister(type):
     """A metaclass to contain world custom rules and automatically convert resolved rules to frozen dataclasses"""
 
-    resolved_rules: ClassVar[dict[int, "Rule.Resolved"]] = {}
+    resolved_rules: ClassVar[dict[int, list["Rule.Resolved"]]] = {}
     """A cached of resolved rules to turn each unique one into a singleton"""
 
     custom_rules: ClassVar[dict[str, dict[str, type["Rule[Any]"]]]] = {}
@@ -66,8 +66,13 @@ class CustomRuleRegister(type):
         rule = super().__call__(*args, **kwds)
         rule_hash = hash(rule)
         if rule_hash in cls.resolved_rules:
-            return cls.resolved_rules[rule_hash]
-        cls.resolved_rules[rule_hash] = rule
+            existing_rules = cls.resolved_rules[rule_hash]
+            for existing_rule in existing_rules:
+                if existing_rule == rule:
+                    return existing_rule
+            existing_rules.append(rule)
+            return rule
+        cls.resolved_rules[rule_hash] = [rule]
         return rule
 
     @classmethod

--- a/rule_builder/rules.py
+++ b/rule_builder/rules.py
@@ -36,7 +36,7 @@ def _create_hash_fn(resolved_rule_cls: "CustomRuleRegister") -> Callable[..., in
 class CustomRuleRegister(type):
     """A metaclass to contain world custom rules and automatically convert resolved rules to frozen dataclasses"""
 
-    resolved_rules: ClassVar[dict[int, list["Rule.Resolved"]]] = {}
+    resolved_rules: ClassVar[dict["Rule.Resolved", "Rule.Resolved"]] = {}
     """A cached of resolved rules to turn each unique one into a singleton"""
 
     custom_rules: ClassVar[dict[str, dict[str, type["Rule[Any]"]]]] = {}
@@ -64,15 +64,9 @@ class CustomRuleRegister(type):
     @override
     def __call__(cls, *args: Any, **kwds: Any) -> Any:
         rule = super().__call__(*args, **kwds)
-        rule_hash = hash(rule)
-        if rule_hash in cls.resolved_rules:
-            existing_rules = cls.resolved_rules[rule_hash]
-            for existing_rule in existing_rules:
-                if existing_rule == rule:
-                    return existing_rule
-            existing_rules.append(rule)
-            return rule
-        cls.resolved_rules[rule_hash] = [rule]
+        if rule in cls.resolved_rules:
+            return cls.resolved_rules[rule]
+        cls.resolved_rules[rule] = rule
         return rule
 
     @classmethod

--- a/test/general/test_rule_builder.py
+++ b/test/general/test_rule_builder.py
@@ -416,6 +416,15 @@ class TestHashes(RuleBuilderTestCase):
         rule2 = HasAll("2", "2", "2", "1")
         self.assertEqual(hash(rule1.resolve(world)), hash(rule2.resolve(world)))
 
+    def test_hash_collision(self) -> None:
+        multiworld = setup_solo_multiworld(self.world_cls, steps=("generate_early",), seed=0)
+        world = multiworld.worlds[1]
+        rule1 = Has("A", count=1).resolve(world)
+        rule2 = Has("A", count=1 << 61).resolve(world)
+        self.assertEqual(hash(rule1), hash(rule2))
+        self.assertNotEqual(rule1, rule2)
+        self.assertNotEqual(id(rule1), id(rule2))
+
 
 class TestCaching(CachedRuleBuilderTestCase):
     multiworld: MultiWorld  # pyright: ignore[reportUninitializedInstanceVariable]


### PR DESCRIPTION
## What is this fixing or adding?

Fixes resolved rules with the same hash but different values being treated as the same rule.

Resolves #6157

## How was this tested?

unit tests

Before:

```py
>>> Has.Resolved('a', count=1, player=1) is Has.Resolved('a', count=1<<61, player=1)
True
```

After:

```py
>>> Has.Resolved('a', count=1, player=1) is Has.Resolved('a', count=1<<61, player=1)
False
```

## If this makes graphical changes, please attach screenshots.

no