### PR TITLE
GER: Prefer expanding reachable regions in stage 1

### DIFF
--- a/docs/entrance randomization.md
+++ b/docs/entrance randomization.md
@@ -403,9 +403,9 @@ algorithms are shared
 ER uses a forward fill approach to create the region layout. First, ER collects `all_state` and performs a region sweep
 from Menu, similar to fill. ER then proceeds in stages to complete the randomization:
 1. Attempt to connect all non-dead-end regions.
-    1. Prioritze entrances that don't decrease placeable exits, either by providing a new exit or unblocking the access
+    1. Prioritize entrances that don't decrease placeable exits, either by providing a new exit or unblocking the access
        rule of an existing randomized exit.
-    2. If not such placements are valid or we already have enough placeable entrances, connect an entrance to an
+    2. If no such placements are valid or we already have enough placeable entrances, connect an entrance to an
        unreachable non-dead-end region.
 2. Attempt to connect all dead-end regions, so that all regions will be placed.
 3. Connect all remaining dangling edges now that all regions are placed.
@@ -417,7 +417,7 @@ The process for each connection will do the following:
 2. Get its group and check `target_group_lookup` to determine which groups are valid targets.
 3. Look up ER targets from those groups and find one which is valid according to `can_connect_to`
 4. Connect the source exit to the target's target_region and delete the target.
-   * In stage 1, when necessary an additional speculative sweep is performed to ensure
+   * In stage 1, when necessary, an additional speculative sweep is performed to ensure
      that there will be enough available exits after the placement so randomization can continue.
 5. If it's coupled mode, find the reverse exit and target by name and connect them as well.
 6. Sweep to update reachable regions.

--- a/docs/entrance randomization.md
+++ b/docs/entrance randomization.md
@@ -402,9 +402,12 @@ algorithms are shared
 
 ER uses a forward fill approach to create the region layout. First, ER collects `all_state` and performs a region sweep
 from Menu, similar to fill. ER then proceeds in stages to complete the randomization:
-1. Attempt to connect all non-dead-end regions, prioritizing access to unseen regions so there will always be new exits
-   to pair off.
-2. Attempt to connect all dead-end regions, so that all regions will be placed
+1. Attempt to connect all non-dead-end regions.
+    1. Prioritze entrances that don't decrease placeable exits, either by providing a new exit or unblocking the access
+       rule of an existing randomized exit.
+    2. If not such placements are valid or we already have enough placeable entrances, connect an entrance to an
+       unreachable non-dead-end region.
+2. Attempt to connect all dead-end regions, so that all regions will be placed.
 3. Connect all remaining dangling edges now that all regions are placed.
     1. Connect any other dead end entrances (e.g. second entrances to the same dead end regions).
     2. Connect all remaining non-dead-ends amongst each other.
@@ -414,8 +417,8 @@ The process for each connection will do the following:
 2. Get its group and check `target_group_lookup` to determine which groups are valid targets.
 3. Look up ER targets from those groups and find one which is valid according to `can_connect_to`
 4. Connect the source exit to the target's target_region and delete the target.
-   * In stage 1, before placing the last valid source transition, an additional speculative sweep is performed to ensure
-     that there will be an available exit after the placement so randomization can continue.
+   * In stage 1, when necessary an additional speculative sweep is performed to ensure
+     that there will be enough available exits after the placement so randomization can continue.
 5. If it's coupled mode, find the reverse exit and target by name and connect them as well.
 6. Sweep to update reachable regions.
 7. Call the `on_connect` callback.

--- a/docs/entrance randomization.md
+++ b/docs/entrance randomization.md
@@ -403,10 +403,10 @@ algorithms are shared
 ER uses a forward fill approach to create the region layout. First, ER collects `all_state` and performs a region sweep
 from Menu, similar to fill. ER then proceeds in stages to complete the randomization:
 1. Attempt to connect all non-dead-end regions.
-    1. Prioritize entrances that don't decrease placeable exits, either by providing a new exit or unblocking the access
-       rule of an existing randomized exit.
-    2. If no such placements are valid or we already have enough placeable entrances, connect an entrance to an
-       unreachable non-dead-end region.
+    1. When using `ERAlgorithm.EXPANDING`, prioritize entrances that don't decrease placeable exits. This can happen by
+       providing a new exit or unblocking the access rule of an existing randomized exit.
+    2. If no such placements are valid, we already have enough placeable entrances, or using `ERAlgorithm.FAST`,
+       connect an entrance to a currently unreachable non-dead-end region.
 2. Attempt to connect all dead-end regions, so that all regions will be placed.
 3. Connect all remaining dangling edges now that all regions are placed.
     1. Connect any other dead end entrances (e.g. second entrances to the same dead end regions).
