### PR TITLE
WebHost: use canonical LOGS_FOLDER for room logs

### DIFF
--- a/WebHostLib/customserver.py
+++ b/WebHostLib/customserver.py
@@ -26,6 +26,7 @@ from MultiServer import (
 from Utils import restricted_loads, cache_argsless
 from .locker import Locker
 from .models import Command, GameDataPackage, Room, db
+from . import LOGS_FOLDER
 
 
 class CustomClientMessageProcessor(ClientMessageProcessor):
@@ -225,7 +226,7 @@ def set_up_logging(room_id) -> logging.Logger:
         handler.close()
 
     file_handler = logging.FileHandler(
-        os.path.join(Utils.user_path("logs"), f"{room_id}.txt"),
+        os.path.join(LOGS_FOLDER, f"{room_id}.txt"),
         "a",
         encoding="utf-8-sig")
     file_handler.setFormatter(logging.Formatter("[%(asctime)s]: %(message)s"))

--- a/WebHostLib/misc.py
+++ b/WebHostLib/misc.py
@@ -11,7 +11,7 @@ from werkzeug.utils import secure_filename
 
 
 from worlds.AutoWorld import AutoWorldRegister, World
-from . import app, cache
+from . import app, cache, LOGS_FOLDER
 from .markdown import render_markdown
 from .models import Seed, Room, Command, UUID, uuid4
 from Utils import title_sorted, utcnow
@@ -194,7 +194,7 @@ def display_log(room: UUID) -> Union[str, Response, Tuple[str, int]]:
     if room is None:
         return abort(404)
     if room.owner == session["_id"]:
-        file_path = os.path.join("logs", str(room.id) + ".txt")
+        file_path = os.path.join(LOGS_FOLDER, str(room.id) + ".txt")
         try:
             log = open(file_path, "rb")
             range_header = request.headers.get("Range")
@@ -254,7 +254,7 @@ def host_room(room: UUID):
         if max_size == 0:
             return "…", 0
         try:
-            with open(os.path.join("logs", str(room.id) + ".txt"), "rb") as log:
+            with open(os.path.join(LOGS_FOLDER, str(room.id) + ".txt"), "rb") as log:
                 raw_size = 0
                 fragments: List[str] = []
                 for block in _read_log(log):


### PR DESCRIPTION
## What is this fixing or adding?

Room logs were written and read using three different path computations:

- `customserver.py` wrote them under `Utils.user_path("logs")`
- `misc.py` read them from the implicit relative `"logs"` (in two places)
- `WebHostLib/__init__.py` defines `LOGS_FOLDER = os.path.relpath("logs")`

When the WebHost is run by itself (self-hosted), `user_path("logs")` and the relative `"logs"` resolve to different directories, so room logs were written where the `/log` views could not find them.

This reuses the canonical `WebHostLib.LOGS_FOLDER` in all three places so the writer and both readers always agree. (The issue also suggests making the location configurable in `config.yaml` like `UPLOADS_FOLDER`; that is left out here to keep the fix minimal and focused.)

Fixes #6046.

## How was this tested?

Confirmed `WebHostLib.LOGS_FOLDER` resolves to the canonical relative `logs` path and that `misc.py` references it after the change; both edited files pass `py_compile`. The change is otherwise inspection-level, since WebHost log-file routing isn't unit-testable here -- it aligns the single writer (`customserver`) and the readers (`misc`) on one constant, which the reporter confirmed fixes self-hosted logging.
