### PR TITLE
Stardew Valley: Support Universal Tracker /explain and /explain_more hooks

### DIFF
--- a/worlds/stardew_valley/__init__.py
+++ b/worlds/stardew_valley/__init__.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Any, ClassVar, TextIO, Optional
 
 import entrance_rando
 from BaseClasses import Region, Location, Item, Tutorial, ItemClassification, MultiWorld, CollectionState
+from NetUtils import JSONMessagePart
 from Options import PerGameCommonOptions
 from worlds.AutoWorld import World, WebWorld
 from worlds.LauncherComponents import components, Component, icon_paths, Type
@@ -189,6 +190,38 @@ class StardewValleyWorld(World):
                                f"Parsed Value: {parsed_option_value}"
                                f"Yaml Value: {self.options.__getattribute__(option_name)}")
         return seed
+
+    def explain_rule(self, target_name: str, state: CollectionState) -> Optional[List[JSONMessagePart]]:
+        """Stardew Valley explain syntax:
+          /explain <Location>          show the rule tree for a location
+          /explain item:<Item>         show what's required to receive an item
+          /explain missing:<Location>  show only the unsatisfied parts of the rule
+          /explain how:<Location>      show only the satisfied parts of the rule
+        Drill into a sub-rule of the previous explanation with:
+          /explain_more                list the available sub-rule indices
+          /explain_more <index>        expand the indexed sub-rule
+        """
+        # Deferred to avoid the circular import (client.py does
+        # `from . import StardewValleyWorld` at module top, which would fail
+        # if this file imported client.py before defining the class).  Same
+        # pattern as the existing `launch_client` above.
+        from .client import StardewUTCommandProcessor
+        proc = StardewUTCommandProcessor(self, state)
+        if target_name.startswith("item:"):
+            proc._cmd_explain_item(target_name[len("item:"):].strip())
+        elif target_name.startswith("missing:"):
+            proc._cmd_explain_missing(target_name[len("missing:"):].strip())
+        elif target_name.startswith("how:"):
+            proc._cmd_explain_how(target_name[len("how:"):].strip())
+        else:
+            proc._cmd_explain(target_name)
+        return proc.buffered_parts or None
+
+    def explain_more(self, target_name: str, state: CollectionState) -> Optional[List[JSONMessagePart]]:
+        from .client import StardewUTCommandProcessor
+        proc = StardewUTCommandProcessor(self, state)
+        proc._cmd_more(target_name)
+        return proc.buffered_parts or None
 
     def generate_early(self):
         force_change_options_if_banned(self.options, self.settings, self.player, self.player_name)

--- a/worlds/stardew_valley/client.py
+++ b/worlds/stardew_valley/client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import re
+import typing
 # webserver imports
 import urllib.parse
 from collections.abc import Iterable
@@ -11,10 +12,18 @@ from BaseClasses import CollectionState, Location
 from CommonClient import logger, get_base_parser, gui_enabled, server_loop
 from MultiServer import mark_raw
 from NetUtils import JSONMessagePart
-from kvui import CommandPromptTextInput
 from . import StardewValleyWorld
 from .logic.logic import StardewLogic
 from .stardew_rule.rule_explain import explain, ExplainMode, RuleExplanation
+
+# kvui boots up a Kivy Window on import (kvui.py:61). Only the custom-client
+# launcher path (StardewClientContext.make_gui) actually needs it; tests and
+# the Universal Tracker world hooks don't. Keep this under TYPE_CHECKING so
+# importing client.py never spawns a stray window. With
+# `from __future__ import annotations`, the type annotation referencing
+# CommandPromptTextInput is never evaluated at runtime.
+if typing.TYPE_CHECKING:
+    from kvui import CommandPromptTextInput
 
 try:
     from worlds.tracker.TrackerClient import TrackerGameContext, TrackerCommandProcessor as ClientCommandProcessor, UT_VERSION  # noqa
@@ -48,50 +57,64 @@ except ImportError as e:
 
 
 class StardewCommandProcessor(ClientCommandProcessor):
+    """The custom Stardew Tracker launcher's slash-command processor.
+
+    Data access is funneled through small `_get_*` / `_set_*` / `_print_json`
+    / `_set_autofillable_command` helpers so that StardewUTCommandProcessor
+    (below) can swap them for World-instance access and buffered JSON output
+    when called from Universal Tracker's `/explain` and `/explain_more` world
+    hooks -- without copying the `_cmd_*` bodies.
+
+    The class attribute `more_command` controls which command name gets
+    rendered in drill-down hints ("[use `/more 0` to explain]" vs
+    "[use `/explain_more 0` to explain]"). StardewUTCommandProcessor
+    overrides it.
+    """
     ctx: StardewClientContext
+    more_command: str = "/more"
 
     @mark_raw
     def _cmd_explain(self, location: str = ""):
         """Explain the logic behind a location."""
-        logic = self.ctx.logic
+        logic = self._get_logic()
         if logic is None:
             return
 
         try:
             rule = logic.region.can_reach_location(location)
-            expl = explain(rule, self.ctx.current_state, expected=None, mode=ExplainMode.CLIENT)
+            expl = explain(rule, self._get_current_state(), expected=None, mode=ExplainMode.CLIENT, more_command=self.more_command)
         except KeyError:
 
-            result, usable, response = Utils.get_intended_text(location, [loc.name for loc in self.ctx.all_locations])
+            result, usable, response = Utils.get_intended_text(location, [loc.name for loc in self._get_all_locations()])
             if usable:
                 rule = logic.region.can_reach_location(result)
-                expl = explain(rule, self.ctx.current_state, expected=None, mode=ExplainMode.CLIENT)
+                expl = explain(rule, self._get_current_state(), expected=None, mode=ExplainMode.CLIENT, more_command=self.more_command)
             else:
