### PR TITLE
Option Creator: add a search to the game list

### DIFF
--- a/OptionsCreator.py
+++ b/OptionsCreator.py
@@ -655,6 +655,9 @@ class OptionsCreator(ThemedApp):
         self.root = self.container
         self.main_layout = self.container.ids.main
         self.scrollbox = self.container.ids.scrollbox
+        self.world_buttons = {}
+        self.search_input = self.container.ids.search_input
+        self.search_input.bind(text = self.search_worlds)
 
         def world_button_action(world_btn: WorldButton):
             if self.current_game != world_btn.world_cls.game:
@@ -680,6 +683,7 @@ class OptionsCreator(ThemedApp):
             world_button.bind(on_release=world_button_action)
             world_button.world_cls = cls
             self.scrollbox.layout.add_widget(world_button)
+            self.world_buttons[world] = world_button
         self.main_panel = self.container.ids.player_layout
         self.player_options = self.container.ids.player_options
         self.game_label = self.container.ids.game
@@ -698,6 +702,13 @@ class OptionsCreator(ThemedApp):
         # create_console(Window, self.container)
 
         return self.container
+        
+    def search_worlds(self, instance, text):
+        self.scrollbox.layout.clear_widgets()
+        for world, world_button in self.world_buttons.items():
+            if (text != "") and (text.lower() not in world.lower()):
+                continue
+            self.scrollbox.layout.add_widget(world_button)
 
 
 def launch():

--- a/data/optionscreator.kv
+++ b/data/optionscreator.kv
@@ -117,10 +117,30 @@ ContainerLayout:
         padding: 3, 5, 0, 3
         spacing: "2dp"
 
-        ScrollBox:
-            id: scrollbox
-            size_hint_x: None
-            width: "150dp"
+        MDBoxLayout:
+			width: "150dp"
+			size_hint_x: None
+			orientation: "vertical"
+			
+			BoxLayout:
+				padding: [0, "10dp", 0, "10dp"]
+				height: "75dp"
+                size_hint_y: None
+			
+				MDTextField:
+					size_hint_x: None
+					width: "150dp"
+					id: search_input
+					multiline: False
+					padding: [0, "10dp", 0, "10dp"]
+				
+					MDTextFieldHintText:
+						text: "Search"
+
+			ScrollBox:
+				id: scrollbox
+				size_hint_x: None
+				width: "150dp"
 
         MDDivider:
             orientation: "vertical"


### PR DESCRIPTION
## What is this fixing or adding?
just adds a search bar to the game list in the options creator. nice for when you have a bunch of custom worlds

## How was this tested?
tested locally with python 3.13. there's no grand changes to how anything works so I can't foresee this having dramatic consequences

## If this makes graphical changes, please attach screenshots.
<img width="601" height="474" alt="image" src="https://github.com/user-attachments/assets/c58a540b-496f-4f41-a50d-e75c6b6c5e3c" />


as a sidenote I have never used kivy before so if I've made some comical blunder in how you're supposed to construct a layout I can only apologise