### PR TITLE
Tests: Remove unneeded world exclusions

### DIFF
--- a/test/general/test_items.py
+++ b/test/general/test_items.py
@@ -138,7 +138,7 @@ class TestBase(unittest.TestCase):
         """Test that worlds don't modify the itempool after `create_items`"""
         gen_steps = ("generate_early", "create_regions", "create_items")
         additional_steps = ("set_rules", "connect_entrances", "generate_basic", "pre_fill")
-        excluded_games = ("Links Awakening DX", "Ocarina of Time", "SMZ3")
+        excluded_games = ("SMZ3",)
         worlds_to_test = {game: world
                           for game, world in AutoWorldRegister.testable_worlds.items() if game not in excluded_games}
         for game_name, world_type in worlds_to_test.items():

--- a/test/general/test_options.py
+++ b/test/general/test_options.py
@@ -110,16 +110,18 @@ class TestOptions(unittest.TestCase):
 
     def test_option_set_keys_random(self):
         """Tests that option sets do not contain 'random' and its variants as valid keys"""
-        for game_name, world_type in AutoWorldRegister.testable_worlds.items():
-            if game_name not in ("Archipelago", "Super Metroid"):
-                for option_key, option in world_type.options_dataclass.type_hints.items():
-                    if issubclass(option, OptionSet):
-                        with self.subTest(game=game_name, option=option_key):
-                            self.assertFalse(any(random_key in option.valid_keys for random_key in ("random",
-                                                                                                    "random-high",
-                                                                                                    "random-low")))
-                            for key in option.valid_keys:
-                                self.assertFalse("random-range" in key)
+        excluded_games = ("Super Metroid",)
+        worlds_to_test = {game: world
+                          for game, world in AutoWorldRegister.testable_worlds.items() if game not in excluded_games}
+        for game_name, world_type in worlds_to_test.items():
+            for option_key, option in world_type.options_dataclass.type_hints.items():
+                if issubclass(option, OptionSet):
+                    with self.subTest(game=game_name, option=option_key):
+                        self.assertFalse(any(random_key in option.valid_keys for random_key in ("random",
+                                                                                                "random-high",
+                                                                                                "random-low")))
+                        for key in option.valid_keys:
+                            self.assertFalse("random-range" in key)
     
     def test_pickle_dumps_plando(self):
         """Test that plando options using containers of a custom type can be pickled"""


### PR DESCRIPTION
## What is this fixing or adding?
A follow up for (or maybe superseding) #6390, removing OoT as well. Also I guess I forgot when writing on there, but seemingly even the initial commit from #1460 doesn't have OoT failing for me.

## How was this tested?
Several times locally. It seems like no other tests' exclusions are redundant.

## If this makes graphical changes, please attach screenshots.
📋