### PR TITLE
[MultiServer] Address Bounce packets that have "None" type for tags, games, and slots. Additionally adds type enforcement on the lists themselves.

### DIFF
--- a/CommonClient.py
+++ b/CommonClient.py
@@ -1092,6 +1092,7 @@ async def process_server_cmd(ctx: CommonContext, args: dict):
 
     elif cmd == "Bounced":
         tags = args.get("tags", [])
+        tags = tags if tags is not None else [] # Some packets don't provide tags at all which is optional / can be None per the docs spec.
         # we can skip checking "DeathLink" in ctx.tags, as otherwise we wouldn't have been sent this
         if "DeathLink" in tags:
             data = args.get("data", {})

--- a/CommonClient.py
+++ b/CommonClient.py
@@ -1092,7 +1092,6 @@ async def process_server_cmd(ctx: CommonContext, args: dict):
 
     elif cmd == "Bounced":
         tags = args.get("tags", [])
-        tags = tags if tags is not None else [] # Some packets don't provide tags at all which is optional / can be None per the docs spec.
         # we can skip checking "DeathLink" in ctx.tags, as otherwise we wouldn't have been sent this
         if "DeathLink" in tags:
             data = args.get("data", {})

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2152,8 +2152,9 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
                 await ctx.send_msgs(client, [{
                     "cmd": "InvalidPacket", "type": "arguments",
                     "text": "Bounce: Games list provided did not have the correct format.",
-                    "original_cmd": cmd
-                }])
+                    "original_cmd": cmd}])
+                return
+
             games = set(games)
 
             tags = args.get("tags", [])
@@ -2162,6 +2163,8 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
                     "cmd": "InvalidPacket", "type": "arguments",
                     "text": "Bounce: Tags list provided did not have the correct format.",
                     "original_cmd": cmd}])
+                return
+
             tags = set(tags)
 
             slots = args.get("slots", [])
@@ -2170,6 +2173,8 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
                     "cmd": "InvalidPacket", "type": "arguments",
                     "text": "Bounce: Slots list provided did not have the correct format.",
                     "original_cmd": cmd}])
+                return
+
             slots = set(slots)
 
             args["cmd"] = "Bounced"

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2148,7 +2148,7 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
 
         elif cmd == "Bounce":
             games = args.get("games", [])
-            if games is None or not isinstance(games, (list, set)) or not all(isinstance(entry, str) for entry in games):
+            if not isinstance(games, (list, set)) or not all(isinstance(entry, str) for entry in games):
                 await ctx.send_msgs(client, [{
                     "cmd": "InvalidPacket", "type": "arguments",
                     "text": "Bounce: Games list provided did not have the correct format.",
@@ -2156,14 +2156,14 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
                 }])
 
             tags = args.get("tags", [])
-            if tags is None or not isinstance(tags, (list, set)) or not all(isinstance(entry, str) for entry in tags):
+            if not isinstance(tags, (list, set)) or not all(isinstance(entry, str) for entry in tags):
                 await ctx.send_msgs(client, [{
                     "cmd": "InvalidPacket", "type": "arguments",
                     "text": "Bounce: Tags list provided did not have the correct format.",
                     "original_cmd": cmd}])
 
             slots = args.get("slots", [])
