### PR TITLE
core: Updating hint not found error message

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1810,12 +1810,12 @@ class ClientMessageProcessor(CommonCommandProcessor):
                 if for_location:
                     self.output(
                         f"Recognized location \"{hint_name}\" does not exist for your slot. "
-                        f"This is may be due to your options."
+                        f"This may be due to your options."
                     )
                 else:
                     self.output(
                         f"Recognized item \"{hint_name}\" does not exist for your slot. "
-                        f"This is may be due to your options."
+                        f"This may be due to your options."
                     )
             else:
                 self.output(f"You can't afford the hint. "
@@ -2467,7 +2467,7 @@ class ServerCommandProcessor(CommonCommandProcessor):
                 else:
                     self.output(
                         f"Recognized item \"{item}\" does not exist for this slot. "
-                        "This is may be due to this slot's options."
+                        "This may be due to this slot's options."
                     )
                 return True
             else:
@@ -2509,7 +2509,7 @@ class ServerCommandProcessor(CommonCommandProcessor):
                 else:
                     self.output(
                         f"Recognized location \"{location}\" does not exist for this slot. "
-                        "This is may be due to this slot's options."
+                        "This may be due to this slot's options."
                     )
                 return True
             else:

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -254,7 +254,7 @@ class Context:
 
     def __init__(self, host: str, port: int, server_password: str, password: str, location_check_points: int,
                  hint_cost: int, item_cheat: bool, release_mode: str = "disabled", collect_mode="disabled",
-                 countdown_mode: str = "auto", remaining_mode: str = "disabled", auto_shutdown: typing.SupportsFloat = 0, 
+                 countdown_mode: str = "auto", remaining_mode: str = "disabled", auto_shutdown: typing.SupportsFloat = 0,
                  compatibility: int = 2, log_network: bool = False, logger: logging.Logger = logging.getLogger()):
         self.logger = logger
         super(Context, self).__init__()
@@ -847,12 +847,12 @@ class Context:
             if hint.location == seeked_location and hint.finding_player == finding_player:
                 return hint
         return None
-    
+
     def replace_hint(self, team: int, slot: int, old_hint: Hint, new_hint: Hint) -> None:
         if old_hint in self.hints[team, slot]:
             self.hints[team, slot].remove(old_hint)
             self.hints[team, slot].add(new_hint)
-    
+
     # "events"
 
     def on_goal_achieved(self, client: Client):
@@ -1271,7 +1271,7 @@ def format_hint(ctx: Context, team: int, hint: Hint) -> str:
 
     if hint.entrance:
         text += f" at {hint.entrance}"
-    
+
     return text + ". " + status_names.get(hint.status, "(unknown)")
 
 
@@ -1808,11 +1808,15 @@ class ClientMessageProcessor(CommonCommandProcessor):
         else:
             if points_available >= cost:
                 if for_location:
-                    self.output(f"Nothing found for recognized location name \"{hint_name}\". "
-                                f"Location appears to not exist in this multiworld.")
+                    self.output(
+                        f"Recognized location \"{hint_name}\" does not exist for your slot. "
+                        f"This is likely due to your options."
+                    )
                 else:
-                    self.output(f"Nothing found for recognized item name \"{hint_name}\". "
-                                f"Item appears to not exist in this multiworld.")
+                    self.output(
+                        f"Recognized item \"{hint_name}\" does not exist for your slot. "
+                        f"This is likely due to your options."
+                    )
             else:
                 self.output(f"You can't afford the hint. "
                             f"You have {points_available} points and need at least "
@@ -2085,7 +2089,7 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
             # As of writing this code, only_new=True does not update status for existing hints
             ctx.notify_hints(client.team, hints, only_new=True, persist_even_if_found=True)
             ctx.save()
-        
+
         elif cmd == 'UpdateHint':
             location = args["location"]
             player = args["player"]

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -1810,12 +1810,12 @@ class ClientMessageProcessor(CommonCommandProcessor):
                 if for_location:
                     self.output(
                         f"Recognized location \"{hint_name}\" does not exist for your slot. "
-                        f"This is likely due to your options."
+                        f"This is may be due to your options."
                     )
                 else:
                     self.output(
                         f"Recognized item \"{hint_name}\" does not exist for your slot. "
-                        f"This is likely due to your options."
+                        f"This is may be due to your options."
                     )
             else:
                 self.output(f"You can't afford the hint. "
@@ -2467,7 +2467,7 @@ class ServerCommandProcessor(CommonCommandProcessor):
                 else:
                     self.output(
                         f"Recognized item \"{item}\" does not exist for this slot. "
-                        "This is likely due to this slot's options."
+                        "This is may be due to this slot's options."
                     )
                 return True
             else:
@@ -2509,7 +2509,7 @@ class ServerCommandProcessor(CommonCommandProcessor):
                 else:
                     self.output(
                         f"Recognized location \"{location}\" does not exist for this slot. "
-                        "This is likely due to this slot's options."
+                        "This is may be due to this slot's options."
                     )
                 return True
             else:

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2465,7 +2465,10 @@ class ServerCommandProcessor(CommonCommandProcessor):
                     self.ctx.notify_hints(team, hints)
 
                 else:
-                    self.output("No hints found.")
+                    self.output(
+                        f"Recognized item \"{item}\" does not exist for this slot. "
+                        "This is likely due to this slot's options."
+                    )
                 return True
             else:
                 self.output(response)
@@ -2504,7 +2507,10 @@ class ServerCommandProcessor(CommonCommandProcessor):
                 if hints:
                     self.ctx.notify_hints(team, hints)
                 else:
-                    self.output("No hints found.")
+                    self.output(
+                        f"Recognized location \"{location}\" does not exist for this slot. "
+                        "This is likely due to this slot's options."
+                    )
                 return True
             else:
                 self.output(response)


### PR DESCRIPTION
## What is this fixing or adding?
Updating the message printed when the user hints and the item or location doesn't exist for the slot.

This is following the decision from the [#general suggestions thread on discord](https://discord.com/channels/731205301247803413/1520587481869979778).

## How was this tested?
Generated an sc2 world locally, connected, set the hint cost to 0, and hinted an item and location that didn't exist in the mission order. Observed the error message was properly updated. Image below.

## If this makes graphical changes, please attach screenshots.
<img width="1063" height="290" alt="image" src="https://github.com/user-attachments/assets/9f6228c1-da7a-4f3f-8c61-52843f1d4e57" />
