### PR TITLE
Civ6 Bug Fix: Missing Logical Era

### DIFF
--- a/worlds/civ_6/__init__.py
+++ b/worlds/civ_6/__init__.py
@@ -136,7 +136,7 @@ class CivVIWorld(World):
             era_index = eras_list.index(era.value)
             self.era_required_progressive_era_counts[era] = (
                 0
-                if era in {EraType.ERA_FUTURE, EraType.ERA_INFORMATION}
+                if era in {EraType.ERA_FUTURE}
                 else era_index + 1
             )
 

--- a/worlds/civ_6/test/TestRegionRequirements.py
+++ b/worlds/civ_6/test/TestRegionRequirements.py
@@ -144,7 +144,7 @@ class TestProgressiveEraRequirements(CivVITestBase):
         accessible_eras = [EraType.ERA_ANCIENT]
         check_eras_accessible(accessible_eras)
 
-        # Classical era requires 2 progressive era items
+        # Classical era requires 2 progressive era items <Wrong assertion it only adds 1 era above
         self.collect(progresive_era_item)
         accessible_eras += [EraType.ERA_CLASSICAL]
         check_eras_accessible(accessible_eras)
@@ -169,9 +169,12 @@ class TestProgressiveEraRequirements(CivVITestBase):
         accessible_eras += [EraType.ERA_ATOMIC]
         check_eras_accessible(accessible_eras)
 
-        # Since we collect 2 in the ancient era, information and future era have same logic requirement
+        # Since we collect 2 in the ancient era, information and future era have same logic requirement <Wrong assertion
         self.collect(progresive_era_item)
         accessible_eras += [EraType.ERA_INFORMATION]
+        check_eras_accessible(accessible_eras)
+
+        self.collect(progresive_era_item)
         accessible_eras += [EraType.ERA_FUTURE]
         check_eras_accessible(accessible_eras)
 

--- a/worlds/civ_6/test/TestRegionRequirements.py
+++ b/worlds/civ_6/test/TestRegionRequirements.py
@@ -230,8 +230,11 @@ class TestProgressiveEraRequirementsWithBoostsanity(CivVITestBase):
         accessible_eras += [EraType.ERA_ATOMIC]
         check_eras_accessible(accessible_eras)
 
-        # Since we collect 2 in the ancient era, information and future era have same logic requirement
+        # Since we collect 2 in the ancient era, information and future era have same logic requirement <Wrong assertion
         self.collect(progresive_era_item)
         accessible_eras += [EraType.ERA_INFORMATION]
+        check_eras_accessible(accessible_eras)
+
+        self.collect(progresive_era_item)
         accessible_eras += [EraType.ERA_FUTURE]
         check_eras_accessible(accessible_eras)


### PR DESCRIPTION
## What is this fixing or adding?
removed what I believe to be the exception of moving from the information era to the future era not costing a progressive era.

## How was this tested?
looked through the spoiler log and confirmed all 8 progressive eras to be in the playthrough.
afterwards hosted it on source with one UT on source and one UT on normal ap. Gave required items until it reached the future era except for the last progressive era required. See screenshot below.
More testing may be necessary, like a fuzzer.

Below a comparison from old logic on the left and new logic on the right after giving all required techs and 7/8 progressive eras.
<img width="1889" height="33" alt="image" src="https://github.com/user-attachments/assets/485c2c0d-64b2-46af-be82-5cab43a400df" />

P.S. Would like some feedback from @hesto2 in case there is more that might need changing based on this.