@@ -417,7 +417,7 @@ The process for each connection will do the following:
 2. Get its group and check `target_group_lookup` to determine which groups are valid targets.
 3. Look up ER targets from those groups and find one which is valid according to `can_connect_to`
 4. Connect the source exit to the target's target_region and delete the target.
-   * In stage 1, when necessary, an additional speculative sweep is performed to ensure
+   * In stage 1, according to the algorithm selected, an additional speculative sweep might be performed to ensure
      that there will be enough available exits after the placement so randomization can continue.
 5. If it's coupled mode, find the reverse exit and target by name and connect them as well.
 6. Sweep to update reachable regions.

--- a/entrance_rando.py
+++ b/entrance_rando.py
@@ -230,7 +230,7 @@ class ERPlacementState:
         self.entrance_lookup.remove(target_entrance)
 
     def test_speculative_connection(self, source_exit: Entrance, target_entrance: Entrance,
-                                    usable_exits: set[Entrance], required_exit_count: int) -> bool:
+                                    usable_exits: set[Entrance], placeable_exits: set[Entrance]) -> bool:
         copied_state = self.collection_state.copy()
         # simulated connection. A real connection is unsafe because the region graph is shallow-copied and would
         # propagate back to the real multiworld.
@@ -242,8 +242,7 @@ class ERPlacementState:
             copied_state.update_reachable_regions(self.world.player)
             copied_state.sweep_for_advancements(self.world.get_locations())
             stale = copied_state.stale[self.world.player]
-        # test that at there are at least required_exit_count placable randomized exits
-        placeable_exit_count = 0
+        # test that at there is at least one new placeable exit
         available_randomized_exits = copied_state.blocked_connections[self.world.player]
         for _exit in available_randomized_exits:
             if _exit.connected_region:
@@ -254,13 +253,14 @@ class ERPlacementState:
             # make sure we are only paying attention to usable exits
             if _exit not in usable_exits:
                 continue
+            # only check for new placeable exits
+            if _exit in placeable_exits:
+                continue
             # technically this should be is_valid_source_transition, but that may rely on side effects from
             # on_connect, which have not happened here (because we didn't do a real connection, and if we did, we would
             # not want them to persist). can_reach is a close enough approximation most of the time.
             if _exit.can_reach(copied_state):
