### PR TITLE
Core: Fix triggers on container types

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -11,7 +11,7 @@ import urllib.parse
 import urllib.request
 from collections import Counter
 from itertools import chain
-from typing import Any
+from typing import Any, cast
 
 import ModuleUpdate
 
@@ -482,7 +482,7 @@ def roll_linked_options(weights: dict) -> dict:
 
 
 def roll_triggers(weights: dict, triggers: list[dict], valid_keys: set[str],
-                  options: dict[str, type[Options.Option]]) -> dict:
+                  options: dict[str, dict[str, type[Options.Option]]]) -> dict:
     weights = copy.deepcopy(weights)  # make sure we don't write back to other weights sets in same_settings
     weights["_Generator_Version"] = Utils.__version__
     for i, option_set in enumerate(triggers):
@@ -496,7 +496,7 @@ def roll_triggers(weights: dict, triggers: list[dict], valid_keys: set[str],
                 logging.warning(f'Specified option name {option_set["option_name"]} did not '
                                 f'match with a root option. '
                                 f'This is probably in error.')
-            option = options.get(key)
+            option = options.get(cast(str, category), {}).get(key)
             if option and option.supports_weighting:
                 trigger_result = get_choice("option_result", option_set)
                 result = get_choice(key, currently_targeted_weights)
@@ -553,6 +553,15 @@ def roll_settings(weights: dict, plando_options: PlandoOptions = PlandoOptions.b
     if "linked_options" in weights:
         weights = roll_linked_options(weights)
 
+    categories = set(weights) - {"description", "name", "game", "requires", "triggers", "linked_options"}
+    # if there's unrecognized game names as categories, we can just ignore them since they'd error if set as game anyway
+    category_options = {category: AutoWorldRegister.world_types[category].options_dataclass.type_hints
+                        for category in categories if category in AutoWorldRegister.world_types}
+
+    valid_keys = {"triggers"}
+    if "triggers" in weights:
+        weights = roll_triggers(weights, weights["triggers"], valid_keys, category_options)
+
     requirements = weights.get("requires", {})
     if requirements:
         version = requirements.get("version", __version__)
@@ -604,13 +613,6 @@ def roll_settings(weights: dict, plando_options: PlandoOptions = PlandoOptions.b
     if ret.game not in weights:
         raise Exception(f"No game options for selected game \"{ret.game}\" found.")
 
-    world_type = AutoWorldRegister.world_types[ret.game]
-    options = world_type.options_dataclass.type_hints
-
-    valid_keys = {"triggers"}
-    if "triggers" in weights:
-        weights = roll_triggers(weights, weights["triggers"], valid_keys, options)
-
     game_weights = weights[ret.game]
 
     for weight in chain(game_weights, weights):
@@ -620,14 +622,14 @@ def roll_settings(weights: dict, plando_options: PlandoOptions = PlandoOptions.b
             raise Exception(f"Remove tag cannot be used outside of trigger contexts. Found {weight}")
 
     if "triggers" in game_weights:
-        weights = roll_triggers(weights, game_weights["triggers"], valid_keys, options)
+        weights = roll_triggers(weights, game_weights["triggers"], valid_keys, category_options)
         game_weights = weights[ret.game]
 
     ret.name = get_choice('name', weights)
     for option_key, option in Options.CommonOptions.type_hints.items():
         setattr(ret, option_key, option.from_any(get_choice(option_key, weights, option.default)))
 
-    for option_key, option in options.items():
+    for option_key, option in category_options[ret.game].items():
         handle_option(ret, game_weights, option_key, option, plando_options)
         valid_keys.add(option_key)
 

--- a/Generate.py
+++ b/Generate.py
@@ -502,7 +502,7 @@ def roll_triggers(weights: dict, triggers: list[dict], valid_keys: set[str],
                 result = get_choice(key, currently_targeted_weights)
             else:
                 trigger_result = option_set["option_result"]
-                result = currently_targeted_weights[key]
+                result = currently_targeted_weights.get(key)
             currently_targeted_weights[key] = result
             if option:
                 trigger_match = option.from_any(result) == option.from_any(trigger_result)

--- a/Generate.py
+++ b/Generate.py
@@ -481,7 +481,8 @@ def roll_linked_options(weights: dict) -> dict:
     return weights
 
 
-def roll_triggers(weights: dict, triggers: list, valid_keys: set) -> dict:
+def roll_triggers(weights: dict, triggers: list[dict], valid_keys: set[str],
+                  options: dict[str, type[Options.Option]]) -> dict:
     weights = copy.deepcopy(weights)  # make sure we don't write back to other weights sets in same_settings
     weights["_Generator_Version"] = Utils.__version__
     for i, option_set in enumerate(triggers):
@@ -495,10 +496,20 @@ def roll_triggers(weights: dict, triggers: list, valid_keys: set) -> dict:
                 logging.warning(f'Specified option name {option_set["option_name"]} did not '
                                 f'match with a root option. '
                                 f'This is probably in error.')
-            trigger_result = get_choice("option_result", option_set)
-            result = get_choice(key, currently_targeted_weights)
+            option = options.get(key)
+            if option and option.supports_weighting:
+                trigger_result = get_choice("option_result", option_set)
+                result = get_choice(key, currently_targeted_weights)
+            else:
+                trigger_result = option_set["option_result"]
+                result = currently_targeted_weights[key]
             currently_targeted_weights[key] = result
-            if result == trigger_result and Options.roll_percentage(get_choice("percentage", option_set, 100)):
+            if option:
+                trigger_match = option.from_any(result) == option.from_any(trigger_result)
+            # If the option is fake, just do a simple comparison of value
+            else:
+                trigger_match = result == trigger_result
+            if trigger_match and Options.roll_percentage(get_choice("percentage", option_set, 100)):
                 for category_name, category_options in option_set["options"].items():
                     currently_targeted_weights = weights
                     if category_name:
@@ -541,10 +552,6 @@ def roll_settings(weights: dict, plando_options: PlandoOptions = PlandoOptions.b
 
     if "linked_options" in weights:
         weights = roll_linked_options(weights)
-
-    valid_keys = {"triggers"}
-    if "triggers" in weights:
-        weights = roll_triggers(weights, weights["triggers"], valid_keys)
 
     requirements = weights.get("requires", {})
     if requirements:
@@ -598,6 +605,12 @@ def roll_settings(weights: dict, plando_options: PlandoOptions = PlandoOptions.b
         raise Exception(f"No game options for selected game \"{ret.game}\" found.")
 
     world_type = AutoWorldRegister.world_types[ret.game]
+    options = world_type.options_dataclass.type_hints
+
+    valid_keys = {"triggers"}
+    if "triggers" in weights:
+        weights = roll_triggers(weights, weights["triggers"], valid_keys, options)
+
     game_weights = weights[ret.game]
 
     for weight in chain(game_weights, weights):
@@ -607,14 +620,14 @@ def roll_settings(weights: dict, plando_options: PlandoOptions = PlandoOptions.b
             raise Exception(f"Remove tag cannot be used outside of trigger contexts. Found {weight}")
 
     if "triggers" in game_weights:
-        weights = roll_triggers(weights, game_weights["triggers"], valid_keys)
+        weights = roll_triggers(weights, game_weights["triggers"], valid_keys, options)
         game_weights = weights[ret.game]
 
     ret.name = get_choice('name', weights)
     for option_key, option in Options.CommonOptions.type_hints.items():
         setattr(ret, option_key, option.from_any(get_choice(option_key, weights, option.default)))
 
-    for option_key, option in world_type.options_dataclass.type_hints.items():
+    for option_key, option in options.items():
         handle_option(ret, game_weights, option_key, option, plando_options)
         valid_keys.add(option_key)
 


### PR DESCRIPTION
## What is this fixing or adding?
Currently, trying to trigger on a unweightable value like an OptionSet will change the value of the option that is being triggered on since `get_choice` tries to pick a single value from it as though it were giving weights. This feeds the options into `roll_triggers` so that it can check similar to other places. It also tries to pass these values through `from_any` to compare them if the option type is present, which is needed for instance on sets to not make them care about order.

I think moving the first `roll_triggers` call down should be fine, but I'm not sure if the new matching logic or typing changes are what'd be preferred.

## How was this tested?
Confirming that triggering on an OptionSet no longer replaces it with a single value, and that OptionDict no longer errors from being given an invalid value (a single element can't be converted to one). Also tried a quick test with "fake options" to make sure they still function. Still could likely use more testing.

## If this makes graphical changes, please attach screenshots.
🔫