### PR TITLE
Core: Skip directly collecting placed items in get_all_state()

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -452,12 +452,14 @@ class MultiWorld():
         ret = CollectionState(self, allow_partial_entrances)
 
         for item in self.itempool:
-            self.worlds[item.player].collect(ret, item)
+            if item.location is None:
+                self.worlds[item.player].collect(ret, item)
         if collect_pre_fill_items:
             for player in self.player_ids:
                 subworld = self.worlds[player]
                 for item in subworld.get_pre_fill_items():
-                    subworld.collect(ret, item)
+                    if item.location is None:
+                        subworld.collect(ret, item)
         if perform_sweep:
             ret.sweep_for_advancements()
 


### PR DESCRIPTION
## What is this fixing or adding?
Depending on when `get_all_state()` is used, items in `multiworld.itempool`, or from a world's `get_pre_fill_items()` could already have been placed, meaning that `get_all_state()` could collect these item instances twice.

This changes `MultiWorld.get_all_state()` to skip directly collecting items that have already been placed.

This does not fix all issues with `MultiWorld.get_all_state()` at all generation steps because some worlds create new `Item` instances every time their `get_pre_fill_items()` is called, but collecting a few `pre_fill`-placed items twice generally doesn't cause problems, otherwise we would see many more generation failures from the vast number of worlds that currently use `get_all_state()` within the `pre_fill` step.

This fixes #6333.
This fixes #6334.
This fixes hiding some issues in worlds' `pre_fill` methods from `test_default_all_state_can_reach_everything`, that uses `get_all_state()` and would often collect items from `get_pre_fill_items()` twice. This notably reveals a potential bug in SMZ3 which now often fails `test_default_all_state_can_reach_everything`.

## How was this tested?
Untested besides running the unit tests.