### PR TITLE
Launcher: build apworlds with files dated before 1980

### DIFF
--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -316,7 +316,8 @@ if not is_frozen():
             local_ignores = read_apignore(pathlib.Path(world_directory, ".apignore"))
             apignores = global_apignores + local_ignores if local_ignores else global_apignores
 
-            with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED, compresslevel=9) as zf:
+            with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED, compresslevel=9,
+                                 strict_timestamps=False) as zf:
                 for file in apignores.match_tree_files(world_directory, negate=True):
                     zf.write(pathlib.Path(world_directory, file), pathlib.Path(file_name, file))
 


### PR DESCRIPTION
## What is this fixing or adding?

Building an `.apworld` via the launcher's "Build APWorlds" component crashes with `ValueError: ZIP does not support timestamps before 1980` when any file in the world folder has a modification time outside the ZIP format's representable range (e.g. a pre-1980 mtime left over from checkout or extraction).

Passing `strict_timestamps=False` to `ZipFile` (the standard-library option for exactly this situation) clamps such timestamps to the ZIP minimum instead of raising, so the build succeeds.

Fixes #5505.

## How was this tested?

Reproduced the crash and confirmed the fix with a minimal repro: a file given a pre-1980 mtime via `os.utime(f, (0, 0))`. With the default `ZipFile` it raises `ValueError: ZIP does not support timestamps before 1980`; adding `strict_timestamps=False` writes the archive without error.
