### PR TITLE
Jak and Daxter: Add UT UI

### DIFF
--- a/worlds/jakanddaxter/__init__.py
+++ b/worlds/jakanddaxter/__init__.py
@@ -505,8 +505,7 @@ class JakAndDaxterWorld(World):
         return change
 
     def fill_slot_data(self) -> dict[str, Any]:
-        options_dict = self.options.as_dict("start_inventory_from_pool",
-                                            "enable_move_randomizer",
+        options_dict = self.options.as_dict("enable_move_randomizer",
                                             "enable_orbsanity",
                                             "global_orbsanity_bundle_size",
                                             "level_orbsanity_bundle_size",

--- a/worlds/jakanddaxter/__init__.py
+++ b/worlds/jakanddaxter/__init__.py
@@ -505,7 +505,8 @@ class JakAndDaxterWorld(World):
         return change
 
     def fill_slot_data(self) -> dict[str, Any]:
-        options_dict = self.options.as_dict("enable_move_randomizer",
+        options_dict = self.options.as_dict("start_inventory_from_pool",
+                                            "enable_move_randomizer",
                                             "enable_orbsanity",
                                             "global_orbsanity_bundle_size",
                                             "level_orbsanity_bundle_size",

--- a/worlds/jakanddaxter/agents/repl_client.py
+++ b/worlds/jakanddaxter/agents/repl_client.py
@@ -280,12 +280,14 @@ class JakAndDaxterReplClient:
     # - It must be a valid character from the ALLOWED_CHARACTERS list.
     # - All lowercase letters must be uppercase.
     # - It must be wrapped in double quotes (for the REPL command).
-    # - Apostrophes must be handled specially - GOAL uses invisible ASCII character 0x12.
+    # - Single quotes must be replaced - GOAL uses invisible ASCII character 0x12.
+    # - Double quotes must be prepended with a backslash to escape it.
     # I also only allotted 32 bytes to each string in OpenGOAL, so we must truncate.
     @staticmethod
     def sanitize_game_text(text: str) -> str:
         result = "".join([c if c in ALLOWED_CHARACTERS else "?" for c in text[:32]]).upper()
         result = result.replace("'", "\\c12")
+        result = result.replace("\"", "\\\"")
         return f"\"{result}\""
 
     # Like sanitize_game_text, but the settings file will NOT allow any whitespace in the slot_name or slot_seed data.

--- a/worlds/jakanddaxter/archipelago.json
+++ b/worlds/jakanddaxter/archipelago.json
@@ -1,6 +1,6 @@
 {
     "game": "Jak and Daxter: The Precursor Legacy",
-    "world_version": "1.1.5",
+    "world_version": "1.1.6",
     "minimum_ap_version": "0.6.2",
     "authors": ["markustulliuscicero"]
 }

--- a/worlds/jakanddaxter/client.py
+++ b/worlds/jakanddaxter/client.py
@@ -43,6 +43,7 @@ try:
     tracker_loaded = True
 except ImportError:
     from CommonClient import ClientCommandProcessor, CommonContext
+    UT_VERSION = 0
 
 
 ModuleUpdate.update()

--- a/worlds/jakanddaxter/client.py
+++ b/worlds/jakanddaxter/client.py
@@ -145,16 +145,6 @@ class JakAndDaxterContext(CommonContext):
         return ui
 
     def run_gui(self):
-        # from kvui import GameManager
-        #
-        # class JakAndDaxterManager(GameManager):
-        #     logging_pairs = [
-        #         ("Client", "Archipelago")
-        #     ]
-        #     base_title = "Jak and Daxter ArchipelaGOAL Client"
-        #
-        # self.ui = JakAndDaxterManager(self)
-
         ui_class = self.make_gui()
         self.ui = ui_class(self)
         self.ui_task = asyncio.create_task(self.ui.async_run(), name="UI")

--- a/worlds/jakanddaxter/client.py
+++ b/worlds/jakanddaxter/client.py
@@ -20,7 +20,7 @@ from psutil import NoSuchProcess
 # Archipelago imports
 import ModuleUpdate
 import Utils
-from CommonClient import ClientCommandProcessor, CommonContext, server_loop, gui_enabled
+from CommonClient import server_loop, gui_enabled
 from NetUtils import ClientStatus
 from PyMemoryEditor import OpenProcess, ProcessNotFoundError
 
@@ -30,6 +30,19 @@ from .options import EnableOrbsanity
 from .agents.memory_reader import JakAndDaxterMemoryReader
 from .agents.repl_client import JakAndDaxterReplClient
 from . import JakAndDaxterWorld
+
+# Load Universal Tracker
+tracker_loaded: bool = False
+try:
+    from worlds.tracker.TrackerClient import (
+        TrackerCommandProcessor as ClientCommandProcessor,
+        TrackerGameContext as CommonContext,
+        UT_VERSION
+    )
+
+    tracker_loaded = True
+except ImportError:
+    from CommonClient import ClientCommandProcessor, CommonContext
 
 
 ModuleUpdate.update()
@@ -116,16 +129,33 @@ class JakAndDaxterContext(CommonContext):
         # self.memr.load_data()
         super().__init__(server_address, password)
 
+    def run_generator(self):
+        if tracker_loaded:
+            super().run_generator()
+
+    def make_gui(self):
+        ui = super().make_gui()
+        ui.base_title = f"Jak and Daxter ArchipelaGOAL Client"
+        if tracker_loaded:
+            ui.base_title += f" | Universal Tracker {UT_VERSION}"
+
+        # AP version is added behind this automatically
+        ui.base_title += " | Archipelago"
+        return ui
+
     def run_gui(self):
-        from kvui import GameManager
+        # from kvui import GameManager
+        #
+        # class JakAndDaxterManager(GameManager):
+        #     logging_pairs = [
+        #         ("Client", "Archipelago")
+        #     ]
+        #     base_title = "Jak and Daxter ArchipelaGOAL Client"
+        #
+        # self.ui = JakAndDaxterManager(self)
 
-        class JakAndDaxterManager(GameManager):
-            logging_pairs = [
-                ("Client", "Archipelago")
-            ]
-            base_title = "Jak and Daxter ArchipelaGOAL Client"
-
-        self.ui = JakAndDaxterManager(self)
+        ui_class = self.make_gui()
+        self.ui = ui_class(self)
         self.ui_task = asyncio.create_task(self.ui.async_run(), name="UI")
 
     async def server_auth(self, password_requested: bool = False):
@@ -146,6 +176,7 @@ class JakAndDaxterContext(CommonContext):
         await super(JakAndDaxterContext, self).disconnect(allow_autoreconnect)
 
     def on_package(self, cmd: str, args: dict):
+        super().on_package(cmd, args)
 
         if cmd == "RoomInfo":
             self.slot_seed = args["seed_name"]
@@ -672,6 +703,12 @@ async def main():
     Utils.init_logging("JakAndDaxterClient", exception_logger="Client")
 
     ctx = JakAndDaxterContext(None, None)
+
+    # If UT is loaded. Run generator, and remove tracker tag.
+    if tracker_loaded:
+        ctx.run_generator()
+        ctx.tags.discard("Tracker")
+
     ctx.server_task = asyncio.create_task(server_loop(ctx), name="server loop")
     ctx.repl_task = create_task_log_exception(ctx.run_repl_loop())
     ctx.memr_task = create_task_log_exception(ctx.run_memr_loop())

--- a/worlds/jakanddaxter/client.py
+++ b/worlds/jakanddaxter/client.py
@@ -130,10 +130,6 @@ class JakAndDaxterContext(CommonContext):
         # self.memr.load_data()
         super().__init__(server_address, password)
 
-    def run_generator(self):
-        if tracker_loaded:
-            super().run_generator()
-
     def make_gui(self):
         ui = super().make_gui()
         ui.base_title = f"Jak and Daxter ArchipelaGOAL Client"
@@ -143,11 +139,6 @@ class JakAndDaxterContext(CommonContext):
         # AP version is added behind this automatically
         ui.base_title += " | Archipelago"
         return ui
-
-    def run_gui(self):
-        ui_class = self.make_gui()
-        self.ui = ui_class(self)
-        self.ui_task = asyncio.create_task(self.ui.async_run(), name="UI")
 
     async def server_auth(self, password_requested: bool = False):
         if password_requested and not self.password:


### PR DESCRIPTION
## What is this fixing or adding?
Adds the Universal Tracker to the client GUI, if the tracker apworld is in of the user's custom_worlds folder. If it is not, the client GUI remains the same as it was.

## How was this tested?
Tested on localhost, played through hub 1 of the game twice: once with the tracker, once without. The tracker UI only renders when intended.

## If this makes graphical changes, please attach screenshots.
<img width="802" height="632" alt="image" src="https://github.com/user-attachments/assets/f56b9812-c994-4584-9883-b6c31c90290d" />
