### PR TITLE
docs: apquest: make it clear that launcher components are optional

### DIFF
--- a/worlds/apquest/components.py
+++ b/worlds/apquest/components.py
@@ -1,6 +1,8 @@
 from worlds.LauncherComponents import Component, Type, components, launch
 
 
+# Launcher components are an optional way to add an entry to the launcher.
+
 # The most common type of component is a client, but there are other components, such as sprite/palette adjusters.
 # (Note: Some worlds distribute their clients as separate, standalone programs,
 #  while others include them in the apworld itself. Standalone clients are not an apworld component,

--- a/worlds/apquest/components.py
+++ b/worlds/apquest/components.py
@@ -1,8 +1,7 @@
 from worlds.LauncherComponents import Component, Type, components, launch
 
 
-# Launcher components are an optional way to add an entry to the launcher.
-
+# Launcher components can be used to add entries to the launcher if desired.
 # The most common type of component is a client, but there are other components, such as sprite/palette adjusters.
 # (Note: Some worlds distribute their clients as separate, standalone programs,
 #  while others include them in the apworld itself. Standalone clients are not an apworld component,


### PR DESCRIPTION
## What is this fixing or adding?

There have been multiple cases in the past few days where people seemed to think this is a mandatory step or were otherwise confused about how to best implement it when the client is not a python client bundled with the world. I can't help with the latter but I can help with the former, so I added a quick remark clarifying component registration as an optional step. I also didn't think it seemed very obvious what a component actually is so I attempted to cover that also

## How was this tested?

Read it 
