### PR TITLE
stardew valley: use /explain from universal tracker instead of stardew valley client

### DIFF
--- a/worlds/stardew_valley/__init__.py
+++ b/worlds/stardew_valley/__init__.py
@@ -1,4 +1,3 @@
-from NetUtils import JSONMessagePart
 import logging
 import math
 import typing
@@ -9,6 +8,7 @@ from typing import Dict, List, Any, ClassVar, TextIO, Optional
 
 import entrance_rando
 from BaseClasses import Region, Location, Item, Tutorial, ItemClassification, MultiWorld, CollectionState
+from NetUtils import JSONMessagePart
 from Options import PerGameCommonOptions
 from worlds.AutoWorld import World, WebWorld
 from worlds.LauncherComponents import components, Component, icon_paths, Type

--- a/worlds/stardew_valley/__init__.py
+++ b/worlds/stardew_valley/__init__.py
@@ -1,3 +1,4 @@
+from NetUtils import JSONMessagePart
 import logging
 import math
 import typing
@@ -34,6 +35,7 @@ from .options.worlds_group import apply_most_restrictive_options
 from .regions import create_regions, prepare_mod_data
 from .rules import set_rules
 from .stardew_rule import True_, StardewRule, HasProgressionPercent
+from .stardew_rule.rule_explain import RuleExplanation
 from .strings.ap_names.ap_option_names import StartWithoutOptionName
 from .strings.ap_names.ap_weapon_names import APWeapon
 from .strings.ap_names.event_names import Event
@@ -87,28 +89,6 @@ class StardewWebWorld(WebWorld):
     )
 
     tutorials = [setup_en, setup_fr]
-
-
-if TRACKER_ENABLED:
-    from .. import user_folder
-    import os
-
-    # Best effort to detect if universal tracker is installed
-    if any("tracker.apworld" in f.name for f in os.scandir(user_folder)):
-        def launch_client(*args):
-            from worlds.LauncherComponents import launch
-            from .client import launch as client_main
-            launch(client_main, name="Stardew Valley Tracker", args=args)
-
-
-        components.append(Component(
-            "Stardew Valley Tracker",
-            func=launch_client,
-            component_type=Type.CLIENT,
-            icon='stardew'
-        ))
-
-        icon_paths['stardew'] = f"ap:{__name__}/stardew.png"
 
 
 class StardewValleyWorld(World):
@@ -269,7 +249,6 @@ class StardewValleyWorld(World):
             while precollected_count < item_count:
                 self.multiworld.push_precollected(self.create_item(item_name))
                 precollected_count += 1
-
 
     def precollect_start_without_items(self):
         if StartWithoutOptionName.landslide not in self.options.start_without:
@@ -561,3 +540,13 @@ class StardewValleyWorld(World):
             # Total progression items is not set until all items are created, but collect will be called during the item creation when an item is precollected.
             # We can't update the percentage if we don't know the total progression items, can't divide by 0.
             player_state[Event.received_progression_percent] = received_progression_count * 100 // self.total_progression_items
+
+    previous_explanation: RuleExplanation | None = None
+
+    def explain_rule(self, target_name: str, state: CollectionState) -> list[JSONMessagePart]:
+        from .client import cmd_explain
+        return cmd_explain(self, target_name, state)
+
+    def explain_more(self, target_name: str, state: CollectionState) -> list[JSONMessagePart]:
+        from .client import cmd_more
+        return cmd_more(self, target_name, state)

--- a/worlds/stardew_valley/client.py
+++ b/worlds/stardew_valley/client.py
@@ -15,27 +15,6 @@ try:
 
     tracker_loaded = True
 except ImportError as e:
-    logger.error(e)
-    from CommonClient import CommonContext, ClientCommandProcessor
-
-    TrackerCore = object
-
-
-    class TrackerGameContextMixin:
-        """Expecting the TrackerGameContext to have these methods."""
-        tracker_core: TrackerCore
-
-        def make_gui(self, manager):
-            ...
-
-        def run_generator(self):
-            ...
-
-
-    class TrackerGameContext(CommonContext, TrackerGameContextMixin):
-        pass
-
-
     tracker_loaded = False
     UT_VERSION = "Not found"
 

--- a/worlds/stardew_valley/client.py
+++ b/worlds/stardew_valley/client.py
@@ -9,15 +9,6 @@ from . import StardewValleyWorld
 from .logic.logic import StardewLogic
 from .stardew_rule.rule_explain import explain, ExplainMode, RuleExplanation
 
