### PR TITLE
WebHost: fix Authors on supported game page

### DIFF
--- a/WebHostLib/static/styles/supportedGames.css
+++ b/WebHostLib/static/styles/supportedGames.css
@@ -42,3 +42,7 @@
 #games .page-controls button{
     margin-left: 0.5rem;
 }
+
+#games .author-label{
+    margin-top: 0.5rem;
+}

--- a/WebHostLib/templates/supportedGames.html
+++ b/WebHostLib/templates/supportedGames.html
@@ -50,7 +50,11 @@
             <summary class="h2">{{ game_name }}</summary>
             {{ world.__doc__ | default("No description provided.", true) }}<br />
             {% if "authors" in world.manifest %}
+            {% if world.manifest["authors"]|length == 1 %}
+            <p style="margin-top: 0.5em;">Author: {{ world.manifest["authors"][0] }}</p>
+            {% else %}
             <p style="margin-top: 0.5em;">Authors: {{ world.manifest["authors"] | join(", ") }}</p>
+            {% endif %}
             {% endif %}
             <a href="{{ url_for("game_info", game=game_name, lang="en") }}">Game Page</a>
             {% if world.web.tutorials %}

--- a/WebHostLib/templates/supportedGames.html
+++ b/WebHostLib/templates/supportedGames.html
@@ -51,9 +51,9 @@
             {{ world.__doc__ | default("No description provided.", true) }}<br />
             {% if "authors" in world.manifest %}
             {% if world.manifest["authors"]|length == 1 %}
-            <p style="margin-top: 0.5em;">Author: {{ world.manifest["authors"][0] }}</p>
+            <p class="author-label">Author: {{ world.manifest["authors"][0] }}</p>
             {% else %}
-            <p style="margin-top: 0.5em;">Authors: {{ world.manifest["authors"] | join(", ") }}</p>
+            <p class="author-label">Authors: {{ world.manifest["authors"] | join(", ") }}</p>
             {% endif %}
             {% endif %}
             <a href="{{ url_for("game_info", game=game_name, lang="en") }}">Game Page</a>

--- a/WebHostLib/templates/supportedGames.html
+++ b/WebHostLib/templates/supportedGames.html
@@ -49,6 +49,9 @@
         <details data-game="{{ game_name }}">
             <summary class="h2">{{ game_name }}</summary>
             {{ world.__doc__ | default("No description provided.", true) }}<br />
+            {% if "authors" in world.manifest %}
+            <p style="margin-top: 0.5em;">Authors: {{ world.manifest["authors"] | join(", ") }}</p>
+            {% endif %}
             <a href="{{ url_for("game_info", game=game_name, lang="en") }}">Game Page</a>
             {% if world.web.tutorials %}
             <span class="link-spacer">|</span>
@@ -68,9 +71,6 @@
             <a href="{{ world.web.bug_report_page }}">Report a Bug</a>
             {% endif %}
         </details>
-        {% if "authors" in world.manifest %}
-        <p>Authors: {{ world.manifest["authors"] | join(", ") }}</p>
-        {% endif %}
         {% endfor %}
     </div>
 {% endblock %}


### PR DESCRIPTION
## What is this fixing or adding?
Authors were not being hidden when a game was hidden by searching, breaking supported games searches.
I moved them into the `<details>` of the game, positioning them just below the description / above the links, with a margin between them and the description of 0.5em.

## How was this tested?
Ran webhost locally.
- Searching properly hides the authors of searched games.
- Authors looks readable, has legible spacing between the authors `<p>` and the description.

## If this makes graphical changes, please attach screenshots.
BEFORE: 
<img width="860" height="483" alt="image" src="https://github.com/user-attachments/assets/237cb5c4-6e16-46cd-9d64-26f6918ff473" />
AFTER:
<img width="921" height="314" alt="image" src="https://github.com/user-attachments/assets/18336518-b9ce-423f-b350-9cb3ed83aa3b" />
<img width="840" height="415" alt="image" src="https://github.com/user-attachments/assets/38fdb350-e404-4641-9cfe-c6d2b6e6d002" />

EDIT: Made `Author` singular for 1-author games, per suggestion
<img width="865" height="444" alt="image" src="https://github.com/user-attachments/assets/5e9bd852-cb8c-439e-b67a-b3d69c8cc952" />
