### PR TITLE
Core: GUI/Kivy: Change some static default and hard-coded colors to use dynamic colors

### DIFF
--- a/Launcher.py
+++ b/Launcher.py
@@ -267,7 +267,6 @@ def run_gui(launch_components: list["Component"], args: Any) -> None:
             self.navigation = self.top_screen.ids.navigation
             self.button_layout = self.top_screen.ids.button_layout
             self.search_box = self.top_screen.ids.search_box
-            self.top_screen.md_bg_color = self.theme_cls.backgroundColor
 
             Window.bind(on_drop_file=self._on_drop_file)
             Window.bind(on_keyboard=self._on_keyboard)

--- a/data/client.kv
+++ b/data/client.kv
@@ -31,7 +31,7 @@
         text: root.text
         theme_text_color: "Custom"
         text_color_active: self.theme_cls.primaryColor
-        text_color_normal: 1, 1, 1, 1
+        text_color_normal: self.theme_cls.onSurfaceVariantColor
         # indicator is on icon only for some reason
         canvas.before:
             Color:
@@ -47,7 +47,7 @@
 <SelectableLabel>:
     size_hint: 1, None
     theme_text_color: "Custom"
-    text_color: 1, 1, 1, 1
+    text_color: self.theme_cls.onBackgroundColor
     canvas.before:
         Color:
             rgba: (self.theme_cls.primaryColor[0], self.theme_cls.primaryColor[1], self.theme_cls.primaryColor[2], .3) if self.selected else self.theme_cls.surfaceContainerLowestColor
@@ -171,6 +171,7 @@
     size_hint_x: 1
     size_hint_y: 1
     pos: (0, 0)
+    md_bg_color: self.theme_cls.backgroundColor
 <ToolTip>:
     size: self.texture_size
     size_hint: None, None
@@ -242,4 +243,3 @@
     halign: "center"
     text_size: self.width, None
     height: self.texture_size[1]
-

--- a/data/client.kv
+++ b/data/client.kv
@@ -47,7 +47,8 @@
 <SelectableLabel>:
     size_hint: 1, None
     theme_text_color: "Custom"
-    text_color: self.theme_cls.onBackgroundColor
+    text_color: self.theme_cls.onSurfaceColor
+    md_bg_color: self.theme_cls.surfaceContainerColor
     canvas.before:
         Color:
             rgba: (self.theme_cls.primaryColor[0], self.theme_cls.primaryColor[1], self.theme_cls.primaryColor[2], .3) if self.selected else self.theme_cls.surfaceContainerLowestColor

--- a/data/launcher.kv
+++ b/data/launcher.kv
@@ -62,6 +62,12 @@
                 text: "Open"
 
 
+<MDSnackBar>:
+    md_bg_color: self.theme_cls.surfaceContainerLowColor
+
+<MDSnackBarText>:
+    color: self.theme_cls.onSecondaryContainerColor
+
 MDFloatLayout:
     id: top_screen
 

--- a/data/launcher.kv
+++ b/data/launcher.kv
@@ -70,6 +70,7 @@ MDFloatLayout:
         cols: 2
         spacing: "5dp"
         padding: "10dp"
+        md_bg_color: self.theme_cls.backgroundColor
 
         MDGridLayout:
             id: navigation

--- a/kvui.py
+++ b/kvui.py
@@ -904,12 +904,6 @@ class GameManager(ThemedApp):
             return max(1, len(self.tabs.children))
         return 1
 
-    def on_start(self):
-        def on_start(*args):
-            self.root.md_bg_color = self.theme_cls.backgroundColor
-        super().on_start()
-        Clock.schedule_once(on_start)
-
     def build(self) -> Layout:
         self.set_colors()
         self.container = ContainerLayout()


### PR DESCRIPTION
This PR replaces some default colors in `client.kv` and `launcher.kv` to instead source from KivyMD ThemeManager's dynamic colors. Some colors hardcoded in `kvui.py` and `Launcher.py` have also been moved to their respective KV files.

## What is this fixing or adding?
This allows the Archipelago GUI to be able to better adapt to user preferences. Most importantly though, GameManager-inheriting Clients can now automatically set the color for the `SelectableLabel` widget. That widget was by default set to a static value of `(1, 1, 1, 1)`, which made it invisible. With this change, users who opt into Light mode will no longer need to change that widget color as well just to read the text in most clients. 

Accompanying changes were made for consistency and aesthetics. Such changes are kept to a minimum.

## How was this tested?
I tested both Light and Dark versions of `Lightsteelblue`, `Red`, `Violet`, `Green` and `Olive` on the Launcher and the Text Client. Options Creator and the OoT Client were also tested to a much lesser degree. Personally, legibility and contrast across all combinations are kept solid and high. These tests were performed on my machine, running Fedora 44 KDE.

Unittests were performed and run by GitHub Actions upon push. They all passed, though one test did need to be rerun before passing. (Python 3.13 - Windows Latest).

## If this makes graphical changes, please attach screenshots.
Provided screenshots showcase both Light and Dark versions of `Lightsteelblue` and `Red` with the PR applied.

<img width="1626" height="1044" alt="image" src="https://github.com/user-attachments/assets/09ef9860-8a97-434b-a73f-a0a763411f21" />
<img width="1629" height="1046" alt="image" src="https://github.com/user-attachments/assets/a806ac05-95d5-4ff9-8481-950c6406379c" />
<img width="1631" height="1040" alt="image" src="https://github.com/user-attachments/assets/36884945-d541-4891-8cdd-1a280ef6d3e8" />
<img width="1630" height="1050" alt="image" src="https://github.com/user-attachments/assets/18eea302-3148-4186-a9dd-1f8abfe45d9b" />

Additionally, the following is a screenshot from the 0.6.7 tarball, when using `Red` in Light Mode, to showcase the problem trying to be fixed.
<img width="1627" height="1050" alt="image" src="https://github.com/user-attachments/assets/96f29408-aa0b-46b6-b718-224819f701ed" />
