### PR TITLE
SMZ3: Fix removing items after sweeping state in pre_fill

### DIFF
--- a/worlds/smz3/__init__.py
+++ b/worlds/smz3/__init__.py
@@ -546,9 +546,10 @@ class SMZ3World(World):
             locations = [loc for loc in self.locations.values() if loc.item is None]
             self.multiworld.random.shuffle(locations)
 
-            all_state = self.multiworld.get_all_state(False)
+            all_state = self.multiworld.get_all_state(perform_sweep=False)
             for item in self.smz3DungeonItems:
                 all_state.remove(item)
+            all_state.sweep_for_advancements()
 
             all_dungeonItems = self.smz3DungeonItems[:]
             fill_restrictive(self.multiworld, all_state, locations, all_dungeonItems, True, True)


### PR DESCRIPTION
## What is this fixing or adding?

SMZ3 would produce an 'all state' for dungeon filling purposes, but it would remove its dungeon items from the state *after* the state had already swept to pick up reachable items, meaning that the state could have collected items that were only reachable because the dungeon items were still collected into the state.

This has been fixed by only performing the sweep after the dungeon items have been removed.

The deprecated `use_cache` argument passed to `get_all_state()`, that no longer does anything since its deprecation, has also been removed.

## How was this tested?

Only by running the unit tests
