### PR TITLE
The Messenger: Fix portal shuffle logic not using unlocked portals

### DIFF
--- a/worlds/messenger/portals.py
+++ b/worlds/messenger/portals.py
@@ -7,7 +7,6 @@ from Options import PlandoConnection
 if TYPE_CHECKING:
     from . import MessengerWorld
 
-
 PORTALS: list[str] = [
     "Autumn Hills",
     "Riviere Turquoise",
@@ -16,7 +15,6 @@ PORTALS: list[str] = [
     "Searing Crags",
     "Glacial Peak",
 ]
-
 
 SHOP_POINTS: dict[str, list[str]] = {
     "Autumn Hills": [
@@ -112,7 +110,6 @@ SHOP_POINTS: dict[str, list[str]] = {
     ]
 }
 
-
 CHECKPOINTS: dict[str, list[str]] = {
     "Autumn Hills": [
         "Hope Latch",
@@ -184,7 +181,6 @@ CHECKPOINTS: dict[str, list[str]] = {
         "Moon Crest",
     ]
 }
-
 
 REGION_ORDER: list[str] = [
     "Autumn Hills",
@@ -306,4 +302,4 @@ def add_closed_portal_reqs(world: "MessengerWorld") -> None:
     closed_portals = [entrance for entrance in PORTALS if f"{entrance} Portal" not in world.starting_portals]
     for portal in closed_portals:
         tower_exit = world.multiworld.get_entrance(f"ToTHQ {portal} Portal", world.player)
-        tower_exit.access_rule = lambda state, portal_item=portal: state.has(portal_item, world.player)
+        tower_exit.access_rule = lambda state, portal_item=portal: state.has(f"{portal_item} Portal", world.player)

--- a/worlds/messenger/test/test_portals.py
+++ b/worlds/messenger/test/test_portals.py
@@ -35,3 +35,29 @@ class PortalTestBase(MessengerTestBase):
                         test_state.collect(item)
                     self.assertTrue(entrance.can_reach(test_state), grouping)
                 entrance.access_rule = lambda state: True
+
+
+class PortalUnlockTest(MessengerTestBase):
+    options = {
+        "available_portals": 3,
+    }
+
+    def test_unlocking_portal(self) -> None:
+        """Validate that unlocking the portal event actually unlock the portal in HQ"""
+
+        print(self.world.starting_portals)
+
+        for portal in PORTALS:
+            name = f"{portal} Portal"
+            if name in self.world.starting_portals:
+                continue
+
+            entrance_name = f"ToTHQ {name}"
+            with self.subTest(portal=name, entrance_name=entrance_name):
+                hq_portal = self.multiworld.get_entrance(entrance_name, self.player)
+                test_state = CollectionState(self.multiworld)
+                self.assertFalse(hq_portal.can_reach(test_state), "reachable with nothing")
+
+                event = self.multiworld.get_location(name, self.player)
+                test_state.collect(event.item)
+                self.assertTrue(hq_portal.can_reach(test_state))


### PR DESCRIPTION
## What is this fixing or adding?

This fixes an issue where the closed portals are never actually unlocked by the event, because the item it needs is not named correctly. The event is called `Sunken Shrine Portal`, but the closed portal needed the `Sunken Shrine` item, without the ` Portal` part.

## How was this tested?

Added a test before fixing, checked that it failed, when fixed the bug and checked the test works.

## If this makes graphical changes, please attach screenshots.

N/A