-try:
-    from worlds.tracker.TrackerClient import TrackerGameContext, TrackerCommandProcessor as ClientCommandProcessor, UT_VERSION  # noqa
-    from worlds.tracker.TrackerCore import TrackerCore
-
-    tracker_loaded = True
-except ImportError as e:
-    tracker_loaded = False
-    UT_VERSION = "Not found"
-
 
 def cmd_explain(world: StardewValleyWorld, target_name: str, state: CollectionState) -> list[JSONMessagePart]:
     logic = world.logic

--- a/worlds/stardew_valley/client.py
+++ b/worlds/stardew_valley/client.py
@@ -1,17 +1,10 @@
 from __future__ import annotations
 
-import asyncio
 import re
-# webserver imports
-import urllib.parse
-from collections.abc import Iterable
 
 import Utils
 from BaseClasses import CollectionState, Location
-from CommonClient import logger, get_base_parser, gui_enabled, server_loop
-from MultiServer import mark_raw
 from NetUtils import JSONMessagePart
-from kvui import CommandPromptTextInput
 from . import StardewValleyWorld
 from .logic.logic import StardewLogic
 from .stardew_rule.rule_explain import explain, ExplainMode, RuleExplanation
@@ -47,160 +40,41 @@ except ImportError as e:
     UT_VERSION = "Not found"
 
 
-class StardewCommandProcessor(ClientCommandProcessor):
-    ctx: StardewClientContext
+def cmd_explain(world: StardewValleyWorld, target_name: str, state: CollectionState) -> list[JSONMessagePart]:
+    logic = world.logic
 
-    @mark_raw
-    def _cmd_explain(self, location: str = ""):
-        """Explain the logic behind a location."""
-        logic = self.ctx.logic
-        if logic is None:
-            return
+    if target_name.startswith("missing "):
+        expected = True
+        target_name = target_name[len("missing "):]
+    elif target_name.startswith("how "):
+        expected = False
+        target_name = target_name[len("how "):]
+    else:
+        expected = None
 
-        try:
-            rule = logic.region.can_reach_location(location)
-            expl = explain(rule, self.ctx.current_state, expected=None, mode=ExplainMode.CLIENT)
-        except KeyError:
-
-            result, usable, response = Utils.get_intended_text(location, [loc.name for loc in self.ctx.all_locations])
-            if usable:
-                rule = logic.region.can_reach_location(result)
-                expl = explain(rule, self.ctx.current_state, expected=None, mode=ExplainMode.CLIENT)
-            else:
-                self.ctx.ui.last_autofillable_command = "/explain"
-                self.output(response)
-                return
-
-        self.ctx.previous_explanation = expl
-        self.ctx.ui.print_json(parse_explanation(expl))
-
-    @mark_raw
-    def _cmd_explain_item(self, item: str = ""):
-        """Explain the logic behind a game item."""
-        logic = self.ctx.logic
-        if logic is None:
-            return
-
-        result, usable, response = Utils.get_intended_text(item, logic.registry.item_rules.keys())
-        if usable:
-            rule = logic.has(result)
-            expl = explain(rule, self.ctx.current_state, expected=None, mode=ExplainMode.CLIENT)
-        else:
-            self.ctx.ui.last_autofillable_command = "/explain_item"
-            self.output(response)
-            return
-
-        self.ctx.previous_explanation = expl
-        self.ctx.ui.print_json(parse_explanation(expl))
-
-    @mark_raw
-    def _cmd_explain_missing(self, location: str = ""):
-        """Explain what is missing for a location to be in logic. It explains the logic behind a location, while skipping the rules that are already satisfied."""
-        self.__explain("/explain_missing", location, expected=True)
-
-    @mark_raw
-    def _cmd_explain_how(self, location: str = ""):
-        """Explain how a location is in logic. It explains the logic behind the location, while skipping the rules that are not satisfied."""
-        self.__explain("/explain_how", location, expected=False)
-
-    def __explain(self, command: str, location: str, expected: bool | None = None):
-        logic = self.ctx.logic
-        if logic is None:
-            return
-
-        try:
-            rule = logic.region.can_reach_location(location)
-            expl = explain(rule, self.ctx.current_state, expected=expected, mode=ExplainMode.CLIENT)
-        except KeyError:
-
-            result, usable, response = Utils.get_intended_text(location, [loc.name for loc in self.ctx.all_locations])
-            if usable:
-                rule = logic.region.can_reach_location(result)
-                expl = explain(rule, self.ctx.current_state, expected=expected, mode=ExplainMode.CLIENT)
-            else:
-                self.ctx.ui.last_autofillable_command = command
-                self.output(response)
-                return
-
-        self.ctx.previous_explanation = expl
-        self.ctx.ui.print_json(parse_explanation(expl))
-
-    @mark_raw
-    def _cmd_more(self, index: str = ""):
-        """Will tell you what's missing to consider a location in logic."""
-        if self.ctx.previous_explanation is None:
-            self.output("No previous explanation found.")
-            return
-
-        try:
-            expl = self.ctx.previous_explanation.more(int(index))
-        except (ValueError, IndexError):
-            self.output("Which previous rule do you want to explained?")
-            self.ctx.ui.last_autofillable_command = "/more"
-            for i, rule in enumerate(self.ctx.previous_explanation.more_explanations):
-                # TODO handle autofillable commands
-                self.output(f"/more {i} -> {str(rule)})")
-            return
-
-        self.ctx.previous_explanation = expl
-        self.ctx.ui.print_json(parse_explanation(expl))
-
-    if not tracker_loaded:
-        del _cmd_explain
-        del _cmd_explain_missing
+    result, usable, response = Utils.get_intended_text(target_name, world.get_all_location_names())
+    if usable:
+        rule = logic.region.can_reach_location(result)
+        expl = explain(rule, state, expected=expected, mode=ExplainMode.CLIENT)
+        world.previous_explanation = expl
+        return parse_explanation(expl)
+    else:
+        return [{"type": "color", "color": "salmon", "text": response}]
 
 
-class StardewClientContext(TrackerGameContext):
-    game = "Stardew Valley"
-    command_processor = StardewCommandProcessor
-    previous_explanation: RuleExplanation | None = None
+def cmd_more(world: StardewValleyWorld, index: str, state: CollectionState) -> list[JSONMessagePart]:
+    logic = world.logic
 
