### PR TITLE
core: Add parameter to visualize_regions to display Rule Builder explanations on exits

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -1087,6 +1087,7 @@ def visualize_regions(
         file_name: str,
         *,
         show_entrance_names: bool = False,
+        show_entrance_rules: bool = False,
         show_locations: bool = True,
         show_other_regions: bool = True,
         linetype_ortho: bool = True,
@@ -1099,6 +1100,7 @@ def visualize_regions(
     :param root_region: The region from which to start the diagram from. (Usually the "Menu" region of your world.)
     :param file_name: The name of the destination .puml file.
     :param show_entrance_names: (default False) If enabled, the name of the entrance will be shown near each connection.
+    :param show_entrance_rules: (default False) If enabled, the Rule Builder explaination of the entrance's access rule will be shown near each connection.
     :param show_locations: (default True) If enabled, the locations will be listed inside each region.
             Priority locations will be shown in bold.
             Excluded locations will be stricken out.
@@ -1188,13 +1190,22 @@ def visualize_regions(
         return re.sub("[\".:]", "", name)
 
     def visualize_exits(region: Region) -> None:
+        import rule_builder.rules
         for exit_ in region.exits:
             color_code: str = ""
             if exit_.randomization_group in entrance_highlighting:
                 color_code = f" #{entrance_highlighting[exit_.randomization_group]:0>6X}"
             if exit_.connected_region:
+                label = ""
                 if show_entrance_names:
-                    uml.append(f"\"{fmt(region)}\" --> \"{fmt(exit_.connected_region)}\" : \"{fmt(exit_)}\"{color_code}")
+                    label += fmt(exit_)
+                if show_entrance_rules:
+                    if isinstance(exit_.access_rule, rule_builder.rules.Rule.Resolved):
+                        if label:
+                            label += "\\n"
+                        label += exit_.access_rule.explain_str()
+                if label:
+                    uml.append(f"\"{fmt(region)}\" --> \"{fmt(exit_.connected_region)}\" : \"{label}\"{color_code}")
                 else:
                     try:
                         uml.remove(f"\"{fmt(exit_.connected_region)}\" --> \"{fmt(region)}\"{color_code}")

--- a/Utils.py
+++ b/Utils.py
@@ -1100,7 +1100,7 @@ def visualize_regions(
     :param root_region: The region from which to start the diagram from. (Usually the "Menu" region of your world.)
     :param file_name: The name of the destination .puml file.
     :param show_entrance_names: (default False) If enabled, the name of the entrance will be shown near each connection.
-    :param show_entrance_rules: (default False) If enabled, the Rule Builder explaination of the entrance's access rule will be shown near each connection.
+    :param show_entrance_rules: (default False) If enabled, the Rule Builder explanation of the entrance's access rule will be shown near each connection.
     :param show_locations: (default True) If enabled, the locations will be listed inside each region.
             Priority locations will be shown in bold.
             Excluded locations will be stricken out.


### PR DESCRIPTION
## What is this fixing or adding?
This adds a new parameter to `visualize_regions` that evaluates a Rule's `explain_str` and adds that as a label to compatible exits.

## How was this tested?

Generated diagrams with setting enabled and disabled, on worlds that do and do not use Rule Builder.

## If this makes graphical changes, please attach screenshots.

APQuest visualization with `show_entrance_rules=True`

<img width="841" height="372" alt="image" src="https://github.com/user-attachments/assets/d961faa0-6c33-457a-87ea-b0d6aa7e7dbc" />
