### PR TITLE
Core: limit depth of received JSON to 16

### DIFF
--- a/NetUtils.py
+++ b/NetUtils.py
@@ -170,7 +170,29 @@ def _object_hook(o: typing.Any) -> typing.Any:
     return o
 
 
-decode = JSONDecoder(object_hook=_object_hook).decode
+_decode = JSONDecoder(object_hook=_object_hook).decode
+
+
+def _check_depth(s: str, limit: int = 16) -> None:
+    depth = 1
+    in_quotes = False
+    for c in s:
+        if c == '"':
+            in_quotes = not in_quotes
+        elif not in_quotes:
+            if c in "[{":
+                depth += 1
+                if depth > limit:
+                    raise ValueError("JSON document too complex")
+            elif c in "}]":
+                depth -= 1
+    if depth != 1:  # free check
+        raise ValueError("JSON document malformed")
+
+
+def decode(s: str) -> typing.Any:
+    _check_depth(s)  # raises ValueError
+    return _decode(s)
 
 
 class Endpoint:

--- a/NetUtils.py
+++ b/NetUtils.py
@@ -173,28 +173,31 @@ def _object_hook(o: typing.Any) -> typing.Any:
 _decode = JSONDecoder(object_hook=_object_hook).decode
 
 
-def _check_depth(s: str, limit: int = 16) -> None:
-    depth = 1
-    in_quotes = False
-    escape = False
-    for c in s:
-        if c == "\\" and not escape:
-            escape = True
-            continue
-        if c == '"' and not escape:
-            in_quotes = not in_quotes
-            continue
-        if not in_quotes:
-            if c in "[{":
-                depth += 1
-                if depth > limit:
-                    raise ValueError("JSON document too complex")
-            elif c in "}]":
-                depth -= 1
+try:
+    from _speedups import check_json_depth as _check_depth
+except ImportError:
+    def _check_depth(s: str, limit: int = 16) -> None:
+        depth = 1
+        in_quotes = False
         escape = False
+        for c in s:
+            if c == "\\" and not escape:
+                escape = True
+                continue
+            if c == '"' and not escape:
+                in_quotes = not in_quotes
+                continue
+            if not in_quotes:
+                if c in "[{":
+                    depth += 1
+                    if depth > limit:
+                        raise ValueError("JSON document too complex")
+                elif c in "}]":
+                    depth -= 1
+            escape = False
 
-    if depth != 1:  # free check
-        raise ValueError("JSON document malformed")
+        if depth != 1:  # free check
+            raise ValueError("JSON document malformed")
 
 
 def decode(s: str) -> typing.Any:

--- a/NetUtils.py
+++ b/NetUtils.py
@@ -176,16 +176,23 @@ _decode = JSONDecoder(object_hook=_object_hook).decode
 def _check_depth(s: str, limit: int = 16) -> None:
     depth = 1
     in_quotes = False
+    escape = False
     for c in s:
-        if c == '"':
+        if c == "\\" and not escape:
+            escape = True
+            continue
+        if c == '"' and not escape:
             in_quotes = not in_quotes
-        elif not in_quotes:
+            continue
+        if not in_quotes:
             if c in "[{":
                 depth += 1
                 if depth > limit:
                     raise ValueError("JSON document too complex")
             elif c in "}]":
                 depth -= 1
+        escape = False
+
     if depth != 1:  # free check
         raise ValueError("JSON document malformed")
 

--- a/_speedups.pyx
+++ b/_speedups.pyx
@@ -376,3 +376,27 @@ cdef class PlayerLocationProxy:
         count = self._store.sender_index[self._player].count
         for entry in self._store.entries[start:start+count]:
             yield entry.location, (entry.item, entry.receiver, entry.flags)
+
+
+cpdef void check_json_depth(s: str, limit: int = 16):
+    cdef Py_ssize_t depth = 1
+    cdef bool in_quotes = False
+    cdef bool escape = False
+    for c in s:
+        if c == "\\" and not escape:
+            escape = True
+            continue
+        if c == '"' and not escape:
+            in_quotes = not in_quotes
+            continue
+        if not in_quotes:
+            if c in "[{":
+                depth += 1
+                if depth > limit:
+                    raise ValueError("JSON document too complex")
+            elif c in "}]":
+                depth -= 1
+        escape = False
+
+    if depth != 1:  # free check
+        raise ValueError("JSON document malformed")

