### PR TITLE
Generate: Improve error messages for missing player files

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -166,27 +166,33 @@ def main(args=None) -> tuple[argparse.Namespace, int]:
 
     args.multi = max(player_id - 1, args.multi)
 
-    if args.multi == 0:
+    if args.multi == 0 and args.weights_file_path in weights_cache:
         if player_errors:
             errors = "\n\n".join(player_errors)
             raise ValueError(f"Encountered {len(player_errors)} error(s) in player files. "
                              f"See logs for full tracebacks.\n\n{errors}")
-        raise ValueError(
-            "No individual player files found and number of players is 0. "
-            "Provide individual player files or specify the number of players via host.yaml or --multi."
-        )
+        raise ValueError("Found only a weights file and number of players is set to 0. "
+                         "Provide individual player files or specify the number of players via host.yaml or --multi.")
 
-    logging.info(f"Generating for {args.multi} player{'s' if args.multi > 1 else ''}, "
-                 f"{seed_name} Seed {seed} with plando: {args.plando}")
+    if player_id - 1 < args.multi and args.weights_file_path not in weights_cache:
+        if player_errors:
+            errors = "\n\n".join(player_errors)
+            raise ValueError("Specified player count is higher than number of players found (excluding "
+                             f"{len(player_errors)} with errors), and no general weights file is present. "
+                             f"See logs for full error tracebacks.\n\n{errors}")
+        raise ValueError("Specified player count is higher than number of players found, and no general weights "
+                         "file is present.")
 
     if not weights_cache:
         if player_errors:
             errors = "\n\n".join(player_errors)
             raise ValueError(f"Encountered {len(player_errors)} error(s) in player files. "
                              f"See logs for full tracebacks.\n\n{errors}")
-        raise Exception(f"No weights found. "
-                        f"Provide a general weights file ({args.weights_file_path}) or individual player files. "
-                        f"A mix is also permitted.")
+        raise ValueError(f"No player weights found. Provide your player files inside of the Players folder, "
+                         "reachable from 'Browse Files' in the Launcher.")
+
+    logging.info(f"Generating for {args.multi} player{'s' if args.multi > 1 else ''}, "
+                 f"{seed_name} Seed {seed} with plando: {args.plando}")
 
     from worlds.AutoWorld import AutoWorldRegister
     args.outputname = seed_name


### PR DESCRIPTION
## What is this fixing or adding?
Seemingly since #2227, if you have no player files present at all (and players set to 0 like usual), then you will get a message including suggestions to specify the number of players in `host.yaml` or CLI, which seems odd to suggest given users are much more likely to want to use regular individual files. There in fact is a message particularly for this, and that PR has seemingly inadvertently overwritten it unless players is specifically set.

This fixes that by restricting that message to when there's actually a weights file present. I also adjusted the regular error to not specifically mention weights (which I think is more confusing than anything) and to give a quick explanation of where the files should go.

Also, currently if there's no weights file present but the players number is specified (and higher than the number found), then you'll get an unhandled error when it tries to read the weights, so I added a message for that as well. (By the way, is it intended that gen just ignores if the player number is *lower* than the given amount?)

## How was this tested?
Trying all of the changed cases to verify the messages.

## If this makes graphical changes, please attach screenshots.
For the new message, before is:
```
Traceback (most recent call last):
  File "C:\Users\Duck\Documents\Code\Repos\Archipelago\Generate.py", line 661, in <module>
    erargs, seed = main()
                   ^^^^^^
  File "C:\Users\Duck\Documents\Code\Repos\Archipelago\Generate.py", line 247, in main
    for doc_index, yaml in enumerate(weights_cache[path]):
                                     ~~~~~~~~~~~~~^^^^^^
KeyError: 'C:\\Users\\Duck\\Documents\\Code\\Repos\\Archipelago\\Players\\weights.yaml'
Press enter to close.
```
After:
```
Traceback (most recent call last):
  File "C:\Users\Duck\Documents\Code\Repos\Archipelago\Generate.py", line 670, in <module>
    erargs, seed = main()
                   ^^^^^^
  File "C:\Users\Duck\Documents\Code\Repos\Archipelago\Generate.py", line 183, in main
    raise ValueError("Specified player count is higher than number of players found, and no general weights "
ValueError: Specified player count is higher than number of players found, and no general weights file is present.
Press enter to close.
```