### PR TITLE
Tests: Add prevent_sweep flag to WorldTestBase collect functions

### DIFF
--- a/test/bases.py
+++ b/test/bases.py
@@ -83,7 +83,7 @@ class WorldTestBase(unittest.TestCase):
 
     # methods that can be called within tests
     def collect_all_but(self, item_names: typing.Union[str, typing.Iterable[str]],
-                        state: typing.Optional[CollectionState] = None) -> None:
+                        state: typing.Optional[CollectionState] = None, prevent_sweep = False) -> None:
         """Collects all pre-placed items and items in the multiworld itempool except those provided"""
         if isinstance(item_names, str):
             item_names = (item_names,)
@@ -91,7 +91,7 @@ class WorldTestBase(unittest.TestCase):
             state = self.multiworld.state
         for item in self.multiworld.get_items():
             if item.name not in item_names:
-                state.collect(item)
+                state.collect(item, prevent_sweep)
 
     def get_item_by_name(self, item_name: str) -> Item:
         """Returns the first item found in placed items, or in the itempool with the matching name"""
@@ -106,19 +106,20 @@ class WorldTestBase(unittest.TestCase):
             item_names = (item_names,)
         return [item for item in self.multiworld.itempool if item.name in item_names]
 
-    def collect_by_name(self, item_names: typing.Union[str, typing.Iterable[str]]) -> typing.List[Item]:
+    def collect_by_name(self, item_names: typing.Union[str, typing.Iterable[str]],
+                        prevent_sweep = False) -> typing.List[Item]:
         """ collect all of the items in the item pool that have the given names """
         items = self.get_items_by_name(item_names)
-        self.collect(items)
+        self.collect(items, prevent_sweep)
         return items
 
-    def collect(self, items: typing.Union[Item, typing.Iterable[Item]]) -> None:
+    def collect(self, items: typing.Union[Item, typing.Iterable[Item]], prevent_sweep = False) -> None:
         """Collects the provided item(s) into state"""
         if isinstance(items, Item):
             items = (items,)
         for item in items:
-            self.multiworld.state.collect(item)
-    
+            self.multiworld.state.collect(item, prevent_sweep)
+
     def remove_by_name(self, item_names: typing.Union[str, typing.Iterable[str]]) -> typing.List[Item]:
         """Remove all of the items in the item pool with the given names from state"""
         items = self.get_items_by_name(item_names)
@@ -141,7 +142,7 @@ class WorldTestBase(unittest.TestCase):
     def can_reach_entrance(self, entrance: str) -> bool:
         """Determines if the current state can reach the provided entrance name"""
         return self.multiworld.state.can_reach(entrance, "Entrance", self.player)
-    
+
     def can_reach_region(self, region: str) -> bool:
         """Determines if the current state can reach the provided region name"""
         return self.multiworld.state.can_reach(region, "Region", self.player)

--- a/test/bases.py
+++ b/test/bases.py
@@ -91,7 +91,7 @@ class WorldTestBase(unittest.TestCase):
             state = self.multiworld.state
         for item in self.multiworld.get_items():
             if item.name not in item_names:
-                state.collect(item, prevent_sweep)
+                state.collect(item, prevent_sweep=prevent_sweep)
 
     def get_item_by_name(self, item_name: str) -> Item:
         """Returns the first item found in placed items, or in the itempool with the matching name"""
@@ -110,7 +110,7 @@ class WorldTestBase(unittest.TestCase):
                         prevent_sweep = False) -> typing.List[Item]:
         """ collect all of the items in the item pool that have the given names """
         items = self.get_items_by_name(item_names)
-        self.collect(items, prevent_sweep)
+        self.collect(items, prevent_sweep=prevent_sweep)
         return items
 
     def collect(self, items: typing.Union[Item, typing.Iterable[Item]], prevent_sweep = False) -> None:
@@ -118,7 +118,7 @@ class WorldTestBase(unittest.TestCase):
         if isinstance(items, Item):
             items = (items,)
         for item in items:
-            self.multiworld.state.collect(item, prevent_sweep)
+            self.multiworld.state.collect(item, prevent_sweep=prevent_sweep)
 
     def remove_by_name(self, item_names: typing.Union[str, typing.Iterable[str]]) -> typing.List[Item]:
         """Remove all of the items in the item pool with the given names from state"""


### PR DESCRIPTION
## What is this fixing or adding?
When manually adding items during unit testing (using `collect` `collect_by_name` or `collect_all_but`), there is no way to prevent a full sweep for accessible items. This can lead to prefilled items being accidentally collected, causing unit tests to fail unexpectedly.

This PR propagates the `prevent_sweep` flag from `CollectionState.collect` up to the `WorldTestBase` collect functions so that they remain viable in worlds with prefilled items. In each function, the added parameter defaults to `False`, in keeping with the `CollectionState.collect` default, so these changes should be fully backwards compatible.

## How was this tested?
Standard AP unit tests + a few more targeted tests with an AP world I'm currently developing. (Struggling with the unit tests for that world was the primary inspiration for this PR.)

## If this makes graphical changes, please attach screenshots.
N/A