### PR TITLE
ModuleUpdate: Add core requirements.txt as a constraint file to pip calls

### DIFF
--- a/ModuleUpdate.py
+++ b/ModuleUpdate.py
@@ -70,7 +70,7 @@ def confirm(msg: str):
 def update_command():
     check_pip()
     for file in requirements_files:
-        subprocess.call([sys.executable, "-m", "pip", "install", "-r", file, "-c", core_constraints])
+        subprocess.call([sys.executable, "-m", "pip", "install", "-r", file, "--constraint", core_constraints])
 
 
 def install_pkg_resources(yes=False):

--- a/ModuleUpdate.py
+++ b/ModuleUpdate.py
@@ -38,7 +38,8 @@ class RequirementsSet(set):
 
 
 local_dir = os.path.dirname(__file__)
-requirements_files = RequirementsSet((os.path.join(local_dir, 'requirements.txt'),))
+core_constraints = os.path.join(local_dir, 'requirements.txt')
+requirements_files = RequirementsSet((core_constraints,))
 
 if not update_ran:
     for entry in os.scandir(os.path.join(local_dir, "worlds")):
@@ -69,7 +70,7 @@ def confirm(msg: str):
 def update_command():
     check_pip()
     for file in requirements_files:
-        subprocess.call([sys.executable, "-m", "pip", "install", "-r", file, "--upgrade"])
+        subprocess.call([sys.executable, "-m", "pip", "install", "-r", file, "-c", core_constraints, "--upgrade"])
 
 
 def install_pkg_resources(yes=False):

--- a/ModuleUpdate.py
+++ b/ModuleUpdate.py
@@ -70,7 +70,7 @@ def confirm(msg: str):
 def update_command():
     check_pip()
     for file in requirements_files:
-        subprocess.call([sys.executable, "-m", "pip", "install", "-r", file, "-c", core_constraints, "--upgrade"])
+        subprocess.call([sys.executable, "-m", "pip", "install", "-r", file, "-c", core_constraints])
 
 
 def install_pkg_resources(yes=False):
@@ -80,7 +80,7 @@ def install_pkg_resources(yes=False):
         check_pip()
         if not yes:
             confirm("pkg_resources not found, press enter to install it")
-        subprocess.call([sys.executable, "-m", "pip", "install", "--upgrade", "setuptools>=75,<81"])
+        subprocess.call([sys.executable, "-m", "pip", "install", "setuptools>=75,<81"])
 
 
 def update(yes: bool = False, force: bool = False) -> None:


### PR DESCRIPTION
## What is this fixing or adding?
currently typing_extensions is getting set to the newest 4.16.0 because zillion's requirements.txt gets processed after core's,
this change adds core's requirements.txt to any pip calls as a "constraint file", which adds limits to the relevant call, 

## How was this tested?
clear venv and ran moduleupdate, seeing no mentions of typing_extensions 4.16.0
edited a world requirements to enforce `typing_extensions>=4.16.0` and saw an error on ModuleUpdate
ci unit tests seem to be behaving again

## If this makes graphical changes, please attach screenshots.
