### PR TITLE
Options: make template generation log the failing world if one fails

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -1856,27 +1856,30 @@ def generate_yaml_templates(target_folder: typing.Union[str, "pathlib.Path"], ge
 
     for game_name, world in AutoWorldRegister.world_types.items():
         if not world.hidden or generate_hidden:
-            presets = world.web.options_presets.copy()
-            presets.update({"": {}})
+            try:
+                presets = world.web.options_presets.copy()
+                presets.update({"": {}})
 
-            option_groups = get_option_groups(world)
-            for name, preset in presets.items():
-                res = template.render(
-                    option_groups=option_groups,
-                    __version__=__version__,
-                    game=game_name, 
-                    world_version=world.world_version.as_simple_string(),
-                    yaml_dump=yaml_dump_scalar,
-                    dictify_range=dictify_range,
-                    cleandoc=cleandoc,
-                    preset_name=name,
-                    preset=preset,
-                )
-                preset_name = f" - {name}" if name else ""
-                with open(os.path.join(preset_folder if name else target_folder,
-                                       get_file_safe_name(game_name + preset_name) + ".yaml"),
-                          "w", encoding="utf-8-sig") as f:
-                    f.write(res)
+                option_groups = get_option_groups(world)
+                for name, preset in presets.items():
+                    res = template.render(
+                        option_groups=option_groups,
+                        __version__=__version__,
+                        game=game_name,
+                        world_version=world.world_version.as_simple_string(),
+                        yaml_dump=yaml_dump_scalar,
+                        dictify_range=dictify_range,
+                        cleandoc=cleandoc,
+                        preset_name=name,
+                        preset=preset,
+                    )
+                    preset_name = f" - {name}" if name else ""
+                    with open(os.path.join(preset_folder if name else target_folder,
+                                           get_file_safe_name(game_name + preset_name) + ".yaml"),
+                              "w", encoding="utf-8-sig") as f:
+                        f.write(res)
+            except Exception as ex:
+                raise Exception(f"Template generation failed for world {game_name}") from ex
 
 
 def dump_player_options(multiworld: MultiWorld) -> None:


### PR DESCRIPTION
## What is this fixing or adding?
Template generation has no error handling meaning the tech support usually ends up being "idk try removing all of your custom worlds until it works again", this catches errors and calls out the problematic world

note: I admit the approach to still fail template generation does still leave some friction on the end-user side, but I didn't like the options of silently ignore the problems nor have an error popup (as then it would have to work around the difference between called from cli and wanting no gui, wanting some gui like the folder to pop up, called from the launcher gui itself, etc.)

## How was this tested?
set an option visibility to `0` in lingo and tried to gen templates
```
Traceback (most recent call last):
  File "/media/qwint/Data/RandoDev/Archipelago-Branch/Options.py", line 1863, in generate_yaml_templates
    option_groups = get_option_groups(world)
                    ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/media/qwint/Data/RandoDev/Archipelago-Branch/Options.py", line 1792, in get_option_groups
    if (visibility_level in option.visibility and option in option_to_name)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'int' is not iterable

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/media/qwint/Data/RandoDev/Archipelago-Branch/Launcher.py", line 523, in <module>
    main(parser.parse_args())
  File "/media/qwint/Data/RandoDev/Archipelago-Branch/Launcher.py", line 503, in main
    run_component(args["component"], *args["args"])
  File "/media/qwint/Data/RandoDev/Archipelago-Branch/Launcher.py", line 464, in run_component
    component.func(*args)
  File "/media/qwint/Data/RandoDev/Archipelago-Branch/Launcher.py", line 87, in generate_yamls
    generate_yaml_templates(target, False)
  File "/media/qwint/Data/RandoDev/Archipelago-Branch/Options.py", line 1882, in generate_yaml_templates
    raise Exception(f"Template generation failed for world {game_name}") from ex
Exception: Template generation failed for world Lingo
```

## If this makes graphical changes, please attach screenshots.
