### PR TITLE
Core: reset log level when using pyximport

### DIFF
--- a/NetUtils.py
+++ b/NetUtils.py
@@ -527,7 +527,11 @@ else:
         except ImportError:
             pyximport = None
         try:
+            import logging
+            logger = logging.getLogger()
+            old_level = logger.level
             from _speedups import LocationStore
+            logger.setLevel(old_level)
         except ImportError:
             warnings.warn("_speedups not available. Falling back to pure python LocationStore. "
                           "Install a matching C++ compiler for your platform to compile _speedups.")


### PR DESCRIPTION
## What is this fixing or adding?
running through this codepath sets base logger level to Warning, this keeps it as intended for the rest of the code regardless of if we need pyximport or not

## How was this tested?
delete the speedups.so file, run `python Launcher.py "Text Client" -- --nogui`
without this change it resets the log level and does not display the log like `/help` responses
with this change it stays as expected and displays text as expected

also tested with the .so file in place and saw no new issues arise

## If this makes graphical changes, please attach screenshots.
