### PR TITLE
Core: Allow multiple games per APWorld

### DIFF
--- a/docs/apworld specification.md
+++ b/docs/apworld specification.md
@@ -94,7 +94,7 @@ For multi-game world folders, the manifest may instead look like this:
 {
     "game": ["Game A", "Game B"],
     "world_version": "1.0.0",
-    "authors": ["Example Author"]
+    "authors": ["NewSoupVi"]
 }
 ```
 
@@ -104,7 +104,7 @@ and it will be packaged into an `.apworld` manifest that also includes the conta
 {
     "game": ["Game A", "Game B"],
     "world_version": "1.0.0",
-    "authors": ["Example Author"],
+    "authors": ["NewSoupVi"],
     "version": 7,
     "compatible_version": 7
 }

--- a/docs/apworld specification.md
+++ b/docs/apworld specification.md
@@ -22,10 +22,16 @@ otherwise they raise a bogus Exception when trying to import in frozen python 3.
 
 Metadata about the APWorld is defined in an `archipelago.json` file.
 
-If the APWorld is a folder, the only required field is "game":
+If the APWorld is a folder, it must define either a single `"game"` or a `"games"` list:
 ```json
 {
   "game": "Game Name"
+}
+```
+
+```json
+{
+  "games": ["Game A", "Game B"]
 }
 ```
 
@@ -80,6 +86,28 @@ will be packaged into an `.apworld` with a manifest file inside of it that looks
 ```
 
 This is the recommended workflow for packaging your world to an `.apworld`.
+
+For multi-game world folders, the manifest may instead look like this:
+
+```json
+{
+    "games": ["Game A", "Game B"],
+    "world_version": "1.0.0",
+    "authors": ["Example Author"]
+}
+```
+
+and it will be packaged into an `.apworld` manifest that also includes the container metadata:
+
+```json
+{
+    "games": ["Game A", "Game B"],
+    "world_version": "1.0.0",
+    "authors": ["Example Author"],
+    "version": 7,
+    "compatible_version": 7
+}
+```
 
 ### .apignore Exclusions
 

--- a/docs/apworld specification.md
+++ b/docs/apworld specification.md
@@ -22,16 +22,17 @@ otherwise they raise a bogus Exception when trying to import in frozen python 3.
 
 Metadata about the APWorld is defined in an `archipelago.json` file.
 
-If the APWorld is a folder, it must define either a single `"game"` or a `"games"` list:
+If the APWorld is a folder, it must define `"game"`. For a single-game world, that value is a string:
 ```json
 {
   "game": "Game Name"
 }
 ```
 
+For a multi-game world folder, `"game"` is a list of strings:
 ```json
 {
-  "games": ["Game A", "Game B"]
+  "game": ["Game A", "Game B"]
 }
 ```
 
