### PR TITLE
BizHawkClient: Fix script compatibility for Lua 5.5+

### DIFF
--- a/data/lua/base64.lua
+++ b/data/lua/base64.lua
@@ -5,11 +5,7 @@ local base64 = {}
 
 local extract = _G.bit32 and _G.bit32.extract -- Lua 5.2/Lua 5.3 in compatibility mode
 if not extract then
-    if _G._VERSION == "Lua 5.4" then
-        extract = load[[return function( v, from, width )
-            return ( v >> from ) & ((1 << width) - 1)
-        end]]()
-    elseif _G.bit then -- LuaJIT
+    if _G.bit then -- LuaJIT
         local shl, shr, band = _G.bit.lshift, _G.bit.rshift, _G.bit.band
         extract = function( v, from, width )
             return band( shr( v, from ), shl( 1, width ) - 1 )
@@ -27,6 +23,10 @@ if not extract then
             end
             return w
         end
+    else -- Lua 5.3+
+        extract = load[[return function( v, from, width )
+            return ( v >> from ) & ((1 << width) - 1)
+        end]]()
     end
 end
 

--- a/data/lua/connector_bizhawk_generic.lua
+++ b/data/lua/connector_bizhawk_generic.lua
@@ -633,8 +633,8 @@ end)
 if bizhawk_major < 2 or (bizhawk_major == 2 and bizhawk_minor < 7) then
     print("Must use BizHawk 2.7.0 or newer")
 else
-    if bizhawk_major > 2 or (bizhawk_major == 2 and bizhawk_minor > 10) then
-        print("Warning: This version of BizHawk is newer than this script. If it doesn't work, consider downgrading to 2.10.")
+    if bizhawk_major > 2 or (bizhawk_major == 2 and bizhawk_minor > 11) then
+        print("Warning: This version of BizHawk is newer than this script. If it doesn't work, consider downgrading to 2.11.")
     end
 
     if emu.getsystemid() == "NULL" then


### PR DESCRIPTION
## What is this fixing or adding?

This is relatively low priority. Reported in https://discord.com/channels/731205301247803413/1491644658495914084.

BizHawk doesn't use Lua 5.5, but the base64 file is used by unofficial scripts for emulators that might pull 5.5 if compiled from source. In any case, the upstream file includes this exact change, and it's inconsequential for our existing supported stuff but future proofs us if BizHawk does update to 5.5. And I don't see them changing bit shift operators in the future.

Also updates the warning message to not trigger on BizHawk 2.11, since plenty of users have been using 2.11 with no issues related to the script itself.

## How was this tested?

User played a seed in mGBA using Lua 5.5.
