### PR TITLE
Generate: check allow_quantity existence or fall back

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -125,7 +125,7 @@ def main(args=None) -> tuple[argparse.Namespace, int]:
     player_id: int = 1
     player_files: dict[int, str] = {}
     player_errors: list[str] = []
-    allow_quantity = args.allow_quantity
+    allow_quantity = getattr(args, "allow_quantity", False)
     for file in os.scandir(args.player_files_path):
         fname = file.name
         if file.is_file() and not fname.startswith(".") and not fname.lower().endswith(".ini") and \


### PR DESCRIPTION
## What is this fixing or adding?
The Archipelago Fuzzer [passes in its own generation settings](https://github.com/Eijebong/Archipelago-fuzzer/blob/0.6.2/fuzz.py#L596).
Without a fix from the Fuzzer to include `allow_quantity`, every Generate call it makes fails.

As of 15561e1, `allow_quantity` is assumed to always be present and in typical usage should be.

Why this fix PR is relevant to Core instead:
- Similar operation from projects other than the Fuzzer could run into this
- Most if not all other uses of `args` in this function are checked/handled or fail gracefully

## How was this tested?
Using the Fuzzer before after and after the fix. The game and options used do not matter.

Before: Every Fuzzer generation fails with
```
  File "Generate.py", line 128, in main
    allow_quantity = args.allow_quantity
                     ^^^^^^^^^^^^^^^^^^^
AttributeError: 'Namespace' object has no attribute 'allow_quantity'
```

After: If there is a Fuzzer failure, it's no longer due to `allow_quantity` missing.

## If this makes graphical changes, please attach screenshots.
