### PR TITLE
core/webhost: Option group descriptions

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -1774,7 +1774,7 @@ it.
 
 def get_option_groups(
     world: typing.Type[World], visibility_level: Visibility = Visibility.template
-) -> dict[str, dict[str, typing.Type[Option[typing.Any]]], str]:
+) -> dict[str, tuple[dict[str, typing.Type[Option[typing.Any]]], str]]:
     """Generates and returns a dictionary for the option groups of a specified world."""
     option_to_name = {option: option_name for option_name, option in world.options_dataclass.type_hints.items()}
 

--- a/Options.py
+++ b/Options.py
@@ -25,12 +25,12 @@ if typing.TYPE_CHECKING:
 
 
 _RANDOM_OPTS = [
-        "random", "random-low", "random-middle", "random-high", 
+        "random", "random-low", "random-middle", "random-high",
         "random-range-low-<min>-<max>", "random-range-middle-<min>-<max>",
         "random-range-high-<min>-<max>", "random-range-<min>-<max>",
 ]
-    
-    
+
+
 def triangular(lower: int, end: int, tri: float = 0.5) -> int:
     """
     Integer triangular distribution for `lower` inclusive to `end` inclusive.
@@ -41,7 +41,7 @@ def triangular(lower: int, end: int, tri: float = 0.5) -> int:
     # random.triangular is actually [a, b] and not [a, b), so there is a very small chance of getting exactly b even
     # when a != b, so ensure the result is never more than `end`.
     return min(end, math.floor(random.triangular(0.0, 1.0, tri) * (end - lower + 1) + lower))
-  
+
 
 def random_weighted_range(text: str, range_start: int, range_end: int):
     if text == "random-low":
@@ -56,7 +56,7 @@ def random_weighted_range(text: str, range_start: int, range_end: int):
             raise Exception(f"random text \"{text}\" did not resolve to a recognized pattern. "
                             f"Acceptable values are: {', '.join(_RANDOM_OPTS)}.")
 
-        
+
 def roll_percentage(percentage: int | float) -> bool:
     """Roll a percentage chance.
     percentage is expected to be in range [0, 100]"""
@@ -1759,6 +1759,8 @@ class OptionGroup(typing.NamedTuple):
     """Options to be in the defined group."""
     start_collapsed: bool = False
     """Whether the group will start collapsed on the WebHost options pages."""
+    description: str = ""
+    """A brief description or help text to appear under the option group header."""
 
 
 item_and_loc_options = [LocalItems, NonLocalItems, StartInventory, StartInventoryPool, StartHints,
@@ -1770,28 +1772,32 @@ it.
 """
 
 
-def get_option_groups(world: typing.Type[World], visibility_level: Visibility = Visibility.template) -> typing.Dict[
-        str, typing.Dict[str, typing.Type[Option[typing.Any]]]]:
+def get_option_groups(
+    world: typing.Type[World], visibility_level: Visibility = Visibility.template
+) -> dict[str, dict[str, typing.Type[Option[typing.Any]]], str]:
     """Generates and returns a dictionary for the option groups of a specified world."""
     option_to_name = {option: option_name for option_name, option in world.options_dataclass.type_hints.items()}
 
-    ordered_groups = {group.name: group.options for group in world.web.option_groups}
+    ordered_groups = {group.name: (group.options, group.description) for group in world.web.option_groups}
 
     # add a default option group for uncategorized options to get thrown into
     if "Game Options" not in ordered_groups:
-        grouped_options = set(option for group in ordered_groups.values() for option in group)
+        grouped_options = set(option for group, _ in ordered_groups.values() for option in group)
         ungrouped_options = [option for option in option_to_name if option not in grouped_options]
         # only add the game options group if we have ungrouped options
         if ungrouped_options:
-            ordered_groups = {**{"Game Options": ungrouped_options}, **ordered_groups}
+            ordered_groups = {**{"Game Options": (ungrouped_options, "")}, **ordered_groups}
 
     return {
-        group: {
-            option_to_name[option]: option
-            for option in group_options
-            if (visibility_level in option.visibility and option in option_to_name)
-        }
-        for group, group_options in ordered_groups.items()
+        group: (
+            {
+                option_to_name[option]: option
+                for option in group_options
+                if (visibility_level in option.visibility and option in option_to_name)
+            },
+            description
+        )
+        for group, (group_options, description) in ordered_groups.items()
     }
 
 

--- a/WebHostLib/templates/playerOptions/playerOptions.html
+++ b/WebHostLib/templates/playerOptions/playerOptions.html
@@ -68,9 +68,17 @@
             </div>
 
             <div id="option-groups">
-                {% for group_name, group_options in option_groups.items() %}
+                {% for group_name, (group_options, description) in option_groups.items() %}
                     <details class="group-container" {% if not start_collapsed[group_name] %}open{% endif %}>
                         <summary class="h2">{{ group_name }}</summary>
+                        {% if description: %}
+                            <text style="font-size: 90%">
+                                {% for line in description.split('\n\n')  %}
+                                {{line}}<br>
+                                {% endfor  %}
+                            </text>
+                            <hr>
+                        {% endif %}
                         <div class="game-options">
                             <div class="left">
                                 {% for option_name, option in group_options.items() %}

--- a/WebHostLib/templates/weightedOptions/weightedOptions.html
+++ b/WebHostLib/templates/weightedOptions/weightedOptions.html
@@ -50,9 +50,16 @@
             </p>
 
             <div id="{{ world_name }}-container">
-                {% for group_name, group_options in option_groups.items() %}
+                {% for group_name, (group_options, description) in option_groups.items() %}
                     <details {% if not start_collapsed[group_name] %}open{% endif %}>
                         <summary class="h2">{{ group_name }}</summary>
+                        {%- if description: %}
+                            <text style="font-size: 90%">
+                                {% for line in description.split('\n\n')  %}
+                                {{line}}<br>
+                                {% endfor  %}
+                            </text>
+                        {%- endif %}
                         {% for option_name, option in group_options.items() %}
                             <div class="option-wrapper">
                                 <h4>{{ option.display_name|default(option_name) }}</h4>

--- a/data/options.yaml
+++ b/data/options.yaml
@@ -49,10 +49,17 @@ requires:
 {% endmacro %}
 
 {{ yaml_dump(game) }}:
-  {%- for group_name, group_options in option_groups.items() %}
+  {%- for group_name, (group_options, description) in option_groups.items() %}
   ##{% for _ in group_name %}#{% endfor %}##
   # {{ group_name }} #
   ##{% for _ in group_name %}#{% endfor %}##
+  {%- if description: %}
+  # {{ cleandoc(description)
+      | trim
+      | replace('\n', '\n# ')
+      | indent(2, first=False)
+    }}
+  {%- endif %}
 
   {%- for option_key, option in group_options.items() %}
   {{ option_key }}:
@@ -79,7 +86,7 @@ requires:
     {%- for suboption_option_id, sub_option_name in option.name_lookup.items() %}
     {{ yaml_dump(sub_option_name) }}: {% if suboption_option_id == option_val or sub_option_name == option_val %}50{% else %}0{% endif %}
     {%- endfor -%}
-  
+
     {%- if option.name_lookup[option_val] not in option.options and option_val not in option.options %}
     {{ yaml_dump(option_val) }}: 50
     {%- endif -%}

--- a/worlds/sc2/options.py
+++ b/worlds/sc2/options.py
@@ -2,6 +2,7 @@ import functools
 from dataclasses import fields, Field, dataclass
 from typing import *
 from datetime import timedelta
