### PR TITLE
Test: flask duplicate route is now a ValueError

### DIFF
--- a/test/webhost/__init__.py
+++ b/test/webhost/__init__.py
@@ -31,6 +31,11 @@ class TestBase(unittest.TestCase):
             if "register_blueprint" not in e.args[0]:
                 raise
             cls.app = raw_app
+        except ValueError as e:
+            # as above, for more recent versions of flask this is now a ValueError
+            if "is already registered for this blueprint" not in e.args[0]:
+                raise
+            cls.app = raw_app
 
     def setUp(self) -> None:
         from WebHostLib.models import db


### PR DESCRIPTION
## What is this fixing or adding?

Sadly our WebHostLib is a bit of a mess and needs a work-around in tests.

Flask changed this from an assertion to a ValueError at some point, so we need to update the TestBase to also detect the ValueError.

## How was this tested?

#6379 fails without this because of the order the tests are instantiated/run in.