### PR TITLE
MultiServer: Correct Bounce Target logic, write unit tests

### DIFF
--- a/MultiServer.py
+++ b/MultiServer.py
@@ -21,8 +21,8 @@ import time
 import typing
 import weakref
 import zlib
-from functools import reduce
 from signal import SIGINT, SIGTERM, signal
+from typing import Sequence
 
 import ModuleUpdate
 
@@ -61,39 +61,66 @@ server_per_message_deflate_factory = ServerPerMessageDeflateFactory(
     compress_settings={"memLevel": 4},
 )
 
-OPERATOR_NAME_TO_OPERATOR = {
-    "or": operator.or_,
-    "and": operator.and_,
-}
-
 class BounceTarget(typing.NamedTuple):
-    teams: set[int]
-    games: set[str]
-    tags: set[str]
-    slots: set[int]
+    teams: set[int] | None
+    games: set[str] | None
+    tags: set[str] | None
+    slots: set[int] | None
 
     def _teams_match(self, target: Client) -> bool:
         return target.team in self.teams
 
     def _games_match(self, target: Client) -> bool:
-        return len(self.games) == 0 or target.ctx.games[target.slot] in self.games
+        return target.ctx.games[target.slot] in self.games
 
     def _tags_match(self, target: Client) -> bool:
-        return len(self.tags) == 0 or bool(set(target.tags) & self.tags)
+        return bool(set(target.tags) & self.tags)
 
     def _slots_match(self, target: Client) -> bool:
-        return len(self.slots) == 0 or target.slot in self.slots
+        return target.slot in self.slots
 
-    def matches_client_legacy(self, target: Client) -> bool:
-        return self._teams_match(target) and (
-            self._games_match(target) or self._tags_match(target) or self._slots_match(target)
-        )
+    def _get_conditions(self, include_teams: bool = True) -> Sequence[typing.Callable[[Client], bool]]:
+        conditions = []
+        if self.teams is not None and include_teams:
+            conditions.append(self._teams_match)
+        if self.games is not None:
+            conditions.append(self._games_match)
+        if self.tags is not None:
+            conditions.append(self._tags_match)
+        if self.slots is not None:
+            conditions.append(self._slots_match)
 
-    def matches_client_operator(self, target: Client, op: typing.Callable[[typing.Any, typing.Any], bool]):
-        return reduce(
-            op,
-            (self._teams_match(target), self._games_match(target), self._tags_match(target), self._games_match(target)),
-        )
+        return conditions
+
+    def match_clients_legacy(self, clients: typing.Iterable[Client]) -> typing.Generator[Client, None, None]:
+        non_team_conditions = self._get_conditions(include_teams=False)
+
+        # Do as little work as possible: Pre-check teams is None
+        if self.teams is None:
+            for bounce_client in clients:
+                if any(condition(bounce_client) for condition in non_team_conditions):
+                    yield bounce_client
+        else:
+            for bounce_client in clients:
+                if self._teams_match(bounce_client) and any(
+                    condition(bounce_client) for condition in non_team_conditions
+                ):
+                    yield bounce_client
+
+    def match_clients_or(self, clients: typing.Iterable[Client]) -> typing.Generator[Client, None, None]:
+        conditions = self._get_conditions(include_teams=True)
+
+        for bounce_client in clients:
+            if any(condition(bounce_client) for condition in conditions):
+                yield bounce_client
+
+    def match_clients_and(self, clients: typing.Iterable[Client]) -> typing.Generator[Client, None, None]:
+        conditions = self._get_conditions(include_teams=True)
+
+        for bounce_client in clients:
+            if all(condition(bounce_client) for condition in conditions):
+                yield bounce_client
+
 
 
 def remove_from_list(container, value):
@@ -2182,45 +2209,28 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
             client.messageprocessor(args["text"])
 
         elif cmd == "Bounce":
-            games = args.get("games", [])
-            if not isinstance(games, (list, set)) or not all(isinstance(entry, str) for entry in games):
-                await ctx.send_msgs(client, [{
-                    "cmd": "InvalidPacket", "type": "arguments",
-                    "text": "Bounce: Games list provided did not have the correct format.",
-                    "original_cmd": cmd}])
-                return
+            teams = args.get("teams", {client.team})
+            games = args.get("games", None)
+            tags = args.get("tags", None)
+            slots = args.get("slots", None)
 
-            games = set(games)
+            for value, name, expected_type in (
+                (teams, str, "Teams"), (games, str, "Games"), (tags, str, "Tags"), (slots, int, "Slots")
+            ):
+                if value is None:
+                    continue
 
