### PR TITLE
Core: Make hints avoid excluded locations

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -323,13 +323,21 @@ def main(args, seed=None, baked_server_options: dict[str, object] | None = None)
 
                 # get spheres -> filter address==None -> skip empty
                 spheres: list[dict[int, set[int]]] = []
+                # In order to make the excluded locations not appear to be early for hints and prioritize non-excluded
+                # locations, place the excluded locations as the last sphere
+                excluded_sphere: dict[int, set[int]] = {}
                 for sphere in multiworld.get_sendable_spheres():
                     current_sphere: dict[int, set[int]] = collections.defaultdict(set)
                     for sphere_location in sphere:
-                        current_sphere[sphere_location.player].add(sphere_location.address)
+                        if sphere_location.progress_type != LocationProgressType.EXCLUDED:
+                            current_sphere[sphere_location.player].add(sphere_location.address)
+                        else:
+                            excluded_sphere[sphere_location.player].add(sphere_location.address)
 
                     if current_sphere:
                         spheres.append(dict(current_sphere))
+                if excluded_sphere:
+                    spheres.append(dict(excluded_sphere))
 
                 multidata: NetUtils.MultiData = {
                     "slot_data": slot_data,


### PR DESCRIPTION
## What is this fixing or adding?
Say you have 4 swords in your pool, only one of them being progression. According to the current behavior of the hints, since they prefer to hit earlier items, it is currently possible that when you hint for one of them, you get an excluded location, which means you wasted your hint, since the excluded location's goal is to not be forced to do it. Worse even, it could cause social pressure between players because a precious hint was used on it, while everything could have been avoided if it hinted for any of the 3 others that aren't in excluded locations

This PR attempts to fix this behavior by creating a new sphere in the multidata for excluded locations. Given that hints prefer the lowest spheres, excluded being the highest means hints will only hit excluded locations as a last resort

## How was this tested?
I just generated a seed