### PR TITLE
LADX: Allow nonlocal tarin's gift

### DIFF
--- a/worlds/ladx/LADXR/locations/startItem.py
+++ b/worlds/ladx/LADXR/locations/startItem.py
@@ -7,15 +7,11 @@ from ..roomEditor import RoomEditor
 
 
 class StartItem(DroppedKey):
-    MULTIWORLD = False
-
     def __init__(self):
         super().__init__(0x2A3)
         self.give_bowwow = False
 
     def patch(self, rom, option, *, multiworld=None):
-        assert multiworld is None
-
         if self.give_bowwow:
             option = BOWWOW
             rom.texts[0xC8] = formatText("Got BowWow!")
@@ -23,4 +19,4 @@ class StartItem(DroppedKey):
         if option != SHIELD:
             rom.patch(5, 0x0CDA, ASM("ld a, $22"), ASM("ld a, $00"))  # do not change links sprite into the one with a shield
 
-        super().patch(rom, option)
+        super().patch(rom, option, multiworld=multiworld)

--- a/worlds/ladx/LADXR/patches/tarin.py
+++ b/worlds/ladx/LADXR/patches/tarin.py
@@ -16,7 +16,7 @@ def updateTarin(rom):
         ld   a, $91
         call $2385
     """), ASM("""
-        ld   a, $0B ; GiveItemAndMessageForRoom
+        ld   a, $0E ; GiveItemAndMessageForRoomMultiworld
         rst  8
     """), fill_nop=True)
 


### PR DESCRIPTION
## What is this fixing or adding?
This allows the item on Tarin's Gift to be nonlocal, until this point it has been a forced local item.

The startItem.py change removes the rule restriction. The tarin.py change adjusts the in-game handler to be able to handle a nonlocal item.

## How was this tested?
It was introduced into the ladx beta with version 13.4.0, in March 2026
