### PR TITLE
core: Update core logging handlers to fix the log level so child loggers don't change the log level

### DIFF
--- a/Fill.py
+++ b/Fill.py
@@ -257,7 +257,7 @@ def fill_restrictive(multiworld: MultiWorld, base_state: CollectionState, locati
 def remaining_fill(multiworld: MultiWorld,
                    locations: typing.List[Location],
                    itempool: typing.List[Item],
-                   name: str = "Remaining", 
+                   name: str = "Remaining",
                    move_unplaceable_to_start_inventory: bool = False,
                    check_location_can_fill: bool = False) -> None:
     unplaced_items: typing.List[Item] = []
@@ -885,7 +885,7 @@ def balance_multiworld_progression(multiworld: MultiWorld) -> None:
                     items_to_replace.sort()
                     multiworld.random.shuffle(items_to_replace)
 
-                    # Start swapping items. Since we swap into earlier spheres, no need for accessibility checks. 
+                    # Start swapping items. Since we swap into earlier spheres, no need for accessibility checks.
                     while replacement_locations and items_to_replace:
                         old_location = items_to_replace.pop()
                         for i, new_location in enumerate(replacement_locations):

--- a/Utils.py
+++ b/Utils.py
@@ -567,6 +567,7 @@ def init_logging(name: str, loglevel: typing.Union[str, int] = logging.INFO,
 
     file_handler.addFilter(Filter("NoStream", lambda record: not getattr(record, "NoFile", False)))
     file_handler.addFilter(Filter("NoCarriageReturn", lambda record: '\r' not in record.getMessage()))
+    file_handler.level = logging.INFO
     root_logger.addHandler(file_handler)
     if sys.stdout:
         formatter = logging.Formatter(fmt='[%(asctime)s] %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
@@ -574,6 +575,7 @@ def init_logging(name: str, loglevel: typing.Union[str, int] = logging.INFO,
         stream_handler.addFilter(Filter("NoFile", lambda record: not getattr(record, "NoStream", False)))
         if add_timestamp:
             stream_handler.setFormatter(formatter)
+        stream_handler.level = logging.INFO
         root_logger.addHandler(stream_handler)
         if hasattr(sys.stdout, "reconfigure"):
             sys.stdout.reconfigure(encoding="utf-8", errors="replace")
@@ -769,7 +771,7 @@ def _mp_save_filename(res: "multiprocessing.Queue[typing.Optional[str]]", *args:
     if is_kivy_running():
         raise RuntimeError("kivy should not be running in multiprocess")
     res.put(save_filename(*args))
-    
+
 def _run_for_stdout(*args: str):
     env = env_cleared_lib_path()
     return subprocess.run(args, capture_output=True, text=True, env=env).stdout.split("\n", 1)[0] or None

--- a/Utils.py
+++ b/Utils.py
@@ -567,7 +567,7 @@ def init_logging(name: str, loglevel: typing.Union[str, int] = logging.INFO,
 
     file_handler.addFilter(Filter("NoStream", lambda record: not getattr(record, "NoFile", False)))
     file_handler.addFilter(Filter("NoCarriageReturn", lambda record: '\r' not in record.getMessage()))
-    file_handler.level = logging.INFO
+    file_handler.level = loglevel
     root_logger.addHandler(file_handler)
     if sys.stdout:
         formatter = logging.Formatter(fmt='[%(asctime)s] %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
@@ -575,7 +575,7 @@ def init_logging(name: str, loglevel: typing.Union[str, int] = logging.INFO,
         stream_handler.addFilter(Filter("NoFile", lambda record: not getattr(record, "NoStream", False)))
         if add_timestamp:
             stream_handler.setFormatter(formatter)
-        stream_handler.level = logging.INFO
+        stream_handler.level = loglevel
         root_logger.addHandler(stream_handler)
         if hasattr(sys.stdout, "reconfigure"):
             sys.stdout.reconfigure(encoding="utf-8", errors="replace")

--- a/Utils.py
+++ b/Utils.py
@@ -567,7 +567,7 @@ def init_logging(name: str, loglevel: typing.Union[str, int] = logging.INFO,
 
     file_handler.addFilter(Filter("NoStream", lambda record: not getattr(record, "NoFile", False)))
     file_handler.addFilter(Filter("NoCarriageReturn", lambda record: '\r' not in record.getMessage()))
-    file_handler.level = loglevel
+    file_handler.setLevel(loglevel)
     root_logger.addHandler(file_handler)
     if sys.stdout:
         formatter = logging.Formatter(fmt='[%(asctime)s] %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
@@ -575,7 +575,7 @@ def init_logging(name: str, loglevel: typing.Union[str, int] = logging.INFO,
         stream_handler.addFilter(Filter("NoFile", lambda record: not getattr(record, "NoStream", False)))
         if add_timestamp:
             stream_handler.setFormatter(formatter)
-        stream_handler.level = loglevel
+        stream_handler.setLevel(loglevel)
         root_logger.addHandler(stream_handler)
         if hasattr(sys.stdout, "reconfigure"):
             sys.stdout.reconfigure(encoding="utf-8", errors="replace")


### PR DESCRIPTION
## What is this fixing or adding?
Currently, if any apworld creates its own logger and sets its own log level, it effectively changes the log level of the global handler. The default log level is INFO, so if worlds want to handle DEBUG messages separately without changing core behaviour, they don't have a way to do that without updating the core handlers.

The context is that Python has separate log levels for the logger itself and for the logger's handlers. If a child logger has a lower log level than its parent, the log message is still passed to the parent's handlers. By default, the root handler level is set to INFO=20, and the default handler level is set to NOTSET=0. So setting a child logger's level to DEBUG=10 means debug messages can now appear in the log, as DEBUG>NOTSET.

I had to add this little snippet to my function that configured an sc2 logger:
```python
        root_logger = logging.getLogger()
        for handler in root_logger.handlers:
            if handler.level == logging.NOTSET:
                handler.level = root_logger.level
```

Default behaviour in situations where a world is not setting up its own logging should be unaffected.

If the old behaviour was desired, then I can cancel this PR and remove my snippet in my own branch. I personally would rather not pollute the global log with spammy debug messages that are better collected into their own separate file. I don't see any core worlds changing a log level so I don't think anyone would be impacted.

## How was this tested?
On my branch with an added logging handler, commented out my snippet. Verified debug logs still appeared in my added log handler, but did not appear in the core output stream handler or the core file handler outputs.

## If this makes graphical changes, please attach screenshots.
None.