### PR TITLE
Launcher: Show error message when world fails to load during install

### DIFF
--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -182,7 +182,8 @@ def _install_apworld(apworld_src: str = "") -> Optional[Tuple[pathlib.Path, path
                         "so a Launcher restart is required to use the new installation.")
     world_source = worlds.WorldSource(str(target), is_zip=True, relative=False)
     bisect.insort(worlds.world_sources, world_source)
-    world_source.load()
+    if not world_source.load():
+        raise Exception(f"World was installed, but failed to load. See the Launcher log for details.")
 
     return apworld_path, target
 


### PR DESCRIPTION
## What is this fixing or adding?
Currently when installing a world by drag and drop onto the launcher window or with the Install APWorld component, a world is attempted to be loaded, but if it fails while doing so, this is not indicated in the GUI at all and it does the same as if the world loaded successfully. The exception raised from here just gets eaten and logged in `WorldSource.load`, so we can't actually get the exception message itself unless this is changed.

This obscured the issue in https://discord.com/channels/731205301247803413/1520174054278172844, but is also just something that should probably be done in general.

## How was this tested?
Trying both of these installation methods on source.

## If this makes graphical changes, please attach screenshots.
<img width="524" height="175" alt="image" src="https://github.com/user-attachments/assets/ab119e87-a2af-42d1-9ec9-93a447bc68c0" />
