### PR TITLE
Stardew Valley: Apworld Version To 7.4.25

### DIFF
--- a/worlds/stardew_valley/archipelago.json
+++ b/worlds/stardew_valley/archipelago.json
@@ -2,5 +2,5 @@
   "game": "Stardew Valley",
   "authors": ["Kaito Kid", "Jouramie", "Witchybun (Mod Support)", "Exempt-Medic (Proofreading)"],
   "minimum_ap_version": "0.6.4",
-  "world_version": "7.4.0"
+  "world_version": "7.4.25"
 }


### PR DESCRIPTION
## What is this fixing or adding?

Since some PRs were merged ( #6214 #6293 ) for Stardew Valley in the next AP release, this is an apworld version bump so that the version is different to reflect the changes

## How was this tested?
Not much. It's a version number

## If this makes graphical changes, please attach screenshots.
<img width="294" height="140" alt="image" src="https://github.com/user-attachments/assets/8416cd18-52dc-4274-a11e-f316c5c15564" />
