### PR TITLE
Core: Don't return placed items twice in multiworld.get_items() after fill

### DIFF
--- a/BaseClasses.py
+++ b/BaseClasses.py
@@ -464,7 +464,7 @@ class MultiWorld():
         return ret
 
     def get_items(self) -> List[Item]:
-        return [loc.item for loc in self.get_filled_locations()] + self.itempool
+        return [loc.item for loc in self.get_filled_locations()] + [item for item in self.itempool if item.location is None]
 
     def find_item_locations(self, item: str, player: int, resolve_group_locations: bool = False) -> List[Location]:
         if resolve_group_locations:


### PR DESCRIPTION
## What is this fixing or adding?

Similar to using `multiworld.get_all_state()` after core AP's main fill is complete (see #6335), using `multiworld.get_items()` after core AP's main fill is complete is another common 'gotcha' that apworld developers fall for, not realising that it will end up returning a list containing most items twice.

This changes `multiworld.get_items()` to only return items from `self.itempool` that are not placed, therefore avoiding the issue of returning an item twice if it is both placed and in `self.itempool`, which often occurs after core AP's main fill is complete.

There are still potentially some issues from the fact that not necessarily all items from `self.itempool` will be placed somewhere, e.g. additional items could have been added into the multiworld through item plando. But, I don't know how `get_items()` is actually supposed to work due to it being undocumented. Additionally, changing `get_items()` to be aware of what it should return depending on which generation steps have been run would be a more involved change to parts of core AP.

## How was this tested?

Only by running the unit tests.