### PR TITLE
Docs: Client Libraries list

### DIFF
--- a/docs/adding games.md
+++ b/docs/adding games.md
@@ -17,7 +17,7 @@ it will not be detailed here.
 The client is an intermediary program between the game and the Archipelago server. This can either be a direct
 modification to the game, an external program, or both. This can be implemented in nearly any modern language, but it
 must fulfill a few requirements in order to function as expected. Libraries for most modern languages can be found in
-the [client libraries](docs/client_libraries.md) list and the spec for various packets can be found in the
+the [client libraries](/docs/client_libraries.md) list and the spec for various packets can be found in the
 [network protocol](/docs/network%20protocol.md) API reference document. Additional help with specific game engines and
 rom formats can be found in the #ap-modding-help channel in the [Discord](https://archipelago.gg/discord).
 

--- a/docs/adding games.md
+++ b/docs/adding games.md
@@ -16,9 +16,10 @@ it will not be detailed here.
 
 The client is an intermediary program between the game and the Archipelago server. This can either be a direct
 modification to the game, an external program, or both. This can be implemented in nearly any modern language, but it
-must fulfill a few requirements in order to function as expected. Libraries for most modern languages and the spec for 
-various packets can be found in the [network protocol](/docs/network%20protocol.md) API reference document. Additional help with specific game
-engines and rom formats can be found in the #ap-modding-help channel in the [Discord](https://archipelago.gg/discord).
+must fulfill a few requirements in order to function as expected. Libraries for most modern languages can be found in
+the [client libraries](docs/client_libraries.md) list and the spec for various packets can be found in the
+[network protocol](/docs/network%20protocol.md) API reference document. Additional help with specific game engines and
+rom formats can be found in the #ap-modding-help channel in the [Discord](https://archipelago.gg/discord).
 
 ### Hard Requirements
 

--- a/docs/client_libraries.md
+++ b/docs/client_libraries.md
@@ -1,0 +1,18 @@
+# Client Libraries
+
+There are a number of community-supported libraries available that implement the [network protocol](/docs/network%20protocol.md).
+
+| Language/Runtime        | Project                                                                                            | Remarks                                                                         |
+|-------------------------|----------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------|
+| Python                  | [Archipelago CommonClient](https://github.com/ArchipelagoMW/Archipelago/blob/main/CommonClient.py) |                                                                                 |
+|                         | [Archipelago SNIClient](https://github.com/ArchipelagoMW/Archipelago/blob/main/SNIClient.py)       | For Super Nintendo Game Support; Utilizes [SNI](https://github.com/alttpo/sni). |
+| JVM (Java / Kotlin)     | [Archipelago.MultiClient.Java](https://github.com/ArchipelagoMW/Archipelago.MultiClient.Java)      |                                                                                 |
+| .NET (C# / F# / VB.NET) | [Archipelago.MultiClient.Net](https://www.nuget.org/packages/Archipelago.MultiClient.Net)          |                                                                                 |
+| C++                     | [apclientpp](https://github.com/black-sliver/apclientpp)                                           | header-only                                                                     |
+|                         | [APCpp](https://github.com/N00byKing/APCpp)                                                        | CMake                                                                           |
+| JavaScript / TypeScript | [archipelago.js](https://www.npmjs.com/package/archipelago.js)                                     | Browser and Node.js Supported                                                   |
+| Haxe                    | [hxArchipelago](https://lib.haxe.org/p/hxArchipelago)                                              |                                                                                 |
+| Rust                    | [ArchipelagoRS](https://github.com/ryanisaacg/archipelago_rs)                                      |                                                                                 |
+| Lua                     | [lua-apclientpp](https://github.com/black-sliver/lua-apclientpp)                                   |                                                                                 |
+| Game Maker + Studio 1.x | [gm-apclientpp](https://github.com/black-sliver/gm-apclientpp)                                     | For GM7, GM8 and GMS1.x, maybe older                                            |
+| GameMaker: Studio 2.x+  | [see Discord](https://discord.com/channels/731205301247803413/1166418532519653396)                 |                                                                                 |

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -13,22 +13,7 @@ These steps should be followed in order to establish a gameplay connection with 
 
 In the case that the client does not authenticate properly and receives a [ConnectionRefused](#ConnectionRefused) then the server will maintain the connection and allow for follow-up [Connect](#Connect) packet.
 
-There are also a number of community-supported libraries available that implement this network protocol to make integrating with Archipelago easier.
-
-| Language/Runtime              | Project                                                                                            | Remarks                                                                         |
-|-------------------------------|----------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------|
-| Python                        | [Archipelago CommonClient](https://github.com/ArchipelagoMW/Archipelago/blob/main/CommonClient.py) |                                                                                 |
-|                               | [Archipelago SNIClient](https://github.com/ArchipelagoMW/Archipelago/blob/main/SNIClient.py)       | For Super Nintendo Game Support; Utilizes [SNI](https://github.com/alttpo/sni). |
-| JVM (Java / Kotlin)           | [Archipelago.MultiClient.Java](https://github.com/ArchipelagoMW/Archipelago.MultiClient.Java)      |                                                                                 |
-| .NET (C# / F# / VB.NET)       | [Archipelago.MultiClient.Net](https://www.nuget.org/packages/Archipelago.MultiClient.Net)          |                                                                                 |
-| C++                           | [apclientpp](https://github.com/black-sliver/apclientpp)                                           | header-only                                                                     |
-|                               | [APCpp](https://github.com/N00byKing/APCpp)                                                        | CMake                                                                           |
-| JavaScript / TypeScript       | [archipelago.js](https://www.npmjs.com/package/archipelago.js)                                     | Browser and Node.js Supported                                                   |
-| Haxe                          | [hxArchipelago](https://lib.haxe.org/p/hxArchipelago)                                              |                                                                                 |
-| Rust                          | [ArchipelagoRS](https://github.com/ryanisaacg/archipelago_rs)                                      |                                                                                 |
-| Lua                           | [lua-apclientpp](https://github.com/black-sliver/lua-apclientpp)                                   |                                                                                 |
-| Game Maker + Studio 1.x       | [gm-apclientpp](https://github.com/black-sliver/gm-apclientpp)                                     | For GM7, GM8 and GMS1.x, maybe older                                            |
-| GameMaker: Studio 2.x+        | [see Discord](https://discord.com/channels/731205301247803413/1166418532519653396)                 |                                                                                 |
+There are also a number of [community-supported libraries](client_libraries.md) available that implement this network protocol to make integrating with Archipelago easier.
 
 ## Synchronizing Items
 After a client connects, it will receive all previously collected items for its associated slot in a [ReceivedItems](#ReceivedItems) packet. This will include items the client may have already processed in a previous play session.  

--- a/docs/world api.md
+++ b/docs/world api.md
@@ -8,6 +8,7 @@ yours, and the following documents:
 
 * [network protocol.md](https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/network%20protocol.md)
 * [adding games.md](https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/adding%20games.md)
+* [community-supported libraries](client_libraries.md)
 
 Archipelago will be abbreviated as "AP" from now on.
 


### PR DESCRIPTION
## What is this fixing or adding?
Refactors the table of community-supported libraries from the network protocol to its own document.

## How was this tested?
Clicking links to be sure they linked to the new document.
