### PR TITLE
SM: fix generation failure when another world has a generate_early call

### DIFF
--- a/worlds/sm/__init__.py
+++ b/worlds/sm/__init__.py
@@ -52,7 +52,7 @@ class SMCollectionState(metaclass=AutoLogicRegister):
         if hasattr(parent, "state"):
             self.smbm = {player: SMBoolManager(player, parent.state.smbm[player].maxDiff,
                                     parent.state.smbm[player].onlyBossLeft) for player in
-                                        parent.get_game_players("Super Metroid")}
+                                        parent.get_game_players("Super Metroid") if player in parent.state.smbm}
             for player, group in parent.groups.items():
                 if (group["game"] == "Super Metroid"):
                     self.smbm[player] = SMBoolManager(player)


### PR DESCRIPTION
## What is this fixing or adding?

When another world uses `generate_early` before SM, the SM `hasattr` init mixin would fail because `parent.state.smbm` would not have data for the world. This PR adds a check to make sure the data exists before using it.

The mixin is called again later during generation with properly initialized data.

```
Traceback (most recent call last):
  File "<ap dir>\Archipelago\Generate.py", line 666, in <module>
    multiworld = ERmain(erargs, seed)
  File "<ap dir>\Archipelago\Main.py", line 76, in main
    AutoWorld.call_all(multiworld, "generate_early")
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<ap dir>\Archipelago\worlds\AutoWorld.py", line 207, in call_all
    call_single(multiworld, method_name, player, *args)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<ap dir>\Archipelago\worlds\AutoWorld.py", line 193, in call_single
    raise e
  File "<ap dir>\Archipelago\worlds\AutoWorld.py", line 186, in call_single
    ret = _timed_call(method, *args, multiworld=multiworld, player=player)
  File "<ap dir>\Archipelago\worlds\AutoWorld.py", line 171, in _timed_call
    ret = method(*args)
  File "<ap dir>\Archipelago\worlds\hk\__init__.py", line 160, in generate_early
    start_validation = self.validate_start(start_location_key)
  File "<ap dir>\Archipelago\worlds\hk\__init__.py", line 212, in validate_start
    test_state = CollectionState(self.multiworld)
  File "<ap dir>\Archipelago\BaseClasses.py", line 744, in __init__
    function(self, parent)
    ~~~~~~~~^^^^^^^^^^^^^^
  File "<ap dir>\Archipelago\worlds\sm\__init__.py", line 53, in init_mixin
    self.smbm = {player: SMBoolManager(player, parent.state.smbm[player].maxDiff,
                                               ~~~~~~~~~~~~~~~~~^^^^^^^^
KeyError: 2
Exception in <bound method HKWorld.generate_early of <worlds.hk.HKWorld object at 0x00000179BDE54C20>> for player 1, named HKRoomRando.
```

## How was this tested?

* Tested a [Hollow Knight Beta](https://github.com/qwint/Archipelago/releases/tag/1.1.4) with a non-default start location, which is a [known instance](https://discord.com/channels/731205301247803413/959203442570715176/1545660914223554682) of this issue & was the case we were running into during our multiworld's generation. I also tested with multiple SM worlds in the multiworld to ensure that that couldn't break it.
[SM1.yaml](https://github.com/user-attachments/files/31882276/SM1.yaml)
[SM2.yaml](https://github.com/user-attachments/files/31882277/SM2.yaml)
[HKRoomRando.yaml](https://github.com/user-attachments/files/31882278/HKRoomRando.yaml)

## If this makes graphical changes, please attach screenshots.

N/A