### PR TITLE
Fill: make non prog start inventory panic actually use the new filler items

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -343,6 +343,8 @@ def remaining_fill(multiworld: MultiWorld,
                 last_batch.append(multiworld.worlds[item.player].create_filler())
             remaining_fill(multiworld, locations, last_batch, name + " Start Inventory Retry")
             itempool.extend(last_batch)
+            # remaining_fill removes the items from the batch when they're placed.
+            # This will only add to the pool the new fillers that were not placed, hopefully none.
             return
         else:
             raise FillError(f"No more spots to place {len(unplaced_items)} items. Remaining locations are invalid.\n"

--- a/Fill.py
+++ b/Fill.py
@@ -341,7 +341,9 @@ def remaining_fill(multiworld: MultiWorld,
                 logging.debug(f"Moved {item} to start_inventory to prevent fill failure.")
                 multiworld.push_precollected(item)
                 last_batch.append(multiworld.worlds[item.player].create_filler())
-            remaining_fill(multiworld, locations, unplaced_items, name + " Start Inventory Retry")
+            remaining_fill(multiworld, locations, last_batch, name + " Start Inventory Retry")
+            itempool.extend(last_batch)
+            return
         else:
             raise FillError(f"No more spots to place {len(unplaced_items)} items. Remaining locations are invalid.\n"
                             f"Unplaced items:\n"


### PR DESCRIPTION
## What is this fixing or adding?
this codepath (which is not hit for unplacable prog items) currently precollects the items it couldn't place, makes filler to replace them, and then tries to place the precollected items a second time,
this fixes it to actually use the new filler

## How was this tested?
made v6 add an item rule to all its locations, both for the prog trinket 1 and the filler trinket 20 (at default options)

## If this makes graphical changes, please attach screenshots.
