### PR TITLE
Bugfix: OptionsCreator loading 1 instead of a 0 for OptionChoice

### DIFF
--- a/OptionsCreator.py
+++ b/OptionsCreator.py
@@ -207,7 +207,7 @@ class VisualListSetCounter(MDDialog):
     def add_set_item(self, key: str, value: int | None = None):
         text = MDListItemSupportingText(text=key, id="value")
         if issubclass(self.option, OptionCounter):
-            value_txt = CounterItemValue(text=str(value) if value else "1")
+            value_txt = CounterItemValue(text=str(value) if value is not None else "1")
             item = MDListItem(text,
                               value_txt,
                               MDIconButton(icon="minus", on_release=self.remove_item), focus_behavior=False)


### PR DESCRIPTION


## What is this fixing or adding?
Fixing the following bug: When the default value of an OptionCounter is set to 0 and then opened in the options creator it is rewritten in the popup window to 1.

Caused by value being 0 which is falsy. 

Discussion link : https://discord.com/channels/731205301247803413/1214608557077700720/1507565354250010694

## How was this tested?
Tested locally, fixes the bug. 

## If this makes graphical changes, please attach screenshots.
