### PR TITLE
MultiServer: Update hint_points when hint cost or check points is changed

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2541,7 +2541,14 @@ class ServerCommandProcessor(CommonCommandProcessor):
         if option_name in {"release_mode", "remaining_mode", "collect_mode"}:
             self.ctx.broadcast_all([{"cmd": "RoomUpdate", 'permissions': get_permissions(self.ctx)}])
         elif option_name in {"hint_cost", "location_check_points"}:
-            self.ctx.broadcast_all([{"cmd": "RoomUpdate", option_name: getattr(self.ctx, option_name)}])
+            # Update hint point amounts per slot
+            for team, players in self.ctx.clients.items():
+                for slot, clients in players.items():
+                    self.ctx.broadcast(clients, [{
+                        "cmd": "RoomUpdate",
+                        option_name: getattr(self.ctx, option_name),
+                        "hint_points": get_slot_points(self.ctx, team, slot),
+                    }])
         return True
 
     def _cmd_datastore(self):


### PR DESCRIPTION
## What is this fixing or adding?
Prior, the `hint_points` value in CommonClient (and possibly other clients relying on just server value) goes out of sync when `hint_cost` or `location_check_points` changes as this changes the point calculation, but the `RoomUpdate` does not send the new amount of points out. This changes the update to include that as well.

## How was this tested?
Running server locally and changing these with `/option` while text client was connected. I verified that hint points was updating properly in the server label now, and that hint cost was still updating properly as before.

## If this makes graphical changes, please attach screenshots.
👈👉