### PR TITLE
Core: Allow TOML documents for player files

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -7,8 +7,6 @@ import os
 import random
 import string
 import sys
-import urllib.parse
-import urllib.request
 from collections import Counter
 from itertools import chain
 from typing import Any
@@ -20,7 +18,7 @@ ModuleUpdate.update()
 import Utils
 import Options
 from BaseClasses import seeddigits, get_seed, PlandoOptions
-from Utils import parse_yamls, version_tuple, __version__, tuplize_version
+from Utils import read_config, read_configs, version_tuple, __version__, tuplize_version
 
 
 def mystery_argparse(argv: list[str] | None = None) -> argparse.Namespace:
@@ -101,22 +99,26 @@ def main(args=None) -> tuple[argparse.Namespace, int]:
     weights_cache: dict[str, tuple[Any, ...]] = {}
     if args.weights_file_path and os.path.exists(args.weights_file_path):
         try:
-            weights_cache[args.weights_file_path] = read_weights_yamls(args.weights_file_path)
+            weights_cache[args.weights_file_path] = read_configs(args.weights_file_path)
+        except (OSError, UnicodeError) as e:
+            raise Exception(f"Failed to read weights ({args.weights_file_path})") from e
         except Exception as e:
-            raise ValueError(f"File {args.weights_file_path} is invalid. Please fix your yaml.") from e
+            raise ValueError(f"File {args.weights_file_path} is invalid. Please fix your options.") from e
         logging.info(f"Weights: {args.weights_file_path} >> "
                      f"{get_choice('description', weights_cache[args.weights_file_path][-1], 'No description specified')}")
 
     if args.meta_file_path and os.path.exists(args.meta_file_path):
         try:
-            meta_weights = read_weights_yamls(args.meta_file_path)[-1]
+            meta_weights = read_config(args.meta_file_path)
+        except (OSError, UnicodeError) as e:
+            raise Exception(f"Failed to read meta file ({args.meta_file_path})") from e
         except Exception as e:
-            raise ValueError(f"File {args.meta_file_path} is invalid. Please fix your yaml.") from e
+            raise ValueError(f"File {args.meta_file_path} is invalid. Please fix your meta file.") from e
         logging.info(f"Meta: {args.meta_file_path} >> {get_choice('meta_description', meta_weights)}")
         try:  # meta description allows us to verify that the file named meta.yaml is intentionally a meta file
             del(meta_weights["meta_description"])
         except Exception as e:
-            raise ValueError("No meta description found for meta.yaml. Unable to verify.") from e
+            raise ValueError("No meta description found for meta file. Unable to verify.") from e
         if args.sameoptions:
             raise Exception("Cannot mix --sameoptions with --meta")
     else:
@@ -133,25 +135,27 @@ def main(args=None) -> tuple[argparse.Namespace, int]:
             path = os.path.join(args.player_files_path, fname)
             try:
                 weights_for_file = []
-                for doc_idx, yaml in enumerate(read_weights_yamls(path)):
-                    if yaml is None:
-                        logging.warning(f"Ignoring empty yaml document #{doc_idx + 1} in {fname}")
+                for idx, doc in enumerate(read_configs(path), start=1):
+                    if doc is None:
+                        logging.warning(f"Ignoring empty document #{idx} in {fname}")
                     else:
-                        quantity = yaml.get("quantity", 1)
+                        quantity = doc.get("quantity", 1)
                         if quantity <= 0:
                             raise ValueError("A quantity of 0 or less is invalid. Please change it to at least 1.")
                         if not allow_quantity and quantity > 1:
                             raise ValueError("Quantity greater than 1 is deactivated by host settings.")
 
                         for _ in range(quantity):
-                            weights_for_file.append(yaml)
+                            weights_for_file.append(doc)
                 weights_cache[fname] = tuple(weights_for_file)
 
+            except (OSError, UnicodeError) as e:
+                raise Exception(f"Failed to read weights ({path})") from e
             except Exception as e:
                 logging.exception(f"Exception reading weights in file {fname}")
                 player_errors.append(
                     f"{len(player_errors) + 1}. "
-                    f"File {fname} is invalid. Please fix your yaml.\n{Utils.get_all_causes(e)}"
+                    f"File {fname} is invalid. Please fix your options.\n{Utils.get_all_causes(e)}"
                 )
 
     # sort dict for consistent results across platforms:
@@ -225,7 +229,7 @@ def main(args=None) -> tuple[argparse.Namespace, int]:
                 logging.exception(f"Exception reading settings in file {fname}")
                 player_errors.append(
                     f"{len(player_errors) + 1}. "
-                    f"File {fname} is invalid. Please fix your yaml.\n{Utils.get_all_causes(e)}"
+                    f"File {fname} is invalid. Please fix your options.\n{Utils.get_all_causes(e)}"
                 )
         # Exit early here to avoid throwing the same errors again later
         if player_errors:
