### PR TITLE
factorio: make energylink bridge recipe actually random

### DIFF
--- a/worlds/factorio/__init__.py
+++ b/worlds/factorio/__init__.py
@@ -559,11 +559,13 @@ class Factorio(World):
                     ingredients_offset=ingredients_offset.value)
                 self.custom_recipes["satellite"] = new_recipe
         bridge = "ap-energy-bridge"
+        bridge_pool = sorted(science_pack_pools[self.options.max_science_pack.get_ordered_science_packs()[0]])
+        self.random.shuffle(bridge_pool)
         new_recipe = self.make_quick_recipe(
             Recipe(bridge, "crafting", {"replace_1": 1, "replace_2": 1, "replace_3": 1,
                                         "replace_4": 1, "replace_5": 1, "replace_6": 1},
                    {bridge: 1}, 10),
-            sorted(science_pack_pools[self.options.max_science_pack.get_ordered_science_packs()[0]]),
+            bridge_pool,
             ingredients_offset=ingredients_offset.value)
         for ingredient_name in new_recipe.ingredients:
             new_recipe.ingredients[ingredient_name] = self.random.randint(50, 500)


### PR DESCRIPTION
## What is this fixing or adding?
Factorio EnergyLink bridge recipe isn't actually picking random ingredients currently, it always uses the alphabetically-last N ingredients from the red science pool, so the recipe is always iron-ore, iron-plate, pipe, stone, stone-brick, transport-belt (plus adjustments for ingredient offset)

`make_quick_recipe` expects the pool to already be shuffled, and just takes the last N items; shuffling the pool before passing it in ensures a random recipe is chosen.

## How was this tested?
Generated several test seeds and observed resulting recipe.
Before the change: always iron-ore, iron-plate, pipe, stone, stone-brick, transport-belt
After the change: random, e.g.:
- electronic-circuit, iron-gear-wheel, iron-ore, pipe, stone-brick, transport-belt
- burner-inserter, coal, copper-cable, copper-ore, iron-plate, stone-brick
- coal, electronic-circuit, iron-ore, iron-plate, pipe, stone

## If this makes graphical changes, please attach screenshots.
n/a