### PR TITLE
Jak and Daxter: Lock PME requirement to 1.6.0.

### DIFF
--- a/worlds/jakanddaxter/requirements.txt
+++ b/worlds/jakanddaxter/requirements.txt
@@ -1,1 +1,1 @@
-PyMemoryEditor>=1.6.0
+PyMemoryEditor=1.6.0

--- a/worlds/jakanddaxter/requirements.txt
+++ b/worlds/jakanddaxter/requirements.txt
@@ -1,1 +1,1 @@
-PyMemoryEditor=1.6.0
+PyMemoryEditor==1.6.0


### PR DESCRIPTION
## What is this fixing or adding?
PyMemoryEditor 2.0.x is incompatible with 1.6.x. Jak's requirements file specifies `>=1.6.0` so this will accidentally grab the later version, which won't work with the way Jak's client is currently written. We'll lock the version to `=1.6.0` until a future update where we can move the whole client to 2.0.x. 

The reason we're not doing that now is there's an active beta world for Jak and I don't want to have multiple versions of the world that require different versions of the same library.

## How was this tested?
Not at all.

## If this makes graphical changes, please attach screenshots.
N/A.