### PR TITLE
Core: linearish, create playthrough alternative

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -2095,6 +2095,7 @@ class Spoiler:
                     for loc in collected_set:
                         roots.pop(loc, None)
                 loop_flippers = set().union(*roots.values())
+                if not loop_flippers: raise RuntimeError("sphere fulfillment unable to satisfy some required locations")
                 bulk_collect(loop_flippers, forced_state, sphere)
                 bulk_collect(loop_flippers, bulk_search_state)
                 bulk_collect(loop_flippers, state)
@@ -2174,11 +2175,12 @@ class Spoiler:
     # player's entries and don't need shared containers.
     @staticmethod
     def player_state_copy(input_state, player):
+        import copy
         ret_state = CollectionState.__new__(CollectionState)
         for attr, val in input_state.__dict__.items():
             if isinstance(val, dict) and player in val:
                 cp = getattr(val[player], "copy", None)
-                setattr(ret_state, attr, {player: cp() if callable(cp) else val[player]})
+                setattr(ret_state, attr, {player: cp() if callable(cp) else copy.deepcopy(val[player])})
             elif isinstance(val, defaultdict):
                 setattr(ret_state, attr, defaultdict(val.default_factory))
             elif callable(getattr(val, "clear", None)):

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1847,9 +1847,9 @@ class Spoiler:
         start_state = CollectionState(multiworld)
         player_ids = multiworld.player_ids
         # spheres partitioned by recepient player for frontier search
-        spheres = []
+        spheres: list[dict[int, list[Location]]] = []
         # snapshots of each sphere for regression without rebuilding the state
-        sphere_snapshots = []
+        sphere_snapshots: list[CollectionState] = []
         # which goals are still unfound, to not recheck found goals
         goals_unfound = set(player_ids)
         tally = Counter()
@@ -1862,108 +1862,144 @@ class Spoiler:
         # wrapper for goals and locations to check if the state fulfills the condition for either.
         # goals are just another condition that needs to be fulfilled each sphere/pass,
         # and being able to reorder when the goal is searched allows more variance
-        def is_met(target, q_state):
-            if isinstance(target, int): return multiworld.has_beaten_game(q_state, target)
+        def is_met(target: int | Location, q_state: CollectionState) -> bool:
+            if isinstance(target, int):
+                return multiworld.has_beaten_game(q_state, target)
             return q_state.can_reach(target)
         # player for a location or goal
-        def owner(target):
-            if target in global_locations: return "global"
+        def owner(target: int | Location) -> int | str:
+            if target in global_locations:
+                return "global"
             return target if isinstance(target, int) else target.player
         # key for sorting locations for determinism
-        def loc_key(loc):
-            if isinstance(loc, int): return (loc, "", loc, "")
-            return (loc.item.player, loc.item.name, loc.player, loc.name)
+        def loc_key(target: int | Location) -> tuple[int, str, int, str]:
+            if isinstance(target, int): 
+                return (target, "", target, "")
+            return (target.item.player, target.item.name, target.player, target.name)
         # bulk check reachability of several locations and optionally provide anything collected/not
-        def bulk_is_met(locs, state, missed = None, met = None):
+        def bulk_is_met(
+            locations: Iterable[int | Location],
+            state: CollectionState,
+            unmet_items: list[int | Location] | None = None,
+            met_items: list[int | Location] | None = None,
+        ) -> bool:
             result = True
-            locs = list(locs)
-            if missed is not None: missed.clear()
-            if met is not None: met.clear()
-            for loc in locs:
-                if is_met(loc, state):
-                    if met is not None: met.append(loc)
+            locations = list(locations)
+            if unmet_items is not None:
+                unmet_items.clear()
+            if met_items is not None:
+                met_items.clear()
+            for location in locations:
+                if is_met(location, state):
+                    if met_items is not None:
+                        met_items.append(location)
                     continue
                 result = False
-                if missed is not None: missed.append(loc)
+                if unmet_items is not None:
+                    unmet_items.append(location)
             return result
         # a simple utility to avoid having to write loops
-        def bulk_collect(seed, state, sphere = None):
+        def bulk_collect(
+            to_collect: Iterable[Any],
+            state: CollectionState,
+            sphere: dict[int, list[Location]] | None = None,
+        ) -> set[int]:
             players_collected = set()
-            if isinstance(seed, list) or isinstance(seed, set):
-                for loc in seed:
-                    if isinstance(loc, int): continue
-                    if loc in state.locations_checked: continue
-                    state.collect(loc.item, True, loc)
-                    players_collected.add(loc.item.player)
-                    if sphere is None: continue
-                    sphere[loc.item.player].remove(loc)
+            if isinstance(to_collect, dict):
+                for locations in to_collect.values():
+                    players_collected.update(bulk_collect(locations, state, sphere))
+            else:
+                for location in to_collect:
+                    if isinstance(location, int):
+                        continue
+                    if location in state.locations_checked:
+                        continue
+                    state.collect(location.item, True, location)
+                    players_collected.add(location.item.player)
+                    if sphere is None:
+                        continue
+                    sphere[location.item.player].remove(location)
                 return players_collected
-            for locs in seed.values(): players_collected.update(bulk_collect(locs, state, sphere))
             return players_collected
         # like binary search, but for all targets at once, still maintaining the player item-location relationship
         # but checking in bulk saves operations and eliminates some order problems
-        def bulk_binary_search(state, locs, targets, player, fungibles_promoted):
-            low, high = 0, len(locs) - 1
+        def bulk_binary_search(
+            state: CollectionState,
+            locations: list[Location],
+            targets: list[int | Location],
+            player: int | str,
+            fungibles_promoted: set[tuple[int, str]],
+        ) -> list[Location]:
+            low, high = 0, len(locations) - 1
             if player == "global":
                 search_stack = [(state.copy(), low, targets.copy(), 0)]
             else:
                 search_stack = [(self.player_state_copy(state, player), low, targets.copy(), 0)]
             results = []
             while search_stack:
-                st, low, tgts, synced = search_stack[-1]
-                for result in results[synced:]: st.collect(result.item, True, result)
-                search_stack[-1] = (st, low, tgts, len(results))
+                stack_state, low, stack_targets, synced = search_stack[-1]
+                for result in results[synced:]:
+                    stack_state.collect(result.item, True, result)
+                search_stack[-1] = (stack_state, low, stack_targets, len(results))
 
-                if bulk_is_met(tgts, st, tgts):
+                if bulk_is_met(stack_targets, stack_state, stack_targets):
                     search_stack.pop()
                     high = low - 1
                     continue
-                if low > high: raise RuntimeError("targets unreachable after frontier exhausted")
-                tgts = tgts.copy()
+                if low > high:
+                    raise RuntimeError("targets unreachable after frontier exhausted")
+                stack_targets = stack_targets.copy()
                 mid = (low + high) // 2
                 if player == "global":
-                    probe_state = st.copy()
+                    probe_state = stack_state.copy()
                 else:
-                    probe_state = self.player_state_copy(st, player)
-                for i in range(low, mid + 1): probe_state.collect(locs[i].item, True, locs[i])
-                if bulk_is_met(tgts, probe_state, tgts):
+                    probe_state = self.player_state_copy(stack_state, player)
+                for i in range(low, mid + 1):
+                    probe_state.collect(locations[i].item, True, locations[i])
+                if bulk_is_met(stack_targets, probe_state, stack_targets):
                     if (low == mid):
-                        results.append(locs[mid])
-                        if (locs[mid].item.player, locs[mid].item.name) in fungibles:
-                            fungibles_promoted.add((locs[mid].item.player, locs[mid].item.name))
-                            item_name = locs[mid].item.name
-                            while mid > 0 and locs[mid - 1].item.name == item_name:
-                                results.append(locs[mid - 1])
+                        results.append(locations[mid])
+                        if (locations[mid].item.player, locations[mid].item.name) in fungibles:
+                            fungibles_promoted.add((locations[mid].item.player, locations[mid].item.name))
+                            item_name = locations[mid].item.name
+                            while mid > 0 and locations[mid - 1].item.name == item_name:
+                                results.append(locations[mid - 1])
                                 mid -= 1
                         high = mid - 1
                     else:
                         high = mid
                 else:
-                    search_stack.append((probe_state, mid + 1, tgts, len(results)))
+                    search_stack.append((probe_state, mid + 1, stack_targets, len(results)))
                     continue
             return results
 
         # sphere building loop. collect items in waves as they become available and populate containers as we go
         while goals_unfound:
-            if not candidates: raise RuntimeError("No more candidates but still goals unfound")
+            if not candidates:
+                raise RuntimeError("No more candidates but still goals unfound")
             # snapshots represent the lower sphere base that stays consistent for the search, so it's taken before the sphere is processed
             sphere_snapshots.append(start_state.copy())
             sphere = defaultdict(list)
-            reached = [loc for loc in candidates if start_state.can_reach(loc)]
-            if not reached: raise RuntimeError("goals_unfound with no remaining reachable advancments: {goals_unfound}\n game unbeatable.")
-            counts = Counter((loc.item.player, loc.item.name) for loc in reached)
-            reached.sort(key=lambda loc: (counts[loc.item.player, loc.item.name], loc_key(loc)))
+            reached = [location for location in candidates if start_state.can_reach(location)]
+            if not reached:
+                raise RuntimeError(
+                    f"goals_unfound with no remaining reachable advancments: {goals_unfound}\n game unbeatable."
+                )
+            counts = Counter((location.item.player, location.item.name) for location in reached)
+            reached.sort(key=lambda location: (counts[location.item.player, location.item.name], loc_key(location)))
             tally.update(counts)
-            for loc in reached:
-                sphere[loc.item.player].append(loc)
-                start_state.collect(loc.item, True, loc)
+            for location in reached:
+                sphere[location.item.player].append(location)
+                start_state.collect(location.item, True, location)
             candidates.difference_update(reached)
             spheres.append(sphere)
 
             sphere_id = len(sphere_snapshots) - 1
-            found_goals = {p for p in goals_unfound if is_met(p, start_state)}
-            for goal in found_goals: seed_vips[sphere_id + 1][goal].add(goal)
-            for goal in found_goals: goal_spheres[goal] = sphere_id + 1
+            found_goals = {player_goal for player_goal in goals_unfound if is_met(player_goal, start_state)}
+            for goal in found_goals:
+                seed_vips[sphere_id + 1][goal].add(goal)
+            for goal in found_goals:
+                goal_spheres[goal] = sphere_id + 1
             goals_unfound -= found_goals
 
         # test if each of a player's items or goals (indexed by player id) can be met with just their own items, add
@@ -1973,8 +2009,11 @@ class Spoiler:
             state = CollectionState(multiworld)
             goal_state = None
             for sphere in range(0, len(spheres)):
-                locations = [loc for loc in chain.from_iterable(spheres[sphere].values()) if loc.player == player]
-                if goal_spheres[player] == sphere: goal_state = state.copy()
+                locations = [
+                    location for location in chain.from_iterable(spheres[sphere].values()) if location.player == player
+                ]
+                if goal_spheres[player] == sphere:
+                    goal_state = state.copy()
                 unmet = []
                 bulk_is_met(locations, state, unmet)
                 bulk_collect(spheres[sphere][player], state)
@@ -1992,7 +2031,13 @@ class Spoiler:
         # found again.
         fungibles = {key for key, count in tally.items() if count > 1}
         # cascade_collect is an efficient way to collect all items reachable from a state that might not yet be collected
-        def cascade_collect(to_check, sphere_id, state1, state2=None, collected_set=None):
+        def cascade_collect(
+            to_check: dict[int, dict[int | str, set[int | Location]]],
+            sphere_id: int,
+            state1: CollectionState,
+            state2: CollectionState | None = None,
+            collected_set: set[Location] | None = None,
+        ) -> dict[int, dict[int | str, set[int | Location]]]:
             unfulfilled = {
                 sphere: remaining_by_player
                 for sphere, player_dicts in to_check.items()
@@ -2036,15 +2081,23 @@ class Spoiler:
         # dependencies so we do individual, order invariant probe searches to try to find the prereqs that locations
         # with circular dependencies need. then repeat until the bulk search doesn't leave circular dependencies and
         # prune any unnecessary circular prereqs
-        def process_sphere_bulk_forced(sphere, state, vips, sphere_id, fungibles_promoted):
+        def process_sphere_bulk_forced(
+            sphere: dict[int, list[Location]],
+            state: CollectionState,
+            vips: dict[int, dict[int | str, set[int | Location]]],
+            sphere_id: int,
+            fungibles_promoted: set[tuple[int, str]],
+        ):
             targets = defaultdict(list)
             forced_state = state.copy()
             prune_state = state.copy()
-            for k, sp in vips.items():
-                if k <= sphere_id: continue
-                for loc in chain.from_iterable(sp.values()):
-                    targets[owner(loc)].append(loc)
-                    if not isinstance(loc, int): forced_state.collect(loc.item, True, loc)
+            for vip_sphere, sphere_dict in vips.items():
+                if vip_sphere <= sphere_id:
+                    continue
+                for location in chain.from_iterable(sphere_dict.values()):
+                    targets[owner(location)].append(location)
+                    if not isinstance(location, int):
+                        forced_state.collect(location.item, True, location)
             bulk_search_state = forced_state.copy()
             prospective_vips = defaultdict(list)
             stale_players = set(targets)
@@ -2058,15 +2111,22 @@ class Spoiler:
                         "global", set(fungibles_promoted))
                     bulk_collect(prospective_vips["global"], bulk_search_state)
                 for player, player_targets in targets.items():
-                    if player not in stale_players: continue
-                    prospective_vips[player] = bulk_binary_search(bulk_search_state, sphere.get(player, []), player_targets,
-                        player, set(fungibles_promoted))
+                    if player not in stale_players:
+                        continue
+                    prospective_vips[player] = bulk_binary_search(
+                        bulk_search_state,
+                        sphere.get(player, []),
+                        player_targets,
+                        player,
+                        set(fungibles_promoted),
+                    )
                     stale_players.remove(player)
                 loop_state = state.copy()
                 loop_sphere = {player: sphere_list.copy() for player, sphere_list in sphere.items()}
                 bulk_collect(prospective_vips, loop_state, loop_sphere)
                 unfulfilled = cascade_collect(vips, sphere_id, loop_state)
-                if not unfulfilled: break
+                if not unfulfilled:
+                    break
                 loop_frontier = loop_state.copy()
                 bulk_collect(loop_sphere, loop_frontier)
                 roots = defaultdict(set)
@@ -2075,7 +2135,8 @@ class Spoiler:
                     met = []
                     bulk_is_met(locs, loop_frontier, None, met)
                     potential_roots.extend(met)
-                if not potential_roots: raise RuntimeError("unfulfilled vips remain unreachable from frontier")
+                if not potential_roots:
+                    raise RuntimeError("unfulfilled vips remain unreachable from frontier")
                 potential_roots = sorted(potential_roots, key=loc_key)
                 while potential_roots:
                     root = potential_roots.pop()
@@ -2086,16 +2147,18 @@ class Spoiler:
                         root_sphere = loop_sphere.get(owner(root), [])
                     flippers = bulk_binary_search(root_state, root_sphere, [root], owner(root), set(fungibles_promoted))
                     roots[root] = set(flippers)
