### PR TITLE
Core: remove per_slot_randoms and DeprecateDict

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -49,7 +49,7 @@ class ThreadBarrierProxy:
             return getattr(self.obj, name)
         else:
             raise RuntimeError("You are in a threaded context and global random state was removed for your safety. "
-                               "Please use multiworld.per_slot_randoms[player] or randomize ahead of output.")
+                               "Please use world.random or randomize ahead of output.")
 
 
 class HasNameAndPlayer(Protocol):
@@ -100,8 +100,6 @@ class MultiWorld():
     game: Dict[int, str]
 
     random: random.Random
-    per_slot_randoms: Utils.DeprecateDict[int, random.Random]
-    """Deprecated. Please use `self.random` instead."""
 
     class AttributeProxy():
         def __init__(self, rule):
@@ -177,8 +175,6 @@ class MultiWorld():
             set_player_attr('game', "Archipelago")
             set_player_attr('completion_condition', lambda state: True)
         self.worlds = {}
-        self.per_slot_randoms = Utils.DeprecateDict("Using per_slot_randoms is now deprecated. Please use the "
-                                                    "world's random object instead (usually self.random)", True)
         self.plando_options = PlandoOptions.none
 
     def get_all_ids(self) -> Tuple[int, ...]:

--- a/Utils.py
+++ b/Utils.py
@@ -1011,23 +1011,6 @@ def deprecate(message: str, add_stacklevels: int = 0):
     warnings.warn(message, stacklevel=2 + add_stacklevels)
 
 
-class DeprecateDict(dict):
-    log_message: str
-    should_error: bool
-
-    def __init__(self, message: str, error: bool = False) -> None:
-        self.log_message = message
-        self.should_error = error
-        super().__init__()
-
-    def __getitem__(self, item: Any) -> Any:
-        if self.should_error:
-            deprecate(self.log_message, add_stacklevels=1)
-        elif __debug__:
-            warnings.warn(self.log_message, stacklevel=2)
-        return super().__getitem__(item)
-
-
 def _extend_freeze_support() -> None:
     """Extend multiprocessing.freeze_support() to also work on Non-Windows and without setting spawn method first."""
     # original upstream issue: https://github.com/python/cpython/issues/76327

--- a/worlds/AutoWorld.py
+++ b/worlds/AutoWorld.py
@@ -359,7 +359,6 @@ class World(metaclass=AutoWorldRegister):
         self.multiworld = multiworld
         self.player = player
         self.random = Random(multiworld.random.getrandbits(64))
-        multiworld.per_slot_randoms[player] = self.random
 
     def __getattr__(self, item: str) -> Any:
         if item == "settings":


### PR DESCRIPTION
## What is this fixing or adding?

removes the long deprecated per_slot_randoms and the associated DeprecateDict

## How was this tested?
I looked for all usages across core and found none remaining, except for a comment in yacht dice.