-            tags = args.get("tags", [])
-            if not isinstance(tags, (list, set)) or not all(isinstance(entry, str) for entry in tags):
-                await ctx.send_msgs(client, [{
-                    "cmd": "InvalidPacket", "type": "arguments",
-                    "text": "Bounce: Tags list provided did not have the correct format.",
-                    "original_cmd": cmd}])
-                return
+                if not isinstance(value, (list, set)) or not all(isinstance(entry, expected_type) for entry in games):
+                    await ctx.send_msgs(client, [{
+                        "cmd": "InvalidPacket", "type": "arguments",
+                        "text": f"Bounce: {expected_type} list provided did not have the correct format.",
+                        "original_cmd": cmd}])
+                    return
 
-            tags = set(tags)
-
-            slots = args.get("slots", [])
-            if not isinstance(slots, (list, set)) or not all(isinstance(entry, int) for entry in slots):
-                await ctx.send_msgs(client, [{
-                    "cmd": "InvalidPacket", "type": "arguments",
-                    "text": "Bounce: Slots list provided did not have the correct format.",
-                    "original_cmd": cmd}])
-                return
-
-            slots = set(slots)
-
-            teams = args.get("teams", [client.team])
-            if not isinstance(teams, (list, set)) or not all(isinstance(entry, int) for entry in teams):
-                await ctx.send_msgs(client, [{
-                    "cmd": "InvalidPacket", "type": "arguments",
-                    "text": "Bounce: Teams list provided did not have the correct format.",
-                    "original_cmd": cmd}])
-                return
-
-            teams = set(teams)
+            teams = None if teams is None else set(teams)
+            games = None if games is None else set(games)
+            tags = None if tags is None else set(tags)
+            slots = None if slots is None else set(slots)
 
             bounce_target = BounceTarget(teams, games, tags, slots)
 
@@ -2230,18 +2240,20 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
             boolean_operator = args.get("operator", "legacy")
 
             if boolean_operator == "legacy":
-                for bounce_client in ctx.endpoints:
-                    if bounce_target.matches_client_legacy(bounce_client):
-                        await ctx.send_encoded_msgs(bounce_client, msg)
-            elif boolean_operator in OPERATOR_NAME_TO_OPERATOR:
-                op = OPERATOR_NAME_TO_OPERATOR[boolean_operator]
-                for bounce_client in ctx.endpoints:
-                    if bounce_target.matches_client_operator(bounce_client, op):
-                        await ctx.send_encoded_msgs(bounce_client, msg)
+                match_function = bounce_target.match_clients_legacy
+            elif boolean_operator == "or":
+                match_function = bounce_target.match_clients_or
+            elif boolean_operator == "and":
+                match_function = bounce_target.match_clients_and
             else:
                 await ctx.send_msgs(client, [{'cmd': 'InvalidPacket', "type": "arguments",
                                               "text": "Bounce", "original_cmd": cmd}])
                 return
+
+            for matching_client in match_function(ctx.endpoints):
+                await ctx.send_encoded_msgs(matching_client, msg)
+
+            return
 
         elif cmd == "Get":
             if "keys" not in args or type(args["keys"]) != list:

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -71,7 +71,7 @@ class BounceTarget(typing.NamedTuple):
         return target.team in self.teams
 
     def _games_match(self, target: Client) -> bool:
-        return target.ctx.games[target.slot] in self.games
+        return target.ctx().games[target.slot] in self.games
 
     def _tags_match(self, target: Client) -> bool:
         return bool(set(target.tags) & self.tags)

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2229,7 +2229,7 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
                     return
 
             # We now know that if a key is present, it is not None, so this should be the best way to get "set or None"
-            teams = set(args["teams"]) if "teams" in args else {client.team}
+            teams = set(args["teams"]) if "teams" in args else {client.team}  # Team default is only same team
             games = set(args["games"]) if "games" in args else None
             tags = set(args["tags"]) if "tags" in args else None
             slots = set(args["slots"]) if "slots" in args else None

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2209,28 +2209,30 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
             client.messageprocessor(args["text"])
 
         elif cmd == "Bounce":
