### PR TITLE
Core: inherit option aliases in subclasses

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -94,8 +94,17 @@ class AssembleOptions(abc.ABCMeta):
         attrs["name_lookup"].update({option_id: name for name, option_id in new_options.items()})
         options.update(new_options)
         # apply aliases, without name_lookup
-        aliases = attrs["aliases"] = {name[6:].lower(): option_id for name, option_id in attrs.items() if
-                                      name.startswith("alias_")}
+        # merge parent class aliases, like options above, so subclasses inherit them. An alias inherited from a
+        # base is dropped when this class turns that name into a real option (e.g. ItemsAccessibility defines
+        # `items`, so Accessibility's `items` alias must not shadow it); this class's own aliases apply last.
+        aliases = attrs["aliases"] = {}
+        for base in bases:
+            if getattr(base, "aliases", None):
+                aliases.update(base.aliases)
+        for option_name in new_options:
+            aliases.pop(option_name, None)
+        aliases.update({name[6:].lower(): option_id for name, option_id in attrs.items() if
+                        name.startswith("alias_")})
 
         assert (
             name in {"Option", "VerifyKeys"} or  # base abstract classes don't need default

--- a/test/general/test_options.py
+++ b/test/general/test_options.py
@@ -46,6 +46,44 @@ class TestOptions(unittest.TestCase):
                 self.assertFalse(hasattr(world_type, "options"),
                                  f"Unexpected assignment to {world_type.__name__}.options!")
 
+    def test_subclassed_choice_inherits_aliases(self):
+        """Regression for #5124: AssembleOptions must merge aliases from base classes (as it already does for
+        options), so a Choice subclass inherits its parent's aliases instead of silently dropping them. An
+        inherited alias is dropped only when the subclass redefines that name as a real option."""
+        from Options import Accessibility, ItemsAccessibility
+
+        # The base class keeps exactly its own aliases.
+        self.assertEqual(Accessibility.aliases, {"none": 2, "locations": 0, "items": 0})
+        # ItemsAccessibility inherits none/locations; `items` is dropped because the subclass defines it as a
+        # real option. This is the exact expected result from issue #5124.
+        self.assertEqual(ItemsAccessibility.aliases, {"none": 2, "locations": 0})
+        self.assertEqual(ItemsAccessibility.from_text("none").value, ItemsAccessibility.option_minimal)
+        self.assertEqual(ItemsAccessibility.from_text("locations").value, ItemsAccessibility.option_full)
+        self.assertEqual(ItemsAccessibility.options["items"], ItemsAccessibility.option_items)
+
+        # The mechanism is general, not specific to the option classes above.
+        class _Base(Choice):
+            option_alpha = 0
+            option_beta = 1
+            alias_a = 0
+            alias_b = 1
+            default = 0
+
+        class _Child(_Base):
+            """Plain subclass: inherits every alias unchanged."""
+            option_gamma = 2
+
+        class _ShadowChild(_Base):
+            """Redefines an inherited alias name as a real option, which must win over the alias."""
+            option_a = 3
+
+        self.assertEqual(_Child.aliases, {"a": 0, "b": 1})
+        self.assertEqual(_Child.from_text("a").value, 0)
+        self.assertEqual(_Child.from_text("b").value, 1)
+        self.assertEqual(_ShadowChild.aliases, {"b": 1})
+        self.assertEqual(_ShadowChild.options["a"], 3)
+        self.assertEqual(_ShadowChild.from_text("a").value, 3)
+
     def test_duplicate_options(self) -> None:
         """Tests that a world doesn't reuse the same option class."""
         for game_name, world_type in AutoWorldRegister.world_types.items():


### PR DESCRIPTION
## What is this fixing or adding?

`AssembleOptions.__new__` rebuilt each option class's `aliases` dict from only that class's own `alias_*` attributes, even though `options` and `name_lookup` are merged from the base classes. So any subclass of a concrete option silently dropped its inherited aliases — e.g. `ItemsAccessibility.aliases` was `{}`, so the documented `none`/`locations` aliases were missing from the alias mapping.

This addresses the root cause (option 1 from #5124) instead of hardcoding the aliases on `ItemsAccessibility`: aliases are now merged from the base classes as well, and any inherited alias whose name the subclass redefines as a real option is dropped (so `ItemsAccessibility`'s `items` option wins over `Accessibility`'s `items` alias). `options` is unchanged, so option resolution via `from_text` is unaffected — only the `.aliases` mapping is corrected. This fixes every subclassed option, not just `ItemsAccessibility`.

Fixes #5124.

## How was this tested?

Rewrote `test_subclassed_choice_inherits_aliases` in `test/general/test_options.py`:
- `ItemsAccessibility.aliases == {"none": 2, "locations": 0}` (the exact expected result from #5124), `Accessibility.aliases` is unchanged, and `none`/`locations` still resolve via `from_text`.
- A synthetic `Choice` subclass hierarchy proves the mechanism is general: a plain subclass inherits all parent aliases, and a subclass that redefines an inherited alias name as a real option drops that alias (the option wins).

`pytest test/general/test_options.py test/webhost/test_option_presets.py` → all pass (12 tests / 14202 subtests), confirming no world's options regress now that aliases are inherited.
