### PR TITLE
kvui: fix ZeroDivisionError on windows after monitor reset by setting fixed DPI

### DIFF
--- a/kvui.py
+++ b/kvui.py
@@ -57,8 +57,29 @@ for classobj in SoundLoader._classes:
     # .extensions(), which e.g. in audio_sdl2.pyx then calls a function called "mix_init()"
     classobj.extensions()
 
-from kivymd.uix.divider import MDDivider
 from kivy.core.window import Window
+
+if sys.platform == "win32":
+    from kivy.core.window.window_sdl2 import WindowSDL, _WindowsSysDPIWatch
+
+    # The process is deliberately DPI-unaware (see above), so Windows scales the whole window for us. Kivy's dynamic
+    # DPI handling conflicts with that after a display reconnects: it can briefly use a zero density and then enter a
+    # resize/layout loop. Keep Kivy's coordinate system at the fixed 96 DPI that a DPI-unaware process expects.
+    def _set_fixed_windows_density(self: WindowSDL):
+        self._density = 1.
+        self.dpi = 96.
+
+    def _ignore_windows_dpi_changes(self: _WindowsSysDPIWatch):
+        pass
+
+    WindowSDL._update_density_and_dpi = _set_fixed_windows_density
+    Window._update_density_and_dpi()
+    if Window._win_dpi_watch is not None:
+        Window._win_dpi_watch.stop()
+        Window._win_dpi_watch = None
+    _WindowsSysDPIWatch.start = _ignore_windows_dpi_changes
+
+from kivymd.uix.divider import MDDivider
 from kivy.core.clipboard import Clipboard
 from kivy.core.text.markup import MarkupLabel
 from kivy.core.image import ImageLoader, ImageLoaderBase, ImageData


### PR DESCRIPTION
## What is this fixing or adding?
On Windows after a monitor is "lost", such as by the system going to sleep, if any kivy clients were on that monitor then the clients would spam a ZeroDivisionError on any mouse move event going through them. We already have disabled DPI aware scaling, so we can just kill off even more of that system and "fix" the exception spam.

## How was this tested?
On my 3-monitor windows 11 system.

## If this makes graphical changes, please attach screenshots.
<img width="2508" height="535" alt="image" src="https://github.com/user-attachments/assets/41c390fa-826f-4e17-96f1-3a5ceee6b200" />
Leftmost client is with this change, the others are 0.6.7 stable release, all on the same monitor after the monitor was turned off and then on again.