### PR TITLE
Aquaria - fixing some logic bugs

### DIFF
--- a/worlds/aquaria/Regions.py
+++ b/worlds/aquaria/Regions.py
@@ -49,6 +49,10 @@ def _has_energy_attack_item(state: CollectionState, player: int) -> bool:
     """`player` in `state` has items that can do a lot of damage (enough to beat bosses)"""
     return _has_energy_form(state, player) or _has_dual_form(state, player)
 
+def _has_final_boss_item(state: CollectionState, player: int) -> bool:
+    """`player` in `state` has items that is necessary to beat the final boss"""
+    return (_has_energy_form(state, player) and _has_dual_form(state, player) and
+            _has_sun_form(state, player) and _has_bind_song(state, player))
 
 def _has_shield_song(state: CollectionState, player: int) -> bool:
     """`player` in `state` has the shield song item"""
@@ -832,11 +836,11 @@ class AquariaRegions:
         Connect entrances of the different regions around The Body
         """
         self.__connect_one_way_regions(self.body_c, self.body_l,
-                                       lambda state: _has_energy_form(state, self.player))
+                                       lambda state: _has_energy_attack_item(state, self.player))
         self.__connect_one_way_regions(self.body_l, self.body_c)
         self.__connect_regions(self.body_c, self.body_rt)
         self.__connect_one_way_regions(self.body_c, self.body_rb,
-                                       lambda state: _has_energy_form(state, self.player))
+                                       lambda state: _has_energy_attack_item(state, self.player))
         self.__connect_one_way_regions(self.body_rb, self.body_c)
         self.__connect_regions(self.body_c, self.body_b,
                                lambda state: _has_dual_form(state, self.player))
@@ -845,25 +849,26 @@ class AquariaRegions:
         self.__connect_regions(self.final_boss_lobby, self.final_boss_tube,
                                lambda state: _has_nature_form(state, self.player))
         self.__connect_one_way_regions(self.final_boss_lobby, self.final_boss,
-                                       lambda state: _has_energy_form(state, self.player) and
-                                                     _has_dual_form(state, self.player) and
-                                                     _has_sun_form(state, self.player) and
-                                                     _has_bind_song(state, self.player))
+                                       lambda state: _has_final_boss_item(state, self.player))
         self.__connect_one_way_regions(self.final_boss, self.final_boss_end)
 
     def __connect_four_gods_end(self, options: AquariaOptions) -> None:
         """
         Connect an entrance for the four gods objective ending
         """
-        if options.mini_bosses_to_beat.value > 6:
-            victory_lambda = lambda state: (_has_four_gods_beated(state, self.player) and
-                                            _has_mini_bosses(state, self.player))
-        elif options.big_bosses_to_beat.value > 0:
-            victory_lambda = lambda state: (_has_four_gods_beated(state, self.player) and
-                                            _has_mini_bosses_four_gods(state, self.player))
-        else:
-            victory_lambda = lambda state: _has_four_gods_beated(state, self.player)
-        self.__connect_one_way_regions(self.menu, self.four_gods_end, victory_lambda)
+        mini_bosses_lambda = lambda state: True
+        if options.mini_bosses_to_beat.value > 0:
+            mini_bosses_lambda = lambda state: _has_mini_bosses(state, self.player)
+        big_bosses_lambda = lambda state: True
+        if options.big_bosses_to_beat.value > 4:
+            big_bosses_lambda = lambda state: state.has(ItemNames.THE_GOLEM_BEATED, self.player)
+        final_bosses_lambda = lambda state: True
+        if options.objective.value == Objective.option_gods_and_creator:
+            final_bosses_lambda = lambda state: _has_final_boss_item(state, self.player)
+        self.__connect_one_way_regions(self.menu, self.four_gods_end,
+                                       lambda state: _has_four_gods_beated(state, self.player) and
+                                                     mini_bosses_lambda(state) and big_bosses_lambda(state) and
+                                                     final_bosses_lambda(state))
 
     def __connect_transturtle(self, item_target: str, region_source: Region, region_target: Region) -> None:
         """Connect a single transturtle to another one"""

--- a/worlds/aquaria/test/test_energy_form_access.py
+++ b/worlds/aquaria/test/test_energy_form_access.py
@@ -22,13 +22,6 @@ class EnergyFormAccessTest(AquariaTestBase):
         locations = [
             AquariaLocationNames.ENERGY_TEMPLE_SECOND_AREA_BULB_UNDER_THE_ROCK,
             AquariaLocationNames.ENERGY_TEMPLE_THIRD_AREA_BULB_IN_THE_BOTTOM_PATH,
-            AquariaLocationNames.THE_BODY_LEFT_AREA_FIRST_BULB_IN_THE_TOP_FACE_ROOM,
-            AquariaLocationNames.THE_BODY_LEFT_AREA_SECOND_BULB_IN_THE_TOP_FACE_ROOM,
-            AquariaLocationNames.THE_BODY_LEFT_AREA_BULB_BELOW_THE_WATER_STREAM,
-            AquariaLocationNames.THE_BODY_LEFT_AREA_BULB_IN_THE_TOP_PATH_TO_THE_TOP_FACE_ROOM,
-            AquariaLocationNames.THE_BODY_LEFT_AREA_BULB_IN_THE_BOTTOM_FACE_ROOM,
-            AquariaLocationNames.THE_BODY_RIGHT_AREA_BULB_IN_THE_TOP_PATH_TO_THE_BOTTOM_FACE_ROOM,
-            AquariaLocationNames.THE_BODY_RIGHT_AREA_BULB_IN_THE_BOTTOM_FACE_ROOM,
             AquariaLocationNames.FINAL_BOSS_AREA_BULB_IN_THE_BOSS_THIRD_FORM_ROOM,
             AquariaLocationNames.OBJECTIVE_COMPLETE,
         ]


### PR DESCRIPTION
## What is this fixing or adding?

- Fixing a minor bug where Energy form and Dual form can be used to navigate the body level; but the randomizer logic just had the Energy form (had to fix energy form unit test too).
- Fixing a major bug where the four gods goals can become inaccessible if the YAML options "Mini bosses to beat" or "Big bosses to beat" is used with minimal accessibility.

## How was this tested?

- Using unit tests;
- Generating 100 completely random games
