### PR TITLE
Core: update platformdirs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ jinja2==3.1.6
 schema==0.7.8
 kivy==2.3.1
 bsdiff4==1.2.6
-platformdirs==4.9.4
+platformdirs==4.10.1
 certifi==2026.2.25
 cython==3.2.4
 cymem==2.0.13


### PR DESCRIPTION
## What is this fixing or adding?
Updates platformdirs to a version with a fixed memory leak, which I found.
https://github.com/tox-dev/platformdirs/issues/501

## How was this tested?
Outside of AP.