-    def make_gui(self):
-        ui = super().make_gui()  # before the kivy imports so kvui gets loaded first
+    if world.previous_explanation is None:
+        return [{"type": "color", "color": "salmon", "text": "No previous explanation found"}]
 
-        class StardewManager(ui):
-            base_title = f"Stardew Valley Tracker with UT {UT_VERSION} for AP version"  # core appends ap version so this works
-            ctx: StardewClientContext
+    try:
+        expl = world.previous_explanation.more(int(index))
+    except (ValueError, IndexError):
+        return [{"type": "text", "text": "Which previous rule do you want to be explained?"}]
 
-            def build(self):
-                container = super().build()
-                if not tracker_loaded:
-                    logger.info("To enable the tracker page, install Universal Tracker.")
-
-                # Until self.ctx.ui.last_autofillable_command allows for / commands, this is needed to remove the "!" before the /commands when using intended text autofill.
-                def on_text_remove_hardcoded_exclamation_mark_garbage(textinput: CommandPromptTextInput, text: str) -> None:
-                    if text.startswith("!/"):
-                        textinput.text = text[1:]
-
-                self.textinput.bind(text=on_text_remove_hardcoded_exclamation_mark_garbage)
-
-                return container
-
-        return StardewManager
-
-    @property
-    def logic(self) -> StardewLogic | None:
-        if self.tracker_core.get_current_world() is None:
-            logger.warning("Internal logic was not able to load, check your yamls and relaunch.")
-            return None
-
-        if self.game != "Stardew Valley":
-            logger.warning(f"Please connect to a slot with explainable logic (not {self.game}).")
-            return None
-
-        return self.tracker_core.get_current_world().logic
-
-    @property
-    def current_state(self) -> CollectionState:
-        return self.tracker_core.updateTracker().state
-
-    @property
-    def world(self) -> StardewValleyWorld:
-        return self.tracker_core.get_current_world()
-
-    @property
-    def all_locations(self) -> Iterable[Location]:
-        return self.tracker_core.multiworld.get_locations(self.tracker_core.player_id)
+    world.previous_explanation = expl
+    return parse_explanation(expl)
 
 
 def parse_explanation(explanation: RuleExplanation) -> list[JSONMessagePart]:
@@ -246,39 +120,3 @@ def parse_explanation(explanation: RuleExplanation) -> list[JSONMessagePart]:
             messages.append({"text": s, "type": "text"})
 
     return messages
-
-
-async def main(args):
-    ctx = StardewClientContext(args.connect, args.password)
-
-    ctx.auth = args.name
-    ctx.server_task = asyncio.create_task(server_loop(ctx), name="server loop")
-
-    if tracker_loaded:
-        ctx.run_generator()
-    else:
-        logger.warning("Could not find Universal Tracker.")
-
-    if gui_enabled:
-        ctx.run_gui()
-    ctx.run_cli()
-
-    await ctx.exit_event.wait()
-    await ctx.shutdown()
-
-
-def launch(*args):
-    parser = get_base_parser(description="Gameless Archipelago Client, for text interfacing.")
-    parser.add_argument('--name', default=None, help="Slot Name to connect as.")
-    parser.add_argument("url", nargs="?", help="Archipelago connection url")
-    args = parser.parse_args(args)
-
-    if args.url:
-        url = urllib.parse.urlparse(args.url)
-        args.connect = url.netloc
-        if url.username:
-            args.name = urllib.parse.unquote(url.username)
-        if url.password:
-            args.password = urllib.parse.unquote(url.password)
-
-    asyncio.run(main(args))

