### PR TITLE
Wargroove: Add item groups

### DIFF
--- a/worlds/wargroove/Items.py
+++ b/worlds/wargroove/Items.py
@@ -1,7 +1,7 @@
 import typing
 
 from BaseClasses import Item, ItemClassification
-from typing import Dict, List
+from typing import Dict, List, Set
 
 PROGRESSION = ItemClassification.progression
 PROGRESSION_SKIP_BALANCING = ItemClassification.progression_skip_balancing
@@ -102,3 +102,18 @@ faction_table: Dict[str, List[CommanderData]] = {
         CommanderData('Vesper', 'commander_vesper')
     ]
 }
+
+item_name_groups: Dict[str, Set[str]] = {}
+for name, item in item_table.items():
+    group = item.type
+    if not group or group == 'Goal':
+        continue
+    if group == "Trigger":
+        # Split triggers since they serve very different purposes.
+        if "Final" in name:
+            group = "Final"
+        else:
+            group = "Event"
+    if group not in item_name_groups:
+        item_name_groups[group] = set()
+    item_name_groups[group].add(name)

--- a/worlds/wargroove/Items.py
+++ b/worlds/wargroove/Items.py
@@ -105,15 +105,15 @@ faction_table: Dict[str, List[CommanderData]] = {
 
 item_name_groups: Dict[str, Set[str]] = {}
 for name, item in item_table.items():
-    group = item.type
-    if not group or group == 'Goal':
+    group = f'{item.type}s'
+    if not group or group == 'Goals':
         continue
-    if group == "Trigger":
+    if group == "Triggers":
         # Split triggers since they serve very different purposes.
         if "Final" in name:
-            group = "Final"
+            group = "Final Items"
         else:
-            group = "Event"
+            group = "Events"
     if group not in item_name_groups:
         item_name_groups[group] = set()
     item_name_groups[group].add(name)

--- a/worlds/wargroove/__init__.py
+++ b/worlds/wargroove/__init__.py
@@ -73,6 +73,7 @@ class WargrooveWorld(World):
 
     item_name_to_id = {name: data.code for name, data in item_table.items()}
     location_name_to_id = location_table
+    item_name_groups = Items.item_name_groups
 
     def _get_slot_data(self):
         return {


### PR DESCRIPTION
## What is this fixing or adding?
This adds item groups to Wargroove. The item groups added are units (named "Unit"), event items that don't unlock the final mission (named "Event"), event items that unlock the final mission (named "Final"), factions (named "Faction"), and filler boosts (named "Boost"). 

## How was this tested?
I generated a test seed, set hint cost to 0, and then hinted each item group. I verified that the hinted items matched the expected contents of each item group.

## If this makes graphical changes, please attach screenshots.
This does not make graphical changes.