### PR TITLE
MLSS: Small Logic Fix

### DIFF
--- a/worlds/mlss/Rules.py
+++ b/worlds/mlss/Rules.py
@@ -22,10 +22,15 @@ def set_rules(world: "MLSSWorld", excluded):
                 world.get_location(location.name),
                 lambda state: StateLogic.canDig(state, world.player),
             )
-        if "Beanstone" in location.name:
+        if "Beanstone" in location.name and location.name != "Beanstone Reward":
             add_rule(
                 world.get_location(location.name),
                 lambda state: StateLogic.canDig(state, world.player),
+            )
+        elif location.name == "Beanstone Reward":
+            add_rule(
+                world.get_location(location.name),
+                lambda state: StateLogic.beanstones(state, world.player),
             )
         if "Shop" in location.name and "Coffee" not in location.name and location.name not in excluded:
             if "Badge" in location.name or "Pants" in location.name:

--- a/worlds/mlss/StateLogic.py
+++ b/worlds/mlss/StateLogic.py
@@ -90,6 +90,11 @@ def winkle(state, player):
     return state.has("Winkle Card", player)
 
 
+def beanstones(state, player):
+    beanstones = ["Beanstone " + str(i) for i in range(1, 11)]
+    return all(state.has(beanstone, player) for beanstone in beanstones)
+
+
 def beanFruit(state, player):
     return (
         state.has("Bean Fruit 1", player)


### PR DESCRIPTION
## What is this fixing or adding?

MLSS: There are eleven Beanstone locations and ten Beanstone items. The ten items are named "Beanstone 1" through "Beanstone 10" and correspond to ten of the locations. The eleventh location is called "Beanstone Reward" and is obtained after getting the ten items and talking to a particular NPC.

The code was erroneously grouping all eleven locations into using the same logic (via a `if "Beanstone" in location.name` conditional). This PR removes the erroneous logic for the eleventh location and adds correct logic (namely, that the ten aforementioned items are collected).

## How was this tested?

`pytest`

## If this makes graphical changes, please attach screenshots.

N/A