### PR TITLE
Stardew Valley: Fixed Artifact spot logic

### DIFF
--- a/worlds/stardew_valley/logic/money_logic.py
+++ b/worlds/stardew_valley/logic/money_logic.py
@@ -14,6 +14,7 @@ from ..strings.currency_names import Currency, MemeCurrency
 from ..strings.food_names import Beverage
 from ..strings.region_names import Region, LogicRegion
 from ..strings.season_names import Season
+from ..strings.tool_names import Tool, ToolMaterial
 
 qi_gem_rewards = ("100 Qi Gems", "50 Qi Gems", "40 Qi Gems", "35 Qi Gems", "25 Qi Gems",
                   "20 Qi Gems", "15 Qi Gems", "10 Qi Gems")
@@ -45,8 +46,8 @@ class MoneyLogic(BaseLogic):
         shipping_rule = self.logic.shipping.can_use_shipping_bin
         pierre_rule = self.logic.region.can_reach_all(Region.pierre_store, Region.forest)
         willy_rule = self.logic.region.can_reach_all(Region.fish_shop, LogicRegion.fishing)
-        clint_rule = self.logic.region.can_reach_all(Region.blacksmith, Region.mines_floor_5)
-        robin_rule = self.logic.region.can_reach_all(Region.carpenter, Region.secret_woods)
+        clint_rule = self.logic.region.can_reach_all(Region.blacksmith, Region.mines_floor_5) & self.logic.tool.has_tool(Tool.pickaxe)
+        robin_rule = self.logic.region.can_reach_all(Region.carpenter, Region.secret_woods) & self.logic.tool.has_tool(Tool.axe, ToolMaterial.copper)
         farming_rule = self.logic.farming.can_plant_and_grow_item(Season.not_winter)
 
         if amount <= 2000:

--- a/worlds/stardew_valley/logic/museum_logic.py
+++ b/worlds/stardew_valley/logic/museum_logic.py
@@ -31,7 +31,9 @@ class MuseumLogic(BaseLogic):
         if item.artifact_spot_locations:
             number_locations = len(item.artifact_spot_locations)
             number_required_locations = math.ceil(number_locations / 2)
-            artifact_spot_rule = self.logic.count(number_required_locations, *[self.logic.tool.can_use_tool_at(Tool.hoe, ToolMaterial.basic, spot) for spot in item.artifact_spot_locations])
+            artifact_spot_rule = self.logic.tool.has_tool(Tool.hoe) & self.logic.count(number_required_locations, *[self.logic.region.can_reach(spot) for spot in item.artifact_spot_locations])
+            if Region.dig_site in item.artifact_spot_locations:
+                artifact_spot_rule = artifact_spot_rule & self.logic.tool.has_tool(Tool.pickaxe)
         else:
             artifact_spot_rule = False_()
         if item.geodes:

--- a/worlds/stardew_valley/rules.py
+++ b/worlds/stardew_valley/rules.py
@@ -323,7 +323,10 @@ def set_bookseller_rules(logic, rule_collector):
 
 
 def set_raccoon_rules(logic: StardewLogic, rule_collector: StardewRuleCollector, bundle_rooms: List[BundleRoom], world_options: StardewValleyOptions):
-    rule_collector.set_entrance_rule(LogicEntrance.has_giant_stump, logic.received(CommunityUpgrade.raccoon))
+    if world_options.quest_locations.has_story_quests():
+        rule_collector.set_entrance_rule(LogicEntrance.has_giant_stump, logic.received(CommunityUpgrade.raccoon, 2))
+    else:
+        rule_collector.set_entrance_rule(LogicEntrance.has_giant_stump, logic.quest.can_complete_quest(Quest.giant_stump))
     rule_collector.set_entrance_rule(LogicEntrance.buy_from_raccoon_1, logic.quest.has_raccoon_shop())
     rule_collector.set_entrance_rule(LogicEntrance.buy_from_raccoon_2, logic.quest.has_raccoon_shop(2))
     rule_collector.set_entrance_rule(LogicEntrance.buy_from_raccoon_3, logic.quest.has_raccoon_shop(3))


### PR DESCRIPTION
## What is this fixing or adding?
Three small logic errors
- Dig Site Artifacts must be gathered with a pickaxe, not a hoe
- When quests are not shuffled, you need to do the giant stump quest to access the raccoon bundles
- When selling things to vendor during the low-money phase, you need tools to gather said things

## How was this tested?
Unit tests
