### PR TITLE
MultiServer: Await closing of websocket server

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2653,27 +2653,28 @@ def parse_args() -> argparse.Namespace:
     return args
 
 
-async def auto_shutdown(ctx, to_cancel=None):
+async def auto_shutdown(ctx: Context, to_cancel=None):
     with contextlib.suppress(asyncio.TimeoutError):
         await asyncio.wait_for(ctx.exit_event.wait(), ctx.auto_shutdown)
 
-    def inactivity_shutdown():
+    async def inactivity_shutdown():
         ctx.server.ws_server.close()
         ctx.exit_event.set()
         if to_cancel:
             for task in to_cancel:
                 task.cancel()
+        await ctx.server.ws_server.wait_closed()
         ctx.logger.info("Shutting down due to inactivity.")
 
     while not ctx.exit_event.is_set():
         if not ctx.client_activity_timers.values():
-            inactivity_shutdown()
+            await inactivity_shutdown()
         else:
             newest_activity = max(ctx.client_activity_timers.values())
             delta = datetime.datetime.now(datetime.timezone.utc) - newest_activity
             seconds = ctx.auto_shutdown - delta.total_seconds()
             if seconds < 0:
-                inactivity_shutdown()
+                await inactivity_shutdown()
             else:
                 with contextlib.suppress(asyncio.TimeoutError):
                     await asyncio.wait_for(ctx.exit_event.wait(), seconds)

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2257,10 +2257,7 @@ class ServerCommandProcessor(CommonCommandProcessor):
 
     def _cmd_exit(self) -> bool:
         """Shutdown the server"""
-        try:
-            self.ctx.server.ws_server.close()
-        finally:
-            self.ctx.exit_event.set()
+        self.ctx.exit_event.set()
         return True
 
     @mark_raw
@@ -2768,7 +2765,9 @@ async def main(args: argparse.Namespace):
             signal(sig, shutdown)
 
     await ctx.exit_event.wait()
+    ctx.server.ws_server.close()
     console_task.cancel()
+    await ctx.server.ws_server.wait_closed()
     if ctx.shutdown_task:
         await ctx.shutdown_task
 

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2657,7 +2657,7 @@ async def auto_shutdown(ctx: Context, to_cancel=None):
     with contextlib.suppress(asyncio.TimeoutError):
         await asyncio.wait_for(ctx.exit_event.wait(), ctx.auto_shutdown)
 
-    async def inactivity_shutdown():
+    def inactivity_shutdown():
         ctx.exit_event.set()
         if to_cancel:
             for task in to_cancel:
@@ -2666,13 +2666,13 @@ async def auto_shutdown(ctx: Context, to_cancel=None):
 
     while not ctx.exit_event.is_set():
         if not ctx.client_activity_timers.values():
-            await inactivity_shutdown()
+            inactivity_shutdown()
         else:
             newest_activity = max(ctx.client_activity_timers.values())
             delta = datetime.datetime.now(datetime.timezone.utc) - newest_activity
             seconds = ctx.auto_shutdown - delta.total_seconds()
             if seconds < 0:
-                await inactivity_shutdown()
+                inactivity_shutdown()
             else:
                 with contextlib.suppress(asyncio.TimeoutError):
                     await asyncio.wait_for(ctx.exit_event.wait(), seconds)

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2658,12 +2658,10 @@ async def auto_shutdown(ctx: Context, to_cancel=None):
         await asyncio.wait_for(ctx.exit_event.wait(), ctx.auto_shutdown)
 
     async def inactivity_shutdown():
-        ctx.server.ws_server.close()
         ctx.exit_event.set()
         if to_cancel:
             for task in to_cancel:
                 task.cancel()
-        await ctx.server.ws_server.wait_closed()
         ctx.logger.info("Shutting down due to inactivity.")
 
     while not ctx.exit_event.is_set():


### PR DESCRIPTION
## What is this fixing or adding?
MultiServer.py does not await closing of its websocket server, leading to non-graceful disconnections of connected clients. Ironically, the only way for a MultiServer to gracefully close a connection with a client, is if a network protocol packet sent by the client causes an Exception in the MultiServer. This PR lets a MultiServer gracefully disconnect clients.

I did a search through the repository to see if there are other occurrences of closing a server not being awaited, and there are indeed two clients for apworlds (`ahit` and `ladx`) create websocket servers of their own which don't even _try_ to close the server, let alone wait for it. The latter does comment that its server should run forever, though. Naturally acting on this is out of scope for this PR (as well as me not being the right person to act on it), but I figured making note of it would allow a world maintainer to act on it if deemed necessary.

## How was this tested?
Running a server locally, connecting a client and using the `/exit` command on the server; additionally, running a server locally with `--auto-shutdown=10`, connecting a client and waiting 10 seconds. In both cases, when observing the websocket close error code received at the client, before this change the code is [1006 (Abnormal Closure)](https://websocket.org/reference/close-codes/#1006-abnormal-closure), and after, the code is [1001 (Going Away)](https://websocket.org/reference/close-codes/#1001-going-away).

## If this makes graphical changes, please attach screenshots.
N/A