-                    if not isinstance(root, int): root_state.collect(root.item, True, root)
+                    if not isinstance(root, int):
+                        root_state.collect(root.item, True, root)
                     bulk_collect(flippers,root_state)
                     collected_set = set()
                     cascade_collect(unfulfilled, sphere_id, root_state, None, collected_set)
                     collected_set.discard(root)
                     potential_roots = [loc for loc in potential_roots if loc not in collected_set]
-                    for loc in collected_set:
-                        roots.pop(loc, None)
+                    for location in collected_set:
+                        roots.pop(location, None)
                 loop_flippers = set().union(*roots.values())
-                if not loop_flippers: raise RuntimeError("sphere fulfillment unable to satisfy some required locations")
+                if not loop_flippers:
+                    raise RuntimeError("sphere fulfillment unable to satisfy some required locations")
                 bulk_collect(loop_flippers, forced_state, sphere)
                 bulk_collect(loop_flippers, bulk_search_state)
                 bulk_collect(loop_flippers, state)
@@ -2116,27 +2179,30 @@ class Spoiler:
                     unfulfilled = cascade_collect(residual, sphere_id, test_state)
                     if not unfulfilled:
                         final_flippers.discard(flipper)
-            for loc in chain.from_iterable(prospective_vips.values()):
-                vips[sphere_id][owner(loc)].add(loc)
-                if (loc.item.player, loc.item.name) in fungibles: fungibles_promoted.add((loc.item.player, loc.item.name))
+            for location in chain.from_iterable(prospective_vips.values()):
+                vips[sphere_id][owner(location)].add(location)
+                if (location.item.player, location.item.name) in fungibles:
+                    fungibles_promoted.add((location.item.player, location.item.name))
             for flipper in final_flippers:
                 vips[sphere_id][owner(flipper)].add(flipper)
-                if (flipper.item.player, flipper.item.name) in fungibles: fungibles_promoted.add((flipper.item.player, flipper.item.name))
+                if (flipper.item.player, flipper.item.name) in fungibles:
+                    fungibles_promoted.add((flipper.item.player, flipper.item.name))
 
-        def run_sphere_fulfillment():
-            vips = defaultdict(lambda: defaultdict(set))
-            for sp in seed_vips:
-                for player in seed_vips[sp]:
-                    vips[sp][player] = seed_vips[sp][player].copy()
+        def run_sphere_fulfillment() -> dict[int, dict[int | str, set[int | Location]]]:
+            vips: dict[int, dict[int | str, set[int | Location]]] = defaultdict(lambda: defaultdict(set))
+            for vip_sphere in seed_vips:
+                for player in seed_vips[vip_sphere]:
+                    vips[vip_sphere][player] = seed_vips[vip_sphere][player].copy()
             sphere_id = len(spheres) - 1
             fungibles_promoted = set()
             # regress through spheres finding a valid set of prerequisites for all goals and vips at each step
             while len(spheres) > 0:
                 sphere = spheres.pop()
                 base_state = sphere_snapshots.pop()
-                for loc in chain.from_iterable(sphere.values()):
-                    if (loc.item.player, loc.item.name) not in fungibles_promoted: continue
-                    vips[sphere_id][owner(loc)].add(loc)
+                for location in chain.from_iterable(sphere.values()):
+                    if (location.item.player, location.item.name) not in fungibles_promoted:
+                        continue
+                    vips[sphere_id][owner(location)].add(location)
                 bulk_collect(vips[sphere_id], base_state, sphere)
                 process_sphere_bulk_forced(sphere, base_state, vips, sphere_id, fungibles_promoted)
                 sphere_id -= 1
@@ -2145,7 +2211,12 @@ class Spoiler:
 
 
         # remove goals from vips to build the playthrough
-        kept = [loc for players in vip_list.values() for locs in players.values() for loc in locs if not isinstance(loc, int)]
+        kept = [
+            location for players in vip_list.values()
+            for locations in players.values()
+            for location in locations
+            if not isinstance(location, int)
+        ]
         if not multiworld.can_beat_game(CollectionState(multiworld), kept):
             raise RuntimeError("Playthrough failed to beat the game")
         # build the playthrough sphere by sphere, collecting items as they are reachable
@@ -2153,9 +2224,11 @@ class Spoiler:
         playthrough_spheres = []
         remaining = set(kept)
         while remaining:
-                sphere = {loc for loc in remaining if walk_state.can_reach(loc)}
-                if not sphere: raise RuntimeError(f"Kept set not beatable; unreachable: {len(remaining)}")
-                for loc in sphere: walk_state.collect(loc.item, True, loc)
+                sphere = {location for location in remaining if walk_state.can_reach(location)}
+                if not sphere:
+                    raise RuntimeError(f"Kept set not beatable; unreachable: {len(remaining)}")
+                for location in sphere:
+                    walk_state.collect(location.item, True, location)
                 playthrough_spheres.append(sphere)
                 remaining -= sphere
         # start the playthrough with precollected items
@@ -2166,9 +2239,10 @@ class Spoiler:
             )}
         # add playthrough spheres
         for i, sphere in enumerate(playthrough_spheres):
-            self.playthrough[str(i + 1)] = {str(loc): str(loc.item) for loc in sorted(sphere)}
+            self.playthrough[str(i + 1)] = {str(location): str(location.item) for location in sorted(sphere)}
 
-        if create_paths: self.create_paths(walk_state, playthrough_spheres)
+        if create_paths:
+            self.create_paths(walk_state, playthrough_spheres)
 
 
     # creates a player-scoped copy of a state. it is intended for use cases where you do not need more than one

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1824,6 +1824,7 @@ class Spoiler:
             multiworld.push_precollected(item)
 
     def create_playthrough_sphere_fulfillment(self, create_paths: bool = True) -> None:
+        import time
         try:
             t1 = time.time()
             self.sphere_fulfillment(create_paths)

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1853,6 +1853,7 @@ class Spoiler:
         # vips are goals and locations that are the found prerequisites for other vips. to maintain reachability across the
         # whole set and ensure the game is beatable. vips must all be met each sphere and pass.
         seed_vips= defaultdict(lambda: defaultdict(set))
+        goal_spheres = defaultdict(int)
 
         # wrapper for goals and locations to check if the state fulfills the condition for either.
         # goals are just another condition that needs to be fulfilled each sphere/pass,
@@ -1861,7 +1862,8 @@ class Spoiler:
             if isinstance(target, int): return multiworld.has_beaten_game(q_state, target)
             return q_state.can_reach(target)
         # player for a location or goal
-        def owner(target) -> int:
+        def owner(target):
+            if target in global_locations: return "global"
             return target if isinstance(target, int) else target.player
         # key for sorting locations for determinism
         def loc_key(loc):
@@ -1880,11 +1882,28 @@ class Spoiler:
                 result = False
                 if missed is not None: missed.append(loc)
             return result
+        # a simple utility to avoid having to write loops
+        def bulk_collect(seed, state, sphere = None):
+            players_collected = set()
+            if isinstance(seed, list) or isinstance(seed, set):
+                for loc in seed:
+                    if isinstance(loc, int): continue
+                    if loc in state.locations_checked: continue
+                    state.collect(loc.item, True, loc)
+                    players_collected.add(loc.item.player)
+                    if sphere is None: continue
+                    sphere[loc.item.player].remove(loc)
+                return players_collected
+            for locs in seed.values(): players_collected.update(bulk_collect(locs, state, sphere))
+            return players_collected
         # like binary search, but for all targets at once, still maintaining the player item-location relationship
         # but checking in bulk saves operations and eliminates some order problems
         def bulk_binary_search(state, locs, targets, player, fungibles_promoted):
             low, high = 0, len(locs) - 1
-            search_stack = [(self.player_state_copy(state, player), low, targets.copy(), 0)]
+            if player == "global":
+                search_stack = [(state.copy(), low, targets.copy(), 0)]
+            else:
+                search_stack = [(self.player_state_copy(state, player), low, targets.copy(), 0)]
             results = []
             while search_stack:
                 st, low, tgts, synced = search_stack[-1]
@@ -1898,7 +1917,10 @@ class Spoiler:
                 if low > high: raise RuntimeError("targets unreachable after frontier exhausted")
                 tgts = tgts.copy()
                 mid = (low + high) // 2
-                probe_state = self.player_state_copy(st, player)
+                if player == "global":
+                    probe_state = st.copy()
+                else:
+                    probe_state = self.player_state_copy(st, player)
                 for i in range(low, mid + 1): probe_state.collect(locs[i].item, True, locs[i])
                 if bulk_is_met(tgts, probe_state, tgts):
                     if (low == mid):
@@ -1936,8 +1958,29 @@ class Spoiler:
             sphere_id = len(sphere_snapshots) - 1
             found_goals = {p for p in goals_unfound if is_met(p, start_state)}
             for goal in found_goals: seed_vips[sphere_id + 1][goal].add(goal)
+            for goal in found_goals: goal_spheres[goal] = sphere_id + 1
             goals_unfound -= found_goals
 
+        # test if each of a player's items or goals (indexed by player id) can be met with just their own items, add
+        # them to the global locations if not.
+        global_locations = set()
+        for player in player_ids:
+            state = CollectionState(multiworld)
+            goal_state = None
+            for sphere in range(0, len(spheres)):
+                locations = [loc for loc in chain.from_iterable(spheres[sphere].values()) if loc.player == player]
+                if goal_spheres[player] == sphere: goal_state = state.copy()
+                unmet = []
+                bulk_is_met(locations, state, unmet)
+                bulk_collect(spheres[sphere][player], state)
+                global_locations.update(unmet)
+            if goal_state is None:
+                goal_state = state
+            if not is_met(player, goal_state):
+                global_locations.add(player)
+                sphere = goal_spheres[player]
+                seed_vips[sphere][player].discard(player)
+                seed_vips[sphere]["global"].add(player)
 
         # fungibles are items for which a player has multiple of the same item. when promoted to vip, we know that all
         # copies in the sphere prefix, and all lower spheres are required to satisfy the prereq and don't need to be
@@ -1957,7 +2000,8 @@ class Spoiler:
                 next_changed, progressed, emptied = set(), False, []
                 for sphere, player_dicts in unfulfilled.items():
                     for player, remaining in player_dicts.items():
-                        if not remaining or (changed_players is not None and player not in changed_players):
+                        if not remaining or (changed_players is not None and player not in changed_players and
+                            player != "global"):
                             continue
                         newly_met = []
                         bulk_is_met(remaining, state1, None, newly_met)
@@ -1996,13 +2040,22 @@ class Spoiler:
                 for loc in chain.from_iterable(sp.values()):
                     targets[owner(loc)].append(loc)
                     if not isinstance(loc, int): forced_state.collect(loc.item, True, loc)
+            bulk_search_state = forced_state.copy()
             prospective_vips = defaultdict(list)
             stale_players = set(targets)
             final_flippers = set()
             while True:
+                if targets.get("global", None) and "global" in stale_players:
+                    bulk_search_state = forced_state.copy()
+                    stale_players.discard("global")
+                    global_sphere = list(chain.from_iterable(sphere.values()))
+                    prospective_vips["global"] = bulk_binary_search(bulk_search_state, global_sphere, targets["global"],
+                        "global", set(fungibles_promoted))
+                    bulk_collect(prospective_vips["global"], bulk_search_state)
                 for player, player_targets in targets.items():
                     if player not in stale_players: continue
-                    prospective_vips[player] = bulk_binary_search(forced_state, sphere.get(player, []), player_targets, player, set(fungibles_promoted))
+                    prospective_vips[player] = bulk_binary_search(bulk_search_state, sphere.get(player, []), player_targets,
+                        player, set(fungibles_promoted))
                     stale_players.remove(player)
                 loop_state = state.copy()
                 loop_sphere = {player: sphere_list.copy() for player, sphere_list in sphere.items()}
@@ -2022,7 +2075,11 @@ class Spoiler:
                 while potential_roots:
                     root = potential_roots.pop()
                     root_state = loop_state.copy()
-                    flippers = bulk_binary_search(root_state, loop_sphere.get(owner(root), []), [root], owner(root), set(fungibles_promoted))
+                    if owner(root) == "global":
+                        root_sphere = list(chain.from_iterable(loop_sphere.values()))
+                    else:
+                        root_sphere = loop_sphere.get(owner(root), [])
+                    flippers = bulk_binary_search(root_state, root_sphere, [root], owner(root), set(fungibles_promoted))
                     roots[root] = set(flippers)
                     if not isinstance(root, int): root_state.collect(root.item, True, root)
                     bulk_collect(flippers,root_state)
@@ -2034,39 +2091,32 @@ class Spoiler:
                         roots.pop(loc, None)
                 loop_flippers = set().union(*roots.values())
                 bulk_collect(loop_flippers, forced_state, sphere)
+                bulk_collect(loop_flippers, bulk_search_state)
                 bulk_collect(loop_flippers, state)
                 final_flippers.update(loop_flippers)
-                stale_players.update(loc.item.player for loc in loop_flippers)
+                if "global" in roots:
+                    stale_players = set(targets)
+                else:
+                    stale_players.update(loc.item.player for loc in loop_flippers)
+            final_flippers.update(prospective_vips["global"])
+            prospective_vips.pop("global", None)
             if final_flippers:
                 bulk_collect(prospective_vips, prune_state)
-                cascade_collect(vips, sphere_id, prune_state)
+                residual = cascade_collect(vips, sphere_id, prune_state)
                 for flipper in sorted(final_flippers, key=loc_key):
                     to_collect = final_flippers - {flipper}
                     test_state = prune_state.copy()
                     bulk_collect(to_collect, test_state)
-                    unfulfilled = cascade_collect(vips, sphere_id, test_state)
+                    unfulfilled = cascade_collect(residual, sphere_id, test_state)
                     if not unfulfilled:
                         final_flippers.discard(flipper)
             for loc in chain.from_iterable(prospective_vips.values()):
-                vips[sphere_id][loc.player].add(loc)
+                vips[sphere_id][owner(loc)].add(loc)
                 if (loc.item.player, loc.item.name) in fungibles: fungibles_promoted.add((loc.item.player, loc.item.name))
             for flipper in final_flippers:
-                vips[sphere_id][flipper.player].add(flipper)
+                vips[sphere_id][owner(flipper)].add(flipper)
                 if (flipper.item.player, flipper.item.name) in fungibles: fungibles_promoted.add((flipper.item.player, flipper.item.name))
-        # a simple utility to avoid having to write loops
-        def bulk_collect(seed, state, sphere = None):
-            players_collected = set()
-            if isinstance(seed, list) or isinstance(seed, set):
-                for loc in seed:
-                    if isinstance(loc, int): continue
-                    if loc in state.locations_checked: continue
-                    state.collect(loc.item, True, loc)
-                    players_collected.add(loc.item.player)
-                    if sphere is None: continue
-                    sphere[loc.item.player].remove(loc)
-                return players_collected
-            for locs in seed.values(): players_collected.update(bulk_collect(locs, state, sphere))
-            return players_collected
+
         def run_sphere_fulfillment():
             vips = defaultdict(lambda: defaultdict(set))
             for sp in seed_vips:
