### PR TITLE
ModuleUpdate: Force Core Reqs Last

### DIFF
--- a/ModuleUpdate.py
+++ b/ModuleUpdate.py
@@ -38,7 +38,7 @@ class RequirementsSet(set):
 
 
 local_dir = os.path.dirname(__file__)
-requirements_files = RequirementsSet((os.path.join(local_dir, 'requirements.txt'),))
+requirements_files = RequirementsSet()
 
 if not update_ran:
     for entry in os.scandir(os.path.join(local_dir, "worlds")):
@@ -48,6 +48,9 @@ if not update_ran:
                 req_file = os.path.join(entry.path, "requirements.txt")
                 if os.path.exists(req_file):
                     requirements_files.add(req_file)
+
+# add core reqs last to override any matching world reqs
+requirements_files.add(os.path.join(local_dir, 'requirements.txt'))
 
 
 def check_pip():


### PR DESCRIPTION
## What is this fixing or adding?
currently `typing_extensions` is getting set to the newest 4.16.0 because zillion's requirements.txt gets processed after core's,
theoretically we could micromanage worlds to enforce pinned reqs, to enforce no core overlaps, etc., but those management solutions alone are likely to find another problem down the road
i'm not sold that this is the best solution, but it does keep core's requirement pins stable
(one usecase it stops is world devs pinning to other requirement versions of core reqs and not having to change the core file to do so)

## How was this tested?
ran ModuleUpdate before and after this, saw `typing_extensions==4.16.0` before, and `typing_extensions==4.15.0` after

## If this makes graphical changes, please attach screenshots.
