### PR TITLE
Core: Fix Open Patch

### DIFF
--- a/worlds/LauncherComponents.py
+++ b/worlds/LauncherComponents.py
@@ -7,6 +7,7 @@ import webbrowser
 from enum import Enum
 from typing import Optional, Callable, Iterable, Sequence
 
+from Launcher import launch as launch_exe
 from Utils import local_path, open_filename, is_frozen, is_kivy_running, open_file, user_path, read_apignore, \
     is_windows
 
@@ -242,7 +243,7 @@ def open_patch():
             if exe is None or not isfile(exe[-1]):
                 exe = get_exe("Launcher")
 
-            launch([*exe, file], component.cli)
+            launch_exe([*exe, file], component.cli)
 
 
 def get_exe(component: str | Component) -> Sequence[str] | None:


### PR DESCRIPTION
## What is this fixing or adding?
#6115 moved the open_patch function, and in doing so, used the wrong `launch` function (the one from LauncherComponents instead of the one in Launcher), making it no longer work. The correct launch is imported as launch_exe in this PR, maybe AP would benefit from renaming these two, but that's for another PR

## How was this tested?
By opening a patch
