### PR TITLE
Subnautica: Handle empty filler item weights with specific error

### DIFF
--- a/worlds/subnautica/__init__.py
+++ b/worlds/subnautica/__init__.py
@@ -4,6 +4,7 @@ import itertools
 from typing import List, Dict, Any, cast
 
 from BaseClasses import Region, Location, Item, Tutorial, ItemClassification
+from Options import OptionError
 from worlds.AutoWorld import World, WebWorld
 from . import items
 from . import locations
@@ -46,8 +47,9 @@ class SubnauticaWorld(World):
     creatures_to_scan: List[str]
 
     def generate_early(self) -> None:
-        if not self.options.filler_items_distribution.weights_pair[1][-1]:
-            raise Exception("Filler Items Distribution needs at least one positive weight.")
+        weights_list = self.options.filler_items_distribution.weights_pair[1]
+        if not weights_list or not weights_list[-1]:
+            raise OptionError("Filler Items Distribution needs at least one positive weight.")
         if self.options.early_seaglide:
             self.multiworld.local_early_items[self.player]["Seaglide Fragment"] = 2
 


### PR DESCRIPTION
Fixes #6360.

A YAML that has an empty filler items distribution value now raises the error that previously existed to also catch negative values:

`Options.OptionError: Filler Items Distribution needs at least one positive weight.`

I also turned it into an OptionError instead of a general Exception, since I was in there.

Tested on source as of time of PR. Generates successfully with the default value of this option, and fails with the above error when the example YAML in the above issue is used.

I don't play Subnautica, so I haven't tested anything of the sort with a Subnautica client. Not that this should even touch that.