### PR TITLE
Validate non-negative (local_)early_items as well as [0, 0]

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -408,8 +408,13 @@ def distribute_early_items(multiworld: MultiWorld,
     for player in multiworld.player_ids:
         items = itertools.chain(multiworld.early_items[player], multiworld.local_early_items[player])
         for item in items:
-            early_items_count[item, player] = [multiworld.early_items[player].get(item, 0),
-                                               multiworld.local_early_items[player].get(item, 0)]
+            item_count = [multiworld.early_items[player].get(item, 0), multiworld.local_early_items[player].get(item, 0)]
+            if item_count[0] < 0:
+                raise ValueError(f"Item {item} has an early_items count of less than 0.")
+            if item_count[1] < 0:
+                raise ValueError(f"Item {item} has a local_early_items count of less than 0.")
+            if item_count != [0, 0]:
+                early_items_count[item, player] = item_count
     if early_items_count:
         early_locations: typing.List[Location] = []
         early_priority_locations: typing.List[Location] = []


### PR DESCRIPTION
## What is this fixing or adding?

Validate that `early_items` and `local_early_items` counts are non-negative by raising a ValueError. Also validate that both are not zero for any player, item combination (and ignore in that case).

Previously, a count of `[0, 0]` was decremented to `[-1, 0]` and then compared to `[0, 0]`. Since they are unequal, the code would proceed to place all of that item in the itempool.

## How was this tested?

Unit tests passed.