@@ -280,7 +284,7 @@ def main(args=None) -> tuple[argparse.Namespace, int]:
                 player_errors.append(
                     f"{len(player_errors) + 1}. "
                     f"File {path} document #{doc_index + 1} (with name: {args.name.get(player, name)}) is invalid. "
-                    f"Please fix your yaml.\n{Utils.get_all_causes(e)}")
+                    f"Please fix your options.\n{Utils.get_all_causes(e)}")
 
             # increment for each yaml document in the file
             player += 1
@@ -297,32 +301,6 @@ def main(args=None) -> tuple[argparse.Namespace, int]:
                          f"See logs for full tracebacks.\n\n{errors}")
 
     return args, seed
-
-
-def read_weights_yamls(path) -> tuple[Any, ...]:
-    try:
-        if urllib.parse.urlparse(path).scheme in ('https', 'file'):
-            yaml = str(urllib.request.urlopen(path).read(), "utf-8-sig")
-        else:
-            with open(path, 'rb') as f:
-                yaml = str(f.read(), "utf-8-sig")
-    except Exception as e:
-        raise Exception(f"Failed to read weights ({path})") from e
-
-    from yaml.error import MarkedYAMLError
-    try:
-        return tuple(parse_yamls(yaml))
-    except MarkedYAMLError as ex:
-        if ex.problem_mark:
-            lines = yaml.splitlines()
-            if ex.context_mark:
-                relevant_lines = "\n".join(lines[ex.context_mark.line:ex.problem_mark.line+1])
-            else:
-                relevant_lines = lines[ex.problem_mark.line]
-            error_line = " " * ex.problem_mark.column + "^"
-            raise Exception(f"{ex.context} {ex.problem} on line {ex.problem_mark.line}:"
-                            f"\n{relevant_lines}\n{error_line}")
-        raise ex
 
 
 def interpret_on_off(value) -> bool:
@@ -488,7 +466,7 @@ def roll_triggers(weights: dict, triggers: list, valid_keys: set) -> dict:
         try:
             currently_targeted_weights = weights
             category = option_set.get("option_category", None)
-            if category:
+            if category and category != "null":
                 currently_targeted_weights = currently_targeted_weights[category]
             key = get_choice("option_name", option_set)
             if key not in currently_targeted_weights:
@@ -501,7 +479,7 @@ def roll_triggers(weights: dict, triggers: list, valid_keys: set) -> dict:
             if result == trigger_result and Options.roll_percentage(get_choice("percentage", option_set, 100)):
                 for category_name, category_options in option_set["options"].items():
                     currently_targeted_weights = weights
-                    if category_name:
+                    if category_name and category_name != "null":
                         currently_targeted_weights = currently_targeted_weights[category_name]
                     update_weights(currently_targeted_weights, category_options, "Triggered", option_set["option_name"])
             valid_keys.add(key)

--- a/Utils.py
+++ b/Utils.py
@@ -1,43 +1,46 @@
 from __future__ import annotations
 
 import asyncio
-import concurrent.futures
-import json
-import typing
 import builtins
-import os
+import collections
+import concurrent.futures
+import functools
+import importlib
+import io
 import itertools
+import json
+import logging
+import os
+import pickle
 import subprocess
 import sys
-import pickle
-import functools
-import io
-import collections
-import importlib
-import logging
+import typing
+import urllib.parse
+import urllib.request
 import warnings
-
 from argparse import Namespace
 from collections.abc import Collection, Iterable
 from datetime import datetime, timezone
-
-from settings import Settings, get_settings
 from time import sleep
 from typing import BinaryIO, Coroutine, Generic, Mapping, Optional, Set, Dict, Any, TypeVar, Union, TypeGuard
-from yaml import load, load_all, dump
+
+import tomlkit as toml
 from pathspec import PathSpec, GitIgnoreSpec
 from typing_extensions import deprecated
+from yaml import load, load_all, dump
 
 try:
     from yaml import CLoader as UnsafeLoader, CSafeLoader as SafeLoader, CDumper as Dumper
 except ImportError:
     from yaml import Loader as UnsafeLoader, SafeLoader, Dumper
 
+from settings import Settings, get_settings
+
 if typing.TYPE_CHECKING:
-    import tkinter
-    import pathlib
-    from BaseClasses import Region
     import multiprocessing
+    import pathlib
+    import tkinter
+    from BaseClasses import Region
 
 
 def tuplize_version(version: str) -> Version:
@@ -262,6 +265,72 @@ parse_yamls = functools.partial(load_all, Loader=UniqueKeyLoader)
 unsafe_parse_yaml = functools.partial(load, Loader=UnsafeLoader)
 
 del load, load_all  # should not be used. don't leak their names
