### PR TITLE
[Webhost API]: Datastorage endpoint

### DIFF
--- a/WebHostLib/api/__init__.py
+++ b/WebHostLib/api/__init__.py
@@ -22,4 +22,4 @@ def get_players(seed: Seed) -> List[Tuple[str, str]]:
     return [(slot.player_name, slot.game) for slot in seed.slots.order_by(Slot.player_id)]
 
 # trigger endpoint registration
-from . import datapackage, generate, room, tracker, user
+from . import datapackage, generate, room, tracker, user, datastore

--- a/WebHostLib/api/__init__.py
+++ b/WebHostLib/api/__init__.py
@@ -11,6 +11,7 @@ cors = CORS(api_endpoints, resources={
                 r"/api/datapackage/*": {"origins": "*"},
                 r"/api/datapackage": {"origins": "*"},
                 r"/api/datapackage_checksum/*": {"origins": "*"},
+                r"/api/datastorage/*": {"origins": "*"},
                 r"/api/room_status/*": {"origins": "*"},
                 r"/api/tracker/*": {"origins": "*"},
                 r"/api/static_tracker/*": {"origins": "*"},

--- a/WebHostLib/api/datastore.py
+++ b/WebHostLib/api/datastore.py
@@ -9,15 +9,20 @@ from ..models import Room
 from Utils import restricted_loads
 
 
-@api_endpoints.route('/datastorage_read/<suuid:room_id>')
+@api_endpoints.route('/datastorage/<suuid:room_id>')
 @cache.memoize(timeout=60)
 def read_datastorage(room_id: UUID) -> Dict[str, str]:
+    # TODO: Impliment POST method to update datastorage. This can be accomplished by:
+    #       1. Importing Command from models, and commit from pony.orm
+    #       2. Mimic the Command interaction from the /room post method from misc.py
+    #         - This submits a command to the room, processed by the Multiserver.py ServerCommandProcessor
+    #       3. Add an additonal command to ServerCommandProcessor to write to the datastorage.
+    #       Currently, there is no need/want to write to the datastorage, and would require a significant lift to do so.
+
     room = Room.get(id=room_id)
     if room is None:
         return abort(404)
     
     datastorage = restricted_loads(room.multisave).get('stored_data',{}) if room.multisave else {}
 
-    return {
-        "data_storage": datastorage
-    }
+    return datastorage

--- a/WebHostLib/api/datastore.py
+++ b/WebHostLib/api/datastore.py
@@ -1,0 +1,23 @@
+from typing import Any, Dict
+from uuid import UUID
+
+from flask import abort
+
+from WebHostLib import cache
+from WebHostLib.api import api_endpoints
+from ..models import Room
+from Utils import restricted_loads
+
+
+@api_endpoints.route('/datastorage_read/<suuid:room_id>')
+@cache.memoize(timeout=60)
+def read_datastorage(room_id: UUID) -> Dict[str, str]:
+    room = Room.get(id=room_id)
+    if room is None:
+        return abort(404)
+    
+    datastorage = restricted_loads(room.multisave).get('stored_data',{}) if room.multisave else {}
+
+    return {
+        "data_storage": datastorage
+    }

--- a/docs/webhost api.md
+++ b/docs/webhost api.md
@@ -11,6 +11,8 @@ Current endpoints:
     - [`/datapackage`](#datapackage)
     - [`/datapackage/<string:checksum>`](#datapackagestringchecksum)
     - [`/datapackage_checksum`](#datapackagechecksum)
+- Datastorage API
+    - [`/datastorage/<suuid:room_id>`](#datastorage)
 - Generation API
     - [`/generate`](#generate)
     - [`/status/<suuid:seed>`](#status)
@@ -113,6 +115,30 @@ Example:
 }
 ```
 
+## Datastorage Endpoint
+<a name="datastorage"></a>
+This endpoint is used to retreive a room's datastorage keys from the multiserver.
+
+### `/datastorage/<suuid:room_id>`
+**Cache timer: 60 seconds**
+
+You'll receive a dict with each of the datastorage keys for a room.  
+
+Due to the custom nature of datastorage, there is not a standard naming convention for keys.  
+Thus, need to know what you're looking for, to read the returned data effectively.  
+
+If no keys are saved, this endpoint will return an empty dict.
+
+Example:
+```json
+{
+    "TestDict": {
+        "NestedInt": 123,
+        "NestedStr": "Hello There!"
+    },
+    "TestInt": 456
+}
+```
 
 ## Generation Endpoint
 These endpoints are used internally for the WebHost to generate games and validate their generation. They are also used by external applications to generate games automatically.


### PR DESCRIPTION
## What is this fixing or adding?
Adds in a simple endpoint for accessing the datastorage keys within a multiworld.  
`/api/datastorage/<room suid>`

Also added a TODO on the endpoint for if/when we want to write to the datastore from the API. There isn't a need/want to at the moment, so just for future us.

## How was this tested?
Local webhost, added and removed data from the datastore.
Also tested with nothing in the datastore.

## If this makes graphical changes, please attach screenshots.
N/A