@@ -2080,7 +2130,7 @@ class Spoiler:
                 base_state = sphere_snapshots.pop()
                 for loc in chain.from_iterable(sphere.values()):
                     if (loc.item.player, loc.item.name) not in fungibles_promoted: continue
-                    vips[sphere_id][loc.player].add(loc)
+                    vips[sphere_id][owner(loc)].add(loc)
                 bulk_collect(vips[sphere_id], base_state, sphere)
                 process_sphere_bulk_forced(sphere, base_state, vips, sphere_id, fungibles_promoted)
                 sphere_id -= 1
@@ -2115,20 +2165,21 @@ class Spoiler:
         if create_paths: self.create_paths(walk_state, playthrough_spheres)
 
 
-    # creates a player-scoped copy of a state. it is intended for use cases where you do not mutate more than one
-    # player's entries and don't need locations_checked.
+    # creates a player-scoped copy of a state. it is intended for use cases where you do not need more than one
+    # player's entries and don't need shared containers.
     @staticmethod
     def player_state_copy(input_state, player):
         ret_state = CollectionState.__new__(CollectionState)
         for attr, val in input_state.__dict__.items():
             if isinstance(val, dict) and player in val:
-                new = dict(val)
-                cp = getattr(new[player], "copy", None)
-                new[player] = cp() if callable(cp) else new[player]
-                setattr(ret_state, attr, new)
+                cp = getattr(val[player], "copy", None)
+                setattr(ret_state, attr, {player: cp() if callable(cp) else val[player]})
+            elif isinstance(val, defaultdict):
+                setattr(ret_state, attr, defaultdict(val.default_factory))
+            elif callable(getattr(val, "clear", None)):
+                setattr(ret_state, attr, type(val)())
             else:
                 setattr(ret_state, attr, val)
-        ret_state.locations_checked = set()
         return ret_state
 
 

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1824,7 +1824,171 @@ class Spoiler:
             multiworld.push_precollected(item)
 
     def create_playthrough_sphere_regression(self, forks: int, create_paths: bool = True) -> None:
-        print(f"Creating playthrough sphere regression with {forks} forks")
+        from itertools import chain
+        import heapq
+        import hashlib
+        multiworld = self.multiworld
+        candidates = {location for location in multiworld.get_filled_locations() if location.item.advancement}
+        state = CollectionState(multiworld)
+        player_ids = multiworld.player_ids
+        # spheres partitioned by recepient player for frontier search
+        spheres = []
+        # snapshots of each sphere for regression without rebuilding the state
+        sphere_snapshots = []
+        # which sphere each player's goal is first fulfilled. added to vips as that sphere passes
+        goals_by_sphere = {}
+        # which goals are still unfound, to not recheck found goals
+        goals_unfound = set(player_ids)
+        # vips are goals and locations that are the found prerequisites for other vips. to maintain reachability across the
+        # whole set and ensure the game is beatable. vips must all be met each sphere and pass.
+        vips = set()
+        key_cache = {}
+
+        # wrapper for goals and locations to check if the state fulfills the condition for either.
+        # goals are just another condition that needs to be fulfilled each sphere/pass,
+        # and being able to reorder when the goal is searched allows more variance
+        def is_met(target, q_state) -> bool:
+            if isinstance(target, int):
+                return multiworld.has_beaten_game(q_state, target)
+            return q_state.can_reach(target)
+        # player for a location or goal
+        def owner(target) -> int:
+            if isinstance(target, int):
+                return target
+            return target.player
+        # hashed heap tuple to allow randomized heap ordering for vips with target tiebreaker
+        def heap_entry(target):
+            if target not in key_cache:
+                identity = ("goal", target) if isinstance(target, int) else ("loc", target.player, target.name)
+                h = hashlib.blake2b(repr(identity).encode(), digest_size=8).digest()
+                key_cache[target] = (h, identity, target)
+            return key_cache[target]
+        # linear search of the items belonging to a player in the frontier for one that flips reachability on a target
+        def linear_prereq_search(state, sphere, target):
+            search_state = self.player_state_copy(state, owner(target))
+            for location in sphere[owner(target)]:
+                search_state.collect(location.item, True, location)
+                if is_met(target, search_state):
+                    sphere[owner(target)].remove(location)
+                    return location
+            raise RuntimeError(f"target {target} unreachable after frontier exhausted")
+
+        # sphere building loop. collect items in waves as they become available and populate containers as we go
+        while goals_unfound:
+            if not candidates:
+                raise RuntimeError("No more candidates but still goals unfound")
+            # snapshots represent the lower sphere base that stays consistent for the search, so it's taken before the sphere is processed
+            sphere_snapshots.append(state.copy())
+            sphere = defaultdict(list)
+            reached = [loc for loc in candidates if state.can_reach(loc)]
+            for loc in reached:
+                sphere[loc.item.player].append(loc)
+                state.collect(loc.item, True, loc)
+            candidates.difference_update(reached)
+            spheres.append(sphere)
+
+            sphere_id = len(sphere_snapshots) - 1
+            found_goals = {p for p in goals_unfound if is_met(p, state)}
+            goals_by_sphere[sphere_id] = found_goals
+            goals_unfound -= found_goals
+        # regress through spheres finding a valid set of prerequisites for all goals and vips at each step
+        while spheres:
+            sphere = spheres.pop()
+            state = sphere_snapshots.pop()
+            sphere_id = len(spheres)
+            # goals are stored as a player id int. we need to add them to vips when they become relevant
+            for goal in goals_by_sphere.get(sphere_id, ()):
+                vips.add(goal)
+            # heap for log(n) sorted list behavior to handle thousands of targets
+            heap = [heap_entry(v) for v in vips]
+            heapq.heapify(heap)
+            # blocked set to avoid rechecking targets if they haven't received an item since they were last checked
+            blocked = defaultdict(set)
+            # build a frontier state to allow checking if a target is reachable without other vips before searching.
+            frontier_state = state.copy()
+            for location in chain.from_iterable(sphere.values()):
+                frontier_state.collect(location.item, True, location)
+
+            while heap:
+                _, _, target = heapq.heappop(heap)
+                if target in blocked.get(owner(target), ()):
+                    continue
+                if not is_met(target, frontier_state):
+                    blocked[owner(target)].add(target)
+                    continue
+                # search the frontier for a complete conjunction of items that make a target reachable
+                while not is_met(target, state):
+                    location = linear_prereq_search(state, sphere, target)
+                    # the frontier already includes items committed from it, so they can't change reachability and blocked is still valid
+                    state.collect(location.item, True, location)
+                    vips.add(location)
+                # commit the target to the state once it becomes reachable
+                if isinstance(target, int):
+                    continue
+                state.collect(target.item, True, target)
+                frontier_state.collect(target.item, True, target)
+                # add blocked locations to the heap for the target item's player as they may now be reachable
+                for block in blocked.pop(target.item.player, ()):
+                    heapq.heappush(heap, heap_entry(block))
+
+            # all targets must be reached after a sphere is completed to ensure continuity from sphere 0 to goals
+            if any(blocked.values()):
+                raise RuntimeError("unreachable targets after heap is empty")
+        # remove goals from vips to build the playthrough
+        kept = [vip for vip in vips if not isinstance(vip, int)]
+        # build the playthrough sphere by sphere, collecting items as they are reachable
+        walk_state = CollectionState(multiworld)
+        playthrough_spheres = []
+        remaining = set(kept)
+        while remaining:
+             sphere = {loc for loc in remaining if walk_state.can_reach(loc)}
+             if not sphere:
+                 raise RuntimeError(f"Kept set not beatable; unreachable: {remaining}")
+             for loc in sphere:
+                 walk_state.collect(loc.item, True, loc)
+             playthrough_spheres.append(sphere)
+             remaining -= sphere
+        # start the playthrough with precollected items
+        self.playthrough = {"0": sorted(
+              multiworld.get_name_string_for_object(item)
+              for item in chain.from_iterable(multiworld.precollected_items.values())
+              if item.advancement
+          )}
+        # add playthrough spheres
+        for i, sphere in enumerate(playthrough_spheres):
+            self.playthrough[str(i + 1)] = {
+                str(loc): str(loc.item) for loc in sorted(sphere)
+            }
+
+        if create_paths:
+            self.create_paths(walk_state, playthrough_spheres)
+
+        if not multiworld.can_beat_game(walk_state):
+            raise Exception("Playthrough failed to beat the game")
+
+    @staticmethod
+    def player_state_copy(input_state, player):
+        ret_state = CollectionState.__new__(CollectionState)
+        ret_state.multiworld = input_state.multiworld
+        ret_state.allow_partial_entrances = input_state.allow_partial_entrances
+
+        ret_state.prog_items = dict(input_state.prog_items)
+        ret_state.prog_items[player] = input_state.prog_items[player].copy()
+
+        ret_state.reachable_regions = dict(input_state.reachable_regions)
+        ret_state.reachable_regions[player] = input_state.reachable_regions[player].copy()
+
+        ret_state.stale = dict(input_state.stale)
+        ret_state.locations_checked = input_state.locations_checked.copy()
+        ret_state.advancements = input_state.advancements
+        ret_state.path = input_state.path
+        ret_state.blocked_connections = dict(input_state.blocked_connections)
+        ret_state.blocked_connections[player] = input_state.blocked_connections[player].copy()
+        for function in CollectionState.additional_init_functions:
+            function(ret_state, input_state.multiworld)
+        for function in CollectionState.additional_copy_functions:
+            ret_state = function(input_state, ret_state)
+        return ret_state
 
     def create_paths(self, state: CollectionState, collection_spheres: List[Set[Location]]) -> None:
         from itertools import zip_longest

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1824,12 +1824,19 @@ class Spoiler:
             multiworld.push_precollected(item)
 
     def create_playthrough_sphere_fulfillment(self, create_paths: bool = True) -> None:
+        try:
+            self.sphere_fulfillment(create_paths)
+        except Exception as e:
+            logging.warning(f"sphere fulfillment failed: {e}; falling back to default")
+            self.create_playthrough(create_paths)
+
+    def sphere_fulfillment(self, create_paths: bool = True) -> None:
         # the main angle of this variation is an acknowledgement that can_beat_game, sweep_for_advancements, and
         # update_reachable_regions are expensive operations to run. the first two can be avoided by ensuring
         # continuity from sphere 0 to each goal manually. urr can't be avoided, but it is most efficient
         # if you keep it player scoped. states are also most efficient when used incrementally, and copying a state
-        # is usually expensive, so if you keep it player scoped and only copy the needed player, you can have snapshots
-        # with o(n) complexity.
+        # is usually expensive, but if you keep it player scoped and only copy the needed players containers without
+        # mutating the others, you can have snapshots with o(n) complexity.
         from itertools import chain
         multiworld = self.multiworld
         candidates = {location for location in multiworld.get_filled_locations() if location.item.advancement}
@@ -1952,8 +1959,9 @@ class Spoiler:
             for goal in found_goals: seed_vips[sphere_id + 1][goal].add(goal)
             goals_unfound -= found_goals
 
-        # fungibles are items for which multiple players have the same item. when promoted to vip, we know that all copies
-        # in the sphere prefix, and all lower spheres are required to satisfy the prereq and don't need to be found again.
+        # fungibles are items for which a player has multiple of the same item. when promoted to vip, we know that all 
+        # copies in the sphere prefix, and all lower spheres are required to satisfy the prereq and don't need to be 
+        # found again.
         fungibles = {key for key, count in tally.items() if count > 1}
         # cascade_collect is an efficient way to collect all items reachable from a state that might not yet be collected
         def cascade_collect(vips, sphere_id, state1, state2=None):
@@ -2126,25 +2134,20 @@ class Spoiler:
         if not multiworld.can_beat_game(CollectionState(multiworld), kept):
             raise RuntimeError("Playthrough failed to beat the game")
 
+    # creates a player-scoped copy of a state. it is intended for use cases where you do not mutate more than one
+    # player's entries and don't need locations_checked.
     @staticmethod
     def player_state_copy(input_state, player):
         ret_state = CollectionState.__new__(CollectionState)
-        ret_state.multiworld = input_state.multiworld
-        ret_state.allow_partial_entrances = input_state.allow_partial_entrances
-        ret_state.prog_items = dict(input_state.prog_items)
-        ret_state.prog_items[player] = input_state.prog_items[player].copy()
-        ret_state.reachable_regions = dict(input_state.reachable_regions)
-        ret_state.reachable_regions[player] = input_state.reachable_regions[player].copy()
-        ret_state.stale = dict(input_state.stale)
-        ret_state.locations_checked = input_state.locations_checked.copy()
-        ret_state.advancements = input_state.advancements
-        ret_state.path = input_state.path
-        ret_state.blocked_connections = dict(input_state.blocked_connections)
-        ret_state.blocked_connections[player] = input_state.blocked_connections[player].copy()
-        for function in CollectionState.additional_init_functions:
-            function(ret_state, input_state.multiworld)
-        for function in CollectionState.additional_copy_functions:
-            ret_state = function(input_state, ret_state)
+        for attr, val in input_state.__dict__.items():
+            if isinstance(val, dict) and player in val:
+                new = dict(val)
+                cp = getattr(new[player], "copy", None)
+                new[player] = cp() if callable(cp) else new[player]
+                setattr(ret_state, attr, new)
+            else:
+                setattr(ret_state, attr, val)
+        ret_state.locations_checked = set()
         return ret_state
 
 

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1982,7 +1982,7 @@ class Spoiler:
         while goals_unfound:
             if not candidates:
                 raise RuntimeError("No more candidates but still goals unfound")
-            # snapshots represent the lower sphere base that stays consistent for the search, so it's taken before the 
+            # snapshots represent the lower sphere base that stays consistent for the search, so it's taken before the
             # sphere is processed
             sphere_snapshots.append(start_state.copy())
             sphere = defaultdict(list)

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1825,7 +1825,10 @@ class Spoiler:
 
     def create_playthrough_sphere_fulfillment(self, create_paths: bool = True) -> None:
         try:
+            t1 = time.time()
             self.sphere_fulfillment(create_paths)
+            t2 = time.time()
+            logging.info(f"sphere fulfillment completed in {t2 - t1:.2f} seconds")
         except Exception as e:
             logging.warning(f"sphere fulfillment failed: {e}; falling back to default")
             self.create_playthrough(create_paths)
@@ -1946,6 +1949,7 @@ class Spoiler:
             sphere_snapshots.append(start_state.copy())
             sphere = defaultdict(list)
             reached = [loc for loc in candidates if start_state.can_reach(loc)]
+            if not reached: raise RuntimeError("goals_unfound with no remaining reachable advancments: {goals_unfound}\n game unbeatable.")
             counts = Counter((loc.item.player, loc.item.name) for loc in reached)
             reached.sort(key=lambda loc: (counts[loc.item.player, loc.item.name], loc_key(loc)))
             tally.update(counts)

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1863,27 +1863,6 @@ class Spoiler:
         # player for a location or goal
         def owner(target) -> int:
             return target if isinstance(target, int) else target.player
