### PR TITLE
KH2 Prevent the client from crashing if the player duplicated items.

### DIFF
--- a/worlds/kh2/ClientStuff/RecieveItems.py
+++ b/worlds/kh2/ClientStuff/RecieveItems.py
@@ -314,7 +314,7 @@ async def verifyItems(self):
                         amount_found_in_slots += 1
             if item_name in self.kh2_seed_save["SoldEquipment"]:
                 amount_found_in_slots += self.kh2_seed_save["SoldEquipment"][item_name]
-            inInventory = self.kh2_seed_save_cache["AmountInvo"]["Equipment"][item_name] - amount_found_in_slots
+            inInventory = max(self.kh2_seed_save_cache["AmountInvo"]["Equipment"][item_name] - amount_found_in_slots, 0)
             if inInventory != self.kh2_read_byte(self.Save + item_data.memaddr):
                 self.kh2_write_byte(self.Save + item_data.memaddr, inInventory)
 


### PR DESCRIPTION
## What is this fixing or adding?
The KH2 Client used to let you duplicate armor and accessories by equipping them to party members but then Jared fixed it without preventing the number to fall below 0 causing a cant convert negative int to unsigned error. This makes the min 0 to prevent this error. This will allow any previous duplicated items to stay duplicated until they are unequipped from the party members but the items being on the party members hardly matters anyways and its only relevant if updating and continuing to play an old seed on the newer clients.

## How was this tested?
Made a room did !getitem ribbon, closed the client, used cheat engine to give myself more than 1 ribbon, put them on sora donald and goofy, connected to the client and saw the error.
updated the 1 line reconnected the error did not happen and when i unequipped the ribbons the were deleted until i went down to the 1 ribbon i was supposed to have.