### PR TITLE
Docs: Update docs and typing for items_handling to not allow None

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -232,7 +232,7 @@ class CommonContext:
     # The following attributes are used to Connect and should be adjusted as needed in subclasses
     tags: typing.Set[str] = {"AP"}
     game: typing.Optional[str] = None
-    items_handling: typing.Optional[int] = None
+    items_handling: int
     want_slot_data: bool = True  # should slot_data be retrieved via Connect
 
     class NameLookupDict:

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -308,7 +308,6 @@ Sent by the client to initiate a connection to an Archipelago game session.
 | 0b001 | Indicates you get items sent from other worlds. |
 | 0b010 | Indicates you get items sent from your own world. Requires 0b001 to be set. |
 | 0b100 | Indicates you get your starting inventory sent. Requires 0b001 to be set. |
-| null  | Null or undefined loads settings from world definition for backwards compatibility. This is deprecated. |
 
 #### Authentication
 Many, if not all, other packets require a successfully authenticated client. This is described in more detail in [Archipelago Connection Handshake](#Archipelago-Connection-Handshake).


### PR DESCRIPTION
## What is this fixing or adding?
this functionality was removed in 0.3.7
https://github.com/ArchipelagoMW/Archipelago/pull/757

Note: this will cause connect to fail if items_handling was not set, but as a recent conversation on discord showed, that flow just got the server to reject you instead

## How was this tested?
:eyes:

## If this makes graphical changes, please attach screenshots.
