### PR TITLE
Docs: Add caveat about init files in subfolders

### DIFF
--- a/docs/apworld specification.md
+++ b/docs/apworld specification.md
@@ -108,3 +108,5 @@ Imports from other files inside the APWorld have to use relative imports. e.g. `
 
 Imports from AP base have to use absolute imports, e.g. `from Options import Toggle` or
 `from worlds.AutoWorld import World`
+
+Any imported subfolders inside the APWorld must contain an `__init__.py`. This file can be empty.


### PR DESCRIPTION
## What is this fixing or adding?

Adds an extra caveat to add `__init__.py` files to modules

## How was this tested?

I read it

## If this makes graphical changes, please attach screenshots.

it's docs