### PR TITLE
Core: Implement Choice option hiding

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -80,13 +80,22 @@ class AssembleOptions(abc.ABCMeta):
     def __new__(mcs, name, bases, attrs):
         options = attrs["options"] = {}
         name_lookup = attrs["name_lookup"] = {}
+        options_visibilities = attrs["options_visibilities"] = {}
         # merge parent class options
         for base in bases:
             if getattr(base, "options", None):
                 options.update(base.options)
+                options_visibilities.update(base.options_visibilities)
                 name_lookup.update(base.name_lookup)
         new_options = {name[7:].lower(): option_id for name, option_id in attrs.items() if
                        name.startswith("option_")}
+        for option in new_options.keys():
+            value = new_options[option]
+            if isinstance(value, OptionValue):
+                options_visibilities[value.value] = value.visibility
+                new_options[option] = value.value
+            else:
+                options_visibilities[value] = Visibility.all
 
         assert "random" not in new_options, "Choice option 'random' cannot be manually assigned."
         assert len(new_options) == len(set(new_options.values())), "same ID cannot be used twice. Try alias?"
@@ -155,6 +164,11 @@ class AssembleOptions(abc.ABCMeta):
 T = typing.TypeVar('T')
 
 
+class OptionValue(typing.Generic[T], typing.NamedTuple):
+    value: T
+    visibility: Visibility = Visibility.all
+
+
 class Option(typing.Generic[T], metaclass=AssembleOptions):
     value: T
     default: typing.ClassVar[typing.Any]  # something that __init__ will be able to convert to the correct type
@@ -188,6 +202,7 @@ class Option(typing.Generic[T], metaclass=AssembleOptions):
     name_lookup: typing.ClassVar[typing.Dict[T, str]]  # type: ignore
     # https://github.com/python/typing/discussions/1460 the reason for this type: ignore
     options: typing.ClassVar[typing.Dict[str, int]]
+    options_visibilities: typing.ClassVar[typing.Dict[int, Visibility]]
     aliases: typing.ClassVar[typing.Dict[str, int]]
 
     def __repr__(self) -> str:
@@ -1872,6 +1887,7 @@ def generate_yaml_templates(target_folder: typing.Union[str, "pathlib.Path"], ge
                         cleandoc=cleandoc,
                         preset_name=name,
                         preset=preset,
+                        option_visible=lambda id,option: option.options_visibilities.get(id, Visibility.all) & Visibility.template != 0
                     )
                     preset_name = f" - {name}" if name else ""
                     with open(os.path.join(preset_folder if name else target_folder,

--- a/Options.py
+++ b/Options.py
@@ -1864,6 +1864,9 @@ def generate_yaml_templates(target_folder: typing.Union[str, "pathlib.Path"], ge
     def yaml_dump_scalar(scalar) -> str:
         # yaml dump may add end of document marker and newlines.
         return yaml.dump(scalar).replace("...\n", "").strip()
+    
+    def visible(id: int, option: type[Option[typing.Any]]) -> bool:
+        return option.options_visibilities.get(id, Visibility.all) & Visibility.template != 0
 
     with open(local_path("data", "options.yaml")) as f:
         file_data = f.read()
@@ -1887,7 +1890,7 @@ def generate_yaml_templates(target_folder: typing.Union[str, "pathlib.Path"], ge
                         cleandoc=cleandoc,
                         preset_name=name,
                         preset=preset,
-                        option_visible=lambda id,option: option.options_visibilities.get(id, Visibility.all) & Visibility.template != 0
+                        option_visible=visible
                     )
                     preset_name = f" - {name}" if name else ""
                     with open(os.path.join(preset_folder if name else target_folder,

--- a/Options.py
+++ b/Options.py
@@ -80,7 +80,7 @@ class AssembleOptions(abc.ABCMeta):
     def __new__(mcs, name, bases, attrs):
         options = attrs["options"] = {}
         name_lookup = attrs["name_lookup"] = {}
-        options_visibilities = attrs["options_visibilities"] = {}
+        options_visibilities = attrs["options_visibilities"] if "options_visibilities" in attrs else {}
         # merge parent class options
         for base in bases:
             if getattr(base, "options", None):
@@ -91,12 +91,10 @@ class AssembleOptions(abc.ABCMeta):
                        name.startswith("option_")}
         for option in new_options.keys():
             value = new_options[option]
-            if isinstance(value, OptionValue):
-                options_visibilities[value.value] = value.visibility
-                new_options[option] = value.value
-            else:
+            if value not in options_visibilities.keys():
                 options_visibilities[value] = Visibility.all
-
+        attrs["options_visibilities"] = options_visibilities
+        
         assert "random" not in new_options, "Choice option 'random' cannot be manually assigned."
         assert len(new_options) == len(set(new_options.values())), "same ID cannot be used twice. Try alias?"
 
@@ -162,11 +160,6 @@ class AssembleOptions(abc.ABCMeta):
 
 
 T = typing.TypeVar('T')
-
-
-class OptionValue(typing.Generic[T], typing.NamedTuple):
-    value: T
-    visibility: Visibility = Visibility.all
 
 
 class Option(typing.Generic[T], metaclass=AssembleOptions):

--- a/OptionsCreator.py
+++ b/OptionsCreator.py
@@ -413,7 +413,7 @@ class OptionsCreator(ThemedApp):
                 "text": option.get_option_name(choice),
                 "on_release": lambda val=choice: set_value(option.get_option_name(val), option.name_lookup[val])
             }
-            for choice in option.name_lookup
+            for choice in option.name_lookup if option.options_visibilities[choice] & Visibility.simple_ui
         ]
         dropdown = MDDropdownMenu(caller=main_button, items=items)
         self.options[name] = option.name_lookup[option.default] if not default_string else option.default

--- a/WebHostLib/options.py
+++ b/WebHostLib/options.py
@@ -42,6 +42,7 @@ def render_options_page(template: str, world_name: str, is_complex: bool = False
         issubclass=issubclass,
         Options=Options,
         theme=get_world_theme(world_name),
+        option_visible=lambda id,option: option.options_visibilities.get(id, Options.Visibility.all) & visibility_flag != 0
     )
 
 

--- a/WebHostLib/options.py
+++ b/WebHostLib/options.py
@@ -2,7 +2,7 @@ import collections.abc
 import json
 import os
 from textwrap import dedent
-from typing import Dict, Union
+from typing import Dict, Union, Any
 from docutils.core import publish_parts
 
 import yaml
@@ -29,6 +29,9 @@ def render_options_page(template: str, world_name: str, is_complex: bool = False
         return redirect("games")
     visibility_flag = Options.Visibility.complex_ui if is_complex else Options.Visibility.simple_ui
 
+    def visible(id: int, option: type[Options.Option[Any]]) -> bool:
+        return option.options_visibilities.get(id, Options.Visibility.all) & visibility_flag != 0
+
     start_collapsed = {"Game Options": False}
     for group in world.web.option_groups:
         start_collapsed[group.name] = group.start_collapsed
@@ -42,7 +45,7 @@ def render_options_page(template: str, world_name: str, is_complex: bool = False
         issubclass=issubclass,
         Options=Options,
         theme=get_world_theme(world_name),
-        option_visible=lambda id,option: option.options_visibilities.get(id, Options.Visibility.all) & visibility_flag != 0
+        option_visible=visible
     )
 
 

--- a/WebHostLib/templates/playerOptions/macros.html
+++ b/WebHostLib/templates/playerOptions/macros.html
@@ -21,8 +21,8 @@
             {% for id, name in option.name_lookup.items() %}
                 {% if name != "random" %}
                     {% if option.default == id %}
-                        <option value="{{ name }}" selected>{{ option.get_option_name(id) }}</option>
-                    {% else %}
+                        <option value="{{ name }}" selected {{ "hidden" if not option_visible(id, option) and option.value != id }}>{{ option.get_option_name(id) }}</option>
+                    {% elif option_visible(id, option) %}
                         <option value="{{ name }}">{{ option.get_option_name(id) }}</option>
                     {% endif %}
                 {% endif %}
@@ -100,11 +100,11 @@
             {% if option.default not in option.options.values()  %}
                 <option value="{{ option.default }}" selected>Default ({{ option.default }})</option>
             {% endif %}
-            {% for id, name in option.name_lookup.items()|sort %}
+            {% for id, name in option.name_lookup.items() %}
                 {% if name != "random" %}
                     {% if option.default == id %}
-                        <option value="{{ name }}" selected>{{ option.get_option_name(id) }}</option>
-                    {% else %}
+                        <option value="{{ name }}" selected {{ "hidden" if not option_visible(id, option) and option.value != id }}>{{ option.get_option_name(id) }}</option>
+                    {% elif option_visible(id, option) %}
                         <option value="{{ name }}">{{ option.get_option_name(id) }}</option>
                     {% endif %}
                 {% endif %}

--- a/WebHostLib/templates/weightedOptions/macros.html
+++ b/WebHostLib/templates/weightedOptions/macros.html
@@ -17,7 +17,7 @@
     <table>
         <tbody>
             {% for id, name in option.name_lookup.items() %}
-                {% if name != 'random' %}
+                {% if name != 'random' and option_visible(id, option) %}
                     {% if option.default != 'random' %}
                         {{ RangeRow(option_name, option, option.get_option_name(id), name, False, name if option.default == id else None) }}
                     {% else %}
@@ -95,7 +95,7 @@
     <table class="range-rows" data-option="{{ option_name }}">
         <tbody>
             {% for id, name in option.name_lookup.items() %}
-                {% if name != 'random' %}
+                {% if name != 'random' and (option.default == id or option_visible(id, option)) %}
                     {% if option.default != 'random' %}
                         {{ RangeRow(option_name, option, option.get_option_name(id), name, False, name if option.default == id else None) }}
                     {% else %}

--- a/WebHostLib/templates/weightedOptions/weightedOptions.html
+++ b/WebHostLib/templates/weightedOptions/weightedOptions.html
@@ -1,5 +1,5 @@
 {% extends 'pageWrapper.html' %}
-{% import 'weightedOptions/macros.html' as inputs %}
+{% import 'weightedOptions/macros.html' as inputs with context %}
 
 {% block head %}
     <title>{{ world_name }} Weighted Options</title>

--- a/data/options.yaml
+++ b/data/options.yaml
@@ -76,8 +76,8 @@ requires:
     {{- range_option(option, option_val) -}}
 
     {%- elif option.options -%}
-    {%- for suboption_option_id, sub_option_name in option.name_lookup.items() %}
-    {{ yaml_dump(sub_option_name) }}: {% if suboption_option_id == option_val or sub_option_name == option_val %}50{% else %}0{% endif %}
+    {%- for suboption_option_id, sub_option_name in option.name_lookup.items() %}{% if option_visible(suboption_option_id, option) or suboption_option_id == option_val or sub_option_name == option_val %}
+    {{ yaml_dump(sub_option_name) }}: {% if suboption_option_id == option_val or sub_option_name == option_val %}50{% else %}0{% endif %}{% endif %}
     {%- endfor -%}
   
     {%- if option.name_lookup[option_val] not in option.options and option_val not in option.options %}

--- a/docs/options api.md
+++ b/docs/options api.md
@@ -139,9 +139,9 @@ options in a yaml. The flags are as follows:
 * `complex_ui` (`0b0100`): This option shows up on the advanced/weighted options page
 * `spoiler` (`0b1000`): This option shows up in spoiler logs
   
-Additionally Choice options can use the `OptionValue` class to hide specific options. Choices hidden this way 
+Additionally Choice options can use the `options_visibilities` dictionary to hide specific options. Choices hidden this way 
 are still valid choices in the yaml. Note that `spoiler` is not used for choices. If a hidden option is set as 
-the default value it will always be shown in the advanced/weighted options page to allow modifying its weight 
+the default value it will always be shown in the advanced/weighted options page and template to allow modifying its weight 
 from the default.
 
 ```python
@@ -155,8 +155,10 @@ class Difficulty(Choice):
     display_name = "Difficulty"
     option_easy = 0
     option_normal = 1
-    option_hard = OptionValue(2, visibility=Visibility.template|Visibility.complex_ui) # only show this to advanced users
+    option_hard = 2
     default = 1
+
+    options_visibilities = {option_hard: Visibility.template|Visibility.complex_ui}
 ```
 
 ### Option Groups

--- a/docs/options api.md
+++ b/docs/options api.md
@@ -138,12 +138,25 @@ options in a yaml. The flags are as follows:
 * `simple_ui` (`0b0010`): This option shows up on the options page
 * `complex_ui` (`0b0100`): This option shows up on the advanced/weighted options page
 * `spoiler` (`0b1000`): This option shows up in spoiler logs
+  
+Additionally Choice options can use the `OptionValue` class to hide specific options. Choices hidden this way 
+are still valid choices in the yaml. Note that `spoiler` is not used for choices. If a hidden option is set as 
+the default value it will always be shown in the advanced/weighted options page to allow modifying its weight 
+from the default.
 
 ```python
-from Options import Choice, Visibility
+from Options import Choice, Visibility, OptionValue
 
 class HiddenChoiceOption(Choice):
     visibility = Visibility.none
+
+class Difficulty(Choice):
+    """Sets overall game difficulty."""
+    display_name = "Difficulty"
+    option_easy = 0
+    option_normal = 1
+    option_hard = OptionValue(2, visibility=Visibility.template|Visibility.complex_ui) # only show this to advanced users
+    default = 1
 ```
 
 ### Option Groups


### PR DESCRIPTION
## What is this fixing or adding?
Adds the ability to hide specific choices in options, by introducing a new class wrapping the value with a Visibility flag. The initial motivation for this were long text choice lists that would clutter the template yaml.
Additionally, a fatal error on the WebHost was fixed when a TextChoice contains int and str options causing it to attempt to compare int and str values with the `>` operator via `sorted`.
Limitations:
- If an option has been hidden but is set as default, it has to ignore being hidden in the weighted option page as it either isn't available at all, or has to be set to the default weight, implicitly changing the default when using the weighted option page. Similarly the choice also has to appear in the template and at least initially in the options page and the Options Creator. Notably the WebHost and the Options Creator show different behaviour here even without these changes, which should be covered in another PR.
- ~~Hiding an option is a breaking change if `Option.option_<option_name>` is used anywhere as it has to be changed to `Option.option_<option_name>.value`~~ addressed by https://github.com/ArchipelagoMW/Archipelago/pull/6208/commits/f675e1510fca1818c27929042432f02d1b13ffa0
Theoretically this system can be expanded to handle other types of options, however for most of them it wouldn't make sense (why hide one of the options of a toggle, at that point it can be hidden entirely). This may be revisited for Option containers (`OptionDict`, `OptionList`, `OptionSet`).
- `Visibility.spoiler` is ignored completely as it seems strange to hide an option only if a specific choice is selected

## How was this tested?
Multiple tests have been ran with `Accessibility.option_minimal` hidden in different configurations and without hiding it to confirm default behaviour stayed intact. Furthermore The `BossShuffle` of Kirby's Dream Land 3 has been modified to contain a hidden str option as default to test TextChoice specific behaviour on all UIs. In all cases seeds have been generated successfully, and apart from the WebHost error no other issues have been observed using any of the option generators.

## If this makes graphical changes, please attach screenshots.
<img width="504" height="211" alt="Screenshot 2026-05-16 230752" src="https://github.com/user-attachments/assets/6a707a9d-9fa4-47f5-8f75-6710b5bd5c3c" />
<img width="650" height="205" alt="Screenshot 2026-05-16 230831" src="https://github.com/user-attachments/assets/7ab3e171-ce0d-4cae-a84d-33b040604468" />
<img width="492" height="147" alt="Screenshot 2026-05-17 011344" src="https://github.com/user-attachments/assets/af9bb96c-1881-46f2-8130-1399657239ba" />
