### PR TITLE
[Factorio] Set technologies as essential if they contain an advancement item

### DIFF
--- a/worlds/factorio/data/mod_template/data-final-fixes.lua
+++ b/worlds/factorio/data/mod_template/data-final-fixes.lua
@@ -178,6 +178,9 @@ copy_factorio_icon(new_tree_copy, "{{ progressive_technology_table[item.name][0]
 {#- use default AP icon if no Factorio graphics exist -#}
 {% if item.advancement or not tech_tree_information %}set_ap_icon(new_tree_copy){% else %}set_ap_unimportant_icon(new_tree_copy){% endif %}
 {%- endif -%}
+{%- if tech_tree_information %}
+new_tree_copy.essential = {{ variable_to_lua(item.advancement) }}
+{%- endif -%}
 {#- connect Technology  #}
 {%- if location in tech_tree_layout_prerequisites %}
 {%- for prerequisite in tech_tree_layout_prerequisites[location] %}


### PR DESCRIPTION
## What is this fixing or adding?

Add the `essential` flag to technologies that contain an advancement item it tech tree information is set to advancement or full.

This allows filtering advancement technologies in Factorio by checking the "show only essential technologies" checkbox.

(someone [asked if there was a way to do this in Discord](https://discord.com/channels/731205301247803413/827139809763262525/1497531946035712122) and today when I've seen the checkbox on the tech screen I though this could be a good way to implement it)

## How was this tested?

Generated a new seed and loaded the corresponding mod.

## If this makes graphical changes, please attach screenshots.

Without the checkbox checked the view is the same as before:
<img width="1351" height="1103" alt="image" src="https://github.com/user-attachments/assets/82ce7bf7-9015-4353-b51f-5548bfcde0dc" />

With it checked only the advancement techs (and their dependencies) are shown:
<img width="1351" height="1103" alt="image" src="https://github.com/user-attachments/assets/82b907b7-3288-455a-9e5c-f85be6c8b4b5" />

(the technology list on the left side stay unfiltered)