### PR TITLE
SM64: Change power star item classification to be deprioritized

### DIFF
--- a/worlds/sm64ex/Items.py
+++ b/worlds/sm64ex/Items.py
@@ -12,7 +12,7 @@ class SM64ItemData(NamedTuple):
     classification: ItemClassification = ItemClassification.progression
 
 generic_item_data_table: dict[str, SM64ItemData] = {
-    "Power Star": SM64ItemData(sm64ex_base_id + 0, ItemClassification.progression_skip_balancing),
+    "Power Star": SM64ItemData(sm64ex_base_id + 0, ItemClassification.progression_deprioritized_skip_balancing),
     "Basement Key": SM64ItemData(sm64ex_base_id + 178),
     "Second Floor Key": SM64ItemData(sm64ex_base_id + 179),
     "Progressive Key": SM64ItemData(sm64ex_base_id + 180),


### PR DESCRIPTION
## What is this fixing or adding?
Previously power stars were classified as progression with the skip balancing flag, meaning they are a progression item but not moved around during the balancing phase of generation.
This PR changes stars' classification to add the [deprioritized flag](https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/world%20api.md#items), which removes them from consideration when filling priority locations. Priority locations will be preferentially filled with priority items first, leading to stars being less likely to be in priority locations (unless there's no other priority items left to fill the location).

This was a request from the Discord.

There is a mild risk of increased failure to generate in a multiworld with large numbers of priority locations. It's easy enough to remedy for someone who knows why that's happening, just remove priority locations, reduce star counts, or add more games to the mix. But, it may cause more confusion for users who aren't aware of how the generation algorithm works.

## How was this tested?
Generated a few seeds with just SM64 and peeked at the sphere output with vs without the deprioritized flag enabled.
Prior to the PR I was able to generate all 17 different test seeds (`--seed 2` through `18`) successfully. With the deprioritized flag enabled, 3 of those 17 failed to generate.
I'm not very familiar with Archipelago's fill algorithm but it seems like enabling the deprioritized flag shifts placing stars to late enough in the fill process that all the priority locations are filled with other items (painting unlocks, moves, caps, etc) and breaks logic.

Attached my test yaml below; it adds a significant amount of priority locations (44), removes 1-up blocks and 100-coin stars from the possible locations, and adds painting unlocks as progression items, leading to a mild location crunch.
[LF23_SM64.yaml](https://github.com/user-attachments/files/27561350/LF23_SM64.yaml)

## If this makes graphical changes, please attach screenshots.
No graphical changes.