### PR TITLE
Stardew Valley: Fixed filler buffs only rolling one of each instead of as many as needed

### DIFF
--- a/worlds/stardew_valley/items/filters.py
+++ b/worlds/stardew_valley/items/filters.py
@@ -27,5 +27,5 @@ def remove_already_included(items: Iterable[ItemData], already_added_items: set[
     return [
         item
         for item in items
-        if item.name not in already_added_items or (item.has_any_group(*FILLER_GROUPS, Group.TRAP) and Group.MAXIMUM_ONE not in item.groups)
+        if item.name not in already_added_items or (item.has_any_group(*FILLER_GROUPS, Group.TRAP, Group.PLAYER_BUFF) and Group.MAXIMUM_ONE not in item.groups)
     ]


### PR DESCRIPTION
## What is this fixing or adding?
Fixes a bug where player buff items weren't properly qualified as fillers that can be duplicated, and as a result, multiworlds only rolled one of each at most, even if there was plenty of room in the item pool

## How was this tested?
Unit test, plus used a yaml that disables all other filler, to confirm that it indeed generates many of each
