### PR TITLE
Docs: note SetReply slot is absent on special _read keys

### DIFF
--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -264,7 +264,7 @@ Sent to clients in response to a [Set](#Set) package if want_reply was set to tr
 | key            | str  | The key that was updated.                                                                  |
 | value          | any  | The new value for the key.                                                                 |
 | original_value | any  | The value the key had before it was updated. Not present on "_read" prefixed special keys. |
-| slot           | int  | The slot that originally sent the Set package causing this change.                         |
+| slot           | int  | The slot that originally sent the Set package causing this change. Not present on "_read" prefixed special keys. |
 
 Additional arguments added to the [Set](#Set) package that triggered this [SetReply](#SetReply) will also be passed along.
 


### PR DESCRIPTION
## What is this fixing or adding?

Fixes #5829.

The SetReply documentation listed the `slot` argument unconditionally, but the server only includes it when the SetReply is triggered by a client `Set` packet (the `Set` handler in `MultiServer.py`). The server-generated SetReplies for the special `_read_hints_{team}_{slot}` and `_read_client_status_{team}_{slot}` keys — sent from `on_changed_hints` and `on_client_status_change` — do not include `slot` (nor `original_value`).

This mirrors the caveat already documented on the `original_value` row, keeping the two entries consistent.

## How was this tested?

Documentation-only change. Verified against `MultiServer.py` on `main`: `slot` is set only in the `Set` command handler and is not added in the `on_changed_hints` / `on_client_status_change` broadcast paths, so it is absent for the `_read_`-prefixed special keys (same as `original_value`). No code paths are affected.