-                placeable_exit_count += 1
-                if placeable_exit_count >= required_exit_count:
-                    return True
+                return True
         return False
 
     def connect(
@@ -436,19 +436,49 @@ def randomize_entrances(
                 er_state.collection_state.sweep_for_advancements()
                 stale = er_state.collection_state.stale[world.player]
 
-    def needs_speculative_sweep(dead_end: bool, exit_requirement: ExitRequirement, placeable_exits: list[Entrance]) -> bool:
+    def needs_speculative_sweep(dead_end: bool, exit_requirement: ExitRequirement, placeable_exits: set[Entrance]) -> bool:
         # in certain stages of randomization we either expect or don't care if the search space shrinks.
         # we should never speculative sweep here.
         if dead_end or exit_requirement == ExitRequirement.NONE or not perform_validity_check:
             return False
 
-        # speculative sweep is expensive. Don't use speculative sweep if there are more placable exits than remaining
-        # entrances to place.
-        return len(placeable_exits) < len(er_state.entrance_lookup.others)
+        # when in NEW_REGIONS mode, only speculative sweep if we are placing the last exit
+        if exit_requirement == ExitRequirement.NEW_REGIONS:
+            if len(placeable_exits) > 1:
+                return False
+
+            # edge case - if all dead ends have pre-placed progression or indirect connections, they are pulled forward
+            # into the non dead end stage. In this case, and only this case, it's possible that the last connection may
+            # actually be placeable in stage 1. We need to skip speculative sweep in this case because we expect the
+            # graph to get capped off.
+
+            # check to see if we are proposing the last placement
+            if not coupled:
+                # in uncoupled, this check is easy as there will only be one target.
+                is_last_placement = len(er_state.entrance_lookup) == 1
+            else:
+                # a bit harder, there may be 1 or 2 targets depending on if the exit to place is one way or two way.
+                # if it is two way, we can safely assume that one of the targets is the logical pair of the exit.
+                desired_target_count = 2 if next(iter(placeable_exits)).randomization_type == EntranceType.TWO_WAY else 1
+                is_last_placement = len(er_state.entrance_lookup) == desired_target_count
+            # if it's not the last placement, we need a sweep
+            return not is_last_placement
+
+        # when in MORE_EXITS, only speculative sweep if there are more new entrances to place than placable exits
+        if exit_requirement == ExitRequirement.MORE_EXITS:
+            new_entrances = 0
+            for entrance in itertools.chain(er_state.entrance_lookup.others, er_state.entrance_lookup.dead_ends):
+                # only count coupled two way entrances if their matching exit isn't a placeable exit
+                if entrance.connected_region not in er_state.placed_regions:
+                    new_entrances += 1
+                    if new_entrances > len(placeable_exits):
+                        return True
+        return False
 
     def find_pairing(dead_end: bool, exit_requirement: ExitRequirement) -> bool:
         nonlocal perform_validity_check
         placeable_exits = er_state.find_placeable_exits(perform_validity_check, exits)
+        placeable_exits_set = set(placeable_exits)
         for source_exit in placeable_exits:
             target_groups = target_group_lookup[source_exit.randomization_group]
             for target_entrance in er_state.entrance_lookup.get_targets(target_groups, dead_end, preserve_group_order):
@@ -461,9 +491,8 @@ def randomize_entrances(
                 exit_requirement_satisfied = (not perform_validity_check or exit_requirement == ExitRequirement.NONE
                                               or target_entrance.connected_region not in er_state.placed_regions)
                 if exit_requirement_satisfied and source_exit.can_connect_to(target_entrance, dead_end, er_state):
-                    required_exit_count = len(placeable_exits) if exit_requirement == ExitRequirement.MORE_EXITS else 1
-                    if (needs_speculative_sweep(dead_end, exit_requirement, placeable_exits)
-                            and not er_state.test_speculative_connection(source_exit, target_entrance, exits_set, required_exit_count)):
+                    if (needs_speculative_sweep(dead_end, exit_requirement, placeable_exits_set)
+                            and not er_state.test_speculative_connection(source_exit, target_entrance, exits_set, placeable_exits_set)):
                         continue
                     do_placement(source_exit, target_entrance)
                     return True

--- a/entrance_rando.py
+++ b/entrance_rando.py
@@ -4,6 +4,7 @@ import random
 import time
 from collections import deque
 from collections.abc import Callable, Iterable
+from enum import IntEnum
 
 from BaseClasses import CollectionState, Entrance, Region, EntranceType
 from Options import Accessibility
@@ -229,7 +230,7 @@ class ERPlacementState:
         self.entrance_lookup.remove(target_entrance)
 
     def test_speculative_connection(self, source_exit: Entrance, target_entrance: Entrance,
-                                    usable_exits: set[Entrance]) -> bool:
+                                    usable_exits: set[Entrance], required_exit_count: int) -> bool:
         copied_state = self.collection_state.copy()
         # simulated connection. A real connection is unsafe because the region graph is shallow-copied and would
         # propagate back to the real multiworld.
@@ -241,7 +242,8 @@ class ERPlacementState:
             copied_state.update_reachable_regions(self.world.player)
             copied_state.sweep_for_advancements(self.world.get_locations())
             stale = copied_state.stale[self.world.player]
-        # test that at there are newly reachable randomized exits that are ACTUALLY reachable
+        # test that at there are at least required_exit_count placable randomized exits
+        placeable_exit_count = 0
         available_randomized_exits = copied_state.blocked_connections[self.world.player]
         for _exit in available_randomized_exits:
             if _exit.connected_region:
@@ -256,7 +258,9 @@ class ERPlacementState:
             # on_connect, which have not happened here (because we didn't do a real connection, and if we did, we would
             # not want them to persist). can_reach is a close enough approximation most of the time.
             if _exit.can_reach(copied_state):
-                return True
+                placeable_exit_count += 1
+                if placeable_exit_count >= required_exit_count:
+                    return True
         return False
 
     def connect(
@@ -412,6 +416,11 @@ def randomize_entrances(
     # place the menu region and connected start region(s)
     er_state.collection_state.update_reachable_regions(world.player)
 
+    class ExitRequirement(IntEnum):
+        NONE = 1
+        NEW_REGIONS = 2
+        MORE_EXITS = 3
+
     def do_placement(source_exit: Entrance, target_entrance: Entrance) -> None:
         placed_exits, paired_entrances = er_state.connect(source_exit, target_entrance)
         # propagate new connections
@@ -427,55 +436,43 @@ def randomize_entrances(
                 er_state.collection_state.sweep_for_advancements()
                 stale = er_state.collection_state.stale[world.player]
 
-    def needs_speculative_sweep(dead_end: bool, require_new_exits: bool, placeable_exits: list[Entrance]) -> bool:
-        # speculative sweep is expensive. We currently only do it as a last resort, if we might cap off the graph
-        # entirely
-        if len(placeable_exits) > 1:
-            return False
-
+    def needs_speculative_sweep(dead_end: bool, exit_requirement: ExitRequirement, placeable_exits: list[Entrance]) -> bool:
         # in certain stages of randomization we either expect or don't care if the search space shrinks.
         # we should never speculative sweep here.
-        if dead_end or not require_new_exits or not perform_validity_check:
+        if dead_end or exit_requirement == ExitRequirement.NONE or not perform_validity_check:
             return False
 
-        # edge case - if all dead ends have pre-placed progression or indirect connections, they are pulled forward
-        # into the non dead end stage. In this case, and only this case, it's possible that the last connection may
-        # actually be placeable in stage 1. We need to skip speculative sweep in this case because we expect the graph
-        # to get capped off.
+        # speculative sweep is expensive. Don't use speculative sweep if there are more placable exits than remaining
+        # entrances to place.
+        return len(placeable_exits) < len(er_state.entrance_lookup.others)
 
-        # check to see if we are proposing the last placement
-        if not coupled:
-            # in uncoupled, this check is easy as there will only be one target.
-            is_last_placement = len(er_state.entrance_lookup) == 1
-        else:
-            # a bit harder, there may be 1 or 2 targets depending on if the exit to place is one way or two way.
-            # if it is two way, we can safely assume that one of the targets is the logical pair of the exit.
-            desired_target_count = 2 if placeable_exits[0].randomization_type == EntranceType.TWO_WAY else 1
-            is_last_placement = len(er_state.entrance_lookup) == desired_target_count
-        # if it's not the last placement, we need a sweep
-        return not is_last_placement
-
-    def find_pairing(dead_end: bool, require_new_exits: bool) -> bool:
+    def find_pairing(dead_end: bool, exit_requirement: ExitRequirement) -> bool:
         nonlocal perform_validity_check
         placeable_exits = er_state.find_placeable_exits(perform_validity_check, exits)
         for source_exit in placeable_exits:
             target_groups = target_group_lookup[source_exit.randomization_group]
             for target_entrance in er_state.entrance_lookup.get_targets(target_groups, dead_end, preserve_group_order):
                 # when requiring new exits, ideally we would like to make it so that every placement increases
-                # (or keeps the same number of) reachable exits. The goal is to continue to expand the search space
-                # so that we do not crash. In the interest of performance and bias reduction, generally, just checking
-                # that we are going to a new region is a good approximation. however, we should take extra care on the
-                # very last exit and check whatever exits we open up are functionally accessible.
-                # this requirement can be ignored on a beaten minimal, islands are no issue there.
-                exit_requirement_satisfied = (not perform_validity_check or not require_new_exits
+                # (or keeps the same number of) reachable exits (MORE_EXITS mode). The goal is to continue to expand the
+                # search space so that we do not crash. However, there are some cases where we need to place entrances
+                # that decrease reachable exits in order to satisfy future entrance access rules. If there are no valid
+                # placements in MORE_EXITS mode, we switch to NEW_REGIONS mode that just checks that we are going to a
+                # new region and that we have at least one reachable exit.
+                exit_requirement_satisfied = (not perform_validity_check or exit_requirement == ExitRequirement.NONE
                                               or target_entrance.connected_region not in er_state.placed_regions)
                 if exit_requirement_satisfied and source_exit.can_connect_to(target_entrance, dead_end, er_state):
-                    if (needs_speculative_sweep(dead_end, require_new_exits, placeable_exits)
-                            and not er_state.test_speculative_connection(source_exit, target_entrance, exits_set)):
+                    required_exit_count = len(placeable_exits) if exit_requirement == ExitRequirement.MORE_EXITS else 1
+                    if (needs_speculative_sweep(dead_end, exit_requirement, placeable_exits)
+                            and not er_state.test_speculative_connection(source_exit, target_entrance, exits_set, required_exit_count)):
                         continue
                     do_placement(source_exit, target_entrance)
                     return True
         else:
+            # in the stage where we are looking for more (or the same number of) reachable exits, just move on to the
+            # next stage.
+            if exit_requirement == ExitRequirement.MORE_EXITS:
+                return False
+
             # no source exits had any valid target so this stage is deadlocked. retries may be implemented if early
             # deadlocking is a frequent issue.
             lookup = er_state.entrance_lookup.dead_ends if dead_end else er_state.entrance_lookup.others
@@ -483,7 +480,7 @@ def randomize_entrances(
             # if we're in a stage where we're trying to get to new regions, we could also enter this
             # branch in a success state (when all regions of the preferred type have been placed, but there are still
             # additional unplaced entrances into those regions)
-            if require_new_exits:
+            if exit_requirement == ExitRequirement.NEW_REGIONS:
                 if all(e.connected_region in er_state.placed_regions for e in lookup):
                     return False
 
@@ -513,7 +510,7 @@ def randomize_entrances(
             unplaced_exits = [exit_ for region in world.multiworld.get_regions(world.player)
                               for exit_ in region.exits if not exit_.connected_region]
             entrance_kind = "dead ends" if dead_end else "non-dead ends"
-            region_access_requirement = "requires" if require_new_exits else "does not require"
+            region_access_requirement = "requires" if exit_requirement == ExitRequirement.NEW_REGIONS else "does not require"
             raise EntranceRandomizationError(
                 f"None of the available entrances are valid targets for the available exits.\n"
                 f"Randomization stage is placing {entrance_kind} and {region_access_requirement} "
@@ -525,21 +522,22 @@ def randomize_entrances(
 
     # stage 1 - try to place all the non-dead-end entrances
     while er_state.entrance_lookup.others:
-        if not find_pairing(dead_end=False, require_new_exits=True):
-            break
+        if not find_pairing(dead_end=False, exit_requirement=ExitRequirement.MORE_EXITS):
+            if not find_pairing(dead_end=False, exit_requirement=ExitRequirement.NEW_REGIONS):
+                break
     # stage 2 - try to place all the dead-end entrances
     while er_state.entrance_lookup.dead_ends:
-        if not find_pairing(dead_end=True, require_new_exits=True):
+        if not find_pairing(dead_end=True, exit_requirement=ExitRequirement.NEW_REGIONS):
             break
     # stage 3 - all the regions should be placed at this point. We now need to connect dangling edges
     # stage 3a - get the rest of the dead ends (e.g. second entrances into already-visited regions)
     #            doing this before the non-dead-ends is important to ensure there are enough connections to
     #            go around
     while er_state.entrance_lookup.dead_ends:
-        find_pairing(dead_end=True, require_new_exits=False)
+        find_pairing(dead_end=True, exit_requirement=ExitRequirement.NONE)
     # stage 3b - tie all the other loose ends connecting visited regions to each other
     while er_state.entrance_lookup.others:
-        find_pairing(dead_end=False, require_new_exits=False)
+        find_pairing(dead_end=False, exit_requirement=ExitRequirement.NONE)
 
     running_time = time.perf_counter() - start_time
     if running_time > 1.0:

--- a/entrance_rando.py
+++ b/entrance_rando.py
@@ -236,8 +236,11 @@ class ERPlacementState:
         copied_state.reachable_regions[self.world.player].add(target_entrance.connected_region)
         copied_state.blocked_connections[self.world.player].remove(source_exit)
         copied_state.blocked_connections[self.world.player].update(target_entrance.connected_region.exits)
-        copied_state.update_reachable_regions(self.world.player)
-        copied_state.sweep_for_advancements(self.world.get_locations())
+        stale = True
+        while stale:
+            copied_state.update_reachable_regions(self.world.player)
+            copied_state.sweep_for_advancements(self.world.get_locations())
+            stale = copied_state.stale[self.world.player]
         # test that at there are newly reachable randomized exits that are ACTUALLY reachable
         available_randomized_exits = copied_state.blocked_connections[self.world.player]
         for _exit in available_randomized_exits:
@@ -412,13 +415,17 @@ def randomize_entrances(
     def do_placement(source_exit: Entrance, target_entrance: Entrance) -> None:
         placed_exits, paired_entrances = er_state.connect(source_exit, target_entrance)
         # propagate new connections
-        er_state.collection_state.update_reachable_regions(world.player)
-        er_state.collection_state.sweep_for_advancements(world.get_locations())
+        stale = True
+        while stale:
+            er_state.collection_state.update_reachable_regions(world.player)
+            er_state.collection_state.sweep_for_advancements(world.get_locations())
+            stale = er_state.collection_state.stale[world.player]
         if on_connect:
-            change = on_connect(er_state, placed_exits, paired_entrances)
-            if change:
+            stale = on_connect(er_state, placed_exits, paired_entrances)
+            while stale:
                 er_state.collection_state.update_reachable_regions(world.player)
                 er_state.collection_state.sweep_for_advancements()
+                stale = er_state.collection_state.stale[world.player]
 
     def needs_speculative_sweep(dead_end: bool, require_new_exits: bool, placeable_exits: list[Entrance]) -> bool:
         # speculative sweep is expensive. We currently only do it as a last resort, if we might cap off the graph

--- a/entrance_rando.py
+++ b/entrance_rando.py
@@ -356,6 +356,11 @@ def disconnect_entrance_for_randomization(entrance: Entrance, target_group: int 
     target.randomization_group = target_group or entrance.randomization_group
 
 
+class ERAlgorithm(IntEnum):
+    EXPANDING = 0
+    FAST = 1
+
+
 def randomize_entrances(
         world: World,
         coupled: bool,
@@ -363,7 +368,9 @@ def randomize_entrances(
         preserve_group_order: bool = False,
         er_targets: list[Entrance] | None = None,
         exits: list[Entrance] | None = None,
-        on_connect: Callable[[ERPlacementState, list[Entrance], list[Entrance]], bool | None] | None = None
+        on_connect: Callable[[ERPlacementState, list[Entrance], list[Entrance]], bool | None] | None = None,
+        *,
+        algorithm: ERAlgorithm = ERAlgorithm.EXPANDING,
 ) -> ERPlacementState:
     """
     Randomizes Entrances for a single world in the multiworld.
@@ -386,6 +393,13 @@ def randomize_entrances(
                        3. The entrances they were connected to.
                        If you use on_connect to make additional placements, you are expected to return True to inform
                        GER that an additional sweep is needed.
+    :param algorithm: Which algorithm to use when randomizing entrances. Options are:
+                      ERAlgorithm.EXPANDING - Prioritizes entrances that don't decrease placeable exits via running a
+                                              speculative sweep at the cost of performance. Will provide a lower failure
+                                              rate for worlds with complicated rules and target_group_lookups.
+                      ERAlgorithm.FAST - Prioritizes speed using a faster and less accurate heuristic for picking
+                                         entrances that will expand the region graph. Will provide faster randomization
+                                         times for games with a large number of entrances.
     """
     if not world.explicit_indirect_conditions:
         raise EntranceRandomizationError("Entrance randomization requires explicit indirect conditions in order "
@@ -417,9 +431,9 @@ def randomize_entrances(
     er_state.collection_state.update_reachable_regions(world.player)
 
     class ExitRequirement(IntEnum):
-        NONE = 1
-        NEW_REGIONS = 2
-        MORE_EXITS = 3
+        NONE = 0
+        NEW_REGIONS = 1
+        MORE_EXITS = 2
 
     def do_placement(source_exit: Entrance, target_entrance: Entrance) -> None:
         placed_exits, paired_entrances = er_state.connect(source_exit, target_entrance)
@@ -551,7 +565,8 @@ def randomize_entrances(
 
     # stage 1 - try to place all the non-dead-end entrances
     while er_state.entrance_lookup.others:
-        if not find_pairing(dead_end=False, exit_requirement=ExitRequirement.MORE_EXITS):
+        if not (algorithm == ERAlgorithm.EXPANDING and
+                find_pairing(dead_end=False, exit_requirement=ExitRequirement.MORE_EXITS)):
             if not find_pairing(dead_end=False, exit_requirement=ExitRequirement.NEW_REGIONS):
                 break
     # stage 2 - try to place all the dead-end entrances

--- a/entrance_rando.py
+++ b/entrance_rando.py
@@ -359,13 +359,17 @@ def disconnect_entrance_for_randomization(entrance: Entrance, target_group: int 
 class ERAlgorithm(IntEnum):
     """
     Changes the behavior of randomize_entrances.
-    EXPANDING -> Prioritizes entrances that don't decrease placeable exits via running a speculative sweep at the cost
-        of performance. Will provide a lower failure rate for worlds with complicated rules and target_group_lookups.
-    FAST -> Prioritizes speed using a faster and less accurate heuristic for picking entrances that will expand the
-        region graph. Will provide faster randomization times for games with a large number of entrances.
     """
     EXPANDING = 0
+    """
+    Prioritizes entrances that don't decrease placeable exits via running a speculative sweep at the cost
+     of performance. Will provide a lower failure rate for worlds with complicated rules and target_group_lookups.
+     """
     FAST = 1
+    """
+    Prioritizes speed using a faster and less accurate heuristic for picking entrances that will expand the
+    region graph. Will provide faster randomization times for games with a large number of entrances.
+    """
 
 
 def randomize_entrances(

--- a/entrance_rando.py
+++ b/entrance_rando.py
@@ -363,8 +363,8 @@ class ERAlgorithm(IntEnum):
     EXPANDING = 0
     """
     Prioritizes entrances that don't decrease placeable exits via running a speculative sweep at the cost
-     of performance. Will provide a lower failure rate for worlds with complicated rules and target_group_lookups.
-     """
+    of performance. Will provide a lower failure rate for worlds with complicated rules and target_group_lookups.
+    """
     FAST = 1
     """
     Prioritizes speed using a faster and less accurate heuristic for picking entrances that will expand the

--- a/entrance_rando.py
+++ b/entrance_rando.py
@@ -357,6 +357,13 @@ def disconnect_entrance_for_randomization(entrance: Entrance, target_group: int 
 
 
 class ERAlgorithm(IntEnum):
+    """
+    Changes the behavior of randomize_entrances.
+    EXPANDING -> Prioritizes entrances that don't decrease placeable exits via running a speculative sweep at the cost
+        of performance. Will provide a lower failure rate for worlds with complicated rules and target_group_lookups.
+    FAST -> Prioritizes speed using a faster and less accurate heuristic for picking entrances that will expand the
+        region graph. Will provide faster randomization times for games with a large number of entrances.
+    """
     EXPANDING = 0
     FAST = 1
 
@@ -393,13 +400,7 @@ def randomize_entrances(
                        3. The entrances they were connected to.
                        If you use on_connect to make additional placements, you are expected to return True to inform
                        GER that an additional sweep is needed.
-    :param algorithm: Which algorithm to use when randomizing entrances. Options are:
-                      ERAlgorithm.EXPANDING - Prioritizes entrances that don't decrease placeable exits via running a
-                                              speculative sweep at the cost of performance. Will provide a lower failure
-                                              rate for worlds with complicated rules and target_group_lookups.
-                      ERAlgorithm.FAST - Prioritizes speed using a faster and less accurate heuristic for picking
-                                         entrances that will expand the region graph. Will provide faster randomization
-                                         times for games with a large number of entrances.
+    :param algorithm: Which algorithm to use when randomizing entrances
     """
     if not world.explicit_indirect_conditions:
         raise EntranceRandomizationError("Entrance randomization requires explicit indirect conditions in order "

--- a/test/general/test_entrance_rando.py
+++ b/test/general/test_entrance_rando.py
@@ -531,3 +531,34 @@ class TestRandomizeEntrances(unittest.TestCase):
 
         self.assertRaises(EntranceRandomizationError, randomize_entrances, multiworld.worlds[1], False,
                           directionally_matched_group_lookup)
+
+    def test_stale_region_access_after_sweep(self):
+        """tests that entrance randomization doesn't fail due to having stale region access after speculative sweep"""
+        multiworld = generate_test_multiworld()
+
+        menu = multiworld.get_region("Menu", 1)
+        r1 = Region("r1", 1, multiworld)
+        r2 = Region("r2", 1, multiworld)
+        r3 = Region("r3", 1, multiworld)
+        multiworld.regions.append(r1)
+        multiworld.regions.append(r2)
+        multiworld.regions.append(r3)
+
+        # place event in r2
+        location = generate_locations(1, 1, r2)[0]
+        prog_item = generate_items(1, 1, True)[0]
+        location.place_locked_item(prog_item)
+
+        # should be first connection made
+        generate_entrance_pair(menu, "_right", ERTestGroups.RIGHT)
+        generate_entrance_pair(r2, "_left", ERTestGroups.LEFT)
+        # r1 should be accessible after sweeping for the prog_item event in r2
+        menu.connect(r1, rule=lambda state: state.has(prog_item.name, 1))
+        # after r1 is reachable, should be second connection made
+        generate_entrance_pair(r1, "_bottom", ERTestGroups.BOTTOM)
+        generate_entrance_pair(r3, "_top", ERTestGroups.TOP)
+
+        result = randomize_entrances(multiworld.worlds[1], True, directionally_matched_group_lookup)
+        # should be fully connected
+        self.assertTrue(("Menu_right", "r2_left") in result.pairings
+                        and ("r1_bottom", "r3_top") in result.pairings)


### PR DESCRIPTION
## What is this fixing or adding?

Changes the behavior of GER to prefer expanding reachable regions in stage 1 (when placing non-dead-end entrances to reach new regions). As long as there is a valid placement and there are less reachable randomized exits than to be placed non-dead-end entrances, it will try to run `test_speculative_connection` to make sure the reachable randomized exit count doesn't decrease. However, it is possible to run out of valid placements and need to place entrances that decrease reachable exits in order to satisfy future entrance access rules.

These changes were motivated by trying to solve an issue with my world where GER was often painting itself into a corner. Some of these issues I was able to solve with complicated `can_connect_to` function but that required playing a lot of whack-a-mole and the resulting code is not very maintainable. With these generic GER changes, I was able to greatly simplify my `can_connect_to` function while improving my ER failure rate. Here are some cases that these changes handle generically that I previously had to specifically account for in my `can_connect_to` function.

1. Regions where only one entrance is randomized and the other is a non randomized entrance that is impassible until it's been unlocked from the other end
2. Making sure expanding dead end regions are not placed if they would cap off that area randomization group
3. Regions where only one entrance is randomized and the other is a non randomized entrance that requires another region to be reachable (I was only allowing these to be placed if their requirements where met to make the entrance passable)

Additionally, this change uncovered a bug where GER wasn't updating reachable regions correctly in `test_speculative_connection` and `do_placement`. It was calling `update_reachable_regions` followed by `sweep_for_advancements`. The latter has the chance to collect items and stale the collection state, requiring more rounds of `update_reachable_regions` followed by `sweep_for_advancements` until nothing is collected.

## How was this tested?

Fuzzing for GER failures and benchmark times.

I tested four worlds that implement GER: Toem (my world), Stardew Valley (core), The Messenger (core), and Hollow Knight (beta). The latter three worlds already had a 0% GER failure rate which was maintained by these changes. On the worst case settings with no retries, Toem has a 11% GER failure rate with the complicated `can_connect_to` before these changes, a 57% GER failure rate with the simple `can_connect_to` before these changes, and a 0% GER failure rate with the simple `can_connect_to` after these changes. The failure rate before these changes can be improved by retrying GER, but obviously that comes at the cost of taking more time.

However, these changes are slower per GER run (around 3-4 times worse in some cases). This is due to more aggressively running `test_speculative_connection` which is reasonably expensive. Here is a table of benchmark times for ER for all the worlds. Note that Toem v1 is with the complicated `can_connect_to` and v2 is the simple `can_connect_to`. These times include retries for Toem as well.

| World | Avg. entrance count | Avg. time before | Avg. time after |
| --- | --- | --- | --- |
| Toem v1 | 162 | 0.0273 s | N/A |
| Toem v2 | 162 | 0.0548 s | 0.0695 s |
| Stardew Valley | 80 | 0.0573 s | 0.0558 s |
| The Messenger | 37 | 0.0061 s | 0.0285 s |
| Hollow Knight | 868 | 2.2350 s | 8.0563 s |