### PR TITLE
Unittests: allow running unittests for specific worlds when using unittest runner

### DIFF
--- a/worlds/__init__.py
+++ b/worlds/__init__.py
@@ -83,7 +83,7 @@ class WorldSource:
 # AP_TEST_WORLDS (pytest only) scopes auto-loading to the named worlds; these are always loaded for the
 # suite's fixtures but aren't themselves worlds under test.
 _SUITE_FIXTURE_WORLDS = {"generic", "apquest"}
-_test_worlds_env = os.environ.get("AP_TEST_WORLDS") if "pytest" in sys.modules else None
+_test_worlds_env = os.environ.get("AP_TEST_WORLDS") if "pytest" in sys.modules or "unittest" in sys.modules else None
 _requested_worlds = {name.strip() for name in _test_worlds_env.split(",") if name.strip()} if _test_worlds_env else None
 test_worlds_filter = _requested_worlds | _SUITE_FIXTURE_WORLDS if _requested_worlds else None
 

--- a/worlds/__init__.py
+++ b/worlds/__init__.py
@@ -80,7 +80,7 @@ class WorldSource:
     def name(self) -> str:
         return Path(self.path).stem
 
-# AP_TEST_WORLDS (pytest only) scopes auto-loading to the named worlds; these are always loaded for the
+# AP_TEST_WORLDS scopes auto-loading to the named worlds; these are always loaded for the
 # suite's fixtures but aren't themselves worlds under test.
 _SUITE_FIXTURE_WORLDS = {"generic", "apquest"}
 _test_worlds_env = os.environ.get("AP_TEST_WORLDS") if "pytest" in sys.modules or "unittest" in sys.modules else None


### PR DESCRIPTION
## What is this fixing or adding?
#6290 was written to only work with the `pytest` runner, this adds support for python's built-in `unittest` module.

## How was this tested?
Ran unittests with AP_TEST_WORLDS set to `apquest,pokemon_pinball_rs` and checked test output that only those two worlds had their unittests ran.

Worth noting there are apparently some IDEs that always load the unittest module, but PyCharm does not do so.
