### PR TITLE
Civ6 Bug Fix : Update BOOST_TECH_CASTLES

### DIFF
--- a/worlds/civ_6/data/boosts.py
+++ b/worlds/civ_6/data/boosts.py
@@ -165,9 +165,9 @@ boosts: List[CivVIBoostData] = [
         "BOOST_TECH_CASTLES",
         "ERA_MEDIEVAL",
         [
-            "CIVIC_SUFFRAGE",
-            "CIVIC_TOTALITARIANISM",
-            "CIVIC_CLASS_STRUGGLE",
+            "CIVIC_EXPLORATION",
+            "CIVIC_DIVINE_RIGHT",
+            "CIVIC_REFORMED_CHURCH",
         ],
         1,
         "DEFAULT",


### PR DESCRIPTION
## What is this fixing or adding?
Adjusted the required techs to BOOST_TECH_CASTLES location. as of right now techs that give 8 slots governments areexpected, which should be 6 slots governments as this is what triggers this tech boost in game.
There was an earlier attempt at fixing this:
https://github.com/ArchipelagoMW/Archipelago/pull/5134#ref-commit-3b98425 
but a mistake slipped in that has the Castles boost have the same Prereq as the Computers boost

## How was this tested?
Ran from source using Universal Tracker and connecting to rooms created on the ap site
After giving the adjusted items this location came in logic