-                self.ctx.ui.last_autofillable_command = "/explain"
+                self._set_autofillable_command("/explain")
                 self.output(response)
                 return
 
-        self.ctx.previous_explanation = expl
-        self.ctx.ui.print_json(parse_explanation(expl))
+        self._set_previous_explanation(expl)
+        self._print_json(parse_explanation(expl))
 
     @mark_raw
     def _cmd_explain_item(self, item: str = ""):
         """Explain the logic behind a game item."""
-        logic = self.ctx.logic
+        logic = self._get_logic()
         if logic is None:
             return
 
         result, usable, response = Utils.get_intended_text(item, logic.registry.item_rules.keys())
         if usable:
             rule = logic.has(result)
-            expl = explain(rule, self.ctx.current_state, expected=None, mode=ExplainMode.CLIENT)
+            expl = explain(rule, self._get_current_state(), expected=None, mode=ExplainMode.CLIENT, more_command=self.more_command)
         else:
-            self.ctx.ui.last_autofillable_command = "/explain_item"
+            self._set_autofillable_command("/explain_item")
             self.output(response)
             return
 
-        self.ctx.previous_explanation = expl
-        self.ctx.ui.print_json(parse_explanation(expl))
+        self._set_previous_explanation(expl)
+        self._print_json(parse_explanation(expl))
 
     @mark_raw
     def _cmd_explain_missing(self, location: str = ""):
@@ -104,50 +127,124 @@ class StardewCommandProcessor(ClientCommandProcessor):
         self.__explain("/explain_how", location, expected=False)
 
     def __explain(self, command: str, location: str, expected: bool | None = None):
-        logic = self.ctx.logic
+        logic = self._get_logic()
         if logic is None:
             return
 
         try:
             rule = logic.region.can_reach_location(location)
-            expl = explain(rule, self.ctx.current_state, expected=expected, mode=ExplainMode.CLIENT)
+            expl = explain(rule, self._get_current_state(), expected=expected, mode=ExplainMode.CLIENT, more_command=self.more_command)
         except KeyError:
 
-            result, usable, response = Utils.get_intended_text(location, [loc.name for loc in self.ctx.all_locations])
+            result, usable, response = Utils.get_intended_text(location, [loc.name for loc in self._get_all_locations()])
             if usable:
                 rule = logic.region.can_reach_location(result)
-                expl = explain(rule, self.ctx.current_state, expected=expected, mode=ExplainMode.CLIENT)
+                expl = explain(rule, self._get_current_state(), expected=expected, mode=ExplainMode.CLIENT, more_command=self.more_command)
             else:
-                self.ctx.ui.last_autofillable_command = command
+                self._set_autofillable_command(command)
                 self.output(response)
                 return
 
-        self.ctx.previous_explanation = expl
-        self.ctx.ui.print_json(parse_explanation(expl))
+        self._set_previous_explanation(expl)
+        self._print_json(parse_explanation(expl))
 
     @mark_raw
     def _cmd_more(self, index: str = ""):
         """Will tell you what's missing to consider a location in logic."""
-        if self.ctx.previous_explanation is None:
+        previous = self._get_previous_explanation()
+        if previous is None:
             self.output("No previous explanation found.")
             return
 
         try:
-            expl = self.ctx.previous_explanation.more(int(index))
+            expl = previous.more(int(index))
         except (ValueError, IndexError):
             self.output("Which previous rule do you want to explained?")
-            self.ctx.ui.last_autofillable_command = "/more"
-            for i, rule in enumerate(self.ctx.previous_explanation.more_explanations):
+            self._set_autofillable_command(self.more_command)
+            for i, rule in enumerate(previous.more_explanations):
                 # TODO handle autofillable commands
-                self.output(f"/more {i} -> {str(rule)})")
+                self.output(f"{self.more_command} {i} -> {str(rule)})")
             return
 
+        self._set_previous_explanation(expl)
+        self._print_json(parse_explanation(expl))
+
+    # --- data-access helpers: defaults are ctx-based (custom-client path); ---
+    # --- StardewUTCommandProcessor overrides these for the UT hook path.   ---
+
+    def _get_logic(self) -> StardewLogic | None:
+        return self.ctx.logic
+
+    def _get_current_state(self) -> CollectionState:
+        return self.ctx.current_state
+
+    def _get_all_locations(self) -> Iterable[Location]:
+        return self.ctx.all_locations
+
+    def _get_previous_explanation(self) -> RuleExplanation | None:
+        return self.ctx.previous_explanation
+
+    def _set_previous_explanation(self, expl: RuleExplanation | None) -> None:
         self.ctx.previous_explanation = expl
-        self.ctx.ui.print_json(parse_explanation(expl))
+
+    def _print_json(self, parts: list[JSONMessagePart]) -> None:
+        self.ctx.ui.print_json(parts)
+
+    def _set_autofillable_command(self, command: str | None) -> None:
+        self.ctx.ui.last_autofillable_command = command
 
     if not tracker_loaded:
         del _cmd_explain
         del _cmd_explain_missing