+
+
+def parse_weights_yamls(data: str) -> tuple[Any, ...]:
+    from yaml.error import MarkedYAMLError
+    try:
+        return tuple(parse_yamls(data))
+    except MarkedYAMLError as ex:
+        if ex.problem_mark:
+            lines = data.splitlines()
+            if ex.context_mark:
+                relevant_lines = "\n".join(lines[ex.context_mark.line:ex.problem_mark.line+1])
+            else:
+                relevant_lines = lines[ex.problem_mark.line]
+            error_line = " " * ex.problem_mark.column + "^"
+            raise Exception(f"{ex.context} {ex.problem} on line {ex.problem_mark.line}:"
+                            f"\n{relevant_lines}\n{error_line}")
+        raise ex
+
+
+def parse_weights_toml(data: str, native=True) -> tuple[Any]:
+    # toml can only have a single document in it, but give tuple since that's expected for yamls
+    doc = toml.loads(data)
+    if native:
+        return (doc.unwrap(),)
+    return (doc,)
+
+
+def parse_weights_json(data: str) -> tuple[Any]:
+    return (json.loads(data),)
+
+
+def parse_configs(data: str, extension: str, native=True) -> tuple[Any, ...]:
+    """
+    Read a configuration document in a format determined by given extension.
+
+    If native is set, this will return standard python values instead of possibly giving subclasses.
+    """
+    # include txt for yamls since webhost accepts it
+    if extension in {"yaml", "yml", "txt"}:
+        return parse_weights_yamls(data)
+    if extension == "toml":
+        return parse_weights_toml(data, native=native)
+    # enforce json syntax with json extension
+    if extension == "json":
+        return parse_weights_json(data)
+    raise ValueError(f"Unrecognized file extension ({extension}) for weights file")
+
+
+def read_configs(path: str, native=True) -> tuple[Any, ...]:
+    """Wrapper for parse_configs that takes in a filepath to read from."""
+    _, sep, extension = path.rpartition(".")
+    if not sep:
+        extension = ""
+
+    with open(path, encoding="utf-8-sig") as file:
+        data = file.read()
+    return parse_configs(data, extension, native=native)
+
+
+def read_config(path: str, native=True):
+    """Wrapper for read_configs that errors in the case of multiple documents being present."""
+    res = read_configs(path, native=native)
+    if len(res) != 1:
+        # message doesn't really match for length 0, but there should always be some document
+        raise ValueError("File has multiple documents when it should only contain one")
+    return res[0]
 
 
 def get_cert_none_ssl_context():

--- a/WebHostLib/check.py
+++ b/WebHostLib/check.py
@@ -85,7 +85,7 @@ def get_yaml_data(files) -> dict[str, str] | str | Markup:
     return options
 
 