-        # binary search of the items belonging to a player in the frontier for one that flips reachability on a target
-        # a player's locations are only able to be reached by that player's items, so we only need those categories
-        # in the search
-        def binary_prereq_search(state, frontier, target):
-            player = owner(target)
-            search_base_state = self.player_state_copy(state, player)
-            low, high = 0, len(frontier) - 1
-            partition_state = self.player_state_copy(search_base_state, player)
-            while low <= high:
-                mid = (low + high) // 2
-                for i in range(low, mid + 1):
-                    location = frontier[i]
-                    partition_state.collect(location.item, True, location)
-                if is_met(target, partition_state):
-                    if (low == high): return low, frontier[low]
-                    high = mid
-                    partition_state = self.player_state_copy(search_base_state, player)
-                else:
-                    low = mid + 1
-                    search_base_state = self.player_state_copy(partition_state, player)
-            raise RuntimeError(f"target {target} unreachable after frontier exhausted")
         # key for sorting locations for determinism
         def loc_key(loc):
             if isinstance(loc, int): return (loc, "", loc, "")
@@ -1959,85 +1938,121 @@ class Spoiler:
             for goal in found_goals: seed_vips[sphere_id + 1][goal].add(goal)
             goals_unfound -= found_goals
 
-        # fungibles are items for which a player has multiple of the same item. when promoted to vip, we know that all 
-        # copies in the sphere prefix, and all lower spheres are required to satisfy the prereq and don't need to be 
+
+        # fungibles are items for which a player has multiple of the same item. when promoted to vip, we know that all
+        # copies in the sphere prefix, and all lower spheres are required to satisfy the prereq and don't need to be
         # found again.
         fungibles = {key for key, count in tally.items() if count > 1}
         # cascade_collect is an efficient way to collect all items reachable from a state that might not yet be collected
-        def cascade_collect(vips, sphere_id, state1, state2=None):
-            unfulfilled = {vip_sphere: {player: set(vip_set) for player, vip_set in player_dicts.items()}
-                           for vip_sphere, player_dicts in vips.items() if vip_sphere > sphere_id}
+        def cascade_collect(to_check, sphere_id, state1, state2=None, collected_set=None):
+            unfulfilled = {
+                sphere: remaining_by_player
+                for sphere, player_dicts in to_check.items()
+                if sphere > sphere_id
+                and (remaining_by_player := {player: set(remaining)
+                for player, remaining in player_dicts.items() if remaining})
+            }
             changed_players = None
             while True:
-                next_changed, progressed = set(), False
-                for player_dicts in unfulfilled.values():
+                next_changed, progressed, emptied = set(), False, []
+                for sphere, player_dicts in unfulfilled.items():
                     for player, remaining in player_dicts.items():
                         if not remaining or (changed_players is not None and player not in changed_players):
                             continue
                         newly_met = []
                         bulk_is_met(remaining, state1, None, newly_met)
-                        if not newly_met: continue
-                        recipients = bulk_collect(newly_met, state1)
-                        if state2 is not None: bulk_collect(newly_met, state2)
+                        if not newly_met:
+                            continue
                         remaining.difference_update(newly_met)
+                        recipients = bulk_collect(newly_met, state1)
+                        if collected_set is not None:
+                            collected_set.update(newly_met)
+                        if state2 is not None:
+                            bulk_collect(newly_met, state2)
                         next_changed |= recipients
                         progressed = True
-                if not progressed: break
+                        if not remaining:
+                            emptied.append((sphere, player))
+                for sphere, player in emptied:
+                    player_dicts = unfulfilled[sphere]
+                    player_dicts.pop(player, None)
+                    if not player_dicts:
+                        unfulfilled.pop(sphere, None)
+                if not progressed:
+                    break
                 changed_players = next_changed
             return unfulfilled
-        # the workhorse of the method finds most of our locations, but we force collect vips to allow items to use them
-        # as dependencies. this violates the continuity assertion of sphere 0 to goal, and allows circular dependencies
-        # but it undercollects, and can be repaired after
+        # we start by violating continuity and forcing all vips into the state to be used as possible prereqs
+        # with bulk searches, we guaranteed don't overcollect, and it's very fast, but it can result in circular
+        # dependencies so we do individual, order invariant probe searches to try to find the prereqs that locations
+        # with circular dependencies need. then repeat until the bulk search doesn't leave circular dependencies and
+        # prune any unnecessary circular prereqs
         def process_sphere_bulk_forced(sphere, state, vips, sphere_id, fungibles_promoted):
             targets = defaultdict(list)
-            state = state.copy()
+            forced_state = state.copy()
+            prune_state = state.copy()
             for k, sp in vips.items():
                 if k <= sphere_id: continue
                 for loc in chain.from_iterable(sp.values()):
                     targets[owner(loc)].append(loc)
-                    if not isinstance(loc, int): state.collect(loc.item, True, loc)
-            for player, player_targets in targets.items():
-                results = bulk_binary_search(state, sphere.get(player, []), player_targets, player, fungibles_promoted)
-                for result in results: vips[sphere_id][result.player].add(result)
-        # a repair pass. in theory it can output a sufficient set from any sufficient frontier, but it's sole purpose is
-        # to add the dependencies of vips that were not found by the forced pass due to circular dependencies
-        def process_sphere(sphere, state, vips, sphere_id, fungibles_promoted, unfulfilled, reverse_targets = False):
-            frontier_state = state.copy()
-            state = state.copy()
-            for loc in chain.from_iterable(sphere.values()): frontier_state.collect(loc.item, True, loc)
-
+                    if not isinstance(loc, int): forced_state.collect(loc.item, True, loc)
+            prospective_vips = defaultdict(list)
+            stale_players = set(targets)
+            final_flippers = set()
             while True:
-                # actual unfulfilled locs, lowest sphere first (handles empty-list entries)
-                rem = [(s, p, loc)
-                       for s in sorted(unfulfilled)
-                       for p, locs in sorted(unfulfilled[s].items(), reverse = reverse_targets)
-                       for loc in sorted(locs, key=loc_key, reverse = reverse_targets)]
-                if not rem: break
-                # one target reachable with the full frontier; if none, we're genuinely stuck
-                pick = next(((s, p, loc) for (s, p, loc) in rem if is_met(loc, frontier_state)), None)
-                if pick is None: raise RuntimeError("unfulfilled remaining without promotion")
-                vip_sphere, player, loc = pick
-
-                while not is_met(loc, state):
-                    idx, found = binary_prereq_search(state, sphere.get(player, []), loc)
-                    if (found.item.player, found.item.name) in fungibles:
-                        fungibles_promoted.add((found.item.player, found.item.name))
-                        item_name = found.item.name
-                        while idx > 0 and sphere[player][idx - 1].item.name == item_name:
-                            fungible_loc = sphere[player][idx - 1]
-                            state.collect(fungible_loc.item, True, fungible_loc)
-                            sphere[player].remove(fungible_loc)
-                            vips[sphere_id][fungible_loc.player].add(fungible_loc)
-                            idx -= 1
-                    state.collect(found.item, True, found)
-                    sphere[player].remove(found)
-                    vips[sphere_id][found.player].add(found)
-
-                unfulfilled[vip_sphere][player].remove(loc)
-                if not isinstance(loc, int):
-                    state.collect(loc.item, True, loc)
-                    frontier_state.collect(loc.item, True, loc)
-                unfulfilled = cascade_collect(unfulfilled, sphere_id, state, frontier_state)
+                for player, player_targets in targets.items():
+                    if player not in stale_players: continue
+                    prospective_vips[player] = bulk_binary_search(forced_state, sphere.get(player, []), player_targets, player, set(fungibles_promoted))
+                    stale_players.remove(player)
+                loop_state = state.copy()
+                loop_sphere = {player: sphere_list.copy() for player, sphere_list in sphere.items()}
+                bulk_collect(prospective_vips, loop_state, loop_sphere)
+                unfulfilled = cascade_collect(vips, sphere_id, loop_state)
+                if not unfulfilled: break
+                loop_frontier = loop_state.copy()
+                bulk_collect(loop_sphere, loop_frontier)
+                roots = defaultdict(set)
+                potential_roots = []
+                for locs in chain.from_iterable(sphere_locs.values() for sphere_locs in unfulfilled.values()):
+                    met = []
+                    bulk_is_met(locs, loop_frontier, None, met)
+                    potential_roots.extend(met)
+                if not potential_roots: raise RuntimeError("unfulfilled vips remain unreachable from frontier")
+                potential_roots = sorted(potential_roots, key=loc_key)
+                while potential_roots:
+                    root = potential_roots.pop()
+                    root_state = loop_state.copy()
+                    flippers = bulk_binary_search(root_state, loop_sphere.get(owner(root), []), [root], owner(root), set(fungibles_promoted))
+                    roots[root] = set(flippers)
+                    if not isinstance(root, int): root_state.collect(root.item, True, root)
+                    bulk_collect(flippers,root_state)
+                    collected_set = set()
+                    cascade_collect(unfulfilled, sphere_id, root_state, None, collected_set)
+                    collected_set.discard(root)
+                    potential_roots = [loc for loc in potential_roots if loc not in collected_set]
+                    for loc in collected_set:
+                        roots.pop(loc, None)
+                loop_flippers = set().union(*roots.values())
+                bulk_collect(loop_flippers, forced_state, sphere)
+                bulk_collect(loop_flippers, state)
+                final_flippers.update(loop_flippers)
+                stale_players.update(loc.item.player for loc in loop_flippers)
+            if final_flippers:
+                bulk_collect(prospective_vips, prune_state)
+                cascade_collect(vips, sphere_id, prune_state)
+                for flipper in sorted(final_flippers, key=loc_key):
+                    to_collect = final_flippers - {flipper}
+                    test_state = prune_state.copy()
+                    bulk_collect(to_collect, test_state)
+                    unfulfilled = cascade_collect(vips, sphere_id, test_state)
+                    if not unfulfilled:
+                        final_flippers.discard(flipper)
+            for loc in chain.from_iterable(prospective_vips.values()):
+                vips[sphere_id][loc.player].add(loc)
+                if (loc.item.player, loc.item.name) in fungibles: fungibles_promoted.add((loc.item.player, loc.item.name))
+            for flipper in final_flippers:
+                vips[sphere_id][flipper.player].add(flipper)
+                if (flipper.item.player, flipper.item.name) in fungibles: fungibles_promoted.add((flipper.item.player, flipper.item.name))
         # a simple utility to avoid having to write loops
         def bulk_collect(seed, state, sphere = None):
             players_collected = set()
@@ -2060,48 +2075,14 @@ class Spoiler:
             sphere_id = len(spheres) - 1
             fungibles_promoted = set()
             # regress through spheres finding a valid set of prerequisites for all goals and vips at each step
-            while sphere_id >= 0:
-                sphere = {player: locs for player, locs in spheres[sphere_id].items()}
-                second_sphere = {player: locs.copy() for player, locs in spheres[sphere_id].items()}
-                base_state = sphere_snapshots[sphere_id].copy()
+            while len(spheres) > 0:
+                sphere = spheres.pop()
+                base_state = sphere_snapshots.pop()
                 for loc in chain.from_iterable(sphere.values()):
                     if (loc.item.player, loc.item.name) not in fungibles_promoted: continue
                     vips[sphere_id][loc.player].add(loc)
                 bulk_collect(vips[sphere_id], base_state, sphere)
-                second_base_state = base_state.copy()
-                second_vips = defaultdict(set, {player: locs.copy() for player, locs in vips[sphere_id].items()})
-                second_fungibles_promoted = fungibles_promoted.copy()
-                # pass 1 force collects all vips into the frontier to allow most items to be able to use vips as a
-                # dependency since we will already be collecting them. this creates a leaner set, and is much faster
-                # than the unforced pass
                 process_sphere_bulk_forced(sphere, base_state, vips, sphere_id, fungibles_promoted)
-                # we need to collect promoted items from the last pass and remove them from the sphere so the next
-                # pass doesn't try to collect them again
-                bulk_collect(vips[sphere_id], base_state, sphere)
-                unfulfilled = cascade_collect(vips, sphere_id, base_state)
-                # pass 2 is a "repair" pass that resolves any remaining circular dependencies. it should hypothetically
-                # also resolve any other reachability issues, but the only supported case is circular dependencies
-                # pass 2 is also much faster than the forced pass because it only needs to search for prereqs for
-                # items with circular dependencies, which is rare.
-                process_sphere(sphere, base_state, vips, sphere_id, fungibles_promoted, unfulfilled)
-                # after the first two passes, we run the whole process through again in reverse order to shave off
-                # additional unnecessary items. we don't lose complexity, and it makes the kept run near minimal
-
-                # first we reset the sphere to only include items that were kept by the last pass so we at worst keep
-                # the full set it did and also reset the other containers to the start of the sphere to effectively
-                # restart the process.
-                new_sphere = defaultdict(list)
-                for player, locs in second_sphere.items():
-                    for loc in reversed(locs):
-                        if loc in vips[sphere_id][loc.player] and loc not in second_vips[loc.player]:
-                            new_sphere[player].append(loc)
-                vips[sphere_id] = defaultdict(set)
-                for player, locs in second_vips.items(): vips[sphere_id][player] = locs.copy()
-                fungibles_promoted = second_fungibles_promoted.copy()
-                process_sphere_bulk_forced(new_sphere, second_base_state, vips, sphere_id, fungibles_promoted)
-                bulk_collect(vips[sphere_id], second_base_state, new_sphere)
-                unfulfilled = cascade_collect(vips, sphere_id, second_base_state)
-                process_sphere(new_sphere, second_base_state, vips, sphere_id, fungibles_promoted, unfulfilled, True)
                 sphere_id -= 1
             return vips
         vip_list = run_sphere_fulfillment()
@@ -2109,6 +2090,8 @@ class Spoiler:
 
         # remove goals from vips to build the playthrough
         kept = [loc for players in vip_list.values() for locs in players.values() for loc in locs if not isinstance(loc, int)]
+        if not multiworld.can_beat_game(CollectionState(multiworld), kept):
+            raise RuntimeError("Playthrough failed to beat the game")
         # build the playthrough sphere by sphere, collecting items as they are reachable
         walk_state = CollectionState(multiworld)
         playthrough_spheres = []
@@ -2131,8 +2114,6 @@ class Spoiler:
 
         if create_paths: self.create_paths(walk_state, playthrough_spheres)
 
-        if not multiworld.can_beat_game(CollectionState(multiworld), kept):
-            raise RuntimeError("Playthrough failed to beat the game")
 
     # creates a player-scoped copy of a state. it is intended for use cases where you do not mutate more than one
     # player's entries and don't need locations_checked.

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1824,6 +1824,9 @@ class Spoiler:
             multiworld.push_precollected(item)
 
     def create_playthrough_sphere_fulfillment(self, create_paths: bool = True) -> None:
+        """
+        Wrapper for sphere_fulfillment that logs timing and falls back to default on failure.
+        """
         import time
         try:
             t1 = time.time()
@@ -1835,12 +1838,14 @@ class Spoiler:
             self.create_playthrough(create_paths)
 
     def sphere_fulfillment(self, create_paths: bool = True) -> None:
-        # the main angle of this variation is an acknowledgement that can_beat_game, sweep_for_advancements, and
-        # update_reachable_regions are expensive operations to run. the first two can be avoided by ensuring
-        # continuity from sphere 0 to each goal manually. urr can't be avoided, but it is most efficient
-        # if you keep it player scoped. states are also most efficient when used incrementally, and copying a state
-        # is usually expensive, but if you keep it player scoped and only copy the needed players containers without
-        # mutating the others, you can have snapshots with o(n) complexity.
+        """
+        the main angle of this variation is an acknowledgement that can_beat_game, sweep_for_advancements, and
+        update_reachable_regions are expensive operations to run. the first two can be avoided by ensuring
+        continuity from sphere 0 to each goal manually. urr can't be avoided, but it is most efficient
+        if you keep it player scoped. states are also most efficient when used incrementally, and copying a state
+        is usually expensive, but if you keep it player scoped and only copy the needed players containers without
+        mutating the others, you can have snapshots with o(n) complexity.
+        """
         from itertools import chain
         multiworld = self.multiworld
         candidates = {location for location in multiworld.get_filled_locations() if location.item.advancement}
@@ -1854,9 +1859,9 @@ class Spoiler:
         goals_unfound = set(player_ids)
         tally = Counter()
 
-        # vips are goals and locations that are the found prerequisites for other vips. to maintain reachability across the
-        # whole set and ensure the game is beatable. vips must all be met each sphere and pass.
-        seed_vips= defaultdict(lambda: defaultdict(set))
+        # vips are goals and locations that are the found prerequisites for other vips. to maintain reachability across
+        # the whole set and ensure the game is beatable. vips must all be met each sphere and pass.
+        seed_vips = defaultdict(lambda: defaultdict(set))
         goal_spheres = defaultdict(int)
 
         # wrapper for goals and locations to check if the state fulfills the condition for either.
@@ -1977,7 +1982,8 @@ class Spoiler:
         while goals_unfound:
             if not candidates:
                 raise RuntimeError("No more candidates but still goals unfound")
-            # snapshots represent the lower sphere base that stays consistent for the search, so it's taken before the sphere is processed
+            # snapshots represent the lower sphere base that stays consistent for the search, so it's taken before the 
+            # sphere is processed
             sphere_snapshots.append(start_state.copy())
             sphere = defaultdict(list)
             reached = [location for location in candidates if start_state.can_reach(location)]
@@ -2030,7 +2036,7 @@ class Spoiler:
         # copies in the sphere prefix, and all lower spheres are required to satisfy the prereq and don't need to be
         # found again.
         fungibles = {key for key, count in tally.items() if count > 1}