-            teams = args.get("teams", {client.team})
-            games = args.get("games", None)
-            tags = args.get("tags", None)
-            slots = args.get("slots", None)
-
-            for value, expected_type, name in (
-                (teams, str, "Teams"), (games, str, "Games"), (tags, str, "Tags"), (slots, int, "Slots")
+            for name, expected_type in (
+                ("teams", int), ("games", str), ("tags", str), ("slots", int)
             ):
-                if value is None:
+                if name not in args:
                     continue
 
-                if not isinstance(value, (list, set)) or not all(isinstance(entry, expected_type) for entry in games):
+                value = args[name]
+
+                if (
+                    value is None
+                    or not isinstance(value, (list, set))
+                    or not all(isinstance(entry, expected_type) for entry in value)
+                ):
                     await ctx.send_msgs(client, [{
                         "cmd": "InvalidPacket", "type": "arguments",
-                        "text": f"Bounce: {name} list provided did not have the correct format.",
+                        "text": f'Bounce: "{name}" list provided did not have the correct format.',
                         "original_cmd": cmd}])
                     return
 
-            teams = None if teams is None else set(teams)
-            games = None if games is None else set(games)
-            tags = None if tags is None else set(tags)
-            slots = None if slots is None else set(slots)
+            # We now know that if a key is present, it is not None, so this should be the best way to get "set or None"
+            teams = set(args["teams"]) if "teams" in args else {client.team}
+            games = set(args["games"]) if "games" in args else None
+            tags = set(args["tags"]) if "tags" in args else None
+            slots = set(args["slots"]) if "slots" in args else None
 
             bounce_target = BounceTarget(teams, games, tags, slots)
 

--- a/MultiServer.py
+++ b/MultiServer.py
@@ -2214,7 +2214,7 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
             tags = args.get("tags", None)
             slots = args.get("slots", None)
 
-            for value, name, expected_type in (
+            for value, expected_type, name in (
                 (teams, str, "Teams"), (games, str, "Games"), (tags, str, "Tags"), (slots, int, "Slots")
             ):
                 if value is None:
@@ -2223,7 +2223,7 @@ async def process_client_cmd(ctx: Context, client: Client, args: dict):
                 if not isinstance(value, (list, set)) or not all(isinstance(entry, expected_type) for entry in games):
                     await ctx.send_msgs(client, [{
                         "cmd": "InvalidPacket", "type": "arguments",
-                        "text": f"Bounce: {expected_type} list provided did not have the correct format.",
+                        "text": f"Bounce: {name} list provided did not have the correct format.",
                         "original_cmd": cmd}])
                     return
 

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -422,7 +422,7 @@ Send this message to the server, tell it which clients should receive the messag
 the message to all those targets to which the requirements ("teams", "games", "slots", "tags") apply according
 to the operator chosen:
 - "or": Conditions are chained with "or".
-- "and": Conditions are chained with "and". Important note: If a condition is empty, it evaluates as **True**.
+- "and": Conditions are chained with "and". Important note: If a condition is empty / None, it evaluates as **True**.
 - "legacy": Evaluates as `teams and (games or slots or tags)`.
 
 #### Arguments

--- a/docs/network protocol.md
+++ b/docs/network protocol.md
@@ -422,7 +422,7 @@ Send this message to the server, tell it which clients should receive the messag
 the message to all those targets to which the requirements ("teams", "games", "slots", "tags") apply according
 to the operator chosen:
 - "or": Conditions are chained with "or".
-- "and": Conditions are chained with "and". Important note: If a condition is empty / None, it evaluates as **True**.
+- "and": Conditions are chained with "and". (Important note: A completely missing key evaluates as **True**, whereas an empty list evaluates as **False**)
 - "legacy": Evaluates as `teams and (games or slots or tags)`.
 
 #### Arguments

--- a/test/general/test_bounce.py
+++ b/test/general/test_bounce.py
@@ -1,0 +1,233 @@
+import unittest
+from unittest.mock import MagicMock
+
+from MultiServer import Client, BounceTarget
+
+
+def create_mock_client(team: int, game: str, tags: set[str], slot: int):
+    client = MagicMock()
+    client.team = team
+    client.tags = tags
+    client.slot = slot
+
+    client.ctx = MagicMock()
+    client.ctx.games = {slot: game}
+
+    return client
+
+TEAM_1_SLOT_1 = create_mock_client(1, "TestGame",set(),  1)
+TEAM_1_SLOT_2 = create_mock_client(1, "TestGame", {"DeathLink", "TrapLink"}, 2)
+TEAM_1_SLOT_3 = create_mock_client(1, "TestGame 2", {"DeathLink"}, 3)
+TEAM_2_SLOT_1 = create_mock_client(2, "TestGame", set(),  1)
+TEAM_2_SLOT_2 = create_mock_client(2, "TestGame",{"DeathLink", "TrapLink"},  2)
+TEAM_2_SLOT_3 = create_mock_client(2, "TestGame 2",{"DeathLink"},  3)
+
+ALL_CLIENTS = [TEAM_1_SLOT_1, TEAM_1_SLOT_2, TEAM_1_SLOT_3, TEAM_2_SLOT_1, TEAM_2_SLOT_2, TEAM_2_SLOT_3]
+
+class TestBounceTargetLegacy(unittest.TestCase):
+    """
+    Test various BounceTarget configurations against six mock clients with different teams, games, tags and slots.
+
+    Uses the "legacy" operator, which is defined as: "team and (game or tags or slot)".
+    """
+
+    def test_legacy_bounce_target_default(self):
+        bounce_target = BounceTarget(None, None, None, None)
+
+        assert list(bounce_target.match_clients_legacy(ALL_CLIENTS)) == []
+
+    def test_legacy_bounce_team_only(self):
+        bounce_target = BounceTarget({1}, None, None, None)
+
+        assert list(bounce_target.match_clients_legacy(ALL_CLIENTS)) == []
+
+    def test_legacy_tags_condition_only(self):
+        bounce_target = BounceTarget(None, None, {"DeathLink"}, None)
+
+        self.assertEqual(list(bounce_target.match_clients_legacy(ALL_CLIENTS)), [TEAM_1_SLOT_2, TEAM_1_SLOT_3, TEAM_2_SLOT_2, TEAM_2_SLOT_3])
+
+    def test_legacy_slot_condition_only(self):
+        bounce_target = BounceTarget(None, None, None, {2})
+
+        self.assertEqual(list(bounce_target.match_clients_legacy(ALL_CLIENTS)), [TEAM_1_SLOT_2, TEAM_2_SLOT_2])
+
+    def test_legacy_empty_conditions(self):
+        bounce_target = BounceTarget(set(), set(), set(), set())
+
+        self.assertEqual(list(bounce_target.match_clients_legacy(ALL_CLIENTS)), [])
+
+    def test_legacy_empty_conditions_except_slot(self):
+        bounce_target = BounceTarget(set(), set(), set(), {3})
+
+        self.assertEqual(list(bounce_target.match_clients_legacy(ALL_CLIENTS)), [])
+
+    def test_legacy_empty_conditions_except_tags_and_team(self):
+        bounce_target = BounceTarget({1}, set(), {"DeathLink"}, set())
+
+        self.assertEqual(list(bounce_target.match_clients_legacy(ALL_CLIENTS)), [TEAM_1_SLOT_2, TEAM_1_SLOT_3])
+
+    def test_legacy_all(self):
+        bounce_target = BounceTarget({2}, {"TestGame 2"}, {"DeathLink"}, {1})
+
+        self.assertEqual(list(bounce_target.match_clients_legacy(ALL_CLIENTS)), [TEAM_2_SLOT_1, TEAM_2_SLOT_2, TEAM_2_SLOT_3])
+
+    def test_legacy_multiple_games(self):
+        bounce_target = BounceTarget({1}, {"TestGame", "TestGame 2"}, None, None)
+
+        self.assertEqual(list(bounce_target.match_clients_legacy(ALL_CLIENTS)), [TEAM_1_SLOT_1, TEAM_1_SLOT_2, TEAM_1_SLOT_3])
+
+    def test_legacy_multiple_tags(self):
+        bounce_target = BounceTarget({2}, None, {"DeathLink", "TrapLink"}, None)
+
+        self.assertEqual(list(bounce_target.match_clients_legacy(ALL_CLIENTS)), [TEAM_2_SLOT_2, TEAM_2_SLOT_3])
+
+    def test_legacy_multiple_slots(self):
+        bounce_target = BounceTarget(None, None, None, {1, 2})
+
+        self.assertEqual(list(bounce_target.match_clients_legacy(ALL_CLIENTS)), [TEAM_1_SLOT_1, TEAM_1_SLOT_2, TEAM_2_SLOT_1, TEAM_2_SLOT_2])
+
+    def test_legacy_multiple_teams(self):
+        bounce_target = BounceTarget({1, 2}, None, None, {1})
+
+        self.assertEqual(list(bounce_target.match_clients_legacy(ALL_CLIENTS)), [TEAM_1_SLOT_1, TEAM_2_SLOT_1])
+
+
+class TestBounceTargetOr(unittest.TestCase):
+    """
+    Test various BounceTarget configurations against six mock clients with different teams, games, tags and slots.
+
+    Uses the "or" operator, which is defined as: "any(team, game, tags, slot)".
+
+    A missing condition (None) is interpreted as always True, where an empty set is treated as always False.
+    """
+
+    def test_or_bounce_target_default(self):
+        bounce_target = BounceTarget(None, None, None, None)
+
+        assert list(bounce_target.match_clients_or(ALL_CLIENTS)) == []
+
+    def test_or_bounce_team_only(self):
+        bounce_target = BounceTarget({1}, None, None, None)
+
+        assert list(bounce_target.match_clients_or(ALL_CLIENTS)) == [TEAM_1_SLOT_1, TEAM_1_SLOT_2, TEAM_1_SLOT_3]
+
+    def test_or_tags_condition_only(self):
+        bounce_target = BounceTarget(None, None, {"DeathLink"}, None)
+
+        self.assertEqual(list(bounce_target.match_clients_or(ALL_CLIENTS)), [TEAM_1_SLOT_2, TEAM_1_SLOT_3, TEAM_2_SLOT_2, TEAM_2_SLOT_3])
+
+    def test_or_slot_condition_only(self):
+        bounce_target = BounceTarget(None, None, None, {2})
+
+        self.assertEqual(list(bounce_target.match_clients_or(ALL_CLIENTS)), [TEAM_1_SLOT_2, TEAM_2_SLOT_2])
+
+    def test_or_empty_conditions(self):
+        bounce_target = BounceTarget(set(), set(), set(), set())
+
+        self.assertEqual(list(bounce_target.match_clients_or(ALL_CLIENTS)), [])
+
+    def test_or_empty_conditions_except_slot(self):
+        bounce_target = BounceTarget(set(), set(), set(), {3})
+
+        self.assertEqual(list(bounce_target.match_clients_or(ALL_CLIENTS)), [TEAM_1_SLOT_3, TEAM_2_SLOT_3])
+
+    def test_or_empty_conditions_except_tags_and_team(self):
+        bounce_target = BounceTarget({1}, set(), {"DeathLink"}, set())
+
+        self.assertEqual(list(bounce_target.match_clients_or(ALL_CLIENTS)), [TEAM_1_SLOT_1, TEAM_1_SLOT_2, TEAM_1_SLOT_3, TEAM_2_SLOT_2, TEAM_2_SLOT_3])
+
+    def test_or_all(self):
+        bounce_target = BounceTarget({2}, {"TestGame 2"}, {"DeathLink"}, {1})
+
+        self.assertEqual(list(bounce_target.match_clients_or(ALL_CLIENTS)), ALL_CLIENTS)
+
+    def test_or_multiple_games(self):
+        bounce_target = BounceTarget({1}, {"TestGame", "TestGame 2"}, None, None)
+
+        self.assertEqual(list(bounce_target.match_clients_or(ALL_CLIENTS)), ALL_CLIENTS)
+
+    def test_or_multiple_tags(self):
+        bounce_target = BounceTarget({2}, None, {"DeathLink", "TrapLink"}, None)
+
+        self.assertEqual(list(bounce_target.match_clients_or(ALL_CLIENTS)), [TEAM_1_SLOT_2, TEAM_1_SLOT_3, TEAM_2_SLOT_1, TEAM_2_SLOT_2, TEAM_2_SLOT_3])
+
+    def test_or_multiple_slots(self):
+        bounce_target = BounceTarget(None, None, None, {1, 2})
+
+        self.assertEqual(list(bounce_target.match_clients_or(ALL_CLIENTS)), [TEAM_1_SLOT_1, TEAM_1_SLOT_2, TEAM_2_SLOT_1, TEAM_2_SLOT_2])
+
+    def test_or_multiple_teams(self):
+        bounce_target = BounceTarget({1, 2}, None, None, {1})
+
+        self.assertEqual(list(bounce_target.match_clients_or(ALL_CLIENTS)), ALL_CLIENTS)
+
+
+class TestBounceTargetAnd(unittest.TestCase):
+    """
+    Test various BounceTarget configurations against six mock clients with different teams, games, tags and slots.
+
+    Uses the "and" operator, which is defined as: "all(team, game, tags, slot)".
+
+    A missing condition (None) is interpreted as always True, where an empty set is treated as always False.
+    This means that for an "and"-type bounce packet, a single empty set means the whole condition selects no clients.
+    """
+
+    def test_and_bounce_target_default(self):
+        bounce_target = BounceTarget(None, None, None, None)
+
+        assert list(bounce_target.match_clients_and(ALL_CLIENTS)) == ALL_CLIENTS
+
+    def test_and_bounce_team_only(self):
+        bounce_target = BounceTarget({1}, None, None, None)
+
+        assert list(bounce_target.match_clients_and(ALL_CLIENTS)) == [TEAM_1_SLOT_1, TEAM_1_SLOT_2, TEAM_1_SLOT_3]
+
+    def test_and_tags_condition_only(self):
+        bounce_target = BounceTarget(None, None, {"DeathLink"}, None)
+
+        self.assertEqual(list(bounce_target.match_clients_and(ALL_CLIENTS)), [TEAM_1_SLOT_2, TEAM_1_SLOT_3, TEAM_2_SLOT_2, TEAM_2_SLOT_3])
+
+    def test_and_slot_condition_only(self):
+        bounce_target = BounceTarget(None, None, None, {2})
+
+        self.assertEqual(list(bounce_target.match_clients_and(ALL_CLIENTS)), [TEAM_1_SLOT_2, TEAM_2_SLOT_2])
+
+    def test_and_empty_conditions(self):
+        bounce_target = BounceTarget(set(), set(), set(), set())
+
+        self.assertEqual(list(bounce_target.match_clients_and(ALL_CLIENTS)), [])
+
+    def test_and_empty_conditions_except_slot(self):
+        bounce_target = BounceTarget(set(), set(), set(), {3})
+
+        self.assertEqual(list(bounce_target.match_clients_and(ALL_CLIENTS)), [])
+
+    def test_and_empty_conditions_except_tags_and_team(self):
+        bounce_target = BounceTarget({1}, None, {"DeathLink"}, None)
+
+        self.assertEqual(list(bounce_target.match_clients_and(ALL_CLIENTS)), [TEAM_1_SLOT_2, TEAM_1_SLOT_3])
+
+    def test_and_all(self):
+        bounce_target = BounceTarget({2}, {"TestGame 2"}, {"DeathLink"}, {3})
+
+        self.assertEqual(list(bounce_target.match_clients_and(ALL_CLIENTS)), [TEAM_2_SLOT_3])
+
+    def test_and_multiple_games(self):
+        bounce_target = BounceTarget({1}, {"TestGame", "TestGame 2"}, None, None)
+
+        self.assertEqual(list(bounce_target.match_clients_and(ALL_CLIENTS)), [TEAM_1_SLOT_1, TEAM_1_SLOT_2, TEAM_1_SLOT_3])
+
+    def test_and_multiple_tags(self):
+        bounce_target = BounceTarget({2}, None, {"DeathLink", "TrapLink"}, None)
+
+        self.assertEqual(list(bounce_target.match_clients_and(ALL_CLIENTS)), [TEAM_2_SLOT_2, TEAM_2_SLOT_3])
+
+    def test_and_multiple_slots(self):
+        bounce_target = BounceTarget(None, None, None, {1, 2})
+
+        self.assertEqual(list(bounce_target.match_clients_and(ALL_CLIENTS)), [TEAM_1_SLOT_1, TEAM_1_SLOT_2, TEAM_2_SLOT_1, TEAM_2_SLOT_2])
+
+    def test_and_multiple_teams(self):
+        bounce_target = BounceTarget({1, 2}, None, None, {1})
+
+        self.assertEqual(list(bounce_target.match_clients_and(ALL_CLIENTS)), [TEAM_1_SLOT_1, TEAM_2_SLOT_1])

--- a/test/general/test_bounce.py
+++ b/test/general/test_bounce.py
@@ -98,7 +98,7 @@ class TestBounceTargetOr(unittest.TestCase):
 
     Uses the "or" operator, which is defined as: "any(team, game, tags, slot)".
 
-    A missing condition (None) is interpreted as always True, where an empty set is treated as always False.
+    A missing condition (None) or an empty set is treated as always False.
     """
 
     def test_or_bounce_target_default(self):

--- a/test/general/test_bounce.py
+++ b/test/general/test_bounce.py
@@ -10,8 +10,10 @@ def create_mock_client(team: int, game: str, tags: set[str], slot: int):
     client.tags = tags
     client.slot = slot
 
-    client.ctx = MagicMock()
-    client.ctx.games = {slot: game}
+    ctx = MagicMock()
+    ctx.games = {slot: game}
+
+    client.ctx = lambda: ctx
 
     return client
 

--- a/test/general/test_bounce.py
+++ b/test/general/test_bounce.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import MagicMock
 
-from MultiServer import Client, BounceTarget
+from MultiServer import BounceTarget
 
 
 def create_mock_client(team: int, game: str, tags: set[str], slot: int):
@@ -15,14 +15,16 @@ def create_mock_client(team: int, game: str, tags: set[str], slot: int):
 
     return client
 
-TEAM_1_SLOT_1 = create_mock_client(1, "TestGame",set(),  1)
+
+TEAM_1_SLOT_1 = create_mock_client(1, "TestGame", set(), 1)
 TEAM_1_SLOT_2 = create_mock_client(1, "TestGame", {"DeathLink", "TrapLink"}, 2)
 TEAM_1_SLOT_3 = create_mock_client(1, "TestGame 2", {"DeathLink"}, 3)
-TEAM_2_SLOT_1 = create_mock_client(2, "TestGame", set(),  1)
-TEAM_2_SLOT_2 = create_mock_client(2, "TestGame",{"DeathLink", "TrapLink"},  2)
-TEAM_2_SLOT_3 = create_mock_client(2, "TestGame 2",{"DeathLink"},  3)
+TEAM_2_SLOT_1 = create_mock_client(2, "TestGame", set(), 1)
+TEAM_2_SLOT_2 = create_mock_client(2, "TestGame", {"DeathLink", "TrapLink"}, 2)
+TEAM_2_SLOT_3 = create_mock_client(2, "TestGame 2", {"DeathLink"}, 3)
 
 ALL_CLIENTS = [TEAM_1_SLOT_1, TEAM_1_SLOT_2, TEAM_1_SLOT_3, TEAM_2_SLOT_1, TEAM_2_SLOT_2, TEAM_2_SLOT_3]
+
 
 class TestBounceTargetLegacy(unittest.TestCase):
     """
@@ -44,7 +46,10 @@ class TestBounceTargetLegacy(unittest.TestCase):
     def test_legacy_tags_condition_only(self):
         bounce_target = BounceTarget(None, None, {"DeathLink"}, None)
 
-        self.assertEqual(list(bounce_target.match_clients_legacy(ALL_CLIENTS)), [TEAM_1_SLOT_2, TEAM_1_SLOT_3, TEAM_2_SLOT_2, TEAM_2_SLOT_3])
+        self.assertEqual(
+            list(bounce_target.match_clients_legacy(ALL_CLIENTS)),
+            [TEAM_1_SLOT_2, TEAM_1_SLOT_3, TEAM_2_SLOT_2, TEAM_2_SLOT_3],
+        )
 
     def test_legacy_slot_condition_only(self):
         bounce_target = BounceTarget(None, None, None, {2})
@@ -69,12 +74,16 @@ class TestBounceTargetLegacy(unittest.TestCase):
     def test_legacy_all(self):
         bounce_target = BounceTarget({2}, {"TestGame 2"}, {"DeathLink"}, {1})
 
-        self.assertEqual(list(bounce_target.match_clients_legacy(ALL_CLIENTS)), [TEAM_2_SLOT_1, TEAM_2_SLOT_2, TEAM_2_SLOT_3])
+        self.assertEqual(
+            list(bounce_target.match_clients_legacy(ALL_CLIENTS)), [TEAM_2_SLOT_1, TEAM_2_SLOT_2, TEAM_2_SLOT_3]
+        )
 
     def test_legacy_multiple_games(self):
         bounce_target = BounceTarget({1}, {"TestGame", "TestGame 2"}, None, None)
 
-        self.assertEqual(list(bounce_target.match_clients_legacy(ALL_CLIENTS)), [TEAM_1_SLOT_1, TEAM_1_SLOT_2, TEAM_1_SLOT_3])
+        self.assertEqual(
+            list(bounce_target.match_clients_legacy(ALL_CLIENTS)), [TEAM_1_SLOT_1, TEAM_1_SLOT_2, TEAM_1_SLOT_3]
+        )
 
     def test_legacy_multiple_tags(self):
         bounce_target = BounceTarget({2}, None, {"DeathLink", "TrapLink"}, None)
@@ -84,7 +93,10 @@ class TestBounceTargetLegacy(unittest.TestCase):
     def test_legacy_multiple_slots(self):
         bounce_target = BounceTarget(None, None, None, {1, 2})
 
-        self.assertEqual(list(bounce_target.match_clients_legacy(ALL_CLIENTS)), [TEAM_1_SLOT_1, TEAM_1_SLOT_2, TEAM_2_SLOT_1, TEAM_2_SLOT_2])
+        self.assertEqual(
+            list(bounce_target.match_clients_legacy(ALL_CLIENTS)),
+            [TEAM_1_SLOT_1, TEAM_1_SLOT_2, TEAM_2_SLOT_1, TEAM_2_SLOT_2],
+        )
 
     def test_legacy_multiple_teams(self):
         bounce_target = BounceTarget({1, 2}, None, None, {1})
@@ -114,7 +126,10 @@ class TestBounceTargetOr(unittest.TestCase):
     def test_or_tags_condition_only(self):
         bounce_target = BounceTarget(None, None, {"DeathLink"}, None)
 
-        self.assertEqual(list(bounce_target.match_clients_or(ALL_CLIENTS)), [TEAM_1_SLOT_2, TEAM_1_SLOT_3, TEAM_2_SLOT_2, TEAM_2_SLOT_3])
+        self.assertEqual(
+            list(bounce_target.match_clients_or(ALL_CLIENTS)),
+            [TEAM_1_SLOT_2, TEAM_1_SLOT_3, TEAM_2_SLOT_2, TEAM_2_SLOT_3],
+        )
 
     def test_or_slot_condition_only(self):
         bounce_target = BounceTarget(None, None, None, {2})
@@ -134,7 +149,10 @@ class TestBounceTargetOr(unittest.TestCase):
     def test_or_empty_conditions_except_tags_and_team(self):
         bounce_target = BounceTarget({1}, set(), {"DeathLink"}, set())
 
-        self.assertEqual(list(bounce_target.match_clients_or(ALL_CLIENTS)), [TEAM_1_SLOT_1, TEAM_1_SLOT_2, TEAM_1_SLOT_3, TEAM_2_SLOT_2, TEAM_2_SLOT_3])
+        self.assertEqual(
+            list(bounce_target.match_clients_or(ALL_CLIENTS)),
+            [TEAM_1_SLOT_1, TEAM_1_SLOT_2, TEAM_1_SLOT_3, TEAM_2_SLOT_2, TEAM_2_SLOT_3],
+        )
 
     def test_or_all(self):
         bounce_target = BounceTarget({2}, {"TestGame 2"}, {"DeathLink"}, {1})
@@ -149,12 +167,18 @@ class TestBounceTargetOr(unittest.TestCase):
     def test_or_multiple_tags(self):
         bounce_target = BounceTarget({2}, None, {"DeathLink", "TrapLink"}, None)
 
-        self.assertEqual(list(bounce_target.match_clients_or(ALL_CLIENTS)), [TEAM_1_SLOT_2, TEAM_1_SLOT_3, TEAM_2_SLOT_1, TEAM_2_SLOT_2, TEAM_2_SLOT_3])
+        self.assertEqual(
+            list(bounce_target.match_clients_or(ALL_CLIENTS)),
+            [TEAM_1_SLOT_2, TEAM_1_SLOT_3, TEAM_2_SLOT_1, TEAM_2_SLOT_2, TEAM_2_SLOT_3],
+        )
 
     def test_or_multiple_slots(self):
         bounce_target = BounceTarget(None, None, None, {1, 2})
 
-        self.assertEqual(list(bounce_target.match_clients_or(ALL_CLIENTS)), [TEAM_1_SLOT_1, TEAM_1_SLOT_2, TEAM_2_SLOT_1, TEAM_2_SLOT_2])
+        self.assertEqual(
+            list(bounce_target.match_clients_or(ALL_CLIENTS)),
+            [TEAM_1_SLOT_1, TEAM_1_SLOT_2, TEAM_2_SLOT_1, TEAM_2_SLOT_2],
+        )
 
     def test_or_multiple_teams(self):
         bounce_target = BounceTarget({1, 2}, None, None, {1})
@@ -185,7 +209,10 @@ class TestBounceTargetAnd(unittest.TestCase):
     def test_and_tags_condition_only(self):
         bounce_target = BounceTarget(None, None, {"DeathLink"}, None)
 
-        self.assertEqual(list(bounce_target.match_clients_and(ALL_CLIENTS)), [TEAM_1_SLOT_2, TEAM_1_SLOT_3, TEAM_2_SLOT_2, TEAM_2_SLOT_3])
+        self.assertEqual(
+            list(bounce_target.match_clients_and(ALL_CLIENTS)),
+            [TEAM_1_SLOT_2, TEAM_1_SLOT_3, TEAM_2_SLOT_2, TEAM_2_SLOT_3],
+        )
 
     def test_and_slot_condition_only(self):
         bounce_target = BounceTarget(None, None, None, {2})
@@ -215,7 +242,9 @@ class TestBounceTargetAnd(unittest.TestCase):
     def test_and_multiple_games(self):
         bounce_target = BounceTarget({1}, {"TestGame", "TestGame 2"}, None, None)
 
-        self.assertEqual(list(bounce_target.match_clients_and(ALL_CLIENTS)), [TEAM_1_SLOT_1, TEAM_1_SLOT_2, TEAM_1_SLOT_3])
+        self.assertEqual(
+            list(bounce_target.match_clients_and(ALL_CLIENTS)), [TEAM_1_SLOT_1, TEAM_1_SLOT_2, TEAM_1_SLOT_3]
+        )
 
     def test_and_multiple_tags(self):
         bounce_target = BounceTarget({2}, None, {"DeathLink", "TrapLink"}, None)
@@ -225,7 +254,10 @@ class TestBounceTargetAnd(unittest.TestCase):
     def test_and_multiple_slots(self):
         bounce_target = BounceTarget(None, None, None, {1, 2})
 
-        self.assertEqual(list(bounce_target.match_clients_and(ALL_CLIENTS)), [TEAM_1_SLOT_1, TEAM_1_SLOT_2, TEAM_2_SLOT_1, TEAM_2_SLOT_2])
+        self.assertEqual(
+            list(bounce_target.match_clients_and(ALL_CLIENTS)),
+            [TEAM_1_SLOT_1, TEAM_1_SLOT_2, TEAM_2_SLOT_1, TEAM_2_SLOT_2],
+        )
 
     def test_and_multiple_teams(self):
         bounce_target = BounceTarget({1, 2}, None, None, {1})


### PR DESCRIPTION
I broke the Bounce logic pretty bad in the last PR, https://github.com/ArchipelagoMW/Archipelago/pull/3845

I fixed that here.

To make sure it doesn't happen again, at least not at a unit level, I wrote some unit tests for the new BounceTarget class.