### PR TITLE
Core: Adjust YAML error message to clarify the name is not the cause of the error

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -279,7 +279,7 @@ def main(args=None) -> tuple[argparse.Namespace, int]:
                                   f"(name: {args.name.get(player, name)})")
                 player_errors.append(
                     f"{len(player_errors) + 1}. "
-                    f"File {path} document #{doc_index + 1} (name: {args.name.get(player, name)}) is invalid. "
+                    f"File {path} document #{doc_index + 1} (with name: {args.name.get(player, name)}) is invalid. "
                     f"Please fix your yaml.\n{Utils.get_all_causes(e)}")
 
             # increment for each yaml document in the file


### PR DESCRIPTION
## What is this fixing or adding?
I've seen players get confused at the current error message here, thinking the name is the source of the error. This should hopefully prevent some of that confusion.

## How was this tested?
I generated with an invalid YAML, it printed the new error.

## If this makes graphical changes, please attach screenshots.
N/A