-        # cascade_collect is an efficient way to collect all items reachable from a state that might not yet be collected
+        # cascade_collect is an efficient sweep of reachable from a state that might not yet be collected
         def cascade_collect(
             to_check: dict[int, dict[int | str, set[int | Location]]],
             sphere_id: int,
@@ -2107,8 +2113,12 @@ class Spoiler:
                     bulk_search_state = forced_state.copy()
                     stale_players.discard("global")
                     global_sphere = list(chain.from_iterable(sphere.values()))
-                    prospective_vips["global"] = bulk_binary_search(bulk_search_state, global_sphere, targets["global"],
-                        "global", set(fungibles_promoted))
+                    prospective_vips["global"] = bulk_binary_search(
+                        bulk_search_state,
+                        global_sphere,
+                        targets["global"],
+                        "global", set(fungibles_promoted)
+                    )
                     bulk_collect(prospective_vips["global"], bulk_search_state)
                 for player, player_targets in targets.items():
                     if player not in stale_players:
@@ -2145,11 +2155,17 @@ class Spoiler:
                         root_sphere = list(chain.from_iterable(loop_sphere.values()))
                     else:
                         root_sphere = loop_sphere.get(owner(root), [])
-                    flippers = bulk_binary_search(root_state, root_sphere, [root], owner(root), set(fungibles_promoted))
+                    flippers = bulk_binary_search(
+                        root_state,
+                        root_sphere,
+                        [root],
+                        owner(root),
+                        set(fungibles_promoted)
+                    )
                     roots[root] = set(flippers)
                     if not isinstance(root, int):
                         root_state.collect(root.item, True, root)
-                    bulk_collect(flippers,root_state)
+                    bulk_collect(flippers, root_state)
                     collected_set = set()
                     cascade_collect(unfulfilled, sphere_id, root_state, None, collected_set)
                     collected_set.discard(root)
@@ -2224,13 +2240,13 @@ class Spoiler:
         playthrough_spheres = []
         remaining = set(kept)
         while remaining:
-                sphere = {location for location in remaining if walk_state.can_reach(location)}
-                if not sphere:
-                    raise RuntimeError(f"Kept set not beatable; unreachable: {len(remaining)}")
-                for location in sphere:
-                    walk_state.collect(location.item, True, location)
-                playthrough_spheres.append(sphere)
-                remaining -= sphere
+            sphere = {location for location in remaining if walk_state.can_reach(location)}
+            if not sphere:
+                raise RuntimeError(f"Kept set not beatable; unreachable: {len(remaining)}")
+            for location in sphere:
+                walk_state.collect(location.item, True, location)
+            playthrough_spheres.append(sphere)
+            remaining -= sphere
         # start the playthrough with precollected items
         self.playthrough = {"0": sorted(
                 multiworld.get_name_string_for_object(item)
@@ -2244,11 +2260,12 @@ class Spoiler:
         if create_paths:
             self.create_paths(walk_state, playthrough_spheres)
 
-
-    # creates a player-scoped copy of a state. it is intended for use cases where you do not need more than one
-    # player's entries and don't need shared containers.
     @staticmethod
-    def player_state_copy(input_state, player):
+    def player_state_copy(input_state: CollectionState, player: int) -> CollectionState:
+        """
+        Creates a player-scoped copy of a state. It is intended for use cases where you do not need more than one
+        player's entries and don't need shared containers.
+        """
         import copy
         ret_state = CollectionState.__new__(CollectionState)
         for attr, val in input_state.__dict__.items():

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1963,7 +1963,7 @@ class Spoiler:
         if create_paths:
             self.create_paths(walk_state, playthrough_spheres)
 
-        if not multiworld.can_beat_game(walk_state):
+        if not multiworld.can_beat_game(CollectionState(multiworld), kept):
             raise Exception("Playthrough failed to beat the game")
 
     @staticmethod

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1833,8 +1833,8 @@ class Spoiler:
             self.sphere_fulfillment(create_paths)
             t2 = time.time()
             logging.info(f"sphere fulfillment completed in {t2 - t1:.2f} seconds")
-        except Exception as e:
-            logging.warning(f"sphere fulfillment failed: {e}; falling back to default")
+        except Exception:
+            logging.exception("sphere fulfillment failed; falling back to default")
             self.create_playthrough(create_paths)
 
     def sphere_fulfillment(self, create_paths: bool = True) -> None:

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1823,10 +1823,14 @@ class Spoiler:
         for item in removed_precollected:
             multiworld.push_precollected(item)
 
-    def create_playthrough_sphere_regression(self, forks: int, create_paths: bool = True) -> None:
+    def create_playthrough_sphere_fulfillment(self, create_paths: bool = True) -> None:
+        # the main angle of this variation is an acknowledgement that can_beat_game, sweep_for_advancements, and
+        # update_reachable_regions are expensive operations to run. the first two can be avoided by ensuring
+        # continuity from sphere 0 to each goal manually. urr can't be avoided, but it is most efficient
+        # if you keep it player scoped. states are also most efficient when used incrementally, and copying a state
+        # is usually expensive, so if you keep it player scoped and only copy the needed player, you can have snapshots
+        # with o(n) complexity.
         from itertools import chain
-        import heapq
-        import hashlib
         multiworld = self.multiworld
         candidates = {location for location in multiworld.get_filled_locations() if location.item.advancement}
         start_state = CollectionState(multiworld)
@@ -1837,9 +1841,7 @@ class Spoiler:
         sphere_snapshots = []
         # which goals are still unfound, to not recheck found goals
         goals_unfound = set(player_ids)
-        key_cache = {}
         tally = Counter()
-        fungibles = set()
 
         # vips are goals and locations that are the found prerequisites for other vips. to maintain reachability across the
         # whole set and ensure the game is beatable. vips must all be met each sphere and pass.
@@ -1849,86 +1851,70 @@ class Spoiler:
         # goals are just another condition that needs to be fulfilled each sphere/pass,
         # and being able to reorder when the goal is searched allows more variance
         def is_met(target, q_state):
-            if isinstance(target, int):
-                return multiworld.has_beaten_game(q_state, target)
+            if isinstance(target, int): return multiworld.has_beaten_game(q_state, target)
             return q_state.can_reach(target)
         # player for a location or goal
         def owner(target) -> int:
-            if isinstance(target, int):
-                return target
-            return target.player
-        def key_of(x):
-            if isinstance(x, int):
-                collapse = ("goal", x)
-                unique = ("goal", x)
-            else:
-                item_key = (x.item.player, x.item.name)
-                collapse = item_key if item_key in fungibles else (x.player, x.name)
-                unique = (x.player, x.name)
-            ck = collapse
-            if ck not in key_cache:
-                key_cache[ck] = hashlib.blake2b(repr(ck).encode(), digest_size=8).digest()
-            return key_cache[ck], unique
-        # hashed heap tuple to allow randomized heap ordering for vips with target tiebreaker
-        def heap_entry(target):
-            h, ident = key_of(target)
-            return (h, ident, target)
-        # linear search of the items belonging to a player in the frontier for one that flips reachability on a target
-        def linear_prereq_search(state, sphere, target):
-            search_state = self.player_state_copy(state, owner(target))
-            for i, location in enumerate(sphere[owner(target)]):
-                search_state.collect(location.item, True, location)
-                if is_met(target, search_state):
-                    return i,location
-            raise RuntimeError(f"target {target} unreachable after frontier exhausted")
+            return target if isinstance(target, int) else target.player
         # binary search of the items belonging to a player in the frontier for one that flips reachability on a target
-        def binary_prereq_search(state, sphere, target):
-            search_base_state = self.player_state_copy(state, owner(target))
-            low, high = 0, len(sphere[owner(target)]) - 1
-            partition_state = self.player_state_copy(search_base_state, owner(target))
+        # a player's locations are only able to be reached by that player's items, so we only need those categories
+        # in the search
+        def binary_prereq_search(state, frontier, target):
+            player = owner(target)
+            search_base_state = self.player_state_copy(state, player)
+            low, high = 0, len(frontier) - 1
+            partition_state = self.player_state_copy(search_base_state, player)
             while low <= high:
                 mid = (low + high) // 2
                 for i in range(low, mid + 1):
-                    location = sphere[owner(target)][i]
+                    location = frontier[i]
                     partition_state.collect(location.item, True, location)
                 if is_met(target, partition_state):
-                    if (low == high):
-                        return low, sphere[owner(target)][low]
+                    if (low == high): return low, frontier[low]
                     high = mid
-                    partition_state = self.player_state_copy(search_base_state, owner(target))
+                    partition_state = self.player_state_copy(search_base_state, player)
                 else:
                     low = mid + 1
-                    search_base_state = self.player_state_copy(partition_state, owner(target))
+                    search_base_state = self.player_state_copy(partition_state, player)
             raise RuntimeError(f"target {target} unreachable after frontier exhausted")
-        def bulk_is_met(locs, state):
-            while locs:
-                if is_met(locs[-1], state):
-                    locs.pop()
-                else:
-                    return False
-            return True
+        # key for sorting locations for determinism
+        def loc_key(loc):
+            if isinstance(loc, int): return (loc, "", loc, "")
+            return (loc.item.player, loc.item.name, loc.player, loc.name)
+        # bulk check reachability of several locations and optionally provide anything collected/not
+        def bulk_is_met(locs, state, missed = None, met = None):
+            result = True
+            locs = list(locs)
+            if missed is not None: missed.clear()
+            if met is not None: met.clear()
+            for loc in locs:
+                if is_met(loc, state):
+                    if met is not None: met.append(loc)
+                    continue
+                result = False
+                if missed is not None: missed.append(loc)
+            return result
+        # like binary search, but for all targets at once, still maintaining the player item-location relationship
+        # but checking in bulk saves operations and eliminates some order problems
         def bulk_binary_search(state, locs, targets, player, fungibles_promoted):
             low, high = 0, len(locs) - 1
             search_stack = [(self.player_state_copy(state, player), low, targets.copy(), 0)]
             results = []
             while search_stack:
                 st, low, tgts, synced = search_stack[-1]
-                for result in results[synced:]:
-                    st.collect(result.item, True, result)
+                for result in results[synced:]: st.collect(result.item, True, result)
                 search_stack[-1] = (st, low, tgts, len(results))
 
-                if bulk_is_met(tgts, st):
+                if bulk_is_met(tgts, st, tgts):
                     search_stack.pop()
                     high = low - 1
                     continue
-                if low > high:
-                    raise RuntimeError("targets unreachable after frontier exhausted")
+                if low > high: raise RuntimeError("targets unreachable after frontier exhausted")
                 tgts = tgts.copy()
                 mid = (low + high) // 2
                 probe_state = self.player_state_copy(st, player)
-                for i in range(low, mid + 1):
-                    probe_state.collect(locs[i].item, True, locs[i])
-                if bulk_is_met(tgts, probe_state):
+                for i in range(low, mid + 1): probe_state.collect(locs[i].item, True, locs[i])
+                if bulk_is_met(tgts, probe_state, tgts):
                     if (low == mid):
                         results.append(locs[mid])
                         if (locs[mid].item.player, locs[mid].item.name) in fungibles:
@@ -1947,13 +1933,14 @@ class Spoiler:
 
         # sphere building loop. collect items in waves as they become available and populate containers as we go
         while goals_unfound:
-            if not candidates:
-                raise RuntimeError("No more candidates but still goals unfound")
+            if not candidates: raise RuntimeError("No more candidates but still goals unfound")
             # snapshots represent the lower sphere base that stays consistent for the search, so it's taken before the sphere is processed
             sphere_snapshots.append(start_state.copy())
             sphere = defaultdict(list)
             reached = [loc for loc in candidates if start_state.can_reach(loc)]
-            tally.update((loc.item.player, loc.item.name) for loc in reached)
+            counts = Counter((loc.item.player, loc.item.name) for loc in reached)
+            reached.sort(key=lambda loc: (counts[loc.item.player, loc.item.name], loc_key(loc)))
+            tally.update(counts)
             for loc in reached:
                 sphere[loc.item.player].append(loc)
                 start_state.collect(loc.item, True, loc)
@@ -1962,120 +1949,102 @@ class Spoiler:
 
             sphere_id = len(sphere_snapshots) - 1
             found_goals = {p for p in goals_unfound if is_met(p, start_state)}
-            for goal in found_goals:
-                seed_vips[sphere_id + 1][goal].add(goal)
+            for goal in found_goals: seed_vips[sphere_id + 1][goal].add(goal)
             goals_unfound -= found_goals
 
         # fungibles are items for which multiple players have the same item. when promoted to vip, we know that all copies
         # in the sphere prefix, and all lower spheres are required to satisfy the prereq and don't need to be found again.
         fungibles = {key for key, count in tally.items() if count > 1}
-
-        def cascade_collect(t_base_state, t_frontier_state, t_target_heap, t_blocked):
-            cascade_blocked = defaultdict(set)
-            while t_target_heap:
-                _, _, target = heapq.heappop(t_target_heap)
-                if target in cascade_blocked.get(owner(target), ()):
-                    continue
-                if is_met(target, t_base_state):
-                    if isinstance(target, int):
-                        continue
-                    t_base_state.collect(target.item, True, target)
-                    t_frontier_state.collect(target.item, True, target)
-                    for block in t_blocked.pop(target.item.player, ()):
-                        heapq.heappush(t_target_heap, heap_entry(block))
-                    for block in cascade_blocked.pop(target.item.player, ()):
-                        heapq.heappush(t_target_heap, heap_entry(block))
-                else:
-                    cascade_blocked[owner(target)].add(target)
-            for block in chain.from_iterable(cascade_blocked.values()):
-                heapq.heappush(t_target_heap, heap_entry(block))
+        # cascade_collect is an efficient way to collect all items reachable from a state that might not yet be collected
+        def cascade_collect(vips, sphere_id, state1, state2=None):
+            unfulfilled = {vip_sphere: {player: set(vip_set) for player, vip_set in player_dicts.items()}
+                           for vip_sphere, player_dicts in vips.items() if vip_sphere > sphere_id}
+            changed_players = None
+            while True:
+                next_changed, progressed = set(), False
+                for player_dicts in unfulfilled.values():
+                    for player, remaining in player_dicts.items():
+                        if not remaining or (changed_players is not None and player not in changed_players):
+                            continue
+                        newly_met = []
+                        bulk_is_met(remaining, state1, None, newly_met)
+                        if not newly_met: continue
+                        recipients = bulk_collect(newly_met, state1)
+                        if state2 is not None: bulk_collect(newly_met, state2)
+                        remaining.difference_update(newly_met)
+                        next_changed |= recipients
+                        progressed = True
+                if not progressed: break
+                changed_players = next_changed
+            return unfulfilled
+        # the workhorse of the method finds most of our locations, but we force collect vips to allow items to use them
+        # as dependencies. this violates the continuity assertion of sphere 0 to goal, and allows circular dependencies
+        # but it undercollects, and can be repaired after
         def process_sphere_bulk_forced(sphere, state, vips, sphere_id, fungibles_promoted):
             targets = defaultdict(list)
             state = state.copy()
             for k, sp in vips.items():
-                if k <= sphere_id:
-                    continue
-                for locs in sp.values():
-                    for loc in locs:
-                        targets[owner(loc)].append(loc)
-                        if isinstance(loc, int):
-                            continue
-                        state.collect(loc.item, True, loc)
+                if k <= sphere_id: continue
+                for loc in chain.from_iterable(sp.values()):
+                    targets[owner(loc)].append(loc)
+                    if not isinstance(loc, int): state.collect(loc.item, True, loc)
             for player, player_targets in targets.items():
-                vips[sphere_id][player].update(bulk_binary_search(state, sphere.get(player, []), player_targets, player, fungibles_promoted))
-
-        def process_sphere(sphere, state, vips, sphere_id, fungibles_promoted, forced = False):
-            target_heap = []
-            for k, sp in vips.items():
-                if k <= sphere_id:
-                    continue
-                for locs in sp.values():
-                    for loc in locs:
-                        target_heap.append(heap_entry(loc))
-                        if not forced:
-                            continue
-                        if isinstance(loc, int):
-                            continue
-                        state.collect(loc.item, True, loc)
-            # heap for log(n) sorted list behavior to handle thousands of targets
-            heapq.heapify(target_heap)
-            # blocked set to avoid rechecking targets if they haven't received an item since they were last checked
-            blocked = defaultdict(set)
-            # build a frontier state to allow checking if a target is reachable without other vips before searching.
+                results = bulk_binary_search(state, sphere.get(player, []), player_targets, player, fungibles_promoted)
+                for result in results: vips[sphere_id][result.player].add(result)
+        # a repair pass. in theory it can output a sufficient set from any sufficient frontier, but it's sole purpose is
+        # to add the dependencies of vips that were not found by the forced pass due to circular dependencies
+        def process_sphere(sphere, state, vips, sphere_id, fungibles_promoted, unfulfilled, reverse_targets = False):
             frontier_state = state.copy()
-            for location in chain.from_iterable(sphere.values()):
-                frontier_state.collect(location.item, True, location)
+            state = state.copy()
+            for loc in chain.from_iterable(sphere.values()): frontier_state.collect(loc.item, True, loc)
 
-            if not forced:
-                cascade_collect(state, frontier_state, target_heap, blocked)
-            while target_heap:
-                _, _, target = heapq.heappop(target_heap)
-                if target in blocked.get(owner(target), ()):
-                    continue
-                if not is_met(target, frontier_state):
-                    blocked[owner(target)].add(target)
-                    continue
-                # search the frontier for a complete conjunction of items that make a target reachable
-                while not is_met(target, state):
-                    index, location = binary_prereq_search(state, sphere, target)
-                    identity = (location.item.player, location.item.name)
-                    # the frontier already includes items committed from it, so they can't change reachability and blocked is still valid
-                    state.collect(location.item, True, location)
-                    sphere[location.item.player].remove(location)
-                    vips[sphere_id][location.player].add(location)
-                    if identity not in fungibles:
-                        continue
-                    #if a fungible item is found, promote it and collect all items up to it
-                    fungibles_promoted.add(identity)
-                    copies = [loc for loc in sphere[owner(target)][:index] if (loc.item.player, loc.item.name) == identity]
-                    for loc in copies:
-                        state.collect(loc.item, True, loc)
-                        sphere[loc.item.player].remove(loc)
-                        vips[sphere_id][loc.player].add(loc)
-                # commit the target to the state once it becomes reachable
-                if isinstance(target, int):
-                    continue
-                # add blocked locations to the heap for the target item's player as they may now be reachable
-                for block in blocked.pop(target.item.player, ()):
-                    heapq.heappush(target_heap, heap_entry(block))
-                if forced:
-                    continue
-                state.collect(target.item, True, target)
-                frontier_state.collect(target.item, True, target)
-                cascade_collect(state, frontier_state, target_heap, blocked)
-            # all targets must be reached after a sphere is completed to ensure continuity from sphere 0 to goals
-            if any(blocked.values()):
-                raise RuntimeError("unreachable targets after heap is empty")
-        def preseed_state(seed, state, sphere):
-            for locs in seed.values():
-                for loc in locs:
-                    if isinstance(loc, int):
-                        continue
-                    if loc in state.locations_checked:
-                        continue
+            while True:
+                # actual unfulfilled locs, lowest sphere first (handles empty-list entries)
+                rem = [(s, p, loc)
+                       for s in sorted(unfulfilled)
+                       for p, locs in sorted(unfulfilled[s].items(), reverse = reverse_targets)
+                       for loc in sorted(locs, key=loc_key, reverse = reverse_targets)]
+                if not rem: break
+                # one target reachable with the full frontier; if none, we're genuinely stuck
+                pick = next(((s, p, loc) for (s, p, loc) in rem if is_met(loc, frontier_state)), None)
+                if pick is None: raise RuntimeError("unfulfilled remaining without promotion")
+                vip_sphere, player, loc = pick
+
+                while not is_met(loc, state):
+                    idx, found = binary_prereq_search(state, sphere.get(player, []), loc)
+                    if (found.item.player, found.item.name) in fungibles:
+                        fungibles_promoted.add((found.item.player, found.item.name))
+                        item_name = found.item.name
+                        while idx > 0 and sphere[player][idx - 1].item.name == item_name:
+                            fungible_loc = sphere[player][idx - 1]
+                            state.collect(fungible_loc.item, True, fungible_loc)
+                            sphere[player].remove(fungible_loc)
+                            vips[sphere_id][fungible_loc.player].add(fungible_loc)
+                            idx -= 1
+                    state.collect(found.item, True, found)
+                    sphere[player].remove(found)
+                    vips[sphere_id][found.player].add(found)
+
+                unfulfilled[vip_sphere][player].remove(loc)
+                if not isinstance(loc, int):
                     state.collect(loc.item, True, loc)
+                    frontier_state.collect(loc.item, True, loc)
+                unfulfilled = cascade_collect(unfulfilled, sphere_id, state, frontier_state)
+        # a simple utility to avoid having to write loops
+        def bulk_collect(seed, state, sphere = None):
+            players_collected = set()
+            if isinstance(seed, list) or isinstance(seed, set):
+                for loc in seed:
+                    if isinstance(loc, int): continue
+                    if loc in state.locations_checked: continue
+                    state.collect(loc.item, True, loc)
+                    players_collected.add(loc.item.player)
+                    if sphere is None: continue
                     sphere[loc.item.player].remove(loc)
-        def run_sphere_regression():
+                return players_collected
+            for locs in seed.values(): players_collected.update(bulk_collect(locs, state, sphere))
+            return players_collected
+        def run_sphere_fulfillment():
             vips = defaultdict(lambda: defaultdict(set))
             for sp in seed_vips:
                 for player in seed_vips[sp]:
@@ -2084,45 +2053,62 @@ class Spoiler:
             fungibles_promoted = set()
             # regress through spheres finding a valid set of prerequisites for all goals and vips at each step
             while sphere_id >= 0:
-                sphere = {player: sorted(locs, key=lambda loc: key_of(loc)) for player, locs in spheres[sphere_id].items()}
+                sphere = {player: locs for player, locs in spheres[sphere_id].items()}
+                second_sphere = {player: locs.copy() for player, locs in spheres[sphere_id].items()}
                 base_state = sphere_snapshots[sphere_id].copy()
-                for loc in list(chain.from_iterable(sphere.values())):
-                    if (loc.item.player, loc.item.name) not in fungibles_promoted:
-                        continue
+                for loc in chain.from_iterable(sphere.values()):
+                    if (loc.item.player, loc.item.name) not in fungibles_promoted: continue
                     vips[sphere_id][loc.player].add(loc)
-                preseed_state(vips[sphere_id], base_state, sphere)
+                bulk_collect(vips[sphere_id], base_state, sphere)
+                second_base_state = base_state.copy()
+                second_vips = defaultdict(set, {player: locs.copy() for player, locs in vips[sphere_id].items()})
+                second_fungibles_promoted = fungibles_promoted.copy()
                 # pass 1 force collects all vips into the frontier to allow most items to be able to use vips as a
                 # dependency since we will already be collecting them. this creates a leaner set, and is much faster
                 # than the unforced pass
-                #forced_sphere = {player: list(locs) for player, locs in sphere.items()}
-                #process_sphere(forced_sphere, base_state.copy(), vips, sphere_id, fungibles_promoted, True)
                 process_sphere_bulk_forced(sphere, base_state, vips, sphere_id, fungibles_promoted)
                 # we need to collect promoted items from the last pass and remove them from the sphere so the next
                 # pass doesn't try to collect them again
-                preseed_state(vips[sphere_id], base_state, sphere)
+                bulk_collect(vips[sphere_id], base_state, sphere)
+                unfulfilled = cascade_collect(vips, sphere_id, base_state)
                 # pass 2 is a "repair" pass that resolves any remaining circular dependencies. it should hypothetically
                 # also resolve any other reachability issues, but the only supported case is circular dependencies
                 # pass 2 is also much faster than the forced pass because it only needs to search for prereqs for
                 # items with circular dependencies, which is rare.
-                process_sphere(sphere, base_state, vips, sphere_id, fungibles_promoted)
+                process_sphere(sphere, base_state, vips, sphere_id, fungibles_promoted, unfulfilled)
+                # after the first two passes, we run the whole process through again in reverse order to shave off
+                # additional unnecessary items. we don't lose complexity, and it makes the kept run near minimal
 
+                # first we reset the sphere to only include items that were kept by the last pass so we at worst keep
+                # the full set it did and also reset the other containers to the start of the sphere to effectively
+                # restart the process.
+                new_sphere = defaultdict(list)
+                for player, locs in second_sphere.items():
+                    for loc in reversed(locs):
+                        if loc in vips[sphere_id][loc.player] and loc not in second_vips[loc.player]:
+                            new_sphere[player].append(loc)
+                vips[sphere_id] = defaultdict(set)
+                for player, locs in second_vips.items(): vips[sphere_id][player] = locs.copy()
+                fungibles_promoted = second_fungibles_promoted.copy()
+                process_sphere_bulk_forced(new_sphere, second_base_state, vips, sphere_id, fungibles_promoted)
+                bulk_collect(vips[sphere_id], second_base_state, new_sphere)
+                unfulfilled = cascade_collect(vips, sphere_id, second_base_state)
+                process_sphere(new_sphere, second_base_state, vips, sphere_id, fungibles_promoted, unfulfilled, True)
                 sphere_id -= 1
             return vips
-        vip_list = [run_sphere_regression() for _ in range(1)]
+        vip_list = run_sphere_fulfillment()
 
 
         # remove goals from vips to build the playthrough
-        kept = [loc for players in vip_list[0].values() for locs in players.values() for loc in locs if not isinstance(loc, int)]
+        kept = [loc for players in vip_list.values() for locs in players.values() for loc in locs if not isinstance(loc, int)]
         # build the playthrough sphere by sphere, collecting items as they are reachable
         walk_state = CollectionState(multiworld)
         playthrough_spheres = []
         remaining = set(kept)
         while remaining:
                 sphere = {loc for loc in remaining if walk_state.can_reach(loc)}
-                if not sphere:
-                    raise RuntimeError(f"Kept set not beatable; unreachable: {remaining}")
-                for loc in sphere:
-                    walk_state.collect(loc.item, True, loc)
+                if not sphere: raise RuntimeError(f"Kept set not beatable; unreachable: {len(remaining)}")
+                for loc in sphere: walk_state.collect(loc.item, True, loc)
                 playthrough_spheres.append(sphere)
                 remaining -= sphere
         # start the playthrough with precollected items
@@ -2133,12 +2119,9 @@ class Spoiler:
             )}
         # add playthrough spheres
         for i, sphere in enumerate(playthrough_spheres):
-            self.playthrough[str(i + 1)] = {
-                str(loc): str(loc.item) for loc in sorted(sphere)
-            }
+            self.playthrough[str(i + 1)] = {str(loc): str(loc.item) for loc in sorted(sphere)}
 
-        if create_paths:
-            self.create_paths(walk_state, playthrough_spheres)
+        if create_paths: self.create_paths(walk_state, playthrough_spheres)
 
         if not multiworld.can_beat_game(CollectionState(multiworld), kept):
             raise RuntimeError("Playthrough failed to beat the game")
@@ -2148,13 +2131,10 @@ class Spoiler:
         ret_state = CollectionState.__new__(CollectionState)
         ret_state.multiworld = input_state.multiworld
         ret_state.allow_partial_entrances = input_state.allow_partial_entrances
-
         ret_state.prog_items = dict(input_state.prog_items)
         ret_state.prog_items[player] = input_state.prog_items[player].copy()
-
         ret_state.reachable_regions = dict(input_state.reachable_regions)
         ret_state.reachable_regions[player] = input_state.reachable_regions[player].copy()
-
         ret_state.stale = dict(input_state.stale)
         ret_state.locations_checked = input_state.locations_checked.copy()
         ret_state.advancements = input_state.advancements

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1829,25 +1829,26 @@ class Spoiler:
         import hashlib
         multiworld = self.multiworld
         candidates = {location for location in multiworld.get_filled_locations() if location.item.advancement}
-        state = CollectionState(multiworld)
+        start_state = CollectionState(multiworld)
         player_ids = multiworld.player_ids
         # spheres partitioned by recepient player for frontier search
         spheres = []
         # snapshots of each sphere for regression without rebuilding the state
         sphere_snapshots = []
-        # which sphere each player's goal is first fulfilled. added to vips as that sphere passes
-        goals_by_sphere = {}
         # which goals are still unfound, to not recheck found goals
         goals_unfound = set(player_ids)
+        key_cache = {}
+        tally = Counter()
+        fungibles = set()
+
         # vips are goals and locations that are the found prerequisites for other vips. to maintain reachability across the
         # whole set and ensure the game is beatable. vips must all be met each sphere and pass.
-        vips = set()
-        key_cache = {}
+        seed_vips= defaultdict(lambda: defaultdict(set))
 
         # wrapper for goals and locations to check if the state fulfills the condition for either.
         # goals are just another condition that needs to be fulfilled each sphere/pass,
         # and being able to reorder when the goal is searched allows more variance
-        def is_met(target, q_state) -> bool:
+        def is_met(target, q_state):
             if isinstance(target, int):
                 return multiworld.has_beaten_game(q_state, target)
             return q_state.can_reach(target)
@@ -1856,52 +1857,168 @@ class Spoiler:
             if isinstance(target, int):
                 return target
             return target.player
+        def key_of(x):
+            if isinstance(x, int):
+                collapse = ("goal", x)
+                unique = ("goal", x)
+            else:
+                item_key = (x.item.player, x.item.name)
+                collapse = item_key if item_key in fungibles else (x.player, x.name)
+                unique = (x.player, x.name)
+            ck = collapse
+            if ck not in key_cache:
+                key_cache[ck] = hashlib.blake2b(repr(ck).encode(), digest_size=8).digest()
+            return key_cache[ck], unique
         # hashed heap tuple to allow randomized heap ordering for vips with target tiebreaker
         def heap_entry(target):
-            if target not in key_cache:
-                identity = ("goal", target) if isinstance(target, int) else ("loc", target.player, target.name)
-                h = hashlib.blake2b(repr(identity).encode(), digest_size=8).digest()
-                key_cache[target] = (h, identity, target)
-            return key_cache[target]
+            h, ident = key_of(target)
+            return (h, ident, target)
         # linear search of the items belonging to a player in the frontier for one that flips reachability on a target
         def linear_prereq_search(state, sphere, target):
             search_state = self.player_state_copy(state, owner(target))
-            for location in sphere[owner(target)]:
+            for i, location in enumerate(sphere[owner(target)]):
                 search_state.collect(location.item, True, location)
                 if is_met(target, search_state):
-                    sphere[owner(target)].remove(location)
-                    return location
+                    return i,location
             raise RuntimeError(f"target {target} unreachable after frontier exhausted")
+        # binary search of the items belonging to a player in the frontier for one that flips reachability on a target
+        def binary_prereq_search(state, sphere, target):
+            search_base_state = self.player_state_copy(state, owner(target))
+            low, high = 0, len(sphere[owner(target)]) - 1
+            partition_state = self.player_state_copy(search_base_state, owner(target))
+            while low <= high:
+                mid = (low + high) // 2
+                for i in range(low, mid + 1):
+                    location = sphere[owner(target)][i]
+                    partition_state.collect(location.item, True, location)
+                if is_met(target, partition_state):
+                    if (low == high):
+                        return low, sphere[owner(target)][low]
+                    high = mid
+                    partition_state = self.player_state_copy(search_base_state, owner(target))
+                else:
+                    low = mid + 1
+                    search_base_state = self.player_state_copy(partition_state, owner(target))
+            raise RuntimeError(f"target {target} unreachable after frontier exhausted")
+        def bulk_is_met(locs, state):
+            while locs:
+                if is_met(locs[-1], state):
+                    locs.pop()
+                else:
+                    return False
+            return True
+        def bulk_binary_search(state, locs, targets, player, fungibles_promoted):
+            low, high = 0, len(locs) - 1
+            search_stack = [(self.player_state_copy(state, player), low, targets.copy(), 0)]
+            results = []
+            while search_stack:
+                st, low, tgts, synced = search_stack[-1]
+                for result in results[synced:]:
+                    st.collect(result.item, True, result)
+                search_stack[-1] = (st, low, tgts, len(results))
+
+                if bulk_is_met(tgts, st):
+                    search_stack.pop()
+                    high = low - 1
+                    continue
+                if low > high:
+                    raise RuntimeError("targets unreachable after frontier exhausted")
+                tgts = tgts.copy()
+                mid = (low + high) // 2
+                probe_state = self.player_state_copy(st, player)
+                for i in range(low, mid + 1):
+                    probe_state.collect(locs[i].item, True, locs[i])
+                if bulk_is_met(tgts, probe_state):
+                    if (low == mid):
+                        results.append(locs[mid])
+                        if (locs[mid].item.player, locs[mid].item.name) in fungibles:
+                            fungibles_promoted.add((locs[mid].item.player, locs[mid].item.name))
+                            item_name = locs[mid].item.name
+                            while mid > 0 and locs[mid - 1].item.name == item_name:
+                                results.append(locs[mid - 1])
+                                mid -= 1
+                        high = mid - 1
+                    else:
+                        high = mid
+                else:
+                    search_stack.append((probe_state, mid + 1, tgts, len(results)))
+                    continue
+            return results
 
         # sphere building loop. collect items in waves as they become available and populate containers as we go
         while goals_unfound:
             if not candidates:
                 raise RuntimeError("No more candidates but still goals unfound")
             # snapshots represent the lower sphere base that stays consistent for the search, so it's taken before the sphere is processed
-            sphere_snapshots.append(state.copy())
+            sphere_snapshots.append(start_state.copy())
             sphere = defaultdict(list)
-            reached = [loc for loc in candidates if state.can_reach(loc)]
+            reached = [loc for loc in candidates if start_state.can_reach(loc)]
+            tally.update((loc.item.player, loc.item.name) for loc in reached)
             for loc in reached:
                 sphere[loc.item.player].append(loc)
-                state.collect(loc.item, True, loc)
+                start_state.collect(loc.item, True, loc)
             candidates.difference_update(reached)
             spheres.append(sphere)
 
             sphere_id = len(sphere_snapshots) - 1
-            found_goals = {p for p in goals_unfound if is_met(p, state)}
-            goals_by_sphere[sphere_id] = found_goals
+            found_goals = {p for p in goals_unfound if is_met(p, start_state)}
+            for goal in found_goals:
+                seed_vips[sphere_id + 1][goal].add(goal)
             goals_unfound -= found_goals
-        # regress through spheres finding a valid set of prerequisites for all goals and vips at each step
-        while spheres:
-            sphere = spheres.pop()
-            state = sphere_snapshots.pop()
-            sphere_id = len(spheres)
-            # goals are stored as a player id int. we need to add them to vips when they become relevant
-            for goal in goals_by_sphere.get(sphere_id, ()):
-                vips.add(goal)
+
+        # fungibles are items for which multiple players have the same item. when promoted to vip, we know that all copies
+        # in the sphere prefix, and all lower spheres are required to satisfy the prereq and don't need to be found again.
+        fungibles = {key for key, count in tally.items() if count > 1}
+
+        def cascade_collect(t_base_state, t_frontier_state, t_target_heap, t_blocked):
+            cascade_blocked = defaultdict(set)
+            while t_target_heap:
+                _, _, target = heapq.heappop(t_target_heap)
+                if target in cascade_blocked.get(owner(target), ()):
+                    continue
+                if is_met(target, t_base_state):
+                    if isinstance(target, int):
+                        continue
+                    t_base_state.collect(target.item, True, target)
+                    t_frontier_state.collect(target.item, True, target)
+                    for block in t_blocked.pop(target.item.player, ()):
+                        heapq.heappush(t_target_heap, heap_entry(block))
+                    for block in cascade_blocked.pop(target.item.player, ()):
+                        heapq.heappush(t_target_heap, heap_entry(block))
+                else:
+                    cascade_blocked[owner(target)].add(target)
+            for block in chain.from_iterable(cascade_blocked.values()):
+                heapq.heappush(t_target_heap, heap_entry(block))
+        def process_sphere_bulk_forced(sphere, state, vips, sphere_id, fungibles_promoted):
+            targets = defaultdict(list)
+            state = state.copy()
+            for k, sp in vips.items():
+                if k <= sphere_id:
+                    continue
+                for locs in sp.values():
+                    for loc in locs:
+                        targets[owner(loc)].append(loc)
+                        if isinstance(loc, int):
+                            continue
+                        state.collect(loc.item, True, loc)
+            for player, player_targets in targets.items():
+                vips[sphere_id][player].update(bulk_binary_search(state, sphere.get(player, []), player_targets, player, fungibles_promoted))
+
+        def process_sphere(sphere, state, vips, sphere_id, fungibles_promoted, forced = False):
+            target_heap = []
+            for k, sp in vips.items():
+                if k <= sphere_id:
+                    continue
+                for locs in sp.values():
+                    for loc in locs:
+                        target_heap.append(heap_entry(loc))
+                        if not forced:
+                            continue
+                        if isinstance(loc, int):
+                            continue
+                        state.collect(loc.item, True, loc)
             # heap for log(n) sorted list behavior to handle thousands of targets
-            heap = [heap_entry(v) for v in vips]
-            heapq.heapify(heap)
+            heapq.heapify(target_heap)
             # blocked set to avoid rechecking targets if they haven't received an item since they were last checked
             blocked = defaultdict(set)
             # build a frontier state to allow checking if a target is reachable without other vips before searching.
@@ -1909,8 +2026,10 @@ class Spoiler:
             for location in chain.from_iterable(sphere.values()):
                 frontier_state.collect(location.item, True, location)
 
-            while heap:
-                _, _, target = heapq.heappop(heap)
+            if not forced:
+                cascade_collect(state, frontier_state, target_heap, blocked)
+            while target_heap:
+                _, _, target = heapq.heappop(target_heap)
                 if target in blocked.get(owner(target), ()):
                     continue
                 if not is_met(target, frontier_state):
@@ -1918,42 +2037,100 @@ class Spoiler:
                     continue
                 # search the frontier for a complete conjunction of items that make a target reachable
                 while not is_met(target, state):
-                    location = linear_prereq_search(state, sphere, target)
+                    index, location = binary_prereq_search(state, sphere, target)
+                    identity = (location.item.player, location.item.name)
                     # the frontier already includes items committed from it, so they can't change reachability and blocked is still valid
                     state.collect(location.item, True, location)
-                    vips.add(location)
+                    sphere[location.item.player].remove(location)
+                    vips[sphere_id][location.player].add(location)
+                    if identity not in fungibles:
+                        continue
+                    #if a fungible item is found, promote it and collect all items up to it
+                    fungibles_promoted.add(identity)
+                    copies = [loc for loc in sphere[owner(target)][:index] if (loc.item.player, loc.item.name) == identity]
+                    for loc in copies:
+                        state.collect(loc.item, True, loc)
+                        sphere[loc.item.player].remove(loc)
+                        vips[sphere_id][loc.player].add(loc)
                 # commit the target to the state once it becomes reachable
                 if isinstance(target, int):
                     continue
-                state.collect(target.item, True, target)
-                frontier_state.collect(target.item, True, target)
                 # add blocked locations to the heap for the target item's player as they may now be reachable
                 for block in blocked.pop(target.item.player, ()):
-                    heapq.heappush(heap, heap_entry(block))
-
+                    heapq.heappush(target_heap, heap_entry(block))
+                if forced:
+                    continue
+                state.collect(target.item, True, target)
+                frontier_state.collect(target.item, True, target)
+                cascade_collect(state, frontier_state, target_heap, blocked)
             # all targets must be reached after a sphere is completed to ensure continuity from sphere 0 to goals
             if any(blocked.values()):
                 raise RuntimeError("unreachable targets after heap is empty")
+        def preseed_state(seed, state, sphere):
+            for locs in seed.values():
+                for loc in locs:
+                    if isinstance(loc, int):
+                        continue
+                    if loc in state.locations_checked:
+                        continue
+                    state.collect(loc.item, True, loc)
+                    sphere[loc.item.player].remove(loc)
+        def run_sphere_regression():
+            vips = defaultdict(lambda: defaultdict(set))
+            for sp in seed_vips:
+                for player in seed_vips[sp]:
+                    vips[sp][player] = seed_vips[sp][player].copy()
+            sphere_id = len(spheres) - 1
+            fungibles_promoted = set()
+            # regress through spheres finding a valid set of prerequisites for all goals and vips at each step
+            while sphere_id >= 0:
+                sphere = {player: sorted(locs, key=lambda loc: key_of(loc)) for player, locs in spheres[sphere_id].items()}
+                base_state = sphere_snapshots[sphere_id].copy()
+                for loc in list(chain.from_iterable(sphere.values())):
+                    if (loc.item.player, loc.item.name) not in fungibles_promoted:
+                        continue
+                    vips[sphere_id][loc.player].add(loc)
+                preseed_state(vips[sphere_id], base_state, sphere)
+                # pass 1 force collects all vips into the frontier to allow most items to be able to use vips as a
+                # dependency since we will already be collecting them. this creates a leaner set, and is much faster
+                # than the unforced pass
+                #forced_sphere = {player: list(locs) for player, locs in sphere.items()}
+                #process_sphere(forced_sphere, base_state.copy(), vips, sphere_id, fungibles_promoted, True)
+                process_sphere_bulk_forced(sphere, base_state, vips, sphere_id, fungibles_promoted)
+                # we need to collect promoted items from the last pass and remove them from the sphere so the next
+                # pass doesn't try to collect them again
+                preseed_state(vips[sphere_id], base_state, sphere)
+                # pass 2 is a "repair" pass that resolves any remaining circular dependencies. it should hypothetically
+                # also resolve any other reachability issues, but the only supported case is circular dependencies
+                # pass 2 is also much faster than the forced pass because it only needs to search for prereqs for
+                # items with circular dependencies, which is rare.
+                process_sphere(sphere, base_state, vips, sphere_id, fungibles_promoted)
+
+                sphere_id -= 1
+            return vips
+        vip_list = [run_sphere_regression() for _ in range(1)]
+
+
         # remove goals from vips to build the playthrough
-        kept = [vip for vip in vips if not isinstance(vip, int)]
+        kept = [loc for players in vip_list[0].values() for locs in players.values() for loc in locs if not isinstance(loc, int)]
         # build the playthrough sphere by sphere, collecting items as they are reachable
         walk_state = CollectionState(multiworld)
         playthrough_spheres = []
         remaining = set(kept)
         while remaining:
-             sphere = {loc for loc in remaining if walk_state.can_reach(loc)}
-             if not sphere:
-                 raise RuntimeError(f"Kept set not beatable; unreachable: {remaining}")
-             for loc in sphere:
-                 walk_state.collect(loc.item, True, loc)
-             playthrough_spheres.append(sphere)
-             remaining -= sphere
+                sphere = {loc for loc in remaining if walk_state.can_reach(loc)}
+                if not sphere:
+                    raise RuntimeError(f"Kept set not beatable; unreachable: {remaining}")
+                for loc in sphere:
+                    walk_state.collect(loc.item, True, loc)
+                playthrough_spheres.append(sphere)
+                remaining -= sphere
         # start the playthrough with precollected items
         self.playthrough = {"0": sorted(
-              multiworld.get_name_string_for_object(item)
-              for item in chain.from_iterable(multiworld.precollected_items.values())
-              if item.advancement
-          )}
+                multiworld.get_name_string_for_object(item)
+                for item in chain.from_iterable(multiworld.precollected_items.values())
+                if item.advancement
+            )}
         # add playthrough spheres
         for i, sphere in enumerate(playthrough_spheres):
             self.playthrough[str(i + 1)] = {
@@ -1964,7 +2141,7 @@ class Spoiler:
             self.create_paths(walk_state, playthrough_spheres)
 
         if not multiworld.can_beat_game(CollectionState(multiworld), kept):
-            raise Exception("Playthrough failed to beat the game")
+            raise RuntimeError("Playthrough failed to beat the game")
 
     @staticmethod
     def player_state_copy(input_state, player):
@@ -1989,6 +2166,7 @@ class Spoiler:
         for function in CollectionState.additional_copy_functions:
             ret_state = function(input_state, ret_state)
         return ret_state
+
 
     def create_paths(self, state: CollectionState, collection_spheres: List[Set[Location]]) -> None:
         from itertools import zip_longest

--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -1823,6 +1823,9 @@ class Spoiler:
         for item in removed_precollected:
             multiworld.push_precollected(item)
 
+    def create_playthrough_sphere_regression(self, forks: int, create_paths: bool = True) -> None:
+        print(f"Creating playthrough sphere regression with {forks} forks")
+
     def create_paths(self, state: CollectionState, collection_spheres: List[Set[Location]]) -> None:
         from itertools import zip_longest
         multiworld = self.multiworld

--- a/Generate.py
+++ b/Generate.py
@@ -39,7 +39,6 @@ def mystery_argparse(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument('--multi', default=defaults.players, type=lambda value: max(int(value), 1))
     parser.add_argument('--spoiler', type=int, default=defaults.spoiler)
     parser.add_argument("--playthrough_mode", type=int, default=defaults.playthrough_mode)
-    parser.add_argument("--sphere_regression_forks", type=int, default=defaults.sphere_regression_forks)
     parser.add_argument('--outputpath', default=settings.general_options.output_path,
                         help="Path to output folder. Absolute or relative to cwd.")  # absolute or relative to cwd
     parser.add_argument('--allow_quantity', action="store_true", default=defaults.allow_quantity,

--- a/Generate.py
+++ b/Generate.py
@@ -38,6 +38,8 @@ def mystery_argparse(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument('--seed', help='Define seed number to generate.', type=int)
     parser.add_argument('--multi', default=defaults.players, type=lambda value: max(int(value), 1))
     parser.add_argument('--spoiler', type=int, default=defaults.spoiler)
+    parser.add_argument("--playthrough_mode", type=int, default=defaults.playthrough_mode)
+    parser.add_argument("--sphere_regression_forks", type=int, default=defaults.sphere_regression_forks)
     parser.add_argument('--outputpath', default=settings.general_options.output_path,
                         help="Path to output folder. Absolute or relative to cwd.")  # absolute or relative to cwd
     parser.add_argument('--allow_quantity', action="store_true", default=defaults.allow_quantity,

--- a/Main.py
+++ b/Main.py
@@ -223,7 +223,10 @@ def main(args, seed=None, baked_server_options: dict[str, object] | None = None)
     if args.spoiler_only:
         if args.spoiler > 1:
             logger.info('Calculating playthrough.')
-            multiworld.spoiler.create_playthrough(create_paths=args.spoiler > 2)
+            if args.playthrough_mode == 0:
+                multiworld.spoiler.create_playthrough(create_paths=args.spoiler > 2)
+            else:
+                multiworld.spoiler.create_playthrough_sphere_regression(forks=args.sphere_regression_forks, create_paths=args.spoiler > 2)
 
         multiworld.spoiler.to_file(output_path('%s_Spoiler.txt' % outfilebase))
         logger.info('Done. Skipped multidata modification. Total time: %s', time.perf_counter() - start)
@@ -374,7 +377,10 @@ def main(args, seed=None, baked_server_options: dict[str, object] | None = None)
 
         if args.spoiler > 1:
             logger.info('Calculating playthrough.')
-            multiworld.spoiler.create_playthrough(create_paths=args.spoiler > 2)
+            if args.playthrough_mode == 0:
+                multiworld.spoiler.create_playthrough(create_paths=args.spoiler > 2)
+            else:
+                multiworld.spoiler.create_playthrough_sphere_regression(forks=args.sphere_regression_forks, create_paths=args.spoiler > 2)
 
         if args.spoiler:
             multiworld.spoiler.to_file(os.path.join(temp_dir, '%s_Spoiler.txt' % outfilebase))

--- a/Main.py
+++ b/Main.py
@@ -226,7 +226,7 @@ def main(args, seed=None, baked_server_options: dict[str, object] | None = None)
             if args.playthrough_mode == 0:
                 multiworld.spoiler.create_playthrough(create_paths=args.spoiler > 2)
             else:
-                multiworld.spoiler.create_playthrough_sphere_regression(forks=args.sphere_regression_forks, create_paths=args.spoiler > 2)
+                multiworld.spoiler.create_playthrough_sphere_fulfillment(create_paths=args.spoiler > 2)
 
         multiworld.spoiler.to_file(output_path('%s_Spoiler.txt' % outfilebase))
         logger.info('Done. Skipped multidata modification. Total time: %s', time.perf_counter() - start)
@@ -380,7 +380,7 @@ def main(args, seed=None, baked_server_options: dict[str, object] | None = None)
             if args.playthrough_mode == 0:
                 multiworld.spoiler.create_playthrough(create_paths=args.spoiler > 2)
             else:
-                multiworld.spoiler.create_playthrough_sphere_regression(forks=args.sphere_regression_forks, create_paths=args.spoiler > 2)
+                multiworld.spoiler.create_playthrough_sphere_fulfillment(create_paths=args.spoiler > 2)
 
         if args.spoiler:
             multiworld.spoiler.to_file(os.path.join(temp_dir, '%s_Spoiler.txt' % outfilebase))

--- a/settings.py
+++ b/settings.py
@@ -671,6 +671,21 @@ class GeneratorOptions(Group):
         BASIC = 1
         PLAYTHROUGH = 2
         FULL = 3
+    class PlaythroughMode(IntEnum):
+        """
+        Mode for playthrough generation.
+        0 -> Standard playthrough generation using greedy removal
+        1 -> Sphere regression playthrough generation
+        """
+
+        STANDARD = 0
+        SPHERE_REGRESSION = 1
+
+    class SphereRegressionForks(int):
+        """
+        Number of forks to use in sphere regression playthrough generation.
+        Higher values will result in lower liklihood of unnecessary items in the playthrough, but will take longer to complete.
+        """
 
     class PlandoOptions(str):
         """
@@ -697,6 +712,8 @@ class GeneratorOptions(Group):
     weights_file_path: WeightsFilePath = WeightsFilePath("weights.yaml")
     meta_file_path: MetaFilePath = MetaFilePath("meta.yaml")
     spoiler: Spoiler = Spoiler(3)
+    playthrough_mode: PlaythroughMode = PlaythroughMode(0)
+    sphere_regression_forks: SphereRegressionForks = SphereRegressionForks(6)
     race: Race = Race(0)
     plando_options: PlandoOptions = PlandoOptions("bosses, connections, texts")
     panic_method: PanicMethod = PanicMethod("swap")

--- a/settings.py
+++ b/settings.py
@@ -713,7 +713,7 @@ class GeneratorOptions(Group):
     meta_file_path: MetaFilePath = MetaFilePath("meta.yaml")
     spoiler: Spoiler = Spoiler(3)
     playthrough_mode: PlaythroughMode = PlaythroughMode(0)
-    sphere_regression_forks: SphereRegressionForks = SphereRegressionForks(6)
+    sphere_regression_forks: SphereRegressionForks = SphereRegressionForks(3)
     race: Race = Race(0)
     plando_options: PlandoOptions = PlandoOptions("bosses, connections, texts")
     panic_method: PanicMethod = PanicMethod("swap")

--- a/settings.py
+++ b/settings.py
@@ -679,13 +679,7 @@ class GeneratorOptions(Group):
         """
 
         STANDARD = 0
-        SPHERE_REGRESSION = 1
-
-    class SphereRegressionForks(int):
-        """
-        Number of forks to use in sphere regression playthrough generation.
-        Higher values will result in lower liklihood of unnecessary items in the playthrough, but will take longer to complete.
-        """
+        SPHERE_FULFILLMENT = 1
 
     class PlandoOptions(str):
         """
@@ -713,7 +707,6 @@ class GeneratorOptions(Group):
     meta_file_path: MetaFilePath = MetaFilePath("meta.yaml")
     spoiler: Spoiler = Spoiler(3)
     playthrough_mode: PlaythroughMode = PlaythroughMode(0)
-    sphere_regression_forks: SphereRegressionForks = SphereRegressionForks(3)
     race: Race = Race(0)
     plando_options: PlandoOptions = PlandoOptions("bosses, connections, texts")
     panic_method: PanicMethod = PanicMethod("swap")

--- a/settings.py
+++ b/settings.py
@@ -671,6 +671,7 @@ class GeneratorOptions(Group):
         BASIC = 1
         PLAYTHROUGH = 2
         FULL = 3
+
     class PlaythroughMode(IntEnum):
         """
         Mode for playthrough generation.

--- a/test/general/test_sphere_fulfillment.py
+++ b/test/general/test_sphere_fulfillment.py
@@ -1,0 +1,43 @@
+import unittest
+
+from BaseClasses import CollectionState, Region
+from Fill import distribute_items_restrictive
+from worlds.AutoWorld import call_all
+from test.general import generate_test_multiworld, generate_locations, generate_items
+
+
+class TestSphereFulfillment(unittest.TestCase):
+    def _filled_gated_chain(self, players: int) -> "MultiWorld":
+        multiworld = generate_test_multiworld(players)
+        for pid in multiworld.player_ids:
+            menu = multiworld.get_region("Menu", pid)
+            inner = Region(f"inner{pid}", pid, multiworld)
+            multiworld.regions.append(inner)
+            generate_locations(2, pid, menu, None, "_menu")
+            generate_locations(1, pid, inner, None, "_inner")
+            keys = generate_items(2, pid, advancement=True)
+            multiworld.itempool += keys
+            multiworld.itempool += generate_items(1, pid, advancement=False)
+            key0, key1 = keys[0].name, keys[1].name
+            menu.connect(inner, rule=lambda state, p=pid, k=key0: state.has(k, p))
+            multiworld.completion_condition[pid] = lambda state, p=pid, k=key1: state.has(k, p)
+        distribute_items_restrictive(multiworld)
+        call_all(multiworld, "post_fill")
+        return multiworld
+
+    def _assert_valid_playthrough(self, multiworld) -> None:
+        multiworld.spoiler.create_playthrough_sphere_fulfillment(create_paths=False)
+        self.assertTrue(multiworld.spoiler.playthrough, "playthrough should be non-empty")
+        state = CollectionState(multiworld)
+        for location in multiworld.get_filled_locations():
+            if location.item.advancement:
+                state.collect(location.item, True, location)
+        state.sweep_for_advancements()
+        for pid in multiworld.player_ids:
+            self.assertTrue(multiworld.has_beaten_game(state, pid), f"player {pid} goal unreachable")
+
+    def test_solo(self) -> None:
+        self._assert_valid_playthrough(self._filled_gated_chain(1))
+
+    def test_two_player(self) -> None:
+        self._assert_valid_playthrough(self._filled_gated_chain(2))


### PR DESCRIPTION
## What is this fixing or adding?
This is a new pr to replace one that was lost with the deletion of a branch.

the algorithm is linear with number of unique advancements x spheres. with progression balancing on, number of spheres tends to stay relatively consistent. without progression balancing, spheres grow sublinearly with number of players and seems to plateu around 300 from my testing. either way it has consistently beaten stock create playthrough in every test i have made.

the algorithm first builds spheres and takes a state snapshot at each sphere to use as a base for later sphere processing.
it then separates locations that require cross world logic by rebuilding the spheres per player using only that players items. any locations that are not reachable at the same sphere they were with the global sphere build are considered global (relies on another players' items)

we loop through every sphere in reverse sphere order looking for an irreducible set of items that allow us to beat the game and collect locations that are required to beat the game or required for other required locations.

the main loop relies on a couple patterns: 
1. if a player only relies on that players' items, then we can use a cheap player scoped copy of the player's state to process it. 
2. you don't need to collect every available advancement to prove beatability. this algorithm assumes every lower sphere is fully collected (will be reduced later), and just looks for what in this sphere is required to beat the game, and acquire any other items deemed necessary. looking for an irreducible set of items from a sphere that allow the goals, and all higher sphere required locations to be reached.
3. if at any point a fungible item (items for which there are multiple copies that do the same thing) is determined to be necessary it is guaranteed that every copy in the state, including those that came before it in this sphere, and those in lower spheres, are required. the reason being that because the search looks for which item flips a condition, we know that before the item was added, the condition was false, and after, the condition is true. since the condition turned true on collection of the fungible item, we know that whatever count of fungible items we have was required. 

the search method takes a bulk group of locations and looks for the minimal set from the sphere that satisfies the group using a binary search with a state cache stack. we collect all items in a sphere in order to a probe point. when we find the item that satisfies the whole set, we know that it is required by the set and nothing before it can satisfy the set, and it's the earliest point in the sphere where that is true, therefore it is minimal to the set we are searching, and necessary. we keep searching in this manner until we find all such items.

for global items we binary search the whole sphere, but for others, we only use player scoped states and their partition of the sphere. 

for efficiency and minimal-ness, we force all higher sphere required items into the state before we search for dependencies so that we can let the set use them as prerequisites. this allows items to become their own prerequisite though, so we have to individually resolve any locations that are still not able to be reached after the search. because we are now adding items that were not found in the bulk search, we lose the minimal guarantee, so we can run it again with the circular resolving items forced to re-minimize. loop through that until there are no circular dependencies.

because the items required to resolve circular dependencies, as well as the prerequisites found in the global search, were found outside the last bulk search, we cannot guarantee that these are necessary. but they are few, and we only need to know if we can reach higher spheres with them, so we do a typical remove and test but cheaper than the stock method and on only a handful of locations.

because we know that all lower sphere copies of a type of fungible item are required whenever we find any required, we can simply promote them to the required set, add them to the base, and move on to the rest of the sphere.

at the end we use a can_beat_game check to ensure that the set is sufficient. falling back to stock if it fails, or any other step cannot fulfill something.

## How was this tested?

this was tested by generating many seeds (i have lost track) across 5-320 player sets with default and randomized settings all coming back sufficient and minimal. (unable to be reduced by the remove and test method)
additional testing was done with hk's grubhunt and item-links with all successful
i even found other bugs with generation while testing and submitted a fix for one i was able to identify the cause of.