### PR TITLE
The Messenger: Fix shop price not correctly handled by UT

### DIFF
--- a/worlds/messenger/__init__.py
+++ b/worlds/messenger/__init__.py
@@ -19,7 +19,7 @@ from .rules import MessengerHardRules, MessengerOOBRules, MessengerRules
 from .shop import FIGURINES, PROG_SHOP_ITEMS, SHOP_ITEMS, USEFUL_SHOP_ITEMS, shuffle_shop_prices
 from .subclasses import MessengerItem, MessengerRegion, MessengerShopLocation
 from .transitions import disconnect_entrances, shuffle_transitions
-from .universal_tracker import reverse_portal_exits_into_portal_plando, reverse_transitions_into_plando_connections
+from .universal_tracker import reverse_portal_exits_into_portal_plando, reverse_shop_prices, reverse_transitions_into_plando_connections
 
 components.append(
     Component(
@@ -169,7 +169,11 @@ class MessengerWorld(World):
         if self.options.early_meditation:
             self.multiworld.early_items[self.player]["Meditation"] = 1
 
-        self.shop_prices, self.figurine_prices = shuffle_shop_prices(self)
+        if not hasattr(self.multiworld, "re_gen_passthrough"):
+            self.shop_prices, self.figurine_prices = shuffle_shop_prices(self)
+        else:
+            if slot_data := self.multiworld.re_gen_passthrough.get(self.game):
+                self.shop_prices, self.figurine_prices = reverse_shop_prices(slot_data["shop"], slot_data["figures"])
 
         starting_portals = ["Autumn Hills", "Howling Grotto", "Glacial Peak", "Riviere Turquoise", "Sunken Shrine",
                             "Searing Crags"]
@@ -275,6 +279,10 @@ class MessengerWorld(World):
         filler = [self.create_filler() for _ in range(remaining_fill)]
 
         self.multiworld.itempool += filler
+
+        if hasattr(self.multiworld, "re_gen_passthrough"):
+            if slot_data := self.multiworld.re_gen_passthrough.get(self.game):
+                self.total_shards = slot_data["max_price"]
 
     def set_rules(self) -> None:
         logic = self.options.logic_level

--- a/worlds/messenger/universal_tracker.py
+++ b/worlds/messenger/universal_tracker.py
@@ -1,9 +1,11 @@
 from Options import PlandoConnection
 from .connections import RANDOMIZED_CONNECTIONS
 from .portals import REGION_ORDER, SHOP_POINTS, CHECKPOINTS
+from .shop import FIGURINES, SHOP_ITEMS
 from .transitions import TRANSITIONS
 
 REVERSED_RANDOMIZED_CONNECTIONS = {v: k for k, v in RANDOMIZED_CONNECTIONS.items()}
+REVERSED_SHOP_ITEMS = {v.internal_name: k for k, v in (SHOP_ITEMS | FIGURINES).items()}
 
 
 def find_spot(portal_key: int) -> str:
@@ -25,6 +27,14 @@ def reverse_portal_exits_into_portal_plando(portal_exits: list[int]) -> list[Pla
         PlandoConnection("Searing Crags", find_spot(portal_exits[4]), "both"),
         PlandoConnection("Glacial Peak", find_spot(portal_exits[5]), "both"),
     ]
+
+def reverse_shop_prices(
+    shop_prices: dict[str, int], figures_prices: dict[str, int]
+) -> tuple[dict[str, int], dict[str, int]]:
+    return (
+        {REVERSED_SHOP_ITEMS[item_internal_name]: price for item_internal_name, price in shop_prices.items()},
+        {REVERSED_SHOP_ITEMS[item_internal_name]: price for item_internal_name, price in figures_prices.items()},
+    )
 
 
 def reverse_transitions_into_plando_connections(transitions: list[list[int]]) -> list[PlandoConnection]:


### PR DESCRIPTION
## What is this fixing or adding?
I have been running the [fuzzer](https://github.com/Eijebong/Archipelago-fuzzer) with the UT hook only to realize that Messenger fails 99% of the runs. 

This is due to the shop prices being re-randomized instead of being set from slot data.

## How was this tested?
Combined with #6132, fuzzer with the UT hook passes 99% of the time. The only failures seems to be due to fill errors. 

## If this makes graphical changes, please attach screenshots.
N/A