### PR TITLE
core: add a progress bar to Calculating Playthrough, like the one in fill

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1750,6 +1750,8 @@ class Spoiler:
         # in the second phase, we cull each sphere such that the game is still beatable,
         # reducing each range of influence to the bare minimum required inside it
         required_locations = {location for sphere in collection_spheres for location in sphere}
+        required_location_count = len(required_locations)
+        checked_locations_count = 0
         for num, sphere in reversed(tuple(enumerate(collection_spheres))):
             to_delete: Set[Location] = set()
             for location in sphere:
@@ -1762,6 +1764,9 @@ class Spoiler:
                 else:
                     # still required, got to keep it around
                     required_locations.add(location)
+                checked_locations_count += 1
+                if checked_locations_count % 1000 == 0 or checked_locations_count == required_location_count:
+                    logging.info("Culling progression tree %d/%d", checked_locations_count, required_location_count)
 
             # cull entries in spheres for spoiler walkthrough at end
             sphere -= to_delete


### PR DESCRIPTION

## What is this fixing or adding?

Adds a progress tracker like the one in Fill to the cull phase of the playthrough calculation.
I chose this phase specifically since it is the one that takes the longest by far.

## How was this tested?

I tried generating a multiworld with 10 instances of stardew valley, and then checked if it showed up.

## If this makes graphical changes, please attach screenshots.

<img width="458" height="156" alt="image" src="https://github.com/user-attachments/assets/58f65f01-3ffc-478c-94e8-3398b4d68597" />

<img width="683" height="493" alt="image" src="https://github.com/user-attachments/assets/201c3058-dd88-4c79-a77d-4518ce0c0c85" />

## AI usage

I wrote this code myself, no AI was used during the writing, nor when thinking about how to do it.