--- a/worlds/stardew_valley/client.py
+++ b/worlds/stardew_valley/client.py
@@ -57,15 +57,19 @@ def cmd_more(world: StardewValleyWorld, index: str, state: CollectionState) -> l
     return parse_explanation(expl)
 
 
-def parse_explanation(explanation: RuleExplanation) -> list[JSONMessagePart]:
+def parse_explanation(explanation: RuleExplanation) -> list[list[JSONMessagePart]]:
     # Split the explanation in parts, by isolating all the delimiters, being \(, \), & , -> , | , \d+x , \[ , \] , \(\w+\), \n\s*
-    result_regex = r"(\(|\)| & | -> | \| |\d+x | \[|\](?: ->)?\s*| \(\w+\)|\n\s*)"
+    result_regex = r"\s*(\(|\)| & | -> | \| |\d+x | \[|\](?: ->)?\s*| \(\w+\)|\n)"
     splits = re.split(result_regex, str(explanation).strip())
 
     messages = []
+    contents = []
+    content_length = 0
     for s in splits:
         if len(s) == 0:
             continue
+
+        content_length += len(s)
 
         if s == "True":
             messages.append({"type": "color", "color": "green", "text": s})
@@ -98,5 +102,13 @@ def parse_explanation(explanation: RuleExplanation) -> list[JSONMessagePart]:
                 messages.append({"text": s, "type": "text"})
         else:
             messages.append({"text": s, "type": "text"})
+
+        if content_length > 5000 and s.endswith("\n"):
+            contents[-1]["text"] = contents[-1]["text"][:-1]
+            messages.append(contents)
+            contents = []
+            content_length = 0
+
+    messages.append(contents)
 
     return messages

--- a/worlds/stardew_valley/client.py
+++ b/worlds/stardew_valley/client.py
@@ -43,6 +43,12 @@ except ImportError as e:
 def cmd_explain(world: StardewValleyWorld, target_name: str, state: CollectionState) -> list[JSONMessagePart]:
     logic = world.logic
 
+    if target_name.startswith("item "):
+        is_item_explain = True
+        target_name = target_name[len("item "):]
+    else:
+        is_item_explain = False
+
     if target_name.startswith("missing "):
         expected = True
         target_name = target_name[len("missing "):]
@@ -52,9 +58,13 @@ def cmd_explain(world: StardewValleyWorld, target_name: str, state: CollectionSt
     else:
         expected = None
 
-    result, usable, response = Utils.get_intended_text(target_name, world.get_all_location_names())
+    possible_answers = logic.registry.item_rules.keys() if is_item_explain else world.get_all_location_names()
+    result, usable, response = Utils.get_intended_text(target_name, possible_answers)
     if usable:
-        rule = logic.region.can_reach_location(result)
+        if is_item_explain:
+            rule = logic.has(result)
+        else:
+            rule = logic.region.can_reach_location(result)
         expl = explain(rule, state, expected=expected, mode=ExplainMode.CLIENT)
         world.previous_explanation = expl
         return parse_explanation(expl)

--- a/worlds/stardew_valley/stardew_rule/rule_explain.py
+++ b/worlds/stardew_valley/stardew_rule/rule_explain.py
@@ -34,7 +34,7 @@ class MoreExplanation:
             depth *= 2
 
         line = "  " * depth + f"{str(self.rule)} -> {self.result}"
-        line += f" [use `/more {self.more_index}` to explain]"
+        line += f" [use `/explain_more {self.more_index}` to explain]"
 
         return line
 


### PR DESCRIPTION
## What is this fixing or adding?

- Makes the `/explain` and `/explain_more` commands from Universal Tracker work.
- Removes the Stardew Valley Tracker client

## Important changes

`/explain_how {location}` moved to `/explain how {location}`
`/explain_missing {location}` moved to `/explain missing {location}`
`/explain_item {non-randomized item}` moved to `/explain item {non-randomized item}`

Item and how/missing can be combined in the order
`/explain item how {non-randomized item}` and `/explain item missing {non-randomized item}`


## How was this tested?

I have logged into a multiworld using Universal Tracker and tested the `/explain` and `/explain_more` commands on a few locations.

Could use more testing especially the /explain how/missing and /explain item.

If you would like to test it but aren't running archipelago from source, extract [this zip](https://github.com/user-attachments/files/28540723/stardew_valley.zip) to get the apworld.