+
+
+class StardewUTCommandProcessor(StardewCommandProcessor):
+    """Universal Tracker variant: constructed per-call by StardewValleyWorld's
+    `explain_rule` and `explain_more` hooks.
+
+    Reads from the World instance plus the CollectionState UT passes in, and
+    buffers JSON output into `self.buffered_parts` for the hook to return.
+    Drill-down state for /explain_more lives on the World instance so it
+    survives across hook calls.
+    """
+
+    more_command: str = "/explain_more"
+
+    def __init__(self, world: StardewValleyWorld, state: CollectionState) -> None:
+        # Intentionally bypass ClientCommandProcessor.__init__ -- that wants a
+        # CommonContext and we don't have (or need) one in the UT hook path.
+        self.world = world
+        self.state = state
+        self.buffered_parts: list[JSONMessagePart] = []
+
+    def output(self, text: str) -> None:
+        # ClientCommandProcessor.output forwards to logger.info, which UT
+        # users never see. Buffer plain text as a text-typed JSONMessagePart
+        # instead so the hook return value carries it back to UT for rendering.
+        self.buffered_parts.append({"type": "text", "text": text})
+
+    def _get_logic(self) -> StardewLogic | None:
+        return self.world.logic
+
+    def _get_current_state(self) -> CollectionState:
+        return self.state
+
+    def _get_all_locations(self) -> Iterable[Location]:
+        return self.world.multiworld.get_locations(self.world.player)
+
+    def _get_previous_explanation(self) -> RuleExplanation | None:
+        return getattr(self.world, "_ut_previous_explanation", None)
+
+    def _set_previous_explanation(self, expl: RuleExplanation | None) -> None:
+        self.world._ut_previous_explanation = expl
+
+    def _print_json(self, parts: list[JSONMessagePart]) -> None:
+        self.buffered_parts.extend(parts)
+
+    def _set_autofillable_command(self, command: str | None) -> None:
+        # UT's generic UI doesn't expose an autofill hook to worlds; the
+        # suggestion text emitted via output() already conveys the hint.
+        pass
 
 
 class StardewClientContext(TrackerGameContext):

--- a/worlds/stardew_valley/stardew_rule/rule_explain.py
+++ b/worlds/stardew_valley/stardew_rule/rule_explain.py
@@ -21,6 +21,7 @@ class MoreExplanation:
     state: CollectionState
     more_index: int
     mode: ExplainMode
+    more_command: str = "/more"
 
     @cached_property
     def result(self) -> bool:
@@ -34,7 +35,7 @@ class MoreExplanation:
             depth *= 2
 
         line = "  " * depth + f"{str(self.rule)} -> {self.result}"
-        line += f" [use `/more {self.more_index}` to explain]"
+        line += f" [use `{self.more_command} {self.more_index}` to explain]"
 
         return line
 
@@ -52,6 +53,7 @@ class RuleExplanation:
     more_explanations: List[StardewRule] = field(default_factory=list, repr=False, hash=False)
     explored_rules_key: Set[Tuple[str, str]] = field(default_factory=set, repr=False, hash=False)
     current_rule_explored: bool = False
+    more_command: str = "/more"
 
     def __post_init__(self):
         checkpoint = _rule_key(self.rule)
@@ -77,7 +79,7 @@ class RuleExplanation:
                                                       for i in sorted(self.explained_sub_rules, key=lambda x: x.result))
 
     def more(self, more_index: int) -> RuleExplanation:
-        return explain(self.more_explanations[more_index], self.state, self.expected, self.mode)
+        return explain(self.more_explanations[more_index], self.state, self.expected, self.mode, self.more_command)
 
     @cached_property
     def result(self) -> bool:
@@ -96,17 +98,17 @@ class RuleExplanation:
             sub_explanations = []
             for sub_rule in self.sub_rules:
                 if isinstance(sub_rule, Reach) and sub_rule.resolution_hint == 'Entrance':
-                    sub_explanations.append(MoreExplanation(sub_rule, self.state, len(self.more_explanations), self.mode))
+                    sub_explanations.append(MoreExplanation(sub_rule, self.state, len(self.more_explanations), self.mode, self.more_command))
                     self.more_explanations.append(sub_rule)
                 elif isinstance(sub_rule, Reach) and sub_rule.resolution_hint == 'Location':
-                    sub_explanations.append(MoreExplanation(sub_rule, self.state, len(self.more_explanations), self.mode))
+                    sub_explanations.append(MoreExplanation(sub_rule, self.state, len(self.more_explanations), self.mode, self.more_command))
                     self.more_explanations.append(sub_rule)
                 else:
-                    sub_explanations.append(_explain(sub_rule, self.state, self.expected, self.mode, self.more_explanations, self.explored_rules_key))
+                    sub_explanations.append(_explain(sub_rule, self.state, self.expected, self.mode, self.more_explanations, self.explored_rules_key, self.more_command))
 
             return sub_explanations
 
-        return [_explain(sub_rule, self.state, self.expected, self.mode, self.more_explanations, self.explored_rules_key) for sub_rule in self.sub_rules]
+        return [_explain(sub_rule, self.state, self.expected, self.mode, self.more_explanations, self.explored_rules_key, self.more_command) for sub_rule in self.sub_rules]
 
 
 @dataclass
@@ -116,7 +118,8 @@ class CountSubRuleExplanation(RuleExplanation):
     @staticmethod
     def from_explanation(expl: RuleExplanation, count: int) -> CountSubRuleExplanation:
         return CountSubRuleExplanation(expl.rule, expl.state, expl.expected, expl.mode, expl.sub_rules, more_explanations=expl.more_explanations,
-                                       explored_rules_key=expl.explored_rules_key, current_rule_explored=expl.current_rule_explored, count=count)
+                                       explored_rules_key=expl.explored_rules_key, current_rule_explored=expl.current_rule_explored,
+                                       more_command=expl.more_command, count=count)
 
     def summary(self, depth=0) -> str:
         if self.mode is ExplainMode.CLIENT:
@@ -138,57 +141,63 @@ class CountExplanation(RuleExplanation):
             return super().explained_sub_rules
 
         return [
-            CountSubRuleExplanation.from_explanation(_explain(rule, self.state, self.expected, self.mode, self.more_explanations, self.explored_rules_key),
+            CountSubRuleExplanation.from_explanation(_explain(rule, self.state, self.expected, self.mode, self.more_explanations, self.explored_rules_key,
+                                                              self.more_command),
                                                      count)
             for rule, count in self.rule.counter.items()
         ]
 
 
-def explain(rule: CollectionRule, state: CollectionState, expected: bool | None = True, mode: ExplainMode = ExplainMode.VERBOSE) -> RuleExplanation:
+def explain(rule: CollectionRule, state: CollectionState, expected: bool | None = True, mode: ExplainMode = ExplainMode.VERBOSE,
+            more_command: str = "/more") -> RuleExplanation:
     if isinstance(rule, StardewRule):
-        return _explain(rule, state, expected, mode, more_explanations=list(), explored_spots=set())
+        return _explain(rule, state, expected, mode, more_explanations=list(), explored_spots=set(), more_command=more_command)
     else:
         return f"Value of rule {str(rule)} was not {str(expected)} in {str(state)}"  # noqa
 
 
 @singledispatch
 def _explain(rule: StardewRule, state: CollectionState, expected: bool | None, mode: ExplainMode, more_explanations: list[StardewRule],
-             explored_spots: Set[Tuple[str, str]]) -> RuleExplanation:
-    return RuleExplanation(rule, state, expected, mode, more_explanations=more_explanations, explored_rules_key=explored_spots)
+             explored_spots: Set[Tuple[str, str]], more_command: str = "/more") -> RuleExplanation:
+    return RuleExplanation(rule, state, expected, mode, more_explanations=more_explanations, explored_rules_key=explored_spots,
+                           more_command=more_command)
 
 
 @_explain.register
 def _(rule: AggregatingStardewRule, state: CollectionState, expected: bool | None, mode: ExplainMode, more_explanations: list[StardewRule],
-      explored_spots: Set[Tuple[str, str]]) -> RuleExplanation:
-    return RuleExplanation(rule, state, expected, mode, rule.original_rules, more_explanations=more_explanations, explored_rules_key=explored_spots)
+      explored_spots: Set[Tuple[str, str]], more_command: str = "/more") -> RuleExplanation:
+    return RuleExplanation(rule, state, expected, mode, rule.original_rules, more_explanations=more_explanations, explored_rules_key=explored_spots,
+                           more_command=more_command)
 
 
 @_explain.register
 def _(rule: Count, state: CollectionState, expected: bool | None, mode: ExplainMode, more_explanations: list[StardewRule],
-      explored_spots: Set[Tuple[str, str]]) -> RuleExplanation:
-    return CountExplanation(rule, state, expected, mode, rule.rules, more_explanations=more_explanations, explored_rules_key=explored_spots)
+      explored_spots: Set[Tuple[str, str]], more_command: str = "/more") -> RuleExplanation:
+    return CountExplanation(rule, state, expected, mode, rule.rules, more_explanations=more_explanations, explored_rules_key=explored_spots,
+                            more_command=more_command)
 
 
 @_explain.register
 def _(rule: Has, state: CollectionState, expected: bool | None, mode: ExplainMode, more_explanations: list[StardewRule],
-      explored_spots: Set[Tuple[str, str]]) -> RuleExplanation:
+      explored_spots: Set[Tuple[str, str]], more_command: str = "/more") -> RuleExplanation:
     try:
         return RuleExplanation(rule, state, expected, mode, [rule.other_rules[rule.item]], more_explanations=more_explanations,
-                               explored_rules_key=explored_spots)
+                               explored_rules_key=explored_spots, more_command=more_command)
     except KeyError:
-        return RuleExplanation(rule, state, expected, mode, more_explanations=more_explanations, explored_rules_key=explored_spots)
+        return RuleExplanation(rule, state, expected, mode, more_explanations=more_explanations, explored_rules_key=explored_spots,
+                               more_command=more_command)
 
 
 @_explain.register
 def _(rule: TotalReceived, state: CollectionState, expected: bool | None, mode: ExplainMode, more_explanations: list[StardewRule],
-      explored_spots: Set[Tuple[str, str]]) -> RuleExplanation:
+      explored_spots: Set[Tuple[str, str]], more_command: str = "/more") -> RuleExplanation:
     return RuleExplanation(rule, state, expected, mode, [Received(i, rule.player, 1) for i in rule.items], more_explanations=more_explanations,
-                           explored_rules_key=explored_spots)
+                           explored_rules_key=explored_spots, more_command=more_command)
 
 
 @_explain.register
 def _(rule: Reach, state: CollectionState, expected: bool | None, mode: ExplainMode, more_explanations: list[StardewRule],
-      explored_spots: Set[Tuple[str, str]]) -> RuleExplanation:
+      explored_spots: Set[Tuple[str, str]], more_command: str = "/more") -> RuleExplanation:
     access_rules = None
     if rule.resolution_hint == 'Location':
         spot = state.multiworld.get_location(rule.spot, rule.player)
@@ -224,14 +233,16 @@ def _(rule: Reach, state: CollectionState, expected: bool | None, mode: ExplainM
         access_rules = [*(Reach(e.name, "Entrance", rule.player) for e in spot.entrances)]
 
     if not access_rules:
-        return RuleExplanation(rule, state, expected, mode, more_explanations=more_explanations, explored_rules_key=explored_spots)
+        return RuleExplanation(rule, state, expected, mode, more_explanations=more_explanations, explored_rules_key=explored_spots,
+                               more_command=more_command)
 
-    return RuleExplanation(rule, state, expected, mode, access_rules, more_explanations=more_explanations, explored_rules_key=explored_spots)
+    return RuleExplanation(rule, state, expected, mode, access_rules, more_explanations=more_explanations, explored_rules_key=explored_spots,
+                           more_command=more_command)
 
 
 @_explain.register
 def _(rule: Received, state: CollectionState, expected: bool | None, mode: ExplainMode, more_explanations: list[StardewRule],
-      explored_spots: Set[Tuple[str, str]]) -> RuleExplanation:
+      explored_spots: Set[Tuple[str, str]], more_command: str = "/more") -> RuleExplanation:
     access_rules = None
     if rule.event:
         try:
@@ -244,9 +255,11 @@ def _(rule: Received, state: CollectionState, expected: bool | None, mode: Expla
             pass
 
     if not access_rules:
-        return RuleExplanation(rule, state, expected, mode, more_explanations=more_explanations, explored_rules_key=explored_spots)
+        return RuleExplanation(rule, state, expected, mode, more_explanations=more_explanations, explored_rules_key=explored_spots,
+                               more_command=more_command)
 
-    return RuleExplanation(rule, state, expected, mode, access_rules, more_explanations=more_explanations, explored_rules_key=explored_spots)
+    return RuleExplanation(rule, state, expected, mode, access_rules, more_explanations=more_explanations, explored_rules_key=explored_spots,
+                           more_command=more_command)
 
 
 @singledispatch

--- a/worlds/stardew_valley/test/TestClient.py
+++ b/worlds/stardew_valley/test/TestClient.py
@@ -316,3 +316,150 @@ class TestParseExplanation(unittest.TestCase):
         shape = [(p.get("type"), p.get("text"), p.get("color")) for p in parts]
         self.assertIn(("text", "Has ", None), shape)
         self.assertIn(("color", "3", "cyan"), shape)
+
+
+class TestUTWorldHooks(SVTestBase):
+    """Pins behavior of explain_rule + explain_more on StardewValleyWorld --
+    the Universal Tracker integration surface.
+
+    Cross-equivalence tests confirm that running each hook produces the same
+    JSONMessagePart payload as invoking the equivalent _cmd_* method on the
+    custom command processor, modulo the documented /more -> /explain_more
+    label swap.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        # Reset cross-test drill-down state on the world.
+        if hasattr(self.world, "_ut_previous_explanation"):
+            del self.world._ut_previous_explanation
+
+    def _capture_custom_output(self, run) -> list:
+        """Run a function with a StardewCommandProcessor + stub ctx, return
+        the captured output normalized to match the UT-hook label scheme."""
+        ctx = _StubCtx(self.world, self.multiworld, self.player)
+        proc = StardewCommandProcessor(ctx)
+        proc.output = ctx.outputs.append
+        run(proc)
+        if ctx.ui.printed:
+            parts = ctx.ui.printed[-1]
+        else:
+            parts = [{"type": "text", "text": line} for line in ctx.outputs]
+        # The custom processor renders /more N in drill-down hints; the UT
+        # processor renders /explain_more N. Normalize so the rest of the
+        # comparison checks content, not label.
+        for p in parts:
+            if "text" in p and isinstance(p["text"], str):
+                p["text"] = p["text"].replace("/more ", "/explain_more ")
+        return parts
+
+    def _a_location(self) -> str:
+        return sorted(loc.name for loc in self.multiworld.get_locations(self.player))[0]
+
+    def _an_item(self) -> str:
+        return sorted(self.world.logic.registry.item_rules.keys())[0]
+
+    def test_explain_rule_default_matches_custom_explain(self):
+        loc = self._a_location()
+        ut_parts = self.world.explain_rule(loc, self.multiworld.state)
+        custom_parts = self._capture_custom_output(lambda p: p._cmd_explain(loc))
+        self.assertEqual(ut_parts, custom_parts)
+
+    def test_explain_rule_item_subcommand_matches_custom_explain_item(self):
+        item = self._an_item()
+        ut_parts = self.world.explain_rule(f"item:{item}", self.multiworld.state)
+        custom_parts = self._capture_custom_output(lambda p: p._cmd_explain_item(item))
+        self.assertEqual(ut_parts, custom_parts)
+
+    def test_explain_rule_missing_subcommand_matches_custom_explain_missing(self):
+        loc = self._a_location()
+        ut_parts = self.world.explain_rule(f"missing:{loc}", self.multiworld.state)
+        custom_parts = self._capture_custom_output(lambda p: p._cmd_explain_missing(loc))
+        self.assertEqual(ut_parts, custom_parts)
+
+    def test_explain_rule_how_subcommand_matches_custom_explain_how(self):
+        loc = self._a_location()
+        ut_parts = self.world.explain_rule(f"how:{loc}", self.multiworld.state)
+        custom_parts = self._capture_custom_output(lambda p: p._cmd_explain_how(loc))
+        self.assertEqual(ut_parts, custom_parts)
+
+    def test_explain_more_with_no_previous_explanation(self):
+        parts = self.world.explain_more("", self.multiworld.state)
+        self.assertEqual(parts, [{"type": "text", "text": "No previous explanation found."}])
+
+    def test_explain_more_drill_down_persists_state_across_calls(self):
+        # Walk locations until /explain produces drill-down candidates.
+        seeded = None
+        for loc_name in sorted(loc.name for loc in self.multiworld.get_locations(self.player)):
+            self.world._ut_previous_explanation = None
+            self.world.explain_rule(loc_name, self.multiworld.state)
+            prev = getattr(self.world, "_ut_previous_explanation", None)
+            if prev is None:
+                continue
+            _ = prev.explained_sub_rules  # populate lazy more_explanations
+            if prev.more_explanations:
+                seeded = prev
+                break
+        if seeded is None:
+            self.skipTest("no location in this seed produces drill-down candidates")
+
+        # Drill in by index. State must update on the world instance so a
+        # follow-up call sees the new previous_explanation.
+        parts = self.world.explain_more("0", self.multiworld.state)
+        self.assertIsNotNone(parts)
+        self.assertGreater(len(parts), 0)
+        self.assertIsNot(self.world._ut_previous_explanation, seeded)
+
+    def test_explain_rule_renders_explain_more_label_in_drill_down_hints(self):
+        # Find a location whose rule tree includes drill-down candidates.
+        joined = ""
+        for loc_name in sorted(loc.name for loc in self.multiworld.get_locations(self.player)):
+            self.world._ut_previous_explanation = None
+            parts = self.world.explain_rule(loc_name, self.multiworld.state)
+            if parts is None:
+                continue
+            joined = "".join(p.get("text", "") for p in parts if "text" in p)
+            if "to explain" in joined:
+                break
+        else:
+            self.skipTest("no location in this seed renders drill-down hints")
+
+        # All drill-down hints must reference /explain_more, never bare /more.
+        self.assertIn("/explain_more ", joined)
+        # Strip out /explain_more substrings first so the negative match doesn't
+        # mistake the inner "/more " of "/explain_more " for a bare /more.
+        non_label = joined.replace("/explain_more ", "")
+        self.assertNotIn("/more ", non_label)
+
+    def test_explain_more_listing_uses_explain_more_label(self):
+        # Seed a previous_explanation with drill-down candidates.
+        seeded = None
+        for loc_name in sorted(loc.name for loc in self.multiworld.get_locations(self.player)):
+            self.world._ut_previous_explanation = None
+            self.world.explain_rule(loc_name, self.multiworld.state)
+            prev = getattr(self.world, "_ut_previous_explanation", None)
+            if prev is None:
+                continue
+            _ = prev.explained_sub_rules
+            if prev.more_explanations:
+                seeded = prev
+                break
+        if seeded is None:
+            self.skipTest("no location in this seed produces drill-down candidates")
+
+        # No index -> listing path. Each enumerated line should be prefixed
+        # with /explain_more, not /more.
+        parts = self.world.explain_more("", self.multiworld.state)
+        joined = "".join(p.get("text", "") for p in parts if "text" in p)
+        self.assertIn("/explain_more 0", joined)
+        self.assertNotIn("/more 0", joined.replace("/explain_more 0", ""))
+
+    def test_explain_rule_docstring_documents_subcommand_syntax(self):
+        # UT propagates this docstring into /help via inspect.getdoc, so the
+        # four sub-command prefixes plus /explain_more must be discoverable.
+        doc = self.world.explain_rule.__doc__ or ""
+        self.assertIn("/explain", doc)
+        self.assertIn("item:", doc)
+        self.assertIn("missing:", doc)
+        self.assertIn("how:", doc)
+        self.assertIn("/explain_more", doc)

--- a/worlds/stardew_valley/test/TestClient.py
+++ b/worlds/stardew_valley/test/TestClient.py
@@ -1,0 +1,318 @@
+"""Pinning tests for StardewCommandProcessor and parse_explanation.
+
+These tests fix the observable behavior of the explain / explain_item /
+explain_missing / explain_how / more slash commands in client.py, so a
+subsequent refactor that hoists this logic into an abstract base + two
+subclasses can be verified input/output-preserving.
+"""
+from __future__ import annotations
+
+import contextlib
+import sys
+import types
+import unittest
+
+
+@contextlib.contextmanager
+def _scoped_client_import_stubs():
+    """Install kvui + worlds.tracker.* stubs in sys.modules, yield, then
+    restore the prior state.
+
+    Scope is tight on purpose: stubs only need to exist while client.py is
+    being imported for the first time. After that, sys.modules caches the
+    real client.py module and later `from ..client import X` lookups don't
+    re-resolve its imports. Restoring sys.modules means a later test in the
+    same pytest process can import the real kvui / worlds.tracker.* (when
+    they exist) without seeing our incomplete stubs.
+
+    - kvui is stubbed because it boots up a Kivy Window on import
+      (kvui.py:61 does `from kivy.core.window import Window`), which spawns
+      a stray GUI window for every test process. client.py only uses one
+      kvui symbol (CommandPromptTextInput) and only as a type annotation
+      inside make_gui, so a dummy module satisfies the import without
+      dragging in Kivy.
+
+    - worlds.tracker.* is stubbed because the class-body
+      `del _cmd_explain / _cmd_explain_missing` block at client.py:148-150
+      strips those methods off the class in environments where Universal
+      Tracker isn't installed -- which is the case for this fork.
+    """
+    keys = ("kvui", "worlds.tracker", "worlds.tracker.TrackerClient", "worlds.tracker.TrackerCore")
+    saved = {k: sys.modules.get(k) for k in keys}
+
+    if "kvui" not in sys.modules:
+        kvui_mod = types.ModuleType("kvui")
+        kvui_mod.CommandPromptTextInput = object
+        sys.modules["kvui"] = kvui_mod
+
+    if "worlds.tracker.TrackerClient" not in sys.modules:
+        from CommonClient import ClientCommandProcessor
+
+        sys.modules["worlds.tracker"] = types.ModuleType("worlds.tracker")
+
+        tc = types.ModuleType("worlds.tracker.TrackerClient")
+        tc.TrackerCommandProcessor = ClientCommandProcessor
+        tc.TrackerGameContext = object
+        tc.UT_VERSION = "test"
+        sys.modules["worlds.tracker.TrackerClient"] = tc
+
+        tcore = types.ModuleType("worlds.tracker.TrackerCore")
+        tcore.TrackerCore = type
+        sys.modules["worlds.tracker.TrackerCore"] = tcore
+
+    try:
+        yield
+    finally:
+        for k, prev in saved.items():
+            if prev is None:
+                sys.modules.pop(k, None)
+            else:
+                sys.modules[k] = prev
+
+
+with _scoped_client_import_stubs():
+    from ..client import StardewCommandProcessor, parse_explanation, tracker_loaded  # noqa: E402
+
+from ..stardew_rule.rule_explain import RuleExplanation  # noqa: E402
+from .bases import SVTestBase  # noqa: E402
+
+BOGUS = "xxxxxxxxxxxxxxxx-zzzzzzzzzzzzzzz-not-a-real-thing"
+
+
+class _StubUI:
+    def __init__(self) -> None:
+        self.printed: list[list[dict]] = []
+        self.last_autofillable_command: str | None = None
+
+    def print_json(self, parts) -> None:
+        self.printed.append(list(parts))
+
+
+class _StubCtx:
+    """Mimics the StardewClientContext attributes the command processor reads."""
+
+    def __init__(self, world, multiworld, player) -> None:
+        self._world = world
+        self._multiworld = multiworld
+        self._player = player
+        self.ui = _StubUI()
+        self.outputs: list[str] = []
+        self.previous_explanation: RuleExplanation | None = None
+
+    @property
+    def logic(self):
+        return self._world.logic
+
+    @property
+    def current_state(self):
+        return self._multiworld.state
+
+    @property
+    def all_locations(self):
+        return self._multiworld.get_locations(self._player)
+
+
+@unittest.skipUnless(tracker_loaded, "tracker stubs failed to install before client import")
+class TestStardewCommandProcessor(SVTestBase):
+    """Pins the observable behavior of every _cmd_* slash command in
+    StardewCommandProcessor against a real Stardew Valley world."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.ctx = _StubCtx(self.world, self.multiworld, self.player)
+        self.proc = StardewCommandProcessor(self.ctx)
+        # ClientCommandProcessor.output forwards to logger.info; redirect to a
+        # list so we can assert against it.
+        self.proc.output = self.ctx.outputs.append
+
+    # --- success path: command produced a rendered explanation ---
+
+    def test_explain_valid_location(self):
+        self.proc._cmd_explain(self._a_location())
+        self._assert_emitted_explanation(expected=None)
+
+    def test_explain_close_typo_resolves_via_fuzzy_match(self):
+        # one-char typo: Utils.get_intended_text should still resolve usable=True
+        self.proc._cmd_explain(self._a_location() + "x")
+        self._assert_emitted_explanation(expected=None)
+
+    def test_explain_item_valid(self):
+        self.proc._cmd_explain_item(self._an_item())
+        self._assert_emitted_explanation(expected=None)
+
+    def test_explain_missing_keeps_expected_true(self):
+        # /explain_missing surfaces only unsatisfied rules
+        self.proc._cmd_explain_missing(self._a_location())
+        self._assert_emitted_explanation(expected=True)
+
+    def test_explain_how_keeps_expected_false(self):
+        # /explain_how surfaces only satisfied rules
+        self.proc._cmd_explain_how(self._a_location())
+        self._assert_emitted_explanation(expected=False)
+
+    # --- failure path: bogus target produces a suggestion + autofill key ---
+
+    def test_bogus_target_emits_suggestion_and_sets_autofill(self):
+        cases = [
+            (self.proc._cmd_explain, "/explain"),
+            (self.proc._cmd_explain_item, "/explain_item"),
+            (self.proc._cmd_explain_missing, "/explain_missing"),
+            (self.proc._cmd_explain_how, "/explain_how"),
+        ]
+        for cmd, autofill_key in cases:
+            with self.subTest(autofill_key):
+                self._reset_captures()
+                cmd(BOGUS)
+                self.assertEqual(self.ctx.ui.printed, [])
+                self.assertEqual(self.ctx.ui.last_autofillable_command, autofill_key)
+                self.assertEqual(len(self.ctx.outputs), 1)
+                self.assertIsNone(self.ctx.previous_explanation)
+
+    # --- /more drill-down chain ---
+
+    def test_more_with_no_previous_explanation_emits_text_only(self):
+        self.proc._cmd_more("")
+
+        self.assertEqual(self.ctx.outputs, ["No previous explanation found."])
+        self.assertEqual(self.ctx.ui.printed, [])
+        self.assertIsNone(self.ctx.ui.last_autofillable_command)
+
+    def test_more_with_no_index_lists_drill_down_candidates(self):
+        prev = self._seed_previous_explanation_with_drill_down()
+        if prev is None:
+            self.skipTest("no location in this seed produces drill-down candidates")
+        self._reset_captures()
+
+        self.proc._cmd_more("")
+
+        self.assertEqual(self.ctx.ui.printed, [])
+        self.assertEqual(self.ctx.ui.last_autofillable_command, "/more")
+        # header line + one per candidate
+        self.assertEqual(len(self.ctx.outputs), 1 + len(prev.more_explanations))
+        for line in self.ctx.outputs[1:]:
+            self.assertTrue(line.startswith("/more "))
+
+    def test_more_with_index_drills_into_sub_rule(self):
+        prev = self._seed_previous_explanation_with_drill_down()
+        if prev is None:
+            self.skipTest("no location in this seed produces drill-down candidates")
+        self._reset_captures()
+
+        self.proc._cmd_more("0")
+
+        self.assertEqual(len(self.ctx.ui.printed), 1)
+        self.assertIsNotNone(self.ctx.previous_explanation)
+        self.assertIsNot(self.ctx.previous_explanation, prev)
+
+    def test_more_with_invalid_index_falls_back_to_listing(self):
+        prev = self._seed_previous_explanation_with_drill_down()
+        if prev is None:
+            self.skipTest("no location in this seed produces drill-down candidates")
+        self._reset_captures()
+
+        self.proc._cmd_more("9999")
+
+        self.assertEqual(self.ctx.ui.printed, [])
+        self.assertEqual(self.ctx.ui.last_autofillable_command, "/more")
+
+    # --- helpers ---
+
+    def _a_location(self) -> str:
+        return sorted(loc.name for loc in self.multiworld.get_locations(self.player))[0]
+
+    def _an_item(self) -> str:
+        return sorted(self.world.logic.registry.item_rules.keys())[0]
+
+    def _assert_emitted_explanation(self, expected: bool | None) -> None:
+        """Asserts the success-path observable contract: one print_json call
+        with a non-empty list of typed message-part dicts, a RuleExplanation
+        stored as previous_explanation whose `expected` field matches, and
+        no plain output or autofill side effects."""
+        self.assertEqual(len(self.ctx.ui.printed), 1, "expected exactly one print_json call")
+        parts = self.ctx.ui.printed[0]
+        self.assertGreater(len(parts), 0)
+        for part in parts:
+            self.assertIsInstance(part, dict)
+            self.assertIn("type", part)
+            self.assertIn("text", part)
+        self.assertIsInstance(self.ctx.previous_explanation, RuleExplanation)
+        self.assertEqual(self.ctx.previous_explanation.expected, expected)
+        self.assertIsNone(self.ctx.ui.last_autofillable_command)
+        self.assertEqual(self.ctx.outputs, [])
+
+    def _reset_captures(self) -> None:
+        """Clear capture buffers between calls. Does NOT touch
+        previous_explanation so post-seed resets stay safe for /more tests."""
+        self.ctx.ui.printed.clear()
+        self.ctx.ui.last_autofillable_command = None
+        self.ctx.outputs.clear()
+
+    def _seed_previous_explanation_with_drill_down(self) -> RuleExplanation | None:
+        """Walk locations in name order until /explain produces a previous
+        explanation with a non-empty more_explanations list. Returns it (or
+        None if no such location exists under this seed)."""
+        for loc_name in sorted(loc.name for loc in self.multiworld.get_locations(self.player)):
+            self._reset_captures()
+            self.ctx.previous_explanation = None
+            self.proc._cmd_explain(loc_name)
+            prev = self.ctx.previous_explanation
+            if prev is None:
+                continue
+            _ = prev.explained_sub_rules  # populate lazy more_explanations
+            if prev.more_explanations:
+                return prev
+        return None
+
+
+class TestParseExplanation(unittest.TestCase):
+    """Direct unit tests of parse_explanation's tokenizer.
+
+    We feed it RuleExplanation-shaped stand-ins whose __str__ produces a known
+    string, so the tokenizer's behavior is pinned independently of which
+    rules are in play at any seed.
+    """
+
+    @staticmethod
+    def _expl(s: str):
+        class _FakeExplanation:
+            def __str__(self_inner) -> str:
+                return s
+        return _FakeExplanation()
+
+    def test_true_renders_as_green(self):
+        self.assertIn({"type": "color", "color": "green", "text": "True"},
+                      parse_explanation(self._expl("True")))
+
+    def test_false_renders_as_salmon(self):
+        self.assertIn({"type": "color", "color": "salmon", "text": "False"},
+                      parse_explanation(self._expl("False")))
+
+    def test_typed_name_tokens(self):
+        cases = [
+            ("Reach Location Beach", "Reach Location ", "location_name", "Beach"),
+            ("Reach Entrance Bus Stop", "Reach Entrance ", "entrance_name", "Bus Stop"),
+            ("Received event Spring", "Received event ", "item_name", "Spring"),
+        ]
+        for src, prefix, typed, name in cases:
+            with self.subTest(src):
+                parts = parse_explanation(self._expl(src))
+                shape = [(p.get("type"), p.get("text")) for p in parts]
+                self.assertIn(("text", prefix), shape)
+                self.assertIn((typed, name), shape)
+
+    def test_reach_region_emits_yellow_color_token(self):
+        self.assertIn({"type": "color", "color": "yellow", "text": "Farm"},
+                      parse_explanation(self._expl("Reach Region Farm")))
+
+    def test_received_item_emits_flagged_item_name_token(self):
+        parts = parse_explanation(self._expl("Received Stardrop"))
+        item_parts = [p for p in parts if p.get("type") == "item_name"]
+        self.assertEqual(len(item_parts), 1)
+        self.assertEqual(item_parts[0]["text"], "Stardrop")
+        self.assertEqual(item_parts[0]["flags"], 0b001)
+
+    def test_has_with_count_splits_digit_into_cyan_token(self):
+        parts = parse_explanation(self._expl("Has 3 Stardrop"))
+        shape = [(p.get("type"), p.get("text"), p.get("color")) for p in parts]
+        self.assertIn(("text", "Has ", None), shape)
+        self.assertIn(("color", "3", "cyan"), shape)


### PR DESCRIPTION
## What is this fixing or adding?

The goal of this PR is to additionally support the UT `/explain` and `/explain_more` command hooks so that both UT and the Stardew Tracker can be used and get the benefits of the advanced explain system that it has.

## How was this tested?

I first added unit tests in the first commit to assert the current expected output of the SV tracker and the later commit only adds tests. I am happy to add more test cases if you have ones you think are reasonable to prove it's the same output.

I had to do some gross patching to get past the auto-detection for if UT is available so if you don't want these tests at all that's ok I can use them just for making the PR higher confidence and not ship them.

## If this makes graphical changes, please attach screenshots.

### Universal Tracker:

<img width="1197" height="977" alt="2026-06-03-23:43:25_1197x977" src="https://github.com/user-attachments/assets/c6686bb2-b134-42a0-8765-0277ec69ca39" />

### Stardew Tracker

<img width="1196" height="1447" alt="2026-06-03-23:45:41_1196x1447" src="https://github.com/user-attachments/assets/829fe0df-49f3-4452-86c3-487b9fe43ada" />

