### PR TITLE
Core: Add an argument to not put files in a zip

### DIFF
--- a/Generate.py
+++ b/Generate.py
@@ -59,6 +59,8 @@ def mystery_argparse(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--spoiler_only", action="store_true",
                         help="Skips generation assertion and multidata, outputting only a spoiler log. "
                              "Intended for debugging and testing purposes.")
+    parser.add_argument("--unzipped", action="store_true",
+                        help="Places all the generated files directly in output instead of in a zip.")
     args = parser.parse_args(argv)
 
     if args.skip_output and args.spoiler_only:

--- a/Main.py
+++ b/Main.py
@@ -1,4 +1,5 @@
 import collections
+import shutil
 from collections.abc import Mapping
 import concurrent.futures
 import logging
@@ -381,12 +382,15 @@ def main(args, seed=None, baked_server_options: dict[str, object] | None = None)
         if args.spoiler:
             multiworld.spoiler.to_file(os.path.join(temp_dir, '%s_Spoiler.txt' % outfilebase))
 
-        zipfilename = output_path(f"AP_{multiworld.seed_name}.zip")
-        logger.info(f"Creating final archive at {zipfilename}")
-        with zipfile.ZipFile(zipfilename, mode="w", compression=zipfile.ZIP_DEFLATED,
-                             compresslevel=9) as zf:
-            for file in os.scandir(temp_dir):
-                zf.write(file.path, arcname=file.name)
+        if args.unzipped:
+            shutil.copytree(temp_dir, output_path(f"AP_{multiworld.seed_name}"), dirs_exist_ok=True)
+        else:
+            zipfilename = output_path(f"AP_{multiworld.seed_name}.zip")
+            logger.info(f"Creating final archive at {zipfilename}")
+            with zipfile.ZipFile(zipfilename, mode="w", compression=zipfile.ZIP_DEFLATED,
+                                 compresslevel=9) as zf:
+                for file in os.scandir(temp_dir):
+                    zf.write(file.path, arcname=file.name)
 
     logger.info('Done. Enjoy. Total Time: %s', time.perf_counter() - start)
     return multiworld


### PR DESCRIPTION
## What is this fixing or adding?
When testing games with a patch files, it is very tiring to generate, go in the output folder, open the zip, extract the patch to the output folder, go back to the launcher, click open patch and finally patch the file.
A solution is to not zip the files, skipping half the steps to generate a patched game
Given that this feature is more for the devs than the players, it was only added as a command line argument `--unzipped`, for now at least

## How was this tested?
I generated a seed of APQuest with and without the argument, everything looked correct
