### PR TITLE
Core: fix `Set` import

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -8,10 +8,10 @@ import secrets
 import warnings
 from argparse import Namespace
 from collections import Counter, deque, defaultdict
-from collections.abc import Callable, Collection, Iterable, Iterator, Mapping, MutableSequence, Set
+from collections.abc import Callable, Collection, Iterable, Iterator, Mapping, MutableSequence, Set as AbstractSet
 from enum import IntEnum, IntFlag
-from typing import (AbstractSet, Any, ClassVar, Dict, List, Literal, NamedTuple,
-                    Optional, Protocol, Tuple, Union, TYPE_CHECKING, overload)
+from typing import (Any, ClassVar, Dict, List, Literal, NamedTuple,
+                    Optional, Protocol, Set, Tuple, Union, TYPE_CHECKING, overload)
 import dataclasses
 
 from typing_extensions import NotRequired, TypedDict


### PR DESCRIPTION
## What is this fixing or adding?

mistake made in pr [#5048](https://github.com/ArchipelagoMW/Archipelago/pull/5048)

https://github.com/ArchipelagoMW/Archipelago/pull/5048#discussion_r3328989050

Also see https://docs.astral.sh/ruff/rules/unaliased-collections-abc-set-import/ for more information.

## How was this tested?

just looking at type checking a little bit
counting on CI tests
