### PR TITLE
Utils: fall back when a Linux file dialog errors

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -775,6 +775,25 @@ def _run_for_stdout(*args: str):
     return subprocess.run(args, capture_output=True, text=True, env=env).stdout.split("\n", 1)[0] or None
 
 
+def _run_file_dialog(*args: str) -> typing.Tuple[bool, typing.Optional[str]]:
+    """Run a native file-dialog helper (kdialog/zenity) and interpret its exit code.
+
+    Returns ``(handled, selection)``. ``handled`` is True when the helper reached a
+    conclusive result -- either a chosen path (``selection``) or a user cancellation
+    (``None``) -- and the caller should stop. ``handled`` is False when the helper
+    errored (any exit code other than success or user-cancel), so the caller should
+    fall back to the next backend instead of treating the failure as a cancellation.
+    """
+    completed = subprocess.run(args, capture_output=True, text=True, env=env_cleared_lib_path())
+    if completed.returncode == 0:  # selection made
+        return True, completed.stdout.split("\n", 1)[0] or None
+    if completed.returncode == 1:  # user cancelled the dialog
+        return True, None
+    logging.warning(f"File dialog '{args[0]}' failed with exit code {completed.returncode}: "
+                    f"{completed.stderr.strip()}")
+    return False, None
+
+
 def open_filename(title: str, filetypes: typing.Iterable[typing.Tuple[str, typing.Iterable[str]]], suggest: str = "") \
         -> typing.Optional[str]:
     logging.info(f"Opening file input dialog for {title}.")
