### PR TITLE
Starcraft 2: item pool reduction overcounting fix

### DIFF
--- a/worlds/sc2/pool_filter.py
+++ b/worlds/sc2/pool_filter.py
@@ -147,10 +147,10 @@ class ValidInventory:
 
     def count_from_list_unique(self, items: Iterable[str], player: int) -> int:
         result = 0
-        for val in my_dict.values():
-            if val > 0:
+        for item in items:
+            if self.logical_inventory[item] > 0:
                 result += 1
-        return result        
+        return result 
 
     def generate_reduced_inventory(self, inventory_size: int, filler_amount: int, mission_requirements: List[Tuple[str, Callable]]) -> List[StarcraftItem]:
         """Attempts to generate a reduced inventory that can fulfill the mission requirements."""

--- a/worlds/sc2/pool_filter.py
+++ b/worlds/sc2/pool_filter.py
@@ -146,7 +146,11 @@ class ValidInventory:
         return sum(self.logical_inventory.get(item, 0) for item in items)
 
     def count_from_list_unique(self, items: Iterable[str], player: int) -> int:
-        return sum(self.logical_inventory.get(item, 0) > 0 for item in items)
+        result = 0
+        for val in my_dict.values():
+            if val > 0:
+                result += 1
+        return result        
 
     def generate_reduced_inventory(self, inventory_size: int, filler_amount: int, mission_requirements: List[Tuple[str, Callable]]) -> List[StarcraftItem]:
         """Attempts to generate a reduced inventory that can fulfill the mission requirements."""

--- a/worlds/sc2/pool_filter.py
+++ b/worlds/sc2/pool_filter.py
@@ -146,7 +146,7 @@ class ValidInventory:
         return sum(self.logical_inventory.get(item, 0) for item in items)
 
     def count_from_list_unique(self, items: Iterable[str], player: int) -> int:
-        return sum(item in self.logical_inventory for item in items)
+        return sum(self.logical_inventory.get(item, 0) > 0 for item in items)
 
     def generate_reduced_inventory(self, inventory_size: int, filler_amount: int, mission_requirements: List[Tuple[str, Callable]]) -> List[StarcraftItem]:
         """Attempts to generate a reduced inventory that can fulfill the mission requirements."""


### PR DESCRIPTION
## What is this fixing or adding?
In sc2, count_from_list_unique would return a count of keys in the dict, even ones that have been reduced to 0, which would later be removed. This leads to the reduction dropping items too aggressively, and generation continuing through to accessibility before erroring for being impossible to beat due to some missions that are required to beat the game directly or indirectly being unable to be satisfied.

The fix is to simply filter out zero count items when summing.

## How was this tested?
Stock unit tests + my own included test for this specific issue

Additionally 20 generations with random options across different seeds with groups of 20 players of various games including 2 sc2 players each time. Also before and after testing of a specific seed/settings combination for which the bug was identified and the fix confirmed.