--- a/test/netutils/test_decode.py
+++ b/test/netutils/test_decode.py
@@ -8,18 +8,18 @@ class DecodeDepthLimitTest(unittest.TestCase):
     LIMIT = 16
 
     @staticmethod
-    def make_data(depth: int) -> list[dict[str, Any]]:
+    def make_data(depth: int = LIMIT, cmd: str = "Cmd") -> list[dict[str, Any]]:
         arg: Any = [1]
         for _ in range(depth - 4):
             arg = [arg]
-        cmd = {"command": "} A command [{", "arg": arg}
+        res = {"cmd": cmd, "arg": arg}
         # [{"arg": [[...[1]...]]}]
         # ^1             ^depth
-        return [cmd]
+        return [res]
 
     @classmethod
-    def make_message(cls, depth: int) -> str:
-        return encode(cls.make_data(depth))
+    def make_message(cls, depth: int = LIMIT, cmd: str = "Cmd") -> str:
+        return encode(cls.make_data(depth, cmd=cmd))
 
     def test_below_limit(self) -> None:
         data = self.make_data(depth=self.LIMIT - 1)
@@ -37,8 +37,32 @@ class DecodeDepthLimitTest(unittest.TestCase):
 
     def test_incomplete(self) -> None:
         with self.assertRaises(ValueError):
-            decode(self.make_message(depth=self.LIMIT)[:-1])
+            decode(self.make_message()[:-1])
 
     def test_invalid(self) -> None:
         with self.assertRaises(ValueError):
-            decode(self.make_message(depth=self.LIMIT).replace(":", ","))
+            decode(self.make_message().replace(":", ","))
+
+    def test_braces_in_str(self) -> None:
+        # should not raise
+        decode(self.make_message(cmd="["))
+        decode(self.make_message(cmd="{"))
+        decode(self.make_message(cmd="}"))
+        decode(self.make_message(cmd="]"))
+
+    def test_quote_in_str(self) -> None:
+        # should not raise
+        decode(self.make_message(cmd='"'))
+
+    def test_bs_quote_in_str(self) -> None:
+        # should not raise
+        decode(self.make_message(cmd=r'\"'))
+
+    def test_quoted_braces_in_str(self) -> None:
+        # should not raise
+        decode(self.make_message(cmd='"{["'))
+
+    def test_escape(self) -> None:
+        # should not raise
+        decode(r"""["\"\\\/\b\f\n\r\t{"]""")
+        self.assertEqual("new\nline", decode(r'"new\u000Aline"'))

--- a/test/netutils/test_decode.py
+++ b/test/netutils/test_decode.py
@@ -1,0 +1,44 @@
+import unittest
+from typing import Any
+
+from NetUtils import decode, encode
+
+
+class DecodeDepthLimitTest(unittest.TestCase):
+    LIMIT = 16
+
+    @staticmethod
+    def make_data(depth: int) -> list[dict[str, Any]]:
+        arg: Any = [1]
+        for _ in range(depth - 4):
+            arg = [arg]
+        cmd = {"command": "} A command [{", "arg": arg}
+        # [{"arg": [[...[1]...]]}]
+        # ^1             ^depth
+        return [cmd]
+
+    @classmethod
+    def make_message(cls, depth: int) -> str:
+        return encode(cls.make_data(depth))
+
+    def test_below_limit(self) -> None:
+        data = self.make_data(depth=self.LIMIT - 1)
+        message = encode(data)
+        self.assertEqual(data, decode(message))
+
+    def test_at_limit(self) -> None:
+        data = self.make_data(depth=self.LIMIT)
+        message = encode(data)
+        self.assertEqual(data, decode(message))
+
+    def test_above_limit(self) -> None:
+        with self.assertRaises(ValueError):
+            decode(self.make_message(depth=self.LIMIT + 1))
+
+    def test_incomplete(self) -> None:
+        with self.assertRaises(ValueError):
+            decode(self.make_message(depth=self.LIMIT)[:-1])
+
+    def test_invalid(self) -> None:
+        with self.assertRaises(ValueError):
+            decode(self.make_message(depth=self.LIMIT).replace(":", ","))


### PR DESCRIPTION
## What is this fixing or adding?

Limits the maximum depth of a received JSON document to 16.

This applies to both MultiServer and CommonClient.

This means DataStorage default is limited to 14 levels, DataStorage op arg is limited to 13 levels.

## How was this tested?

Unit tests.