-            if slots is None or not isinstance(slots, (list, set)) or not all(isinstance(entry, int) for entry in slots):
+            if not isinstance(slots, (list, set)) or not all(isinstance(entry, int) for entry in slots):
                 await ctx.send_msgs(client, [{
                     "cmd": "InvalidPacket", "type": "arguments",
                     "text": "Bounce: Slots list provided did not have the correct format.",

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2147,26 +2147,27 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
             client.messageprocessor(args["text"])
 
         elif cmd == "Bounce":
-            games = set(args.get("games", []))
-            if games is None:
-                args["games"] = []
-            if games and not all(type(entry) is str for entry in games):
-                await ctx.send_msgs(client, [{'cmd': 'InvalidPacket', "type": "arguments",
-                    "text": "Bounce: Games list provided did not have the correct format.", "original_cmd": cmd}])
+            games = args.get("games", [])
+            if games is None or not isinstance(games, (list, set)) or not all(type(entry) is str for entry in games):
+                await ctx.send_msgs(client, [{
+                    "cmd": "InvalidPacket", "type": "arguments",
+                    "text": "Bounce: Games list provided did not have the correct format.",
+                    "original_cmd": cmd
+                }])
 
-            tags = set(args.get("tags", []))
-            if tags is None:
-                args["tags"] = []
-            if tags and not all(type(entry) is str for entry in tags):
-                await ctx.send_msgs(client, [{'cmd': 'InvalidPacket', "type": "arguments",
-                    "text": "Bounce: Tags list provided did not have the correct format.", "original_cmd": cmd}])
+            tags = args.get("tags", [])
+            if tags is None or not isinstance(tags, (list, set)) or not all(type(entry) is str for entry in tags):
+                await ctx.send_msgs(client, [{
+                    "cmd": "InvalidPacket", "type": "arguments",
+                    "text": "Bounce: Tags list provided did not have the correct format.",
+                    "original_cmd": cmd}])
 
-            slots = set(args.get("slots", []))
-            if slots is None:
-                args["slots"] = []
-            if slots and not all(type(entry) is int for entry in slots):
-                await ctx.send_msgs(client, [{'cmd': 'InvalidPacket', "type": "arguments",
-                    "text": "Bounce: Slots list provided did not have the correct format.", "original_cmd": cmd}])
+            slots = args.get("slots", [])
+            if slots is None or not isinstance(slots, (list, set)) or not all(type(entry) is int for entry in slots):
+                await ctx.send_msgs(client, [{
+                    "cmd": "InvalidPacket", "type": "arguments",
+                    "text": "Bounce: Slots list provided did not have the correct format.",
+                    "original_cmd": cmd}])
 
             args["cmd"] = "Bounced"
             msg = ctx.dumper([args])

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2154,6 +2154,7 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
                     "text": "Bounce: Games list provided did not have the correct format.",
                     "original_cmd": cmd
                 }])
+            games = set(games)
 
             tags = args.get("tags", [])
             if not isinstance(tags, (list, set)) or not all(isinstance(entry, str) for entry in tags):
@@ -2161,6 +2162,7 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
                     "cmd": "InvalidPacket", "type": "arguments",
                     "text": "Bounce: Tags list provided did not have the correct format.",
                     "original_cmd": cmd}])
+            tags = set(tags)
 
             slots = args.get("slots", [])
             if not isinstance(slots, (list, set)) or not all(isinstance(entry, int) for entry in slots):
@@ -2168,6 +2170,7 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
                     "cmd": "InvalidPacket", "type": "arguments",
                     "text": "Bounce: Slots list provided did not have the correct format.",
                     "original_cmd": cmd}])
+            slots = set(slots)
 
             args["cmd"] = "Bounced"
             msg = ctx.dumper([args])

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2148,8 +2148,23 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
 
         elif cmd == "Bounce":
             games = set(args.get("games", []))
+            games = games if games is not None else []
+            if games and not all(type(entry) is str for entry in games):
+                await ctx.send_msgs(client, [{'cmd': 'InvalidPacket', "type": "arguments",
+                    "text": "Bounce: Games list provided did not have the correct format.", "original_cmd": cmd}])
+
             tags = set(args.get("tags", []))
+            tags = tags if tags is not None else []
+            if tags and not all(type(entry) is str for entry in tags):
+                await ctx.send_msgs(client, [{'cmd': 'InvalidPacket', "type": "arguments",
+                    "text": "Bounce: Tags list provided did not have the correct format.", "original_cmd": cmd}])
+
             slots = set(args.get("slots", []))
