### PR TITLE
CommonClient: Prevent disconnect from being sent bad DeathLink data

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -1092,9 +1092,12 @@ async def process_server_cmd(ctx: CommonContext, args: dict):
 
     elif cmd == "Bounced":
         tags = args.get("tags", [])
-        # we can skip checking "DeathLink" in ctx.tags, as otherwise we wouldn't have been send this
-        if "DeathLink" in tags and ctx.last_death_link != args["data"]["time"]:
-            ctx.on_deathlink(args["data"])
+        # we can skip checking "DeathLink" in ctx.tags, as otherwise we wouldn't have been sent this
+        if "DeathLink" in tags:
+            data = args.get("data", {})
+            time = data.get("time")
+            if time is not None and ctx.last_death_link != time:
+                ctx.on_deathlink(args["data"])
 
     elif cmd == "Retrieved":
         ctx.stored_data.update(args["keys"])


### PR DESCRIPTION
## What is this fixing or adding?

Some clients send incorrectly made DeathLink packets, usually by forgetting to add the timestamp.

This prevents CommonClient from disconnecting when trying to handle missing `data` or `time` fields in a DeathLink packet sent by a another client. Bad packets are ignored.

This doesn't do type checking of fields, but I'd argue that shouldn't really happen outside of a malicious client. Feel free to add that as well.

## How was this tested?

Connect a deathlink game, open another websocket and deliberately send the packets described in the linked issue.

Closes #6375 
