### PR TITLE
MMBN3: Handle timeouts on dual stack networks by catching OSError

### DIFF
--- a/MMBN3Client.py
+++ b/MMBN3Client.py
@@ -279,7 +279,7 @@ async def gba_sync_task(ctx: MMBN3Context):
                 logger.debug("Attempting to connect to GBA")
                 ctx.gba_streams = await asyncio.wait_for(asyncio.open_connection("localhost", 28922), timeout=10)
                 ctx.gba_status = CONNECTION_TENTATIVE_STATUS
-            except TimeoutError:
+            except (TimeoutError, OSError):
                 logger.debug("Connection Timed Out, Trying Again")
                 ctx.gba_status = CONNECTION_TIMING_OUT_STATUS
                 continue


### PR DESCRIPTION
## What is this fixing or adding?
This fixes the MMBN3 client lua script connection task dying when python attempts to connect to `127.0.0.1` and `::1` on a dual stack system, both of them fail, and an `OSError` is raised instead of `TimeoutError`.

## How was this tested?
I successfully connected the client to the lua script on a dual stack IPv4+IPv6 system, which I could not do before this change.

## If this makes graphical changes, please attach screenshots.
N/A

## AI Usage Disclosure
I used Claude Code to help me find this bug. The fix was written by me.