### PR TITLE
WebHost: Fix authors display when searching on games page

### DIFF
--- a/WebHostLib/templates/supportedGames.html
+++ b/WebHostLib/templates/supportedGames.html
@@ -47,7 +47,13 @@
         {% for game_name in worlds | title_sorted %}
         {% set world = worlds[game_name] %}
         <details data-game="{{ game_name }}">
-            <summary class="h2">{{ game_name }}</summary>
+            <summary class="h2">
+                {{ game_name }}
+                {% if "authors" in world.manifest %}
+                <h5>Author{% if world.manifest["authors"] | length != 1%}s{% endif %}: 
+                    {{ world.manifest["authors"] | join(", ") }}</h5>
+                {% endif %}
+            </summary>
             {{ world.__doc__ | default("No description provided.", true) }}<br />
             <a href="{{ url_for("game_info", game=game_name, lang="en") }}">Game Page</a>
             {% if world.web.tutorials %}
@@ -68,9 +74,6 @@
             <a href="{{ world.web.bug_report_page }}">Report a Bug</a>
             {% endif %}
         </details>
-        {% if "authors" in world.manifest %}
-        <p>Authors: {{ world.manifest["authors"] | join(", ") }}</p>
-        {% endif %}
         {% endfor %}
     </div>
 {% endblock %}


### PR DESCRIPTION
## What is this fixing or adding?
Alternative to #6218 that keeps the authors visible at all times by putting them in the summary block (and restyling from h2). This keeps it working without JS and also doesn't have to do weird CSS stuff. Possible disadvantage is that it might be weird for clicking on the game name to also expand/collapse.

Also I felt like it made sense to just label it "authors", but I added the singular since I guess others wanted that.

## How was this tested?
Searching on local webhost, and then also expanding stuff with JS disabled just to make sure.

## If this makes graphical changes, please attach screenshots.
<img width="380" height="238" alt="image" src="https://github.com/user-attachments/assets/88662ddb-fedb-437a-b808-1225fbb691ac" />
<img width="767" height="393" alt="image" src="https://github.com/user-attachments/assets/0f47db3b-888f-4e54-ace2-e3c0c1cda067" />