+            slots = slots if slots is not None else []
+            if slots and not all(type(entry) is int for entry in slots):
+                await ctx.send_msgs(client, [{'cmd': 'InvalidPacket', "type": "arguments",
+                    "text": "Bounce: Slots list provided did not have the correct format.", "original_cmd": cmd}])
+
             args["cmd"] = "Bounced"
             msg = ctx.dumper([args])
 

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2148,7 +2148,7 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
 
         elif cmd == "Bounce":
             games = args.get("games", [])
-            if games is None or not isinstance(games, (list, set)) or not all(type(entry) is str for entry in games):
+            if games is None or not isinstance(games, (list, set)) or not all(isinstance(entry, str) for entry in games):
                 await ctx.send_msgs(client, [{
                     "cmd": "InvalidPacket", "type": "arguments",
                     "text": "Bounce: Games list provided did not have the correct format.",
@@ -2156,14 +2156,14 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
                 }])
 
             tags = args.get("tags", [])
-            if tags is None or not isinstance(tags, (list, set)) or not all(type(entry) is str for entry in tags):
+            if tags is None or not isinstance(tags, (list, set)) or not all(isinstance(entry, str) for entry in tags):
                 await ctx.send_msgs(client, [{
                     "cmd": "InvalidPacket", "type": "arguments",
                     "text": "Bounce: Tags list provided did not have the correct format.",
                     "original_cmd": cmd}])
 
             slots = args.get("slots", [])
-            if slots is None or not isinstance(slots, (list, set)) or not all(type(entry) is int for entry in slots):
+            if slots is None or not isinstance(slots, (list, set)) or not all(isinstance(entry, int) for entry in slots):
                 await ctx.send_msgs(client, [{
                     "cmd": "InvalidPacket", "type": "arguments",
                     "text": "Bounce: Slots list provided did not have the correct format.",

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2148,19 +2148,22 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
 
         elif cmd == "Bounce":
             games = set(args.get("games", []))
-            games = games if games is not None else []
+            if games is None:
+                args["games"] = []
             if games and not all(type(entry) is str for entry in games):
                 await ctx.send_msgs(client, [{'cmd': 'InvalidPacket', "type": "arguments",
                     "text": "Bounce: Games list provided did not have the correct format.", "original_cmd": cmd}])
 
             tags = set(args.get("tags", []))
-            tags = tags if tags is not None else []
+            if tags is None:
+                args["tags"] = []
             if tags and not all(type(entry) is str for entry in tags):
                 await ctx.send_msgs(client, [{'cmd': 'InvalidPacket', "type": "arguments",
                     "text": "Bounce: Tags list provided did not have the correct format.", "original_cmd": cmd}])
 
             slots = set(args.get("slots", []))
-            slots = slots if slots is not None else []
+            if slots is None:
+                args["slots"] = []
             if slots and not all(type(entry) is int for entry in slots):
                 await ctx.send_msgs(client, [{'cmd': 'InvalidPacket', "type": "arguments",
                     "text": "Bounce: Slots list provided did not have the correct format.", "original_cmd": cmd}])


### PR DESCRIPTION
What is this fixing or adding?
Some bounce packets have set as `"tags": null` or `"tags":None` at all to their packets, as [the docs specify that this is optional](https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/network%20protocol.md#Bounced). By this being None, clients are being disconnected for "TypeError: argument of type 'NoneType' is not iterable" if you try to find "DeathLink" in the None tags object.

Instead of addressing at the client level, per a request from Beserker, this is enforcing the spec at the MultiServer level. Additionally, this is adding type enforcement to any data in those lists to ensure that slots are of type int, games are of type str, and tags are of type str.

How was this tested?
Send a packet similarly below and this should now allow for Clients (such as CommonClient) to properly handle Bounce packets that do not provide tags, slots, or games properly. Additionally, sending in junk in slots, i.e. data["slots"]: ["test"], now results in an InvalidPacket.

<img width="690" height="235" alt="image" src="https://github.com/user-attachments/assets/1f61dcdc-3508-4bfa-aeb8-7982b6adc832" />