@@ -785,12 +804,17 @@ def open_filename(title: str, filetypes: typing.Iterable[typing.Tuple[str, typin
         kdialog = which("kdialog")
         if kdialog:
             k_filters = '|'.join((f'{text} (*{" *".join(ext)})' for (text, ext) in filetypes))
-            return _run_for_stdout(kdialog, f"--title={title}", "--getopenfilename", suggest or ".", k_filters)
+            handled, result = _run_file_dialog(kdialog, f"--title={title}", "--getopenfilename",
+                                               suggest or ".", k_filters)
+            if handled:
+                return result
         zenity = which("zenity")
         if zenity:
             z_filters = (f'--file-filter={text} ({", ".join(ext)}) | *{" *".join(ext)}' for (text, ext) in filetypes)
             selection = (f"--filename={suggest}",) if suggest else ()
-            return _run_for_stdout(zenity, f"--title={title}", "--file-selection", *z_filters, *selection)
+            handled, result = _run_file_dialog(zenity, f"--title={title}", "--file-selection", *z_filters, *selection)
+            if handled:
+                return result
 
     # fall back to tk
     try:
@@ -833,12 +857,18 @@ def save_filename(title: str, filetypes: typing.Iterable[typing.Tuple[str, typin
         kdialog = which("kdialog")
         if kdialog:
             k_filters = '|'.join((f'{text} (*{" *".join(ext)})' for (text, ext) in filetypes))
-            return _run_for_stdout(kdialog, f"--title={title}", "--getsavefilename", suggest or ".", k_filters)
+            handled, result = _run_file_dialog(kdialog, f"--title={title}", "--getsavefilename",
+                                               suggest or ".", k_filters)
+            if handled:
+                return result
         zenity = which("zenity")
         if zenity:
             z_filters = (f'--file-filter={text} ({", ".join(ext)}) | *{" *".join(ext)}' for (text, ext) in filetypes)
             selection = (f"--filename={suggest}",) if suggest else ()
-            return _run_for_stdout(zenity, f"--title={title}", "--file-selection", "--save", *z_filters, *selection)
+            handled, result = _run_file_dialog(zenity, f"--title={title}", "--file-selection", "--save",
+                                               *z_filters, *selection)
+            if handled:
+                return result
 
     # fall back to tk
     try:
@@ -883,13 +913,17 @@ def open_directory(title: str, suggest: str = "") -> typing.Optional[str]:
         from shutil import which
         kdialog = which("kdialog")
         if kdialog:
-            return _run_for_stdout(kdialog, f"--title={title}", "--getexistingdirectory",
-                       os.path.abspath(suggest) if suggest else ".")
+            handled, result = _run_file_dialog(kdialog, f"--title={title}", "--getexistingdirectory",
+                                               os.path.abspath(suggest) if suggest else ".")
+            if handled:
+                return result
         zenity = which("zenity")
         if zenity:
             z_filters = ("--directory",)
             selection = (f"--filename={os.path.abspath(suggest)}/",) if suggest else ()
-            return _run_for_stdout(zenity, f"--title={title}", "--file-selection", *z_filters, *selection)
+            handled, result = _run_file_dialog(zenity, f"--title={title}", "--file-selection", *z_filters, *selection)
+            if handled:
+                return result
 
     # fall back to tk
     try:

--- a/test/general/test_utils.py
+++ b/test/general/test_utils.py
@@ -1,0 +1,68 @@
+import subprocess
+import unittest
+from unittest import mock
+
+import Utils
+
+
+class TestLinuxFileDialogFallback(unittest.TestCase):
+    """The Linux native file dialogs (kdialog/zenity) must honor the helper's exit code.
+
+    Exit code 0 -> a path was chosen; exit code 1 -> the user cancelled (no fallback);
+    any other exit code -> the helper errored, so we must fall back to the next backend
+    instead of silently treating the failure as a cancellation (issue #5991).
+    """
+
+    FILETYPES = (("Patch", (".aptest",)),)
+
+    def _which(self, tool: str) -> str:
+        return f"/usr/bin/{tool}"
+
+    def test_kdialog_success_returns_path_without_fallback(self) -> None:
+        """A successful kdialog selection is returned and zenity is never consulted."""
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="/home/user/file.aptest\n", stderr="")
+        with mock.patch.object(Utils, "is_linux", True), \
+                mock.patch.object(Utils, "env_cleared_lib_path", return_value={}), \
+                mock.patch("shutil.which", side_effect=self._which) as which_mock, \
+                mock.patch("subprocess.run", return_value=completed) as run_mock:
+            result = Utils.open_filename("title", self.FILETYPES)
+
+        self.assertEqual(result, "/home/user/file.aptest")
+        # Only kdialog should have been run; zenity must not be invoked once kdialog handled it.
+        self.assertEqual(run_mock.call_count, 1)
+        self.assertIn("kdialog", run_mock.call_args.args[0][0])
+        which_mock.assert_called_once_with("kdialog")
+
+    def test_user_cancel_returns_none_without_fallback(self) -> None:
+        """Exit code 1 (user cancel) returns None and must NOT fall back to another backend."""
+        cancelled = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="")
+        with mock.patch.object(Utils, "is_linux", True), \
+                mock.patch.object(Utils, "env_cleared_lib_path", return_value={}), \
+                mock.patch("shutil.which", side_effect=self._which), \
+                mock.patch("subprocess.run", return_value=cancelled) as run_mock:
+            result = Utils.save_filename("title", self.FILETYPES)
+
+        self.assertIsNone(result)
+        # A cancel is conclusive: only the first backend (kdialog) runs, no zenity fallback.
+        self.assertEqual(run_mock.call_count, 1)
+        self.assertIn("kdialog", run_mock.call_args.args[0][0])
+
+    def test_tool_error_falls_back_to_next_backend(self) -> None:
+        """Exit code 2 (tool error) must fall back to zenity, which then succeeds."""
+        errored = subprocess.CompletedProcess(args=[], returncode=2, stdout="", stderr="boom")
+        success = subprocess.CompletedProcess(args=[], returncode=0, stdout="/srv/games\n", stderr="")
+        with mock.patch.object(Utils, "is_linux", True), \
+                mock.patch.object(Utils, "env_cleared_lib_path", return_value={}), \
+                mock.patch("shutil.which", side_effect=self._which), \
+                mock.patch("subprocess.run", side_effect=[errored, success]) as run_mock:
+            result = Utils.open_directory("title")
+
+        self.assertEqual(result, "/srv/games")
+        # kdialog errors (rc 2), so we must invoke zenity as the next backend.
+        self.assertEqual(run_mock.call_count, 2)
+        self.assertIn("kdialog", run_mock.call_args_list[0].args[0][0])
+        self.assertIn("zenity", run_mock.call_args_list[1].args[0][0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What is this fixing or adding?

Fixes #5991.

On Linux the native file pickers `open_filename`, `save_filename` and `open_directory` shell out to `kdialog` or `zenity` via `_run_for_stdout`, which reads only the helper's **stdout** and discards its exit code. These helpers exit `0` when the user picks a path, `1` when the user cancels, and `>= 2` on an error (e.g. a missing display, a malformed argument, or the binary failing to start).

Because the exit code was thrown away, an *errored* helper returned empty stdout that looked identical to a user cancellation: the picker silently returned `None`, the error was swallowed, and the existing tk fallback was never reached. The user just saw "nothing happened".

This PR adds a small `_run_file_dialog` helper next to `_run_for_stdout` that interprets the exit code and returns `(handled, selection)`:

- exit `0` -> `(True, <path>)` -- a selection was made;
- exit `1` -> `(True, None)` -- the user cancelled (conclusive, do **not** fall back);
- any other exit code -> logs a warning and returns `(False, None)` so the caller falls through to the next backend.

Each of the three pickers now replaces its `return _run_for_stdout(...)` calls for both kdialog and zenity with a fall-through pattern that returns only when the helper reports a conclusive result. A broken `kdialog` therefore now correctly falls back to `zenity`, and then to tk. `messagebox` is intentionally left unchanged since it is not a file picker.

## How was this tested?

- Added `test/general/test_utils.py` with mock-based tests that patch `Utils.is_linux`, `Utils.env_cleared_lib_path`, `shutil.which` and `subprocess.run` to exercise the Linux branch on any OS:
  - exit `0` returns the chosen path and never consults the next backend;
  - exit `1` (user cancel) returns `None` and does **not** fall back;
  - exit `2` (tool error) falls back to the next backend (zenity), which then succeeds.
- `python -m pytest test/general/test_utils.py -q` -> 3 passed.
- `python -m py_compile Utils.py` -> clean.
- `python -m flake8 --max-line-length=120 Utils.py test/general/test_utils.py` -> no new warnings on the changed lines.
