### PR TITLE
KH2 Make Lucky Emblems behave like bounties and keyblade stats.

### DIFF
--- a/worlds/kh2/__init__.py
+++ b/worlds/kh2/__init__.py
@@ -473,9 +473,10 @@ class KH2World(World):
             logging.info(
                     f"Lucky Emblem Amount {self.options.LuckyEmblemsAmount.value} is less than required "
                     f"{self.options.LuckyEmblemsRequired.value} for player {self.multiworld.get_file_safe_player_name(self.player)}."
-                    f" Setting amount to {self.options.LuckyEmblemsRequired.value}")
-            luckyemblemamount = max(self.lucky_emblem_amount, self.lucky_emblem_required)
-            self.options.LuckyEmblemsAmount.value = luckyemblemamount
+                    f" Swapping {self.options.LuckyEmblemsRequired.value} and {self.options.LuckyEmblemsAmount.value}")
+            temp = self.options.LuckyEmblemsAmount.value
+            self.options.LuckyEmblemsAmount.value = self.options.LuckyEmblemsRequired.value
+            self.options.LuckyEmblemsRequired.value = temp
 
         self.item_quantity_dict[ItemName.LuckyEmblem] = self.options.LuckyEmblemsAmount.value
         # give this proof to unlock the final door once the player has the amount of lucky emblem required


### PR DESCRIPTION
## What is this fixing or adding?
Swap the amount required and available if required is more than available instead of making available equal required

## How was this tested?
Rolled some seeds before and after and read the warning and looked at the spoiler logs.