### PR TITLE
Core: DataStorage keys prefixed with `_admin_` require admin access to modify

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2179,6 +2179,10 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
                 await ctx.send_msgs(client, [{'cmd': 'InvalidPacket', "type": "arguments",
                                               "text": 'Set', "original_cmd": cmd}])
                 return
+            if args["key"].startswith("_admin_") and not client.messageprocessor.is_authenticated():
+                await ctx.send_msgs(client, [{'cmd': 'InvalidPacket', 'type': 'permission',
+                                              'text': 'Modifying an "_admin_" key requires admin authentication first', 'original_cmd': cmd}])
+                return
             args["cmd"] = "SetReply"
             value = ctx.stored_data.get(args["key"], args.get("default", 0))
             args["original_value"] = copy.copy(value)

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -244,6 +244,7 @@ Sent to clients if the server caught a problem with a packet. This only occurs f
 | ---- | ----- |
 | cmd | `cmd` argument of the faulty packet that could not be parsed correctly. |
 | arguments | Arguments of the faulty packet which were not correct. |
+| permission | Client was not authenticated as admin, and command required admin permission. |
 
 ### Retrieved
 Sent to clients as a response the a [Get](#Get) package.
@@ -450,6 +451,7 @@ Some special keys exist with specific return data, all of them have the prefix `
 ### Set
 Used to write data to the server's data storage, that data can then be shared across worlds or just saved for later. Values for keys in the data storage can be retrieved with a [Get](#Get) package, or monitored with a [SetNotify](#SetNotify) package.
 Keys that start with `_read_` cannot be set.
+Keys that start with `_admin_` require the client to be logged in as a room admin via `!admin login` before modifying.
 #### Arguments
 | Name       | Type                                                  | Notes                                                                                                                  |
 |------------|-------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
## What is this fixing or adding?
`Set` packets to keys prefixed with `_admin_` will fail if the sending client is not authenticated as an admin.
A failed attempt to modify such a key sends back an `InvalidPacket` with a new `PacketProblemType`, `permission`.

Use case for this is things like APSudoku's "Admin Settings" which apply to the entire room via datastorage- similar to per-slot passwords, this change serves as an added security against bad actors. (The apsudoku client already requires admin authentication before it allows you to see the UI for modifying it's settings, but a customly written/modified client could bypass this requirement on the client-side; having a server-side auth check is more secure)

## How was this tested?
Locally hosted with the changes and a modified APSudoku that prefixes it's key with `_admin_`. Tried to modify settings by bypassing the client-side admin password check, got back InvalidPacket. Authenticated with admin password and tried again, `Set` was successful.

I had APSudoku set to log it's network comms and it produced the following output as I did this:
<img width="819" height="276" alt="image" src="https://github.com/user-attachments/assets/78d07f71-1ebe-4700-bd69-ba14969ee2bb" />