### PR TITLE
Update settings.py line 819

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -816,7 +816,7 @@ class Settings(Group):
             with open(location, encoding="utf-8-sig") as f:
                 from yaml.error import MarkedYAMLError
                 try:
-                    options = parse_yaml(f.read())
+                    options = parse_yaml(f.read().replace("\\", "/")) # Prevent user error for paths
                 except MarkedYAMLError as ex:
                     if ex.problem_mark:
                         f.seek(0)


### PR DESCRIPTION
## What is this fixing or adding?
Replace "\\" with "/" when reading the host.yaml. Because many users just copy paths containing "\\" then complain when it doesn't work.

## How was this tested?
Loaded host.yaml containing the following example paths for functionality:
"\\\\mnt\\\\disk1\\\\SteamLibrary\\\\steamapps\\\\common\\\\Total War WARHAMMER III"
"\\mnt\\disk1\\SteamLibrary\\steamapps\\common\\Total War WARHAMMER III"
"/mnt/disk1/SteamLibrary/steamapps/common/Total War WARHAMMER III"
All 3 do not throw errors and work identically.