### PR TITLE
Tests: Force race mode off in test_generate_yaml

### DIFF
--- a/test/programs/test_generate.py
+++ b/test/programs/test_generate.py
@@ -115,6 +115,7 @@ class TestGenerateWeights(TestGenerateMain):
         settings = get_settings()
         settings.generator.player_files_path = settings.generator.PlayerFilesPath(self.yaml_input_dir)
         settings.generator.players = 5  # arbitrary number, should be enough
+        settings.generator.race = 0 # make sure race mode is disabled so the below seed is actually respected
         settings._filename = None
         user_path_backup = user_path.cached_path
         user_path.cached_path = local_path()


### PR DESCRIPTION
## What is this fixing or adding?
Previously, `test_generate_yaml` would fail if your local host.yaml had race mode enabled, since the fixed seed in the test wouldn't be respected. This PR forces race mode off in the test so that it doesn't fail.

## How was this tested?
Ran the tests.

## If this makes graphical changes, please attach screenshots.
It doesn't.