### PR TITLE
alttp: fix instant option of menu_speed setting being a list

### DIFF
--- a/worlds/alttp/Options.py
+++ b/worlds/alttp/Options.py
@@ -668,7 +668,7 @@ class MenuSpeed(Choice):
     """How quickly the menu appears/disappears"""
     display_name = "Menu Speed"
     option_normal = 0
-    option_instant = 1,
+    option_instant = 1
     option_double = 2
     option_triple = 3
     option_quadruple = 4


### PR DESCRIPTION
## What is this fixing or adding?
fixes #6229 

## How was this tested?
not yet at all, but seems like a tiny change

## If this makes graphical changes, please attach screenshots.
N/A