### PR TITLE
Setup: bump cx-Freeze to fix frozen linux shortcuts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ SNI_VERSION = "v0.0.100"  # change back to "latest" once tray icon issues are fi
 
 
 # This is a bit jank. We need cx-Freeze to be able to run anything from this script, so install it
-requirement = 'cx-Freeze==8.4.0'
+requirement = 'cx-Freeze==8.6.4'
 try:
     import pkg_resources
     try:

--- a/setup.py
+++ b/setup.py
@@ -41,9 +41,9 @@ if install_cx_freeze:
     except ImportError:
         raise RuntimeError("pip not available. Please install pip.")
     # install and import cx_freeze
-    if '--yes' not in sys.argv and '-y' not in sys.argv:
-        input(f'Requirement {requirement} is not satisfied, press enter to install it')
-    subprocess.call([sys.executable, '-m', 'pip', 'install', requirement, '-c', 'setup_constraints.txt'])
+    if "--yes" not in sys.argv and "-y" not in sys.argv:
+        input(f"Requirement {requirement} is not satisfied, press enter to install it")
+    subprocess.call([sys.executable, "-m", "pip", "install", requirement, "-c", "setup_constraints.txt"])
     import pkg_resources
 
 import cx_Freeze

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ if install_cx_freeze:
     # install and import cx_freeze
     if '--yes' not in sys.argv and '-y' not in sys.argv:
         input(f'Requirement {requirement} is not satisfied, press enter to install it')
-    subprocess.call([sys.executable, '-m', 'pip', 'install', requirement, '--upgrade'])
+    subprocess.call([sys.executable, '-m', 'pip', 'install', requirement, '-c', 'setup_constraints.txt'])
     import pkg_resources
 
 import cx_Freeze

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ SNI_VERSION = "v0.0.100"  # change back to "latest" once tray icon issues are fi
 
 
 # This is a bit jank. We need cx-Freeze to be able to run anything from this script, so install it
-requirement = 'cx-Freeze==8.6.4'
+requirement = "cx-Freeze==8.6.4"
 try:
     import pkg_resources
     try:

--- a/setup.py
+++ b/setup.py
@@ -188,7 +188,7 @@ exes = [
         script=f"{c.script_name}.py",
         target_name=c.frozen_name + (".exe" if is_windows else ""),
         icon=resolve_icon(c.icon),
-        base="Win32GUI" if is_windows and not c.cli else None
+        base="gui" if is_windows and not c.cli else None
     ) for c in components if c.script_name and c.frozen_name
 ]
 

--- a/setup_constraints.txt
+++ b/setup_constraints.txt
@@ -1,0 +1,1 @@
+setuptools>=75,<81


### PR DESCRIPTION
## What is this fixing or adding?
frozen linux fails to make shortcuts from the launcher because charset_normalizer (a requirement of pyshortcuts) fails to import because of a strange interaction between it and cx-Freeze, it was fixed in cx-Freeze 8.6.3 
<https://github.com/marcelotduarte/cx_Freeze/issues/3286#issuecomment-4114125852>
but i figured the one more minor release is probably safe/correct

## How was this tested?
froze ap (and made an appimage) and was able to make shortcuts without a module import error
also tested other basic functions like gen/host/text client to see if there were any obvious regressions

## If this makes graphical changes, please attach screenshots.
