### PR TITLE
Options Creator: Fix handling of options with random default

### DIFF
--- a/OptionsCreator.py
+++ b/OptionsCreator.py
@@ -402,6 +402,9 @@ class OptionsCreator(ThemedApp):
             dropdown.dismiss()
 
         def open_dropdown(button):
+            # clicking the edge of a choice button apparently still runs this?
+            if button.disabled:
+                return
             # for some reason this fixes an issue causing some to not open
             dropdown.open()
 

--- a/OptionsCreator.py
+++ b/OptionsCreator.py
@@ -522,25 +522,23 @@ class OptionsCreator(ThemedApp):
 
         option_base.add_widget(label_box)
         if issubclass(option, NamedRange):
-            widget = self.create_named_range(option, name)
+            option_base.add_widget(self.create_named_range(option, name))
         elif issubclass(option, Range):
-            widget = self.create_range(option, name)
+            option_base.add_widget(self.create_range(option, name))
         elif issubclass(option, Toggle):
-            widget = self.create_toggle(option, name)
+            option_base.add_widget(self.create_toggle(option, name))
         elif issubclass(option, TextChoice):
-            widget = self.create_text_choice(option, name)
+            option_base.add_widget(self.create_text_choice(option, name))
         elif issubclass(option, Choice):
-            widget = self.create_choice(option, name)
+            option_base.add_widget(self.create_choice(option, name))
         elif issubclass(option, FreeText):
-            widget = self.create_free_text(option, name)
+            option_base.add_widget(self.create_free_text(option, name))
         elif issubclass(option, (OptionSet, OptionList, OptionCounter)):
-            widget = self.create_option_set_list_counter(option, name, world)
+            option_base.add_widget(self.create_option_set_list_counter(option, name, world))
         else:
             option_base.add_widget(MDLabel(text="This option isn't supported by the option creator.\n"
                                                 "Please edit your yaml manually to set this option."))
             return option_base
-
-        option_base.add_widget(widget)
 
         if option_can_be_randomized(option):
             def randomize_option(instance: Widget, value: str):
@@ -567,14 +565,10 @@ class OptionsCreator(ThemedApp):
             label_box.add_widget(random_toggle)
             if default_random:
                 # change stored value to match displayed one before randomizing it
-                if isinstance(widget, VisualNamedRange):
-                    self.options[name] = widget.range.tag.text
-                elif isinstance(widget, VisualRange):
-                    self.options[name] = widget.tag.text
-                elif isinstance(widget, VisualTextChoice):
-                    self.options[name] = widget.choice.text.text
-                elif isinstance(widget, VisualChoice):
-                    self.options[name] = widget.text.text
+                if issubclass(option, Range):
+                    self.options[name] = option.range_start
+                elif issubclass(option, Choice):
+                    self.options[name] = list(option.options.values())[0]
 
                 randomize_option(random_toggle, "down")
 

--- a/OptionsCreator.py
+++ b/OptionsCreator.py
@@ -518,22 +518,25 @@ class OptionsCreator(ThemedApp):
 
         option_base.add_widget(label_box)
         if issubclass(option, NamedRange):
-            option_base.add_widget(self.create_named_range(option, name))
+            widget = self.create_named_range(option, name)
         elif issubclass(option, Range):
-            option_base.add_widget(self.create_range(option, name))
+            widget = self.create_range(option, name)
         elif issubclass(option, Toggle):
-            option_base.add_widget(self.create_toggle(option, name))
+            widget = self.create_toggle(option, name)
         elif issubclass(option, TextChoice):
-            option_base.add_widget(self.create_text_choice(option, name))
+            widget = self.create_text_choice(option, name)
         elif issubclass(option, Choice):
-            option_base.add_widget(self.create_choice(option, name))
+            widget = self.create_choice(option, name)
         elif issubclass(option, FreeText):
-            option_base.add_widget(self.create_free_text(option, name))
-        elif any(issubclass(option, cls) for cls in (OptionSet, OptionList, OptionCounter)):
-            option_base.add_widget(self.create_option_set_list_counter(option, name, world))
+            widget = self.create_free_text(option, name)
+        elif issubclass(option, (OptionSet, OptionList, OptionCounter)):
+            widget = self.create_option_set_list_counter(option, name, world)
         else:
             option_base.add_widget(MDLabel(text="This option isn't supported by the option creator.\n"
                                                 "Please edit your yaml manually to set this option."))
+            return option_base
+
+        option_base.add_widget(widget)
 
         if option_can_be_randomized(option):
             def randomize_option(instance: Widget, value: str):
@@ -559,6 +562,16 @@ class OptionsCreator(ThemedApp):
             random_toggle.bind(state=randomize_option)
             label_box.add_widget(random_toggle)
             if default_random:
+                # change stored value to match displayed one before randomizing it
+                if isinstance(widget, VisualNamedRange):
+                    self.options[name] = widget.range.tag.text
+                elif isinstance(widget, VisualRange):
+                    self.options[name] = widget.tag.text
+                elif isinstance(widget, VisualTextChoice):
+                    self.options[name] = widget.choice.text.text
+                elif isinstance(widget, VisualChoice):
+                    self.options[name] = widget.text.text
+
                 randomize_option(random_toggle, "down")
 
         return option_base

--- a/OptionsCreator.py
+++ b/OptionsCreator.py
@@ -381,13 +381,14 @@ class OptionsCreator(ThemedApp):
         self.options[name] = default
         return box
 
-    def create_free_text(self, option: typing.Type[FreeText] | typing.Type[TextChoice], name: str):
+    def create_free_text(self, option: typing.Type[FreeText] | typing.Type[TextChoice], name: str, bind=True):
         text = VisualFreeText(option=option, name=name)
 
         def set_value(instance, value):
             self.options[name] = value
 
-        text.bind(text=set_value)
+        if bind:
+            text.bind(text=set_value)
         self.options[name] = option.default
         return text
 
@@ -426,13 +427,13 @@ class OptionsCreator(ThemedApp):
                     child.text = text
 
         box = VisualTextChoice(option=option, name=name, choice=self.create_choice(option, name),
-                               text=self.create_free_text(option, name))
+                               text=self.create_free_text(option, name, bind=False))
 
-        def set_value(instance):
+        def set_value(instance, value):
             set_button_text(box.choice, "Custom")
-            self.options[name] = instance.text
+            self.options[name] = value
 
-        box.text.bind(on_text_validate=set_value)
+        box.text.bind(text=set_value)
         return box
 
     def create_toggle(self, option: typing.Type[Toggle], name: str) -> Widget:


### PR DESCRIPTION
## What is this fixing or adding?
Currently, an option which defaults to `random` will be shown as such in the Options Creator, but if it is unselected, its underlying value remains as `random` (and it will be exported as such) even though the displayed value is now something else. Example: https://discord.com/channels/731205301247803413/1522543645826355271
This sets the value upon initialization to the same thing that is being displayed so there isn't a mismatch.

Also while doing this, I noticed that the random button can appear (and seemingly just error if used) for option types the creator can't actually display, that it's apparently possible to click on the edge of a disabled Choice option and set it to something else while randomized (which also causes a mismatch between display and actual value), and that on a `TextChoice` the "Custom" text doesn't show unless you press enter, whereas the value updates upon any text change, so I changed these things as well.

## How was this tested?
Exporting options from ALttP and The Witness, which have default-random Choices/Ranges, and also testing changing other option types to default to random to make sure they also work.

## If this makes graphical changes, please attach screenshots.
🎲