-def roll_options(options: dict[str, str],
+def roll_options(options: dict[str, str | dict],
                  plando_options: Set[str] = frozenset({"bosses", "items", "connections", "texts"})) -> \
         tuple[dict[str, str | bool], dict[str, Namespace]]:
     plando = PlandoOptions.from_set(set(plando_options))
@@ -97,7 +97,10 @@ def roll_options(options: dict[str, str],
             extension = ""
 
         try:
-            documents = parse_configs(text, extension)
+            if isinstance(text, dict):
+                documents = (text,)
+            else:
+                documents = parse_configs(text, extension)
         except Exception as e:
             results[filename] = f"Failed to parse YAML data in {filename}: {e}"
         else:

--- a/WebHostLib/check.py
+++ b/WebHostLib/check.py
@@ -1,6 +1,7 @@
+import base64
 import os
 import zipfile
-import base64
+from argparse import Namespace
 from collections.abc import Set
 
 from flask import request, flash, redirect, url_for, render_template
@@ -10,7 +11,7 @@ from WebHostLib import app
 from WebHostLib.upload import allowed_options, allowed_options_extensions, banned_file
 
 from Generate import roll_settings, PlandoOptions
-from Utils import parse_yamls
+from Utils import parse_configs
 
 
 @app.route('/check', methods=['GET', 'POST'])
@@ -84,30 +85,29 @@ def get_yaml_data(files) -> dict[str, str] | str | Markup:
     return options
 
 
-def roll_options(options: dict[str, dict | str],
+def roll_options(options: dict[str, str],
                  plando_options: Set[str] = frozenset({"bosses", "items", "connections", "texts"})) -> \
-        tuple[dict[str, str | bool], dict[str, dict]]:
-    plando_options = PlandoOptions.from_set(set(plando_options))
+        tuple[dict[str, str | bool], dict[str, Namespace]]:
+    plando = PlandoOptions.from_set(set(plando_options))
     results: dict[str, str | bool] = {}
-    rolled_results: dict[str, dict] = {}
+    rolled_results: dict[str, Namespace] = {}
     for filename, text in options.items():
+        _, sep, extension = filename.rpartition(".")
+        if not sep:
+            extension = ""
+
         try:
-            if type(text) is dict:
-                yaml_datas = (text, )
-            else:
-                yaml_datas = tuple(parse_yamls(text))
+            documents = parse_configs(text, extension)
         except Exception as e:
             results[filename] = f"Failed to parse YAML data in {filename}: {e}"
         else:
             try:
-                if len(yaml_datas) == 1:
-                    rolled_results[filename] = roll_settings(yaml_datas[0],
-                                                             plando_options=plando_options)
+                if len(documents) == 1:
+                    rolled_results[filename] = roll_settings(documents[0], plando_options=plando)
                 else:
-                    for i, yaml_data in enumerate(yaml_datas):
-                        if yaml_data is not None:
-                            rolled_results[f"{filename}/{i + 1}"] = roll_settings(yaml_data,
-                                                                                  plando_options=plando_options)
+                    for i, document in enumerate(documents):
+                        if document is not None:
+                            rolled_results[f"{filename}/{i + 1}"] = roll_settings(document, plando_options=plando)
             except Exception as e:
                 if e.__cause__:
                     results[filename] = f"Failed to generate options in {filename}: {e} - {e.__cause__}"

--- a/WebHostLib/upload.py
+++ b/WebHostLib/upload.py
@@ -21,7 +21,7 @@ from . import app
 from .models import Seed, Room, Slot, GameDataPackage
 
 banned_extensions = (".sfc", ".z64", ".n64", ".nes", ".smc", ".sms", ".gb", ".gbc", ".gba")
-allowed_options_extensions = (".yaml", ".json", ".yml", ".txt", ".zip")
+allowed_options_extensions = (".yaml", ".json", ".yml", ".toml", ".txt", ".zip")
 allowed_generation_extensions = (".archipelago", ".zip")
 
 games_package_schema = schema.Schema({

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ orjson==3.11.7
 typing_extensions==4.15.0
 pyshortcuts==1.9.7
 pathspec==1.0.4
+tomlkit==0.15.1
 kivymd @ git+https://github.com/kivymd/KivyMD@5ff9d0d
 kivymd>=2.0.1.dev0
 


### PR DESCRIPTION
## What is this fixing or adding?
Probably a longshot on this being desired, but I feel like there are some pretty big problems with YAML that may make this easier in the long run.
As player files are already meant to at least mostly work with JSON, this can largely just be dropped in. The biggest concern probably is that TOML does not have a `null` value or something that otherwise maps well to python `None`, even though some things do use that. I've done a bandaid fix for trigger categories here to use the string `"null"`, but this may not work everywhere. Even though I think it'd make sense to use it there as well, this would make translating the `host.yaml` trickier in addition to the work needed on supporting it on `Group` and such already.
Since there's now conflicting formats, I think this now necessitates extension checking for local gen. I also figured it makes sense to handle json specifically so people will know if their file that was meant to be a json is only actually valid as a yaml.

If we do actually want to do this, I think rollout should probably follow something like the following:
1. Merge just the functionality for reading player files (it'd probably also be worth doing some more cleanup around this) and leave it undocumented for now.
2. One release after being introduced (once it can hopefully get some testing in practice), work out any of these issues and then add it as an optional alternative for templates, option exports, maybe the settings file, etc. Add explanations for using it to the relevant guides, possibly as the recommended.
3. At some point possibly switch it out to be default. I doubt we'll ever want to actually deprecate YAML support, but I guess we could if it really becomes ubiquitous.

Also, since we don't write anything for now, we could probably get away with the standard `tomllib`. I think we could want to in the future though, and the functionality here to keep the state of the document intact when reading could be beneficial for things like the host config. I also think it'd be good to introduce this with TOML 1.1 support, which would have to wait until python 3.15 for stdlib. (Plus the dependency is pure-python and quite light.)

## How was this tested?
Tested local and webhost gen with the following player ~~yaml~~ toml. Also tried to make sure some error cases were still handled sensibly.
```toml
# Top level values.
name = "TOMLQuest{player}"
# Here's a way that you can do weights.
game.APQuest = 10
game."A Hat in Time" = 5 # Names with things like spaces will need to be quoted.
quantity = 10

[APQuest]
# Alternate weights method. These keys are strings, so like json, this could run into ambiguity for things that can take
# string keys or another type. (The non-inline style relies on TOML 1.1)
progression_balancing = {
    10 = 10,
    90 = 10,
}

["A Hat in Time"]
# Empty game section.

[[triggers]]
# Arrays of tables actually work out pretty nicely with things like triggers, except for not being able to represent
# null natively.
option_category = "null"
option_name = "game"
option_result = "A Hat in Time"
[triggers.options.null]
name = "A TOML in Time {player}"
```

## If this makes graphical changes, please attach screenshots.
👨🇱