+from inspect import cleandoc
 
 from Options import (
     Choice, Toggle, DefaultOnToggle, OptionSet, Range,
@@ -358,9 +359,9 @@ class RequiredTactics(Choice):
 
 class EnableVoidTrade(Toggle):
     """
-    Enables the Void Trade Wormhole to be built from the Advanced Construction tab of SCVs, Drones and Probes.  
-    This structure allows sending units to the Archipelago server, as well as buying random units from the server.  
-    
+    Enables the Void Trade Wormhole to be built from the Advanced Construction tab of SCVs, Drones and Probes.
+    This structure allows sending units to the Archipelago server, as well as buying random units from the server.
+
     Note: Always disabled if there is no other Starcraft II world with Void Trade enabled in the multiworld.  You cannot receive units that you send.
     """
     display_name = "Enable Void Trade"
@@ -583,7 +584,7 @@ class KerriganLevelsPerMissionCompleted(Range):
 
 class KerriganLevelsPerMissionCompletedCap(Range):
     """
-    Limits how many total levels Kerrigan can gain from beating missions.  This does not affect levels gained from items.  
+    Limits how many total levels Kerrigan can gain from beating missions.  This does not affect levels gained from items.
     Set to -1 to disable this limit.
 
     NOTE: The following missions have these level requirements:
@@ -1445,20 +1446,28 @@ class Starcraft2Options(PerGameCommonOptions):
 
 option_groups = [
     OptionGroup("Difficulty Settings", [
-        GameDifficulty,
-        GameSpeed,
-        StarterUnit,
-        RequiredTactics,
-        WarCouncilNerfs,
-        DifficultyCurve,
-    ]),
+            GameDifficulty,
+            GameSpeed,
+            StarterUnit,
+            RequiredTactics,
+            WarCouncilNerfs,
+            DifficultyCurve,
+        ],
+        description=cleandoc("""
+        Note the Logic Level option is the most impactful on difficulty early in the campaign.
+        For a first time player, we recommend playing a difficulty level down from your hardest vanilla playthrough.
+        Game difficulty can be changed after generation in the client.
+        """)
+    ),
     OptionGroup("Primary Campaign Settings", [
-        MissionOrder,
-        MaximumCampaignSize,
-        EnabledCampaigns,
-        EnableRaceSwapVariants,
-        ShuffleNoBuild,
-    ]),
+            MissionOrder,
+            MaximumCampaignSize,
+            EnabledCampaigns,
+            EnableRaceSwapVariants,
+            ShuffleNoBuild,
+        ],
+        description="The average mission takes around 20 minutes to complete, plan the campaign size accordingly."
+    ),
     OptionGroup("Optional Campaign Settings", [
         KeyMode,
         ShuffleCampaigns,
@@ -1509,26 +1518,43 @@ option_groups = [
         MercenaryHighlanders,
     ]),
     OptionGroup("Check Locations", [
-        VictoryCache,
-        VanillaLocations,
-        ExtraLocations,
-        ChallengeLocations,
-        MasteryLocations,
-        BasebustLocations,
-        SpeedrunLocations,
-        PreventativeLocations,
-    ]),
+            VictoryCache,
+            VanillaLocations,
+            ExtraLocations,
+            ChallengeLocations,
+            MasteryLocations,
+            BasebustLocations,
+            SpeedrunLocations,
+            PreventativeLocations,
+        ],
+        description=cleandoc("""
+        Extra, challenge, and mastery groups are roughly sorted by difficulty.
+        Extra locations are milestones that are usually gotten while completing a mission, such as rescuing units on The Moebius Factor.
+        Challenge locations are as difficult as regular achievements, such as beating the kill team on The Great Train Robbery.
+        Mastery locations are as difficult as mastery achievements, such as beating the base on Welcome to the Jungle.
+
+        Basebust, Speedrun, and Preventative locations are classifications on top of vanilla and the difficulty groups.
+        For locations with a classification, setting both their difficulty and classification groups to half chance
+        will result in the location having a 25% chance of appearing.
+        """)
+    ),
     OptionGroup("Filler Options", [
-        FillerPercentage,
-        MineralsPerItem,
-        VespenePerItem,
-        StartingSupplyPerItem,
-        MaximumSupplyPerItem,
-        MaximumSupplyReductionPerItem,
-        LowestMaximumSupply,
-        ResearchCostReductionPerItem,
-        FillerItemsDistribution,
-    ]),
+            FillerPercentage,
+            MineralsPerItem,
+            VespenePerItem,
+            StartingSupplyPerItem,
+            MaximumSupplyPerItem,
+            MaximumSupplyReductionPerItem,
+            LowestMaximumSupply,
+            ResearchCostReductionPerItem,
+            FillerItemsDistribution,
+        ],
+        description=cleandoc("""
+        In Archipelago, the item count must always match the location count for a world.
+        If there are too few items, the remaining count is made up by adding filler items.
+        If you are getting too many filler items, you must reduce your location count.
+        """)
+    ),
     OptionGroup("Inclusions & Exclusions", [
         LockedItems,
         ExcludedItems,

--- a/worlds/stardew_valley/options/option_groups.py
+++ b/worlds/stardew_valley/options/option_groups.py
@@ -1,4 +1,5 @@
 import logging
+from inspect import cleandoc
 
 import Options as ap_options
 from . import options
@@ -10,81 +11,141 @@ except ImportError:
     logging.warning("Old AP Version, OptionGroup not available.")
 else:
     sv_option_groups = [
-        OptionGroup("General", [
-            options.Goal,
-            options.FarmType,
-            options.BundleRandomization,
-            options.BundlePrice,
-            options.BundlePerRoom,
-            options.EntranceRandomization,
-            options.ExcludeGingerIsland,
-        ]),
-        OptionGroup("Major Unlocks", [
-            options.SeasonRandomization,
-            options.Cropsanity,
-            options.BackpackProgression,
-            options.ToolProgression,
-            options.ElevatorProgression,
-            options.SkillProgression,
-            options.BuildingProgression,
-            options.StartWithout,
-        ]),
-        OptionGroup("Extra Shuffling", [
-            options.FestivalLocations,
-            options.ArcadeMachineLocations,
-            options.SpecialOrderLocations,
-            options.QuestLocations,
-            options.Fishsanity,
-            options.Museumsanity,
-            options.Friendsanity,
-            options.Monstersanity,
-            options.Chefsanity,
-            options.Booksanity,
-            options.Walnutsanity,
-            options.Moviesanity,
-        ]),
-        OptionGroup("Extreme Options", [
-            options.Shipsanity,
-            options.Cooksanity,
-            options.Craftsanity,
-            options.Eatsanity,
-            options.Secretsanity,
-            options.Hatsanity,
-            options.IncludeEndgameLocations,
-        ]),
-        OptionGroup("Multipliers, Buffs and extra customization", [
-            options.StartingMoney,
-            options.ProfitMargin,
-            options.ExperienceMultiplier,
-            options.FriendshipMultiplier,
-            options.FriendsanityHeartSize,
-            options.DebrisMultiplier,
-            options.BackpackSize,
-            options.NumberOfMovementBuffs,
-            options.EnabledFillerBuffs,
-            options.AllowedFillerItems,
-            options.TrapDifficulty,
-            options.TrapDistribution,
-            options.MultipleDaySleepEnabled,
-            options.MultipleDaySleepCost,
-            options.QuickStart,
-        ]),
-        OptionGroup("Advanced Options", [
-            options.Gifting,
-            ap_options.DeathLink,
-            options.Mods,
-            options.BundleWhitelist,
-            options.BundleBlacklist,
-            options.CustomLogic,
-            ap_options.ProgressionBalancing,
-            ap_options.Accessibility,
-        ]),
-        OptionGroup("Jojapocalypse", [
-            options.Jojapocalypse,
-            options.JojaStartPrice,
-            options.JojaEndPrice,
-            options.JojaPricingPattern,
-            options.JojaPurchasesForMembership,
-            options.JojaAreYouSure,
-        ]),
+        OptionGroup(
+            "General",
+            [
+                options.Goal,
+                options.FarmType,
+                options.BundleRandomization,
+                options.BundlePrice,
+                options.BundlePerRoom,
+                options.EntranceRandomization,
+                options.ExcludeGingerIsland,
+            ],
+            description=cleandoc(
+                """
+                These settings decide what your playthrough will be.
+                They do not directly add or remove shuffled locations or items, but instead shape the playthrough in other ways.
+                """
+            )),
+        OptionGroup(
+            "Major Unlocks",
+            [
+                options.SeasonRandomization,
+                options.Cropsanity,
+                options.BackpackProgression,
+                options.ToolProgression,
+                options.ElevatorProgression,
+                options.SkillProgression,
+                options.BuildingProgression,
+                options.StartWithout,
+            ],
+            description=cleandoc(
+                """
+                These settings are critical customization of items and locations.
+                They are the biggest deciders of progression style, and how much of the core mechanics of the game will start out locked and be randomized.
+                Turning off some of these settings can make the playthrough more open, and more difficult as a result.
+                """
+            )),
+        OptionGroup(
+            "Extra Shuffling",
+            [
+                options.FestivalLocations,
+                options.ArcadeMachineLocations,
+                options.SpecialOrderLocations,
+                options.QuestLocations,
+                options.Fishsanity,
+                options.Museumsanity,
+                options.Friendsanity,
+                options.Monstersanity,
+                options.Chefsanity,
+                options.Booksanity,
+                options.Walnutsanity,
+                options.Moviesanity,
+            ],
+            description=cleandoc(
+                """
+                These settings will shuffle an extra game mechanic, that is not critical to the playthrough but can help fit a specific theme, or add replayability to something that is otherwise always the same.
+                They generally focus on one very specific mechanic, and you decide whether to shuffle it or not, and to what extent.
+                """
+            )),
+        OptionGroup(
+            "Extreme Options",
+            [
+                options.Shipsanity,
+                options.Cooksanity,
+                options.Craftsanity,
+                options.Eatsanity,
+                options.Secretsanity,
+                options.Hatsanity,
+                options.IncludeEndgameLocations,
+            ],
+            description=cleandoc(
+                """
+                These settings work similarly to the "Extra Shuffling" settings, but have the potential to make a run extremely difficult or time-consuming.
+                Recommended only for experienced players, not for the faint of heart.
+                """
+            )),
+        OptionGroup(
+            "Multipliers, Buffs and extra customization",
+            [
+                options.StartingMoney,
+                options.ProfitMargin,
+                options.ExperienceMultiplier,
+                options.FriendshipMultiplier,
+                options.FriendsanityHeartSize,
+                options.DebrisMultiplier,
+                options.BackpackSize,
+                options.NumberOfMovementBuffs,
+                options.EnabledFillerBuffs,
+                options.AllowedFillerItems,
+                options.TrapDifficulty,
+                options.TrapDistribution,
+                options.MultipleDaySleepEnabled,
+                options.MultipleDaySleepCost,
+                options.QuickStart,
+            ],
+            description=cleandoc(
+                """
+                These settings do not directly add or remove randomization, but instead serve to customize difficulty, grinding, and overall duration of the slot.
+                These have direct effects on in-game behaviors, not tied to the Archipelago randomization.
+                These settings are a good way to make a seed objectively easier or harder in a very predictable way.
+                """
+            )),
+        OptionGroup(
+            "Advanced Options",
+            [
+                options.Gifting,
+                ap_options.DeathLink,
+                options.Mods,
+                options.BundleWhitelist,
+                options.BundleBlacklist,
+                options.CustomLogic,
+                ap_options.ProgressionBalancing,
+                ap_options.Accessibility,
+            ],
+            description=cleandoc(
+                """
+                These settings are more complicated to understand and should generally be left default.
+                Intended for power users, experienced Archipelago players and hosts, and people trying to create an extremely customized run, for example for a themed event.
+                """
+            )),
+        OptionGroup(
+            "Jojapocalypse",
+            [
+                options.Jojapocalypse,
+                options.JojaStartPrice,
+                options.JojaEndPrice,
+                options.JojaPricingPattern,
+                options.JojaPurchasesForMembership,
+                options.JojaAreYouSure,
+            ],
+            description=cleandoc(
+                """
+                Jojapocalypse is an overhaul of the progression of the randomizer, thematically equivalent to the Joja Route from the vanilla game.
+                It is designed as an intnetionally unsatisfying, difficult, unfun experience, to make the player experience the consequences of encouraging Joja, and regret their choice.
+                Jojapocalypse can be extremely mentally taxing and unpleasant. As a result, it can only be generated locally, not on the website, and only by having the host explicitly consent to it by modifying their `host.yaml` file to allow it.
+                These settings serve to enable and customize Jojapocalypse
+                """
+            )),
     ]

--- a/worlds/stardew_valley/options/option_groups.py
+++ b/worlds/stardew_valley/options/option_groups.py
@@ -143,7 +143,7 @@ else:
             description=cleandoc(
                 """
                 Jojapocalypse is an overhaul of the progression of the randomizer, thematically equivalent to the Joja Route from the vanilla game.
-                It is designed as an intnetionally unsatisfying, difficult, unfun experience, to make the player experience the consequences of encouraging Joja, and regret their choice.
+                It is designed as an intentionally unsatisfying, difficult, unfun experience, to make the player experience the consequences of encouraging Joja, and regret their choice.
                 Jojapocalypse can be extremely mentally taxing and unpleasant. As a result, it can only be generated locally, not on the website, and only by having the host explicitly consent to it by modifying their `host.yaml` file to allow it.
                 These settings serve to enable and customize Jojapocalypse
                 """


### PR DESCRIPTION
## What is this fixing or adding?
Adding descriptions to option groups. These extra bits of documentation get included in yaml templates and the webhost under the option group header. Option groups without a description are unaffected.

I've made a #general-suggestions thread on the discord, [Option Group Descriptions](https://discord.com/channels/731205301247803413/1515550533086347294/1515550533086347294) for faster communication.

Adding option group descriptions to the Starcraft 2 options. These are targeted at some of the most common issues players come to us for help on getting their yamls working.

Note that this PR changes the return type of Options.get_option_groups() to also return descriptions. I updated all usages so this is fine with current main, but there will be a conflict with #6216.

### A note on newlines
One of the common pain points for my own dev when working with options descriptions and help text is that the same source is used for both yaml and webhost, with completely different display characteristics. Newlines get abandoned on webhost, and the full description gets crammed into a tiny box; whereas yaml preserves newlines, has no line wrap, has more space for description, and also wants extra detail wherever particular strings are expected but not provided by the template.

To try and give _some_ amount of targeted control, I've made the browser displays only substitute `<br>` tags on double-newlines. This means a single newline can be used to ensure a line wrap in yaml only, without creating a paragraph break in HTML.

## How was this tested?
- [x] Generated template yamls. Checked that description comments appeared under option group headers
- [x] Ran the webhost. Checked both options page and weighted options page for the descriptions.
  - [x] Checked export yaml and generate single-player game buttons both still worked for the regular options page

## If this makes graphical changes, please attach screenshots.
### yaml
<img width="951" height="326" alt="image" src="https://github.com/user-attachments/assets/285b1093-9ceb-4255-93ec-e097e3fa2e0e" />
<img width="1098" height="274" alt="image" src="https://github.com/user-attachments/assets/54cd263b-61d3-4f8a-8456-918ebf4ebc82" />

### Options page
<img width="1060" height="278" alt="image" src="https://github.com/user-attachments/assets/582d7087-5461-4085-8282-e2d7d1368f7c" />
<img width="1038" height="466" alt="image" src="https://github.com/user-attachments/assets/9a1f9308-e602-403b-8c72-1478a61ba8af" />

### Weighted options page
<img width="1051" height="431" alt="image" src="https://github.com/user-attachments/assets/b3ad4cac-4adf-4515-af65-d6f3bdeef3bb" />
<img width="1042" height="348" alt="image" src="https://github.com/user-attachments/assets/eae4fbbd-f5c8-499b-a912-a773b63d40be" />