@@ -91,7 +92,7 @@ For multi-game world folders, the manifest may instead look like this:
 
 ```json
 {
-    "games": ["Game A", "Game B"],
+    "game": ["Game A", "Game B"],
     "world_version": "1.0.0",
     "authors": ["Example Author"]
 }
@@ -101,7 +102,7 @@ and it will be packaged into an `.apworld` manifest that also includes the conta
 
 ```json
 {
-    "games": ["Game A", "Game B"],
+    "game": ["Game A", "Game B"],
     "world_version": "1.0.0",
     "authors": ["Example Author"],
     "version": 7,

--- a/setup.py
+++ b/setup.py
@@ -379,22 +379,25 @@ class BuildExeCommand(cx_Freeze.command.build_exe.build_exe):
         os.makedirs(self.buildfolder / "Players" / "Templates", exist_ok=True)
         from Options import generate_yaml_templates
         from worlds.AutoWorld import AutoWorldRegister
-        from worlds.Files import APWorldContainer, get_apworld_manifest_games
+        from worlds.Files import APWorldContainer
         assert not non_apworlds - set(AutoWorldRegister.world_types), \
             f"Unknown world {non_apworlds - set(AutoWorldRegister.world_types)} designated for .apworld"
         folders_to_remove: list[str] = []
         generate_yaml_templates(self.buildfolder / "Players" / "Templates", False)
-        grouped_worlds: dict[str, list[tuple[str, object]]] = {}
+        grouped_worlds = set()
         for worldname, worldtype in AutoWorldRegister.world_types.items():
-            file_name = os.path.split(os.path.dirname(worldtype.__file__))[1]
-            grouped_worlds.setdefault(file_name, []).append((worldname, worldtype))
-
-        for file_name, grouped_types in grouped_worlds.items():
-            package_games = sorted(worldname for worldname, _ in grouped_types)
-            included_games = [worldname for worldname in package_games if worldname not in non_apworlds]
-            if not included_games:
+            if worldname in non_apworlds:
                 continue
-            assert len(included_games) == len(package_games), (
+            file_name = os.path.split(os.path.dirname(worldtype.__file__))[1]
+            if file_name in grouped_worlds:
+                continue
+            grouped_worlds.add(file_name)
+            package_games = sorted(
+                other_name
+                for other_name, other_type in AutoWorldRegister.world_types.items()
+                if os.path.split(os.path.dirname(other_type.__file__))[1] == file_name
+            )
+            assert not any(game in non_apworlds for game in package_games), (
                 f"World folder {file_name} mixes apworld and non-apworld games, which is not supported: "
                 f"{', '.join(package_games)}"
             )
@@ -403,19 +406,16 @@ class BuildExeCommand(cx_Freeze.command.build_exe.build_exe):
             if os.path.isfile(world_directory / "archipelago.json"):
                 with open(os.path.join(world_directory, "archipelago.json"), mode="r", encoding="utf-8") as manifest_file:
                     source_manifest = json.load(manifest_file)
-                source_games = get_apworld_manifest_games(source_manifest)
-                assert source_games, (
-                    f"World directory {world_directory} has an archipelago.json manifest file, but it "
-                    "does not define a \"game\" or \"games\"."
-                )
+                source_games = source_manifest.get("game")
+                if not isinstance(source_games, list):
+                    source_games = [source_games]
                 assert set(source_games) == set(package_games), (
-                    f"World directory {world_directory} has an archipelago.json manifest file, but its declared games "
-                    f"({', '.join(sorted(source_games))}) do not match the folder's World classes "
+                    f"World directory {world_directory} has an archipelago.json manifest file, but its game field "
+                    f"({source_manifest.get('game')}) does not match the folder's World classes "
                     f"({', '.join(package_games)})."
                 )
             else:
                 source_manifest = {}
-                source_games = []
 
             manifest = dict(source_manifest)
 
@@ -425,8 +425,7 @@ class BuildExeCommand(cx_Freeze.command.build_exe.build_exe):
             apworld = APWorldContainer(str(zip_path))
             apworld.minimum_ap_version = version_tuple
             apworld.maximum_ap_version = version_tuple
-            apworld.games = tuple(package_games)
-            apworld.game = package_games[0] if len(package_games) == 1 else None
+            apworld.game = package_games[0] if len(package_games) == 1 else package_games
             manifest.update(apworld.get_manifest())
             apworld.manifest_path = f"{file_name}/archipelago.json"
             with zipfile.ZipFile(zip_path, "x", zipfile.ZIP_DEFLATED,

--- a/setup.py
+++ b/setup.py
@@ -407,7 +407,7 @@ class BuildExeCommand(cx_Freeze.command.build_exe.build_exe):
                 with open(os.path.join(world_directory, "archipelago.json"), mode="r", encoding="utf-8") as manifest_file:
                     source_manifest = json.load(manifest_file)
                 source_games = source_manifest.get("game")
-                if not isinstance(source_games, list):
+                if isinstance(source_games, str):
                     source_games = [source_games]
                 assert set(source_games) == set(package_games), (
                     f"World directory {world_directory} has an archipelago.json manifest file, but its game field "

--- a/setup.py
+++ b/setup.py
@@ -379,47 +379,65 @@ class BuildExeCommand(cx_Freeze.command.build_exe.build_exe):
         os.makedirs(self.buildfolder / "Players" / "Templates", exist_ok=True)
         from Options import generate_yaml_templates
         from worlds.AutoWorld import AutoWorldRegister
-        from worlds.Files import APWorldContainer
+        from worlds.Files import APWorldContainer, get_apworld_manifest_games
         assert not non_apworlds - set(AutoWorldRegister.world_types), \
             f"Unknown world {non_apworlds - set(AutoWorldRegister.world_types)} designated for .apworld"
         folders_to_remove: list[str] = []
         generate_yaml_templates(self.buildfolder / "Players" / "Templates", False)
+        grouped_worlds: dict[str, list[tuple[str, object]]] = {}
         for worldname, worldtype in AutoWorldRegister.world_types.items():
-            if worldname not in non_apworlds:
-                file_name = os.path.split(os.path.dirname(worldtype.__file__))[1]
-                world_directory = self.libfolder / "worlds" / file_name
-                if os.path.isfile(world_directory / "archipelago.json"):
-                    with open(os.path.join(world_directory, "archipelago.json"), mode="r", encoding="utf-8") as manifest_file:
-                        manifest = json.load(manifest_file)
+            file_name = os.path.split(os.path.dirname(worldtype.__file__))[1]
+            grouped_worlds.setdefault(file_name, []).append((worldname, worldtype))
 
-                    assert "game" in manifest, (
-                        f"World directory {world_directory} has an archipelago.json manifest file, but it "
-                        "does not define a \"game\"."
-                    )
-                    assert manifest["game"] == worldtype.game, (
-                        f"World directory {world_directory} has an archipelago.json manifest file, but value of the "
-                        f"\"game\" field ({manifest['game']} does not equal the World class's game ({worldtype.game})."
-                    )
-                else:
-                    manifest = {}
-                # this method creates an apworld that cannot be moved to a different OS or minor python version,
-                # which should be ok
-                zip_path = self.libfolder / "worlds" / (file_name + ".apworld")
-                apworld = APWorldContainer(str(zip_path))
-                apworld.minimum_ap_version = version_tuple
-                apworld.maximum_ap_version = version_tuple
-                apworld.game = worldtype.game
-                manifest.update(apworld.get_manifest())
-                apworld.manifest_path = f"{file_name}/archipelago.json"
-                with zipfile.ZipFile(zip_path, "x", zipfile.ZIP_DEFLATED,
-                                     compresslevel=9) as zf:
-                    for path in world_directory.rglob("*.*"):
-                        relative_path = os.path.join(*path.parts[path.parts.index("worlds")+1:])
-                        if not relative_path.endswith("archipelago.json"):
-                            zf.write(path, relative_path)
-                    zf.writestr(apworld.manifest_path, json.dumps(manifest))
-                    folders_to_remove.append(file_name)
-                shutil.rmtree(world_directory)
+        for file_name, grouped_types in grouped_worlds.items():
+            package_games = sorted(worldname for worldname, _ in grouped_types)
+            included_games = [worldname for worldname in package_games if worldname not in non_apworlds]
+            if not included_games:
+                continue
+            assert len(included_games) == len(package_games), (
+                f"World folder {file_name} mixes apworld and non-apworld games, which is not supported: "
+                f"{', '.join(package_games)}"
+            )
+
+            world_directory = self.libfolder / "worlds" / file_name
+            if os.path.isfile(world_directory / "archipelago.json"):
+                with open(os.path.join(world_directory, "archipelago.json"), mode="r", encoding="utf-8") as manifest_file:
+                    source_manifest = json.load(manifest_file)
+                source_games = get_apworld_manifest_games(source_manifest)
+                assert source_games, (
+                    f"World directory {world_directory} has an archipelago.json manifest file, but it "
+                    "does not define a \"game\" or \"games\"."
+                )
+                assert set(source_games) == set(package_games), (
+                    f"World directory {world_directory} has an archipelago.json manifest file, but its declared games "
+                    f"({', '.join(sorted(source_games))}) do not match the folder's World classes "
+                    f"({', '.join(package_games)})."
+                )
+            else:
+                source_manifest = {}
+                source_games = []
+
+            manifest = dict(source_manifest)
+
+            # this method creates an apworld that cannot be moved to a different OS or minor python version,
+            # which should be ok
+            zip_path = self.libfolder / "worlds" / (file_name + ".apworld")
+            apworld = APWorldContainer(str(zip_path))
+            apworld.minimum_ap_version = version_tuple
+            apworld.maximum_ap_version = version_tuple
+            apworld.games = tuple(package_games)
+            apworld.game = package_games[0] if len(package_games) == 1 else None
+            manifest.update(apworld.get_manifest())
+            apworld.manifest_path = f"{file_name}/archipelago.json"
+            with zipfile.ZipFile(zip_path, "x", zipfile.ZIP_DEFLATED,
+                                 compresslevel=9) as zf:
+                for path in world_directory.rglob("*.*"):
+                    relative_path = os.path.join(*path.parts[path.parts.index("worlds")+1:])
+                    if not relative_path.endswith("archipelago.json"):
+                        zf.write(path, relative_path)
+                zf.writestr(apworld.manifest_path, json.dumps(manifest))
+                folders_to_remove.append(file_name)
+            shutil.rmtree(world_directory)
         shutil.copyfile("meta.yaml", self.buildfolder / "Players" / "Templates" / "meta.yaml")
         try:
             from maseya import z3pr  # type: ignore[import-untyped]

--- a/test/general/test_world_manifest.py
+++ b/test/general/test_world_manifest.py
@@ -56,22 +56,31 @@ class TestWorldManifest(unittest.TestCase):
             cls.manifest = json.load(f)
 
     def test_game(self) -> None:
-        """Test that 'game' will be correctly defined when generating APWorld manifest from source."""
+        """Test that the manifest correctly declares the current game's source metadata."""
+        if "game" in self.manifest:
+            self.assertEqual(
+                self.manifest["game"],
+                self.game,
+                f"archipelago.json manifest for {self.game} specifies wrong game '{self.manifest['game']}'",
+            )
+            return
+
         self.assertIn(
-            "game",
+            "games",
             self.manifest,
-            f"archipelago.json manifest exists for {self.game} but does not contain 'game'",
+            f"archipelago.json manifest exists for {self.game} but does not contain 'game' or 'games'",
         )
-        self.assertEqual(
-            self.manifest["game"],
+        self.assertIn(
             self.game,
-            f"archipelago.json manifest for {self.game} specifies wrong game '{self.manifest['game']}'",
+            self.manifest["games"],
+            f"archipelago.json manifest does not contain entry for '{self.game}' in 'games'",
         )
 
     def test_world_version(self) -> None:
         """Test that world_version matches the requirements in apworld specification.md""" 
-        if "world_version" in self.manifest:
-            world_version: str = self.manifest["world_version"]
+        world_version = self.manifest.get("world_version")
+
+        if world_version is not None:
             self.assertIsInstance(
                 world_version,
                 str,

--- a/test/general/test_world_manifest.py
+++ b/test/general/test_world_manifest.py
@@ -56,31 +56,26 @@ class TestWorldManifest(unittest.TestCase):
             cls.manifest = json.load(f)
 
     def test_game(self) -> None:
-        """Test that the manifest correctly declares the current game's source metadata."""
-        if "game" in self.manifest:
+        """Test that 'game' will be correctly defined when generating APWorld manifest from source."""
+        game = self.manifest["game"]
+        if isinstance(game, str):
             self.assertEqual(
-                self.manifest["game"],
+                game,
                 self.game,
-                f"archipelago.json manifest for {self.game} specifies wrong game '{self.manifest['game']}'",
+                f"archipelago.json manifest for {self.game} specifies wrong game '{game}'",
             )
             return
 
         self.assertIn(
-            "games",
-            self.manifest,
-            f"archipelago.json manifest exists for {self.game} but does not contain 'game' or 'games'",
-        )
-        self.assertIn(
             self.game,
-            self.manifest["games"],
-            f"archipelago.json manifest does not contain entry for '{self.game}' in 'games'",
+            game,
+            f"archipelago.json manifest does not contain entry for '{self.game}' in 'game'",
         )
 
     def test_world_version(self) -> None:
         """Test that world_version matches the requirements in apworld specification.md""" 
-        world_version = self.manifest.get("world_version")
-
-        if world_version is not None:
+        if "world_version" in self.manifest:
+            world_version: str = self.manifest["world_version"]
             self.assertIsInstance(
                 world_version,
                 str,

--- a/worlds/Files.py
+++ b/worlds/Files.py
@@ -96,26 +96,6 @@ class AutoPatchExtensionRegister(abc.ABCMeta):
 container_version: int = 7
 
 
-def get_apworld_manifest_games(manifest: Dict[str, Any]) -> List[str]:
-    """Return the game names declared by a single-game or multi-game apworld manifest."""
-    assert "game" not in manifest or "games" not in manifest, \
-        "Manifest must not define both 'game' and 'games'."
-    if "games" in manifest:
-        raw_games = manifest["games"]
-        if not isinstance(raw_games, list):
-            raise ValueError("Manifest 'games' must be a list of strings.")
-        if not all(isinstance(game, str) for game in raw_games):
-            raise ValueError("Manifest 'games' list entries must be strings.")
-        return list(raw_games)
-
-    if "game" in manifest:
-        if not isinstance(manifest["game"], str):
-            raise ValueError("Manifest 'game' must be a string.")
-        return [manifest["game"]]
-
-    return []
-
-
 def is_ap_player_container(game: str, data: bytes, player: int):
     if not zipfile.is_zipfile(BytesIO(data)):
         return False
@@ -213,8 +193,7 @@ class APContainer:
 
 class APWorldContainer(APContainer):
     """A zipfile containing a world implementation."""
-    game: str | None = None
-    games: Sequence[str] = ()
+    game: str | list[str] | None = None
     world_version: "Version | None" = None
     minimum_ap_version: "Version | None" = None
     maximum_ap_version: "Version | None" = None
@@ -222,11 +201,7 @@ class APWorldContainer(APContainer):
     def read_contents(self, opened_zipfile: zipfile.ZipFile) -> Dict[str, Any]:
         from Utils import tuplize_version
         manifest = super().read_contents(opened_zipfile)
-        self.games = tuple(get_apworld_manifest_games(manifest))
-        if not self.games:
-            raise ValueError("Manifest must define either 'game' or 'games'.")
-        self.game = self.games[0] if len(self.games) == 1 else None
-
+        self.game = manifest["game"]
         for version_key in ("world_version", "minimum_ap_version", "maximum_ap_version"):
             if version_key in manifest:
                 setattr(self, version_key, tuplize_version(manifest[version_key]))
@@ -234,15 +209,9 @@ class APWorldContainer(APContainer):
 
     def get_manifest(self) -> Dict[str, Any]:
         manifest = super().get_manifest()
+        manifest["game"] = self.game
         manifest["compatible_version"] = 7
-        games = tuple(self.games) if self.games else ((self.game,) if self.game else ())
-        if len(games) == 1:
-            manifest["game"] = games[0]
-        elif games:
-            manifest["games"] = list(games)
-        if self.world_version:
-            manifest["world_version"] = self.world_version.as_simple_string()
-        for version_key in ("minimum_ap_version", "maximum_ap_version"):
+        for version_key in ("world_version", "minimum_ap_version", "maximum_ap_version"):
             version = getattr(self, version_key)
             if version:
                 manifest[version_key] = version.as_simple_string()

--- a/worlds/Files.py
+++ b/worlds/Files.py
@@ -96,6 +96,26 @@ class AutoPatchExtensionRegister(abc.ABCMeta):
 container_version: int = 7
 
 
+def get_apworld_manifest_games(manifest: Dict[str, Any]) -> List[str]:
+    """Return the game names declared by a single-game or multi-game apworld manifest."""
+    assert "game" not in manifest or "games" not in manifest, \
+        "Manifest must not define both 'game' and 'games'."
+    if "games" in manifest:
+        raw_games = manifest["games"]
+        if not isinstance(raw_games, list):
+            raise ValueError("Manifest 'games' must be a list of strings.")
+        if not all(isinstance(game, str) for game in raw_games):
+            raise ValueError("Manifest 'games' list entries must be strings.")
+        return list(raw_games)
+
+    if "game" in manifest:
+        if not isinstance(manifest["game"], str):
+            raise ValueError("Manifest 'game' must be a string.")
+        return [manifest["game"]]
+
+    return []
+
+
 def is_ap_player_container(game: str, data: bytes, player: int):
     if not zipfile.is_zipfile(BytesIO(data)):
         return False
@@ -194,6 +214,7 @@ class APContainer:
 class APWorldContainer(APContainer):
     """A zipfile containing a world implementation."""
     game: str | None = None
+    games: Sequence[str] = ()
     world_version: "Version | None" = None
     minimum_ap_version: "Version | None" = None
     maximum_ap_version: "Version | None" = None
@@ -201,7 +222,11 @@ class APWorldContainer(APContainer):
     def read_contents(self, opened_zipfile: zipfile.ZipFile) -> Dict[str, Any]:
         from Utils import tuplize_version
         manifest = super().read_contents(opened_zipfile)
-        self.game = manifest["game"]
+        self.games = tuple(get_apworld_manifest_games(manifest))
+        if not self.games:
+            raise ValueError("Manifest must define either 'game' or 'games'.")
+        self.game = self.games[0] if len(self.games) == 1 else None
+
         for version_key in ("world_version", "minimum_ap_version", "maximum_ap_version"):
             if version_key in manifest:
                 setattr(self, version_key, tuplize_version(manifest[version_key]))
@@ -209,9 +234,15 @@ class APWorldContainer(APContainer):
 
     def get_manifest(self) -> Dict[str, Any]:
         manifest = super().get_manifest()
-        manifest["game"] = self.game
         manifest["compatible_version"] = 7
-        for version_key in ("world_version", "minimum_ap_version", "maximum_ap_version"):
+        games = tuple(self.games) if self.games else ((self.game,) if self.game else ())
+        if len(games) == 1:
+            manifest["game"] = games[0]
+        elif games:
+            manifest["games"] = list(games)
+        if self.world_version:
+            manifest["world_version"] = self.world_version.as_simple_string()
+        for version_key in ("minimum_ap_version", "maximum_ap_version"):
             version = getattr(self, version_key)
             if version:
                 manifest[version_key] = version.as_simple_string()

--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -306,7 +306,7 @@ if not is_frozen():
                     source_manifest = json.load(manifest_file)
 
                 source_games = source_manifest.get("game")
-                if not isinstance(source_games, list):
+                if isinstance(source_games, str):
                     source_games = [source_games]
                 assert set(source_games) == set(package_games), (
                     f"World directory {world_directory} has an archipelago.json manifest file, but its game field "

--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -265,7 +265,7 @@ if not is_frozen():
         import zipfile
 
         from worlds import AutoWorldRegister
-        from worlds.Files import APWorldContainer
+        from worlds.Files import APWorldContainer, get_apworld_manifest_games
         from Launcher import open_folder
 
         import argparse
@@ -286,30 +286,49 @@ if not is_frozen():
 
         apworlds_folder = os.path.join("build", "apworlds")
         os.makedirs(apworlds_folder, exist_ok=True)
+
+        all_grouped_worlds = {}
+        for all_worldname, all_worldtype in AutoWorldRegister.world_types.items():
+            if all_worldtype.zip_path:
+                continue
+            folder_name = os.path.split(os.path.dirname(all_worldtype.__file__))[1]
+            all_grouped_worlds.setdefault(folder_name, []).append((all_worldname, all_worldtype))
+
+        selected_folders = set()
         for worldname, worldtype in games:
             if not worldtype:
                 logging.error(f"Requested APWorld \"{worldname}\" does not exist.")
                 continue
-            file_name = os.path.split(os.path.dirname(worldtype.__file__))[1]
+            selected_folders.add(os.path.split(os.path.dirname(worldtype.__file__))[1])
+
+        for file_name in sorted(selected_folders):
+            grouped_types = all_grouped_worlds[file_name]
+            package_games = sorted(worldname for worldname, _ in grouped_types)
             world_directory = os.path.join("worlds", file_name)
             if os.path.isfile(os.path.join(world_directory, "archipelago.json")):
                 with open(os.path.join(world_directory, "archipelago.json"), mode="r", encoding="utf-8") as manifest_file:
-                    manifest = json.load(manifest_file)
+                    source_manifest = json.load(manifest_file)
 
-                assert "game" in manifest, (
+                source_games = get_apworld_manifest_games(source_manifest)
+                assert source_games, (
                     f"World directory {world_directory} has an archipelago.json manifest file, but it "
-                    "does not define a \"game\"."
+                    "does not define a \"game\" or \"games\"."
                 )
-                assert manifest["game"] == worldtype.game, (
-                    f"World directory {world_directory} has an archipelago.json manifest file, but value of the "
-                    f"\"game\" field ({manifest['game']} does not equal the World class's game ({worldtype.game})."
+                assert set(source_games) == set(package_games), (
+                    f"World directory {world_directory} has an archipelago.json manifest file, but its declared games "
+                    f"({', '.join(sorted(source_games))}) do not match the folder's World classes "
+                    f"({', '.join(package_games)})."
                 )
             else:
-                manifest = {}
+                source_manifest = {}
+                source_games = []
+
+            manifest = dict(source_manifest)
 
             zip_path = os.path.join(apworlds_folder, file_name + ".apworld")
             apworld = APWorldContainer(str(zip_path))
-            apworld.game = worldtype.game
+            apworld.games = tuple(package_games)
+            apworld.game = package_games[0] if len(package_games) == 1 else None
             manifest.update(apworld.get_manifest())
             apworld.manifest_path = os.path.join(file_name, "archipelago.json")
 

--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -265,7 +265,7 @@ if not is_frozen():
         import zipfile
 
         from worlds import AutoWorldRegister
-        from worlds.Files import APWorldContainer, get_apworld_manifest_games
+        from worlds.Files import APWorldContainer
         from Launcher import open_folder
 
         import argparse
@@ -286,49 +286,41 @@ if not is_frozen():
 
         apworlds_folder = os.path.join("build", "apworlds")
         os.makedirs(apworlds_folder, exist_ok=True)
-
-        all_grouped_worlds = {}
-        for all_worldname, all_worldtype in AutoWorldRegister.world_types.items():
-            if all_worldtype.zip_path:
-                continue
-            folder_name = os.path.split(os.path.dirname(all_worldtype.__file__))[1]
-            all_grouped_worlds.setdefault(folder_name, []).append((all_worldname, all_worldtype))
-
         selected_folders = set()
         for worldname, worldtype in games:
             if not worldtype:
                 logging.error(f"Requested APWorld \"{worldname}\" does not exist.")
                 continue
-            selected_folders.add(os.path.split(os.path.dirname(worldtype.__file__))[1])
-
-        for file_name in sorted(selected_folders):
-            grouped_types = all_grouped_worlds[file_name]
-            package_games = sorted(worldname for worldname, _ in grouped_types)
+            file_name = os.path.split(os.path.dirname(worldtype.__file__))[1]
+            if file_name in selected_folders:
+                continue
+            selected_folders.add(file_name)
+            package_games = sorted(
+                other_name
+                for other_name, other_type in AutoWorldRegister.world_types.items()
+                if not other_type.zip_path and os.path.split(os.path.dirname(other_type.__file__))[1] == file_name
+            )
             world_directory = os.path.join("worlds", file_name)
             if os.path.isfile(os.path.join(world_directory, "archipelago.json")):
                 with open(os.path.join(world_directory, "archipelago.json"), mode="r", encoding="utf-8") as manifest_file:
                     source_manifest = json.load(manifest_file)
 
-                source_games = get_apworld_manifest_games(source_manifest)
-                assert source_games, (
-                    f"World directory {world_directory} has an archipelago.json manifest file, but it "
-                    "does not define a \"game\" or \"games\"."
-                )
+                source_games = source_manifest.get("game")
+                if not isinstance(source_games, list):
+                    source_games = [source_games]
                 assert set(source_games) == set(package_games), (
-                    f"World directory {world_directory} has an archipelago.json manifest file, but its declared games "
-                    f"({', '.join(sorted(source_games))}) do not match the folder's World classes "
+                    f"World directory {world_directory} has an archipelago.json manifest file, but its game field "
+                    f"({source_manifest.get('game')}) does not match the folder's World classes "
                     f"({', '.join(package_games)})."
                 )
             else:
                 source_manifest = {}
-                source_games = []
 
             manifest = dict(source_manifest)
 
             zip_path = os.path.join(apworlds_folder, file_name + ".apworld")
             apworld = APWorldContainer(str(zip_path))
-            apworld.games = tuple(package_games)
-            apworld.game = package_games[0] if len(package_games) == 1 else None
+            apworld.game = package_games[0] if len(package_games) == 1 else package_games
             manifest.update(apworld.get_manifest())
             apworld.manifest_path = os.path.join(file_name, "archipelago.json")
 

--- a/worlds/__init__.py
+++ b/worlds/__init__.py
@@ -36,6 +36,12 @@ __all__ = [
 failed_world_loads: dict[str, str] = {}
 
 
+def normalize_game_names(games: str | Sequence[str] | None) -> Sequence[str]:
+    if isinstance(games, str):
+        return (games,)
+    return games or ()
+
+
 @dataclasses.dataclass(order=True)
 class WorldSource:
     path: str  # typically relative path from this module
@@ -116,8 +122,7 @@ for world_source in world_sources:
                     break
             if manifest:
                 break
-        games = manifest.get("game")
-        for game in games if isinstance(games, list) else [games] if games else ():
+        for game in normalize_game_names(manifest.get("game")):
             if game in AutoWorldRegister.world_types:
                 AutoWorldRegister.world_types[game].world_version = tuplize_version(manifest.get("world_version", "0.0.0"))
                 AutoWorldRegister.world_types[game].manifest = manifest
@@ -159,7 +164,7 @@ if apworlds:
                     messagebox("Couldn't load worlds", err_message, error=True)
                     sys.exit(1)
 
-            games = apworld.game if isinstance(apworld.game, list) else [apworld.game] if apworld.game else []
+            games = normalize_game_names(apworld.game)
             if apworld.minimum_ap_version and apworld.minimum_ap_version > version_tuple:
                 fail_worlds(games,
                             f"Did not load {apworld_source.path} "
@@ -187,7 +192,7 @@ if apworlds:
         sys.meta_path.insert(0, APWorldModuleFinder())
 
         for apworld_source, apworld in core_compatible:
-            games = apworld.game if isinstance(apworld.game, list) else [apworld.game] if apworld.game else []
+            games = normalize_game_names(apworld.game)
             duplicate_games = [game for game in games if game in AutoWorldRegister.world_types]
             if duplicate_games:
                 fail_worlds(duplicate_games,

--- a/worlds/__init__.py
+++ b/worlds/__init__.py
@@ -15,6 +15,7 @@ from zipfile import ZipFile, BadZipFile
 
 from NetUtils import DataPackage
 from Utils import local_path, user_path, Version, version_tuple, tuplize_version, messagebox
+from .Files import get_apworld_manifest_games
 
 local_folder = os.path.dirname(__file__)
 user_folder = user_path("worlds") if user_path() != local_path() else user_path("custom_worlds")
@@ -116,10 +117,11 @@ for world_source in world_sources:
                     break
             if manifest:
                 break
-        game = manifest.get("game")
-        if game in AutoWorldRegister.world_types:
-            AutoWorldRegister.world_types[game].world_version = tuplize_version(manifest.get("world_version", "0.0.0"))
-            AutoWorldRegister.world_types[game].manifest = manifest
+        for game in get_apworld_manifest_games(manifest):
+            if game in AutoWorldRegister.world_types:
+                if "world_version" in manifest:
+                    AutoWorldRegister.world_types[game].world_version = tuplize_version(manifest["world_version"])
+                AutoWorldRegister.world_types[game].manifest = manifest
 
 if apworlds:
     # encapsulation for namespace / gc purposes
@@ -128,9 +130,10 @@ if apworlds:
         from .Files import APWorldContainer, InvalidDataError
         core_compatible: list[tuple[WorldSource, APWorldContainer]] = []
 
-        def fail_world(game_name: str, reason: str, add_as_failed_to_load: bool = True) -> None:
+        def fail_worlds(game_names: Sequence[str], reason: str, add_as_failed_to_load: bool = True) -> None:
             if add_as_failed_to_load:
-                failed_world_loads[game_name] = reason
+                for game_name in game_names:
+                    failed_world_loads[game_name] = reason
             logging.warning(reason)
 
         for apworld_source in apworlds:
@@ -158,15 +161,15 @@ if apworlds:
                     sys.exit(1)
 
             if apworld.minimum_ap_version and apworld.minimum_ap_version > version_tuple:
-                fail_world(apworld.game,
-                           f"Did not load {apworld_source.path} "
-                           f"as its minimum core version {apworld.minimum_ap_version} "
-                           f"is higher than current core version {version_tuple}.")
+                fail_worlds(apworld.games,
+                            f"Did not load {apworld_source.path} "
+                            f"as its minimum core version {apworld.minimum_ap_version} "
+                            f"is higher than current core version {version_tuple}.")
             elif apworld.maximum_ap_version and apworld.maximum_ap_version < version_tuple:
-                fail_world(apworld.game,
-                           f"Did not load {apworld_source.path} "
-                           f"as its maximum core version {apworld.maximum_ap_version} "
-                           f"is lower than current core version {version_tuple}.")
+                fail_worlds(apworld.games,
+                            f"Did not load {apworld_source.path} "
+                            f"as its maximum core version {apworld.maximum_ap_version} "
+                            f"is lower than current core version {version_tuple}.")
             else:
                 core_compatible.append((apworld_source, apworld))
         # load highest version first
@@ -184,11 +187,12 @@ if apworlds:
         sys.meta_path.insert(0, APWorldModuleFinder())
 
         for apworld_source, apworld in core_compatible:
-            if apworld.game and apworld.game in AutoWorldRegister.world_types:
-                fail_world(apworld.game,
-                           f"Did not load {apworld_source.path} "
-                           f"as its game {apworld.game} is already loaded.",
-                           add_as_failed_to_load=False)
+            duplicate_games = [game for game in apworld.games if game in AutoWorldRegister.world_types]
+            if duplicate_games:
+                fail_worlds(duplicate_games,
+                            f"Did not load {apworld_source.path} "
+                            f"as its game(s) {', '.join(duplicate_games)} are already loaded.",
+                            add_as_failed_to_load=False)
             else:
                 importer = zipimport.zipimporter(apworld_source.resolved_path)
                 world_name = Path(apworld.path).stem
@@ -197,19 +201,25 @@ if apworlds:
                 apworld_module_specs[f"worlds.{world_name}"] = spec
 
                 apworld_source.load()
-                if apworld.game in AutoWorldRegister.world_types:
-                    # world could fail to load at this point
-                    if apworld.world_version:
-                        AutoWorldRegister.world_types[apworld.game].world_version = apworld.world_version
+                missing_games = [game for game in apworld.games if game not in AutoWorldRegister.world_types]
+                if missing_games:
+                    fail_worlds(missing_games,
+                                f"Loaded {apworld_source.path}, but it did not register expected game(s): "
+                                f"{', '.join(missing_games)}.")
+                    continue
 
-                    assert apworld.path
-                    with ZipFile(apworld.path, "r") as zf:
-                        manifest = apworld.read_contents(zf)
-                    # version/compatible_version shouldn't be needed by world, makes it consistent with folder world
-                    manifest.pop("version", None)
-                    manifest.pop("compatible_version", None)
-                    AutoWorldRegister.world_types[apworld.game].manifest = manifest
+                if apworld.world_version:
+                    for game in apworld.games:
+                        AutoWorldRegister.world_types[game].world_version = apworld.world_version
 
+                assert apworld.path
+                with ZipFile(apworld.path, "r") as zf:
+                    manifest = apworld.read_contents(zf)
+                # version/compatible_version shouldn't be needed by world, makes it consistent with folder world
+                manifest.pop("version", None)
+                manifest.pop("compatible_version", None)
+                for game in apworld.games:
+                    AutoWorldRegister.world_types[game].manifest = manifest
     load_apworlds()
     del load_apworlds
 
@@ -219,4 +229,3 @@ del apworlds
 network_data_package: DataPackage = {
     "games": {world_name: world.get_data_package_data() for world_name, world in AutoWorldRegister.world_types.items()},
 }
-

--- a/worlds/__init__.py
+++ b/worlds/__init__.py
@@ -15,7 +15,6 @@ from zipfile import ZipFile, BadZipFile
 
 from NetUtils import DataPackage
 from Utils import local_path, user_path, Version, version_tuple, tuplize_version, messagebox
-from .Files import get_apworld_manifest_games
 
 local_folder = os.path.dirname(__file__)
 user_folder = user_path("worlds") if user_path() != local_path() else user_path("custom_worlds")
@@ -117,10 +116,10 @@ for world_source in world_sources:
                     break
             if manifest:
                 break
-        for game in get_apworld_manifest_games(manifest):
+        games = manifest.get("game")
+        for game in games if isinstance(games, list) else [games] if games else ():
             if game in AutoWorldRegister.world_types:
-                if "world_version" in manifest:
-                    AutoWorldRegister.world_types[game].world_version = tuplize_version(manifest["world_version"])
+                AutoWorldRegister.world_types[game].world_version = tuplize_version(manifest.get("world_version", "0.0.0"))
                 AutoWorldRegister.world_types[game].manifest = manifest
 
 if apworlds:
@@ -160,13 +159,14 @@ if apworlds:
                     messagebox("Couldn't load worlds", err_message, error=True)
                     sys.exit(1)
 
+            games = apworld.game if isinstance(apworld.game, list) else [apworld.game] if apworld.game else []
             if apworld.minimum_ap_version and apworld.minimum_ap_version > version_tuple:
-                fail_worlds(apworld.games,
+                fail_worlds(games,
                             f"Did not load {apworld_source.path} "
                             f"as its minimum core version {apworld.minimum_ap_version} "
                             f"is higher than current core version {version_tuple}.")
             elif apworld.maximum_ap_version and apworld.maximum_ap_version < version_tuple:
-                fail_worlds(apworld.games,
+                fail_worlds(games,
                             f"Did not load {apworld_source.path} "
                             f"as its maximum core version {apworld.maximum_ap_version} "
                             f"is lower than current core version {version_tuple}.")
@@ -187,7 +187,8 @@ if apworlds:
         sys.meta_path.insert(0, APWorldModuleFinder())
 
         for apworld_source, apworld in core_compatible:
-            duplicate_games = [game for game in apworld.games if game in AutoWorldRegister.world_types]
+            games = apworld.game if isinstance(apworld.game, list) else [apworld.game] if apworld.game else []
+            duplicate_games = [game for game in games if game in AutoWorldRegister.world_types]
             if duplicate_games:
                 fail_worlds(duplicate_games,
                             f"Did not load {apworld_source.path} "
@@ -201,7 +202,7 @@ if apworlds:
                 apworld_module_specs[f"worlds.{world_name}"] = spec
 
                 apworld_source.load()
-                missing_games = [game for game in apworld.games if game not in AutoWorldRegister.world_types]
+                missing_games = [game for game in games if game not in AutoWorldRegister.world_types]
                 if missing_games:
                     fail_worlds(missing_games,
                                 f"Loaded {apworld_source.path}, but it did not register expected game(s): "
@@ -209,7 +210,7 @@ if apworlds:
                     continue
 
                 if apworld.world_version:
-                    for game in apworld.games:
+                    for game in games:
                         AutoWorldRegister.world_types[game].world_version = apworld.world_version
 
                 assert apworld.path
@@ -218,7 +219,7 @@ if apworlds:
                 # version/compatible_version shouldn't be needed by world, makes it consistent with folder world
                 manifest.pop("version", None)
                 manifest.pop("compatible_version", None)
-                for game in apworld.games:
+                for game in games:
                     AutoWorldRegister.world_types[game].manifest = manifest
     load_apworlds()
     del load_apworlds


### PR DESCRIPTION
## What is this fixing or adding?

This updates APWorld manifests so the `game` field in `archipelago.json` can be either:

- a string for single-game worlds
- a list of strings for multi-game worlds

The change is scoped down to the minimum required behavior:

- `APWorldContainer` now reads and writes `game` as either a string or list
- world loading now handles `game` as either a string or list when registering manifests
- APWorld packaging/build paths now package one folder as one `.apworld` and validate its `game` field against all `World` classes in that folder
- source manifest validation now accepts `game` as either a string or list
- docs now state that `game` may be a string or list

## How was this tested?

- Unit tests
- Building an APWorld that contains multiple games defined and observing expected output of archipelago.json format

## But why?

https://github.com/Alchav/Archipelago/blob/864434bbf8df35d9dfa51c9282e01ca22f8671d1/worlds/pokemon_rby/__init__.py#L722